### PR TITLE
8272169: runtime/logging/LoaderConstraintsTest.java doesn't build test.Empty

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/LoaderConstraintsTest.java
@@ -27,6 +27,7 @@
  * @bug 8149996
  * @modules java.base/jdk.internal.misc
  * @library /test/lib classes
+ * @build test.Empty
  * @run driver LoaderConstraintsTest
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272169](https://bugs.openjdk.java.net/browse/JDK-8272169): runtime/logging/LoaderConstraintsTest.java doesn't build test.Empty


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/221.diff">https://git.openjdk.java.net/jdk17u-dev/pull/221.diff</a>

</details>
