### PR TITLE
8274944: AppCDS dump causes SEGV in VM thread while adjusting lambda proxy class info

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -111,6 +111,7 @@ public:
     // Block concurrent class unloading from changing the _dumptime_table
     MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
     SystemDictionaryShared::check_excluded_classes();
+    SystemDictionaryShared::cleanup_lambda_proxy_class_dictionary();
 
     init_header();
     gather_source_objs();

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -487,6 +487,7 @@ void VM_PopulateDumpSharedSpace::doit() {
   // Block concurrent class unloading from changing the _dumptime_table
   MutexLocker ml(DumpTimeTable_lock, Mutex::_no_safepoint_check_flag);
   SystemDictionaryShared::check_excluded_classes();
+  SystemDictionaryShared::cleanup_lambda_proxy_class_dictionary();
 
   StaticArchiveBuilder builder;
   builder.gather_source_objs();

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -2405,6 +2405,28 @@ bool SystemDictionaryShared::empty_dumptime_table() {
   return false;
 }
 
+class CleanupDumpTimeLambdaProxyClassTable: StackObj {
+ public:
+  bool do_entry(LambdaProxyClassKey& key, DumpTimeLambdaProxyClassInfo& info) {
+    assert_lock_strong(DumpTimeTable_lock);
+    for (int i = 0; i < info._proxy_klasses->length(); i++) {
+      InstanceKlass* ik = info._proxy_klasses->at(i);
+      if (!ik->can_be_verified_at_dumptime()) {
+        info._proxy_klasses->remove_at(i);
+      }
+    }
+    return info._proxy_klasses->length() == 0 ? true /* delete the node*/ : false;
+  }
+};
+
+void SystemDictionaryShared::cleanup_lambda_proxy_class_dictionary() {
+  assert_lock_strong(DumpTimeTable_lock);
+  if (_dumptime_lambda_proxy_class_dictionary != NULL) {
+    CleanupDumpTimeLambdaProxyClassTable cleanup_proxy_classes;
+    _dumptime_lambda_proxy_class_dictionary->unlink(&cleanup_proxy_classes);
+  }
+}
+
 #if INCLUDE_CDS_JAVA_HEAP
 
 class ArchivedMirrorPatcher {

--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -331,6 +331,7 @@ public:
   static size_t estimate_size_for_archive();
   static void write_to_archive(bool is_static_archive = true);
   static void adjust_lambda_proxy_class_dictionary();
+  static void cleanup_lambda_proxy_class_dictionary();
   static void serialize_dictionary_headers(class SerializeClosure* soc,
                                            bool is_static_archive = true);
   static void serialize_vm_classes(class SerializeClosure* soc);

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -195,6 +195,32 @@ class ResourceHashtable : public ResourceObj {
       ++bucket;
     }
   }
+
+  // ITER contains bool do_entry(K const&, V const&), which will be
+  // called for each entry in the table.  If do_entry() returns true,
+  // the entry is deleted.
+  template<class ITER>
+  void unlink(ITER* iter) {
+    Node** bucket =  const_cast<Node**>(_table);
+    while (bucket < &_table[SIZE]) {
+      Node** ptr = bucket;
+      while (*ptr != NULL) {
+        Node* node = *ptr;
+        // do_entry must clean up the key and value in Node.
+        bool clean = iter->do_entry(node->_key, node->_value);
+        if (clean) {
+          *ptr = node->_next;
+          if (ALLOC_TYPE == ResourceObj::C_HEAP) {
+            delete node;
+          }
+        } else {
+          ptr = &(node->_next);
+        }
+      }
+      ++bucket;
+    }
+  }
+
 };
 
 

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -60,6 +60,21 @@ class CommonResourceHashtableTest : public ::testing::Test {
     }
   };
 
+  class DeleterTestIter {
+    int _val;
+   public:
+    DeleterTestIter(int i) : _val(i) {}
+
+    bool do_entry(K const& k, V const& v) {
+      if ((uintptr_t) k == (uintptr_t) _val) {
+        // Delete me!
+        return true;
+      } else {
+        return false; // continue iteration
+      }
+    }
+  };
+
 };
 
 class SmallResourceHashtableTest : public CommonResourceHashtableTest {
@@ -233,6 +248,15 @@ class GenericResourceHashtableTest : public CommonResourceHashtableTest {
         ASSERT_FALSE(rh.remove(as_K(index)));
       }
       rh.iterate(&et);
+
+      // Add more entries in and then delete one.
+      for (uintptr_t i = 10; i > 0; --i) {
+        uintptr_t index = i - 1;
+        ASSERT_TRUE(rh.put(as_K(index), index));
+      }
+      DeleterTestIter dt(5);
+      rh.unlink(&dt);
+      ASSERT_FALSE(rh.get(as_K(5)));
     }
   };
 };

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -399,6 +399,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/DumpClassList.java \
  -runtime/cds/appcds/DumpClassListWithLF.java \
  -runtime/cds/appcds/ExtraSymbols.java \
+ -runtime/cds/appcds/LambdaContainsOldInf.java \
  -runtime/cds/appcds/LambdaEagerInit.java \
  -runtime/cds/appcds/LambdaProxyClasslist.java \
  -runtime/cds/appcds/LambdaVerificationFailedDuringDump.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/LambdaContainsOldInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/LambdaContainsOldInf.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8274944
