### PR TITLE
8277299: STACK_OVERFLOW in Java_sun_awt_shell_Win32ShellFolder2_getIconBits

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -1056,38 +1056,57 @@ JNIEXPORT jintArray JNICALL Java_sun_awt_shell_Win32ShellFolder2_getIconBits
             bmi.bmiHeader.biCompression = BI_RGB;
             // Extract the color bitmap
             int nBits = iconSize * iconSize;
-            long colorBits[MAX_ICON_SIZE * MAX_ICON_SIZE];
-            GetDIBits(dc, iconInfo.hbmColor, 0, iconSize, colorBits, &bmi, DIB_RGB_COLORS);
-            // XP supports alpha in some icons, and depending on device.
-            // This should take precedence over the icon mask bits.
-            BOOL hasAlpha = FALSE;
-            if (IS_WINXP) {
-                for (int i = 0; i < nBits; i++) {
-                    if ((colorBits[i] & 0xff000000) != 0) {
-                        hasAlpha = TRUE;
-                        break;
+
+            long *colorBits = NULL;
+            long *maskBits = NULL;
+
+            try {
+                entry_point();
+                colorBits = (long*)safe_Malloc(MAX_ICON_SIZE * MAX_ICON_SIZE * sizeof(long));
+                GetDIBits(dc, iconInfo.hbmColor, 0, iconSize, colorBits, &bmi, DIB_RGB_COLORS);
+                // XP supports alpha in some icons, and depending on device.
+                // This should take precedence over the icon mask bits.
+                BOOL hasAlpha = FALSE;
+                if (IS_WINXP) {
+                    for (int i = 0; i < nBits; i++) {
+                        if ((colorBits[i] & 0xff000000) != 0) {
+                            hasAlpha = TRUE;
+                            break;
+                        }
                     }
                 }
-            }
-            if (!hasAlpha) {
-                // Extract the mask bitmap
-                long maskBits[MAX_ICON_SIZE * MAX_ICON_SIZE];
-                GetDIBits(dc, iconInfo.hbmMask, 0, iconSize, maskBits, &bmi, DIB_RGB_COLORS);
-                // Copy the mask alphas into the color bits
-                for (int i = 0; i < nBits; i++) {
-                    if (maskBits[i] == 0) {
-                        colorBits[i] |= 0xff000000;
+                if (!hasAlpha) {
+                    // Extract the mask bitmap
+                    maskBits = (long*)safe_Malloc(MAX_ICON_SIZE * MAX_ICON_SIZE * sizeof(long));
+                    GetDIBits(dc, iconInfo.hbmMask, 0, iconSize, maskBits, &bmi, DIB_RGB_COLORS);
+                    // Copy the mask alphas into the color bits
+                    for (int i = 0; i < nBits; i++) {
+                        if (maskBits[i] == 0) {
+                            colorBits[i] |= 0xff000000;
+                        }
                     }
                 }
+                // Create java array
+                iconBits = env->NewIntArray(nBits);
+                if (!(env->ExceptionCheck())) {
+                    // Copy values to java array
+                    env->SetIntArrayRegion(iconBits, 0, nBits, colorBits);
+                }
+            } catch(std::bad_alloc&) {
+                handle_bad_alloc();
             }
+
             // Release DC
             ReleaseDC(NULL, dc);
-            // Create java array
-            iconBits = env->NewIntArray(nBits);
-            if (!(env->ExceptionCheck())) {
-            // Copy values to java array
-            env->SetIntArrayRegion(iconBits, 0, nBits, colorBits);
-        }
+
+            // Free bitmap buffers if they were allocated
+            if (colorBits != NULL) {
+                free(colorBits);
+            }
+
+            if (maskBits != NULL) {
+                free(maskBits);
+            }
         }
         // Fix 4745575 GDI Resource Leak
         // MSDN

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/ShellFolderStackOverflow.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/ShellFolderStackOverflow.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277299
+ * @requires (os.family == "windows")
+ * @summary STACK_OVERFLOW in Java_sun_awt_shell_Win32ShellFolder2_getIconBits
+ * @run main/othervm -Xss320k ShellFolderStackOverflow
+ */
+import javax.swing.UIManager;
+
+public class ShellFolderStackOverflow {
+    public static void main(final String... args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        // With default stack size for 32-bit VM next call will cause VM crash
+        UIManager.getIcon("Tree.openIcon");
+    }
+}


### PR DESCRIPTION
Makes colorBits and maskBits dynamic variables to force allocation on the heap instead of the stack and avoid a stackoverflow. Also adds a test to confirm this stackoverflow is no longer happening.

Tier1 and the newly added test passes on Windows. Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277299](https://bugs.openjdk.java.net/browse/JDK-8277299): STACK_OVERFLOW in Java_sun_awt_shell_Win32ShellFolder2_getIconBits


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/98.diff">https://git.openjdk.java.net/jdk17u-dev/pull/98.diff</a>

</details>
