### PR TITLE
8277906: Incorrect type for IV phi of long counted loops after CCP

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1510,13 +1510,13 @@ void PhaseIterGVN::add_users_to_worklist0( Node *n ) {
 
 // Return counted loop Phi if as a counted loop exit condition, cmp
 // compares the the induction variable with n
-static PhiNode* countedloop_phi_from_cmp(CmpINode* cmp, Node* n) {
+static PhiNode* countedloop_phi_from_cmp(CmpNode* cmp, Node* n) {
   for (DUIterator_Fast imax, i = cmp->fast_outs(imax); i < imax; i++) {
     Node* bol = cmp->fast_out(i);
     for (DUIterator_Fast i2max, i2 = bol->fast_outs(i2max); i2 < i2max; i2++) {
       Node* iff = bol->fast_out(i2);
-      if (iff->is_CountedLoopEnd()) {
-        CountedLoopEndNode* cle = iff->as_CountedLoopEnd();
+      if (iff->is_BaseCountedLoopEnd()) {
+        BaseCountedLoopEndNode* cle = iff->as_BaseCountedLoopEnd();
         if (cle->limit() == n) {
           PhiNode* phi = cle->phi();
           if (phi != NULL) {
@@ -1834,8 +1834,8 @@ void PhaseCCP::analyze() {
         // If n is used in a counted loop exit condition then the type
         // of the counted loop's Phi depends on the type of n. See
         // PhiNode::Value().
-        if (m_op == Op_CmpI) {
-          PhiNode* phi = countedloop_phi_from_cmp((CmpINode*)m, n);
+        if (m_op == Op_CmpI || m_op == Op_CmpL) {
+          PhiNode* phi = countedloop_phi_from_cmp(m->as_Cmp(), n);
           if (phi != NULL) {
             worklist.push(phi);
           }

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestIVPhiTypeIncorrectAfterCCP.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestIVPhiTypeIncorrectAfterCCP.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8277906
+ * @summary Incorrect type for IV phi of long counted loops after CCP
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestIVPhiTypeIncorrectAfterCCP::test -XX:-BackgroundCompilation TestIVPhiTypeIncorrectAfterCCP
+ *
+ */
+
+public class TestIVPhiTypeIncorrectAfterCCP {
+
+    static int test() {
+        int array[] = new int[50];
+
+        float f = 0;
+        for (int i = 3; i < 49; i++) {
+            for (long l = 1; l < i; l++) {
+                array[(int)l] = i;
+                f += l;
+            }
+        }
+        int sum = 0;
+        for (int i = 0; i < array.length; i++) {
+            sum += array[i];
+        }
+        return sum;
+    }
+
+    public static void main(String[] args) {
+        long expected = test();
+        for (int i = 0; i < 10_000; i++) {
+            int res = test();
+            if (res != expected) {
+                throw new RuntimeException("Unexpected result: " + res + " != " + expected);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of JDK-8277906.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277906](https://bugs.openjdk.java.net/browse/JDK-8277906): Incorrect type for IV phi of long counted loops after CCP


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/187/head:pull/187` \
`$ git checkout pull/187`

Update a local copy of the PR: \
`$ git checkout pull/187` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 187`

View PR using the GUI difftool: \
`$ git pr show -t 187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/187.diff">https://git.openjdk.java.net/jdk17u-dev/pull/187.diff</a>

</details>
