### PR TITLE
Backport 595446bff4af65a30fc88470f20baec2199cd139

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -58,7 +58,7 @@ public class CheckSegmentedCodeCache {
                 out.shouldContain(NON_METHOD);
             } catch (RuntimeException e) {
                 // Check if TieredCompilation is disabled (in a client VM)
-                if (!out.getOutput().contains("-XX:+TieredCompilation not supported in this VM")) {
+                if (Platform.isTieredSupported()) {
                     // Code cache is not segmented
                     throw new RuntimeException("No code cache segmentation.");
                 }


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.