### PR TITLE
8273095: vmTestbase/vm/mlvm/anonloader/stress/oome/heap/Test.java fails with "wrong OOME"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/hiddenloader/stress/oome/heap/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/hiddenloader/stress/oome/heap/Test.java
@@ -63,7 +63,7 @@ public class Test extends MlvmOOMTest {
     @Override
     protected void checkOOME(OutOfMemoryError oome) {
         String message = oome.getMessage();
-        if (!"Java heap space".equals(message)) {
+        if (!message.startsWith("Java heap space")) {
             throw new RuntimeException("TEST FAIL : wrong OOME", oome);
         }
     }


### PR DESCRIPTION
Clean backport of testfix [JDK-8273095](https://bugs.openjdk.java.net/browse/JDK-8273095)
Test is not problem listed in 17u and therefore this PR is not automatically recognized as clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273095](https://bugs.openjdk.java.net/browse/JDK-8273095): vmTestbase/vm/mlvm/anonloader/stress/oome/heap/Test.java fails with "wrong OOME"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/360/head:pull/360` \
`$ git checkout pull/360`

Update a local copy of the PR: \
`$ git checkout pull/360` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 360`

View PR using the GUI difftool: \
`$ git pr show -t 360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/360.diff">https://git.openjdk.java.net/jdk17u-dev/pull/360.diff</a>

</details>
