### PR TITLE
8280414: Memory leak in DefaultProxySelector

### DIFF
--- a/src/java.base/windows/native/libnet/DefaultProxySelector.c
+++ b/src/java.base/windows/native/libnet/DefaultProxySelector.c
@@ -104,7 +104,6 @@ static int createProxyList(LPWSTR win_proxy, const WCHAR *pproto, list_item **he
     int nr_elems = 0;
     wchar_t *context = NULL;
     wchar_t *current_proxy = NULL;
-    BOOL error = FALSE;
 
     /*
      * The proxy server list contains one or more of the following strings
@@ -116,7 +115,6 @@ static int createProxyList(LPWSTR win_proxy, const WCHAR *pproto, list_item **he
         LPWSTR pport;
         LPWSTR phost;
         int portVal = 0;
-        wchar_t *next_proxy = NULL;
         list_item *proxy = NULL;
         wchar_t* pos = NULL;
 
@@ -290,7 +288,6 @@ Java_sun_net_spi_DefaultProxySelector_getSystemProxies(JNIEnv *env,
     }
 
     if (win_proxy != NULL) {
-        wchar_t *context = NULL;
         int defport = 0;
         int nr_elems = 0;
 
@@ -313,27 +310,28 @@ Java_sun_net_spi_DefaultProxySelector_getSystemProxies(JNIEnv *env,
         nr_elems = createProxyList(win_proxy, lpProto, &head);
         if (nr_elems != 0 && head != NULL) {
             int index = 0;
+            list_item *current = head;
             proxy_array = (*env)->NewObjectArray(env, nr_elems, proxy_class, NULL);
             if (proxy_array == NULL || (*env)->ExceptionCheck(env)) {
                 goto noproxy;
             }
-            while (head != NULL && index < nr_elems) {
+            while (current != NULL && index < nr_elems) {
                 jstring jhost;
                 jobject isa;
                 jobject proxy;
 
-                if (head->host != NULL && proxy_array != NULL) {
+                if (current->host != NULL && proxy_array != NULL) {
                     /* Let's create the appropriate Proxy object then. */
-                    if (head->port == 0) {
-                        head->port = defport;
+                    if (current->port == 0) {
+                        current->port = defport;
                     }
-                    jhost = (*env)->NewString(env, head->host, (jsize)wcslen(head->host));
+                    jhost = (*env)->NewString(env, current->host, (jsize)wcslen(current->host));
                     if (jhost == NULL || (*env)->ExceptionCheck(env)) {
                         proxy_array = NULL;
                     }
                     isa = (*env)->CallStaticObjectMethod(env, isaddr_class,
                                                          isaddr_createUnresolvedID, jhost,
-                                                         head->port);
+                                                         current->port);
                     if (isa == NULL || (*env)->ExceptionCheck(env)) {
                         proxy_array = NULL;
                     }
@@ -347,7 +345,7 @@ Java_sun_net_spi_DefaultProxySelector_getSystemProxies(JNIEnv *env,
                     }
                     index++;
                 }
-                head = head->next;
+                current = current->next;
             }
         }
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280414](https://bugs.openjdk.java.net/browse/JDK-8280414): Memory leak in DefaultProxySelector


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/135/head:pull/135` \
`$ git checkout pull/135`

Update a local copy of the PR: \
`$ git checkout pull/135` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 135`

View PR using the GUI difftool: \
`$ git pr show -t 135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/135.diff">https://git.openjdk.java.net/jdk17u-dev/pull/135.diff</a>

</details>
