### PR TITLE
8276129: PretouchTask should page-align the chunk size

### DIFF
--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -28,6 +28,7 @@
 #include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/os.hpp"
+#include "utilities/align.hpp"
 
 PretouchTask::PretouchTask(const char* task_name,
                            char* start_address,
@@ -65,9 +66,9 @@ void PretouchTask::work(uint worker_id) {
 
 void PretouchTask::pretouch(const char* task_name, char* start_address, char* end_address,
                             size_t page_size, WorkGang* pretouch_gang) {
-  // Chunk size should be at least (unmodified) page size as using multiple threads
-  // pretouch on a single page can decrease performance.
-  size_t chunk_size = MAX2(PretouchTask::chunk_size(), page_size);
+  // Page-align the chunk size, so if start_address is also page-aligned (as
+  // is common) then there won't be any pages shared by multiple chunks.
+  size_t chunk_size = align_down_bounded(PretouchTask::chunk_size(), page_size);
 #ifdef LINUX
   // When using THP we need to always pre-touch using small pages as the OS will
   // initially always use small pages.


### PR DESCRIPTION
[Tiny] Avoid pretouch chunks overlapping the same page.

Original patch does not apply because of PretouchTask::pretouch parameter renaming (context), the change itself is the same.

Testing: jtreg tier1 & gc (aarch64 build).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276129](https://bugs.openjdk.java.net/browse/JDK-8276129): PretouchTask should page-align the chunk size


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/41.diff">https://git.openjdk.java.net/jdk17u-dev/pull/41.diff</a>

</details>
