### PR TITLE
8280476: [macOS] : hotspot arm64 bug exposed by latest clang

### DIFF
--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -129,8 +129,17 @@ static inline uint32_t uimm(uint32_t val, int hi, int lo)
 
 uint64_t replicate(uint64_t bits, int nbits, int count)
 {
+  assert(count > 0, "must be");
+  assert(nbits > 0, "must be");
+  assert(count * nbits <= 64, "must be");
+
+  // Special case nbits == 64 since the shift below with that nbits value
+  // would result in undefined behavior.
+  if (nbits == 64) {
+    return bits;
+  }
+
   uint64_t result = 0;
-  // nbits may be 64 in which case we want mask to be -1
   uint64_t mask = ones(nbits);
   for (int i = 0; i < count ; i++) {
     result <<= nbits;


### PR DESCRIPTION
Clean Backport to jdk17u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280476](https://bugs.openjdk.java.net/browse/JDK-8280476): [macOS] : hotspot arm64 bug exposed by latest clang


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/259/head:pull/259` \
`$ git checkout pull/259`

Update a local copy of the PR: \
`$ git checkout pull/259` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 259`

View PR using the GUI difftool: \
`$ git pr show -t 259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/259.diff">https://git.openjdk.java.net/jdk17u-dev/pull/259.diff</a>

</details>
