### PR TITLE
8276796: gc/TestSystemGC.java large pages subtest fails with ZGC

### DIFF
--- a/test/hotspot/jtreg/gc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/TestSystemGC.java
@@ -24,39 +24,46 @@
 package gc;
 
 /*
- * @test TestSystemGCSerial
+ * @test id=Serial
  * @requires vm.gc.Serial
  * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseSerialGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseSerialGC -XX:+UseLargePages gc.TestSystemGC
  */
 
 /*
- * @test TestSystemGCParallel
+ * @test id=Parallel
  * @requires vm.gc.Parallel
  * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseParallelGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseParallelGC -XX:+UseLargePages gc.TestSystemGC
  */
 
 /*
- * @test TestSystemGCG1
+ * @test id=G1
  * @requires vm.gc.G1
  * @summary Runs System.gc() with different flags.
  * @run main/othervm -XX:+UseG1GC gc.TestSystemGC
  * @run main/othervm -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
+ * @run main/othervm -XX:+UseG1GC -XX:+UseLargePages gc.TestSystemGC
  */
 
 /*
- * @test TestSystemGCShenandoah
+ * @test id=Shenandoah
  * @requires vm.gc.Shenandoah
  * @summary Runs System.gc() with different flags.
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC gc.TestSystemGC
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
+ * @run main/othervm -XX:+UseShenandoahGC gc.TestSystemGC
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+ExplicitGCInvokesConcurrent gc.TestSystemGC
+ * @run main/othervm -XX:+UseShenandoahGC -XX:+UseLargePages gc.TestSystemGC
  */
 
 /*
- * @test TestSystemGCLargePages
+ * @test id=Z
+ * @requires vm.gc.Z
+ * @comment ZGC will not start when LargePages cannot be allocated, therefore
+ *          we do not run such configuration.
  * @summary Runs System.gc() with different flags.
- * @run main/othervm -XX:+UseLargePages gc.TestSystemGC
+ * @run main/othervm -XX:+UseZGC gc.TestSystemGC
  */
 
 public class TestSystemGC {


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276796](https://bugs.openjdk.java.net/browse/JDK-8276796): gc/TestSystemGC.java large pages subtest fails with ZGC


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/261/head:pull/261` \
`$ git checkout pull/261`

Update a local copy of the PR: \
`$ git checkout pull/261` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 261`

View PR using the GUI difftool: \
`$ git pr show -t 261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/261.diff">https://git.openjdk.java.net/jdk17u-dev/pull/261.diff</a>

</details>
