### PR TITLE
Backport 4d45c3ebc493bb2c85dab84b97840c8ba093ab1f

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,10 +135,9 @@ CodeBuffer::~CodeBuffer() {
     // Previous incarnations of this buffer are held live, so that internal
     // addresses constructed before expansions will not be confused.
     cb->free_blob();
+    // free any overflow storage
+    delete cb->_overflow_arena;
   }
-
-  // free any overflow storage
-  delete _overflow_arena;
 
   // Claim is that stack allocation ensures resources are cleaned up.
   // This is resource clean up, let's hope that all were properly copied out.
@@ -942,6 +941,7 @@ void CodeBuffer::take_over_code_from(CodeBuffer* cb) {
     this_sect->take_over_code_from(cb_sect);
   }
   _overflow_arena = cb->_overflow_arena;
+  cb->_overflow_arena = NULL;
   // Make sure the old cb won't try to use it or free it.
   DEBUG_ONLY(cb->_blob = (BufferBlob*)badAddress);
 }


### PR DESCRIPTION
I would like to backport this patch to 17u for fixing a memory leak.

The original patch does not apply cleanly, mainly due to context difference introduced by JDK-8264207 and JDK-8054292. However, the patch is small, easily resolved manually.

Test:
- [x] hotspot_compiler
