### PR TITLE
8278016: Add compiler tests to tier{2,3}

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -172,6 +172,50 @@ tier1_compiler_3 = \
   -compiler/loopopts/Test7052494.java \
   -compiler/runtime/Test6826736.java
 
+tier2_compiler = \
+  compiler/allocation/ \
+  compiler/arguments/ \
+  compiler/calls/ \
+  compiler/cha/ \
+  compiler/controldependency/ \
+  compiler/conversions/ \
+  compiler/codegen/ \
+  compiler/linkage/ \
+  compiler/loopstripmining/ \
+  compiler/loopopts/Test7052494.java \
+  compiler/longcountedloops/ \
+  compiler/intrinsics/bmi \
+  compiler/intrinsics/mathexact \
+  compiler/intrinsics/sha \
+  compiler/intrinsics/bigInteger/TestMultiplyToLen.java \
+  compiler/intrinsics/zip/TestAdler32.java \
+  compiler/membars/ \
+  compiler/onSpinWait/ \
+  compiler/parsing/ \
+  compiler/rangechecks/ \
+  compiler/reflection/ \
+  compiler/rtm/ \
+  compiler/runtime/Test6826736.java \
+  compiler/stable/ \
+  compiler/stringopts/ \
+  -:tier1_compiler \
+  -:hotspot_slow_compiler
+
+tier3_compiler = \
+  compiler/c2/ \
+  compiler/ciReplay/ \
+  compiler/compilercontrol/ \
+  compiler/debug/ \
+  compiler/oracle/ \
+  compiler/print/ \
+  compiler/relocations/ \
+  compiler/tiered/ \
+  compiler/vectorapi/ \
+  compiler/whitebox/ \
+  :hotspot_slow_compiler \
+  -:tier1_compiler \
+  -:tier2_compiler
+
 tier1_compiler_not_xcomp = \
   compiler/profiling
 
@@ -456,11 +500,13 @@ tier2 = \
   :hotspot_tier2_runtime \
   :hotspot_tier2_runtime_platform_agnostic \
   :hotspot_tier2_serviceability \
+  :tier2_compiler \
   :tier2_gc_epsilon \
   :tier2_gc_shenandoah
 
 tier3 = \
   :hotspot_tier3_runtime \
+  :tier3_compiler \
   :tier3_gc_shenandoah
 
 # Everything that is not in other tiers, but not apps


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier2_compiler`
 - [x] Linux x86_64 fastdebug `tier3_compiler`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278016](https://bugs.openjdk.java.net/browse/JDK-8278016): Add compiler tests to tier{2,3}


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/18.diff">https://git.openjdk.java.net/jdk17u-dev/pull/18.diff</a>

</details>
