### PR TITLE
8247980: Exclusive execution of java/util/stream tests slows down tier1

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -27,7 +27,7 @@ exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/tools/jcmd \
 sun/tools/jinfo sun/tools/jmap sun/tools/jps sun/tools/jstack sun/tools/jstat \
-com/sun/tools/attach sun/security/mscapi java/util/stream java/util/Arrays/largeMemory \
+com/sun/tools/attach sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket
 
 # Group definitions


### PR DESCRIPTION
Clean backport to improve 17u testing. There seem to be no bugtail from the mainline improvement pushed back in September 2020.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk:tier1`

Motivational improvements on TR 3970X:

```
# Before
real	14m48.189s
user	425m10.750s
sys	17m11.072s

# After
real	9m21.856s
user	417m29.605s
sys	15m27.971s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247980](https://bugs.openjdk.java.net/browse/JDK-8247980): Exclusive execution of java/util/stream tests slows down tier1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/22.diff">https://git.openjdk.java.net/jdk17u-dev/pull/22.diff</a>

</details>
