### PR TITLE
8280155: [PPC64, s390] frame size checks are not yet correct

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -302,7 +302,8 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   if (sp() == 0 || (intptr_t(sp()) & (wordSize-1)) != 0) {
     return false;
   }
-  if (fp() - (abi_minframe_size + ijava_state_size) < sp()) {
+  int min_frame_slots = (abi_minframe_size + ijava_state_size) / sizeof(intptr_t);
+  if (fp() - min_frame_slots < sp()) {
     return false;
   }
   // These are hacks to keep us out of trouble.

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -306,7 +306,8 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   if (sp() == 0 || (intptr_t(sp()) & (wordSize-1)) != 0) {
     return false;
   }
-  if (fp() - (z_abi_16_size + z_ijava_state_size) < sp()) {
+  int min_frame_slots = (z_abi_16_size + z_ijava_state_size) / sizeof(intptr_t);
+  if (fp() - min_frame_slots < sp()) {
     return false;
   }
   // These are hacks to keep us out of trouble.

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,13 +58,14 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   // if we were running Java code when SIGPROF came in.
   if (isInJava) {
     ucontext_t* uc = (ucontext_t*) ucontext;
-    frame ret_frame((intptr_t*)uc->uc_mcontext.regs->gpr[1/*REG_SP*/],
-                     (address)uc->uc_mcontext.regs->nip);
+    address pc = (address)uc->uc_mcontext.regs->nip;
 
-    if (ret_frame.pc() == NULL) {
+    if (pc == NULL) {
       // ucontext wasn't useful
       return false;
     }
+
+    frame ret_frame((intptr_t*)uc->uc_mcontext.regs->gpr[1/*REG_SP*/], pc);
 
     if (ret_frame.fp() == NULL) {
       // The found frame does not have a valid frame pointer.


### PR DESCRIPTION
Clean Backport of JDK-8279924.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280155](https://bugs.openjdk.java.net/browse/JDK-8280155): [PPC64, s390] frame size checks are not yet correct


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/123.diff">https://git.openjdk.java.net/jdk17u-dev/pull/123.diff</a>

</details>
