### PR TITLE
8273433: Enable parallelism in vmTestbase_nsk_sysdict tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree001/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree001/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree002/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree002/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree003/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree003/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree004/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree004/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree005/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree005/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree006/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree006/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree007/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree007/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree008/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree008/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree009/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree009/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree010/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree010/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree011/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree011/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree012/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/btree/btree012/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain001/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain001/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain002/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain002/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain003/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain003/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain004/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain004/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain005/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain005/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain006/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain006/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain007/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain007/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain008/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/vm/stress/chain/chain008/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] Linux x86_64 fastdebug `vmTestbase_nsk_sysdict` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273433](https://bugs.openjdk.java.net/browse/JDK-8273433): Enable parallelism in vmTestbase_nsk_sysdict tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/104.diff">https://git.openjdk.java.net/jdk17u-dev/pull/104.diff</a>

</details>
