### PR TITLE
8269032: Stringdedup tests are failing if the ergonomically select GC does not support it

### DIFF
--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationAgeThreshold.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationAgeThreshold.java
@@ -27,17 +27,31 @@ package gc.stringdedup;
  * @test TestStringDeduplicationAgeThreshold
  * @summary Test string deduplication age threshold
  * @bug 8029075
- * @requires vm.gc == "null" | vm.gc == "G1" | vm.gc == "Shenandoah"
+ * @requires vm.gc.G1
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationAgeThreshold
+ * @run driver gc.stringdedup.TestStringDeduplicationAgeThreshold G1
+ */
+
+/*
+ * @test TestStringDeduplicationAgeThreshold
+ * @summary Test string deduplication age threshold
+ * @bug 8029075
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationAgeThreshold Shenandoah
  */
 
 public class TestStringDeduplicationAgeThreshold {
     public static void main(String[] args) throws Exception {
+        TestStringDeduplicationTools.selectGC(args);
         TestStringDeduplicationTools.testAgeThreshold();
     }
 }

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationFullGC.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationFullGC.java
@@ -27,17 +27,31 @@ package gc.stringdedup;
  * @test TestStringDeduplicationFullGC
  * @summary Test string deduplication during full GC
  * @bug 8029075
- * @requires vm.gc == "null" | vm.gc == "G1" | vm.gc == "Shenandoah"
+ * @requires vm.gc.G1
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationFullGC
+ * @run driver gc.stringdedup.TestStringDeduplicationFullGC G1
+ */
+
+/*
+ * @test TestStringDeduplicationFullGC
+ * @summary Test string deduplication during full GC
+ * @bug 8029075
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationFullGC Shenandoah
  */
 
 public class TestStringDeduplicationFullGC {
     public static void main(String[] args) throws Exception {
+        TestStringDeduplicationTools.selectGC(args);
         TestStringDeduplicationTools.testFullGC();
     }
 }

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationInterned.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationInterned.java
@@ -27,17 +27,18 @@ package gc.stringdedup;
  * @test TestStringDeduplicationInterned
  * @summary Test string deduplication of interned strings
  * @bug 8029075
- * @requires vm.gc == "null" | vm.gc == "G1"
+ * @requires vm.gc.G1
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationInterned
+ * @run driver gc.stringdedup.TestStringDeduplicationInterned G1
  */
 
 public class TestStringDeduplicationInterned {
     public static void main(String[] args) throws Exception {
+        TestStringDeduplicationTools.selectGC(args);
         TestStringDeduplicationTools.testInterned();
     }
 }

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationPrintOptions.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationPrintOptions.java
@@ -27,17 +27,31 @@ package gc.stringdedup;
  * @test TestStringDeduplicationPrintOptions
  * @summary Test string deduplication print options
  * @bug 8029075
- * @requires vm.gc == "null" | vm.gc == "G1" | vm.gc == "Shenandoah"
+ * @requires vm.gc.G1
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationPrintOptions
+ * @run driver gc.stringdedup.TestStringDeduplicationPrintOptions G1
+ */
+
+/*
+ * @test TestStringDeduplicationPrintOptions
+ * @summary Test string deduplication print options
+ * @bug 8029075
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationPrintOptions Shenandoah
  */
 
 public class TestStringDeduplicationPrintOptions {
     public static void main(String[] args) throws Exception {
+        TestStringDeduplicationTools.selectGC(args);
         TestStringDeduplicationTools.testPrintOptions();
     }
 }

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTableResize.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTableResize.java
@@ -27,17 +27,31 @@ package gc.stringdedup;
  * @test TestStringDeduplicationTableResize
  * @summary Test string deduplication table resize
  * @bug 8029075
- * @requires vm.gc == "null" | vm.gc == "G1" | vm.gc == "Shenandoah"
+ * @requires vm.gc.G1
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationTableResize
+ * @run driver gc.stringdedup.TestStringDeduplicationTableResize G1
+ */
+
+/*
+ * @test TestStringDeduplicationTableResize
+ * @summary Test string deduplication table resize
+ * @bug 8029075
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationTableResize Shenandoah
  */
 
 public class TestStringDeduplicationTableResize {
     public static void main(String[] args) throws Exception {
+        TestStringDeduplicationTools.selectGC(args);
         TestStringDeduplicationTools.testTableResize();
     }
 }

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -50,6 +50,8 @@ class TestStringDeduplicationTools {
     private static Unsafe unsafe;
     private static byte[] dummy;
 
+    private static String selectedGC = null;
+
     static {
         try {
             Field field = Unsafe.class.getDeclaredField("theUnsafe");
@@ -61,6 +63,10 @@ class TestStringDeduplicationTools {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static void selectGC(String[] args) {
+        selectedGC = args[0];
     }
 
     private static Object getValue(String string) {
@@ -226,6 +232,7 @@ class TestStringDeduplicationTools {
         };
 
         ArrayList<String> args = new ArrayList<String>();
+        args.add("-XX:+Use" + selectedGC + "GC");
         args.addAll(Arrays.asList(defaultArgs));
         args.addAll(Arrays.asList(extraArgs));
 

--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationYoungGC.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationYoungGC.java
@@ -27,17 +27,31 @@ package gc.stringdedup;
  * @test TestStringDeduplicationYoungGC
  * @summary Test string deduplication during young GC
  * @bug 8029075
- * @requires vm.gc == "null" | vm.gc == "G1" | vm.gc == "Shenandoah"
+ * @requires vm.gc.G1
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  *          java.management
- * @run driver gc.stringdedup.TestStringDeduplicationYoungGC
+ * @run driver gc.stringdedup.TestStringDeduplicationYoungGC G1
+ */
+
+/*
+ * @test TestStringDeduplicationYoungGC
+ * @summary Test string deduplication during young GC
+ * @bug 8029075
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @library /
+ * @modules java.base/jdk.internal.misc:open
+ * @modules java.base/java.lang:open
+ *          java.management
+ * @run driver gc.stringdedup.TestStringDeduplicationYoungGC Shenandoah
  */
 
 public class TestStringDeduplicationYoungGC {
     public static void main(String[] args) throws Exception {
+        TestStringDeduplicationTools.selectGC(args);
         TestStringDeduplicationTools.testYoungGC();
     }
 }


### PR DESCRIPTION
I want to backport this test-only change to simplify follow up backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269032](https://bugs.openjdk.java.net/browse/JDK-8269032): Stringdedup tests are failing if the ergonomically select GC does not support it


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/105.diff">https://git.openjdk.java.net/jdk17u-dev/pull/105.diff</a>

</details>
