### PR TITLE
8283469: Don't use memset to initialize members in FileMapInfo and fix memory leak

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -193,6 +193,7 @@ FileMapInfo::~FileMapInfo() {
     assert(_dynamic_archive_info == this, "must be singleton"); // not thread safe
     _dynamic_archive_info = NULL;
   }
+
   if (_header != nullptr) {
     os::free(_header);
   }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -165,9 +165,9 @@ template <int N> static void get_header_version(char (&header_version) [N]) {
   assert(header_version[JVM_IDENT_MAX-1] == 0, "must be");
 }
 
-FileMapInfo::FileMapInfo(bool is_static) {
-  memset((void*)this, 0, sizeof(FileMapInfo));
-  _is_static = is_static;
+FileMapInfo::FileMapInfo(bool is_static) :
+  _is_static(is_static), _file_open(false), _is_mapped(false), _fd(-1), _file_offset(0),
+  _full_path(nullptr), _base_archive_name(nullptr), _header(nullptr) {
   size_t header_size;
   if (is_static) {
     assert(_current_info == NULL, "must be singleton"); // not thread safe
@@ -183,8 +183,6 @@ FileMapInfo::FileMapInfo(bool is_static) {
   _header->set_header_size(header_size);
   _header->set_version(INVALID_CDS_ARCHIVE_VERSION);
   _header->set_has_platform_or_app_classes(true);
-  _file_offset = 0;
-  _file_open = false;
 }
 
 FileMapInfo::~FileMapInfo() {
@@ -194,6 +192,13 @@ FileMapInfo::~FileMapInfo() {
   } else {
     assert(_dynamic_archive_info == this, "must be singleton"); // not thread safe
     _dynamic_archive_info = NULL;
+  }
+  if (_header != nullptr) {
+    os::free(_header);
+  }
+
+  if (_file_open) {
+    ::close(_fd);
   }
 }
 


### PR DESCRIPTION
I would like to backport this patch to 17u, to fix a memory leak, also eliminates dangerous memset call, could potentially result in fatal crash.

The original patch does not apply cleanly, due to [JDK-8261455](https://bugs.openjdk.java.net/browse/JDK-8261455), where it changed FileMapInfo's constructor signature to pass in full_path as a parameter. The conflict is resolved manually by initializing _full_path to nullptr.

I also bought down following code from [JDK-8261455](https://bugs.openjdk.java.net/browse/JDK-8261455), given it is a P4 enhancement, I don't see it is a candidate for backport itself. But following code obviously fixes a bug that leaves file open after use. 

``` 
  if (_file_open) {
    os::close(_fd);
  }
```

Test:
  - [x] hotspot_cds on Linux x86_64
  - [x]  GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8283469](https://bugs.openjdk.java.net/browse/JDK-8283469): Don't use memset to initialize members in FileMapInfo and fix memory leak


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [63f416a5](https://git.openjdk.java.net/jdk17u-dev/pull/397/files/63f416a5e63ac197f398a679b982a968edef346c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/397/head:pull/397` \
`$ git checkout pull/397`

Update a local copy of the PR: \
`$ git checkout pull/397` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 397`

View PR using the GUI difftool: \
`$ git pr show -t 397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/397.diff">https://git.openjdk.java.net/jdk17u-dev/pull/397.diff</a>

</details>
