### PR TITLE
8273162: AbstractSplittableWithBrineGenerator does not create a random salt

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -2380,7 +2380,7 @@ public class RandomSupport {
             long bits = nextLong();
             long multiplier = (1L << SALT_SHIFT) - 1;
             long salt = multiplier << (64 - SALT_SHIFT);
-            while ((salt & multiplier) != 0) {
+            while ((salt & multiplier) == 0) {
                 long digit = Math.multiplyHigh(bits, multiplier);
                 salt = (salt >>> SALT_SHIFT) | (digit << (64 - SALT_SHIFT));
                 bits *= multiplier;


### PR DESCRIPTION
Transplanted from https://github.com/openjdk/jdk17u/pull/288.

Additional testing:
 - `java/util/Random` tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8273162](https://bugs.openjdk.java.net/browse/JDK-8273162): AbstractSplittableWithBrineGenerator does not create a random salt
 * [JDK-8273183](https://bugs.openjdk.java.net/browse/JDK-8273183): AbstractSplittableWithBrineGenerator does not create a random salt (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/6.diff">https://git.openjdk.java.net/jdk17u-dev/pull/6.diff</a>

</details>
