### PR TITLE
8282293: Domain value for system property jdk.https.negotiate.cbt should be case-insensitive

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/https/AbstractDelegateHttpsURLConnection.java
@@ -332,10 +332,11 @@ public abstract class AbstractDelegateHttpsURLConnection extends
         if (prop.startsWith("domain:")) {
             String[] domains = prop.substring(7).split(",");
             for (String domain : domains) {
-                if (target.equals(domain)) {
+                if (target.equalsIgnoreCase(domain)) {
                     return true;
                 }
-                if (domain.startsWith("*.") && target.endsWith(domain.substring(1))) {
+                if (domain.startsWith("*.") && target.regionMatches(
+                        true, target.length() - domain.length() + 1, domain, 1, domain.length() - 1)) {
                     return true;
                 }
             }

--- a/test/jdk/sun/security/krb5/auto/HttpsCB.java
+++ b/test/jdk/sun/security/krb5/auto/HttpsCB.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8279842
+ * @bug 8279842 8282293
  * @modules java.base/sun.security.util
  *          java.security.jgss/sun.security.jgss
  *          java.security.jgss/sun.security.jgss.krb5
@@ -52,7 +52,13 @@
  * @run main/othervm -Djdk.net.hosts.file=TestHosts
  *          -Djdk.https.negotiate.cbt=domain:host.web.domain HttpsCB true true
  * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:HOST.WEB.DOMAIN HttpsCB true true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
  *          -Djdk.https.negotiate.cbt=domain:*.web.domain HttpsCB true true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:*.WEB.Domain HttpsCB true true
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *          -Djdk.https.negotiate.cbt=domain:*.Invalid,*.WEB.Domain HttpsCB true true
  */
 
 import com.sun.net.httpserver.Headers;
@@ -199,6 +205,7 @@ public class HttpsCB {
                     conn.getInputStream()));
             return reader.readLine().equals(CONTENT);
         } catch (IOException e) {
+            e.printStackTrace(System.out);
             return false;
         }
     }


### PR DESCRIPTION
Clean backport of [JDK-8282293](https://bugs.openjdk.java.net/browse/JDK-8282293)
on top of https://git.openjdk.java.net/jdk17u-dev/pull/349

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282293](https://bugs.openjdk.java.net/browse/JDK-8282293): Domain value for system property jdk.https.negotiate.cbt should be case-insensitive


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/350/head:pull/350` \
`$ git checkout pull/350`

Update a local copy of the PR: \
`$ git checkout pull/350` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 350`

View PR using the GUI difftool: \
`$ git pr show -t 350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/350.diff">https://git.openjdk.java.net/jdk17u-dev/pull/350.diff</a>

</details>
