### PR TITLE
8269129: Multiple tier1 tests in hotspot/jtreg/compiler are failing for client VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/arraycopy/TestCloneAccess.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestCloneAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
  * @test
  * @bug 8248791
  * @summary Test cloning with more than 8 (=ArrayCopyLoadStoreMaxElem) where loads are wrongly replaced by zero.
+ * @requires vm.compiler2.enabled | vm.graal.enabled
+ *
  * @run main/othervm -XX:-ReduceBulkZeroing
  *                   -XX:CompileCommand=dontinline,compiler.arraycopy.TestCloneAccess::*
  *                   compiler.arraycopy.TestCloneAccess

--- a/test/hotspot/jtreg/compiler/arraycopy/TestCloneAccessStressGCM.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestCloneAccessStressGCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @bug 8235332 8248226
  * @summary Test cloning with more than 8 (=ArrayCopyLoadStoreMaxElem) fields with StressGCM
  * @library /
+ * @requires vm.compiler2.enabled | vm.graal.enabled
  *
  * @run main/othervm -Xbatch
  *                   -XX:CompileCommand=dontinline,compiler.arraycopy.TestCloneAccessStressGCM::test

--- a/test/hotspot/jtreg/compiler/c2/TestJumpTable.java
+++ b/test/hotspot/jtreg/compiler/c2/TestJumpTable.java
@@ -25,6 +25,8 @@
  * @test
  * @bug 8229855 8238812
  * @summary Test jump table with key value that gets out of bounds after loop unrolling.
+ * @requires vm.compiler2.enabled
+ *
  * @run main/othervm -XX:CompileCommand=dontinline,compiler.c2.TestJumpTable::test*
  *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:-UseSwitchProfiling
  *                   compiler.c2.TestJumpTable

--- a/test/hotspot/jtreg/compiler/c2/TestReplaceEquivPhis.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReplaceEquivPhis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8243670
  * @summary Unexpected test result caused by C2 MergeMemNode::Ideal
+ * @requires vm.compiler2.enabled
  *
  * @run main/othervm -Xcomp -XX:-SplitIfBlocks
  *      -XX:CompileOnly=compiler.c2.TestReplaceEquivPhis::test

--- a/test/hotspot/jtreg/compiler/c2/TestShiftRightAndAccumulate.java
+++ b/test/hotspot/jtreg/compiler/c2/TestShiftRightAndAccumulate.java
@@ -25,8 +25,17 @@
  * @test
  * @bug 8260585
  * @summary AArch64: Wrong code generated for shifting right and accumulating four unsigned short integers.
+ *
  * @run main/othervm compiler.c2.TestShiftRightAndAccumulate
  * @run main/othervm -Xcomp compiler.c2.TestShiftRightAndAccumulate
+ */
+
+/**
+ * @test
+ * @bug 8260585
+ * @summary AArch64: Wrong code generated for shifting right and accumulating four unsigned short integers.
+ * @requires vm.compiler2.enabled
+ *
  * @run main/othervm -XX:-SuperWordLoopUnrollAnalysis compiler.c2.TestShiftRightAndAccumulate
  */
 

--- a/test/hotspot/jtreg/compiler/codegen/ClearArrayTest.java
+++ b/test/hotspot/jtreg/compiler/codegen/ClearArrayTest.java
@@ -25,7 +25,10 @@
  * @test
  * @bug 8260716
  * @summary Test for correct code generation by the JIT
- * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,*ClearArrayTest.test -XX:+UnlockDiagnosticVMOptions -XX:-IdealizeClearArrayNode compiler.codegen.ClearArrayTest
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,*ClearArrayTest.test
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:-IdealizeClearArrayNode
+ *                   compiler.codegen.ClearArrayTest
  */
 
 package compiler.codegen;


### PR DESCRIPTION
Clean backport of [JDK-8269129](https://bugs.openjdk.java.net/browse/JDK-8269129)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269129](https://bugs.openjdk.java.net/browse/JDK-8269129): Multiple tier1 tests in hotspot/jtreg/compiler are failing for client VMs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/207/head:pull/207` \
`$ git checkout pull/207`

Update a local copy of the PR: \
`$ git checkout pull/207` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 207`

View PR using the GUI difftool: \
`$ git pr show -t 207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/207.diff">https://git.openjdk.java.net/jdk17u-dev/pull/207.diff</a>

</details>
