### PR TITLE
8272553: several hotspot runtime/CommandLine tests don't check exit code

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/CompilerConfigFileWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/CompilerConfigFileWarning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,8 @@ public class CompilerConfigFileWarning {
 
         pb = ProcessTools.createJavaProcessBuilder("-XX:CompileCommandFile=hs_comp.txt", "-version");
         output = new OutputAnalyzer(pb.start());
+        // problems in CompileCommandFile are treated as warnings
+        output.shouldHaveExitValue(0);
         output.shouldContain("An error occurred during parsing");
         output.shouldContain("Unrecognized option 'aaa'");
         output.shouldContain("aaa, aaa");
@@ -60,6 +62,7 @@ public class CompilerConfigFileWarning {
 
             pb = ProcessTools.createJavaProcessBuilder("-version");
             output = new OutputAnalyzer(pb.start());
+            output.shouldHaveExitValue(0);
             output.shouldContain("warning: .hotspot_compiler file is present but has been ignored.  Run with -XX:CompileCommandFile=.hotspot_compiler to load the file.");
         }
     }

--- a/test/hotspot/jtreg/runtime/CommandLine/ConfigFileWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/ConfigFileWarning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,7 @@ public class ConfigFileWarning {
 
             pb = ProcessTools.createJavaProcessBuilder("-version");
             output = new OutputAnalyzer(pb.start());
+            output.shouldHaveExitValue(0);
             output.shouldContain("warning: .hotspotrc file is present but has been ignored.  Run with -XX:Flags=.hotspotrc to load the file.");
         }
     }

--- a/test/hotspot/jtreg/runtime/CommandLine/ObsoleteFlagErrorMessage.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/ObsoleteFlagErrorMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ public class ObsoleteFlagErrorMessage {
         "-XX:+" + flag, "-version");
 
     OutputAnalyzer output2 = new OutputAnalyzer(pb2.start());
+    output2.shouldHaveExitValue(0);
     output2.shouldContain("Ignoring option").shouldContain("support was removed");
     output2.shouldContain(flag);
   }

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ public class PrintTouchedMethods {
 
       // UnlockDiagnostic turned off, should fail
       OutputAnalyzer output = new OutputAnalyzer(pb.start());
+      output.shouldNotHaveExitValue(0);
       output.shouldContain("Error: VM option 'LogTouchedMethods' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
       output.shouldContain("Error: Could not create the Java Virtual Machine.");
 

--- a/test/hotspot/jtreg/runtime/CommandLine/TestHexArguments.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/TestHexArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ public class TestHexArguments {
       pb = ProcessTools.createJavaProcessBuilder(
           "-XX:SharedBaseAddress=1D000000", "-version");
       output = new OutputAnalyzer(pb.start());
+      output.shouldNotHaveExitValue(0);
       output.shouldContain("Could not create the Java Virtual Machine");
   }
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/TestVMOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/TestVMOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,11 +42,13 @@ public class TestVMOptions {
         "-XX:+IgnoreUnrecognizedVMOptions",
         "-XX:+PrintFlagsInitial");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(0);
     output.shouldContain("bool UseSerialGC");
 
     pb = ProcessTools.createJavaProcessBuilder(
         "-XX:-PrintVMOptions", "-version");
     output = new OutputAnalyzer(pb.start());
+    output.shouldHaveExitValue(0);
     output.shouldMatch("(openjdk|java)\\sversion");
 
     File dir = new File(System.getProperty("test.src", "."));
@@ -54,6 +56,7 @@ public class TestVMOptions {
     String s = file.getAbsolutePath();
     pb = ProcessTools.createJavaProcessBuilder("-XX:Flags="+s);
     output = new OutputAnalyzer(pb.start());
+    output.shouldNotHaveExitValue(0);
     output.shouldContain("VM option '-IgnoreUnrecognizedVMOptions'");
   }
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public class VMOptionWarning {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+AlwaysSafeConstructors", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
         output.shouldContain("Error: VM option 'AlwaysSafeConstructors' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.");
 
         if (Platform.isDebugBuild()) {
@@ -48,14 +49,17 @@ public class VMOptionWarning {
 
         pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintInlining", "-version");
         output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
         output.shouldContain("Error: VM option 'PrintInlining' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
 
         pb = ProcessTools.createJavaProcessBuilder("-XX:+VerifyStack", "-version");
         output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
         output.shouldContain("Error: VM option 'VerifyStack' is develop and is available only in debug version of VM.");
 
         pb = ProcessTools.createJavaProcessBuilder("-XX:+CheckCompressedOops", "-version");
         output = new OutputAnalyzer(pb.start());
+        output.shouldNotHaveExitValue(0);
         output.shouldContain("Error: VM option 'CheckCompressedOops' is notproduct and is available only in debug version of VM.");
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272553](https://bugs.openjdk.java.net/browse/JDK-8272553): several hotspot runtime/CommandLine tests don't check exit code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/111.diff">https://git.openjdk.java.net/jdk17u-dev/pull/111.diff</a>

</details>
