### PR TITLE
8287202: GHA: Add macOS aarch64 to the list of default platforms for workflow_dispatch event

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -10,7 +10,7 @@ on:
       platforms:
         description: "Platform(s) to execute on"
         required: true
-        default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows aarch64, Windows x64, macOS x64"
+        default: "Linux additional (hotspot only), Linux x64, Linux x86, Windows aarch64, Windows x64, macOS x64, macOS aarch64"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of https://bugs.openjdk.java.net/browse/JDK-8287202 from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Christoph Langer on 25 May 2022 and was reviewed by Magnus Ihse Bursie and Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287202](https://bugs.openjdk.java.net/browse/JDK-8287202): GHA: Add macOS aarch64 to the list of default platforms for workflow_dispatch event


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/412/head:pull/412` \
`$ git checkout pull/412`

Update a local copy of the PR: \
`$ git checkout pull/412` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 412`

View PR using the GUI difftool: \
`$ git pr show -t 412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/412.diff">https://git.openjdk.java.net/jdk17u-dev/pull/412.diff</a>

</details>
