### PR TITLE
8285956: (fs) Excessive default poll interval in PollingWatchService

### DIFF
--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -61,6 +61,11 @@ import java.util.concurrent.TimeUnit;
 class PollingWatchService
     extends AbstractWatchService
 {
+    // Wait between polling thread creation and first poll (seconds)
+    private static final int POLLING_INIT_DELAY = 1;
+    // Default time between polls (seconds)
+    private static final int DEFAULT_POLLING_INTERVAL = 2;
+
     // map of registrations
     private final Map<Object, PollingWatchKey> map = new HashMap<>();
 
@@ -115,7 +120,7 @@ class PollingWatchService
             throw new IllegalArgumentException("No events to register");
 
         // Extended modifiers may be used to specify the sensitivity level
-        int sensitivity = 10;
+        int sensitivity = DEFAULT_POLLING_INTERVAL;
         if (modifiers.length > 0) {
             for (WatchEvent.Modifier modifier: modifiers) {
                 if (modifier == null)
@@ -247,6 +252,7 @@ class PollingWatchService
      * directory and queue keys when entries are added, modified, or deleted.
      */
     private class PollingWatchKey extends AbstractWatchKey {
+
         private final Object fileKey;
 
         // current event set
@@ -305,10 +311,10 @@ class PollingWatchService
                 // update the events
                 this.events = events;
 
-                // create the periodic task
+                // create the periodic task with initialDelay set to the specified constant
                 Runnable thunk = new Runnable() { public void run() { poll(); }};
                 this.poller = scheduledExecutor
-                    .scheduleAtFixedRate(thunk, period, period, TimeUnit.SECONDS);
+                    .scheduleAtFixedRate(thunk, POLLING_INIT_DELAY, period, TimeUnit.SECONDS);
             }
         }
 


### PR DESCRIPTION
This PR backports changes that reduce the wait time for a user of the WatchService API on AIX and BSD.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285956](https://bugs.openjdk.java.net/browse/JDK-8285956): (fs) Excessive default poll interval in PollingWatchService


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/384/head:pull/384` \
`$ git checkout pull/384`

Update a local copy of the PR: \
`$ git checkout pull/384` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 384`

View PR using the GUI difftool: \
`$ git pr show -t 384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/384.diff">https://git.openjdk.java.net/jdk17u-dev/pull/384.diff</a>

</details>
