### PR TITLE
8282225: GHA: Allow one concurrent run per PR only

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -12,6 +12,10 @@ on:
         required: true
         default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows aarch64, Windows x64, macOS x64"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prerequisites:
     name: Prerequisites


### PR DESCRIPTION
Clean backport to improve GHA performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282225](https://bugs.openjdk.java.net/browse/JDK-8282225): GHA: Allow one concurrent run per PR only


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/224.diff">https://git.openjdk.java.net/jdk17u-dev/pull/224.diff</a>

</details>
