### PR TITLE
8284661: Reproducible assembly builds without relative linking

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -95,8 +95,24 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
   # info flags for toolchains unless we know they work.
   # See JDK-8207057.
   ASFLAGS_DEBUG_SYMBOLS=""
+
+  # Debug prefix mapping if supported by compiler
+  DEBUG_PREFIX_CFLAGS=
+
   # Debug symbols
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
+    if test "x$ALLOW_ABSOLUTE_PATHS_IN_OUTPUT" = "xfalse"; then
+      # Check if compiler supports -fdebug-prefix-map. If so, use that to make
+      # the debug symbol paths resolve to paths relative to the workspace root.
+      workspace_root_trailing_slash="${WORKSPACE_ROOT%/}/"
+      DEBUG_PREFIX_CFLAGS="-fdebug-prefix-map=${workspace_root_trailing_slash}="
+      FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${DEBUG_PREFIX_CFLAGS}],
+        IF_FALSE: [
+            DEBUG_PREFIX_CFLAGS=
+        ]
+      )
+    fi
+
     CFLAGS_DEBUG_SYMBOLS="-g"
     ASFLAGS_DEBUG_SYMBOLS="-g"
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
@@ -106,6 +122,11 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
     CFLAGS_DEBUG_SYMBOLS="-g1"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     CFLAGS_DEBUG_SYMBOLS="-Z7"
+  fi
+
+  if test "x$DEBUG_PREFIX_CFLAGS" != x; then
+    CFLAGS_DEBUG_SYMBOLS="$CFLAGS_DEBUG_SYMBOLS $DEBUG_PREFIX_CFLAGS"
+    ASFLAGS_DEBUG_SYMBOLS="$ASFLAGS_DEBUG_SYMBOLS $DEBUG_PREFIX_CFLAGS"
   fi
 
   AC_SUBST(CFLAGS_DEBUG_SYMBOLS)

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -389,6 +389,12 @@ define SetupCompileNativeFileBody
     $1_OBJ_DEPS := $$($1_SRC_FILE) $$($$($1_BASE)_COMPILE_VARDEPS_FILE) \
         $$($$($1_BASE)_EXTRA_DEPS) $$($1_VARDEPS_FILE)
     $1_COMPILE_OPTIONS := $$($1_FLAGS) $(CC_OUT_OPTION)$$($1_OBJ) $$($1_SRC_FILE)
+    # For reproducible builds with gcc ensure random symbol generation is seeded deterministically
+    ifeq ($(TOOLCHAIN_TYPE), gcc)
+       ifeq ($$(ENABLE_REPRODUCIBLE_BUILD), true)
+         $1_COMPILE_OPTIONS += -frandom-seed="$$($1_FILENAME)"
+       endif
+    endif
 
     $$($1_OBJ_JSON): $$($1_OBJ_DEPS)
 	$$(call WriteCompileCommandsFragment, $$@, $$(PWD), $$($1_SRC_FILE), \
@@ -1137,6 +1143,19 @@ define SetupNativeCompilationBody
         # There is no strlen function in make, but checking path depth is a
         # reasonable approximation.
         ifneq ($$(word 10, $$(subst /, ,$$(OUTPUTDIR))), )
+          $1_LINK_OBJS_RELATIVE := true
+          $1_ALL_OBJS_RELATIVE := $$(patsubst $$(OUTPUTDIR)/%, %, $$($1_ALL_OBJS))
+        endif
+      endif
+    endif
+
+    # Debuginfo of ASM objects always embeds the absolute object path,
+    # as ASM debuginfo paths do not get prefix mapped.
+    # So for reproducible builds use relative paths to ensure a reproducible
+    # debuginfo and libs, when creating debug symbols.
+    ifeq ($$(ENABLE_REPRODUCIBLE_BUILD), true)
+      ifeq ($(call isTargetOs, linux), true)
+        ifeq ($$($1_COMPILE_WITH_DEBUG_SYMBOLS), true)
           $1_LINK_OBJS_RELATIVE := true
           $1_ALL_OBJS_RELATIVE := $$(patsubst $$(OUTPUTDIR)/%, %, $$($1_ALL_OBJS))
         endif

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -358,6 +358,20 @@ define SetupCompileNativeFileBody
       # Compile as preprocessed assembler file
       $1_FLAGS := $(BASIC_ASFLAGS) $$($1_BASE_ASFLAGS)
       $1_COMPILER := $(AS)
+
+      # gcc assembly files must contain an appropriate relative .file
+      # path for reproducible builds.
+      ifeq ($(TOOLCHAIN_TYPE), gcc)
+        # If no absolute paths allowed, work out relative source file path
+        # for assembly .file substitution, otherwise use full file path
+        ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT), false)
+          $1_REL_ASM_SRC := $$(call RelativePath, $$($1_FILE), $(WORKSPACE_ROOT))
+        else
+          $1_REL_ASM_SRC := $$($1_FILE)
+        endif
+        $1_FLAGS := $$($1_FLAGS) -DASSEMBLY_SRC_FILE='"$$($1_REL_ASM_SRC)"' \
+            -include $(TOPDIR)/make/data/autoheaders/assemblyprefix.h
+      endif
     else ifneq ($$(filter %.cpp %.cc %.mm, $$($1_FILENAME)), )
       # Compile as a C++ or Objective-C++ file
       $1_FLAGS := $(CFLAGS_CCACHE) $$($1_USE_PCH_FLAGS) $$($1_BASE_CXXFLAGS) \