+ * @summary VM should not crash during CDS dump when a lambda proxy class
+ *          contains an old version of interface.
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/OldProvider.jasm
+ * @compile test-classes/LambdaContainsOldInfApp.java
+ * @run driver LambdaContainsOldInf
+ */
+
+import jdk.test.lib.cds.CDSOptions;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class LambdaContainsOldInf {
+
+    public static void main(String[] args) throws Exception {
+        String mainClass = "LambdaContainsOldInfApp";
+        String namePrefix = "lambdacontainsoldinf";
+        JarBuilder.build(namePrefix, mainClass, "OldProvider");
+
+        String appJar = TestCommon.getTestJar(namePrefix + ".jar");
+        String classList = namePrefix + ".list";
+        String archiveName = namePrefix + ".jsa";
+
+        // dump class list
+        CDSTestUtils.dumpClassList(classList, "-cp", appJar, mainClass);
+
+        // create archive with the class list
+        CDSOptions opts = (new CDSOptions())
+            .addPrefix("-XX:ExtraSharedClassListFile=" + classList,
+                       "-cp", appJar,
+                       "-Xlog:class+load,cds")
+            .setArchiveName(archiveName);
+        OutputAnalyzer output = CDSTestUtils.createArchiveAndCheck(opts);
+        TestCommon.checkExecReturn(output, 0, true,
+                                   "Skipping OldProvider: Old class has been linked");
+        output.shouldMatch("Skipping.LambdaContainsOldInfApp[$][$]Lambda[$].*0x.*:.*Old.class.has.been.linked");
+
+        // run with archive
+        CDSOptions runOpts = (new CDSOptions())
+            .addPrefix("-cp", appJar, "-Xlog:class+load,cds=debug")
+            .setArchiveName(archiveName)
+            .setUseVersion(false)
+            .addSuffix(mainClass);
+        output = CDSTestUtils.runWithArchive(runOpts);
+        TestCommon.checkExecReturn(output, 0, true,
+            "[class,load] LambdaContainsOldInfApp source: shared objects file");
+        output.shouldMatch(".class.load. OldProvider.source:.*lambdacontainsoldinf.jar")
+              .shouldMatch(".class.load. LambdaContainsOldInfApp[$][$]Lambda[$].*/0x.*source:.*LambdaContainsOldInf");
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaContainsOldInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaContainsOldInf.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8274944
+ * @summary VM should not crash during CDS dump when a lambda proxy class
+ *          contains an old version of interface.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes
+ * @build LambdaContainsOldInfApp sun.hotspot.WhiteBox OldProvider LambdaVerification
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar lambda_contains_old_inf.jar LambdaVerification
+ *             LambdaContainsOldInfApp OldProvider
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. LambdaContainsOldInf
+ */
+
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class LambdaContainsOldInf extends DynamicArchiveTestBase {
+    public static void main(String[] args) throws Exception {
+        runTest(LambdaContainsOldInf::test);
+    }
+
+    static void test() throws Exception {
+        String topArchiveName = getNewArchiveName();
+        String appJar = ClassFileInstaller.getJarPath("lambda_contains_old_inf.jar");
+        String mainClass = "LambdaContainsOldInfApp";
+        String wbJar = ClassFileInstaller.getJarPath("WhiteBox.jar");
+        String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
+
+        dump(topArchiveName,
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+WhiteBoxAPI",
+            "-Xlog:class+load=debug,cds=debug,cds+dynamic=info",
+            use_whitebox_jar,
+            "-cp", appJar, mainClass)
+            .assertNormalExit(output -> {
+                output
+                      .shouldMatch("Skipping.LambdaContainsOldInfApp[$][$]Lambda[$].*0x.*:.*Old.class.has.been.linked")
+                      .shouldHaveExitValue(0);
+            });
+
+        run(topArchiveName,
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+WhiteBoxAPI",
+            use_whitebox_jar,
+            "-Xlog:class+load=debug",
+            "-cp", appJar, mainClass)
+            .assertNormalExit(output -> {
+                output.shouldContain("[class,load] LambdaContainsOldInfApp source: shared objects file (top)")
+                      .shouldMatch(".class.load. OldProvider.source:.*lambda_contains_old_inf.jar")
+                      .shouldMatch(".class.load. LambdaContainsOldInfApp[$][$]Lambda[$].*/0x.*source:.*LambdaContainsOldInf")
+                      .shouldHaveExitValue(0);
+            });
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/LambdaContainsOldInfApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/LambdaContainsOldInfApp.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public class LambdaContainsOldInfApp {
+    public static void main(final String... args) {
+        getProvider();
+    }
+
+    public static OldProvider getProvider() {
+        return () -> {
+            return null;
+        };
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldProvider.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/OldProvider.jasm
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+public interface  OldProvider
+	version 49:0
+{
+  public abstract Method get:"()Ljava/lang/Object;";
+
+} // end Class OldProvider


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

I had to adapt the tests: I removed one check from dynamicArchive/LambdaContainsOldInf.java.

This depends on JDK-8271506.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274944](https://bugs.openjdk.java.net/browse/JDK-8274944): AppCDS dump causes SEGV in VM thread while adjusting lambda proxy class info


### Reviewers
 * [Thomas Stuefe](https://openjdk.java.net/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/133.diff">https://git.openjdk.java.net/jdk17u-dev/pull/133.diff</a>

</details>
