### PR TITLE
8275745: Reproducible copyright headers

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -356,6 +356,14 @@ AC_DEFUN_ONCE([BASIC_SETUP_COMPLEX_TOOLS],
   fi
   AC_SUBST(IS_GNU_TIME)
 
+  # Check if it's GNU date
+  check_date=`$DATE --version 2>&1 | $GREP GNU`
+  if test "x$check_date" != x; then
+    IS_GNU_DATE=yes
+  else
+    IS_GNU_DATE=no
+  fi
+
   if test "x$OPENJDK_TARGET_OS" = "xmacosx"; then
     UTIL_REQUIRE_PROGS(DSYMUTIL, dsymutil)
     UTIL_REQUIRE_PROGS(MIG, mig)

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -216,6 +216,12 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
     AC_MSG_ERROR([Copyright year must have a value])
   elif test "x$with_copyright_year" != x; then
     COPYRIGHT_YEAR="$with_copyright_year"
+  elif test "x$SOURCE_DATE_EPOCH" != x; then
+    if test "x$IS_GNU_DATE" = xyes; then
+      COPYRIGHT_YEAR=`date --date=@$SOURCE_DATE_EPOCH +%Y`
+    else
+      COPYRIGHT_YEAR=`date -j -f %s $SOURCE_DATE_EPOCH +%Y`
+    fi
   else
     COPYRIGHT_YEAR=`$DATE +'%Y'`
   fi

--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -114,6 +114,7 @@ public class CLDRConverter {
         ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_DEFAULT);
 
     private static Set<String> AVAILABLE_TZIDS;
+    static int copyrightYear;
     private static String zoneNameTempFile;
     private static String tzDataDir;
     private static final Map<String, String> canonicalTZMap = new HashMap<>();
@@ -217,6 +218,10 @@ public class CLDRConverter {
                         verbose = true;
                         break;
 
+                    case "-year":
+                        copyrightYear = Integer.parseInt(args[++i]);
+                        break;
+
                     case "-zntempfile":
                         zoneNameTempFile = args[++i];
                         break;
@@ -235,7 +240,7 @@ public class CLDRConverter {
                     }
                 }
             } catch (RuntimeException e) {
-                severe("unknown or imcomplete arg(s): " + currentArg);
+                severe("unknown or incomplete arg(s): " + currentArg);
                 usage();
                 System.exit(1);
             }
