### PR TITLE
8277893: Arraycopy stress tests

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -94,6 +94,9 @@ hotspot_vector_2 = \
   compiler/vectorapi/VectorRebracket128Test.java \
   -compiler/intrinsics/string/TestStringLatin1IndexOfChar.java
 
+hotspot_compiler_arraycopy = \
+  compiler/arraycopy/stress
+
 tier1_common = \
   sanity/BasicVMTest.java \
   gtest/GTestWrapper.java \
@@ -114,7 +117,8 @@ hotspot_not_fast_compiler = \
 hotspot_slow_compiler = \
   compiler/codegen/aes \
   compiler/codecache/stress \
-  compiler/gcbarriers/PreserveFPRegistersTest.java
+  compiler/gcbarriers/PreserveFPRegistersTest.java \
+  :hotspot_compiler_arraycopy
 
 tier1_compiler_1 = \
   compiler/arraycopy/ \
@@ -131,6 +135,7 @@ tier1_compiler_1 = \
   -compiler/c2/Test6792161.java \
   -compiler/c2/Test6603011.java \
   -compiler/c2/Test6912517.java \
+  -:hotspot_slow_compiler
 
 tier1_compiler_2 = \
   compiler/classUnloading/ \

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/AbstractStressArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/AbstractStressArrayCopy.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Random;
+
+public abstract class AbstractStressArrayCopy {
+    /**
+     * Max array size to test. This should be reasonably high to test
+     * massive vectorized copies, plus cases that cross the cache lines and
+     * (small) page boundaries. But it should also be reasonably low to
+     * keep the test costs down.
+     *
+     * A rough guideline:
+     *   - AVX-512: 64-byte copies over 32 registers copies roughly 2K per step.
+     *   - AArch64: small pages can be about 64K large
+     */
+    static final int MAX_SIZE = 128*1024 + 1;
+
+    /**
+     * Arrays up to this size would be tested exhaustively: with all combinations
+     * of source/destination starts and copy lengths. Exercise restraint when bumping
+     * this value, as the test costs are proportional to N^3 of this setting.
+     */
+    static final int EXHAUSTIVE_SIZES = Integer.getInteger("exhaustiveSizes", 192);
+
+    /*
+     * Larger arrays would fuzzed with this many attempts.
+     */
+    static final int FUZZ_COUNT = Integer.getInteger("fuzzCount", 300);
+
+    public static void throwSeedError(int len, int pos) {
+        throw new RuntimeException("Error after seed: " +
+            len + " elements, at pos " + pos);
+    }
+
+    public static void throwContentsError(int l, int r, int len, int pos) {
+        throwError("in contents", l, r, len, pos);
+    }
+
+    public static void throwHeadError(int l, int r, int len, int pos) {
+        throwError("in head", l, r, len, pos);
+    }
+
+    public static void throwTailError(int l, int r, int len, int pos) {
+        throwError("in tail", l, r, len, pos);
+    }
+
+    private static void throwError(String phase, int l, int r, int len, int pos) {
+        throw new RuntimeException("Error " + phase + ": " +
+            len + " elements, " +
+            "[" + l + ", " + (l+len) + ") -> " +
+            "[" + r + ", " + (r+len) + "), " +
+            "at pos " + pos);
+    }
+
+    protected abstract void testWith(int size, int l, int r, int len);
+
+    private void checkBounds(int size, int l, int r, int len) {
+        if (l >= size)      throw new IllegalStateException("l is out of bounds");
+        if (l + len > size) throw new IllegalStateException("l+len is out of bounds");
+        if (r >= size)      throw new IllegalStateException("r is out of bounds");
+        if (r + len > size) throw new IllegalStateException("r+len is out of bounds: " + l + " " + r + " " + len + " " + size);
+    }
+
+    private void checkDisjoint(int size, int l, int r, int len) {
+        if (l == r)               throw new IllegalStateException("Not disjoint: l == r");
+        if (l < r && l + len > r) throw new IllegalStateException("Not disjoint");
+        if (l > r && r + len > l) throw new IllegalStateException("Not disjoint");
+    }
+
+    private void checkConjoint(int size, int l, int r, int len) {
+        if (l == r) return; // Definitely conjoint, even with zero len
+        if (l < r && l + len < r) throw new IllegalStateException("Not conjoint");
+        if (l > r && r + len < l) throw new IllegalStateException("Not conjoint");
+    }
+
+    public void exhaustiveWith(int size) {
+        for (int l = 0; l < size; l++) {
+            for (int r = 0; r < size; r++) {
+                int maxLen = Math.min(size - l, size - r);
+                for (int len = 0; len <= maxLen; len++) {
+                    checkBounds(size, l, r, len);
+                    testWith(size, l, r, len);
+                }
+            }
+        }
+    }
+
+    public void fuzzWith(Random rand, int size) {
+        // Some basic checks first
+        testWith(size, 0, 1, 1);
+        testWith(size, 0, 1, size-1);
+
+        // Test disjoint:
+        for (int c = 0; c < FUZZ_COUNT; c++) {
+            int l = rand.nextInt(size / 2);
+            int len = rand.nextInt((size - l) / 2);
+            int r = (l + len + 1) + rand.nextInt(size - 2*len - l - 1);
+
+            checkBounds(size, l, r, len);
+            checkDisjoint(size, l, r, len);
+
+            testWith(size, l, r, len);
+            testWith(size, r, l, len);
+        }
+
+        // Test conjoint:
+        for (int c = 0; c < FUZZ_COUNT; c++) {
+            int l = rand.nextInt(size);
+            int len = rand.nextInt(size - l);
+            int r = Math.min(l + (len > 0 ? rand.nextInt(len) : 0), size - len);
+
+            checkBounds(size, l, r, len);
+            checkConjoint(size, l, r, len);
+
+            testWith(size, l, r, len);
+            testWith(size, r, l, len);
+        }
+    }
+
+    public void run(Random rand) {
+        // Exhaustive on all small arrays
+        for (int size = 1; size <= EXHAUSTIVE_SIZES; size++) {
+            exhaustiveWith(size);
+        }
+
+        // Fuzz powers of ten
+        for (int size = 10; size < MAX_SIZE; size *= 10) {
+            if (size <= EXHAUSTIVE_SIZES) continue;
+            fuzzWith(rand, size - 1);
+            fuzzWith(rand, size);
+            fuzzWith(rand, size + 1);
+        }
+
+        // Fuzz powers of two
+        for (int size = 2; size < MAX_SIZE; size *= 2) {
+            if (size <= EXHAUSTIVE_SIZES) continue;
+            fuzzWith(rand, size - 1);
+            fuzzWith(rand, size);
+            fuzzWith(rand, size + 1);
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressBooleanArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressBooleanArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressBooleanArrayCopy extends AbstractStressArrayCopy {
+
+    private static final boolean[] orig = new boolean[MAX_SIZE];
+    private static final boolean[] test = new boolean[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = rand.nextBoolean();
+        }
+        new StressBooleanArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressByteArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressByteArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressByteArrayCopy extends AbstractStressArrayCopy {
+
+    private static final byte[] orig = new byte[MAX_SIZE];
+    private static final byte[] test = new byte[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = (byte)rand.nextInt();
+        }
+        new StressByteArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressCharArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressCharArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressCharArrayCopy extends AbstractStressArrayCopy {
+
+    private static final char[] orig = new char[MAX_SIZE];
+    private static final char[] test = new char[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = (char)rand.nextInt();
+        }
+        new StressCharArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressDoubleArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressDoubleArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressDoubleArrayCopy extends AbstractStressArrayCopy {
+
+    private static final double[] orig = new double[MAX_SIZE];
+    private static final double[] test = new double[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = rand.nextDouble();
+        }
+        new StressDoubleArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressFloatArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressFloatArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressFloatArrayCopy extends AbstractStressArrayCopy {
+
+    private static final float[] orig = new float[MAX_SIZE];
+    private static final float[] test = new float[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = rand.nextFloat();
+        }
+        new StressFloatArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressIntArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressIntArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressIntArrayCopy extends AbstractStressArrayCopy {
+
+    private static final int[] orig = new int[MAX_SIZE];
+    private static final int[] test = new int[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = rand.nextInt();
+        }
+        new StressIntArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressLongArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressLongArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressLongArrayCopy extends AbstractStressArrayCopy {
+
+    private static final long[] orig = new long[MAX_SIZE];
+    private static final long[] test = new long[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = rand.nextLong();
+        }
+        new StressLongArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressObjectArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressObjectArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressObjectArrayCopy extends AbstractStressArrayCopy {
+
+    private static final Object[] orig = new Object[MAX_SIZE];
+    private static final Object[] test = new Object[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = new Object();
+        }
+        new StressObjectArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/StressShortArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/StressShortArrayCopy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.Arrays;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class StressShortArrayCopy extends AbstractStressArrayCopy {
+
+    private static final short[] orig = new short[MAX_SIZE];
+    private static final short[] test = new short[MAX_SIZE];
+
+    protected void testWith(int size, int l, int r, int len) {
+        // Seed the test from the original
+        System.arraycopy(orig, 0, test, 0, size);
+
+        // Check the seed is correct
+        {
+            int m = Arrays.mismatch(test, 0, size,
+                                    orig, 0, size);
+            if (m != -1) {
+                throwSeedError(size, m);
+            }
+        }
+
+        // Perform the tested copy
+        System.arraycopy(test, l, test, r, len);
+
+        // Check the copy has proper contents
+        {
+            int m = Arrays.mismatch(test, r, r+len,
+                                    orig, l, l+len);
+            if (m != -1) {
+                throwContentsError(l, r, len, r+m);
+            }
+        }
+
+        // Check anything else was not affected: head and tail
+        {
+            int m = Arrays.mismatch(test, 0, r,
+                                    orig, 0, r);
+            if (m != -1) {
+                throwHeadError(l, r, len, m);
+            }
+        }
+        {
+            int m = Arrays.mismatch(test, r + len, size,
+                                    orig, r + len, size);
+            if (m != -1) {
+                throwTailError(l, r, len, m);
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        Random rand = Utils.getRandomInstance();
+        for (int c = 0; c < orig.length; c++) {
+            orig[c] = (short)rand.nextInt();
+        }
+        new StressShortArrayCopy().run(rand);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/stress/TestStressArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/stress/TestStressArrayCopy.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy.stress;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import jdk.test.whitebox.cpuinfo.CPUInfo;
+
+/**
+ * @test
+ * @key stress randomness
+ * @library /test/lib
+ * @build compiler.arraycopy.stress.AbstractStressArrayCopy
+ *        compiler.arraycopy.stress.StressBooleanArrayCopy
+ *        compiler.arraycopy.stress.StressByteArrayCopy
+ *        compiler.arraycopy.stress.StressCharArrayCopy
+ *        compiler.arraycopy.stress.StressShortArrayCopy
+ *        compiler.arraycopy.stress.StressIntArrayCopy
+ *        compiler.arraycopy.stress.StressFloatArrayCopy
+ *        compiler.arraycopy.stress.StressLongArrayCopy
+ *        compiler.arraycopy.stress.StressDoubleArrayCopy
+ *        compiler.arraycopy.stress.StressObjectArrayCopy
+ *        jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/timeout=7200
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      compiler.arraycopy.stress.TestStressArrayCopy
+ */
+public class TestStressArrayCopy {
+
+    // These tests are remarkably memory bandwidth hungry. Running multiple
+    // configs in parallel makes sense only when running a single test in
+    // isolation, and only on machines with many memory channels. In common
+    // testing, or even running all arraycopy stress tests at once, overloading
+    // the system with many configs become counter-productive very quickly.
+    //
+    // Default to 1/4 of the CPUs, and allow users to override.
+    static final int MAX_PARALLELISM = Integer.getInteger("maxParallelism",
+        Math.max(1, Runtime.getRuntime().availableProcessors() / 4));
+
+    private static List<String> mix(List<String> o, String... mix) {
+        List<String> n = new ArrayList<>(o);
+        for (String m : mix) {
+            n.add(m);
+        }
+        return n;
+    }
+
+    private static List<List<String>> product(List<List<String>> list, String... mix) {
+        List<List<String>> newList = new ArrayList<>();
+        for (List<String> c : list) {
+            for (String m : mix) {
+                newList.add(mix(c, m));
+            }
+        }
+        return newList;
+    }
+
+    private static List<List<String>> alternate(List<List<String>> list, String opt) {
+        return product(list, "-XX:+" + opt, "-XX:-" + opt);
+    }
+
+    private static boolean containsFuzzy(List<String> list, String sub) {
+        for (String s : list) {
+            if (s.contains(sub)) return true;
+        }
+        return false;
+    }
+
+    public static void main(String... args) throws Exception {
+        List<List<String>> configs = new ArrayList<>();
+        List<String> cpuFeatures = CPUInfo.getFeatures();
+
+        if (Platform.isX64() || Platform.isX86()) {
+            // If CPU features were not found, provide a default config.
+            if (cpuFeatures.isEmpty()) {
+                configs.add(new ArrayList());
+            }
+
+            // Otherwise, select the tests that make sense on current platform.
+            if (containsFuzzy(cpuFeatures, "avx512")) {
+                configs.add(List.of("-XX:UseAVX=3"));
+            }
+            if (containsFuzzy(cpuFeatures, "avx2")) {
+                configs.add(List.of("-XX:UseAVX=2"));
+            }
+            if (containsFuzzy(cpuFeatures, "avx")) {
+                configs.add(List.of("-XX:UseAVX=1"));
+            }
+            if (containsFuzzy(cpuFeatures, "sse4")) {
+                configs.add(List.of("-XX:UseAVX=0", "-XX:UseSSE=4"));
+            }
+            if (containsFuzzy(cpuFeatures, "sse3")) {
+                configs.add(List.of("-XX:UseAVX=0", "-XX:UseSSE=3"));
+            }
+            if (containsFuzzy(cpuFeatures, "sse2")) {
+                configs.add(List.of("-XX:UseAVX=0", "-XX:UseSSE=2"));
+            }
+
+            // x86_64 always has UseSSE >= 2. These lower configurations only
+            // make sense for x86_32.
+            if (Platform.isX86()) {
+                if (containsFuzzy(cpuFeatures, "sse")) {
+                    configs.add(List.of("-XX:UseAVX=0", "-XX:UseSSE=1"));
+                }
+
+                configs.add(List.of("-XX:UseAVX=0", "-XX:UseSSE=0"));
+            }
+
+            // Alternate configs with other flags
+            if (Platform.isX64()) {
+                configs = alternate(configs, "UseCompressedOops");
+            }
+            configs = alternate(configs, "UseUnalignedLoadStores");
+
+        } else if (Platform.isAArch64()) {
+            // AArch64.
+            configs.add(new ArrayList());
+
+            // Alternate configs with other flags
+            configs = alternate(configs, "UseCompressedOops");
+            configs = alternate(configs, "UseSIMDForMemoryOps");
+        } else {
+            // Generic config.
+            configs.add(new ArrayList());
+        }
+
+        String[] classNames = {
+            "compiler.arraycopy.stress.StressBooleanArrayCopy",
+            "compiler.arraycopy.stress.StressByteArrayCopy",
+            "compiler.arraycopy.stress.StressCharArrayCopy",
+            "compiler.arraycopy.stress.StressShortArrayCopy",
+            "compiler.arraycopy.stress.StressIntArrayCopy",
+            "compiler.arraycopy.stress.StressFloatArrayCopy",
+            "compiler.arraycopy.stress.StressLongArrayCopy",
+            "compiler.arraycopy.stress.StressDoubleArrayCopy",
+            "compiler.arraycopy.stress.StressObjectArrayCopy",
+        };
+
+        ArrayList<Fork> forks = new ArrayList<>();
+        int jobs = 0;
+
+        for (List<String> c : configs) {
+            for (String className : classNames) {
+                // Start a new job
+                {
+                    ProcessBuilder pb = ProcessTools.createTestJvm(mix(c, "-Xmx256m", className));
+                    Process p = pb.start();
+                    OutputAnalyzer oa = new OutputAnalyzer(p);
+                    forks.add(new Fork(p, oa));
+                    jobs++;
+                }
+
+                // Wait for the completion of other jobs
+                while (jobs >= MAX_PARALLELISM) {
+                    Fork f = findDone(forks);
+                    if (f != null) {
+                        OutputAnalyzer oa = f.oa();
+                        oa.shouldHaveExitValue(0);
+                        forks.remove(f);
+                        jobs--;
+                    } else {
+                        // Nothing is done, wait a little.
+                        Thread.sleep(200);
+                    }
+                }
+            }
+        }
+
+        // Drain the rest
+        for (Fork f : forks) {
+            OutputAnalyzer oa = f.oa();
+            oa.shouldHaveExitValue(0);
+        }
+    }
+
+    private static Fork findDone(List<Fork> forks) {
+        for (Fork f : forks) {
+            if (!f.p().isAlive()) {
+                return f;
+            }
+        }
+        return null;
+    }
+
+    private static record Fork(Process p, OutputAnalyzer oa) {};
+
+}


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] Linux x86_64 fastdebug passes `hotspot_compiler_arraycopy`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277893](https://bugs.openjdk.java.net/browse/JDK-8277893): Arraycopy stress tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/242/head:pull/242` \
`$ git checkout pull/242`

Update a local copy of the PR: \
`$ git checkout pull/242` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 242`

View PR using the GUI difftool: \
`$ git pr show -t 242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/242.diff">https://git.openjdk.java.net/jdk17u-dev/pull/242.diff</a>

</details>
