### PR TITLE
8281061: [s390] JFR runs into assertions while validating interpreter frames

### DIFF
--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -117,8 +117,8 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
-    z_abi_160* sender_abi = (z_abi_160*) fp;
-    intptr_t* sender_sp = (intptr_t*) sender_abi->callers_sp;
+    z_abi_16* sender_abi = (z_abi_16*)fp;
+    intptr_t* sender_sp = (intptr_t*) fp;
     address   sender_pc = (address)   sender_abi->return_pc;
 
     // We must always be able to find a recognizable pc.
@@ -142,7 +142,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
     // sender_fp must be within the stack and above (but not
     // equal) current frame's fp.
     if (!thread->is_in_stack_range_excl(sender_fp, fp)) {
-        return false;
+      return false;
     }
 
     // If the potential sender is the interpreter then we can do some more checking.
@@ -319,8 +319,8 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   // do some validation of frame elements
 
   // first the method
-
-  Method* m = *interpreter_frame_method_addr();
+  // Need to use "unchecked" versions to avoid "z_istate_magic_number" assertion.
+  Method* m = (Method*)(ijava_state_unchecked()->method);
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;
@@ -335,19 +335,17 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   }
 
   // validate bci/bcx
-
-  address  bcp    = interpreter_frame_bcp();
+  address bcp = (address)(ijava_state_unchecked()->bcp);
   if (m->validate_bci_from_bcp(bcp) < 0) {
     return false;
   }
 
   // validate constantPoolCache*
-  ConstantPoolCache* cp = *interpreter_frame_cache_addr();
+  ConstantPoolCache* cp = (ConstantPoolCache*)(ijava_state_unchecked()->cpoolCache);
   if (MetaspaceObj::is_valid(cp) == false) return false;
 
   // validate locals
-
-  address locals =  (address) *interpreter_frame_locals_addr();
+  address locals = (address)(ijava_state_unchecked()->locals);
   return thread->is_in_stack_range_incl(locals, (address)fp());
 }
 


### PR DESCRIPTION
Clean backport of JDK-8281061.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281061](https://bugs.openjdk.java.net/browse/JDK-8281061): [s390] JFR runs into assertions while validating interpreter frames


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/149.diff">https://git.openjdk.java.net/jdk17u-dev/pull/149.diff</a>

</details>
