### PR TITLE
8236136: tests which use CompilationMode shouldn't be run w/ TieredStopAtLevel

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/CompilationModeHighOnlyTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/CompilationModeHighOnlyTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8233885
+ * @requires (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @summary CompLevel_initial_compile should be CompLevel_full_optimization for high-only mode
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xcomp -XX:CompilationMode=high-only
  *                   -XX:CompileCommand=compileonly,java.lang.Object::<init>

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
@@ -27,7 +27,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.instrument
- * @requires vm.jvmti
+ * @requires vm.jvmti & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @build compiler.profiling.spectrapredefineclass.Agent
  * @run driver jdk.test.lib.helpers.ClassFileInstaller compiler.profiling.spectrapredefineclass.Agent
  * @run driver compiler.profiling.spectrapredefineclass.Launcher

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
@@ -27,7 +27,7 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.instrument
- * @requires vm.jvmti
+ * @requires vm.jvmti & (vm.opt.TieredStopAtLevel == null | vm.opt.TieredStopAtLevel == 4)
  * @build compiler.profiling.spectrapredefineclass_classloaders.Agent
  *        compiler.profiling.spectrapredefineclass_classloaders.Test
  *        compiler.profiling.spectrapredefineclass_classloaders.A


### PR DESCRIPTION
I backport this test-only change for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8236136](https://bugs.openjdk.java.net/browse/JDK-8236136): tests which use CompilationMode shouldn't be run w/ TieredStopAtLevel


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/400/head:pull/400` \
`$ git checkout pull/400`

Update a local copy of the PR: \
`$ git checkout pull/400` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 400`

View PR using the GUI difftool: \
`$ git pr show -t 400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/400.diff">https://git.openjdk.java.net/jdk17u-dev/pull/400.diff</a>

</details>
