### PR TITLE
8268558: [TESTBUG] Case 2 in TestP11KeyFactoryGetRSAKeySpec is skipped

### DIFF
--- a/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
+++ b/test/jdk/sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Amazon.com, Inc. or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -21,7 +22,6 @@
  * questions.
  */
 
-import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -86,7 +86,7 @@ public class TestP11KeyFactoryGetRSAKeySpec extends PKCS11Test {
 
     private static void testKeySpec(KeyFactory factory, PrivateKey key, Class<? extends KeySpec> specClass) throws Exception {
         try {
-            KeySpec spec = factory.getKeySpec(key, RSAPrivateKeySpec.class);
+            KeySpec spec = factory.getKeySpec(key, specClass);
             if (testingSensitiveKeys) {
                 throw new Exception("Able to retrieve spec from sensitive key");
             }


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268558](https://bugs.openjdk.java.net/browse/JDK-8268558): [TESTBUG] Case 2 in TestP11KeyFactoryGetRSAKeySpec is skipped


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/223.diff">https://git.openjdk.java.net/jdk17u-dev/pull/223.diff</a>

</details>
