### PR TITLE
8270021: Incorrect log decorators in gc/g1/plab/TestPLABEvacuationFailure.java

### DIFF
--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
@@ -68,7 +68,7 @@ public class TestPLABEvacuationFailure {
             "failure wasted"));
 
     private static final String[] COMMON_OPTIONS = {
-        "-Xlog:gc=debug,gc+phases=trace",
+        "-Xlog:gc,gc+plab=debug",
         "-XX:+UseG1GC",
         "-XX:InitiatingHeapOccupancyPercent=100",
         "-XX:-G1UseAdaptiveIHOP",

--- a/test/hotspot/jtreg/gc/g1/plab/lib/LogParser.java
+++ b/test/hotspot/jtreg/gc/g1/plab/lib/LogParser.java
@@ -190,13 +190,17 @@ final public class LogParser {
     }
 
     private Map<Long, PlabInfo> getSpecifiedStats(List<Long> gcIds, LogParser.ReportType type, List<String> fieldNames, boolean extractId) {
-        return new HashMap<>(
-                getEntries().entryStream()
-                .filter(gcLogItem -> extractId == gcIds.contains(gcLogItem.getKey()))
-                .collect(Collectors.toMap(gcLogItem -> gcLogItem.getKey(),
-                                gcLogItem -> gcLogItem.getValue().get(type).filter(fieldNames)
+        var map = new HashMap<>(
+                        getEntries().entryStream()
+                        .filter(gcLogItem -> extractId == gcIds.contains(gcLogItem.getKey()))
+                        .collect(Collectors.toMap(gcLogItem -> gcLogItem.getKey(),
+                                        gcLogItem -> gcLogItem.getValue().get(type).filter(fieldNames)
+                                )
                         )
-                )
-        );
+                 );
+        if (map.isEmpty()) {
+            throw new RuntimeException("Cannot find relevant PLAB statistics in the log");
+        }
+        return map;
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270021](https://bugs.openjdk.java.net/browse/JDK-8270021): Incorrect log decorators in gc/g1/plab/TestPLABEvacuationFailure.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/215.diff">https://git.openjdk.java.net/jdk17u-dev/pull/215.diff</a>

</details>
