### PR TITLE
8281274: deal with ActiveProcessorCount in os::Linux::print_container_info

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2253,7 +2253,11 @@ bool os::Linux::print_container_info(outputStream* st) {
   int i = OSContainer::active_processor_count();
   st->print("active_processor_count: ");
   if (i > 0) {
-    st->print_cr("%d", i);
+    if (ActiveProcessorCount > 0) {
+      st->print_cr("%d, but overridden by -XX:ActiveProcessorCount %d", i, ActiveProcessorCount);
+    } else {
+      st->print_cr("%d", i);
+    }
   } else {
     st->print_cr("not supported");
   }

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ public class TestMisc {
             testMinusContainerSupport();
             testIsContainerized();
             testPrintContainerInfo();
+            testPrintContainerInfoActiveProcessorCount();
         } finally {
             DockerTestUtils.removeDockerImage(imageName);
         }
@@ -92,6 +93,15 @@ public class TestMisc {
         checkContainerInfo(Common.run(opts));
     }
 
+    private static void testPrintContainerInfoActiveProcessorCount() throws Exception {
+        Common.logNewTestCase("Test print_container_info()");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo").addJavaOpts("-XX:ActiveProcessorCount=2");
+        Common.addWhiteBoxOpts(opts);
+
+        OutputAnalyzer out = Common.run(opts);
+        out.shouldContain("but overridden by -XX:ActiveProcessorCount 2");
+    }
 
     private static void checkContainerInfo(OutputAnalyzer out) throws Exception {
         String[] expectedToContain = new String[] {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281274](https://bugs.openjdk.java.net/browse/JDK-8281274): deal with ActiveProcessorCount in os::Linux::print_container_info


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/279/head:pull/279` \
`$ git checkout pull/279`

Update a local copy of the PR: \
`$ git checkout pull/279` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 279`

View PR using the GUI difftool: \
`$ git pr show -t 279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/279.diff">https://git.openjdk.java.net/jdk17u-dev/pull/279.diff</a>

</details>
