### PR TITLE
8277992: Add fast jdk_svc subtests to jdk:tier3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -74,7 +74,9 @@ tier3 = \
     :build \
     :jdk_vector \
     :jdk_rmi \
-    :jdk_jfr_tier3
+    :jdk_svc \
+   -:jdk_svc_sanity \
+   -:svc_tools
 
 # Everything not in other tiers
 tier4 = \
@@ -282,9 +284,6 @@ jdk_tools = \
 
 jdk_jfr = \
     jdk/jfr
-
-jdk_jfr_tier3 = \
-    jdk/jfr/event/metadata/TestLookForUntestedEvents.java
 
 #
 # Catch-all for other areas with a small number of tests


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk:tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277992](https://bugs.openjdk.java.net/browse/JDK-8277992): Add fast jdk_svc subtests to jdk:tier3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/19.diff">https://git.openjdk.java.net/jdk17u-dev/pull/19.diff</a>

</details>
