### PR TITLE
8274753: ZGC: SEGV in MetaspaceShared::link_shared_classes

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -550,20 +550,19 @@ void VM_PopulateDumpSharedSpace::doit() {
 
 class CollectCLDClosure : public CLDClosure {
   GrowableArray<ClassLoaderData*> _loaded_cld;
-  GrowableArray<Handle> _loaded_cld_handles; // keep the CLDs alive
+  GrowableArray<OopHandle> _loaded_cld_handles; // keep the CLDs alive
   Thread* _current_thread;
 public:
   CollectCLDClosure(Thread* thread) : _current_thread(thread) {}
   ~CollectCLDClosure() {
-    for (int i = 0; i < _loaded_cld.length(); i++) {
-      ClassLoaderData* cld = _loaded_cld.at(i);
+    for (int i = 0; i < _loaded_cld_handles.length(); i++) {
+      _loaded_cld_handles.at(i).release(Universe::vm_global());
     }
   }
   void do_cld(ClassLoaderData* cld) {
-    if (!cld->is_unloading()) {
-      _loaded_cld.append(cld);
-      _loaded_cld_handles.append(Handle(_current_thread, cld->holder_phantom()));
-    }
+    assert(cld->is_alive(), "must be");
+    _loaded_cld.append(cld);
+    _loaded_cld_handles.append(OopHandle(Universe::vm_global(), cld->holder_phantom()));
   }
 
   int nof_cld() const                { return _loaded_cld.length(); }

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -55,6 +55,7 @@
 #include "classfile/packageEntry.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
@@ -886,6 +887,8 @@ void ClassLoaderData::free_deallocate_list_C_heap_structures() {
       // Remove the class so unloading events aren't triggered for
       // this class (scratch or error class) in do_unloading().
       remove_class(ik);
+      // But still have to remove it from the dumptime_table.
+      SystemDictionaryShared::handle_class_unloading(ik);
     }
   }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -52,6 +52,23 @@
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom
  */
 
+/**
+ * @test id=custom-cl-zgc
+ * @requires vm.cds.custom.loaders
+ * @requires vm.gc.Z
+ * @summary Test dumptime_table entries are removed with zgc eager class unloading
+ * @bug 8274935
+ * @library /test/lib
+ *          /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive
+ * @modules java.base/jdk.internal.misc
+ *          jdk.httpserver
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm/timeout=180 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. DynamicLoaderConstraintsTest custom-zgc
+ */
+
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import jdk.test.lib.Asserts;
@@ -83,9 +100,11 @@ public class DynamicLoaderConstraintsTest extends DynamicArchiveTestBase {
      *                  if false, LoaderConstraintsApp will be loaded by the built-in AppClassLoader.
      */
     static boolean useCustomLoader;
+    static boolean useZGC;
 
     public static void main(String[] args) throws Exception {
         useCustomLoader = (args.length != 0);
+        useZGC = (args.length != 0 && args[0].equals("custom-zgc"));
         runTest(DynamicLoaderConstraintsTest::doTest);
     }
 
@@ -124,8 +143,15 @@ public class DynamicLoaderConstraintsTest extends DynamicArchiveTestBase {
             };
 
             if (useCustomLoader) {
-                cmdLine = TestCommon.concat(cmdLine, "-cp", loaderJar,
-                                          loaderMainClass, appJar);
+                if (useZGC) {
+                    // Add options to force eager class unloading.
+                    cmdLine = TestCommon.concat(cmdLine, "-cp", loaderJar,
+                                                "-XX:+UseZGC", "-XX:ZCollectionInterval=0.01",
+                                                loaderMainClass, appJar);
+                } else {
+                    cmdLine = TestCommon.concat(cmdLine, "-cp", loaderJar,
+                                                loaderMainClass, appJar);
+                }
             } else {
                 cmdLine = TestCommon.concat(cmdLine, "-cp", appJar);
             }


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8274753](https://bugs.openjdk.java.net/browse/JDK-8274753): ZGC: SEGV in MetaspaceShared::link_shared_classes
 * [JDK-8274935](https://bugs.openjdk.java.net/browse/JDK-8274935): dumptime_table has stale entry


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/10.diff">https://git.openjdk.java.net/jdk17u-dev/pull/10.diff</a>

</details>
