### PR TITLE
8271721: Split gc/g1/TestMixedGCLiveThreshold into separate tests

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
+++ b/test/hotspot/jtreg/gc/g1/TestMixedGCLiveThreshold.java
@@ -24,14 +24,36 @@
 package gc.g1;
 
 /*
- * @test TestMixedGCLiveThreshold
- * @summary Test G1MixedGCLiveThresholdPercent. Fill up a region to at least 1/3 region-size,
- * the region should not be selected for mixed GC cycle if liveness is above threshold.
+ * @test id=0percent
+ * @summary Test G1MixedGCLiveThresholdPercent=0. Fill up a region to at least 33 percent,
+ * the region should not be selected for mixed GC cycle.
  * @requires vm.gc.G1
  * @library /test/lib
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run driver gc.g1.TestMixedGCLiveThreshold
+ * @run driver gc.g1.TestMixedGCLiveThreshold 0 false
+ */
+
+/*
+ * @test id=25percent
+ * @summary Test G1MixedGCLiveThresholdPercent=25. Fill up a region to at least 33 percent,
+ * the region should not be selected for mixed GC cycle.
+ * @requires vm.gc.G1
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver gc.g1.TestMixedGCLiveThreshold 25 false
+ */
+
+/*
+ * @test id=100percent
+ * @summary Test G1MixedGCLiveThresholdPercent=100. Fill up a region to at least 33 percent,
+ * the region should be selected for mixed GC cycle.
+ * @requires vm.gc.G1
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run driver gc.g1.TestMixedGCLiveThreshold 100 true
  */
 
 import java.util.ArrayList;
@@ -48,14 +70,9 @@ public class TestMixedGCLiveThreshold {
     private static final String pattern = "Remembered Set Tracking update regions total ([0-9]+), selected ([0-9]+)$";
 
     public static void main(String[] args) throws Exception {
-        // -XX:G1MixedGCLiveThresholdPercent=0
-        testMixedGCLiveThresholdPercent(0, false);
-
-        // -XX:G1MixedGCLiveThresholdPercent=25
-        testMixedGCLiveThresholdPercent(25, false);
-
-        // -XX:G1MixedGCLiveThresholdPercent=100
-        testMixedGCLiveThresholdPercent(100, true);
+        int liveThresholdPercent = Integer.parseInt(args[0]);
+        boolean expectRebuild = Boolean.parseBoolean(args[1]);
+        testMixedGCLiveThresholdPercent(liveThresholdPercent, expectRebuild);
     }
 
     private static void testMixedGCLiveThresholdPercent(int liveThresholdPercent, boolean expectedRebuild) throws Exception {
@@ -71,6 +88,7 @@ public class TestMixedGCLiveThreshold {
                              " no regions should be selected")
                             );
         output.shouldHaveExitValue(0);
+        output.reportDiagnosticSummary();
     }
 
     private static OutputAnalyzer testWithMixedGCLiveThresholdPercent(int percent) throws Exception {


### PR DESCRIPTION
Hi all,

I'd like to backport this little enhancement to cut down on testing time in jdk17u. The fix is low risk and has been in jdk18+ since last September. Fix applies cleanly.

The commit being backported was authored by Thomas Stuefe on 4 Aug 2021 and was reviewed by Thomas Schatzl and Richard Reingruber.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271721](https://bugs.openjdk.java.net/browse/JDK-8271721): Split gc/g1/TestMixedGCLiveThreshold into separate tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/174.diff">https://git.openjdk.java.net/jdk17u-dev/pull/174.diff</a>

</details>
