### PR TITLE
JDK-8283347: [macos] Bad JNI lookup accessibilityHitTest is shown when Screen magnifier is enabled

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -1092,11 +1092,11 @@ static jobject sAccessibilityClass = NULL;
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
+    GET_CACCESSIBILITY_CLASS_RETURN(nil);
     DECLARE_CLASS_RETURN(jc_Container, "java/awt/Container", nil);
     DECLARE_STATIC_METHOD_RETURN(jm_accessibilityHitTest, sjc_CAccessibility, "accessibilityHitTest",
                                  "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;", nil);
 
-    GET_CACCESSIBILITY_CLASS_RETURN(nil);
     // Make it into java screen coords
     point.y = [[[[self view] window] screen] frame].size.height - point.y;
 


### PR DESCRIPTION
Hi, we get unwanted exceptions on macOS in jdk17 when Screen magnifier is enabled.
Looks like this was caused by a wrong placing of  GET_CACCESSIBILITY_CLASS_RETURN in
  (id)accessibilityHitTest:(NSPoint)point  .

It was placed after the DECLARE_CLASS_RETURN and DECLARE_STATIC_METHOD_RETURN clauses. That is incorrect. So after i moved it up before the DECLARE_CLASS_RETURN clause the bug stops reproducing.
Thanks to Alexander Zuev for the analysis. 

Best regards, Matthias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283347](https://bugs.openjdk.java.net/browse/JDK-8283347): [macos] Bad JNI lookup accessibilityHitTest is shown when Screen magnifier is enabled


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/338/head:pull/338` \
`$ git checkout pull/338`

Update a local copy of the PR: \
`$ git checkout pull/338` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 338`

View PR using the GUI difftool: \
`$ git pr show -t 338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/338.diff">https://git.openjdk.java.net/jdk17u-dev/pull/338.diff</a>

</details>
