### PR TITLE
8286444: javac errors after JDK-8251329 are not helpful enough to find root cause

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.zip.ZipException;
 
 import javax.lang.model.SourceVersion;
 import javax.tools.FileObject;
@@ -564,7 +565,11 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                 Map<String,String> env = Collections.singletonMap("multi-release", multiReleaseValue);
                 FileSystemProvider jarFSProvider = fsInfo.getJarFSProvider();
                 Assert.checkNonNull(jarFSProvider, "should have been caught before!");
-                this.fileSystem = jarFSProvider.newFileSystem(archivePath, env);
+                try {
+                    this.fileSystem = jarFSProvider.newFileSystem(archivePath, env);
+                } catch (ZipException ze) {
+                    throw new IOException("ZipException opening \"" + archivePath + "\": " + ze.getMessage(), ze);
+                }
             } else {
                 this.fileSystem = FileSystems.newFileSystem(archivePath, (ClassLoader)null);
             }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8286444](https://bugs.openjdk.java.net/browse/JDK-8286444), commit [29c4b8e8](https://github.com/openjdk/jdk/commit/29c4b8e80d1860249a79cfd1941354150468fc5b) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.

The commit being backported was authored by Christoph Langer on 14 May 2022 and was reviewed by Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286444](https://bugs.openjdk.java.net/browse/JDK-8286444): javac errors after JDK-8251329 are not helpful enough to find root cause


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/424/head:pull/424` \
`$ git checkout pull/424`

Update a local copy of the PR: \
`$ git checkout pull/424` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 424`

View PR using the GUI difftool: \
`$ git pr show -t 424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/424.diff">https://git.openjdk.java.net/jdk17u-dev/pull/424.diff</a>

</details>
