### PR TITLE
8273438: Enable parallelism in vmTestbase/metaspace/stressHierarchy tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy001/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy001/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy002/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy002/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy003/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy003/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy004/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy004/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy005/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy005/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy006/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy006/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy007/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy007/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy008/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy008/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy009/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy009/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy010/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy010/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy011/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy011/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy012/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy012/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy013/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy013/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy014/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy014/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.

--- a/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy015/TEST.properties
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/stressHierarchy/stressHierarchy015/TEST.properties
@@ -1,1 +1,0 @@
-exclusiveAccess.dirs=.


### PR DESCRIPTION
Clean backport to improve testing performance.

Additional testing:
 - [x] Linux x86_64 fastdebug `vmTestbase/metaspace/stressHierarchy` passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273438](https://bugs.openjdk.java.net/browse/JDK-8273438): Enable parallelism in vmTestbase/metaspace/stressHierarchy tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/106/head:pull/106` \
`$ git checkout pull/106`

Update a local copy of the PR: \
`$ git checkout pull/106` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 106`

View PR using the GUI difftool: \
`$ git pr show -t 106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/106.diff">https://git.openjdk.java.net/jdk17u-dev/pull/106.diff</a>

</details>
