### PR TITLE
8282509: [exploded image] ResolvedClassTest fails with similar output

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
@@ -125,9 +125,9 @@ public class ResolvedClassTest {
 
         analyzer.shouldHaveExitValue(0);
 
-        analyzer.shouldNotContain("java.lang.invoke.Invokers$Holder::linkToTargetMethod (9 bytes)   not inlineable");
+        analyzer.shouldNotMatch("java\\.lang\\.invoke\\..+::linkToTargetMethod \\(9 bytes\\)   not inlineable");
 
-        analyzer.shouldContain("java.lang.invoke.Invokers$Holder::linkToTargetMethod (9 bytes)   force inline by annotation");
+        analyzer.shouldMatch("java\\.lang\\.invoke\\..+::linkToTargetMethod \\(9 bytes\\)   force inline by annotation");
         analyzer.shouldContain("java/lang/invoke/MethodHandle::invokeBasic (not loaded)   not inlineable");
     }
 


### PR DESCRIPTION
Clean backport of [JDK-8282509](https://bugs.openjdk.java.net/browse/JDK-8282509)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282509](https://bugs.openjdk.java.net/browse/JDK-8282509): [exploded image] ResolvedClassTest fails with similar output


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/231/head:pull/231` \
`$ git checkout pull/231`

Update a local copy of the PR: \
`$ git checkout pull/231` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 231`

View PR using the GUI difftool: \
`$ git pr show -t 231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/231.diff">https://git.openjdk.java.net/jdk17u-dev/pull/231.diff</a>

</details>
