### PR TITLE
8274855: vectorapi tests failing with assert(!vbox->is_Phi()) failed

### DIFF
--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -315,6 +315,21 @@ Node* PhaseVector::expand_vbox_node_helper(Node* vbox,
     }
     new_phi = C->initial_gvn()->transform(new_phi);
     return new_phi;
+  } else if (vbox->is_Phi() && (vect->is_Vector() || vect->is_LoadVector())) {
+    // Handle the case when the allocation input to VectorBoxNode is a phi
+    // but the vector input is not, which can definitely be the case if the
+    // vector input has been value-numbered. It seems to be safe to do by
+    // construction because VectorBoxNode and VectorBoxAllocate come in a
+    // specific order as a result of expanding an intrinsic call. After that, if
+    // any of the inputs to VectorBoxNode are value-numbered they can only
+    // move up and are guaranteed to dominate.
+    Node* new_phi = new PhiNode(vbox->as_Phi()->region(), box_type);
+    for (uint i = 1; i < vbox->req(); i++) {
+      Node* new_box = expand_vbox_node_helper(vbox->in(i), vect, box_type, vect_type);
+      new_phi->set_req(i, new_box);
+    }
+    new_phi = C->initial_gvn()->transform(new_phi);
+    return new_phi;
   } else if (vbox->is_Proj() && vbox->in(0)->Opcode() == Op_VectorBoxAllocate) {
     VectorBoxAllocateNode* vbox_alloc = static_cast<VectorBoxAllocateNode*>(vbox->in(0));
     return expand_vbox_alloc_node(vbox_alloc, vect, box_type, vect_type);


### PR DESCRIPTION
Basically clean backport of JDK-8274855. Removal from ProblemList does not apply because vectorapi tests are not problem listed in 17 (JDK-8274920 not in 17).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274855](https://bugs.openjdk.java.net/browse/JDK-8274855): vectorapi tests failing with assert(!vbox->is_Phi()) failed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/193/head:pull/193` \
`$ git checkout pull/193`

Update a local copy of the PR: \
`$ git checkout pull/193` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 193`

View PR using the GUI difftool: \
`$ git pr show -t 193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/193.diff">https://git.openjdk.java.net/jdk17u-dev/pull/193.diff</a>

</details>
