### PR TITLE
8272327: Shenandoah: Avoid enqueuing duplicate string candidates

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMark.inline.hpp
@@ -261,7 +261,9 @@ inline void ShenandoahMark::mark_through_ref(T* p, ShenandoahObjToScanQueue* q, 
       if ((STRING_DEDUP == ENQUEUE_DEDUP) && ShenandoahStringDedup::is_candidate(obj)) {
         assert(ShenandoahStringDedup::is_enabled(), "Must be enabled");
         req->add(obj);
-      } else if ((STRING_DEDUP == ALWAYS_DEDUP) && ShenandoahStringDedup::is_string_candidate(obj)) {
+      } else if ((STRING_DEDUP == ALWAYS_DEDUP) &&
+                 ShenandoahStringDedup::is_string_candidate(obj) &&
+                 !ShenandoahStringDedup::dedup_requested(obj)) {
         assert(ShenandoahStringDedup::is_enabled(), "Must be enabled");
         req->add(obj);
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahStringDedup.hpp
@@ -31,6 +31,7 @@ class ShenandoahStringDedup : public StringDedup {
 public:
   static inline bool is_string_candidate(oop obj);
   static inline bool is_candidate(oop obj);
+  static inline bool dedup_requested(oop obj);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHSTRINGDEDUP_HPP


### PR DESCRIPTION
Clean backport to improve Shenandoah.

Additional testing:
 - [x] Linux x86_64 fastdebug `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272327](https://bugs.openjdk.java.net/browse/JDK-8272327): Shenandoah: Avoid enqueuing duplicate string candidates


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/23.diff">https://git.openjdk.java.net/jdk17u-dev/pull/23.diff</a>

</details>
