### PR TITLE
8268906: gc/g1/mixedgc/TestOldGenCollectionUsage.java assumes that GCs take 1ms minimum

### DIFF
--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
@@ -139,8 +139,8 @@ public class TestOldGenCollectionUsage {
         if (newCollectionCount <= collectionCount) {
             throw new RuntimeException("No new collection");
         }
-        if (newCollectionTime <= collectionTime) {
-            throw new RuntimeException("Collector has not run some more");
+        if (newCollectionTime < collectionTime) {
+            throw new RuntimeException("Collection time ran backwards");
         }
 
         System.out.println("Test passed.");


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268906](https://bugs.openjdk.java.net/browse/JDK-8268906): gc/g1/mixedgc/TestOldGenCollectionUsage.java assumes that GCs take 1ms minimum


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/212/head:pull/212` \
`$ git checkout pull/212`

Update a local copy of the PR: \
`$ git checkout pull/212` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 212`

View PR using the GUI difftool: \
`$ git pr show -t 212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/212.diff">https://git.openjdk.java.net/jdk17u-dev/pull/212.diff</a>

</details>
