### PR TITLE
8272996: JNDI DNS provider fails to resolve SRV entries when IPV6 stack is enabled

### DIFF
--- a/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
+++ b/src/jdk.naming.dns/share/classes/com/sun/jndi/dns/DnsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,12 @@
 package com.sun.jndi.dns;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.DatagramSocket;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.PortUnreachableException;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.security.SecureRandom;
@@ -275,19 +277,22 @@ public class DnsClient {
                             } // servers
                         }
                         return new ResourceRecords(msg, msg.length, hdr, false);
-
+                    } catch (UncheckedIOException | PortUnreachableException ex) {
+                        // DatagramSocket.connect in doUdpQuery can throw UncheckedIOException
+                        // DatagramSocket.send in doUdpQuery can throw PortUnreachableException
+                        if (debug) {
+                            dprint("Caught Exception:" + ex);
+                        }
+                        if (caughtException == null) {
+                            caughtException = ex;
+                        }
+                        doNotRetry[i] = true;
                     } catch (IOException e) {
                         if (debug) {
                             dprint("Caught IOException:" + e);
                         }
                         if (caughtException == null) {
                             caughtException = e;
-                        }
-                        // Use reflection to allow pre-1.4 compilation.
-                        // This won't be needed much longer.
-                        if (e.getClass().getName().equals(
-                                "java.net.PortUnreachableException")) {
-                            doNotRetry[i] = true;
                         }
                     } catch (NameNotFoundException e) {
                         // This is authoritative, so return immediately


### PR DESCRIPTION
Backport of 65d11651a595ee255c22094658bcb76ee6927aa6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272996](https://bugs.openjdk.java.net/browse/JDK-8272996): JNDI DNS provider fails to resolve SRV entries when IPV6 stack is enabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/172.diff">https://git.openjdk.java.net/jdk17u-dev/pull/172.diff</a>

</details>
