### PR TITLE
8278099: two sun/security/pkcs11/Signature tests failed with AssertionError

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM.java
@@ -164,7 +164,6 @@ public class CK_MECHANISM {
     // CK_MECHANISM(long) constructor and setParameter(CK_RSA_PKCS_PSS_PARAMS)
     // methods instead of creating yet another constructor
     public void setParameter(CK_RSA_PKCS_PSS_PARAMS params) {
-        assert(this.mechanism == CKM_RSA_PKCS_PSS);
         assert(params != null);
         if (this.pParameter != null && this.pParameter.equals(params)) {
             return;


### PR DESCRIPTION
I want to backpot this to 17u-dev as we see this in testing there, too. 
Obviously it depends on the system setup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278099](https://bugs.openjdk.java.net/browse/JDK-8278099): two sun/security/pkcs11/Signature tests failed with AssertionError


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/30.diff">https://git.openjdk.java.net/jdk17u-dev/pull/30.diff</a>

</details>
