### PR TITLE
8284884: Replace polling with waiting in javax/swing/text/html/parser/Parser/8078268/bug8078268.java

### DIFF
--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -24,50 +24,52 @@
 
 import java.io.File;
 import java.io.FileReader;
+import java.util.concurrent.CountDownLatch;
+
 import javax.swing.SwingUtilities;
 import javax.swing.text.Document;
 import javax.swing.text.html.HTMLEditorKit;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 /* @test
    @bug 8078268
    @summary  javax.swing.text.html.parser.Parser parseScript incorrectly optimized
-   @author Mikhail Cherkasov
    @run main bug8078268
 */
 public class bug8078268 {
-    static volatile boolean parsingDone = false;
-    static volatile Exception exception;
+    private static final long TIMEOUT = 10_000;
+
+    private static final String FILENAME = "slowparse.html";
+
+    private static final CountDownLatch latch = new CountDownLatch(1);
+    private static volatile Exception exception;
 
     public static void main(String[] args) throws Exception {
-        long timeout = 10_000;
-        long s = System.currentTimeMillis();
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
                 HTMLEditorKit htmlKit = new HTMLEditorKit();
                 Document doc = htmlKit.createDefaultDocument();
                 try {
-                    htmlKit.read(new FileReader(getDirURL() + "slowparse.html"), doc, 0);
-                    parsingDone = true;
+                    htmlKit.read(new FileReader(getAbsolutePath()), doc, 0);
                 } catch (Exception e) {
                     exception = e;
                 }
+                latch.countDown();
             }
         });
-        while (!parsingDone && exception == null && System.currentTimeMillis() - s < timeout) {
-            Thread.sleep(200);
+
+        if (!latch.await(TIMEOUT, MILLISECONDS)) {
+            throw new RuntimeException("Parsing takes too long.");
         }
-        final long took = System.currentTimeMillis() - s;
         if (exception != null) {
             throw exception;
         }
-        if (took > timeout) {
-            throw new RuntimeException("Parsing takes too long.");
-        }
     }
 
-    static String getDirURL() {
-        return new File(System.getProperty("test.src", ".")).getAbsolutePath() +
-                File.separator;
+    private static String getAbsolutePath() {
+        return System.getProperty("test.src", ".")
+               + File.separator + FILENAME;
     }
 }


### PR DESCRIPTION
Clean backport of [JDK-8284884](https://bugs.openjdk.java.net/browse/JDK-8284884)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284884](https://bugs.openjdk.java.net/browse/JDK-8284884): Replace polling with waiting in javax/swing/text/html/parser/Parser/8078268/bug8078268.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/353/head:pull/353` \
`$ git checkout pull/353`

Update a local copy of the PR: \
`$ git checkout pull/353` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 353`

View PR using the GUI difftool: \
`$ git pr show -t 353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/353.diff">https://git.openjdk.java.net/jdk17u-dev/pull/353.diff</a>

</details>
