### PR TITLE
8275830: C2: Receiver downcast is missing when inlining through method handle linkers

### DIFF
--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,13 +67,17 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
                                        JVMState* jvms, bool allow_inline,
                                        float prof_factor, ciKlass* speculative_receiver_type,
                                        bool allow_intrinsics) {
-  ciMethod*       caller   = jvms->method();
-  int             bci      = jvms->bci();
-  Bytecodes::Code bytecode = caller->java_code_at_bci(bci);
-  guarantee(callee != NULL, "failed method resolution");
+  assert(callee != NULL, "failed method resolution");
+
+  ciMethod*       caller      = jvms->method();
+  int             bci         = jvms->bci();
+  Bytecodes::Code bytecode    = caller->java_code_at_bci(bci);
+  ciMethod*       orig_callee = caller->get_method_at_bci(bci);
 
   const bool is_virtual_or_interface = (bytecode == Bytecodes::_invokevirtual) ||
-                                       (bytecode == Bytecodes::_invokeinterface);
+                                       (bytecode == Bytecodes::_invokeinterface) ||
+                                       (orig_callee->intrinsic_id() == vmIntrinsics::_linkToVirtual) ||
+                                       (orig_callee->intrinsic_id() == vmIntrinsics::_linkToInterface);
 
   // Dtrace currently doesn't work unless all calls are vanilla
   if (env()->dtrace_method_probes()) {


### PR DESCRIPTION
Clean Backport of JDK-8275830.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275830](https://bugs.openjdk.java.net/browse/JDK-8275830): C2: Receiver downcast is missing when inlining through method handle linkers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/197/head:pull/197` \
`$ git checkout pull/197`

Update a local copy of the PR: \
`$ git checkout pull/197` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 197`

View PR using the GUI difftool: \
`$ git pr show -t 197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/197.diff">https://git.openjdk.java.net/jdk17u-dev/pull/197.diff</a>

</details>
