### PR TITLE
8274561: sun/net/ftp/TestFtpTimeValue.java timed out on slow machines

### DIFF
--- a/test/jdk/sun/net/ftp/TestFtpTimeValue.java
+++ b/test/jdk/sun/net/ftp/TestFtpTimeValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,7 +116,7 @@ public class TestFtpTimeValue {
         public void handleClient(Socket client) throws IOException {
             String str;
 
-            client.setSoTimeout(2000);
+            client.setSoTimeout(10000);
             BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
             PrintWriter out = new PrintWriter(client.getOutputStream(), true);
             out.println("220 FTP serverSocket is ready.");


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274561](https://bugs.openjdk.java.net/browse/JDK-8274561): sun/net/ftp/TestFtpTimeValue.java timed out on slow machines


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/229/head:pull/229` \
`$ git checkout pull/229`

Update a local copy of the PR: \
`$ git checkout pull/229` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 229`

View PR using the GUI difftool: \
`$ git pr show -t 229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/229.diff">https://git.openjdk.java.net/jdk17u-dev/pull/229.diff</a>

</details>
