### PR TITLE
8274130: C2: MulNode::Ideal chained transformations may act on wrong nodes

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -59,13 +59,11 @@ Node* MulNode::Identity(PhaseGVN* phase) {
 // We also canonicalize the Node, moving constants to the right input,
 // and flatten expressions (so that 1+x+2 becomes x+3).
 Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
-  const Type *t1 = phase->type( in(1) );
-  const Type *t2 = phase->type( in(2) );
-  Node *progress = NULL;        // Progress flag
+  Node* in1 = in(1);
+  Node* in2 = in(2);
+  Node* progress = NULL;        // Progress flag
 
   // convert "max(a,b) * min(a,b)" into "a*b".
-  Node *in1 = in(1);
-  Node *in2 = in(2);
   if ((in(1)->Opcode() == max_opcode() && in(2)->Opcode() == min_opcode())
       || (in(1)->Opcode() == min_opcode() && in(2)->Opcode() == max_opcode())) {
     Node *in11 = in(1)->in(1);
@@ -83,9 +81,14 @@ Node *MulNode::Ideal(PhaseGVN *phase, bool can_reshape) {
         igvn->_worklist.push(in1);
         igvn->_worklist.push(in2);
       }
+      in1 = in(1);
+      in2 = in(2);
       progress = this;
     }
   }
+
+  const Type* t1 = phase->type(in1);
+  const Type* t2 = phase->type(in2);
 
   // We are OK if right is a constant, or right is a load and
   // left is a non-constant.


### PR DESCRIPTION
Unclean backport to fix the potential C2 bug. The uncleanliness comes from the fact that [JDK-8273454](https://bugs.openjdk.java.net/browse/JDK-8273454) is missing in 17, therefore its hunk is ignored. But the other change, [JDK-8263006](https://bugs.openjdk.java.net/browse/JDK-8263006) is present in 17, which still introduces the bug this fix addresses.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274130](https://bugs.openjdk.java.net/browse/JDK-8274130): C2: MulNode::Ideal chained transformations may act on wrong nodes


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/25.diff">https://git.openjdk.java.net/jdk17u-dev/pull/25.diff</a>

</details>
