### PR TITLE
8278163: --with-cacerts-src variable resolved after GenerateCacerts recipe setup

### DIFF
--- a/make/modules/java.base/Gendata.gmk
+++ b/make/modules/java.base/Gendata.gmk
@@ -60,7 +60,11 @@ TARGETS += $(GENDATA_CURDATA)
 
 ################################################################################
 
-GENDATA_CACERTS_SRC := $(TOPDIR)/make/data/cacerts/
+ifneq ($(CACERTS_SRC), )
+  GENDATA_CACERTS_SRC := $(CACERTS_SRC)
+else
+  GENDATA_CACERTS_SRC := $(TOPDIR)/make/data/cacerts/
+endif
 GENDATA_CACERTS := $(SUPPORT_OUTPUTDIR)/modules_libs/java.base/security/cacerts
 
 $(GENDATA_CACERTS): $(BUILD_TOOLS_JDK) $(wildcard $(GENDATA_CACERTS_SRC)/*)


### PR DESCRIPTION
This is the dependent PR fix for https://github.com/openjdk/jdk17u-dev/pull/164 to correctly resolve the --with-cacerts-src recipe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Dependency #164 must be integrated first

### Issue
 * [JDK-8278163](https://bugs.openjdk.java.net/browse/JDK-8278163): --with-cacerts-src variable resolved after GenerateCacerts recipe setup


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/168/head:pull/168` \
`$ git checkout pull/168`

Update a local copy of the PR: \
`$ git checkout pull/168` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 168`

View PR using the GUI difftool: \
`$ git pr show -t 168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/168.diff">https://git.openjdk.java.net/jdk17u-dev/pull/168.diff</a>

</details>
