### PR TITLE
8277449: compiler/vectorapi/TestLongVectorNeg.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestLongVectorNeg.java
@@ -30,6 +30,7 @@ import jdk.incubator.vector.LongVector;
  * @bug 8275643
  * @summary Test that LongVector.neg is properly handled by the _VectorUnaryOp C2 intrinsic
  * @modules jdk.incubator.vector
+ * @requires vm.debug
  * @run main/othervm -XX:-TieredCompilation -XX:+AlwaysIncrementalInline -Xbatch
  *                   -XX:CompileCommand=dontinline,compiler.vectorapi.TestLongVectorNeg::test
  *                   compiler.vectorapi.TestLongVectorNeg


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.
Follow up to JDK-8275643

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277449](https://bugs.openjdk.java.net/browse/JDK-8277449): compiler/vectorapi/TestLongVectorNeg.java fails with release VMs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/140.diff">https://git.openjdk.java.net/jdk17u-dev/pull/140.diff</a>

</details>
