### PR TITLE
8276260: (se) Remove java/nio/channels/Selector/Wakeup.java from ProblemList (win)

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -619,8 +619,6 @@ java/nio/channels/DatagramChannel/Unref.java                    8233519 generic-
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
-java/nio/channels/Selector/Wakeup.java                          6963118 windows-all
-
 ############################################################################
 
 # jdk_rmi


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276260](https://bugs.openjdk.java.net/browse/JDK-8276260): (se) Remove java/nio/channels/Selector/Wakeup.java from ProblemList (win)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/236/head:pull/236` \
`$ git checkout pull/236`

Update a local copy of the PR: \
`$ git checkout pull/236` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 236`

View PR using the GUI difftool: \
`$ git pr show -t 236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/236.diff">https://git.openjdk.java.net/jdk17u-dev/pull/236.diff</a>

</details>
