### PR TITLE
8279998: PPC64 debug builds fail with "untested: RangeCheckStub: predicate_failed_trap_id"

### DIFF
--- a/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
@@ -81,8 +81,6 @@ void RangeCheckStub::emit_code(LIR_Assembler* ce) {
 
   if (_info->deoptimize_on_exception()) {
     address a = Runtime1::entry_for(Runtime1::predicate_failed_trap_id);
-    // May be used by optimizations like LoopInvariantCodeMotion or RangeCheckEliminator.
-    DEBUG_ONLY( __ untested("RangeCheckStub: predicate_failed_trap_id"); )
     //__ load_const_optimized(R0, a);
     __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(a));
     __ mtctr(R0);


### PR DESCRIPTION
Clean backport to fix PPC64 fast/slowdebug bootcycle-builds.

Additional testing:
 - [x] Linux PPC64 fastdebug bootcycle-images now works, used to fail

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279998](https://bugs.openjdk.java.net/browse/JDK-8279998): PPC64 debug builds fail with "untested: RangeCheckStub: predicate_failed_trap_id"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/100/head:pull/100` \
`$ git checkout pull/100`

Update a local copy of the PR: \
`$ git checkout pull/100` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 100`

View PR using the GUI difftool: \
`$ git pr show -t 100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/100.diff">https://git.openjdk.java.net/jdk17u-dev/pull/100.diff</a>

</details>
