### PR TITLE
8269077: TestSystemGC uses "require vm.gc.G1" for large pages subtest

### DIFF
--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -43,8 +43,7 @@ package gc;
  * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseG1GC gc.TestSystemGC
  * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
- * @run main/othervm -XX:+UseLargePages gc.TestSystemGC
-  */
+ */
 
 /*
  * @test TestSystemGCShenandoah
@@ -53,6 +52,13 @@ package gc;
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.TestSystemGC
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
  */
+
+/*
+ * @test TestSystemGCLargePages
+ * @summary Runs System.gc() with different flags.
+ * @run main/othervm -XX:+UseLargePages gc.TestSystemGC
+ */
+
 public class TestSystemGC {
   public static void main(String args[]) throws Exception {
     System.gc();


### PR DESCRIPTION
I backport this test fix to simplify a follow up backport. 
I think this is useful, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269077](https://bugs.openjdk.java.net/browse/JDK-8269077): TestSystemGC uses "require vm.gc.G1" for large pages subtest


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/238.diff">https://git.openjdk.java.net/jdk17u-dev/pull/238.diff</a>

</details>
