### PR TITLE
8284848: C2: Compiler blackhole arguments should be treated as globally escaping

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -618,6 +618,24 @@ void ConnectionGraph::add_node_to_connection_graph(Node *n, Unique_Node_List *de
       add_java_object(n, PointsToNode::ArgEscape);
       break;
     }
+    case Op_Blackhole: {
+      // All blackhole pointer arguments are globally escaping.
+      // Only do this if there is at least one pointer argument.
+      // Do not add edges during first iteration because some could be
+      // not defined yet, defer to final step.
+      for (uint i = 0; i < n->req(); i++) {
+        Node* in = n->in(i);
+        if (in != nullptr) {
+          const Type* at = _igvn->type(in);
+          if (!at->isa_ptr()) continue;
+
+          add_local_var(n, PointsToNode::GlobalEscape);
+          delayed_worklist->push(n);
+          break;
+        }
+      }
+      break;
+    }
     default:
       ; // Do nothing for nodes not related to EA.
   }
@@ -784,6 +802,26 @@ void ConnectionGraph::add_final_edges(Node *n) {
           }
           PointsToNode* ptn = ptnode_adr(adr->_idx);
           assert(ptn != NULL, "node should be registered");
+          add_edge(n_ptn, ptn);
+        }
+      }
+      break;
+    }
+    case Op_Blackhole: {
+      // All blackhole pointer arguments are globally escaping.
+      for (uint i = 0; i < n->req(); i++) {
+        Node* in = n->in(i);
+        if (in != nullptr) {
+          const Type* at = _igvn->type(in);
+          if (!at->isa_ptr()) continue;
+
+          if (in->is_AddP()) {
+            in = get_addp_base(in);
+          }
+
+          PointsToNode* ptn = ptnode_adr(in->_idx);
+          assert(ptn != nullptr, "should be defined already");
+          set_escape_state(ptn, PointsToNode::GlobalEscape);
           add_edge(n_ptn, ptn);
         }
       }

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeIntrinsicTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeIntrinsicTest.java
@@ -77,6 +77,15 @@ public class BlackholeIntrinsicTest {
         TESTS.put("bh_s_long_2",    BlackholeIntrinsicTest::test_long_2);
         TESTS.put("bh_s_double_2",  BlackholeIntrinsicTest::test_double_2);
         TESTS.put("bh_s_Object_2",  BlackholeIntrinsicTest::test_Object_2);
+
+        // Test calling static methods through instance method to exercise
+        // unusual intrinsic shapes.
+        TESTS.put("bh_is_int_0",    BlackholeIntrinsicTest::test_is_int_0);
+        TESTS.put("bh_is_Object_0", BlackholeIntrinsicTest::test_is_Object_0);
+        TESTS.put("bh_is_int_1",    BlackholeIntrinsicTest::test_is_int_1);
+        TESTS.put("bh_is_Object_1", BlackholeIntrinsicTest::test_is_Object_1);
+        TESTS.put("bh_is_int_2",    BlackholeIntrinsicTest::test_is_int_2);
+        TESTS.put("bh_is_Object_2", BlackholeIntrinsicTest::test_is_Object_2);
     }
 
     private static final int CYCLES = 100_000;
@@ -162,6 +171,13 @@ public class BlackholeIntrinsicTest {
         }
     }
 
