### PR TITLE
8280550: SplittableRandom#nextDouble(double,double) can return result >= bound

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -645,7 +645,7 @@ public class RandomSupport {
         if (origin < bound) {
             r = r * (bound - origin) + origin;
             if (r >= bound)  // may need to correct a rounding problem
-                r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+                r = Math.nextAfter(r, origin);
         }
         return r;
     }
@@ -677,7 +677,7 @@ public class RandomSupport {
         double r = rng.nextDouble();
         r = r * bound;
         if (r >= bound)  // may need to correct a rounding problem
-            r = Double.longBitsToDouble(Double.doubleToLongBits(bound) - 1);
+            r = Math.nextDown(r);
         return r;
     }
 

--- a/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
+++ b/test/jdk/java/util/Random/RandomNextDoubleBoundary.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify nextDouble stays within range
+ * @bug 8280550
+ */
+
+import java.util.SplittableRandom;
+
+public class RandomNextDoubleBoundary {
+    public static void main(String... args) {
+        // Both bounds are negative
+        double lowerBound = -1.0000000000000002;
+        double upperBound = -1.0;
+        var sr = new SplittableRandom(42L);
+        var r = sr.nextDouble(lowerBound, upperBound);
+
+        if (r >= upperBound) {
+            System.err.println("r = " + r + "\t" + Double.toHexString(r));
+            System.err.println("ub = " + upperBound + "\t" + Double.toHexString(upperBound));
+            throw new RuntimeException("Greater than upper bound");
+        }
+
+        if (r < lowerBound) {
+            System.err.println("r = " + r + "\t" + Double.toHexString(r));
+            System.err.println("lb = " + lowerBound + "\t" + Double.toHexString(lowerBound));
+            throw new RuntimeException("Less than lower bound");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.4-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280550](https://bugs.openjdk.java.net/browse/JDK-8280550): SplittableRandom#nextDouble(double,double) can return result >= bound


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/399/head:pull/399` \
`$ git checkout pull/399`

Update a local copy of the PR: \
`$ git checkout pull/399` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 399`

View PR using the GUI difftool: \
`$ git pr show -t 399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/399.diff">https://git.openjdk.java.net/jdk17u-dev/pull/399.diff</a>

</details>
