### PR TITLE
8284023: java.sun.awt.X11GraphicsDevice.getDoubleBufferVisuals() leaks XdbeScreenVisualInfo

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1428,6 +1428,9 @@ Java_sun_awt_X11GraphicsDevice_getDoubleBufferVisuals(JNIEnv *env,
             break;
         }
     }
+    AWT_LOCK();
+    XdbeFreeVisualInfo(visScreenInfo);
+    AWT_UNLOCK();
 }
 
 /*


### PR DESCRIPTION
A clean, low risk backport to fix a memory leak

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284023](https://bugs.openjdk.java.net/browse/JDK-8284023): java.sun.awt.X11GraphicsDevice.getDoubleBufferVisuals() leaks XdbeScreenVisualInfo


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/355/head:pull/355` \
`$ git checkout pull/355`

Update a local copy of the PR: \
`$ git checkout pull/355` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 355`

View PR using the GUI difftool: \
`$ git pr show -t 355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/355.diff">https://git.openjdk.java.net/jdk17u-dev/pull/355.diff</a>

</details>
