### PR TITLE
8278020: ~13% variation in Renaissance-Scrabble

### DIFF
--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -117,8 +117,8 @@ class Klass : public Metadata {
   // Klass identifier used to implement devirtualized oop closure dispatching.
   const KlassID _id;
 
-  // vtable length
-  int _vtable_len;
+  // Processed access flags, for use by Class.getModifiers.
+  jint        _modifier_flags;
 
   // The fields _super_check_offset, _secondary_super_cache, _secondary_supers
   // and _primary_supers all help make fast subtype checks.  See big discussion
@@ -154,7 +154,10 @@ class Klass : public Metadata {
   // Provide access the corresponding instance java.lang.ClassLoader.
   ClassLoaderData* _class_loader_data;
 
-  jint        _modifier_flags;  // Processed access flags, for use by Class.getModifiers.
+  int _vtable_len;              // vtable length. This field may be read very often when we
+                                // have lots of itable dispatches (e.g., lambdas and streams).
+                                // Keep it away from the beginning of a Klass to avoid cacheline
+                                // contention that may happen when a nearby object is modified.
   AccessFlags _access_flags;    // Access flags. The class/interface distinction is stored here.
 
   JFR_ONLY(DEFINE_TRACE_ID_FIELD;)


### PR DESCRIPTION
Clean backport to fix recent regression.

Motivational improvements (lower is better):

```
$ for I in `seq 1 5`; do build/linux-x86_64-server-release/images/jdk/bin/java -jar renaissance-gpl-0.13.0.jar scrabble | grep iteration | grep completed | tail -n 3; done

# jdk17u baseline
====== scrabble (functional) [default], iteration 47 completed (130.122 ms) ======
====== scrabble (functional) [default], iteration 48 completed (131.078 ms) ======
====== scrabble (functional) [default], iteration 49 completed (142.820 ms) ======
====== scrabble (functional) [default], iteration 47 completed (131.464 ms) ======
====== scrabble (functional) [default], iteration 48 completed (131.028 ms) ======
====== scrabble (functional) [default], iteration 49 completed (130.961 ms) ======
====== scrabble (functional) [default], iteration 47 completed (135.189 ms) ======
====== scrabble (functional) [default], iteration 48 completed (131.175 ms) ======
====== scrabble (functional) [default], iteration 49 completed (131.381 ms) ======
====== scrabble (functional) [default], iteration 47 completed (129.268 ms) ======
====== scrabble (functional) [default], iteration 48 completed (129.083 ms) ======
====== scrabble (functional) [default], iteration 49 completed (128.731 ms) ======
====== scrabble (functional) [default], iteration 47 completed (143.267 ms) ======
====== scrabble (functional) [default], iteration 48 completed (141.836 ms) ======
====== scrabble (functional) [default], iteration 49 completed (137.348 ms) ======

# jdk17u patched
====== scrabble (functional) [default], iteration 47 completed (120.403 ms) ======
====== scrabble (functional) [default], iteration 48 completed (120.454 ms) ======
====== scrabble (functional) [default], iteration 49 completed (119.403 ms) ======
====== scrabble (functional) [default], iteration 47 completed (121.162 ms) ======
====== scrabble (functional) [default], iteration 48 completed (121.821 ms) ======
====== scrabble (functional) [default], iteration 49 completed (121.946 ms) ======
====== scrabble (functional) [default], iteration 47 completed (120.279 ms) ======
====== scrabble (functional) [default], iteration 48 completed (119.175 ms) ======
====== scrabble (functional) [default], iteration 49 completed (121.211 ms) ======
====== scrabble (functional) [default], iteration 47 completed (122.553 ms) ======
====== scrabble (functional) [default], iteration 48 completed (122.422 ms) ======
====== scrabble (functional) [default], iteration 49 completed (121.078 ms) ======
====== scrabble (functional) [default], iteration 47 completed (121.104 ms) ======
====== scrabble (functional) [default], iteration 48 completed (121.320 ms) ======
====== scrabble (functional) [default], iteration 49 completed (120.224 ms) ======


```

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`
 - [x]  Linux x86_64 fastdebug `tier2`
 - [x] Renaissance `scrabble`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278020](https://bugs.openjdk.java.net/browse/JDK-8278020): ~13% variation in Renaissance-Scrabble


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/64.diff">https://git.openjdk.java.net/jdk17u-dev/pull/64.diff</a>

</details>
