### PR TITLE
8274687: JDWP deadlocks if some Java thread reaches wait in blockOnDebuggerSuspend

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -73,6 +73,7 @@ typedef struct ThreadNode {
     unsigned int popFrameEvent : 1;
     unsigned int popFrameProceed : 1;
     unsigned int popFrameThread : 1;
+    unsigned int handlingAppResume : 1;
     EventIndex current_ei; /* Used to determine if we are currently handling an event on this thread. */
     jobject pendingStop;   /* Object we are throwing to stop the thread (ThreadReferenceImpl.stop). */
     jint suspendCount;
@@ -655,7 +656,10 @@ pendingAppResume(jboolean includeSuspended)
                 if (error != JVMTI_ERROR_NONE) {
                     EXIT_ERROR(error, "getting thread state");
                 }
-                if (!(state & JVMTI_THREAD_STATE_SUSPENDED)) {
+                /* !node->handlingAppResume && resumeFrameDepth > 0
+                 * means the thread has entered Thread.resume() */
+                if (!(state & JVMTI_THREAD_STATE_SUSPENDED) &&
+                    !node->handlingAppResume) {
                     return JNI_TRUE;
                 }
             }
@@ -728,6 +732,11 @@ blockOnDebuggerSuspend(jthread thread)
     }
 }
 
