### PR TITLE
8279529: ProblemList java/nio/channels/DatagramChannel/ManySourcesAndTargets.java on macosx-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -619,6 +619,8 @@ java/nio/channels/DatagramChannel/Unref.java                    8233519 generic-
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
+java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
+
 ############################################################################
 
 # jdk_rmi
@@ -684,6 +686,7 @@ javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
+sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java 8277970 linux-all,macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8279529](https://bugs.openjdk.java.net/browse/JDK-8279529): ProblemList java/nio/channels/DatagramChannel/ManySourcesAndTargets.java on macosx-aarch64
 * [JDK-8279532](https://bugs.openjdk.java.net/browse/JDK-8279532): ProblemList sun/security/ssl/SSLSessionImpl/NoInvalidateSocketException.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/371/head:pull/371` \
`$ git checkout pull/371`

Update a local copy of the PR: \
`$ git checkout pull/371` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 371`

View PR using the GUI difftool: \
`$ git pr show -t 371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/371.diff">https://git.openjdk.java.net/jdk17u-dev/pull/371.diff</a>

</details>
