### PR TITLE
8214733: runtime/8176717/TestInheritFD.java timed out

### DIFF
--- a/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
+++ b/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,7 @@ public class TestInheritFD {
     public static final String RETAINS_FD = "VM RESULT => RETAINS FD";
     public static final String EXIT = "VM RESULT => VM EXIT";
     public static final String LOG_SUFFIX = ".strangelogsuffixthatcanbecheckedfor";
+    public static final String USER_DIR = System.getProperty("user.dir");
 
     // first VM
     public static void main(String[] args) throws Exception {
@@ -187,10 +188,10 @@ public class TestInheritFD {
 
     static Collection<String> outputContainingFilenames() {
         long pid = ProcessHandle.current().pid();
-
         String[] command = lsofCommand().orElseThrow(() -> new RuntimeException("lsof like command not found"));
-        System.out.println("using command: " + command[0] + " " + command[1]);
-        return run(command[0], command[1], "" + pid).collect(toList());
+        // Only search the directory in which the VM is running (user.dir property).
+        System.out.println("using command: " + command[0] + " -a +d " + USER_DIR + " " + command[1] + " " + pid);
+        return run(command[0], "-a", "+d", USER_DIR, command[1], "" + pid).collect(toList());
     }
 
     static boolean findOpenLogFile(Collection<String> fileNames) {


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8214733](https://bugs.openjdk.java.net/browse/JDK-8214733): runtime/8176717/TestInheritFD.java timed out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/255/head:pull/255` \
`$ git checkout pull/255`

Update a local copy of the PR: \
`$ git checkout pull/255` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 255`

View PR using the GUI difftool: \
`$ git pr show -t 255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/255.diff">https://git.openjdk.java.net/jdk17u-dev/pull/255.diff</a>

</details>
