### PR TITLE
8244602: Add JTREG_REPEAT_COUNT to repeat execution of a test

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -194,6 +194,8 @@ TEST FAILURE</code></pre>
 <p>Generate AOT modules before testing for the specified module, or set of modules. If multiple modules are specified, they should be separated by space (or, to help avoid quoting issues, the special value <code>%20</code>).</p>
 <h4 id="retry_count">RETRY_COUNT</h4>
 <p>Retry failed tests up to a set number of times. Defaults to 0.</p>
+<h4 id="repeat_count">REPEAT_COUNT</h4>
+<p>Repeat the tests for a set number of times. Defaults to 0.</p>
 <h3 id="gtest-keywords">Gtest keywords</h3>
 <h4 id="repeat">REPEAT</h4>
 <p>The number of times to repeat the tests (<code>--gtest_repeat</code>).</p>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -421,6 +421,10 @@ modules. If multiple modules are specified, they should be separated by space
 
 Retry failed tests up to a set number of times. Defaults to 0.
 
+#### REPEAT_COUNT
+
+Repeat the tests for a set number of times. Defaults to 0.
+
 ### Gtest keywords
 
 #### REPEAT

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -200,7 +200,7 @@ $(eval $(call SetTestOpt,FAILURE_HANDLER_TIMEOUT,JTREG))
 $(eval $(call ParseKeywordVariable, JTREG, \
     SINGLE_KEYWORDS := JOBS TIMEOUT_FACTOR FAILURE_HANDLER_TIMEOUT \
         TEST_MODE ASSERT VERBOSE RETAIN MAX_MEM RUN_PROBLEM_LISTS \
-        RETRY_COUNT MAX_OUTPUT, \
+        RETRY_COUNT REPEAT_COUNT MAX_OUTPUT, \
     STRING_KEYWORDS := OPTIONS JAVA_OPTIONS VM_OPTIONS KEYWORDS \
         EXTRA_PROBLEM_LISTS LAUNCHER_OPTIONS, \
 ))
@@ -744,6 +744,15 @@ define SetupRunJtregTestBody
   JTREG_RETAIN ?= fail,error
   JTREG_RUN_PROBLEM_LISTS ?= false
   JTREG_RETRY_COUNT ?= 0
+  JTREG_REPEAT_COUNT ?= 0
+
+  ifneq ($$(JTREG_RETRY_COUNT), 0)
+    ifneq ($$(JTREG_REPEAT_COUNT), 0)
+      $$(info Error: Cannot use both JTREG_RETRY_COUNT and JTREG_REPEAT_COUNT together.)
+      $$(info Please choose one or the other.)
+      $$(error Cannot continue)
+    endif
+  endif
 
   ifneq ($$(JTREG_LAUNCHER_OPTIONS), )
     $1_JTREG_LAUNCHER_OPTIONS += $$(JTREG_LAUNCHER_OPTIONS)
@@ -863,6 +872,18 @@ define SetupRunJtregTestBody
             break; \
           fi; \
           export JTREG_STATUS="-status:error,fail"; \
+        done
+  endif
+
+  ifneq ($$(JTREG_REPEAT_COUNT), 0)
+    $1_COMMAND_LINE := \
+        for i in {1..$$(JTREG_REPEAT_COUNT)}; do \
+          $$(PRINTF) "\nRepeating Jtreg run: $$$$i out of $$(JTREG_REPEAT_COUNT)\n"; \
+          $$($1_COMMAND_LINE); \
+          if [ "`$$(CAT) $$($1_EXITCODE)`" != "0" ]; then \
+            $$(PRINTF) "\nFailures detected, no more repeats.\n"; \
+            break; \
+          fi; \
         done
   endif
 


### PR DESCRIPTION
Unclean backport to improve testing. It does not apply cleanly, because there is a minor conflict in `SINGLE_KEYWORDS` definition due to absent [JDK-8274170](https://bugs.openjdk.java.net/browse/JDK-8274170).

Additional testing:
 - [x] `sanity/IntermittentTest.java` behaves as in original PR

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244602](https://bugs.openjdk.java.net/browse/JDK-8244602): Add JTREG_REPEAT_COUNT to repeat execution of a test


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/52.diff">https://git.openjdk.java.net/jdk17u-dev/pull/52.diff</a>

</details>
