### PR TITLE
8278185: Custom JRE cannot find non-ASCII named module inside

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
@@ -309,7 +309,7 @@ public class ImageStringsReader implements ImageStrings {
                 return -1;
             }
         }
-        return length;
+        return current - offset + length;
     }
 
     static int mutf8FromStringLength(String s) {

--- a/test/jdk/tools/jimage/JImageNonAsciiNameTest.java
+++ b/test/jdk/tools/jimage/JImageNonAsciiNameTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import jdk.internal.jimage.BasicImageReader;
+import jdk.internal.jimage.ImageLocation;
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.util.JarBuilder;
+
+import tests.Helper;
+import tests.JImageGenerator;
+import tests.Result;
+
+/*
+ * @test
+ * @bug 8278185
+ * @summary Test non-ASCII path in custom JRE
+ * @library ../lib
+ *          /test/lib
+ * @modules java.base/jdk.internal.jimage
+ *          jdk.jdeps/com.sun.tools.classfile
+ *          jdk.jlink/jdk.tools.jimage
+ * @build tests.*
+ * @run main/othervm JImageNonAsciiNameTest
+ */
+
+public class JImageNonAsciiNameTest {
+    private final static String moduleName = "A_module";
+    private final static String packageName = "test.\u3042"; //non-ASCII
+    private final static String className = "A";
+    private final static String fullName = packageName + "." + className;
+    private static Helper helper;
+
+    public static void main(String[] args) throws Exception {
+        helper = Helper.newHelper();
+        if (helper == null) {
+            System.err.println("Test not run");
+            return;
+        }
+
+        String source =
+            "package "+packageName+";" +
+            "public class "+className+" {" +
+            "    public static void main(String[] args) {}" +
+            "}";
+        String moduleInfo = "module " + moduleName + " {}";
+
+        // Using InMemory features to avoid generating non-ASCII name file
+        byte[] byteA = InMemoryJavaCompiler.compile(fullName, source);
+        byte[] byteModule = InMemoryJavaCompiler.compile(
+                "module-info", moduleInfo);
+
+        Path jarDir = helper.getJarDir();
+        JarBuilder jb = new JarBuilder(
+                jarDir.resolve(moduleName + ".jar").toString());
+        jb.addEntry(fullName.replace(".","/") + ".class", byteA);
+        jb.addEntry("module-info.class", byteModule);
+        jb.build();
+
+        Path outDir = helper.createNewImageDir(moduleName);
+
+        Result result = JImageGenerator.getJLinkTask()
+                .modulePath(helper.defaultModulePath())
+                .output(outDir)
+                .addMods(moduleName)
+                .call();
+        Path testImage = result.assertSuccess();
+
+        BasicImageReader bir = BasicImageReader.open(
+                testImage.resolve("lib").resolve("modules"));
+        ImageLocation loc = bir.findLocation(moduleName,
+                fullName.replace(".","/") + ".class");
+        if (loc == null) {
+            throw new RuntimeException("Failed to find " +
+                    fullName + " in module " +moduleName);
+        }
+    }
+}


### PR DESCRIPTION
I'd like to backport this to jdk17 since it fixes jlink issue with non-ASCII named module. Fix is low risk and applies cleanly. tier1 and tier2 tests have no regression with the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278185](https://bugs.openjdk.java.net/browse/JDK-8278185): Custom JRE cannot find non-ASCII named module inside


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/177/head:pull/177` \
`$ git checkout pull/177`

Update a local copy of the PR: \
`$ git checkout pull/177` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 177`

View PR using the GUI difftool: \
`$ git pr show -t 177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/177.diff">https://git.openjdk.java.net/jdk17u-dev/pull/177.diff</a>

</details>
