### PR TITLE
8271202: C1: assert(false) failed: live_in set of first block must be empty

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -979,6 +979,14 @@ void LIRGenerator::move_to_phi(PhiResolver* resolver, Value cur_val, Value sux_v
   Phi* phi = sux_val->as_Phi();
   // cur_val can be null without phi being null in conjunction with inlining
   if (phi != NULL && cur_val != NULL && cur_val != phi && !phi->is_illegal()) {
+    if (phi->is_local()) {
+      for (int i = 0; i < phi->operand_count(); i++) {
+        Value op = phi->operand_at(i);
+        if (op != NULL && op->type()->is_illegal()) {
+          bailout("illegal phi operand");
+        }
+      }
+    }
     Phi* cur_phi = cur_val->as_Phi();
     if (cur_phi != NULL && cur_phi->is_illegal()) {
       // Phi and local would need to get invalidated

--- a/test/hotspot/jtreg/compiler/c1/Test8271202.java
+++ b/test/hotspot/jtreg/compiler/c1/Test8271202.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8271202
+ * @requires vm.debug == true & vm.compiler1.enabled
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1 -XX:+DeoptimizeALot
+ *                   Test8271202
+ */
+
+public class Test8271202 {
+    public static void main(String[] strArr) {
+        try {
+            test();
+        } catch (Exception e) {
+            // Expected
+        }
+    }
+
+    static void test() {
+        long l6 = 10L;
+        int counter = 0;
+        int i2, i26, i29, iArr[] = new int[400];
+        boolean b3 = true;
+        for (int smallinvoc = 0; smallinvoc < 139; smallinvoc++) {
+        }
+        for (i2 = 13; i2 < 1000; i2++) {
+            for (i26 = 2; i26 < 114; l6 += 2) {
+                // Infinite loop
+                if (b3) {
+                    for (i29 = 1; i29 < 2; i29++) {
+                        try {
+                            iArr[i26] = 0;
+                        } catch (ArithmeticException a_e) {
+                        }
+                    }
+                }
+                counter++;
+                if (counter == 100000) {
+                    throw new RuntimeException("expected");
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271202](https://bugs.openjdk.java.net/browse/JDK-8271202): C1: assert(false) failed: live_in set of first block must be empty


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/92.diff">https://git.openjdk.java.net/jdk17u-dev/pull/92.diff</a>

</details>