+    private static void test_is_int_0() {
+        BlackholeTarget t = new BlackholeTarget();
+        for (int c = 0; c < CYCLES; c++) {
+            t.bh_is_int_0();
+        }
+    }
+
     private static void test_float_0() {
         for (int c = 0; c < CYCLES; c++) {
             BlackholeTarget.bh_s_float_0();
@@ -183,6 +199,13 @@ public class BlackholeIntrinsicTest {
     private static void test_Object_0() {
         for (int c = 0; c < CYCLES; c++) {
             BlackholeTarget.bh_s_Object_0();
+        }
+    }
+
+    private static void test_is_Object_0() {
+        BlackholeTarget t = new BlackholeTarget();
+        for (int c = 0; c < CYCLES; c++) {
+            t.bh_is_Object_0();
         }
     }
 
@@ -216,6 +239,13 @@ public class BlackholeIntrinsicTest {
         }
     }
 
+    private static void test_is_int_1() {
+        BlackholeTarget t = new BlackholeTarget();
+        for (int c = 0; c < CYCLES; c++) {
+            t.bh_is_int_1(c);
+        }
+    }
+
     private static void test_float_1() {
         for (int c = 0; c < CYCLES; c++) {
             BlackholeTarget.bh_s_float_1(c);
@@ -238,6 +268,14 @@ public class BlackholeIntrinsicTest {
         for (int c = 0; c < CYCLES; c++) {
             Object o = new Object();
             BlackholeTarget.bh_s_Object_1(o);
+        }
+    }
+
+    private static void test_is_Object_1() {
+        BlackholeTarget t = new BlackholeTarget();
+        for (int c = 0; c < CYCLES; c++) {
+            Object o = new Object();
+            t.bh_is_Object_1(o);
         }
     }
 
@@ -271,6 +309,13 @@ public class BlackholeIntrinsicTest {
         }
     }
 
+    private static void test_is_int_2() {
+        BlackholeTarget t = new BlackholeTarget();
+        for (int c = 0; c < CYCLES; c++) {
+            t.bh_is_int_2(c, c + 1);
+        }
+    }
+
     private static void test_float_2() {
         for (int c = 0; c < CYCLES; c++) {
             BlackholeTarget.bh_s_float_2(c, c + 1);
@@ -294,6 +339,15 @@ public class BlackholeIntrinsicTest {
             Object o1 = new Object();
             Object o2 = new Object();
             BlackholeTarget.bh_s_Object_2(o1, o2);
+        }
+    }
+
+    private static void test_is_Object_2() {
+        BlackholeTarget t = new BlackholeTarget();
+        for (int c = 0; c < CYCLES; c++) {
+            Object o1 = new Object();
+            Object o2 = new Object();
+            t.bh_is_Object_2(o1, o2);
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeTarget.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeTarget.java
@@ -48,6 +48,9 @@ public class BlackholeTarget {
     public static void    bh_s_double_0()            {}
     public static void    bh_s_Object_0()            {}
 
+    public static void    bh_is_int_0()              {}
+    public static void    bh_is_Object_0()           {}
+
     public static void    bh_s_boolean_1(boolean v)  {}
     public static void    bh_s_byte_1(byte v)        {}
     public static void    bh_s_short_1(short v)      {}
@@ -57,6 +60,9 @@ public class BlackholeTarget {
     public static void    bh_s_long_1(long v)        {}
     public static void    bh_s_double_1(double v)    {}
     public static void    bh_s_Object_1(Object v)    {}
+
+    public static void    bh_is_int_1(int v)         {}
+    public static void    bh_is_Object_1(Object v)   {}
 
     public static void    bh_s_boolean_1_delegate(boolean v)  { bh_s_boolean_1(v); }
     public static void    bh_s_byte_1_delegate(byte v)        { bh_s_byte_1(v);    }
@@ -77,6 +83,9 @@ public class BlackholeTarget {
     public static void    bh_s_long_2(long v1, long v2)          {}
     public static void    bh_s_double_2(double v1, double v2)    {}
     public static void    bh_s_Object_2(Object v1, Object v2)    {}
+
+    public static void    bh_is_int_2(int v1, int v2)            {}
+    public static void    bh_is_Object_2(Object v1, Object v2)   {}
 
     public static boolean bh_sr_boolean(boolean v) { return false; }
     public static byte    bh_sr_byte(byte v)       { return 0;     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/blackhole/BlackholeStoreStoreEATest.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/blackhole/BlackholeStoreStoreEATest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8284848
+ * @requires vm.compiler2.enabled
+ * @summary Blackhole arguments are globally escaping, thus preventing advanced EA optimizations
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.blackhole.BlackholeStoreStoreEATest
+ */
+
+package compiler.c2.irTests.blackhole;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+public class BlackholeStoreStoreEATest {
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags(
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:CompileCommand=blackhole,compiler.c2.irTests.blackhole.BlackholeStoreStoreEATest::blackhole"
+        );
+    }
+
+    /*
+     * Negative test is not possible: the StoreStore barrier is still in, even if we just do dontinline.
+     * Positive test: check that blackhole keeps the StoreStore barrier in.
+     */
+
+    @Test
+    @IR(counts = {IRNode.MEMBAR_STORESTORE, "1"})
+    static void testBlackholed() {
+        Object o = new Object();
+        blackhole(o);
+    }
+
+    static void blackhole(Object o) {}
+
+    @Run(test = "testBlackholed")
+    static void runBlackholed() {
+        testBlackholed();
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/blackhole/BlackholeSyncEATest.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/blackhole/BlackholeSyncEATest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8284848
+ * @requires vm.compiler2.enabled
+ * @summary Blackhole arguments are globally escaping, thus preventing advanced EA optimizations
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.blackhole.BlackholeSyncEATest
+ */
+
+package compiler.c2.irTests.blackhole;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+public class BlackholeSyncEATest {
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags(
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:CompileCommand=blackhole,compiler.c2.irTests.blackhole.BlackholeSyncEATest::blackhole",
+            "-XX:CompileCommand=dontinline,compiler.c2.irTests.blackhole.BlackholeSyncEATest::dontinline"
+        );
+    }
+
+    /*
+     * Negative test: check that dontinline method still allows EA to eliminate the synchronization.
+     */
+
+    @Test
+    @IR(failOn = {IRNode.FAST_LOCK, IRNode.FAST_UNLOCK})
+    static void testDontline() {
+        Object o = new Object();
+        synchronized (o) {}
+        dontinline(o);
+    }
+
+    static void dontinline(Object o) {}
+
+    @Run(test = "testDontline")
+    static void runDontinline() {
+        testDontline();
+    }
+
+    /*
+     * Positive test: check that blackhole keeps the synchronization in.
+     */
+
+    @Test
+    @IR(counts = {IRNode.FAST_LOCK, "1"})
+    @IR(counts = {IRNode.FAST_UNLOCK, "1"})
+    static void testBlackholed() {
+        Object o = new Object();
+        synchronized (o) {}
+        blackhole(o);
+    }
+
+    static void blackhole(Object o) {}
+
+    @Run(test = "testBlackholed")
+    static void runBlackholed() {
+        testBlackholed();
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -133,8 +133,12 @@ public class IRNode {
 
     public static final String SCOPE_OBJECT = "(.*# ScObj.*" + END;
     public static final String MEMBAR = START + "MemBar" + MID + END;
+    public static final String MEMBAR_STORESTORE = START + "MemBarStoreStore" + MID + END;
     public static final String SAFEPOINT = START + "SafePoint" + MID + END;
     public static final String POPCOUNT_L = START + "PopCountL" + MID + END;
+
+    public static final String FAST_LOCK   = START + "FastLock" + MID + END;
+    public static final String FAST_UNLOCK = START + "FastUnlock" + MID + END;
 
     /**
      * Called by {@link IRMatcher} to merge special composite nodes together with additional user-defined input.


### PR DESCRIPTION
Unclean backport to improve Blackhole - EA interactions. The backport is not clean, because `IRNode` needs missing constants, and `set_escape_state` does not accept third argument (description) in 18u.

Additional testing:
 - [x] `compiler/c2/irTests/blackhole` fail without the patch, pass with it
 - [x] `compiler/blackhole` continue to pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 reviews required, with at least 1 reviewer)

### Issue
 * [JDK-8284848](https://bugs.openjdk.java.net/browse/JDK-8284848): C2: Compiler blackhole arguments should be treated as globally escaping


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [63dff48a](https://git.openjdk.java.net/jdk17u-dev/pull/379/files/63dff48ace68dc50f0863ffcdd45fac54042aaf6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/379/head:pull/379` \
`$ git checkout pull/379`

Update a local copy of the PR: \
`$ git checkout pull/379` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 379`

View PR using the GUI difftool: \
`$ git pr show -t 379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/379.diff">https://git.openjdk.java.net/jdk17u-dev/pull/379.diff</a>

</details>
