### PR TITLE
8269037: jsig/Testjsig.java doesn't have to be restricted to linux only

### DIFF
--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -863,7 +863,7 @@ ifeq ($(call isTargetOs, linux), true)
     BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exeFPRegs := -ldl
     BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libAsyncGetCallTraceTest := -ldl
 else
-  BUILD_HOTSPOT_JTREG_EXCLUDE += libtest-rw.c libtest-rwx.c libTestJNI.c \
+  BUILD_HOTSPOT_JTREG_EXCLUDE += libtest-rw.c libtest-rwx.c \
       exeinvoke.c exestack-gap.c exestack-tls.c libAsyncGetCallTraceTest.cpp
 endif
 
@@ -871,7 +871,7 @@ BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exesigtest := -ljvm
 
 ifeq ($(call isTargetOs, windows), true)
     BUILD_HOTSPOT_JTREG_EXECUTABLES_CFLAGS_exeFPRegs := -MT
-    BUILD_HOTSPOT_JTREG_EXCLUDE += exesigtest.c libterminatedThread.c
+    BUILD_HOTSPOT_JTREG_EXCLUDE += exesigtest.c libterminatedThread.c libTestJNI.c
     BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libatExit := jvm.lib
 else
     BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libbootclssearch_agent += -lpthread

--- a/test/hotspot/jtreg/runtime/jsig/Testjsig.java
+++ b/test/hotspot/jtreg/runtime/jsig/Testjsig.java
@@ -29,7 +29,7 @@
  * @bug 8022301
  * @bug 8025519
  * @summary sigaction(sig) results in process hang/timed-out if sig is much greater than SIGRTMAX
- * @requires (os.family == "linux")
+ * @requires os.family != "windows"
  * @library /test/lib
  * @compile TestJNI.java
  * @run driver Testjsig


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269037](https://bugs.openjdk.java.net/browse/JDK-8269037): jsig/Testjsig.java doesn't have to be restricted to linux only


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/70.diff">https://git.openjdk.java.net/jdk17u-dev/pull/70.diff</a>

</details>
