### PR TITLE
8190748: java/text/Format/DateFormat/DateFormatTest.java and NonGregorianFormatTest fail intermittently

### DIFF
--- a/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 4052223 4089987 4469904 4326988 4486735 8008577 8045998 8140571
- *      8216969
+ *      8190748 8216969
  * @summary test DateFormat and SimpleDateFormat.
  * @library /java/text/testlib
  * @modules jdk.localedata
@@ -342,7 +342,7 @@ public class DateFormatTest extends IntlTest
     // Test pattern with runs things together
     public void TestRunTogetherPattern985()
     {
-        String format = "yyyyMMddHHmmssSSS";
+        String format = "yyyyMMddHHmmssSSSzzzz";
         String now, then;
 
         SimpleDateFormat formatter = new SimpleDateFormat(format);

--- a/test/jdk/java/text/Format/DateFormat/NonGregorianFormatTest.java
+++ b/test/jdk/java/text/Format/DateFormat/NonGregorianFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,13 @@
 
 /*
  * @test
- * @bug 4833268 6253991 8008577
+ * @bug 4833268 6253991 8008577 8190748
  * @summary Test formatting and parsing with non-Gregorian calendars
  * @modules jdk.localedata
  * @run main/othervm -Djava.locale.providers=COMPAT,SPI NonGregorianFormatTest
  */
 
+import java.time.ZoneId;
 import java.util.*;
 import java.text.*;
 import static java.util.Calendar.*;
@@ -160,10 +161,15 @@ public class NonGregorianFormatTest {
 
     private static void testRoundTrip(DateFormat df, Date orig) {
         try {
+            var defZone = ZoneId.systemDefault();
+            if (defZone.getRules().getTransition(orig.toInstant().atZone(defZone).toLocalDateTime()) != null) {
+                System.out.println("At the offset transition. Round trip test skipped.");
+                return;
+            }
             String s = df.format(orig);
             Date parsed = df.parse(s);
             if (!orig.equals(parsed)) {
-                error("testRoundTrip: bad date: origianl: '%s', parsed '%s'%n", orig, parsed);
+                error("testRoundTrip: bad date: original: '%s', parsed '%s'%n", orig, parsed);
             }
         } catch (Exception e) {
             error("Unexpected exception: %s%n", e);


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8190748](https://bugs.openjdk.java.net/browse/JDK-8190748): java/text/Format/DateFormat/DateFormatTest.java and NonGregorianFormatTest fail intermittently


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/144.diff">https://git.openjdk.java.net/jdk17u-dev/pull/144.diff</a>

</details>
