### PR TITLE
8275643: C2's unaryOp vector intrinsic does not properly handle LongVector.neg

### DIFF
--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -291,6 +291,7 @@ int VectorSupport::vop2ideal(jint id, BasicType bt) {
         case T_BYTE:   // fall-through
         case T_SHORT:  // fall-through
         case T_INT:    return Op_NegI;
+        case T_LONG:   return Op_NegL;
         case T_FLOAT:  return Op_NegF;
         case T_DOUBLE: return Op_NegD;
         default: fatal("NEG: %s", type2name(bt));

--- a/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.LongVector;
+
+/*
+ * @test
+ * @bug 8275643
+ * @summary Test that LongVector.neg is properly handled by the _VectorUnaryOp C2 intrinsic
+ * @modules jdk.incubator.vector
+ * @run main/othervm -XX:-TieredCompilation -XX:+AlwaysIncrementalInline -Xbatch
+ *                   -XX:CompileCommand=dontinline,compiler.vectorapi.TestLongVectorNeg::test
+ *                   compiler.vectorapi.TestLongVectorNeg
+ */
+public class TestLongVectorNeg {
+
+    static LongVector test(LongVector v) {
+        return v.neg();
+    }
+
+    public static void main(String[] args) {
+        LongVector v = LongVector.zero(LongVector.SPECIES_128);
+        for (int i = 0; i < 50_000; ++i) {
+            v.abs(); // Warmup to make sure the !VO_SPECIAL code path is taken as well
+            test(v);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.
Requires follow-up test fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275643](https://bugs.openjdk.java.net/browse/JDK-8275643): C2's unaryOp vector intrinsic does not properly handle LongVector.neg


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/139.diff">https://git.openjdk.java.net/jdk17u-dev/pull/139.diff</a>

</details>
