### PR TITLE
8270435: UT: MonitorUsedDeflationThresholdTest failed: did not find too_many string in output

### DIFF
--- a/test/hotspot/jtreg/runtime/Monitor/MonitorUsedDeflationThresholdTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/MonitorUsedDeflationThresholdTest.java
@@ -80,6 +80,11 @@ public class MonitorUsedDeflationThresholdTest {
                 // of monitors for threads that call Object.wait().
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:AvgMonitorsPerThreadEstimate=1",
+                // MonitorUsedDeflationThreshold == 10 means we'll request
+                // deflations when 10% of monitors are used rather than the
+                // default 90%. This should allow the test to tolerate a burst
+                // of used monitors by threads not under this test's control.
+                "-XX:MonitorUsedDeflationThreshold=10",
                 // Enable monitorinflation logging so we can see that
                 // MonitorUsedDeflationThreshold and
                 // NoAsyncDeflationProgressMaxoption are working.
@@ -88,8 +93,9 @@ public class MonitorUsedDeflationThresholdTest {
                 "-Xlog:safepoint+cleanup=info",
                 "-Xlog:safepoint+stats=debug",
                 // Run the test with inflate_count == 33 since that
-                // reproduced the bug with JDK13. Anything above the
-                // in_use_list_ceiling will do the trick.
+                // reproduced the bug with JDK13. With inflate_count == 33, an
+                // initial ceiling == 12 and MonitorUsedDeflationThreshold == 10,
+                // we should hit NoAsyncDeflationProgressMax at least 3 times.
                 "MonitorUsedDeflationThresholdTest", "33");
 
             OutputAnalyzer output_detail = new OutputAnalyzer(pb.start());
@@ -110,6 +116,8 @@ public class MonitorUsedDeflationThresholdTest {
                 throw new RuntimeException("Did not find too_many string in output.\n");
             }
             System.out.println("too_many='" + too_many + "'");
+            // Uncomment the following line for dumping test output in passing runs:
+            // output_detail.reportDiagnosticSummary();
 
             System.out.println("PASSED.");
             return;


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270435](https://bugs.openjdk.java.net/browse/JDK-8270435): UT: MonitorUsedDeflationThresholdTest failed: did not find too_many string in output


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/250/head:pull/250` \
`$ git checkout pull/250`

Update a local copy of the PR: \
`$ git checkout pull/250` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 250`

View PR using the GUI difftool: \
`$ git pr show -t 250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/250.diff">https://git.openjdk.java.net/jdk17u-dev/pull/250.diff</a>

</details>
