### PR TITLE
8279520: SPNEGO has not passed channel binding info into the underlying mechanism

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoContext.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -866,6 +866,7 @@ public class SpNegoContext implements GSSContextSpi {
             mechContext.requestMutualAuth(mutualAuthState);
             mechContext.requestReplayDet(replayDetState);
             mechContext.requestSequenceDet(sequenceDetState);
+            mechContext.setChannelBinding(channelBinding);
             if (mechContext instanceof GSSContextImpl) {
                 ((GSSContextImpl)mechContext).requestDelegPolicy(
                         delegPolicyState);
@@ -899,6 +900,7 @@ public class SpNegoContext implements GSSContextSpi {
                 myCred.getInternalCred());
             }
             mechContext = factory.manager.createContext(cred);
+            mechContext.setChannelBinding(channelBinding);
         }
 
         // pass token to mechanism acceptSecContext


### PR DESCRIPTION
Clean backport of [JDK-8279520](https://bugs.openjdk.java.net/browse/JDK-8279520)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279520](https://bugs.openjdk.java.net/browse/JDK-8279520): SPNEGO has not passed channel binding info into the underlying mechanism


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/345/head:pull/345` \
`$ git checkout pull/345`

Update a local copy of the PR: \
`$ git checkout pull/345` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 345`

View PR using the GUI difftool: \
`$ git pr show -t 345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/345.diff">https://git.openjdk.java.net/jdk17u-dev/pull/345.diff</a>

</details>
