### PR TITLE
8274750: java/io/File/GetXSpace.java failed: '/dev': 191488 != 190976

### DIFF
--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -51,6 +51,7 @@ import jdk.test.lib.Platform;
 import static java.lang.System.err;
 import static java.lang.System.out;
 
+@SuppressWarnings("removal")
 public class GetXSpace {
 
     private static SecurityManager [] sma = { null, new Allow(), new DenyFSA(),
@@ -213,8 +214,9 @@ public class GetXSpace {
         out.format(fmt, "df", s.total(), 0, s.free());
         out.format(fmt, "getX", ts, fs, us);
 
-        // if the file system can dynamically change size, this check will fail
-        if (ts != s.total()) {
+        // If the file system can dynamically change size, this check will fail.
+        // This can happen on macOS for the /dev files system.
+        if (ts != s.total() && (!Platform.isOSX() || !s.name().equals("/dev"))) {
             long blockSize = 1;
             long numBlocks = 0;
             try {
@@ -230,7 +232,6 @@ public class GetXSpace {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-
 
             // On macOS, the number of 1024 byte blocks might be incorrectly
             // calculated by 'df' using integer division by 2 of the number of


### PR DESCRIPTION
I backport this for parity with 11.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274750](https://bugs.openjdk.java.net/browse/JDK-8274750): java/io/File/GetXSpace.java failed: '/dev': 191488 != 190976


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/129.diff">https://git.openjdk.java.net/jdk17u-dev/pull/129.diff</a>

</details>
