### PR TITLE
8278389: SuspendibleThreadSet::_suspend_all should be volatile/atomic

### DIFF
--- a/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
+++ b/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_SHARED_SUSPENDIBLETHREADSET_HPP
 
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 
 // A SuspendibleThreadSet is a set of threads that can be suspended.
 // A thread can join and later leave the set, and periodically yield.
@@ -40,9 +41,10 @@ class SuspendibleThreadSet : public AllStatic {
   friend class SuspendibleThreadSetLeaver;
 
 private:
+  static volatile bool _suspend_all;
+
   static uint   _nthreads;
   static uint   _nthreads_stopped;
-  static bool   _suspend_all;
   static double _suspend_all_start;
 
   static bool is_synchronized();
@@ -53,9 +55,11 @@ private:
   // Removes the current thread from the set.
   static void leave();
 
+  static bool suspend_all() { return Atomic::load(&_suspend_all); }
+
 public:
   // Returns true if an suspension is in progress.
-  static bool should_yield() { return _suspend_all; }
+  static bool should_yield() { return suspend_all(); }
 
   // Suspends the current thread if a suspension is in progress.
   static void yield();


### PR DESCRIPTION
Clean backport for GC reliability. Will wait a bit for mainline testing to catch up.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278389](https://bugs.openjdk.java.net/browse/JDK-8278389): SuspendibleThreadSet::_suspend_all should be volatile/atomic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/54.diff">https://git.openjdk.java.net/jdk17u-dev/pull/54.diff</a>

</details>
