### PR TITLE
8283249: CompressedClassPointers.java fails on ppc with 'Narrow klass shift: 0' missing

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -223,8 +223,8 @@ public class CompressedClassPointers {
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("Narrow klass base: 0x0000000000000000");
-        if (!Platform.isAArch64()) {
-            // Currently relax this test for Aarch64.
+        if (!Platform.isAArch64() && !Platform.isPPC()) {
+            // Currently relax this test for Aarch64 and ppc.
             output.shouldContain("Narrow klass shift: 0");
         }
         output.shouldHaveExitValue(0);
@@ -243,8 +243,8 @@ public class CompressedClassPointers {
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldContain("Narrow klass base: 0x0000000000000000");
-        if (!Platform.isAArch64()) {
-            // Currently relax this test for Aarch64.
+        if (!Platform.isAArch64() && !Platform.isPPC()) {
+            // Currently relax this test for Aarch64 and ppc.
             output.shouldContain("Narrow klass shift: 0");
         }
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
Work around for sporadic errors on ppc. Low risk, applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283249](https://bugs.openjdk.java.net/browse/JDK-8283249): CompressedClassPointers.java fails on ppc with 'Narrow klass shift: 0' missing


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/330/head:pull/330` \
`$ git checkout pull/330`

Update a local copy of the PR: \
`$ git checkout pull/330` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 330`

View PR using the GUI difftool: \
`$ git pr show -t 330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/330.diff">https://git.openjdk.java.net/jdk17u-dev/pull/330.diff</a>

</details>
