### PR TITLE
8271506: Add ResourceHashtable support for deleting selected entries

### DIFF
--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -195,6 +195,32 @@ class ResourceHashtable : public ResourceObj {
       ++bucket;
     }
   }
+
+  // ITER contains bool do_entry(K const&, V const&), which will be
+  // called for each entry in the table.  If do_entry() returns true,
+  // the entry is deleted.
+  template<class ITER>
+  void unlink(ITER* iter) {
+    Node** bucket =  const_cast<Node**>(_table);
+    while (bucket < &_table[SIZE]) {
+      Node** ptr = bucket;
+      while (*ptr != NULL) {
+        Node* node = *ptr;
+        // do_entry must clean up the key and value in Node.
+        bool clean = iter->do_entry(node->_key, node->_value);
+        if (clean) {
+          *ptr = node->_next;
+          if (ALLOC_TYPE == ResourceObj::C_HEAP) {
+            delete node;
+          }
+        } else {
+          ptr = &(node->_next);
+        }
+      }
+      ++bucket;
+    }
+  }
+
 };
 
 

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -60,6 +60,21 @@ class CommonResourceHashtableTest : public ::testing::Test {
     }
   };
 
+  class DeleterTestIter {
+    int _val;
+   public:
+    DeleterTestIter(int i) : _val(i) {}
+
+    bool do_entry(K const& k, V const& v) {
+      if ((uintptr_t) k == (uintptr_t) _val) {
+        // Delete me!
+        return true;
+      } else {
+        return false; // continue iteration
+      }
+    }
+  };
+
 };
 
 class SmallResourceHashtableTest : public CommonResourceHashtableTest {
@@ -233,6 +248,15 @@ class GenericResourceHashtableTest : public CommonResourceHashtableTest {
         ASSERT_FALSE(rh.remove(as_K(index)));
       }
       rh.iterate(&et);
+
+      // Add more entries in and then delete one.
+      for (uintptr_t i = 10; i > 0; --i) {
+        uintptr_t index = i - 1;
+        ASSERT_TRUE(rh.put(as_K(index), index));
+      }
+      DeleterTestIter dt(5);
+      rh.unlink(&dt);
+      ASSERT_FALSE(rh.get(as_K(5)));
     }
   };
 };


### PR DESCRIPTION
I backport this as prerequisite to JDK-8274944 which calls the new method unlink().

I had to adapt the code to work in jdk17 because ""JDK-8269004: Implement ResizableResourceHashtable" is missing in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271506](https://bugs.openjdk.java.net/browse/JDK-8271506): Add ResourceHashtable support for deleting selected entries


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/132/head:pull/132` \
`$ git checkout pull/132`

Update a local copy of the PR: \
`$ git checkout pull/132` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 132`

View PR using the GUI difftool: \
`$ git pr show -t 132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/132.diff">https://git.openjdk.java.net/jdk17u-dev/pull/132.diff</a>

</details>
