### PR TITLE
8276825: hotspot/runtime/SelectionResolution test errors

### DIFF
--- a/test/hotspot/jtreg/runtime/SelectionResolution/classes/selectionresolution/ClassBuilder.java
+++ b/test/hotspot/jtreg/runtime/SelectionResolution/classes/selectionresolution/ClassBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,7 @@ public class ClassBuilder extends Builder {
         int packageId = classdata.get(classId).packageId.ordinal();
         Clazz C = helpers[packageId];
         if (C == null) {
-            C = new Clazz(getPackageName(packageId) + "Helper", -1, ACC_PUBLIC);
+            C = new Clazz(getPackageName(packageId) + "Helper", ACC_PUBLIC, -1);
             helpers[packageId] = C;
             classes.add(C);
         }

--- a/test/hotspot/jtreg/runtime/SelectionResolution/classes/selectionresolution/Clazz.java
+++ b/test/hotspot/jtreg/runtime/SelectionResolution/classes/selectionresolution/Clazz.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ class Clazz extends ClassConstruct {
      * @param implementing Interfaces implemented
      */
     public Clazz(String name, String extending, int access, int classFileVersion, int index, String... implementing) {
-        super(name, extending == null ? "java/lang/Object" : extending, access + ACC_SUPER, classFileVersion, index, implementing);
+        super(name, extending == null ? "java/lang/Object" : extending, access | ACC_SUPER, classFileVersion, index, implementing);
         // Add the default constructor
         addMethod("<init>", "()V", ACC_PUBLIC).makeConstructor(extending, false);
     }

--- a/test/hotspot/jtreg/runtime/SelectionResolution/classes/selectionresolution/TestBuilder.java
+++ b/test/hotspot/jtreg/runtime/SelectionResolution/classes/selectionresolution/TestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ class TestBuilder extends Builder {
         super(testcase);
 
         // Make a public class Test that contains all our test methods
-        testClass = new Clazz("Test", null, -1, ACC_PUBLIC);
+        testClass = new Clazz("Test", null, ACC_PUBLIC, -1);
 
         // Add a main method
         mainMethod = testClass.addMethod("main", "([Ljava/lang/String;)V", ACC_PUBLIC + ACC_STATIC);


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276825](https://bugs.openjdk.java.net/browse/JDK-8276825): hotspot/runtime/SelectionResolution test errors


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/237/head:pull/237` \
`$ git checkout pull/237`

Update a local copy of the PR: \
`$ git checkout pull/237` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 237`

View PR using the GUI difftool: \
`$ git pr show -t 237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/237.diff">https://git.openjdk.java.net/jdk17u-dev/pull/237.diff</a>

</details>
