### PR TITLE
8275687: runtime/CommandLine/PrintTouchedMethods test shouldn't catch RuntimeException

### DIFF
--- a/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethodsJcmd.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintTouchedMethodsJcmd.java
@@ -41,10 +41,6 @@ public class PrintTouchedMethodsJcmd {
       var pb = new ProcessBuilder();
       pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), pid, "VM.print_touched_methods"});
       var output = new OutputAnalyzer(pb.start());
-      try {
-        output.shouldContain("PrintTouchedMethodsJcmd.main:([Ljava/lang/String;)V");
-      } catch (RuntimeException e) {
-        output.shouldContain("Unknown diagnostic command");
-      }
-  }
+      output.shouldContain("PrintTouchedMethodsJcmd.main:([Ljava/lang/String;)V");
+    }
 }


### PR DESCRIPTION
Clean backport to improve testing. Affected test still passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275687](https://bugs.openjdk.java.net/browse/JDK-8275687): runtime/CommandLine/PrintTouchedMethods test shouldn't catch RuntimeException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/115.diff">https://git.openjdk.java.net/jdk17u-dev/pull/115.diff</a>

</details>
