### PR TITLE
8272146: Disable Fibonacci test on memory constrained systems

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/Fibonacci.java
+++ b/test/hotspot/jtreg/runtime/Thread/Fibonacci.java
@@ -28,6 +28,7 @@
  *     This test is skipped on 32-bit Windows: limited virtual space on Win-32
  *     make this test inherently unstable on Windows with 32-bit VM data model.
  * @requires !(os.family == "windows" & sun.arch.data.model == "32")
+ * @requires !(os.family == "linux" & os.maxMemory < 512M)
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run main/othervm Fibonacci 15


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272146](https://bugs.openjdk.java.net/browse/JDK-8272146): Disable Fibonacci test on memory constrained systems


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/222.diff">https://git.openjdk.java.net/jdk17u-dev/pull/222.diff</a>

</details>
