### PR TITLE
8274939: Incorrect size of the pixel storage is used by the robot on macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CRobot.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CRobot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,9 +168,9 @@ final class CRobot implements RobotPeer {
      */
     @Override
     public int getRGBPixel(int x, int y) {
-        int[] c = new int[1];
-        double scale = fDevice.getScaleFactor();
-        getScreenPixels(new Rectangle(x, y, (int) scale, (int) scale), c);
+        int scale = fDevice.getScaleFactor();
+        int[] c = new int[scale * scale];
+        getScreenPixels(new Rectangle(x, y, scale, scale), c);
         return c[0];
     }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -321,6 +321,11 @@ Java_sun_lwawt_macosx_CRobot_nativeGetScreenPixels
     jint picY = y;
     jint picWidth = width;
     jint picHeight = height;
+    jsize size = (*env)->GetArrayLength(env, pixels);
+    if (size < (long) picWidth * picHeight || picWidth < 0 || picHeight < 0) {
+        JNU_ThrowInternalError(env, "Invalid arguments to get screen pixels");
+        return;
+    }
 
     CGRect screenRect = CGRectMake(picX / scale, picY / scale,
                                 picWidth / scale, picHeight / scale);

--- a/test/jdk/java/awt/Robot/CheckCommonColors/CheckCommonColors.java
+++ b/test/jdk/java/awt/Robot/CheckCommonColors/CheckCommonColors.java
@@ -42,6 +42,8 @@ import javax.imageio.ImageIO;
  * @key headful
  * @bug 8215105 8211999
  * @summary tests that Robot can capture the common colors without artifacts
+ * @run main/othervm CheckCommonColors
+ * @run main/othervm -Xcheck:jni CheckCommonColors
  */
 public final class CheckCommonColors {
 


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [eff5dafb](https://github.com/openjdk/jdk/commit/eff5dafba9f72bd0612357712ffa472ce1c9166a) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 12 Feb 2022 and was reviewed by Alexey Ivanov and Phil Race.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274939](https://bugs.openjdk.java.net/browse/JDK-8274939): Incorrect size of the pixel storage is used by the robot on macOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/324/head:pull/324` \
`$ git checkout pull/324`

Update a local copy of the PR: \
`$ git checkout pull/324` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 324`

View PR using the GUI difftool: \
`$ git pr show -t 324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/324.diff">https://git.openjdk.java.net/jdk17u-dev/pull/324.diff</a>

</details>
