### PR TITLE
8278966: two microbenchmarks tests fail "assert(!jvms->method()->has_exception_handlers()) failed: no exception handler expected" after JDK-8275638

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -420,7 +420,9 @@ bool LateInlineMHCallGenerator::do_late_inline_check(Compile* C, JVMState* jvms)
   // expression stacks which causes late inlining to break. The MH invoker is not expected to be called from a method wih
   // exception handlers. When there is no exception handler, GraphKit::builtin_throw() pops the stack which solves the issue
   // of late inlining with exceptions.
-  assert(!jvms->method()->has_exception_handlers(), "no exception handler expected");
+  assert(!jvms->method()->has_exception_handlers() ||
+         (method()->intrinsic_id() != vmIntrinsics::_linkToVirtual &&
+          method()->intrinsic_id() != vmIntrinsics::_linkToInterface), "no exception handler expected");
   // Even if inlining is not allowed, a virtual call can be strength-reduced to a direct call.
   bool allow_inline = C->inlining_incrementally();
   bool input_not_const = true;


### PR DESCRIPTION
Clean Backport of JDK-8278966 on top of JDK-8275638.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278966](https://bugs.openjdk.java.net/browse/JDK-8278966): two microbenchmarks tests fail "assert(!jvms->method()->has_exception_handlers()) failed: no exception handler expected" after JDK-8275638


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/201/head:pull/201` \
`$ git checkout pull/201`

Update a local copy of the PR: \
`$ git checkout pull/201` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 201`

View PR using the GUI difftool: \
`$ git pr show -t 201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/201.diff">https://git.openjdk.java.net/jdk17u-dev/pull/201.diff</a>

</details>
