### PR TITLE
8278080: Add --with-cacerts-src='user cacerts folder' to enable deterministic cacerts generation

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -169,6 +169,23 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
   fi
   AC_SUBST(CACERTS_FILE)
 
+  # Choose cacerts source folder for user provided PEM files
+  AC_ARG_WITH(cacerts-src, [AS_HELP_STRING([--with-cacerts-src],
+      [specify alternative cacerts source folder containing certificates])])
+  CACERTS_SRC=""
+  AC_MSG_CHECKING([for cacerts source])
+  if test "x$with_cacerts_src" == x; then
+    AC_MSG_RESULT([default])
+  else
+    CACERTS_SRC=$with_cacerts_src
+    if test ! -d "$CACERTS_SRC"; then
+      AC_MSG_RESULT([fail])
+      AC_MSG_ERROR([Specified cacerts source folder "$CACERTS_SRC" does not exist])
+    fi
+    AC_MSG_RESULT([$CACERTS_SRC])
+  fi
+  AC_SUBST(CACERTS_SRC)
+
   # Enable or disable unlimited crypto
   UTIL_ARG_ENABLE(NAME: unlimited-crypto, DEFAULT: true, RESULT: UNLIMITED_CRYPTO,
       DESC: [enable unlimited crypto policy])

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -409,6 +409,8 @@ GTEST_FRAMEWORK_SRC := @GTEST_FRAMEWORK_SRC@
 
 # Source file for cacerts
 CACERTS_FILE=@CACERTS_FILE@
+# Source folder for user provided cacerts PEM files 
+CACERTS_SRC=@CACERTS_SRC@
 
 # Enable unlimited crypto policy
 UNLIMITED_CRYPTO=@UNLIMITED_CRYPTO@

--- a/make/modules/java.base/Gendata.gmk
+++ b/make/modules/java.base/Gendata.gmk
@@ -71,6 +71,9 @@ $(GENDATA_CACERTS): $(BUILD_TOOLS_JDK) $(wildcard $(GENDATA_CACERTS_SRC)/*)
 ifeq ($(CACERTS_FILE), )
   TARGETS += $(GENDATA_CACERTS)
 endif
+ifneq ($(CACERTS_SRC), )
+  GENDATA_CACERTS_SRC := $(CACERTS_SRC)
+endif
 
 ################################################################################
 


### PR DESCRIPTION
Provide a new configure argument --with-cacerts-src=<cacerts directory>, that allows openjdk builds to specify their own source of cacerts, similar to the existing --with-cacerts-file option for pre-built ketstores, but this new option allows builds to use the GenerateCacerts openjdk tooling which produces a deterministic "reproducible" keystore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278080](https://bugs.openjdk.java.net/browse/JDK-8278080): Add --with-cacerts-src='user cacerts folder' to enable deterministic cacerts generation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/164/head:pull/164` \
`$ git checkout pull/164`

Update a local copy of the PR: \
`$ git checkout pull/164` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 164`

View PR using the GUI difftool: \
`$ git pr show -t 164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/164.diff">https://git.openjdk.java.net/jdk17u-dev/pull/164.diff</a>

</details>