@@ -258,6 +263,10 @@ public class CLDRConverter {
 
         if (BASE_LOCALES.isEmpty()) {
             setupBaseLocales("en-US");
+        }
+
+        if (copyrightYear == 0) {
+            copyrightYear = ZonedDateTime.now(ZoneId.of("America/Los_Angeles")).getYear();
         }
 
         bundleGenerator = new ResourceBundleGenerator();
@@ -292,6 +301,7 @@ public class CLDRConverter {
                 + "\t-basemodule    generates bundles that go into java.base module%n"
                 + "\t-baselocales loc(,loc)*      locales that go into the base module%n"
                 + "\t-o dir         output directory (default: ./build/gensrc)%n"
+                + "\t-year year     copyright year in output%n"
                 + "\t-zntempfile    template file for java.time.format.ZoneName.java%n"
                 + "\t-tzdatadir     tzdata directory for java.time.format.ZoneName.java%n"
                 + "\t-utf8          use UTF-8 rather than \\uxxxx (for debug)%n");

--- a/make/jdk/src/classes/build/tools/cldrconverter/CopyrightHeaders.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CopyrightHeaders.java
@@ -26,6 +26,7 @@
 package build.tools.cldrconverter;
 
 import java.util.Calendar;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -131,8 +132,7 @@ class CopyrightHeaders {
         " * questions.\n" +
         " */\n";
 
-    static String getOracleCopyright() {
-        int year = getYear();
+    static String getOracleCopyright(int year) {
         return String.format(year > 2012 ? ORACLE_AFTER2012 : ORACLE2012, year);
     }
 
@@ -140,14 +140,8 @@ class CopyrightHeaders {
         return UNICODE;
     }
 
-    static String getOpenJDKCopyright() {
-        int year = getYear();
+    static String getOpenJDKCopyright(int year) {
         return String.format(year > 2012 ? OPENJDK_AFTER2012 : OPENJDK2012, year);
-    }
-
-    private static int getYear() {
-        return new GregorianCalendar(TimeZone.getTimeZone("America/Los_Angeles"),
-                                         Locale.US).get(Calendar.YEAR);
     }
 
     // no instantiation

--- a/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
@@ -198,7 +198,7 @@ class ResourceBundleGenerator implements BundleGenerator {
 
         try (PrintWriter out = new PrintWriter(file, encoding)) {
             // Output copyright headers
-            out.println(CopyrightHeaders.getOpenJDKCopyright());
+            out.println(CopyrightHeaders.getOpenJDKCopyright(CLDRConverter.copyrightYear));
             out.println(CopyrightHeaders.getUnicodeCopyright());
 
             if (useJava) {
@@ -266,7 +266,7 @@ class ResourceBundleGenerator implements BundleGenerator {
         CLDRConverter.info("Generating file " + file);
 
         try (PrintWriter out = new PrintWriter(file, "us-ascii")) {
-            out.printf(CopyrightHeaders.getOpenJDKCopyright());
+            out.printf(CopyrightHeaders.getOpenJDKCopyright(CLDRConverter.copyrightYear));
 
             out.printf((CLDRConverter.isBaseModule ? "package sun.util.cldr;\n\n" :
                                   "package sun.util.resources.cldr.provider;\n\n")

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -30,13 +30,15 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -52,17 +54,19 @@ import java.util.stream.Collectors;
 public class EquivMapsGenerator {
 
     public static void main(String[] args) throws Exception {
-        if (args.length != 2) {
+        if (args.length != 3) {
             System.err.println("Usage: java EquivMapsGenerator"
-                    + " language-subtag-registry.txt LocaleEquivalentMaps.java");
+                    + " language-subtag-registry.txt LocaleEquivalentMaps.java copyrightYear");
             System.exit(1);
         }
+        copyrightYear = Integer.parseInt(args[2]);
         readLSRfile(args[0]);
         generateEquivalentMap();
         generateSourceCode(args[1]);
     }
 
     private static String LSRrevisionDate;
+    private static int copyrightYear;
     private static Map<String, StringBuilder> initialLanguageMap =
         new TreeMap<>();
     private static Map<String, StringBuilder> initialRegionVariantMap =
@@ -246,9 +250,7 @@ public class EquivMapsGenerator {
         + "}";
 
     private static String getOpenJDKCopyright() {
-        int year = ZonedDateTime.now(ZoneId
-                .of("America/Los_Angeles")).getYear();
-        return String.format(Locale.US, COPYRIGHT, year);
+        return String.format(Locale.US, COPYRIGHT, copyrightYear);
     }
 
     /**

--- a/make/modules/java.base/Gensrc.gmk
+++ b/make/modules/java.base/Gensrc.gmk
@@ -62,6 +62,7 @@ $(CLDR_GEN_DONE): $(wildcard $(CLDR_DATA_DIR)/dtd/*.dtd) \
 	    -baselocales "en-US" \
 	    -o $(GENSRC_DIR) \
 	    -basemodule \
+	    -year $(COPYRIGHT_YEAR) \
 	    -zntempfile $(ZONENAME_TEMPLATE) \
 	    -tzdatadir $(TZ_DATA_DIR))
 	$(TOUCH) $@
@@ -99,7 +100,7 @@ GENSRC_LSREQUIVMAPS := $(SUPPORT_OUTPUTDIR)/gensrc/java.base/sun/util/locale/Loc
 
 $(GENSRC_LSREQUIVMAPS): $(TOPDIR)/make/data/lsrdata/language-subtag-registry.txt $(BUILD_TOOLS_JDK)
 	$(call MakeDir, $(@D))
-	$(TOOL_GENERATELSREQUIVMAPS) $< $@
+	$(TOOL_GENERATELSREQUIVMAPS) $< $@ $(COPYRIGHT_YEAR)
 
 TARGETS += $(GENSRC_LSREQUIVMAPS)
 

--- a/make/modules/jdk.localedata/Gensrc.gmk
+++ b/make/modules/jdk.localedata/Gensrc.gmk
@@ -46,6 +46,7 @@ $(CLDR_GEN_DONE): $(wildcard $(CLDR_DATA_DIR)/dtd/*.dtd) \
 	$(call ExecuteWithLog, $@, \
 	    $(TOOL_CLDRCONVERTER) -base $(CLDR_DATA_DIR) \
 	    -baselocales "en-US" \
+	    -year $(COPYRIGHT_YEAR) \
 	    -o $(GENSRC_DIR))
 	$(TOUCH) $@
 


### PR DESCRIPTION
The copyright headers are generated at build time, and the year inserted in the template depends on the current date. This means the headers are not reproducible if the project is built a year later. This PR uses the year derived from the SOURCE_DATE_EPOCH environment variable to make the build reproducible (this variable is already used in other parts of the build).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275745](https://bugs.openjdk.java.net/browse/JDK-8275745): Reproducible copyright headers


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/206/head:pull/206` \
`$ git checkout pull/206`

Update a local copy of the PR: \
`$ git checkout pull/206` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 206`

View PR using the GUI difftool: \
`$ git pr show -t 206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/206.diff">https://git.openjdk.java.net/jdk17u-dev/pull/206.diff</a>

</details>
