### PR TITLE
8177814: jdk/editpad is not in jdk TEST.groups

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -381,6 +381,9 @@ jdk_accessibility = \
 jfc_demo = \
      demo/jfc
 
+jdk_editpad = \
+     jdk/editpad
+
 jdk_desktop = \
     :jdk_awt \
     :jdk_2d \
@@ -390,7 +393,8 @@ jdk_desktop = \
     :jdk_imageio \
     :jdk_accessibility \
     :jfc_demo \
-    :jdk_client_sanity
+    :jdk_client_sanity \
+    :jdk_editpad
 
 # SwingSet3 tests.
 jdk_client_sanity = \


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8177814](https://bugs.openjdk.java.net/browse/JDK-8177814): jdk/editpad is not in jdk TEST.groups


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/114.diff">https://git.openjdk.java.net/jdk17u-dev/pull/114.diff</a>

</details>
