### PR TITLE
8240756: [macos] SwingSet2:TableDemo:Printed Japanese characters were garbled

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTextPipe.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CTextPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,16 +81,88 @@ public class CTextPipe implements TextPipe {
         }
     }
 
-    public void drawGlyphVector(final SunGraphics2D sg2d, final GlyphVector gV, final float x, final float y) {
-        final Font prevFont = sg2d.getFont();
-        sg2d.setFont(gV.getFont());
+    private boolean hasSlotData(GlyphVector gv) {
+        final int length = gv.getNumGlyphs();
+        for (int i = 0; i < length; i++) {
+            if ((gv.getGlyphCode(i) & CompositeGlyphMapper.SLOTMASK) != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
 
+    private Font getSlotFont(Font font, int slot) {
+        Font2D f2d = FontUtilities.getFont2D(font);
+        if (f2d instanceof CFont) {
+            CompositeFont cf = ((CFont)f2d).getCompositeFont2D();
+            PhysicalFont pf = cf.getSlotFont(slot);
+            Font f = new Font(pf.getFontName(null),
+                              font.getStyle(), font.getSize());
+            return f;
+        }
+        return null;
+    }
+
+    private GlyphVector getGlyphVectorWithRange(final Font font, final GlyphVector gV, int start, int count) {
+        int[] glyphs = new int[count];
+        for (int i = 0; i < count; i++) {
+            glyphs[i] = gV.getGlyphCode(start+i) & CompositeGlyphMapper.GLYPHMASK;
+        }
+        // Positions should be null to recalculate by native methods,
+        // if GV was segmented.
+        StandardGlyphVector sgv = new StandardGlyphVector(font,
+                                          gV.getFontRenderContext(),
+                                          glyphs,
+                                          null, // positions
+                                          null, // indices
+                                          gV.getLayoutFlags());
+        return sgv;
+    }
+
+    private int getLengthOfSameSlot(final GlyphVector gV, final int targetSlot, final int start, final int length) {
+        int count = 1;
+        for (; start + count < length; count++) {
+            int slot = (gV.getGlyphCode(start + count) &
+                        CompositeGlyphMapper.SLOTMASK) >> 24;
+            if (targetSlot != slot) {
+                break;
+            }
+        }
+        return count;
+    }
+
+    private void drawGlyphVectorImpl(final SunGraphics2D sg2d, final GlyphVector gV, final float x, final float y) {
         final long nativeStrikePtr = getNativeStrikePtr(sg2d);
         if (OSXSurfaceData.IsSimpleColor(sg2d.paint) && nativeStrikePtr != 0) {
             final OSXSurfaceData surfaceData = (OSXSurfaceData)sg2d.getSurfaceData();
             surfaceData.drawGlyphs(this, sg2d, nativeStrikePtr, gV, x, y);
         } else {
             drawGlyphVectorAsShape(sg2d, gV, x, y);
+        }
+    }
+
+    public void drawGlyphVector(final SunGraphics2D sg2d, final GlyphVector gV, final float x, final float y) {
+        final Font prevFont = sg2d.getFont();
+        sg2d.setFont(gV.getFont());
+
+        if (hasSlotData(gV)) {
+            final int length = gV.getNumGlyphs();
+            float[] positions = gV.getGlyphPositions(0, length, null);
+            int start = 0;
+            while (start < length) {
+                int slot = (gV.getGlyphCode(start) &
+                            CompositeGlyphMapper.SLOTMASK) >> 24;
+                sg2d.setFont(getSlotFont(gV.getFont(), slot));
+                int count = getLengthOfSameSlot(gV, slot, start, length);
+                GlyphVector rangeGV = getGlyphVectorWithRange(sg2d.getFont(),
+                                                              gV, start, count);
+                drawGlyphVectorImpl(sg2d, rangeGV,
+                                    x + positions[start * 2],
+                                    y + positions[start * 2 + 1]);
+                start += count;
+            }
+        } else {
+            drawGlyphVectorImpl(sg2d, gV, x, y);
         }
         sg2d.setFont(prevFont);
     }

--- a/test/jdk/java/awt/font/GlyphVector/MultiSlotFontTest.java
+++ b/test/jdk/java/awt/font/GlyphVector/MultiSlotFontTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8240756
+ * @summary Non-English characters are printed with wrong glyphs on MacOS
+ * @modules java.desktop/sun.java2d java.desktop/sun.java2d.loops java.desktop/sun.font
+ * @requires os.family == "mac"
+ * @run main MultiSlotFontTest
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.RenderingHints;
+import java.awt.font.FontRenderContext;
+import java.awt.font.GlyphVector;
+import java.awt.image.BufferedImage;
+import sun.font.StandardGlyphVector;
+import sun.java2d.OSXOffScreenSurfaceData;
+import sun.java2d.SunGraphics2D;
+import sun.java2d.SurfaceData;
+import sun.java2d.loops.SurfaceType;
+
+public class MultiSlotFontTest {
+
+    private static final int WIDTH = 100;
+    private static final int HEIGHT = 60;
+
+    private static final String TEST_STR = "\u3042\u3044\u3046\u3048\u304Aabc";
+    private static final int EXPECTED_HEIGHT = 10;
+    private static final int EXPECTED_WIDTH = 77;
+    private static final int LIMIT_DIFF_HEIGHT = 3;
+    private static final int LIMIT_DIFF_WIDTH = 15;
+
+    public static void main(String[] args) throws Exception {
+        MultiSlotFontTest test = new MultiSlotFontTest();
+    }
+
+    public MultiSlotFontTest() {
+        BufferedImage img = createImage();
+
+        SurfaceData sd = OSXOffScreenSurfaceData.createDataIC(img,
+                             SurfaceType.IntRgb);
+        SunGraphics2D g2d = new SunGraphics2D(sd,
+                                    Color.BLACK, Color.WHITE, null);
+        Font font = g2d.getFont();
+
+        if (font.canDisplayUpTo(TEST_STR) != -1) {
+            System.out.println("There is no capable font. Skipping the test.");
+            System.out.println("Font: " + font);
+            return;
+        }
+
+        FontRenderContext frc = new FontRenderContext(null, false, false);
+        StandardGlyphVector gv = new StandardGlyphVector(font, TEST_STR, frc);
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                             RenderingHints.VALUE_ANTIALIAS_OFF);
+        g2d.drawGlyphVector(gv, 0.0f, (float)(HEIGHT - 5));
+        g2d.dispose();
+
+        Dimension d = getBounds(img);
+
+        if (Math.abs(d.height - EXPECTED_HEIGHT) > LIMIT_DIFF_HEIGHT ||
+            Math.abs(d.width  - EXPECTED_WIDTH)  > LIMIT_DIFF_WIDTH) {
+            debugOut(img);
+            throw new RuntimeException(
+                "Incorrect GlyphVector shape " + d + "," + gv);
+        }
+    }
+
+    private static BufferedImage createImage() {
+        BufferedImage image = new BufferedImage(WIDTH, HEIGHT,
+                                      BufferedImage.TYPE_INT_RGB);
+        Graphics g = image.createGraphics();
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, WIDTH, HEIGHT);
+        g.dispose();
+        return image;
+    }
+
+    private Dimension getBounds(BufferedImage img) {
+        int top = HEIGHT;
+        int left = WIDTH;
+        int right = 0;
+        int bottom = 0;
+        for (int y = 0; y < HEIGHT; y++) {
+            for (int x = 0; x < WIDTH; x++) {
+                if ((img.getRGB(x, y) & 0xFFFFFF) == 0) {
+                    if (top    > y) top = y;
+                    if (bottom < y) bottom = y;
+                    if (left   > x) left = x;
+                    if (right  < x) right = x;
+                }
+            }
+        }
+        return new Dimension(right - left, bottom - top);
+    }
+
+    private void debugOut(BufferedImage img) {
+        for (int y = 0; y < HEIGHT; y++) {
+            for (int x = 0; x < WIDTH; x++) {
+                int c = img.getRGB(x, y) & 0xFFFFFF;
+                if (c == 0) {
+                    System.out.print("*");
+                } else {
+                    System.out.print(" ");
+                }
+            }
+            System.out.println();
+        }
+    }
+}


### PR DESCRIPTION
Backport JDK-8240756

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8240756](https://bugs.openjdk.java.net/browse/JDK-8240756): [macos] SwingSet2:TableDemo:Printed Japanese characters were garbled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/404/head:pull/404` \
`$ git checkout pull/404`

Update a local copy of the PR: \
`$ git checkout pull/404` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 404`

View PR using the GUI difftool: \
`$ git pr show -t 404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/404.diff">https://git.openjdk.java.net/jdk17u-dev/pull/404.diff</a>

</details>
