### PR TITLE
8285523: Improve test java/io/FileOutputStream/OpenNUL.java

### DIFF
--- a/test/jdk/java/io/FileOutputStream/OpenNUL.java
+++ b/test/jdk/java/io/FileOutputStream/OpenNUL.java
@@ -26,7 +26,9 @@
  * @bug 8285445
  * @requires (os.family == "windows")
  * @summary Verify behavior of opening "NUL:" with ADS enabled and disabled.
+ * @run main/othervm OpenNUL
  * @run main/othervm -Djdk.io.File.enableADS OpenNUL
+ * @run main/othervm -Djdk.io.File.enableADS=FalsE OpenNUL
  * @run main/othervm -Djdk.io.File.enableADS=true OpenNUL
  */
 
@@ -36,7 +38,7 @@ import java.io.IOException;
 
 public class OpenNUL {
     public static void main(String args[]) throws IOException {
-        String enableADS = System.getProperty("jdk.io.File.enableADS");
+        String enableADS = System.getProperty("jdk.io.File.enableADS", "true");
         boolean fails = enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
 
         FileOutputStream fos;


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [f42631e3](https://github.com/openjdk/jdk/commit/f42631e354d4abf7994abd92aa5def6b2ceeab3a) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 29 Apr 2022 and was reviewed by Andrew John Hughes and Brian Burkhalter.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285523](https://bugs.openjdk.java.net/browse/JDK-8285523): Improve test java/io/FileOutputStream/OpenNUL.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/398/head:pull/398` \
`$ git checkout pull/398`

Update a local copy of the PR: \
`$ git checkout pull/398` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 398`

View PR using the GUI difftool: \
`$ git pr show -t 398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/398.diff">https://git.openjdk.java.net/jdk17u-dev/pull/398.diff</a>

</details>
