### PR TITLE
8279586: [macos] custom JCheckBox and JRadioBox with custom icon set: focus is still displayed after unchecking

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonLabeledUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaButtonLabeledUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,7 +170,7 @@ public abstract class AquaButtonLabeledUI extends AquaButtonToggleUI implements 
             }
 
             int offset = 0;
-            if (b.isFocusOwner()) {
+            if (b.isFocusOwner() && b.isFocusPainted()) {
                 offset = 2;
                 altIcon = AquaFocus.createFocusedIcon(altIcon, c, 2);
             }

--- a/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
+++ b/test/jdk/javax/swing/JCheckBox/ImageCheckboxFocus/ImageCheckboxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import javax.swing.JCheckBox;
 /*
  * @test
  * @key headful
- * @bug 8216358
+ * @bug 8216358 8279586
  * @summary [macos] The focus is invisible when tab to "Image Radio Buttons" and "Image CheckBoxes"
  * @library ../../regtesthelpers/
  * @build Util
@@ -51,8 +51,12 @@ public class ImageCheckboxTest {
                 BufferedImage.TYPE_INT_ARGB);
         BufferedImage imageFocus = new BufferedImage(100, 50,
                 BufferedImage.TYPE_INT_ARGB);
+        BufferedImage imageFocusNotPainted = new BufferedImage(100, 50,
+                BufferedImage.TYPE_INT_ARGB);
+
 
         CustomCheckBox checkbox = new CustomCheckBox("Test", new MyIcon(Color.GREEN));
+        checkbox.setFocusPainted(true);
         checkbox.setSize(100, 50);
         checkbox.setFocused(false);
         checkbox.paint(imageNoFocus.createGraphics());
@@ -63,6 +67,17 @@ public class ImageCheckboxTest {
             ImageIO.write(imageFocus, "png", new File("imageFocus.png"));
             ImageIO.write(imageNoFocus, "png", new File("imageNoFocus.png"));
             throw new Exception("Changing focus is not visualized");
+        }
+
+        checkbox.setFocusPainted(false);
+        checkbox.paint(imageFocusNotPainted.createGraphics());
+
+        if (!Util.compareBufferedImages(imageFocusNotPainted, imageNoFocus)) {
+            ImageIO.write(imageFocusNotPainted, "png",
+                    new File("imageFocusNotPainted.png"));
+            ImageIO.write(imageFocus, "png", new File("imageFocus.png"));
+            ImageIO.write(imageNoFocus, "png", new File("imageNoFocus.png"));
+            throw new Exception("setFocusPainted(false) is ignored");
         }
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [18a7dc8c](https://github.com/openjdk/jdk/commit/18a7dc8c08fa15a260b4a39b18c068d30ee45962) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Alexander Zuev on 1 Feb 2022 and was reviewed by Sergey Bylokhov and Alexander Zvegintsev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279586](https://bugs.openjdk.java.net/browse/JDK-8279586): [macos] custom JCheckBox and JRadioBox with custom icon set: focus is still displayed after unchecking


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/258/head:pull/258` \
`$ git checkout pull/258`

Update a local copy of the PR: \
`$ git checkout pull/258` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 258`

View PR using the GUI difftool: \
`$ git pr show -t 258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/258.diff">https://git.openjdk.java.net/jdk17u-dev/pull/258.diff</a>

</details>
