### PR TITLE
8287362: FieldAccessWatch testcase failed on AIX platform

### DIFF
--- a/test/hotspot/jtreg/compiler/jsr292/cr8026328/libTest8026328.c
+++ b/test/hotspot/jtreg/compiler/jsr292/cr8026328/libTest8026328.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ Agent_OnLoad(JavaVM* vm,
              void* reserved) {
 
     jvmtiCapabilities capa;
-    jvmtiEventCallbacks cbs = {0};
+    jvmtiEventCallbacks cbs;
 
     (*vm)->GetEnv(vm, (void**)&jvmti, JVMTI_VERSION_1_0);
 
@@ -110,6 +110,7 @@ Agent_OnLoad(JavaVM* vm,
     capa.can_generate_single_step_events = 1;
     (*jvmti)->AddCapabilities(jvmti, &capa);
 
+    memset(&cbs, 0, sizeof(cbs));
     cbs.ClassPrepare = classprepare;
     cbs.Breakpoint = breakpoint;
     (*jvmti)->SetEventCallbacks(jvmti, &cbs, sizeof(cbs));

--- a/test/hotspot/jtreg/runtime/jni/FastGetField/libFastGetField.c
+++ b/test/hotspot/jtreg/runtime/jni/FastGetField/libFastGetField.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SAP SE and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022 SAP SE and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ static void JNICALL onFieldAccess(jvmtiEnv *jvmti_env, JNIEnv* jni_env, jthread 
 
 JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
   jvmtiCapabilities capa;
-  jvmtiEventCallbacks cbs = {0};
+  jvmtiEventCallbacks cbs;
 
   (*vm)->GetEnv(vm, (void**)&jvmti, JVMTI_VERSION_1_0);
 
@@ -127,6 +127,7 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
   capa.can_generate_field_access_events = 1;
   (*jvmti)->AddCapabilities(jvmti, &capa);
 
+  memset(&cbs, 0, sizeof(cbs));
   cbs.FieldAccess = &onFieldAccess;
   (*jvmti)->SetEventCallbacks(jvmti, &cbs, sizeof(cbs));
   (*jvmti)->SetEventNotificationMode(jvmti, JVMTI_ENABLE, JVMTI_EVENT_FIELD_ACCESS, NULL);

--- a/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/FieldAccessWatch/libFieldAccessWatch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -214,14 +214,15 @@ JNIEXPORT jint JNICALL
 Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
 {
     jvmtiError err;
-    jvmtiCapabilities caps = {0};
-    jvmtiEventCallbacks callbacks = {0};
+    jvmtiCapabilities caps;
+    jvmtiEventCallbacks callbacks;
     jint res = (*jvm)->GetEnv(jvm, (void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         reportError("GetEnv failed", res);
         return JNI_ERR;
     }
 
+    memset(&caps, 0, sizeof(caps));
     caps.can_generate_field_modification_events = 1;
     caps.can_generate_field_access_events = 1;
     caps.can_tag_objects = 1;
@@ -231,6 +232,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved)
         return JNI_ERR;
     }
 
+    memset(&callbacks, 0, sizeof(callbacks));
     callbacks.FieldModification = &onFieldModification;
     callbacks.FieldAccess = &onFieldAccess;
 

--- a/test/hotspot/jtreg/serviceability/jvmti/GetClassMethods/libOverpassMethods.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetClassMethods/libOverpassMethods.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,8 @@ JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *vm, char *options, void *reserved) {
 
   if (options != NULL && strcmp(options, "maintain_original_method_order") == 0) {
     printf("Enabled capability: maintain_original_method_order\n");
-    jvmtiCapabilities caps = {};
+    jvmtiCapabilities caps;
+    memset(&caps, 0, sizeof(caps));
     caps.can_maintain_original_method_order = 1;
 
     jvmtiError err = jvmti->AddCapabilities(&caps);


### PR DESCRIPTION
Backport JDK-8287362

Clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287362](https://bugs.openjdk.java.net/browse/JDK-8287362): FieldAccessWatch testcase failed on AIX platform


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/420/head:pull/420` \
`$ git checkout pull/420`

Update a local copy of the PR: \
`$ git checkout pull/420` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 420`

View PR using the GUI difftool: \
`$ git pr show -t 420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/420.diff">https://git.openjdk.java.net/jdk17u-dev/pull/420.diff</a>

</details>
