### PR TITLE
8276177: nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption failed with "assert(def_ik->is_being_redefined()) failed: should be being redefined to get here"

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -254,8 +254,7 @@ class InstanceKlass: public Klass {
     _misc_is_shared_platform_class            = 1 << 11, // defining class loader is platform class loader
     _misc_is_shared_app_class                 = 1 << 12, // defining class loader is app class loader
     _misc_has_resolved_methods                = 1 << 13, // resolved methods table entries added for this class
-    _misc_is_being_redefined                  = 1 << 14, // used for locking redefinition
-    _misc_has_contended_annotations           = 1 << 15  // has @Contended annotation
+    _misc_has_contended_annotations           = 1 << 14  // has @Contended annotation
   };
   u2 shared_loader_type_bits() const {
     return _misc_is_shared_boot_class|_misc_is_shared_platform_class|_misc_is_shared_app_class;
@@ -738,14 +737,16 @@ public:
 
 #if INCLUDE_JVMTI
   // Redefinition locking.  Class can only be redefined by one thread at a time.
+  // The flag is in access_flags so that it can be set and reset using atomic
+  // operations, and not be reset by other misc_flag settings.
   bool is_being_redefined() const          {
-    return ((_misc_flags & _misc_is_being_redefined) != 0);
+    return _access_flags.is_being_redefined();
   }
   void set_is_being_redefined(bool value)  {
     if (value) {
-      _misc_flags |= _misc_is_being_redefined;
+      _access_flags.set_is_being_redefined();
     } else {
-      _misc_flags &= ~_misc_is_being_redefined;
+      _access_flags.clear_is_being_redefined();
     }
   }
 

--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -69,6 +69,7 @@ enum {
   JVM_ACC_IS_SHARED_CLASS         = 0x02000000,     // True if klass is shared
   JVM_ACC_IS_HIDDEN_CLASS         = 0x04000000,     // True if klass is hidden
   JVM_ACC_IS_VALUE_BASED_CLASS    = 0x08000000,     // True if klass is marked as a ValueBased class
+  JVM_ACC_IS_BEING_REDEFINED      = 0x00100000,     // True if the klass is being redefined.
 
   // Klass* and Method* flags
   JVM_ACC_HAS_LOCAL_VARIABLE_TABLE= 0x00200000,
@@ -158,6 +159,10 @@ class AccessFlags {
   bool has_localvariable_table () const { return (_flags & JVM_ACC_HAS_LOCAL_VARIABLE_TABLE) != 0; }
   void set_has_localvariable_table()    { atomic_set_bits(JVM_ACC_HAS_LOCAL_VARIABLE_TABLE); }
   void clear_has_localvariable_table()  { atomic_clear_bits(JVM_ACC_HAS_LOCAL_VARIABLE_TABLE); }
+
+  bool is_being_redefined() const       { return (_flags & JVM_ACC_IS_BEING_REDEFINED) != 0; }
+  void set_is_being_redefined()         { atomic_set_bits(JVM_ACC_IS_BEING_REDEFINED); }
+  void clear_is_being_redefined()       { atomic_clear_bits(JVM_ACC_IS_BEING_REDEFINED); }
 
   // field flags
   bool is_field_access_watched() const  { return (_flags & JVM_ACC_FIELD_ACCESS_WATCHED) != 0; }


### PR DESCRIPTION
A clean backport for parity with Oracle 17.0.3.

Test:

- [x] nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption now passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276177](https://bugs.openjdk.java.net/browse/JDK-8276177): nsk/jvmti/RedefineClasses/StressRedefineWithoutBytecodeCorruption failed with "assert(def_ik->is_being_redefined()) failed: should be being redefined to get here"


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/15.diff">https://git.openjdk.java.net/jdk17u-dev/pull/15.diff</a>

</details>
