### PR TITLE
8274244: ReportOnImportedModuleAnnotation.java fails on rerun

### DIFF
--- a/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
+++ b/test/langtools/tools/javac/processing/ReportOnImportedModuleAnnotation/ReportOnImportedModuleAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,10 @@
  *      8235458
  * @summary javac shouldn't fail when an annotation processor report a message about an annotation on a module
  *          javac should process annotated module when imports statement are present
+ * @library /tools/lib
  * @modules jdk.compiler
+ * @build toolbox.ToolBox
+ * @run main ReportOnImportedModuleAnnotation
  */
 
 import java.io.PrintWriter;
@@ -41,6 +44,8 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
+import toolbox.ToolBox;
+
 public class ReportOnImportedModuleAnnotation {
 
     public static void main(String[] args) throws Exception {
@@ -48,6 +53,9 @@ public class ReportOnImportedModuleAnnotation {
         final Path testOutputPath = Path.of(System.getProperty("test.classes"));
 
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+        // Clean any existing files in output directory
+        (new ToolBox()).cleanDirectory(testOutputPath);
 
         // Compile annotation and processor modules
         StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274244](https://bugs.openjdk.java.net/browse/JDK-8274244): ReportOnImportedModuleAnnotation.java fails on rerun


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/233/head:pull/233` \
`$ git checkout pull/233`

Update a local copy of the PR: \
`$ git checkout pull/233` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 233`

View PR using the GUI difftool: \
`$ git pr show -t 233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/233.diff">https://git.openjdk.java.net/jdk17u-dev/pull/233.diff</a>

</details>
