### PR TITLE
8269373: some tests in jdk/tools/launcher/ fails on localized Windows platform

### DIFF
--- a/test/jdk/tools/launcher/FXLauncherTest.java
+++ b/test/jdk/tools/launcher/FXLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,6 +360,10 @@ public class FXLauncherTest extends TestHelper {
      */
     @Test
     static void testMissingMC() throws Exception {
+        if (!isEnglishLocale()) {
+            return;
+        }
+
         String testname = "testMissingMC";
         testcount++;
         line();

--- a/test/jdk/tools/launcher/SourceMode.java
+++ b/test/jdk/tools/launcher/SourceMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,6 +200,10 @@ public class SourceMode extends TestHelper {
     // java --add-exports=... Export.java --help
     @Test
     void testAddExports() throws IOException {
+        if (!isEnglishLocale()) {
+            return;
+        }
+
         starting("testAddExports");
         Path exportJava = Paths.get("Export.java");
         createFile(exportJava, List.of(
@@ -254,6 +258,10 @@ public class SourceMode extends TestHelper {
     // java --source N -cp ... HelloWorld
     @Test
     void testSourceClasspath() throws IOException {
+        if (!isEnglishLocale()) {
+            return;
+        }
+
         starting("testSourceClasspath");
         Path base = Files.createDirectories(Paths.get("testSourceClasspath"));
         Path src = Files.createDirectories(base.resolve("src"));


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269373](https://bugs.openjdk.java.net/browse/JDK-8269373): some tests in jdk/tools/launcher/ fails on localized Windows platform


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/227/head:pull/227` \
`$ git checkout pull/227`

Update a local copy of the PR: \
`$ git checkout pull/227` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 227`

View PR using the GUI difftool: \
`$ git pr show -t 227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/227.diff">https://git.openjdk.java.net/jdk17u-dev/pull/227.diff</a>

</details>
