### PR TITLE
8278627: Shenandoah: TestHeapDump test failed

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahClosures.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahClosures.inline.hpp
@@ -227,7 +227,7 @@ ShenandoahCodeBlobAndDisarmClosure::ShenandoahCodeBlobAndDisarmClosure(OopClosur
 
 void ShenandoahCodeBlobAndDisarmClosure::do_code_blob(CodeBlob* cb) {
   nmethod* const nm = cb->as_nmethod_or_null();
-  if (nm != NULL && nm->oops_do_try_claim()) {
+  if (nm != NULL) {
     assert(!ShenandoahNMethod::gc_data(nm)->is_unregistered(), "Should not be here");
     CodeBlobToOopClosure::do_code_blob(cb);
     _bs->disarm(nm);

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -278,8 +278,8 @@ public:
 };
 
 void ShenandoahHeapIterationRootScanner::roots_do(OopClosure* oops) {
-  // Must use _claim_other to avoid interfering with concurrent CLDG iteration
-  CLDToOopClosure clds(oops, ClassLoaderData::_claim_other);
+  // Must use _claim_none to avoid interfering with concurrent CLDG iteration
+  CLDToOopClosure clds(oops, ClassLoaderData::_claim_none);
   ShenandoahMarkCodeBlobClosure code(oops);
   ShenandoahParallelOopsDoThreadClosure tc_cl(oops, &code, NULL);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -79,16 +79,11 @@ ShenandoahThreadRoots::~ShenandoahThreadRoots() {
 }
 
 ShenandoahCodeCacheRoots::ShenandoahCodeCacheRoots(ShenandoahPhaseTimings::Phase phase) : _phase(phase) {
-  nmethod::oops_do_marking_prologue();
 }
 
 void ShenandoahCodeCacheRoots::code_blobs_do(CodeBlobClosure* blob_cl, uint worker_id) {
   ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCacheRoots, worker_id);
   _coderoots_iterator.possibly_parallel_blobs_do(blob_cl);
-}
-
-ShenandoahCodeCacheRoots::~ShenandoahCodeCacheRoots() {
-  nmethod::oops_do_marking_epilogue();
 }
 
 ShenandoahRootProcessor::ShenandoahRootProcessor(ShenandoahPhaseTimings::Phase phase) :
@@ -258,22 +253,44 @@ ShenandoahHeapIterationRootScanner::ShenandoahHeapIterationRootScanner() :
    _code_roots(ShenandoahPhaseTimings::heap_iteration_roots) {
  }
 
- void ShenandoahHeapIterationRootScanner::roots_do(OopClosure* oops) {
-   assert(Thread::current()->is_VM_thread(), "Only by VM thread");
-   // Must use _claim_none to avoid interfering with concurrent CLDG iteration
-   CLDToOopClosure clds(oops, ClassLoaderData::_claim_none);
-   MarkingCodeBlobClosure code(oops, !CodeBlobToOopClosure::FixRelocations);
-   ShenandoahParallelOopsDoThreadClosure tc_cl(oops, &code, NULL);
-   AlwaysTrueClosure always_true;
+class ShenandoahMarkCodeBlobClosure : public CodeBlobClosure {
+private:
+  OopClosure* const _oops;
+  BarrierSetNMethod* const _bs_nm;
 
-   ResourceMark rm;
+public:
+  ShenandoahMarkCodeBlobClosure(OopClosure* oops) :
+    _oops(oops),
+    _bs_nm(BarrierSet::barrier_set()->barrier_set_nmethod()) {}
 
-   // Process light-weight/limited parallel roots then
-   _vm_roots.oops_do(oops, 0);
-   _weak_roots.oops_do<OopClosure>(oops, 0);
-   _cld_roots.cld_do(&clds, 0);
+  virtual void do_code_blob(CodeBlob* cb) {
+    nmethod* const nm = cb->as_nmethod_or_null();
+    if (nm != nullptr) {
+      if (_bs_nm != nullptr) {
+        // Make sure it only sees to-space objects
+        _bs_nm->nmethod_entry_barrier(nm);
+      }
+      ShenandoahNMethod* const snm = ShenandoahNMethod::gc_data(nm);
+      assert(snm != nullptr, "Sanity");
+      snm->oops_do(_oops, false /*fix_relocations*/);
+    }
+  }
+};
 
-   // Process heavy-weight/fully parallel roots the last
-   _code_roots.code_blobs_do(&code, 0);
-   _thread_roots.threads_do(&tc_cl, 0);
- }
+void ShenandoahHeapIterationRootScanner::roots_do(OopClosure* oops) {
+  // Must use _claim_other to avoid interfering with concurrent CLDG iteration
+  CLDToOopClosure clds(oops, ClassLoaderData::_claim_other);
+  ShenandoahMarkCodeBlobClosure code(oops);
+  ShenandoahParallelOopsDoThreadClosure tc_cl(oops, &code, NULL);
+
+  ResourceMark rm;
+
+  // Process light-weight/limited parallel roots then
+  _vm_roots.oops_do(oops, 0);
+  _weak_roots.oops_do<OopClosure>(oops, 0);
+  _cld_roots.cld_do(&clds, 0);
+
+  // Process heavy-weight/fully parallel roots the last
+  _code_roots.code_blobs_do(&code, 0);
+  _thread_roots.threads_do(&tc_cl, 0);
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
@@ -102,7 +102,6 @@ private:
   ShenandoahCodeRootsIterator   _coderoots_iterator;
 public:
   ShenandoahCodeCacheRoots(ShenandoahPhaseTimings::Phase phase);
-  ~ShenandoahCodeCacheRoots();
 
   void code_blobs_do(CodeBlobClosure* blob_cl, uint worker_id);
 };


### PR DESCRIPTION
I would like to backport this patch to 17u, it fixes a potential fatal crash during heap dump.

The original patch does not apply cleanly, due to context differences, e.g. JDK-8273559 and JDK-8268368 do not in 17u.

Test:
- [x] hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278627](https://bugs.openjdk.java.net/browse/JDK-8278627): Shenandoah: TestHeapDump test failed


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/58.diff">https://git.openjdk.java.net/jdk17u-dev/pull/58.diff</a>

</details>
