### PR TITLE
8279011: JFR: JfrChunkWriter incorrectly handles int64_t chunk size as size_t

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrChunkWriter.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunkWriter.cpp
@@ -207,7 +207,7 @@ int64_t JfrChunkWriter::write_chunk_header_checkpoint(bool flushpoint) {
   const u4 checkpoint_size = current_offset() - event_size_offset;
   write_padded_at_offset<u4>(checkpoint_size, event_size_offset);
   set_last_checkpoint_offset(event_size_offset);
-  const size_t sz_written = size_written();
+  const int64_t sz_written = size_written();
   write_be_at_offset(sz_written, chunk_size_offset);
   return sz_written;
 }


### PR DESCRIPTION
Clean backport to fix JFR bug manifesting on 32-bit platforms. This PR would stay open a bit to get the change tested in mainline first.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk_jfr` (passes)
 - [x] Linux x86_32 fastdebug `jdk_jfr` (used to fail, now passes with 1 unrelated failure)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279011](https://bugs.openjdk.java.net/browse/JDK-8279011): JFR: JfrChunkWriter incorrectly handles int64_t chunk size as size_t


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/24.diff">https://git.openjdk.java.net/jdk17u-dev/pull/24.diff</a>

</details>
