### PR TITLE
8277795: ldap connection timeout not honoured under contention

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClientFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClientFactory.java
@@ -65,7 +65,23 @@ final class LdapClientFactory implements PooledConnectionFactory {
                 connTimeout, readTimeout, trace, pcb);
     }
 
+    public PooledConnection createPooledConnection(PoolCallback pcb, long timeout)
+        throws NamingException {
+        return new LdapClient(host, port, socketFactory,
+                guardedIntegerCast(timeout),
+                readTimeout, trace, pcb);
+    }
+
     public String toString() {
         return host + ":" + port;
+    }
+
+    private int guardedIntegerCast(long timeout) {
+        if (timeout < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        } else if (timeout > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) timeout;
     }
 }

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/Pool.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/Pool.java
@@ -31,10 +31,13 @@ import java.util.WeakHashMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import java.io.PrintStream;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
+import javax.naming.CommunicationException;
 import javax.naming.NamingException;
 
 /**
@@ -117,44 +120,108 @@ public final class Pool {
     public PooledConnection getPooledConnection(Object id, long timeout,
         PooledConnectionFactory factory) throws NamingException {
 
+        final long start = System.nanoTime();
+        long remaining = timeout;
+
         d("get(): ", id);
         if (debug) {
             synchronized (map) {
                 d("size: ", map.size());
             }
+            remaining = checkRemaining(start, remaining);
         }
 
         expungeStaleConnections();
 
-        Connections conns;
-        synchronized (map) {
-            conns = getConnections(id);
-            if (conns == null) {
-                d("get(): creating new connections list for ", id);
+        Connections conns = getOrCreateConnections(factory, id);
+        d("get(): size after: ", map.size());
+        remaining = checkRemaining(start, remaining);
 
-                // No connections for this id so create a new list
-                conns = new Connections(id, initSize, prefSize, maxSize,
-                    factory);
-                ConnectionsRef connsRef = new ConnectionsRef(conns);
-                map.put(id, connsRef);
-
-                // Create a weak reference to ConnectionsRef
-                Reference<ConnectionsRef> weakRef =
-                        new ConnectionsWeakRef(connsRef, queue);
-
-                // Keep the weak reference through the element of a linked list
-                weakRefs.add(weakRef);
-            }
-            d("get(): size after: ", map.size());
+        if (!conns.grabLock(remaining)) {
+            throw new CommunicationException("Timed out waiting for lock");
         }
 
-        return conns.get(timeout, factory); // get one connection from list
+        try {
+            remaining = checkRemaining(start, remaining);
+            PooledConnection conn = null;
+            while (remaining > 0 && conn == null) {
+                conn = getOrCreatePooledConnection(factory, conns, start, remaining);
+                // don't loop if the timeout has expired
+                remaining = checkRemaining(start, timeout);
+            }
+            return conn;
+        } finally {
+            conns.unlock();
+        }
     }
 
-    private Connections getConnections(Object id) {
-        ConnectionsRef ref = map.get(id);
-        return (ref != null) ? ref.getConnections() : null;
+    private Connections getOrCreateConnections(PooledConnectionFactory factory, Object id)
+            throws NamingException {
+
+        Connections conns;
+        synchronized (map) {
+            ConnectionsRef ref = map.get(id);
+            if (ref != null) {
+                return ref.getConnections();
+            }
+
+            d("get(): creating new connections list for ", id);
+
+            // No connections for this id so create a new list
+            conns = new Connections(id, initSize, prefSize, maxSize,
+                    factory, new ReentrantLock());
+
+            ConnectionsRef connsRef = new ConnectionsRef(conns);
+            map.put(id, connsRef);
+
+            // Create a weak reference to ConnectionsRef
+            Reference<ConnectionsRef> weakRef = new ConnectionsWeakRef(connsRef, queue);
+
+            // Keep the weak reference through the element of a linked list
+            weakRefs.add(weakRef);
+        }
+        return conns;
     }
+
+    private PooledConnection getOrCreatePooledConnection(
+            PooledConnectionFactory factory, Connections conns, long start, long timeout)
+            throws NamingException {
+        PooledConnection conn = conns.getAvailableConnection(timeout);
+        if (conn != null) {
+            return conn;
+        }
+        // no available cached connection
+        // check if list size already at maxSize before creating a new one
+        conn = conns.createConnection(factory, timeout);
+        if (conn != null) {
+            return conn;
+        }
+        // max number of connections already created,
+        // try waiting around for one to become available
+        if (timeout <= 0) {
+            conns.waitForAvailableConnection();
+        } else {
+            long remaining = checkRemaining(start, timeout);
+            conns.waitForAvailableConnection(remaining);
+        }
+        return null;
+    }
+
+    // Check whether we timed out
+    private long checkRemaining(long start, long timeout) throws CommunicationException {
+        if (timeout > 0) {
+            long current = System.nanoTime();
+            long remaining = timeout - TimeUnit.NANOSECONDS.toMillis(current - start);
+            if (remaining <= 0) {
+                throw new CommunicationException(
+                        "Timeout exceeded while waiting for a connection: " +
+                                timeout + "ms");
+            }
+            return remaining;
+        }
+        return Long.MAX_VALUE;
+    }
+
 
     /**
      * Goes through the connections in this Pool and expires ones that

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/pool/PooledConnectionFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/pool/PooledConnectionFactory.java
@@ -44,4 +44,13 @@ public interface PooledConnectionFactory {
      */
     public abstract PooledConnection createPooledConnection(PoolCallback pcb)
         throws NamingException;
