### PR TITLE
8269135: TestDifferentProtectionDomains runs into timeout in client VM

### DIFF
--- a/test/hotspot/jtreg/runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java
+++ b/test/hotspot/jtreg/runtime/Nestmates/protectionDomain/TestDifferentProtectionDomains.java
@@ -29,7 +29,8 @@
  *          perform a nestmate access check.
  * @comment We use WB to force-compile a constructor to recreate the original
  *          failure scenario, so only run when we have "normal" compiler flags.
- * @requires vm.compMode=="Xmixed" &
+ * @requires vm.compMode == "Xmixed" &
+ *           vm.compiler2.enabled &
  *           (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @library /test/lib /
  * @build sun.hotspot.WhiteBox
@@ -110,7 +111,9 @@ public class TestDifferentProtectionDomains {
 
         // Force the constructor to compile, which then triggers the nestmate
         // access check in the compiler thread, which leads to the original bug.
-        wb.enqueueMethodForCompilation(cons,  CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+        if (!wb.enqueueMethodForCompilation(cons, CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION)) {
+            throw new RuntimeException("Failed to queue constructor for compilation");
+        }
         while (!wb.isMethodCompiled(cons)) {
             Thread.sleep(100);
         }


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269135](https://bugs.openjdk.java.net/browse/JDK-8269135): TestDifferentProtectionDomains runs into timeout in client VM


### Reviewers
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/213/head:pull/213` \
`$ git checkout pull/213`

Update a local copy of the PR: \
`$ git checkout pull/213` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 213`

View PR using the GUI difftool: \
`$ git pr show -t 213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/213.diff">https://git.openjdk.java.net/jdk17u-dev/pull/213.diff</a>

</details>
