### PR TITLE
Backport b46f0b0b1f2ada705f8b5aac9b7d8423699437a1

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -837,6 +837,11 @@ bool BlockBegin::try_merge(ValueStack* new_state) {
           existing_state->invalidate_local(index);
           TRACE_PHI(tty->print_cr("invalidating local %d because of type mismatch", index));
         }
+
+        if (existing_value != new_state->local_at(index) && existing_value->as_Phi() == NULL) {
+          TRACE_PHI(tty->print_cr("required phi for local %d is missing, irreducible loop?", index));
+          return false; // BAILOUT in caller
+        }
       }
 
 #ifdef ASSERT

--- a/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathology.jasm
+++ b/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathology.jasm
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+super public class TestC1PhiPlacementPathology
+   version 55:0
+{
+  public static volatile Field sideEffect:I;
+
+  public Method "<init>":"()V"
+   stack 1 locals 1
+  {
+      aload_0;
+      invokespecial   Method java/lang/Object."<init>":"()V";
+      return;
+  }
+  private static Method effect:"(I)V"
+   stack 2 locals 1
+  {
+      getstatic   Field sideEffect:"I";
+      iload_0;
+      iadd;
+      putstatic   Field sideEffect:"I";
+      return;
+  }
+  public static Method test:"(I)V"
+   stack 2 locals 2
+  {
+      iconst_0;
+      istore_1;
+      iload_0;
+      iconst_2;
+      irem;
+      ifne   MODIFY_LOCAL;
+      iinc   1, 1;
+      goto   LH2;
+   MODIFY_LOCAL:   stack_frame_type append;
+      locals_map int;
+      iinc   1, 2;
+      iinc   0, 1;
+    goto LH1;
+   LH1:   stack_frame_type same;
+      iinc   1, 1;
+      iload_1;
+      sipush   10000;
+      if_icmpge   EXIT;
+   LH2:   stack_frame_type same;
+      iinc   1, 1;
+      goto   LH1;
+   EXIT:   stack_frame_type same;
+      iload_1;
+      iload_0;
+      iadd;
+      invokestatic   Method effect:"(I)V";
+      return;
+  }
+} // end Class TestC1PhiPlacementPathology

--- a/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathologyMain.java
+++ b/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathologyMain.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277447
+ * @summary Test a pathological case for phi placement with an irreducible loop of a particular shape.
+ *
+ * @compile TestC1PhiPlacementPathology.jasm
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,TestC1PhiPlacementPathology::test
+ *                   -XX:CompilationMode=quick-only -XX:-UseOnStackReplacement TestC1PhiPlacementPathologyMain
+ */
+
+public class TestC1PhiPlacementPathologyMain {
+    public static void main(String[] args) {
+        for (int i = 0; i < 11000; i++) {
+            TestC1PhiPlacementPathology.test(0);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

I adapted the class file version in the .jasm file from 62 to 61.