### PR TITLE
8287336: GHA: Workflows break on patch versions

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -78,7 +78,10 @@ jobs:
           FEATURE=${{ fromJson(steps.check_deps.outputs.dependencies).DEFAULT_VERSION_FEATURE }}
           INTERIM=${{ fromJson(steps.check_deps.outputs.dependencies).DEFAULT_VERSION_INTERIM }}
           UPDATE=${{ fromJson(steps.check_deps.outputs.dependencies).DEFAULT_VERSION_UPDATE }}
-          if [ "x${UPDATE}" != "x0" ]; then
+          PATCH=${{ fromJson(steps.check_deps.outputs.dependencies).DEFAULT_VERSION_PATCH }}
+          if [ "x${PATCH}" != "x0" ]; then
+             V=${FEATURE}.${INTERIM}.${UPDATE}.${PATCH}
+          elif [ "x${UPDATE}" != "x0" ]; then
              V=${FEATURE}.${INTERIM}.${UPDATE}
           elif [ "x${INTERIM}" != "x0" ]; then
              V={FEATURE}.${INTERIM}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8287336](https://bugs.openjdk.java.net/browse/JDK-8287336), commit [e44465d4](https://github.com/openjdk/jdk/commit/e44465d4d6eaddebfc5a1b149223aa8332affa8b) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Christoph Langer on 26 May 2022 and was reviewed by Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287336](https://bugs.openjdk.java.net/browse/JDK-8287336): GHA: Workflows break on patch versions


### Reviewers
 * [Andrew John Hughes](https://openjdk.java.net/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/418/head:pull/418` \
`$ git checkout pull/418`

Update a local copy of the PR: \
`$ git checkout pull/418` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 418`

View PR using the GUI difftool: \
`$ git pr show -t 418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/418.diff">https://git.openjdk.java.net/jdk17u-dev/pull/418.diff</a>

</details>
