### PR TITLE
8282929: Localized monetary symbols are not reflected in `toLocalizedPattern` return value

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3210,16 +3210,18 @@ public class DecimalFormat extends NumberFormat {
             for (i = digitCount; i > 0; --i) {
                 if (i != digitCount && isGroupingUsed() && groupingSize != 0 &&
                     i % groupingSize == 0) {
-                    result.append(localized ? symbols.getGroupingSeparator() :
-                                  PATTERN_GROUPING_SEPARATOR);
+                    result.append(localized ?
+                        (isCurrencyFormat ? symbols.getMonetaryGroupingSeparator() : symbols.getGroupingSeparator()) :
+                        PATTERN_GROUPING_SEPARATOR);
                 }
                 result.append(i <= getMinimumIntegerDigits()
                     ? (localized ? symbols.getZeroDigit() : PATTERN_ZERO_DIGIT)
                     : (localized ? symbols.getDigit() : PATTERN_DIGIT));
             }
             if (getMaximumFractionDigits() > 0 || decimalSeparatorAlwaysShown)
-                result.append(localized ? symbols.getDecimalSeparator() :
-                              PATTERN_DECIMAL_SEPARATOR);
+                result.append(localized ?
+                    (isCurrencyFormat ? symbols.getMonetaryDecimalSeparator() : symbols.getDecimalSeparator()) :
+                    PATTERN_DECIMAL_SEPARATOR);
             for (i = 0; i < getMaximumFractionDigits(); ++i) {
                 if (i < getMinimumFractionDigits()) {
                     result.append(localized ? symbols.getZeroDigit() :

--- a/test/jdk/java/text/Format/DecimalFormat/ToLocalizedPatternTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/ToLocalizedPatternTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282929
+ * @summary Verifies that toLocalizedPattern() method correctly returns
+ *          monetary symbols in a currency formatter
+ * @run testng ToLocalizedPatternTest
+ */
+
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+@Test
+public class ToLocalizedPatternTest {
+    private static final char MONETARY_GROUPING = 'g';
+    private static final char MONETARY_DECIMAL = 'd';
+
+    public void testToLocalizedPattern() {
+        var dfs = new DecimalFormatSymbols(Locale.US);
+
+        // Customize the decimal format symbols
+        dfs.setMonetaryGroupingSeparator(MONETARY_GROUPING);
+        dfs.setMonetaryDecimalSeparator(MONETARY_DECIMAL);
+
+        // create a currency formatter
+        var cf = (DecimalFormat)DecimalFormat.getCurrencyInstance(Locale.US);
+        cf.setDecimalFormatSymbols(dfs);
+
+        // check
+        assertEquals(cf.toLocalizedPattern(),
+            cf.toPattern()
+               .replace(',', MONETARY_GROUPING)
+               .replace('.', MONETARY_DECIMAL));
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8282929](https://bugs.openjdk.java.net/browse/JDK-8282929)
Clean except Copyright year update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282929](https://bugs.openjdk.java.net/browse/JDK-8282929): Localized monetary symbols are not reflected in `toLocalizedPattern` return value


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/383/head:pull/383` \
`$ git checkout pull/383`

Update a local copy of the PR: \
`$ git checkout pull/383` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 383`

View PR using the GUI difftool: \
`$ git pr show -t 383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/383.diff">https://git.openjdk.java.net/jdk17u-dev/pull/383.diff</a>

</details>
