### PR TITLE
8277328: jdk/jshell/CommandCompletionTest.java failures on Windows

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -254,7 +254,7 @@ public class JShellTool implements MessageHandler {
             Pattern.compile(OPTION_PRE_PATTERN.pattern() + "(?<dd>-??)(?<flag>-([a-z][a-z\\-]*)?)");
     // match an option flag and a (possibly missing or incomplete) value
     private static final Pattern OPTION_VALUE_PATTERN =
-            Pattern.compile(OPTION_PATTERN.pattern() + "\\s+(?<val>\\S*)");
+            Pattern.compile(OPTION_PATTERN.pattern() + "\\s+(?<val>(\\S|\\\\ )*)");
 
     // Tool id (tid) mapping: the three name spaces
     NameSpace mainNamespace;
@@ -1555,13 +1555,13 @@ public class JShellTool implements MessageHandler {
     private static CompletionProvider fileCompletions(Predicate<Path> accept) {
         return (code, cursor, anchor) -> {
             int lastSlash = code.lastIndexOf('/');
-            String path = code.substring(0, lastSlash + 1);
-            String prefix = lastSlash != (-1) ? code.substring(lastSlash + 1) : code;
+            String path = code.substring(0, lastSlash + 1).replace("\\ ", " ");
+            String prefix = (lastSlash != (-1) ? code.substring(lastSlash + 1) : code).replace("\\ ", " ");
             Path current = toPathResolvingUserHome(path);
             List<Suggestion> result = new ArrayList<>();
             try (Stream<Path> dir = Files.list(current)) {
                 dir.filter(f -> accept.test(f) && f.getFileName().toString().startsWith(prefix))
-                   .map(f -> new ArgSuggestion(f.getFileName() + (Files.isDirectory(f) ? "/" : "")))
+                   .map(f -> new ArgSuggestion(f.getFileName().toString().replace(" ", "\\ ") + (Files.isDirectory(f) ? "/" : "")))
                    .forEach(result::add);
             } catch (IOException ex) {
                 //ignore...


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277328](https://bugs.openjdk.java.net/browse/JDK-8277328): jdk/jshell/CommandCompletionTest.java failures on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/26.diff">https://git.openjdk.java.net/jdk17u-dev/pull/26.diff</a>

</details>
