### PR TITLE
8269523: runtime/Safepoint/TestAbortOnVMOperationTimeout.java failed when expecting 'VM operation took too long'

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -26,7 +26,7 @@ import jdk.test.lib.process.*;
 
 /*
  * @test TestAbortOnVMOperationTimeout
- * @bug 8181143
+ * @bug 8181143 8269523
  * @summary Check abort on VM timeout is working
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -36,12 +36,17 @@ import jdk.test.lib.process.*;
 
 public class TestAbortOnVMOperationTimeout {
 
+    // A static array is unlikely to be optimised away by the JIT.
+    static Object[] arr;
+
     public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            Object[] arr = new Object[10_000_000];
+            arr = new Object[10_000_000];
             for (int i = 0; i < arr.length; i++) {
                arr[i] = new Object();
             }
+            // Try to force at least one full GC cycle.
+            System.gc();
             return;
         }
 
@@ -51,9 +56,9 @@ public class TestAbortOnVMOperationTimeout {
             testWith(delay, true);
         }
 
-        // These should fail: Serial is not very fast. Traversing 10M objects in 5 ms
-        // means less than 0.5 ns per object, which is not doable.
-        for (int delay : new int[]{0, 1, 5}) {
+        // These should fail: Serial is not very fast but we have seen the test
+        // execute as quickly as 2ms!
+        for (int delay : new int[]{0, 1}) {
             testWith(delay, false);
         }
     }
@@ -66,6 +71,7 @@ public class TestAbortOnVMOperationTimeout {
                 "-Xmx256m",
                 "-XX:+UseSerialGC",
                 "-XX:-CreateCoredumpOnCrash",
+                "-Xlog:gc",
                 "TestAbortOnVMOperationTimeout",
                 "foo"
         );
@@ -77,6 +83,6 @@ public class TestAbortOnVMOperationTimeout {
             output.shouldContain("VM operation took too long");
             output.shouldNotHaveExitValue(0);
         }
+        output.reportDiagnosticSummary();
     }
 }
-


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269523](https://bugs.openjdk.java.net/browse/JDK-8269523): runtime/Safepoint/TestAbortOnVMOperationTimeout.java failed when expecting 'VM operation took too long'


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/69.diff">https://git.openjdk.java.net/jdk17u-dev/pull/69.diff</a>

</details>
