### PR TITLE
8271055: Crash during deoptimization with "assert(bb->is_reachable()) failed: getting result from unreachable basicblock" with -XX:+VerifyStack

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -683,6 +683,21 @@ void Deoptimization::unwind_callee_save_values(frame* f, vframeArray* vframe_arr
   assert(f->is_interpreted_frame(), "must be interpreted");
 }
 
+#ifndef PRODUCT
+static bool falls_through(Bytecodes::Code bc) {
+  switch (bc) {
+    // List may be incomplete.  Here we really only care about bytecodes where compiled code
+    // can deoptimize.
+    case Bytecodes::_goto:
+    case Bytecodes::_goto_w:
+    case Bytecodes::_athrow:
+      return false;
+    default:
+      return true;
+  }
+}
+#endif
+
 // Return BasicType of value being returned
 JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_mode))
 
@@ -791,7 +806,7 @@ JRT_LEAF(BasicType, Deoptimization::unpack_frames(JavaThread* thread, int exec_m
           // calls. It seems to be hard to tell whether the compiler
           // has emitted debug information matching the "state before"
           // a given bytecode or the state after, so we try both
-          if (!Bytecodes::is_invoke(cur_code) && cur_code != Bytecodes::_athrow) {
+          if (!Bytecodes::is_invoke(cur_code) && falls_through(cur_code)) {
             // Get expression stack size for the next bytecode
             InterpreterOopMap next_mask;
             OopMapCache::compute_one_oop_map(mh, str.bci(), &next_mask);

--- a/test/hotspot/jtreg/compiler/interpreter/Custom.jasm
+++ b/test/hotspot/jtreg/compiler/interpreter/Custom.jasm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler/interpreter;
+
+/* JASM simplified from the following Java pattern:
+ *
+ * public class Custom {
+ *
+ *  static void test(int v) {
+ *      int i8 = 1;
+ *      try {
+ *          v += 1;
+ *      } catch (ArithmeticException exc1) {
+ *      } finally {
+ *          for (; i8 < 100; i8++) {
+ *          }
+ *      }
+ *  }
+ *
+ */
+
+super public class Custom {
+
+    public static Method test:"(I)V" stack 2 locals 3 {
+        iconst_1;
+        istore_1;
+    try t0;
+        iinc          0, 1;
+    endtry t0;
+Loop:
+        iload_1;
+        bipush        100;
+        if_icmpge     Lexit;
+        iinc          1, 1;
+        goto          Loop;                 // deoptimize here on backwards branch
+    catch t0 java/lang/ArithmeticException; // unreachable block
+        astore_2;
+Lexit:
+        return
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/interpreter/VerifyStackWithUnreachableBlock.java
+++ b/test/hotspot/jtreg/compiler/interpreter/VerifyStackWithUnreachableBlock.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test VerifyStackWithUnreachableBlock
+ * @bug 8271055
+ * @compile Custom.jasm VerifyStackWithUnreachableBlock.java
+ * @summary Using VerifyStack for method that contains unreachable basic blocks
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack compiler.interpreter.VerifyStackWithUnreachableBlock
+ */
+
+package compiler.interpreter;
+
+public class VerifyStackWithUnreachableBlock {
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            Custom.test(i);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of [JDK-8271055](https://bugs.openjdk.java.net/browse/JDK-8271055)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271055](https://bugs.openjdk.java.net/browse/JDK-8271055): Crash during deoptimization with "assert(bb->is_reachable()) failed: getting result from unreachable basicblock" with -XX:+VerifyStack


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/298/head:pull/298` \
`$ git checkout pull/298`

Update a local copy of the PR: \
`$ git checkout pull/298` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 298`

View PR using the GUI difftool: \
`$ git pr show -t 298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/298.diff">https://git.openjdk.java.net/jdk17u-dev/pull/298.diff</a>

</details>
