### PR TITLE
8282467: add extra diagnostics for JDK-8268184

### DIFF
--- a/src/hotspot/share/opto/ifg.cpp
+++ b/src/hotspot/share/opto/ifg.cpp
@@ -37,6 +37,8 @@
 #include "opto/memnode.hpp"
 #include "opto/opcodes.hpp"
 
+#include <fenv.h>
+
 PhaseIFG::PhaseIFG( Arena *arena ) : Phase(Interference_Graph), _arena(arena) {
 }
 
@@ -784,7 +786,7 @@ void PhaseChaitin::add_input_to_liveout(Block* b, Node* n, IndexSet* liveout, do
       assert(int_pressure.current_pressure() == count_int_pressure(liveout), "the int pressure is incorrect");
       assert(float_pressure.current_pressure() == count_float_pressure(liveout), "the float pressure is incorrect");
     }
-    assert(lrg._area >= 0.0, "negative spill area" );
+    assert(lrg._area >= 0.0, "unexpected spill area value %g (rounding mode %x)", lrg._area, fegetround());
   }
 }
 
@@ -895,7 +897,7 @@ uint PhaseChaitin::build_ifg_physical( ResourceArea *a ) {
           if (g_isfinite(cost)) {
             lrg._area -= cost;
           }
-          assert(lrg._area >= 0.0, "negative spill area" );
+          assert(lrg._area >= 0.0, "unexpected spill area value %g (rounding mode %x)", lrg._area, fegetround());
 
           assign_high_score_to_immediate_copies(block, n, lrg, location + 1, last_inst);
 


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282467](https://bugs.openjdk.org/browse/JDK-8282467): add extra diagnostics for JDK-8268184


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/436.diff">https://git.openjdk.java.net/jdk17u-dev/pull/436.diff</a>

</details>
