### PR TITLE
Backport 769f14db847813f5a3601e9ec21e6cadbd99ee96

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -1029,7 +1029,6 @@ int ExceptionMessageBuilder::do_instruction(int bci) {
       break;
 
     case Bytecodes::_arraylength:
-      // The return type of arraylength is wrong in the bytecodes table (T_VOID).
       stack->pop(1);
       stack->push(bci, T_INT);
       break;

--- a/src/hotspot/share/interpreter/bytecodes.cpp
+++ b/src/hotspot/share/interpreter/bytecodes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -471,7 +471,7 @@ void Bytecodes::initialize() {
   def(_new                 , "new"                 , "bkk"  , NULL    , T_OBJECT ,  1, true );
   def(_newarray            , "newarray"            , "bc"   , NULL    , T_OBJECT ,  0, true );
   def(_anewarray           , "anewarray"           , "bkk"  , NULL    , T_OBJECT ,  0, true );
-  def(_arraylength         , "arraylength"         , "b"    , NULL    , T_VOID   ,  0, true );
+  def(_arraylength         , "arraylength"         , "b"    , NULL    , T_INT    ,  0, true );
   def(_athrow              , "athrow"              , "b"    , NULL    , T_VOID   , -1, true );
   def(_checkcast           , "checkcast"           , "bkk"  , NULL    , T_OBJECT ,  0, true );
   def(_instanceof          , "instanceof"          , "bkk"  , NULL    , T_INT    ,  0, true );


### PR DESCRIPTION
A clean backport for parity with Oracle 17.0.3.

This bug could potentially cause unexpected and intermittent failures that would be difficult to find.