@@ -1143,19 +1157,6 @@ define SetupNativeCompilationBody
         # There is no strlen function in make, but checking path depth is a
         # reasonable approximation.
         ifneq ($$(word 10, $$(subst /, ,$$(OUTPUTDIR))), )
-          $1_LINK_OBJS_RELATIVE := true
-          $1_ALL_OBJS_RELATIVE := $$(patsubst $$(OUTPUTDIR)/%, %, $$($1_ALL_OBJS))
-        endif
-      endif
-    endif
-
-    # Debuginfo of ASM objects always embeds the absolute object path,
-    # as ASM debuginfo paths do not get prefix mapped.
-    # So for reproducible builds use relative paths to ensure a reproducible
-    # debuginfo and libs, when creating debug symbols.
-    ifeq ($$(ENABLE_REPRODUCIBLE_BUILD), true)
-      ifeq ($(call isTargetOs, linux), true)
-        ifeq ($$($1_COMPILE_WITH_DEBUG_SYMBOLS), true)
           $1_LINK_OBJS_RELATIVE := true
           $1_ALL_OBJS_RELATIVE := $$(patsubst $$(OUTPUTDIR)/%, %, $$($1_ALL_OBJS))
         endif

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1163,19 +1163,6 @@ define SetupNativeCompilationBody
       endif
     endif
 
-    # Debuginfo of ASM objects always embeds the absolute object path,
-    # as ASM debuginfo paths do not get prefix mapped.
-    # So for reproducible builds use relative paths to ensure a reproducible
-    # debuginfo and libs, when creating debug symbols.
-    ifeq ($$(ENABLE_REPRODUCIBLE_BUILD), true)
-      ifeq ($(call isTargetOs, linux), true)
-        ifeq ($$($1_COMPILE_WITH_DEBUG_SYMBOLS), true)
-          $1_LINK_OBJS_RELATIVE := true
-          $1_ALL_OBJS_RELATIVE := $$(patsubst $$(OUTPUTDIR)/%, %, $$($1_ALL_OBJS))
-        endif
-      endif
-    endif
-
     $1_TARGET_DEPS := $$($1_ALL_OBJS) $$($1_RES) $$($1_MANIFEST) \
         $$($1_REAL_MAPFILE) $$($1_VARDEPS_FILE)
 

--- a/make/data/autoheaders/assemblyprefix.h
+++ b/make/data/autoheaders/assemblyprefix.h
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+// ASSEMBLY_SRC_FILE gets replaced by relative or absolute file path
+// in NativeCompilation.gmk for gcc tooling on Linux. This ensures a
+// reproducible object file through a predictable value of the STT_FILE
+// symbol, and subsequently a reproducible .debuginfo.
+.file ASSEMBLY_SRC_FILE
+

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -58,6 +58,9 @@ ifeq ($(call check-jvm-feature, compiler2), true)
 
   ADLC_CFLAGS += -I$(TOPDIR)/src/hotspot/share
 
