### PR TITLE
8276654: element-list order is non deterministic

### DIFF
--- a/make/modules/jdk.javadoc/Gendata.gmk
+++ b/make/modules/jdk.javadoc/Gendata.gmk
@@ -72,7 +72,9 @@ $(JDK_JAVADOC_DIR)/_element_lists.marker: \
     $(MODULE_INFOS)
 	$(call MakeTargetDir)
 	$(call LogInfo, Creating javadoc element lists)
-	$(RM) -r $(ELEMENT_LISTS_DIR)
+	$(RM) $(ELEMENT_LISTS_DIR)/element-list-{$(call CommaList, \
+		$(call sequence, $(GENERATE_SYMBOLS_FROM_JDK_VERSION), \
+				 $(JDK_SOURCE_TARGET_VERSION)))}.txt
         # Generate element-list files for JDK 11 to current-1
 	$(call ExecuteWithLog, $@_historic, \
 	    $(JAVA_SMALL) $(INTERIM_LANGTOOLS_ARGS) \


### PR DESCRIPTION
Backporting this for reproducible build support in jdk-17.0.3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276654](https://bugs.openjdk.java.net/browse/JDK-8276654): element-list order is non deterministic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/61.diff">https://git.openjdk.java.net/jdk17u-dev/pull/61.diff</a>

</details>
