### PR TITLE
Backport db08127c5f73c53f23a7ebff3e0d8ff0f7b5f290

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -2936,8 +2936,11 @@ public class Utils {
     }
 
     public PreviewSummary declaredUsingPreviewAPIs(Element el) {
-        List<TypeElement> usedInDeclaration = new ArrayList<>();
-        usedInDeclaration.addAll(annotations2Classes(el));
+        if (el.asType().getKind() == ERROR) {
+            // Can happen with undocumented --ignore-source-errors option
+            return new PreviewSummary(Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+        }
+        List<TypeElement> usedInDeclaration = new ArrayList<>(annotations2Classes(el));
         switch (el.getKind()) {
             case ANNOTATION_TYPE, CLASS, ENUM, INTERFACE, RECORD -> {
                 TypeElement te = (TypeElement) el;

--- a/test/langtools/jdk/javadoc/tool/IgnoreSourceErrors.java
+++ b/test/langtools/jdk/javadoc/tool/IgnoreSourceErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8175219
+ * @bug 8175219 8268582
  * @summary test --ignore-errors works correctly
  * @modules
  *      jdk.javadoc/jdk.javadoc.internal.api
@@ -73,6 +73,12 @@ public class IgnoreSourceErrors  extends TestRunner {
         if (!out.contains("modifier static not allowed here")) {
             throw new Exception("expected string not found \'modifier static not allowed here\'");
         }
+        if (!out.contains("package invalid.example does not exist")) {
+            throw new Exception("expected string not found \'package invalid.example does not exist\'");
+        }
+        if (!out.contains("cannot find symbol")) {
+            throw new Exception("expected string not found \'cannot find symbol\'");
+        }
     }
 
     @Test
@@ -84,12 +90,19 @@ public class IgnoreSourceErrors  extends TestRunner {
         if (!out.contains("modifier static not allowed here")) {
             throw new Exception("expected string not found \'modifier static not allowed here\'");
         }
+        if (!out.contains("package invalid.example does not exist")) {
+            throw new Exception("expected string not found \'package invalid.example does not exist\'");
+        }
+        if (!out.contains("cannot find symbol")) {
+            throw new Exception("expected string not found \'cannot find symbol\'");
+        }
     }
 
     void emitSample(Path file) throws IOException {
         String[] contents = {
             "/** A java file with errors */",
-            "public static class Foo {}"
+            "import invalid.example.OtherClass;",
+            "public static class Foo<T> extends OtherClass<T> {}"
         };
         Files.write(file, Arrays.asList(contents), StandardOpenOption.CREATE);
     }


### PR DESCRIPTION
I'd like to backport JDK-8268582 to jdk17u-dev

The patch fixes javadoc NPE when using the --ignore-source-errors option with an non-existing type.

Original patch applied cleanly

Verification: `javadoc --ignore-source-errors ./Test.java` where Test.java has the following content

```
import invalid.example.OtherClass;

public class Test<T> extends OtherClass<T> {

}

```
Regression: langtools_javadoc (20.04/amd64)