### PR TITLE
8282874: Bad performance on gather/scatter API caused by different IntSpecies of indexMap

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -4029,12 +4029,12 @@ public abstract class ByteVector extends AbstractVector<Byte> {
      */
     static ByteSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (ByteSpecies) SPECIES_64;
-            case S_128_BIT: return (ByteSpecies) SPECIES_128;
-            case S_256_BIT: return (ByteSpecies) SPECIES_256;
-            case S_512_BIT: return (ByteSpecies) SPECIES_512;
-            case S_Max_BIT: return (ByteSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (ByteSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (ByteSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (ByteSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (ByteSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (ByteSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3631,12 +3631,12 @@ public abstract class DoubleVector extends AbstractVector<Double> {
      */
     static DoubleSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (DoubleSpecies) SPECIES_64;
-            case S_128_BIT: return (DoubleSpecies) SPECIES_128;
-            case S_256_BIT: return (DoubleSpecies) SPECIES_256;
-            case S_512_BIT: return (DoubleSpecies) SPECIES_512;
-            case S_Max_BIT: return (DoubleSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (DoubleSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (DoubleSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (DoubleSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (DoubleSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (DoubleSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3618,12 +3618,12 @@ public abstract class FloatVector extends AbstractVector<Float> {
      */
     static FloatSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (FloatSpecies) SPECIES_64;
-            case S_128_BIT: return (FloatSpecies) SPECIES_128;
-            case S_256_BIT: return (FloatSpecies) SPECIES_256;
-            case S_512_BIT: return (FloatSpecies) SPECIES_512;
-            case S_Max_BIT: return (FloatSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (FloatSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (FloatSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (FloatSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (FloatSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (FloatSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3727,12 +3727,12 @@ public abstract class IntVector extends AbstractVector<Integer> {
      */
     static IntSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (IntSpecies) SPECIES_64;
-            case S_128_BIT: return (IntSpecies) SPECIES_128;
-            case S_256_BIT: return (IntSpecies) SPECIES_256;
-            case S_512_BIT: return (IntSpecies) SPECIES_512;
-            case S_Max_BIT: return (IntSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (IntSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (IntSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (IntSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (IntSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (IntSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3621,12 +3621,12 @@ public abstract class LongVector extends AbstractVector<Long> {
      */
     static LongSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (LongSpecies) SPECIES_64;
-            case S_128_BIT: return (LongSpecies) SPECIES_128;
-            case S_256_BIT: return (LongSpecies) SPECIES_256;
-            case S_512_BIT: return (LongSpecies) SPECIES_512;
-            case S_Max_BIT: return (LongSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (LongSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (LongSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (LongSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (LongSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (LongSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -4024,12 +4024,12 @@ public abstract class ShortVector extends AbstractVector<Short> {
      */
     static ShortSpecies species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return (ShortSpecies) SPECIES_64;
-            case S_128_BIT: return (ShortSpecies) SPECIES_128;
-            case S_256_BIT: return (ShortSpecies) SPECIES_256;
-            case S_512_BIT: return (ShortSpecies) SPECIES_512;
-            case S_Max_BIT: return (ShortSpecies) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return (ShortSpecies) SPECIES_64;
+            case VectorShape.SK_128_BIT: return (ShortSpecies) SPECIES_128;
+            case VectorShape.SK_256_BIT: return (ShortSpecies) SPECIES_256;
+            case VectorShape.SK_512_BIT: return (ShortSpecies) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return (ShortSpecies) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -5033,12 +5033,12 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
      */
     static $Type$Species species(VectorShape s) {
         Objects.requireNonNull(s);
-        switch (s) {
-            case S_64_BIT: return ($Type$Species) SPECIES_64;
-            case S_128_BIT: return ($Type$Species) SPECIES_128;
-            case S_256_BIT: return ($Type$Species) SPECIES_256;
-            case S_512_BIT: return ($Type$Species) SPECIES_512;
-            case S_Max_BIT: return ($Type$Species) SPECIES_MAX;
+        switch (s.switchKey) {
+            case VectorShape.SK_64_BIT: return ($Type$Species) SPECIES_64;
+            case VectorShape.SK_128_BIT: return ($Type$Species) SPECIES_128;
+            case VectorShape.SK_256_BIT: return ($Type$Species) SPECIES_256;
+            case VectorShape.SK_512_BIT: return ($Type$Species) SPECIES_512;
+            case VectorShape.SK_Max_BIT: return ($Type$Species) SPECIES_MAX;
             default: throw new IllegalArgumentException("Bad shape: " + s);
         }
     }


### PR DESCRIPTION
Clean backport of [JDK-8282874](https://bugs.openjdk.java.net/browse/JDK-8282874)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282874](https://bugs.openjdk.java.net/browse/JDK-8282874): Bad performance on gather/scatter API caused by different IntSpecies of indexMap


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/314/head:pull/314` \
`$ git checkout pull/314`

Update a local copy of the PR: \
`$ git checkout pull/314` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 314`

View PR using the GUI difftool: \
`$ git pr show -t 314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/314.diff">https://git.openjdk.java.net/jdk17u-dev/pull/314.diff</a>

</details>
