### PR TITLE
8271579: G1: Move copy before CAS in do_copy_to_survivor_space

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -466,11 +466,11 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
 
   // We're going to allocate linearly, so might as well prefetch ahead.
   Prefetch::write(obj_ptr, PrefetchCopyIntervalInBytes);
+  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(old), obj_ptr, word_sz);
 
   const oop obj = cast_to_oop(obj_ptr);
   const oop forward_ptr = old->forward_to_atomic(obj, old_mark, memory_order_relaxed);
   if (forward_ptr == NULL) {
-    Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(old), obj_ptr, word_sz);
 
     {
       const uint young_index = from_region->young_index_in_cset();
@@ -482,19 +482,9 @@ oop G1ParScanThreadState::do_copy_to_survivor_space(G1HeapRegionAttr const regio
     if (dest_attr.is_young()) {
       if (age < markWord::max_age) {
         age++;
-      }
-      if (old_mark.has_displaced_mark_helper()) {
-        // In this case, we have to install the old mark word containing the
-        // displacement tag, and update the age in the displaced mark word.
-        markWord new_mark = old_mark.displaced_mark_helper().set_age(age);
-        old_mark.set_displaced_mark_helper(new_mark);
-        obj->set_mark(old_mark);
-      } else {
-        obj->set_mark(old_mark.set_age(age));
+        obj->incr_age();
       }
       _age_table.add(age, word_sz);
-    } else {
-      obj->set_mark(old_mark);
     }
 
     // Most objects are not arrays, so do one array check rather than


### PR DESCRIPTION
Small change in G1 with good performance effect. Original patch applies cleanly.

Testing: jtreg tier1 & gc (aarch64 build).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8271579](https://bugs.openjdk.java.net/browse/JDK-8271579): G1: Move copy before CAS in do_copy_to_survivor_space
 * [JDK-8272070](https://bugs.openjdk.java.net/browse/JDK-8272070): G1: Simplify age calculation after JDK-8271579


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/42.diff">https://git.openjdk.java.net/jdk17u-dev/pull/42.diff</a>

</details>
