### PR TITLE
8281522: Rename ADLC classes which have the same name as hotspot variants

### DIFF
--- a/src/hotspot/share/adlc/adlArena.hpp
+++ b/src/hotspot/share/adlc/adlArena.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,11 @@
  *
  */
 
-#ifndef SHARE_ADLC_ARENA_HPP
-#define SHARE_ADLC_ARENA_HPP
+#ifndef SHARE_ADLC_ADLARENA_HPP
+#define SHARE_ADLC_ADLARENA_HPP
 
-void* AllocateHeap(size_t size);
-void* ReAllocateHeap(void* old_ptr, size_t size);
+void* AdlAllocateHeap(size_t size);
+void* AdlReAllocateHeap(void* old_ptr, size_t size);
 
 // All classes in adlc may be derived
 // from one of the following allocation classes:
@@ -35,10 +35,10 @@ void* ReAllocateHeap(void* old_ptr, size_t size);
 // - CHeapObj
 //
 // For classes used as name spaces.
-// - AllStatic
+// - AdlAllStatic
 //
 
-class CHeapObj {
+class AdlCHeapObj {
  public:
   void* operator new(size_t size) throw();
   void  operator delete(void* p);
@@ -47,16 +47,16 @@ class CHeapObj {
 
 // Base class for classes that constitute name spaces.
 
-class AllStatic {
+class AdlAllStatic {
  public:
   void* operator new(size_t size) throw();
   void operator delete(void* p);
 };
 
 
-//------------------------------Chunk------------------------------------------
+//------------------------------AdlChunk------------------------------------------
 // Linked list of raw memory chunks
-class Chunk: public CHeapObj {
+class AdlChunk: public AdlCHeapObj {
  private:
   // This ordinary operator delete is needed even though not used, so the
   // below two-argument operator delete will be treated as a placement
@@ -65,41 +65,41 @@ class Chunk: public CHeapObj {
  public:
   void* operator new(size_t size, size_t length) throw();
   void  operator delete(void* p, size_t length);
-  Chunk(size_t length);
+  AdlChunk(size_t length);
 
   enum {
       init_size =  1*1024,      // Size of first chunk
-      size      = 32*1024       // Default size of an Arena chunk (following the first)
+      size      = 32*1024       // Default size of an AdlArena chunk (following the first)
   };
-  Chunk*       _next;           // Next Chunk in list
-  size_t       _len;            // Size of this Chunk
+  AdlChunk*       _next;        // Next AdlChunk in list
+  size_t       _len;            // Size of this AdlChunk
 
   void chop();                  // Chop this chunk
   void next_chop();             // Chop next chunk
 
   // Boundaries of data area (possibly unused)
-  char* bottom() const { return ((char*) this) + sizeof(Chunk);  }
+  char* bottom() const { return ((char*) this) + sizeof(AdlChunk);  }
   char* top()    const { return bottom() + _len; }
 };
 
 
-//------------------------------Arena------------------------------------------
+//------------------------------AdlArena------------------------------------------
 // Fast allocation of memory
-class Arena: public CHeapObj {
+class AdlArena: public AdlCHeapObj {
 protected:
   friend class ResourceMark;
   friend class HandleMark;
   friend class NoHandleMark;
-  Chunk *_first;                // First chunk
-  Chunk *_chunk;                // current chunk
+  AdlChunk *_first;             // First chunk
+  AdlChunk *_chunk;             // current chunk
   char *_hwm, *_max;            // High water mark and max in current chunk
-  void* grow(size_t x);         // Get a new Chunk of at least size x
+  void* grow(size_t x);         // Get a new AdlChunk of at least size x
   size_t _size_in_bytes;          // Size of arena (used for memory usage tracing)
 public:
-  Arena();
-  Arena(size_t init_size);
-  Arena(Arena *old);
-  ~Arena()                      { _first->chop(); }
+  AdlArena();
+  AdlArena(size_t init_size);
+  AdlArena(AdlArena *old);
+  ~AdlArena()                   { _first->chop(); }
   char* hwm() const             { return _hwm; }
 
   // Fast allocate in the arena.  Common case is: pointer test + increment.
@@ -138,10 +138,10 @@ public:
   void *Acalloc( size_t items, size_t x );
   void *Arealloc( void *old_ptr, size_t old_size, size_t new_size );
 
-  // Reset this Arena to empty, and return this Arenas guts in a new Arena.
-  Arena *reset(void);
+  // Reset this AdlArena to empty, and return this AdlArenas guts in a new AdlArena.
+  AdlArena *reset(void);
 
-  // Determine if pointer belongs to this Arena or not.
+  // Determine if pointer belongs to this AdlArena or not.
   bool contains( const void *ptr ) const;
 
   // Total of all chunks in use (not thread-safe)
@@ -152,4 +152,4 @@ public:
   void   set_size_in_bytes(size_t size)  { _size_in_bytes = size;   }
 };
 
-#endif // SHARE_ADLC_ARENA_HPP
+#endif // SHARE_ADLC_ADLARENA_HPP

--- a/src/hotspot/share/adlc/adlc.hpp
+++ b/src/hotspot/share/adlc/adlc.hpp
@@ -93,7 +93,7 @@ typedef unsigned int uintptr_t;
 #define max(a, b)   (((a)>(b)) ? (a) : (b))
 
 // ADLC components
-#include "arena.hpp"
+#include "adlArena.hpp"
 #include "opto/adlcVMDeps.hpp"
 #include "filebuff.hpp"
 #include "dict2.hpp"

--- a/src/hotspot/share/adlc/adlparse.cpp
+++ b/src/hotspot/share/adlc/adlparse.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,7 +211,7 @@ void ADLParser::instr_parse(void) {
             return;
           }
           assert(match_rules_cnt < 100," too many match rule clones");
-          char* buf = (char*) AllocateHeap(strlen(instr->_ident) + 4);
+          char* buf = (char*) AdlAllocateHeap(strlen(instr->_ident) + 4);
           sprintf(buf, "%s_%d", instr->_ident, match_rules_cnt++);
           rule->_result = buf;
           // Check for commutative operations with tree operands.
@@ -2805,7 +2805,7 @@ void ADLParser::ins_encode_parse_block(InstructForm& inst) {
   // Create a new encoding name based on the name of the instruction
   // definition, which should be unique.
   const char* prefix = "__ins_encode_";
-  char* ec_name = (char*) AllocateHeap(strlen(inst._ident) + strlen(prefix) + 1);
+  char* ec_name = (char*) AdlAllocateHeap(strlen(inst._ident) + strlen(prefix) + 1);
   sprintf(ec_name, "%s%s", prefix, inst._ident);
 
   assert(_AD._encode->encClass(ec_name) == NULL, "shouldn't already exist");
@@ -3276,7 +3276,7 @@ void ADLParser::constant_parse(InstructForm& inst) {
   // Create a new encoding name based on the name of the instruction
   // definition, which should be unique.
   const char* prefix = "__constant_";
-  char* ec_name = (char*) AllocateHeap(strlen(inst._ident) + strlen(prefix) + 1);
+  char* ec_name = (char*) AdlAllocateHeap(strlen(inst._ident) + strlen(prefix) + 1);
   sprintf(ec_name, "%s%s", prefix, inst._ident);
 
   assert(_AD._encode->encClass(ec_name) == NULL, "shouldn't already exist");
@@ -4409,7 +4409,7 @@ char* ADLParser::find_cpp_block(const char* description) {
     if (_AD._adlocation_debug) {
       char* location = get_line_string(line);
       char* end_loc  = end_line_marker();
-      char* result = (char *)AllocateHeap(strlen(location) + strlen(cppBlock) + strlen(end_loc) + 1);
+      char* result = (char *)AdlAllocateHeap(strlen(location) + strlen(cppBlock) + strlen(end_loc) + 1);
       strcpy(result, location);
       strcat(result, cppBlock);
       strcat(result, end_loc);
@@ -4498,7 +4498,7 @@ char *ADLParser::get_paren_expr(const char *description, bool include_location) 
     // Prepend location descriptor, for debugging.
     char* location = get_line_string(line);
     char* end_loc  = end_line_marker();
-    char* result = (char *)AllocateHeap(strlen(location) + strlen(token2) + strlen(end_loc) + 1);
+    char* result = (char *)AdlAllocateHeap(strlen(location) + strlen(token2) + strlen(end_loc) + 1);
     strcpy(result, location);
     strcat(result, token2);
     strcat(result, end_loc);
@@ -4596,7 +4596,7 @@ char *ADLParser::get_ident_or_literal_constant(const char* description) {
     // Grab a constant expression.
     param = get_paren_expr(description);
     if (param[0] != '(') {
-      char* buf = (char*) AllocateHeap(strlen(param) + 3);
+      char* buf = (char*) AdlAllocateHeap(strlen(param) + 3);
       sprintf(buf, "(%s)", param);
       param = buf;
     }
@@ -5204,7 +5204,7 @@ void ADLParser::next_line() {
 char* ADLParser::get_line_string(int linenum) {
   const char* file = _AD._ADL_file._name;
   int         line = linenum ? linenum : this->linenum();
-  char* location = (char *)AllocateHeap(strlen(file) + 100);
+  char* location = (char *)AdlAllocateHeap(strlen(file) + 100);
   sprintf(location, "\n#line %d \"%s\"\n", line, file);
   return location;
 }

--- a/src/hotspot/share/adlc/dfa.cpp
+++ b/src/hotspot/share/adlc/dfa.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ private:
 
 public:
   // cmpstr does string comparisions.  hashstr computes a key.
-  ProductionState(Arena *arena) : _production(cmpstr, hashstr, arena) { initialize(); };
+  ProductionState(AdlArena *arena) : _production(cmpstr, hashstr, arena) { initialize(); };
   ~ProductionState() { };
 
   void        initialize();                // reset local and dictionary state
@@ -817,7 +817,7 @@ bool Expr::check_buffers() {
 
 //------------------------------ExprDict---------------------------------------
 // Constructor
-ExprDict::ExprDict( CmpKey cmp, Hash hash, Arena *arena )
+ExprDict::ExprDict( CmpKey cmp, Hash hash, AdlArena *arena )
   : _expr(cmp, hash, arena), _defines()  {
 }
 ExprDict::~ExprDict() {

--- a/src/hotspot/share/adlc/dict2.cpp
+++ b/src/hotspot/share/adlc/dict2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ Dict::Dict(CmpKey initcmp, Hash inithash) : _hash(inithash), _cmp(initcmp), _are
   init();
 }
 
-Dict::Dict(CmpKey initcmp, Hash inithash, Arena *arena) : _hash(inithash), _cmp(initcmp), _arena(arena) {
+Dict::Dict(CmpKey initcmp, Hash inithash, AdlArena *arena) : _hash(inithash), _cmp(initcmp), _arena(arena) {
   init();
 }
 

--- a/src/hotspot/share/adlc/dict2.hpp
+++ b/src/hotspot/share/adlc/dict2.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ typedef void (*FuncDict)(const void *key, const void *val, Dict *d);
 
 class Dict { // Dictionary structure
  private:
-  class Arena *_arena;          // Where to draw storage from
+  class AdlArena *_arena;       // Where to draw storage from
   class bucket *_bin;           // Hash table is array of buckets
   int _size;                    // Size (# of slots) in hash table
   int _cnt;                     // Number of key-value pairs in hash table
@@ -56,7 +56,7 @@ class Dict { // Dictionary structure
 
   // cmp is a key comparision routine.  hash is a routine to hash a key.
   Dict( CmpKey cmp, Hash hash );
-  Dict( CmpKey cmp, Hash hash, Arena *arena );
+  Dict( CmpKey cmp, Hash hash, AdlArena *arena );
   void init();
   ~Dict();
 

--- a/src/hotspot/share/adlc/forms.cpp
+++ b/src/hotspot/share/adlc/forms.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,9 @@
 
 //------------------------------Static Initializers----------------------------
 // allocate arena used by forms
-Arena  *Form::arena = Form::generate_arena(); //  = Form::generate_arena();
-Arena *Form::generate_arena() {
-  return (new Arena);
+AdlArena  *Form::arena = Form::generate_arena(); //  = Form::generate_arena();
+AdlArena *Form::generate_arena() {
+  return (new AdlArena);
 }
 
 //------------------------------NameList---------------------------------------
@@ -40,7 +40,7 @@ const char  *NameList::_signal3  = "$$SIGNAL3$$";
 
 // Constructor and Destructor
 NameList::NameList() : _cur(0), _max(4), _iter(0), _justReset(true) {
-  _names = (const char**) AllocateHeap(_max*sizeof(char*));
+  _names = (const char**) AdlAllocateHeap(_max*sizeof(char*));
 }
 NameList::~NameList() {
   // The following free is a double-free, and crashes the program:
@@ -49,7 +49,7 @@ NameList::~NameList() {
 
 void   NameList::addName(const char *name) {
   if (_cur == _max) {
-    _names = (const char**) ReAllocateHeap(_names, (_max *=2)*sizeof(char*));
+    _names = (const char**) AdlReAllocateHeap(_names, (_max *=2)*sizeof(char*));
   }
   _names[_cur++] = name;
 }
@@ -310,7 +310,7 @@ FormList::~FormList()  {
 
 //------------------------------FormDict---------------------------------------
 // Constructor
-FormDict::FormDict( CmpKey cmp, Hash hash, Arena *arena )
+FormDict::FormDict( CmpKey cmp, Hash hash, AdlArena *arena )
   : _form(cmp, hash, arena) {
 }
 FormDict::~FormDict() {

--- a/src/hotspot/share/adlc/forms.hpp
+++ b/src/hotspot/share/adlc/forms.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,7 @@ private:
 public:
   // cmp is a key comparision routine.  hash is a routine to hash a key.
   // FormDict( CmpKey cmp, Hash hash );
-  FormDict( CmpKey cmp, Hash hash, Arena *arena );
+  FormDict( CmpKey cmp, Hash hash, AdlArena *arena );
   FormDict( const FormDict & fd );    // Deep-copy guts
   ~FormDict();
 
@@ -119,9 +119,9 @@ public:
 //------------------------------Form-------------------------------------------
 class Form {
 public:
-  static Arena  *arena;            // arena used by forms
+  static AdlArena  *arena;         // arena used by forms
 private:
-  static Arena  *generate_arena(); // allocate arena used by forms
+  static AdlArena  *generate_arena(); // allocate arena used by forms
 
 protected:
   int   _ftype;                    // Indicator for derived class type
@@ -573,7 +573,7 @@ private:
 
 public:
   // cmp is a key comparision routine.  hash is a routine to hash a key.
-  ExprDict( CmpKey cmp, Hash hash, Arena *arena );
+  ExprDict( CmpKey cmp, Hash hash, AdlArena *arena );
   ~ExprDict();
 
   // Return # of key-value pairs in dict

--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,7 +206,7 @@ RegDef::RegDef(char *regname, char *callconv, char *c_conv, char * idealtype, ch
     _concrete(concrete),
     _register_num(0) {
 
-  // Chunk and register mask are determined by the register number
+  // AdlChunk and register mask are determined by the register number
   // _register_num is set when registers are added to an allocation class
 }
 RegDef::~RegDef() {                      // Destructor

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -1366,7 +1366,7 @@ void InstructForm::set_unique_opnds() {
     // component back to an index and any DEF always goes at 0 so the
     // length of the array has to be the number of components + 1.
     _uniq_idx_length = _components.count() + 1;
-    uniq_idx = (uint*) AllocateHeap(sizeof(uint) * _uniq_idx_length);
+    uniq_idx = (uint*) AdlAllocateHeap(sizeof(uint) * _uniq_idx_length);
     for (i = 0; i < _uniq_idx_length; i++) {
       uniq_idx[i] = i;
     }
@@ -3475,7 +3475,7 @@ void MatchNode::build_internalop( ) {
   rstr = (_rChild) ? ((_rChild->_internalop) ?
                        _rChild->_internalop : _rChild->_opType) : "";
   len += (int)strlen(lstr) + (int)strlen(rstr);
-  subtree = (char *)AllocateHeap(len);
+  subtree = (char *)AdlAllocateHeap(len);
   sprintf(subtree,"_%s_%s_%s", _opType, lstr, rstr);
   // Hash the subtree string in _internalOps; if a name exists, use it
   iop = (char *)_AD._internalOps[subtree];
@@ -3898,7 +3898,7 @@ void MatchRule::matchrule_swap_commutative_op(const char* instr_ident, int count
   MatchRule* clone = new MatchRule(_AD, this);
   // Swap operands of commutative operation
   ((MatchNode*)clone)->swap_commutative_op(true, count);
-  char* buf = (char*) AllocateHeap(strlen(instr_ident) + 4);
+  char* buf = (char*) AdlAllocateHeap(strlen(instr_ident) + 4);
   sprintf(buf, "%s_%d", instr_ident, match_rules_cnt++);
   clone->_result = buf;
 


### PR DESCRIPTION
I'd like to bring this into JDK17. Its a purely mechanical renaming of classes in ADLC. It does not apply cleanly, but the only conflicts were copyright headers (ADLC gets touched very rarely).

The reason I want this downported is to make future code changes easier and to simplify development. I was on the fence about this one, but since its really low risk, I think it makes sense to downport this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281522](https://bugs.openjdk.java.net/browse/JDK-8281522): Rename ADLC classes which have the same name as hotspot variants


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to e18b4943d78a675faaa03a287665cd0a86b3487d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/332/head:pull/332` \
`$ git checkout pull/332`

Update a local copy of the PR: \
`$ git checkout pull/332` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 332`

View PR using the GUI difftool: \
`$ git pr show -t 332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/332.diff">https://git.openjdk.java.net/jdk17u-dev/pull/332.diff</a>

</details>
