### PR TITLE
8274471: Add support for RSASSA-PSS in OCSP Response

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -56,6 +56,8 @@ import sun.security.x509.PKIXExtensions;
 import sun.security.x509.URIName;
 import sun.security.x509.X509CertImpl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * This is a class that checks the revocation status of a certificate(s) using
  * OCSP. It is not a PKIXCertPathChecker and therefore can be used outside of
@@ -226,22 +228,26 @@ public final class OCSP {
             List<Extension> extensions) throws IOException {
         OCSPRequest request = new OCSPRequest(certIds, extensions);
         byte[] bytes = request.encodeBytes();
+        String responder = responderURI.toString();
 
         if (debug != null) {
-            debug.println("connecting to OCSP service at: " + responderURI);
+            debug.println("connecting to OCSP service at: " + responder);
         }
         Event.report(Event.ReporterCategory.CRLCHECK, "event.ocsp.check",
-                responderURI.toString());
+                responder);
 
         URL url;
         HttpURLConnection con = null;
         try {
-            String encodedGetReq = responderURI.toString() + "/" +
-                    URLEncoder.encode(Base64.getEncoder().encodeToString(bytes),
-                            "UTF-8");
+            StringBuilder encodedGetReq = new StringBuilder(responder);
+            if (!responder.endsWith("/")) {
+                encodedGetReq.append("/");
+            }
+            encodedGetReq.append(URLEncoder.encode(
+                    Base64.getEncoder().encodeToString(bytes), UTF_8));
 
             if (encodedGetReq.length() <= 255) {
-                url = new URL(encodedGetReq);
+                url = new URL(encodedGetReq.toString());
                 con = (HttpURLConnection)url.openConnection();
                 con.setDoOutput(true);
                 con.setDoInput(true);

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,8 +55,6 @@ import sun.security.x509.GeneralNameInterface;
 import sun.security.x509.PKIXExtensions;
 import sun.security.x509.URIName;
 import sun.security.x509.X509CertImpl;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This is a class that checks the revocation status of a certificate(s) using
@@ -244,7 +242,7 @@ public final class OCSP {
                 encodedGetReq.append("/");
             }
             encodedGetReq.append(URLEncoder.encode(
-                    Base64.getEncoder().encodeToString(bytes), UTF_8));
+                    Base64.getEncoder().encodeToString(bytes), "UTF-8"));
 
             if (encodedGetReq.length() <= 255) {
                 url = new URL(encodedGetReq.toString());

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
@@ -638,7 +638,10 @@ public final class OCSPResponse {
 
         try {
             Signature respSignature = Signature.getInstance(sigAlgId.getName());
-            respSignature.initVerify(cert.getPublicKey());
+            SignatureUtil.initVerifyWithParam(respSignature,
+                    cert.getPublicKey(),
+                    SignatureUtil.getParamSpec(sigAlgId.getName(),
+                            sigAlgId.getEncodedParams()));
             respSignature.update(tbsResponseData);
 
             if (respSignature.verify(signature)) {
@@ -654,8 +657,8 @@ public final class OCSPResponse {
                 }
                 return false;
             }
-        } catch (InvalidKeyException | NoSuchAlgorithmException |
-                 SignatureException e)
+        } catch (InvalidAlgorithmParameterException | InvalidKeyException
+                | NoSuchAlgorithmException | SignatureException e)
         {
             throw new CertPathValidatorException(e);
         }

--- a/src/java.base/share/classes/sun/security/util/SignatureUtil.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,8 +170,7 @@ public class SignatureUtil {
     // for verification with the specified key and params (may be null)
     public static void initVerifyWithParam(Signature s, PublicKey key,
             AlgorithmParameterSpec params)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initVerify(s, key, params);
     }
 
@@ -180,8 +179,7 @@ public class SignatureUtil {
     public static void initVerifyWithParam(Signature s,
             java.security.cert.Certificate cert,
             AlgorithmParameterSpec params)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initVerify(s, cert, params);
     }
 
@@ -189,8 +187,7 @@ public class SignatureUtil {
     // for signing with the specified key and params (may be null)
     public static void initSignWithParam(Signature s, PrivateKey key,
             AlgorithmParameterSpec params, SecureRandom sr)
-            throws ProviderException, InvalidAlgorithmParameterException,
-            InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         SharedSecrets.getJavaSecuritySignatureAccess().initSign(s, key, params, sr);
     }
 
@@ -342,10 +339,10 @@ public class SignatureUtil {
      * Create a Signature that has been initialized with proper key and params.
      *
      * @param sigAlg signature algorithms
-     * @param key public or private key
+     * @param key private key
      * @param provider (optional) provider
      */
-    public static Signature fromKey(String sigAlg, Key key, String provider)
+    public static Signature fromKey(String sigAlg, PrivateKey key, String provider)
             throws NoSuchAlgorithmException, NoSuchProviderException,
                    InvalidKeyException{
         Signature sigEngine = (provider == null || provider.isEmpty())
@@ -358,10 +355,10 @@ public class SignatureUtil {
      * Create a Signature that has been initialized with proper key and params.
      *
      * @param sigAlg signature algorithms
-     * @param key public or private key
+     * @param key private key
      * @param provider (optional) provider
      */
-    public static Signature fromKey(String sigAlg, Key key, Provider provider)
+    public static Signature fromKey(String sigAlg, PrivateKey key, Provider provider)
             throws NoSuchAlgorithmException, InvalidKeyException{
         Signature sigEngine = (provider == null)
                 ? Signature.getInstance(sigAlg)
@@ -369,17 +366,12 @@ public class SignatureUtil {
         return autoInitInternal(sigAlg, key, sigEngine);
     }
 
-    private static Signature autoInitInternal(String alg, Key key, Signature s)
+    private static Signature autoInitInternal(String alg, PrivateKey key, Signature s)
             throws InvalidKeyException {
         AlgorithmParameterSpec params = SignatureUtil
                 .getDefaultParamSpec(alg, key);
         try {
-            if (key instanceof PrivateKey) {
-                SignatureUtil.initSignWithParam(s, (PrivateKey) key, params,
-                        null);
-            } else {
-                SignatureUtil.initVerifyWithParam(s, (PublicKey) key, params);
-            }
+            SignatureUtil.initSignWithParam(s, key, params, null);
         } catch (InvalidAlgorithmParameterException e) {
             throw new AssertionError("Should not happen", e);
         }

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -312,7 +312,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
      *
      * @return DER encoded parameters, or null not present.
      */
-    public byte[] getEncodedParams() throws IOException {
+    public byte[] getEncodedParams() {
         return (encodedParams == null ||
             algid.toString().equals(KnownOIDs.SpecifiedSHA2withECDSA.value()))
                 ? null

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -820,13 +820,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
      *         null if no parameters are present.
      */
     public byte[] getSigAlgParams() {
-        if (sigAlgId == null)
-            return null;
-        try {
-            return sigAlgId.getEncodedParams();
-        } catch (IOException e) {
-            return null;
-        }
+        return sigAlgId == null ? null : sigAlgId.getEncodedParams();
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -1030,13 +1030,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
      *         null if no parameters are present.
      */
     public byte[] getSigAlgParams() {
-        if (algId == null)
-            return null;
-        try {
-            return algId.getEncodedParams();
-        } catch (IOException e) {
-            return null;
-        }
+        return algId == null ? null : algId.getEncodedParams();
     }
 
     /**

--- a/test/jdk/javax/net/ssl/Stapling/HttpsUrlConnClient.java
+++ b/test/jdk/javax/net/ssl/Stapling/HttpsUrlConnClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,8 @@
  * @summary OCSP Stapling for TLS
  * @library ../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
- * @run main/othervm HttpsUrlConnClient
+ * @run main/othervm HttpsUrlConnClient RSA SHA256withRSA
+ * @run main/othervm HttpsUrlConnClient RSASSA-PSS RSASSA-PSS
  */
 
 import java.io.*;
@@ -60,7 +61,6 @@ import java.util.concurrent.TimeUnit;
 
 import sun.security.testlibrary.SimpleOCSPServer;
 import sun.security.testlibrary.CertificateBuilder;
-import sun.security.validator.ValidatorException;
 
 public class HttpsUrlConnClient {
 
@@ -72,6 +72,9 @@ public class HttpsUrlConnClient {
 
     static final byte[] LINESEP = { 10 };
     static final Base64.Encoder B64E = Base64.getMimeEncoder(64, LINESEP);
+
+    static String SIGALG;
+    static String KEYALG;
 
     // Turn on TLS debugging
     static boolean debug = true;
@@ -136,6 +139,9 @@ public class HttpsUrlConnClient {
         System.setProperty("javax.net.ssl.keyStorePassword", "");
         System.setProperty("javax.net.ssl.trustStore", "");
         System.setProperty("javax.net.ssl.trustStorePassword", "");
+
+        KEYALG = args[0];
+        SIGALG = args[1];
 
         // Create the PKI we will use for the test and start the OCSP servers
         createPKI();
@@ -514,7 +520,7 @@ public class HttpsUrlConnClient {
      */
     private static void createPKI() throws Exception {
         CertificateBuilder cbld = new CertificateBuilder();
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEYALG);
         keyGen.initialize(2048);
         KeyStore.Builder keyStoreBuilder =
                 KeyStore.Builder.newInstance("PKCS12", null,
@@ -540,7 +546,7 @@ public class HttpsUrlConnClient {
         addCommonCAExts(cbld);
         // Make our Root CA Cert!
         X509Certificate rootCert = cbld.build(null, rootCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("Root CA Created:\n" + certInfo(rootCert));
 
         // Now build a keystore and add the keys and cert
@@ -582,7 +588,7 @@ public class HttpsUrlConnClient {
         cbld.addAIAExt(Collections.singletonList(rootRespURI));
         // Make our Intermediate CA Cert!
         X509Certificate intCaCert = cbld.build(rootCert, rootCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("Intermediate CA Created:\n" + certInfo(intCaCert));
 
         // Provide intermediate CA cert revocation info to the Root CA
@@ -644,7 +650,7 @@ public class HttpsUrlConnClient {
         cbld.addAIAExt(Collections.singletonList(intCaRespURI));
         // Make our SSL Server Cert!
         X509Certificate sslCert = cbld.build(intCaCert, intCaKP.getPrivate(),
-                "SHA256withRSA");
+                SIGALG);
         log("SSL Certificate Created:\n" + certInfo(sslCert));
 
         // Provide SSL server cert revocation info to the Intermeidate CA


### PR DESCRIPTION
This one is submitted in place of https://github.com/openjdk/jdk17u/pull/248 that was too late to jdk17u

I'd like to backport JDK-8274471 to jdk17u-dev

The patch fixes internal error upon verification of OCSP Response signed with RSASSA-PSS

The original patch applied with minor changes to src/java.base/share/classes/sun/security/provider/certpath/OCSP.java

- resolved baseline conflict: the original patch was done on top of JDK-8272120: Avoid looking for standard encodings in "java." modules and cannot be applied cleanly although it deletes the changes done against JDK-8272120 (see lines 249-241)
- imported few required packages

Verified (20.04 LTS/amd64) with attached [Test8274471.java.zip](https://github.com/openjdk/jdk17u/files/7514663/Test8274471.java.zip). Regression: jdk_security

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274471](https://bugs.openjdk.java.net/browse/JDK-8274471): Add support for RSASSA-PSS in OCSP Response


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/36.diff">https://git.openjdk.java.net/jdk17u-dev/pull/36.diff</a>

</details>
