### PR TITLE
8280593: [PPC64, S390] redundant allocation of MacroAssembler in StubGenerator ctor

### DIFF
--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4616,8 +4616,6 @@ class StubGenerator: public StubCodeGenerator {
 
  public:
   StubGenerator(CodeBuffer* code, bool all) : StubCodeGenerator(code) {
-    // replace the standard masm with a special one:
-    _masm = new MacroAssembler(code);
     if (all) {
       generate_all();
     } else {

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2404,9 +2404,6 @@ class StubGenerator: public StubCodeGenerator {
 
  public:
   StubGenerator(CodeBuffer* code, bool all) : StubCodeGenerator(code) {
-    // Replace the standard masm with a special one:
-    _masm = new MacroAssembler(code);
-
     _stub_count = !all ? 0x100 : 0x200;
     if (all) {
       generate_all();

--- a/src/hotspot/share/runtime/stubCodeGenerator.cpp
+++ b/src/hotspot/share/runtime/stubCodeGenerator.cpp
@@ -69,7 +69,7 @@ void StubCodeDesc::print() const { print_on(tty); }
 // Implementation of StubCodeGenerator
 
 StubCodeGenerator::StubCodeGenerator(CodeBuffer* code, bool print_code) {
-  _masm = new MacroAssembler(code );
+  _masm = new MacroAssembler(code);
   _print_code = PrintStubCode || print_code;
 }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c936e705](https://github.com/openjdk/jdk/commit/c936e7059b848d0e0be5f3234c4367657f2af2a7) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Richard Reingruber on 4 Feb 2022 and was reviewed by Martin Doerr and Lutz Schmidt.

Thanks!
Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280593](https://bugs.openjdk.java.net/browse/JDK-8280593): [PPC64, S390] redundant allocation of MacroAssembler in StubGenerator ctor


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/376/head:pull/376` \
`$ git checkout pull/376`

Update a local copy of the PR: \
`$ git checkout pull/376` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 376`

View PR using the GUI difftool: \
`$ git pr show -t 376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/376.diff">https://git.openjdk.java.net/jdk17u-dev/pull/376.diff</a>

</details>
