### PR TITLE
Backport 35361270cb3aae9fa560736f8d05f1b258704c87

### DIFF
--- a/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceDCmd.cpp
@@ -42,6 +42,7 @@ MetaspaceDCmd::MetaspaceDCmd(outputStream* output, bool heap) :
   _by_spacetype("by-spacetype", "Break down numbers by loader type.", "BOOLEAN", false, "false"),
   _by_chunktype("by-chunktype", "Break down numbers by chunk type.", "BOOLEAN", false, "false"),
   _show_vslist("vslist", "Shows details about the underlying virtual space.", "BOOLEAN", false, "false"),
+  _show_chunkfreelist("chunkfreelist", "Shows details about global chunk free lists (ChunkManager).", "BOOLEAN", false, "false"),
   _scale("scale", "Memory usage in which to scale. Valid values are: 1, KB, MB or GB (fixed scale) "
          "or \"dynamic\" for a dynamically choosen scale.",
          "STRING", false, "dynamic"),
@@ -53,6 +54,7 @@ MetaspaceDCmd::MetaspaceDCmd(outputStream* output, bool heap) :
   _dcmdparser.add_dcmd_option(&_by_chunktype);
   _dcmdparser.add_dcmd_option(&_by_spacetype);
   _dcmdparser.add_dcmd_option(&_show_vslist);
+  _dcmdparser.add_dcmd_option(&_show_chunkfreelist);
   _dcmdparser.add_dcmd_option(&_scale);
 }
 
@@ -96,6 +98,7 @@ void MetaspaceDCmd::execute(DCmdSource source, TRAPS) {
     if (_by_chunktype.value())         flags |= (int)MetaspaceReporter::Option::BreakDownByChunkType;
     if (_by_spacetype.value())         flags |= (int)MetaspaceReporter::Option::BreakDownBySpaceType;
     if (_show_vslist.value())          flags |= (int)MetaspaceReporter::Option::ShowVSList;
+    if (_show_chunkfreelist.value())   flags |= (int)MetaspaceReporter::Option::ShowChunkFreeList;
     VM_PrintMetadata op(output(), scale, flags);
     VMThread::execute(&op);
   }

--- a/src/hotspot/share/memory/metaspace/metaspaceDCmd.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceDCmd.hpp
@@ -38,6 +38,7 @@ class MetaspaceDCmd : public DCmdWithParser {
   DCmdArgument<bool> _by_spacetype;
   DCmdArgument<bool> _by_chunktype;
   DCmdArgument<bool> _show_vslist;
+  DCmdArgument<bool> _show_chunkfreelist;
   DCmdArgument<char*> _scale;
   DCmdArgument<bool> _show_classes;
 public:

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
@@ -300,6 +300,24 @@ void MetaspaceReporter::print_report(outputStream* out, size_t scale, int flags)
     out->cr();
   }
 
+  // -- Print Chunkmanager details.
+  if ((flags & (int)Option::ShowChunkFreeList) > 0) {
+    out->cr();
+    out->print_cr("Chunk freelist details:");
+    if (Metaspace::using_class_space()) {
+      out->print_cr("   Non-Class:");
+    }
+    ChunkManager::chunkmanager_nonclass()->print_on(out);
+    out->cr();
+    if (Metaspace::using_class_space()) {
+      out->print_cr("       Class:");
+      ChunkManager::chunkmanager_class()->print_on(out);
+      out->cr();
+    }
+  }
+  out->cr();
+
+
   //////////// Waste section ///////////////////////////
   // As a convenience, print a summary of common waste.
   out->cr();

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.hpp
@@ -44,7 +44,9 @@ public:
     // Print details about the underlying virtual spaces.
     ShowVSList                  = (1 << 3),
     // If show_loaders: show loaded classes for each loader.
-    ShowClasses                 = (1 << 4)
+    ShowClasses                 = (1 << 4),
+    // Print details about the underlying virtual spaces.
+    ShowChunkFreeList           = (1 << 5)
   };
 
   // This will print out a basic metaspace usage report but


### PR DESCRIPTION
I'd like to backport this to jdk17 since it adds a useful option for metaspace analysis. Fix is low risk and applies cleanly.

The commit being backported was authored by Thomas Stuefe on 7 Dec 2021 and was reviewed by Coleen Phillimore and Aleksey Shipilev.