### PR TITLE
8283834: Unmappable character for US-ASCII encoding in TestPredicateInputBelowLoopPredicate

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestPredicateInputBelowLoopPredicate.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPredicateInputBelowLoopPredicate.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * bug 8280799
- * @summary С2: assert(false) failed: cyclic dependency prevents range check elimination
+ * @summary C2: assert(false) failed: cyclic dependency prevents range check elimination
  * @run main/othervm -XX:-BackgroundCompilation -XX:-UseCountedLoopSafepoints TestPredicateInputBelowLoopPredicate
  */
 


### PR DESCRIPTION
Backport of [JDK-8283834](https://bugs.openjdk.java.net/browse/JDK-8283834)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283834](https://bugs.openjdk.java.net/browse/JDK-8283834): Unmappable character for US-ASCII encoding in TestPredicateInputBelowLoopPredicate


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/322/head:pull/322` \
`$ git checkout pull/322`

Update a local copy of the PR: \
`$ git checkout pull/322` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/322/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 322`

View PR using the GUI difftool: \
`$ git pr show -t 322`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/322.diff">https://git.openjdk.java.net/jdk17u-dev/pull/322.diff</a>

</details>
