### PR TITLE
8268595: java/io/Serializable/serialFilter/GlobalFilterTest.java#id1 failed in timeout

### DIFF
--- a/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
+++ b/test/jdk/java/io/Serializable/serialFilter/GlobalFilterTest.java
@@ -53,18 +53,6 @@ import org.testng.annotations.DataProvider;
  *
  * @summary Test Global Filters
  */
-
-/* @test
- * @bug 8261160
- * @summary Add a deserialization JFR event
- * @build GlobalFilterTest SerialFilterTest
- * @requires vm.hasJFR
- * @run testng/othervm/policy=security.policy
- *        -XX:StartFlightRecording:name=DeserializationEvent,dumponexit=true
- *        -Djava.security.properties=${test.src}/java.security-extra1
- *        -Djava.security.debug=properties GlobalFilterTest
- */
-
 @Test
 public class GlobalFilterTest {
     private static final String serialPropName = "jdk.serialFilter";


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268595](https://bugs.openjdk.java.net/browse/JDK-8268595): java/io/Serializable/serialFilter/GlobalFilterTest.java#id1 failed in timeout


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/234/head:pull/234` \
`$ git checkout pull/234`

Update a local copy of the PR: \
`$ git checkout pull/234` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 234`

View PR using the GUI difftool: \
`$ git pr show -t 234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/234.diff">https://git.openjdk.java.net/jdk17u-dev/pull/234.diff</a>

</details>
