### PR TITLE
8272358: Some tests may fail when executed with other locales than the US

### DIFF
--- a/test/langtools/jdk/jshell/ToolBasicTest.java
+++ b/test/langtools/jdk/jshell/ToolBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -553,7 +553,7 @@ public class ToolBasicTest extends ReplToolTesting {
     }
 
     public void testOpenResource() {
-        test(
+        test(new String[]{"-R", "-Duser.language=en", "-R", "-Duser.country=US"},
                 (a) -> assertCommand(a, "/open PRINTING", ""),
                 (a) -> assertCommandOutputContains(a, "/list",
                         "void println", "System.out.printf"),

--- a/test/langtools/jdk/jshell/ToolSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolSimpleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -744,7 +744,8 @@ public class ToolSimpleTest extends ReplToolTesting {
 
     @Test
     public void testCompoundStart() {
-        test(new String[]{"--startup", "DEFAULT", "--startup", "PRINTING"},
+        test(new String[]{"-R", "-Duser.language=en", "-R", "-Duser.country=US",
+                          "--startup", "DEFAULT", "--startup", "PRINTING"},
                 (a) -> assertCommand(a, "printf(\"%4.2f\", Math.PI)",
                         "", "", null, "3.14", "")
         );

--- a/test/langtools/tools/javac/lambda/lambdaExecution/LambdaTranslationTest1.java
+++ b/test/langtools/tools/javac/lambda/lambdaExecution/LambdaTranslationTest1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8003639
  * @summary convert lambda testng tests to jtreg and add them
- * @run testng LambdaTranslationTest1
+ * @run testng/othervm -Duser.language=en -Duser.country=US LambdaTranslationTest1
  */
 
 import org.testng.annotations.Test;

--- a/test/langtools/tools/javac/lambda/lambdaExecution/LambdaTranslationTest2.java
+++ b/test/langtools/tools/javac/lambda/lambdaExecution/LambdaTranslationTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8003639
  * @summary convert lambda testng tests to jtreg and add them
- * @run testng LambdaTranslationTest2
+ * @run testng/othervm -Duser.language=en -Duser.country=US LambdaTranslationTest2
  */
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
Clean backport of [JDK-8272358](https://bugs.openjdk.java.net/browse/JDK-8272358)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272358](https://bugs.openjdk.java.net/browse/JDK-8272358): Some tests may fail when executed with other locales than the US


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/292/head:pull/292` \
`$ git checkout pull/292`

Update a local copy of the PR: \
`$ git checkout pull/292` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 292`

View PR using the GUI difftool: \
`$ git pr show -t 292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/292.diff">https://git.openjdk.java.net/jdk17u-dev/pull/292.diff</a>

</details>
