### PR TITLE
8287824: The MTPerLineTransformValidation tests has a typo in the @run tag

### DIFF
--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/MTPerLineTransformValidation.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/MTPerLineTransformValidation.java
@@ -29,7 +29,7 @@ import java.awt.image.ColorConvertOp;
  * @test
  * @bug 8273972
  * @summary Verifies that ColorConvertOp works fine if shared between threads
- * @run main/othervm/timeout=600 MTTransformValidation
+ * @run main/othervm/timeout=600 MTPerLineTransformValidation
  */
 public final class MTPerLineTransformValidation {
 


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [645be42f](https://github.com/openjdk/jdk/commit/645be42f76b8983a9096ed90caa70b5c59dd822c) from the [openjdk/jdk](https://git.openjdk.java.net/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 6 Jun 2022 and was reviewed by Iris Clark and Phil Race.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287824](https://bugs.openjdk.org/browse/JDK-8287824): The MTPerLineTransformValidation tests has a typo in the @run tag


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/432/head:pull/432` \
`$ git checkout pull/432`

Update a local copy of the PR: \
`$ git checkout pull/432` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 432`

View PR using the GUI difftool: \
`$ git pr show -t 432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/432.diff">https://git.openjdk.java.net/jdk17u-dev/pull/432.diff</a>

</details>
