### PR TITLE
8277396: [TESTBUG] In DefaultButtonModelCrashTest.java, frame is accessed from main thread

### DIFF
--- a/test/jdk/javax/swing/DefaultButtonModel/DefaultButtonModelCrashTest.java
+++ b/test/jdk/javax/swing/DefaultButtonModel/DefaultButtonModelCrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,23 +21,21 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8182577
- * @summary  Verifies if moving focus via custom ButtonModel causes crash
+ * @summary  Verifies if moving focus to JToggleButton with DefaultButtonModel
+ *           that is added to a ButtonGroup doesn't throw ClassCastException
  * @key headful
  * @run main DefaultButtonModelCrashTest
  */
 
 import java.awt.BorderLayout;
-import java.awt.Container;
-import java.awt.Point;
 import java.awt.Robot;
 import java.awt.event.KeyEvent;
 import javax.swing.ButtonModel;
 import javax.swing.DefaultButtonModel;
 import javax.swing.JCheckBox;
-import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -45,8 +43,6 @@ import javax.swing.SwingUtilities;
 
 public class DefaultButtonModelCrashTest {
     private JFrame frame = null;
-    private JPanel panel;
-    private volatile Point p = null;
 
     public static void main(String[] args) throws Exception {
         new DefaultButtonModelCrashTest();
@@ -58,29 +54,34 @@ public class DefaultButtonModelCrashTest {
             robot.setAutoDelay(200);
             SwingUtilities.invokeAndWait(() -> go());
             robot.waitForIdle();
+            robot.delay(1000);
             robot.keyPress(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_TAB);
             robot.delay(100);
             robot.keyPress(KeyEvent.VK_TAB);
             robot.keyRelease(KeyEvent.VK_TAB);
         } finally {
-            if (frame != null) { SwingUtilities.invokeAndWait(()->frame.dispose()); }
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 
     private void go() {
-
         frame = new JFrame();
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        Container contentPane = frame.getContentPane();
-        ButtonModel model = new DefaultButtonModel();
 
+        ButtonModel model = new DefaultButtonModel();
         JCheckBox check = new JCheckBox("a bit broken");
         check.setModel(model);
-        panel = new JPanel(new BorderLayout());
+
+        JPanel panel = new JPanel(new BorderLayout());
         panel.add(new JTextField("Press Tab (twice?)"), BorderLayout.NORTH);
         panel.add(check);
-        contentPane.add(panel);
+
+        frame.getContentPane().add(panel);
         frame.setLocationRelativeTo(null);
         frame.pack();
         frame.setVisible(true);


### PR DESCRIPTION
Clean backport of [JDK-8277396](https://bugs.openjdk.java.net/browse/JDK-8277396)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277396](https://bugs.openjdk.java.net/browse/JDK-8277396): [TESTBUG] In DefaultButtonModelCrashTest.java, frame is accessed from main thread


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/361/head:pull/361` \
`$ git checkout pull/361`

Update a local copy of the PR: \
`$ git checkout pull/361` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 361`

View PR using the GUI difftool: \
`$ git pr show -t 361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/361.diff">https://git.openjdk.java.net/jdk17u-dev/pull/361.diff</a>

</details>
