### PR TITLE
8278824: Uneven work distribution when scanning heap roots in G1

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -107,7 +107,7 @@ class G1RemSetScanState : public CHeapObj<mtGC> {
   // within a region to claim. Dependent on the region size as proxy for the heap
   // size, we limit the total number of chunks to limit memory usage and maintenance
   // effort of that table vs. granularity of distributing scanning work.
-  // Testing showed that 8 for 1M/2M region, 16 for 4M/8M regions, 32 for 16/32M regions
+  // Testing showed that 64 for 1M/2M region, 128 for 4M/8M regions, 256 for 16/32M regions
   // seems to be such a good trade-off.
   static uint get_chunks_per_region(uint log_region_size) {
     // Limit the expected input values to current known possible values of the
@@ -115,7 +115,7 @@ class G1RemSetScanState : public CHeapObj<mtGC> {
     // values for region size.
     assert(log_region_size >= 20 && log_region_size <= 25,
            "expected value in [20,25], but got %u", log_region_size);
-    return 1u << (log_region_size / 2 - 7);
+    return 1u << (log_region_size / 2 - 4);
   }
 
   uint _scan_chunks_per_region;         // Number of chunks per region.


### PR DESCRIPTION
Resolved a conflict in a comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278824](https://bugs.openjdk.java.net/browse/JDK-8278824): Uneven work distribution when scanning heap roots in G1


### Reviewers
 * [Paul Hohensee](https://openjdk.java.net/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/39.diff">https://git.openjdk.java.net/jdk17u-dev/pull/39.diff</a>

</details>