+  # Add file macro mappings
+  ADLC_CFLAGS += $(FILE_MACRO_CFLAGS)
+
   $(eval $(call SetupNativeCompilation, BUILD_ADLC, \
       NAME := adlc, \
       TYPE := EXECUTABLE, \

--- a/make/jdk/src/classes/build/tools/makezipreproducible/MakeZipReproducible.java
+++ b/make/jdk/src/classes/build/tools/makezipreproducible/MakeZipReproducible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,6 +203,10 @@ public class MakeZipReproducible {
         if (timestamp != null) {
             entry.setTimeLocal(timestamp);
         }
+
+        // Ensure "extra" field is not set from original ZipEntry info that may be not deterministic
+        // eg.may contain specific UID/GID
+        entry.setExtra(null);
 
         zos.putNextEntry(entry);
         if (entry.getSize() > 0 && entryInputStream != null) {

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_acos_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_acos_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_acos.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_acos2_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_asin_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_asin_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_asin.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_asin2_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_atan2_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_atan2_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_atan2.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_atan22_ha_ex_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_atan_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_atan_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_atan.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_atan2_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_cbrt_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_cbrt_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_cbrt.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_cbrt1_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_cos_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_cos_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_cos.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_cos2_ha_ex_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_cosh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_cosh_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_cosh.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_cosh1_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_exp_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_exp_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_exp.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_exp1_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_expm1_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_expm1_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_expm1.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_expm14_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_hypot_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_hypot_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_hypot.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_hypot2_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_log10_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_log10_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_log10.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_log102_ha_ex_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_log1p_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_log1p_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_log1p.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_log1p4_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_log_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_log_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_log.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_log1_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_pow_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_pow_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_pow.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_pow2_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_sin_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_sin_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_sin.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_sin2_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_sinh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_sinh_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_sinh.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_sinh1_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_tan_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_tan_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_tan.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_tan1_ha_ex_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_tanh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_d_tanh_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_d_tanh.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_tanh4_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_acos_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_acos_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_acos.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_acosf16_ha_z0_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_asin_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_asin_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_asin.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_asinf8_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_atan2_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_atan2_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_atan2.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_atan2f4_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_atan_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_atan_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_atan.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_atanf8_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_cbrt_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_cbrt_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_cbrt.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_cbrtf4_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_cos_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_cos_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_cos.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_cosf8_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_cosh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_cosh_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_cosh.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_coshf16_ha_z0_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_exp_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_exp_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_exp.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_expf4_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_expm1_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_expm1_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_expm1.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_expm1f4_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_hypot_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_hypot_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_hypot.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_hypotf8_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_log10_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_log10_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_log10.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_log10f4_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_log1p_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_log1p_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_log1p.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_log1pf4_ha_e9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_log_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_log_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_log.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_logf4_ha_ex_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_pow_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_pow_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_pow.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_powf16_ha_z0_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_sin_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_sin_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_sin.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_sinf16_ha_z0_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_sinh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_sinh_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_sinh.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_sinhf4_ha_l9_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_tan_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_tan_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_tan.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_tanf4_ha_ex_0:

--- a/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_tanh_linux_x86.S
+++ b/src/jdk.incubator.vector/linux/native/libjsvml/jsvml_s_tanh_linux_x86.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2018, 2022, Intel Corporation. All rights reserved.
  * Intel Short Vector Math Library (SVML) Source Code
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,7 +28,6 @@
 #include "globals_vectorApiSupport_linux.S.inc"
 #ifdef __VECTOR_API_MATH_INTRINSICS_LINUX
 # -- Machine type EM64t
-	.file "svml_s_tanh.c"
 	.text
 ..TXTST0:
 .L_2__routine_start___jsvml_tanhf4_ha_l9_0:

--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ public class AbsPathsInImage {
     // JTREG=JAVA_OPTIONS=-Djdk.test.build.AbsPathInImage.dir=/path/to/dir
     public static final String DIR_PROPERTY = "jdk.test.build.AbsPathsInImage.dir";
     private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("windows");
+    private static final boolean IS_LINUX   = System.getProperty("os.name").toLowerCase().contains("linux");
 
     private boolean matchFound = false;
 
@@ -164,7 +165,7 @@ public class AbsPathsInImage {
                 String fileName = file.toString();
                 if (Files.isSymbolicLink(file)) {
                     return super.visitFile(file, attrs);
-                } else if (fileName.endsWith(".debuginfo") || fileName.endsWith(".pdb")) {
+                } else if ((fileName.endsWith(".debuginfo") && !IS_LINUX) || fileName.endsWith(".pdb")) {
                     // Do nothing
                 } else if (fileName.endsWith(".zip")) {
                     scanZipFile(file, searchPatterns);


### PR DESCRIPTION
Dependent fix for enabling reproducible builds when the built workspace folder and or user is different between the two builds, this updates the fix to not rely on relative linking.
This should be merged after the dependent PR: https://github.com/openjdk/jdk17u-dev/pull/415 on which this PR is based upon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284661](https://bugs.openjdk.java.net/browse/JDK-8284661): Reproducible assembly builds without relative linking


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/416/head:pull/416` \
`$ git checkout pull/416`

Update a local copy of the PR: \
`$ git checkout pull/416` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 416`

View PR using the GUI difftool: \
`$ git pr show -t 416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/416.diff">https://git.openjdk.java.net/jdk17u-dev/pull/416.diff</a>

</details>
