### PR TITLE
8276108: Wrong instruction generation in aarch64 backend

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -476,16 +476,17 @@ class Address {
           assert(size == 0, "bad size");
           size = 0b100;
         }
+        assert(offset_ok_for_immed(_offset, size),
+               "must be, was: %ld, %d", _offset, size);
         unsigned mask = (1 << size) - 1;
-        if (_offset < 0 || _offset & mask)
-          {
-            i->f(0b00, 25, 24);
-            i->f(0, 21), i->f(0b00, 11, 10);
-            i->sf(_offset, 20, 12);
-          } else {
-            i->f(0b01, 25, 24);
-            i->f(_offset >> size, 21, 10);
-          }
+        if (_offset < 0 || _offset & mask) {
+          i->f(0b00, 25, 24);
+          i->f(0, 21), i->f(0b00, 11, 10);
+          i->sf(_offset, 20, 12);
+        } else {
+          i->f(0b01, 25, 24);
+          i->f(_offset >> size, 21, 10);
+        }
       }
       break;
 

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.inline.hpp
@@ -30,8 +30,14 @@
 #include "asm/codeBuffer.hpp"
 #include "code/codeCache.hpp"
 
-
+// Check if an offset is within the encoding range for LDR/STR instructions
+// with an immediate offset, either using unscaled signed 9-bits or, scaled
+// unsigned 12-bits. We favour the scaled unsigned encoding for all aligned
+// offsets (only using the signed 9-bit encoding for negative and unaligned
+// offsets). As a precondition, 0 <= shift <= 4 is the log2(size), for the
+// supported data widths, {1, 2, 4, 8, 16} bytes.
 inline bool Address::offset_ok_for_immed(int64_t offset, uint shift) {
+  precond(shift < 5);
   uint mask = (1 << shift) - 1;
   if (offset < 0 || (offset & mask) != 0) {
     // Unscaled signed offset, encoded in a signed imm9 field.

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -187,14 +187,13 @@ Address LIR_Assembler::as_Address(LIR_Address* addr, Register tmp) {
       default:
         ShouldNotReachHere();
       }
-  } else  {
-    intptr_t addr_offset = intptr_t(addr->disp());
-    if (Address::offset_ok_for_immed(addr_offset, addr->scale()))
-      return Address(base, addr_offset, Address::lsl(addr->scale()));
-    else {
-      __ mov(tmp, addr_offset);
-      return Address(base, tmp, Address::lsl(addr->scale()));
-    }
+  } else {
+    assert(addr->scale() == 0,
+           "expected for immediate operand, was: %d", addr->scale());
+    ptrdiff_t offset = ptrdiff_t(addr->disp());
+    // NOTE: Does not handle any 16 byte vector access.
+    const uint type_size = type2aelembytes(addr->type(), true);
+    return __ legitimize_address(Address(base, offset), type_size, tmp);
   }
   return Address();
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [72bacf8d](https://github.com/openjdk/jdk/commit/72bacf8d256071773d8fd9f9c2d0aebb2cb32dea) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Patric Hedlin on 29 Nov 2021 and was reviewed by Andrew Haley and Nils Eliasson.

This backport is a dependency of [JDK-8277928](https://bugs.openjdk.org/browse/JDK-8277928) and [JDK-8278417](https://bugs.openjdk.org/browse/JDK-8278417) ([JDK-8293826](https://bugs.openjdk.org/browse/JDK-8293826)).

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276108](https://bugs.openjdk.org/browse/JDK-8276108): Wrong instruction generation in aarch64 backend


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/370/head:pull/370` \
`$ git checkout pull/370`

Update a local copy of the PR: \
`$ git checkout pull/370` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 370`

View PR using the GUI difftool: \
`$ git pr show -t 370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/370.diff">https://git.openjdk.org/jdk17u-dev/pull/370.diff</a>

</details>
