### PR TITLE
8275854: C2: assert(stride_con != 0) failed: missed some peephole opt

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1721,6 +1721,16 @@ Node* IfProjNode::Identity(PhaseGVN* phase) {
        // will cause this node to be reprocessed once the dead branch is killed.
        in(0)->outcnt() == 1))) {
     // IfNode control
+    if (in(0)->is_BaseCountedLoopEnd()) {
+      // CountedLoopEndNode may be eliminated by if subsuming, replace CountedLoopNode with LoopNode to
+      // avoid mismatching between CountedLoopNode and CountedLoopEndNode in the following optimization.
+      Node* head = unique_ctrl_out();
+      if (head != NULL && head->is_BaseCountedLoop() && head->in(LoopNode::LoopBackControl) == this) {
+        Node* new_head = new LoopNode(head->in(LoopNode::EntryControl), this);
+        phase->is_IterGVN()->register_new_node_with_optimizer(new_head);
+        phase->is_IterGVN()->replace_node(head, new_head);
+      }
+    }
     return in(0)->in(0);
   }
   // no progress

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopEndNodeEliminate.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopEndNodeEliminate.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8275854
+ * @summary Crashes in PhaseIdealLoop::transform_long_counted_loop
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,TestLoopEndNodeEliminate::lMeth TestLoopEndNodeEliminate
+ *
+ */
+
+public class TestLoopEndNodeEliminate {
+     public volatile boolean bFld=true;
+     public volatile byte byFld=0;
+     public volatile short sArrFld[]=new short[N];
+     public int iArrFld[]=new int[N];
+     public boolean bArrFld[]=new boolean[N];
+
+     public static int iFld=10;
+     public static final int N = 400;
+     public static long instanceCount=0L;
+     public static long lMeth_check_sum = 0;
+
+     public long lMeth() {
+         long l1=-33582180L;
+         int i14=-5, i15=-14, i16=0, i17=25699, i18=97, i19=-3, i20=0, i21=0, i22=42, i23=0, i24=25699, i25=97;
+
+         for (l1 = 286; l1 > 16; l1 -= 3) {
+             for (i15 = 17; i15 > l1; --i15) {
+                 switch (((iArrFld[i15] >>> 1) % 7) + 101) {
+                 case 101:
+                 case 102:
+                 case 103:
+                 case 104:
+                     for (i17 = (int)(l1); i17 < 1; i17++) {
+                         bArrFld[i17] = bFld;
+                     }
+                     break;
+                 case 105:
+                 case 106:
+                 case 107:
+                 }
+             }
+             for (i19 = 1; i19 < 270; ++i19) {
+                 TestLoopEndNodeEliminate.iFld += byFld;
+                 i21 = 1;
+                 while (++i21 < 2) {
+                     bFld = true;
+                 }
+                 for (i22 = 1; 2 > i22; ++i22) {
+                     bFld = true;
+                 }
+                 for (i24 = 1; 2 > i24; ++i24) {
+                     bFld = true;
+                 }
+                 bArrFld[(int)(l1) % N] = bFld;
+                 sArrFld[i19 - 1] ^= (short)(++TestLoopEndNodeEliminate.instanceCount);
+             }
+         }
+         long meth_res = l1 + i14 + i15 + i16 + i17 + i18 + i19 + i20 + i21 + i22 + i23 + i24 + i25;
+         lMeth_check_sum += meth_res;
+         return (long)meth_res;
+     }
+
+     public static void main(String[] strArr) {
+        TestLoopEndNodeEliminate _instance = new TestLoopEndNodeEliminate();
+        for (int i = 0; i < 10000; i++ ) {
+            _instance.lMeth();
+        }
+     }
+}


### PR DESCRIPTION
Clean backport of JDK-8275854.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275854](https://bugs.openjdk.java.net/browse/JDK-8275854): C2: assert(stride_con != 0) failed: missed some peephole opt


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/185.diff">https://git.openjdk.java.net/jdk17u-dev/pull/185.diff</a>

</details>
