### PR TITLE
8272866: java.util.random package summary contains incorrect mixing function in table

### DIFF
--- a/src/java.base/share/classes/java/util/random/package-info.java
+++ b/src/java.base/share/classes/java/util/random/package-info.java
@@ -599,32 +599,32 @@
  *       <td style="text-align:right">{@code 0xd1342543de82ef95L}</td>
  *       <td style="text-align:left">{@code xoroshiro128}, version 1.0</td>
  *       <td style="text-align:left">{@code (24, 16, 37)}</td>
- *       <td style="text-align:left">mixLea32{@code (s+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (s+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L64X256MixRandom"</td>
  *       <td style="text-align:right">{@code 0xd1342543de82ef95L}</td>
  *       <td style="text-align:left">{@code xoshiro256}, version 1.0</td>
  *       <td style="text-align:left">{@code (17, 45)}</td>
- *       <td style="text-align:left">mixLea32{@code (s+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (s+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L64X1024MixRandom"</td>
  *       <td style="text-align:right">{@code 0xd1342543de82ef95L}</td>
  *       <td style="text-align:left">{@code xoroshiro1024}, version 1.0</td>
  *       <td style="text-align:left">{@code (25, 27, 36)}</td>
- *       <td style="text-align:left">mixLea32{@code (s+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (s+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L128X128MixRandom"</td>
  *       <td style="text-align:right">{@code 0x1d605bbb58c8abbfdL}</td>
  *       <td style="text-align:left">{@code xoroshiro128}, version 1.0</td>
  *       <td style="text-align:left">{@code (24, 16, 37)}</td>
- *       <td style="text-align:left">mixLea32{@code (sh+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (sh+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L128X256MixRandom"</td>
  *       <td style="text-align:right">{@code 0x1d605bbb58c8abbfdL}</td>
  *       <td style="text-align:left">{@code xoshiro256}, version 1.0</td>
  *       <td style="text-align:left">{@code (17, 45)}</td>
- *       <td style="text-align:left">mixLea32{@code (sh+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (sh+x0)}</td></tr>
  *   <tr><td style="text-align:left">"L128X1024MixRandom"</td>
  *       <td style="text-align:right">{@code 0x1d605bbb58c8abbfdL}</td>
  *       <td style="text-align:left">{@code xoroshiro1024}, version 1.0</td>
  *       <td style="text-align:left">{@code (25, 27, 36)}</td>
- *       <td style="text-align:left">mixLea32{@code (sh+x0)}</td></tr>
+ *       <td style="text-align:left">mixLea64{@code (sh+x0)}</td></tr>
  * </tbody>
  * </table>
  *


### PR DESCRIPTION
Backporting as it was dedicated for backport to earlier releases but then slipped through.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8272866](https://bugs.openjdk.java.net/browse/JDK-8272866): java.util.random package summary contains incorrect mixing function in table
 * [JDK-8272988](https://bugs.openjdk.java.net/browse/JDK-8272988): java.util.random package summary contains incorrect mixing function in table (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/178/head:pull/178` \
`$ git checkout pull/178`

Update a local copy of the PR: \
`$ git checkout pull/178` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 178`

View PR using the GUI difftool: \
`$ git pr show -t 178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/178.diff">https://git.openjdk.java.net/jdk17u-dev/pull/178.diff</a>

</details>
