### PR TITLE
8279834: Alpine Linux fails to build when --with-source-date enabled

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -356,9 +356,9 @@ AC_DEFUN_ONCE([BASIC_SETUP_COMPLEX_TOOLS],
   fi
   AC_SUBST(IS_GNU_TIME)
 
-  # Check if it's GNU date
-  AC_MSG_CHECKING([if date is the GNU version])
-  check_date=`$DATE --version 2>&1 | $GREP GNU`
+  # Check if it's a GNU date compatible version
+  AC_MSG_CHECKING([if date is a GNU compatible version])
+  check_date=`$DATE --version 2>&1 | $GREP "GNU\|BusyBox"`
   if test "x$check_date" != x; then
     AC_MSG_RESULT([yes])
     IS_GNU_DATE=yes


### PR DESCRIPTION
Alpine linux fails to configure if --with-source-date option for reproducible builds is specified.
This is the accompanying fix for Alpine Linux with recently merged PR https://github.com/openjdk/jdk17u-dev/pull/246.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279834](https://bugs.openjdk.java.net/browse/JDK-8279834): Alpine Linux fails to build when --with-source-date enabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/257/head:pull/257` \
`$ git checkout pull/257`

Update a local copy of the PR: \
`$ git checkout pull/257` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 257`

View PR using the GUI difftool: \
`$ git pr show -t 257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/257.diff">https://git.openjdk.java.net/jdk17u-dev/pull/257.diff</a>

</details>