+/*
+ * The caller is expected to hold threadLock and handlerLock.
+ * eventHandler_createInternalThreadOnly() can deadlock because of
+ * wrong lock ordering if the caller does not hold handlerLock.
+ */
 static void
 trackAppResume(jthread thread)
 {
@@ -776,28 +785,19 @@ handleAppResumeBreakpoint(JNIEnv *env, EventInfo *evinfo,
                           struct bag *eventBag)
 {
     jthread resumer = evinfo->thread;
-    jthread resumee = getResumee(resumer);
 
     debugMonitorEnter(threadLock);
-    if (resumee != NULL) {
-        /*
-         * Hold up any attempt to resume as long as the debugger
-         * has suspended the resumee.
-         */
-        blockOnDebuggerSuspend(resumee);
-    }
 
+    /*
+     * Actual handling has to be deferred. We cannot block right here if the
+     * target of the resume call is suspended by the debugger since we are
+     * holding handlerLock which must not be released. See doPendingTasks().
+     */
     if (resumer != NULL) {
-        /*
-         * Track the resuming thread by marking it as being within
-         * a resume and by setting up for notification on
-         * a frame pop or exception. We won't allow the debugger
-         * to suspend threads while any thread is within a
-         * call to resume. This (along with the block above)
-         * ensures that when the debugger
-         * suspends a thread it will remain suspended.
-         */
-        trackAppResume(resumer);
+        ThreadNode* node = findThread(&runningThreads, resumer);
+        if (node != NULL) {
+            node->handlingAppResume = JNI_TRUE;
+        }
     }
 
     debugMonitorExit(threadLock);
@@ -2155,6 +2155,59 @@ threadControl_onEventHandlerEntry(jbyte sessionID, EventInfo *evinfo, jobject cu
 static void
 doPendingTasks(JNIEnv *env, ThreadNode *node)
 {
+    /* Deferred breakpoint handling for Thread.resume() */
+    if (node->handlingAppResume) {
+        jthread resumer = node->thread;
+        jthread resumee = getResumee(resumer);
+
+        if (resumer != NULL) {
+            /*
+             * trackAppResume indirectly aquires handlerLock. For proper lock
+             * ordering handlerLock has to be acquired before threadLock.
+             */
+            debugMonitorExit(threadLock);
+            eventHandler_lock();
+            debugMonitorEnter(threadLock);
+
+            /*
+             * Track the resuming thread by marking it as being within
+             * a resume and by setting up for notification on
+             * a frame pop or exception. We won't allow the debugger
+             * to suspend threads while any thread is within a
+             * call to resume. This (along with the block below)
+             * ensures that when the debugger
+             * suspends a thread it will remain suspended.
+             */
+            trackAppResume(resumer);
+
+            /*
+             * handlerLock is not needed anymore. We must release it before calling
+             * blockOnDebuggerSuspend() because it is required for resumes done by
+             * the debugger. If resumee is currently suspended by the debugger, then
+             * blockOnDebuggerSuspend() will block until a debugger resume is done.
+             * If it blocks while holding the handlerLock, then the resume will deadlock.
+             */
+            eventHandler_unlock();
+        }
+
+        if (resumee != NULL) {
+            /*
+             * Hold up any attempt to resume as long as the debugger
+             * has suspended the resumee.
+             */
+            blockOnDebuggerSuspend(resumee);
+        }
+
+        node->handlingAppResume = JNI_FALSE;
+
+        /*
+         * The blocks exit condition: resumee's suspendCount == 0.
+         *
+         * Debugger suspends are blocked if any thread is executing
+         * Thread.resume(), i.e. !handlingAppResume && frameDepth > 0.
+         */
+    }
+
     /*
      * Take care of any pending interrupts/stops, and clear out
      * info on pending interrupts/stops.
@@ -2455,6 +2508,8 @@ threadControl_reset(void)
     /* Everything should have been resumed */
     JDI_ASSERT(otherThreads.first == NULL);
 
+    /* Threads could be waiting in blockOnDebuggerSuspend */
+    debugMonitorNotifyAll(threadLock);
     debugMonitorExit(threadLock);
     eventHandler_unlock();
 }

--- a/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
+++ b/test/jdk/com/sun/jdi/ResumeAfterThreadResumeCallTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8274687
+ * @summary Test the special handling in the JDWP agent of threads that call
+ *          j.l.Thread.resume().
+ *
+ *          This is the sequence of actions by the debugger and the threads
+ *          "main" and "resumee" in the target vm.
+ *
+ *          "resumee": Reaches breakpoint in methodWithBreakpoint() and is
+ *                     suspended then.
+ *
+ *          "main": Calls j.l.Thread.resume() for "resumee". There is an internal
+ *                  breakpoint in Thread.resume() so the JDWP agent receives a
+ *                  breakpoint event. It finds that "resumee" is suspended because
+ *                  of JDWP actions. The resume() call would interfere with the
+ *                  debugger therefore "main" is blocked.
+ *
+ *          Debugger: Tests if the suspended "resumee" can be suspended a second
+ *                    time and resumes it again.
+ *
+ *          Debugger: Resumes "resumee" by calling ThreadReference.resume().
+ *                    The JDWP agent notifies "main" about it.
+ *
+ *          "resumee": Continues execution.
+ *
+ *          "main": Receives the notification, finds that "resumee" is not
+ *                  suspended anymore and continues execution.
+ *
+ *          Debugger: Verifies that "main" is no longer blocked.
+ *
+ * @author Richard Reingruber richard DOT reingruber AT sap DOT com
+ *
+ * @library /test/lib
+ *
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter
+ * @run compile -g ResumeAfterThreadResumeCallTest.java
+ * @run driver ResumeAfterThreadResumeCallTest
+ */
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import jdk.test.lib.Asserts;
+
+import java.util.*;
+
+// Target program for the debugger
+class ResumeAfterThreadResumeCallTarg extends Thread {
+
+    public boolean reachedBreakpoint;
+    public boolean mainThreadReturnedFromResumeCall;
+    public boolean testFinished;
+
+    public ResumeAfterThreadResumeCallTarg(String name) {
+        super(name);
+    }
+
+    public static void log(String m) {
+        String threadName = Thread.currentThread().getName();
+        System.out.println("###(Target,"+ threadName +") " + m);
+    }
+
+    public static void main(String[] args) {
+        log("Entered main()");
+
+        // Start "resumee" thread.
+        ResumeAfterThreadResumeCallTarg resumee = new ResumeAfterThreadResumeCallTarg("resumee");
+        resumee.start();
+
+        // Wait for "resumee" to reach the breakpoint in methodWithBreakpoint().
+        while (!resumee.reachedBreakpoint) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) { /* ignored */ }
+        }
+
+        // "resumee" is suspended now because of the breakpoint
+        // Calling Thread.resume() will block this thread.
+        log("Calling Thread.resume()");
+        resumee.resume();
+        resumee.mainThreadReturnedFromResumeCall = true;
+        log("Thread.resume() returned");
+
+        // Wait for debugger
+        while (!resumee.testFinished) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) { /* ignored */ }
+        }
+    }
+
+    public void run() {
+        log("up and running.");
+        methodWithBreakpoint();
+    }
+
+    public void methodWithBreakpoint() {
+        log("Entered methodWithBreakpoint()");
+    }
+}
+
+
+// Debugger program
+
+public class ResumeAfterThreadResumeCallTest extends TestScaffold {
+    public static final String TARGET_CLS_NAME = ResumeAfterThreadResumeCallTarg.class.getName();
+    public static final long UNBLOCK_TIMEOUT = 10000;
+
+    ResumeAfterThreadResumeCallTest (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args)      throws Exception {
+        new ResumeAfterThreadResumeCallTest(args).startTests();
+    }
+
+    /**
+     * Set a breakpoint in the given method and resume all threads. The
+     * breakpoint is configured to suspend just the thread that reaches it
+     * instead of all threads.
+     */
+    public BreakpointEvent resumeTo(String clsName, String methodName, String signature) {
+        boolean suspendThreadOnly = true;
+        return resumeTo(clsName, methodName, signature, suspendThreadOnly);
+    }
+
+    protected void runTests() throws Exception {
+        BreakpointEvent bpe = startToMain(TARGET_CLS_NAME);
+        mainThread = bpe.thread();
+
+        log("Resuming to methodWithBreakpoint()");
+        bpe = resumeTo(TARGET_CLS_NAME, "methodWithBreakpoint", "()V");
+
+        log("Thread \"resumee\" has reached the breakpoint and is suspended now.");
+        ThreadReference resumee = bpe.thread();
+        ObjectReference resumeeThreadObj = resumee.frame(1).thisObject();
+        printStack(resumee);
+        mainThread.suspend();
+        printStack(mainThread);
+        mainThread.resume();
+        log("resumee.isSuspended() -> " + resumee.isSuspended());
+        log("mainThread.isSuspended() -> " + mainThread.isSuspended());
+        log("Notify target main thread to continue by setting reachedBreakpoint = true.");
+        setField(resumeeThreadObj, "reachedBreakpoint", vm().mirrorOf(true));
+
+        log("Sleeping 500ms so that the main thread is blocked calling Thread.resume() on \"resumee\" Thread.");
+        Thread.sleep(500);
+        log("After sleep.");
+        mainThread.suspend();
+        printStack(mainThread);
+        mainThread.resume();
+
+        boolean mainThreadReturnedFromResumeCall = false;
+        boolean resumedResumee = false;
+        for (long sleepTime = 50; sleepTime < UNBLOCK_TIMEOUT && !mainThreadReturnedFromResumeCall; sleepTime <<= 1) {
+            log("mainThread.isSuspended() -> " + mainThread.isSuspended());
+            Value v = getField(resumeeThreadObj, "mainThreadReturnedFromResumeCall");
+            mainThreadReturnedFromResumeCall = ((PrimitiveValue) v).booleanValue();
+            if (!resumedResumee) {
+                // main thread should still be blocked.
+                Asserts.assertFalse(mainThreadReturnedFromResumeCall, "main Thread was not blocked");
+
+                // Test suspending the already suspended resumee thread.
+                Asserts.assertTrue(resumee.isSuspended(), "\"resumee\" is not suspended.");
+                log("Check if suspended \"resumee\" can be suspended a 2nd time.");
+                resumee.suspend();
+                log("resumee.isSuspended() -> " + resumee.isSuspended());
+                log("Resuming \"resumee\"");
+                resumee.resume();
+                Asserts.assertTrue(resumee.isSuspended(), "\"resumee\" is not suspended.");
+
+                // Really resume the resumee thread.
+                log("Resuming \"resumee\" a 2nd time will unblock the main thread.");
+                resumee.resume();
+                Asserts.assertFalse(resumee.isSuspended(), "\"resumee\" is still suspended.");
+                resumedResumee = true;
+            }
+            log("Sleeping " + sleepTime + "ms");
+            Thread.sleep(sleepTime);
+        }
+        Asserts.assertTrue(mainThreadReturnedFromResumeCall, "main Thread was not unblocked");
+
+        setField(resumeeThreadObj, "testFinished", vm().mirrorOf(true));
+
+        // Resume the target listening for events
+        listenUntilVMDisconnect();
+    }
+
+    public void printStack(ThreadReference thread) throws Exception {
+        log("Stack of thread '" + thread.name() + "':");
+        List<StackFrame> stack_frames = thread.frames();
+        int i = 0;
+        for (StackFrame ff : stack_frames) {
+            Location loc = ff.location();
+            String locString = "bci:" + loc.codeIndex();
+            try {
+                locString = loc.sourceName() + ":" + loc.lineNumber() + "," + locString;
+            } catch (AbsentInformationException e) {/* empty */};
+            log("  frame[" + i++ +"]: " + ff.location().method() + " (" + locString + ")");
+        }
+    }
+
+    public void setField(ObjectReference obj, String fName, Value val) throws Exception {
+        log("set field " + fName + " = " + val);
+        ReferenceType rt = obj.referenceType();
+        Field fld = rt.fieldByName(fName);
+        obj.setValue(fld, val);
+        log("ok");
+    }
+
+    public Value getField(ObjectReference obj, String fName) throws Exception {
+        log("get field " + fName);
+        ReferenceType rt = obj.referenceType();
+        Field fld = rt.fieldByName(fName);
+        Value val = obj.getValue(fld);
+        log("result : " + val);
+        return val;
+    }
+
+    public void log(String m) {
+        System.out.println("###(Debugger) " + m);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ca2efb73](https://github.com/openjdk/jdk/commit/ca2efb73f59112d9be2ec29db405deb4c58dd435) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Richard Reingruber on 15 Nov 2021 and was reviewed by Chris Plummer, Serguei Spitsyn and Ralf Schmelter.

Thanks!
Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274687](https://bugs.openjdk.java.net/browse/JDK-8274687): JDWP deadlocks if some Java thread reaches wait in blockOnDebuggerSuspend


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/375/head:pull/375` \
`$ git checkout pull/375`

Update a local copy of the PR: \
`$ git checkout pull/375` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 375`

View PR using the GUI difftool: \
`$ git pr show -t 375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/375.diff">https://git.openjdk.java.net/jdk17u-dev/pull/375.diff</a>

</details>