+
+    /**
+     * Creates a pooled connection.
+     * @param pcb callback responsible for removing and releasing the pooled
+     * connection from the pool.
+     * @param timeout the connection timeout
+     */
+    public abstract PooledConnection createPooledConnection(PoolCallback pcb, long timeout)
+        throws NamingException;
 };

--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277795
+ * @summary Multi-threaded client timeout tests for ldap pool
+ * @library /test/lib
+ *          lib/
+ * @run testng/othervm LdapPoolTimeoutTest
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
+
+import static jdk.test.lib.Utils.adjustTimeout;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class LdapPoolTimeoutTest {
+    /*
+     * Practical representation of an infinite timeout.
+     */
+    private static final long INFINITY_MILLIS = adjustTimeout(20_000);
+    /*
+     * The acceptable variation in timeout measurements.
+     */
+    private static final long TOLERANCE       = adjustTimeout( 3_500);
+
+    private static final long CONNECT_MILLIS  = adjustTimeout( 3_000);
+    private static final long READ_MILLIS     = adjustTimeout(10_000);
+
+    static {
+        // a series of checks to make sure this timeouts configuration is
+        // consistent and the timeouts do not overlap
+
+        assert (TOLERANCE >= 0);
+        // context creation
+        assert (2 * CONNECT_MILLIS + TOLERANCE < READ_MILLIS);
+        // context creation immediately followed by search
+        assert (2 * CONNECT_MILLIS + READ_MILLIS + TOLERANCE < INFINITY_MILLIS);
+    }
+
+    @Test
+    public void test() throws Exception {
+        List<Future<?>> futures = new ArrayList<>();
+        ExecutorService executorService = Executors.newCachedThreadPool();
+
+        Hashtable<Object, Object> env = new Hashtable<>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put("com.sun.jndi.ldap.read.timeout", String.valueOf(READ_MILLIS));
+        env.put("com.sun.jndi.ldap.connect.timeout", String.valueOf(CONNECT_MILLIS));
+        env.put("com.sun.jndi.ldap.connect.pool", "true");
+        env.put(Context.PROVIDER_URL, "ldap://example.com:1234");
+
+        try {
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+            futures.add(executorService.submit(() -> { attemptConnect(env); return null; }));
+        } finally {
+            executorService.shutdown();
+        }
+        int failedCount = 0;
+        for (var f : futures) {
+            try {
+                f.get();
+            } catch (ExecutionException e) {
+                failedCount++;
+                e.getCause().printStackTrace(System.out);
+            }
+        }
+        if (failedCount > 0)
+            throw new RuntimeException(failedCount + " (sub)tests failed");
+    }
+
+    private static void attemptConnect(Hashtable<Object, Object> env) throws Exception {
+        try {
+            LdapTimeoutTest.assertCompletion(CONNECT_MILLIS - 1000,
+                   2 * CONNECT_MILLIS + TOLERANCE,
+                   () -> new InitialDirContext(env));
+        } catch (RuntimeException e) {
+            String msg = e.getCause() == null ? e.getMessage() : e.getCause().getMessage();
+            System.err.println("MSG RTE: " + msg);
+            // assertCompletion may wrap a CommunicationException in an RTE
+            assertTrue(msg != null && msg.contains("Network is unreachable"));
+        } catch (NamingException ex) {
+            String msg = ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage();
+            System.err.println("MSG: " + msg);
+            assertTrue(msg != null &&
+                    (msg.contains("Network is unreachable")
+                        || msg.contains("Timed out waiting for lock")
+                        || msg.contains("Connect timed out")
+                        || msg.contains("Timeout exceeded while waiting for a connection")));
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+}
+


### PR DESCRIPTION
I backport this for parity with 17.0.3-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8277795](https://bugs.openjdk.java.net/browse/JDK-8277795): ldap connection timeout not honoured under contention
 * [JDK-8280829](https://bugs.openjdk.java.net/browse/JDK-8280829): ldap connection timeout not honoured under contention (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/180/head:pull/180` \
`$ git checkout pull/180`

Update a local copy of the PR: \
`$ git checkout pull/180` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 180`

View PR using the GUI difftool: \
`$ git pr show -t 180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/180.diff">https://git.openjdk.java.net/jdk17u-dev/pull/180.diff</a>

</details>
