### PR TITLE
8275037: Test vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java crashes with memory exhaustion on Windows

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/GenClassesBuilder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/GenClassesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ public class GenClassesBuilder {
         moveJavaFiles(genSrcDir, prefix);
 
         JDKToolLauncher javac = JDKToolLauncher.create("javac")
+                                               .addToolArg("-J-Xmx1G")
                                                .addToolArg("-d")
                                                .addToolArg(classesDir.toString())
                                                .addToolArg("-cp")

--- a/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/sysdict/share/SysDictTest.java
@@ -148,8 +148,8 @@ public abstract class SysDictTest extends ThreadedGCTest {
                     // set name into public variable just to be sure
                     // that class is loaded
                     tmp = clz.getName();
-                } catch (OutOfMemoryError | ClassNotFoundException e) {
-                    // just ignore
+                } catch (OutOfMemoryError | ClassNotFoundException | NoClassDefFoundError e) {
+                    // just ignore, note that CNFE and NCDFE can be caused by OOM exceptions.
                 } catch (StackOverflowError soe) {
                     // just ignore, chains could be too large
                     // StackOverflowError could be in some sparcs


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275037](https://bugs.openjdk.java.net/browse/JDK-8275037): Test vmTestbase/nsk/sysdict/vm/stress/btree/btree011/btree011.java crashes with memory exhaustion on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/249/head:pull/249` \
`$ git checkout pull/249`

Update a local copy of the PR: \
`$ git checkout pull/249` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 249`

View PR using the GUI difftool: \
`$ git pr show -t 249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/249.diff">https://git.openjdk.java.net/jdk17u-dev/pull/249.diff</a>

</details>
