### PR TITLE
8278549: UNIX sun/font coding misses SUSE distro detection on recent distro SUSE 15

### DIFF
--- a/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/FcFontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -294,6 +294,12 @@ public class FcFontConfiguration extends FontConfiguration {
         return null;
     }
 
+    private String extractOsInfo(String s) {
+        if (s.startsWith("\"")) s = s.substring(1);
+        if (s.endsWith("\"")) s = s.substring(0, s.length()-1);
+        return s;
+    }
+
     /**
      * Sets the OS name and version from environment information.
      */
@@ -328,6 +334,16 @@ public class FcFontConfiguration extends FontConfiguration {
             } else if ((f = new File("/etc/fedora-release")).canRead()) {
                 osName = "Fedora";
                 osVersion = getVersionString(f);
+            } else if ((f = new File("/etc/os-release")).canRead()) {
+                Properties props = new Properties();
+                try (FileInputStream fis = new FileInputStream(f)) {
+                    props.load(fis);
+                }
+                osName = props.getProperty("NAME");
+                osVersion = props.getProperty("VERSION_ID");
+                osName = extractOsInfo(osName);
+                if (osName.equals("SLES")) osName = "SuSE";
+                osVersion = extractOsInfo(osVersion);
             }
         } catch (Exception e) {
             if (FontUtilities.debugFonts()) {

--- a/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
+++ b/src/java.desktop/unix/classes/sun/font/MFontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,6 +112,16 @@ public class MFontConfiguration extends FontConfiguration {
                     props.load(new FileInputStream(f));
                     osName = props.getProperty("DISTRIB_ID");
                     osVersion =  props.getProperty("DISTRIB_RELEASE");
+                } else if ((f = new File("/etc/os-release")).canRead()) {
+                    Properties props = new Properties();
+                    try (FileInputStream fis = new FileInputStream(f)) {
+                        props.load(fis);
+                    }
+                    osName = props.getProperty("NAME");
+                    osVersion = props.getProperty("VERSION_ID");
+                    osName = extractOsInfo(osName);
+                    if (osName.equals("SLES")) osName = "SuSE";
+                    osVersion = extractOsInfo(osVersion);
                 }
             } catch (Exception e) {
             }
@@ -130,6 +140,12 @@ public class MFontConfiguration extends FontConfiguration {
         catch (Exception e){
         }
         return null;
+    }
+
+    private String extractOsInfo(String s) {
+        if (s.startsWith("\"")) s = s.substring(1);
+        if (s.endsWith("\"")) s = s.substring(0, s.length()-1);
+        return s;
     }
 
     private static final String fontsDirPrefix = "$JRE_LIB_FONTS";


### PR DESCRIPTION
backport of 8278549

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278549](https://bugs.openjdk.java.net/browse/JDK-8278549): UNIX sun/font coding misses SUSE distro detection on recent distro SUSE 15


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/283/head:pull/283` \
`$ git checkout pull/283`

Update a local copy of the PR: \
`$ git checkout pull/283` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 283`

View PR using the GUI difftool: \
`$ git pr show -t 283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/283.diff">https://git.openjdk.java.net/jdk17u-dev/pull/283.diff</a>

</details>
