### PR TITLE
8284694: Avoid evaluating SSLAlgorithmConstraints twice

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
+++ b/src/java.base/share/classes/sun/security/ssl/HandshakeContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,7 +164,7 @@ abstract class HandshakeContext implements ConnectionContext {
         this.conContext = conContext;
         this.sslConfig = (SSLConfiguration)conContext.sslConfig.clone();
 
-        this.algorithmConstraints = new SSLAlgorithmConstraints(
+        this.algorithmConstraints = SSLAlgorithmConstraints.wrap(
                 sslConfig.userSpecifiedAlgorithmConstraints);
         this.activeProtocols = getActiveProtocols(sslConfig.enabledProtocols,
                 sslConfig.enabledCipherSuites, algorithmConstraints);

--- a/src/java.base/share/classes/sun/security/ssl/SSLAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLAlgorithmConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,46 +57,98 @@ final class SSLAlgorithmConstraints implements AlgorithmConstraints {
 
     // the default algorithm constraints
     static final AlgorithmConstraints DEFAULT =
-                        new SSLAlgorithmConstraints(null);
+                        new SSLAlgorithmConstraints(null, true);
 
     // the default SSL only algorithm constraints
     static final AlgorithmConstraints DEFAULT_SSL_ONLY =
-                        new SSLAlgorithmConstraints((SSLSocket)null, false);
+                        new SSLAlgorithmConstraints(null, false);
 
-    SSLAlgorithmConstraints(AlgorithmConstraints userSpecifiedConstraints) {
+    private SSLAlgorithmConstraints(AlgorithmConstraints userSpecifiedConstraints,
+                                    boolean enabledX509DisabledAlgConstraints) {
+        this(userSpecifiedConstraints, null, enabledX509DisabledAlgConstraints);
+    }
+
+    private SSLAlgorithmConstraints(
+            AlgorithmConstraints userSpecifiedConstraints,
+            SupportedSignatureAlgorithmConstraints peerSpecifiedConstraints,
+            boolean withDefaultCertPathConstraints) {
         this.userSpecifiedConstraints = userSpecifiedConstraints;
-        this.peerSpecifiedConstraints = null;
-        this.enabledX509DisabledAlgConstraints = true;
-    }
-
-    SSLAlgorithmConstraints(SSLSocket socket,
-            boolean withDefaultCertPathConstraints) {
-        this.userSpecifiedConstraints = getUserSpecifiedConstraints(socket);
-        this.peerSpecifiedConstraints = null;
+        this.peerSpecifiedConstraints = peerSpecifiedConstraints;
         this.enabledX509DisabledAlgConstraints = withDefaultCertPathConstraints;
     }
 
-    SSLAlgorithmConstraints(SSLEngine engine,
-            boolean withDefaultCertPathConstraints) {
-        this.userSpecifiedConstraints = getUserSpecifiedConstraints(engine);
-        this.peerSpecifiedConstraints = null;
-        this.enabledX509DisabledAlgConstraints = withDefaultCertPathConstraints;
+    /**
+     * Returns a SSLAlgorithmConstraints instance that checks the provided
+     * {@code userSpecifiedConstraints} in addition to standard checks.
+     * Returns a singleton instance if parameter is null or DEFAULT.
+     * @param userSpecifiedConstraints additional constraints to check
+     * @return a SSLAlgorithmConstraints instance
+     */
+    static AlgorithmConstraints wrap(AlgorithmConstraints userSpecifiedConstraints) {
+        return wrap(userSpecifiedConstraints, true);
     }
 
-    SSLAlgorithmConstraints(SSLSocket socket, String[] supportedAlgorithms,
+    private static AlgorithmConstraints wrap(
+            AlgorithmConstraints userSpecifiedConstraints,
             boolean withDefaultCertPathConstraints) {
-        this.userSpecifiedConstraints = getUserSpecifiedConstraints(socket);
-        this.peerSpecifiedConstraints =
-                new SupportedSignatureAlgorithmConstraints(supportedAlgorithms);
-        this.enabledX509DisabledAlgConstraints = withDefaultCertPathConstraints;
+        if (nullIfDefault(userSpecifiedConstraints) == null) {
+            return withDefaultCertPathConstraints ? DEFAULT : DEFAULT_SSL_ONLY;
+        }
+        return new SSLAlgorithmConstraints(userSpecifiedConstraints,
+                withDefaultCertPathConstraints);
     }
 
-    SSLAlgorithmConstraints(SSLEngine engine, String[] supportedAlgorithms,
+    /**
+     * Returns a SSLAlgorithmConstraints instance that checks the constraints
+     * configured for the given {@code socket} in addition to standard checks.
+     * Returns a singleton instance if the constraints are null or DEFAULT.
+     * @param socket socket with configured constraints
+     * @return a SSLAlgorithmConstraints instance
+     */
+    static AlgorithmConstraints forSocket(SSLSocket socket,
+                                          boolean withDefaultCertPathConstraints) {
+        AlgorithmConstraints userSpecifiedConstraints =
+                getUserSpecifiedConstraints(socket);
+        return wrap(userSpecifiedConstraints, withDefaultCertPathConstraints);
+    }
+
+    static SSLAlgorithmConstraints forSocket(
+            SSLSocket socket,
+            String[] supportedAlgorithms,
             boolean withDefaultCertPathConstraints) {
-        this.userSpecifiedConstraints = getUserSpecifiedConstraints(engine);
-        this.peerSpecifiedConstraints =
-                new SupportedSignatureAlgorithmConstraints(supportedAlgorithms);
-        this.enabledX509DisabledAlgConstraints = withDefaultCertPathConstraints;
+        return new SSLAlgorithmConstraints(
+                nullIfDefault(getUserSpecifiedConstraints(socket)),
+                new SupportedSignatureAlgorithmConstraints(supportedAlgorithms),
+                withDefaultCertPathConstraints);
+    }
+
+    /**
+     * Returns a SSLAlgorithmConstraints instance that checks the constraints
+     * configured for the given {@code engine} in addition to standard checks.
+     * Returns a singleton instance if the constraints are null or DEFAULT.
+     * @param engine engine with configured constraints
+     * @return a SSLAlgorithmConstraints instance
+     */
+    static AlgorithmConstraints forEngine(SSLEngine engine,
+                                          boolean withDefaultCertPathConstraints) {
+        AlgorithmConstraints userSpecifiedConstraints =
+                getUserSpecifiedConstraints(engine);
+        return wrap(userSpecifiedConstraints, withDefaultCertPathConstraints);
+    }
+
+    static SSLAlgorithmConstraints forEngine(
+            SSLEngine engine,
+            String[] supportedAlgorithms,
+            boolean withDefaultCertPathConstraints) {
+        return new SSLAlgorithmConstraints(
+                nullIfDefault(getUserSpecifiedConstraints(engine)),
+                new SupportedSignatureAlgorithmConstraints(supportedAlgorithms),
+                withDefaultCertPathConstraints);
+    }
+
+    private static AlgorithmConstraints nullIfDefault(
+            AlgorithmConstraints constraints) {
+        return constraints == DEFAULT ? null : constraints;
     }
 
     private static AlgorithmConstraints getUserSpecifiedConstraints(

--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -1485,14 +1485,14 @@ final class AbstractTrustManagerWrapper extends X509ExtendedTrustManager
                     String[] peerSupportedSignAlgs =
                             extSession.getLocalSupportedSignatureAlgorithms();
 
-                    constraints = new SSLAlgorithmConstraints(
+                    constraints = SSLAlgorithmConstraints.forSocket(
                                     sslSocket, peerSupportedSignAlgs, true);
                 } else {
                     constraints =
-                            new SSLAlgorithmConstraints(sslSocket, true);
+                            SSLAlgorithmConstraints.forSocket(sslSocket, true);
                 }
             } else {
-                constraints = new SSLAlgorithmConstraints(sslSocket, true);
+                constraints = SSLAlgorithmConstraints.forSocket(sslSocket, true);
             }
 
             checkAlgorithmConstraints(chain, constraints, checkClientTrusted);
@@ -1525,14 +1525,14 @@ final class AbstractTrustManagerWrapper extends X509ExtendedTrustManager
                     String[] peerSupportedSignAlgs =
                             extSession.getLocalSupportedSignatureAlgorithms();
 
-                    constraints = new SSLAlgorithmConstraints(
+                    constraints = SSLAlgorithmConstraints.forEngine(
                                     engine, peerSupportedSignAlgs, true);
                 } else {
                     constraints =
-                            new SSLAlgorithmConstraints(engine, true);
+                            SSLAlgorithmConstraints.forEngine(engine, true);
                 }
             } else {
-                constraints = new SSLAlgorithmConstraints(engine, true);
+                constraints = SSLAlgorithmConstraints.forEngine(engine, true);
             }
 
             checkAlgorithmConstraints(chain, constraints, checkClientTrusted);

--- a/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,15 +199,15 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
                             extSession.getPeerSupportedSignatureAlgorithms();
                     }
 
-                    return new SSLAlgorithmConstraints(
+                    return SSLAlgorithmConstraints.forSocket(
                         sslSocket, peerSupportedSignAlgs, true);
                 }
             }
 
-            return new SSLAlgorithmConstraints(sslSocket, true);
+            return SSLAlgorithmConstraints.forSocket(sslSocket, true);
         }
 
-        return new SSLAlgorithmConstraints((SSLSocket)null, true);
+        return SSLAlgorithmConstraints.DEFAULT;
     }
 
     // Gets algorithm constraints of the engine.
@@ -225,13 +225,13 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
                             extSession.getPeerSupportedSignatureAlgorithms();
                     }
 
-                    return new SSLAlgorithmConstraints(
+                    return SSLAlgorithmConstraints.forEngine(
                         engine, peerSupportedSignAlgs, true);
                 }
             }
         }
 
-        return new SSLAlgorithmConstraints(engine, true);
+        return SSLAlgorithmConstraints.forEngine(engine, true);
     }
 
     // we construct the alias we return to JSSE as seen in the code below

--- a/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
@@ -216,10 +216,10 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
                 String[] localSupportedSignAlgs =
                         extSession.getLocalSupportedSignatureAlgorithms();
 
-                constraints = new SSLAlgorithmConstraints(
+                constraints = SSLAlgorithmConstraints.forSocket(
                                 sslSocket, localSupportedSignAlgs, false);
             } else {
-                constraints = new SSLAlgorithmConstraints(sslSocket, false);
+                constraints = SSLAlgorithmConstraints.forSocket(sslSocket, false);
             }
 
             // Grab any stapled OCSP responses for use in validation
@@ -270,10 +270,10 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
                 String[] localSupportedSignAlgs =
                         extSession.getLocalSupportedSignatureAlgorithms();
 
-                constraints = new SSLAlgorithmConstraints(
+                constraints = SSLAlgorithmConstraints.forEngine(
                                 engine, localSupportedSignAlgs, false);
             } else {
-                constraints = new SSLAlgorithmConstraints(engine, false);
+                constraints = SSLAlgorithmConstraints.forEngine(engine, false);
             }
 
             // Grab any stapled OCSP responses for use in validation

--- a/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
+++ b/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.security;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.ByteBuffer;
+import java.security.KeyStore;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManagerFactory;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+public class SSLHandshake {
+
+    private SSLContext sslc;
+
+    private SSLEngine clientEngine;
+    private ByteBuffer clientOut = ByteBuffer.allocate(5);
+    private ByteBuffer clientIn = ByteBuffer.allocate(1 << 15);
+
+    private SSLEngine serverEngine;
+    private ByteBuffer serverOut = ByteBuffer.allocate(5);
+    private ByteBuffer serverIn = ByteBuffer.allocate(1 << 15);
+
+    private ByteBuffer cTOs = ByteBuffer.allocateDirect(1 << 16);
+    private ByteBuffer sTOc = ByteBuffer.allocateDirect(1 << 16);
+
+    @Param({"true", "false"})
+    boolean resume;
+
+    @Param({"TLSv1.2", "TLS"})
+    String tlsVersion;
+
+    @Setup(Level.Trial)
+    public void init() throws Exception {
+        KeyStore ks = TestCertificates.getKeyStore();
+        KeyStore ts = TestCertificates.getTrustStore();
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, new char[0]);
+
+        TrustManagerFactory tmf =
+                TrustManagerFactory.getInstance("SunX509");
+        tmf.init(ts);
+
+        SSLContext sslCtx = SSLContext.getInstance(tlsVersion);
+        sslCtx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        sslc = sslCtx;
+    }
+
+    private HandshakeStatus checkResult(SSLEngine engine, SSLEngineResult result) {
+
+        HandshakeStatus hsStatus = result.getHandshakeStatus();
+
+        if (hsStatus == HandshakeStatus.NEED_TASK) {
+            Runnable runnable;
+            while ((runnable = engine.getDelegatedTask()) != null) {
+                runnable.run();
+            }
+            hsStatus = engine.getHandshakeStatus();
+        }
+        return hsStatus;
+    }
+
+    /**
+     * This benchmark measures the time needed to perform a TLS handshake.
+     * Data is exchanged using a pair of ByteBuffers.
+     * The client and the server both operate on the same thread.
+     */
+    @Benchmark
+    @Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+    @Fork(3)
+    public SSLSession doHandshake() throws Exception {
+
+        createSSLEngines();
+        boolean isCtoS = true;
+        for (;;) {
+            HandshakeStatus result;
+            if (isCtoS) {
+                result = checkResult(clientEngine,
+                        clientEngine.wrap(clientOut, cTOs)
+                );
+                cTOs.flip();
+                checkResult(serverEngine,
+                        serverEngine.unwrap(cTOs, serverIn)
+                );
+                cTOs.compact();
+                if (result == HandshakeStatus.NEED_UNWRAP) {
+                    isCtoS = false;
+                } else if (result == HandshakeStatus.FINISHED) {
+                    break;
+                } else if (result != HandshakeStatus.NEED_WRAP) {
+                    throw new Exception("Unexpected result "+result);
+                }
+            } else {
+                result = checkResult(serverEngine,
+                        serverEngine.wrap(serverOut, sTOc)
+                );
+                sTOc.flip();
+                checkResult(clientEngine,
+                        clientEngine.unwrap(sTOc, clientIn)
+                );
+                sTOc.compact();
+                if (result == HandshakeStatus.NEED_UNWRAP) {
+                    isCtoS = true;
+                } else if (result == HandshakeStatus.FINISHED) {
+                    break;
+                } else if (result != HandshakeStatus.NEED_WRAP) {
+                    throw new Exception("Unexpected result "+result);
+                }
+            }
+        }
+
+        SSLSession session = clientEngine.getSession();
+        if (resume) {
+            // TLS 1.3 needs another wrap/unwrap to deliver a session ticket
+            serverEngine.wrap(serverOut, sTOc);
+            sTOc.flip();
+            clientEngine.unwrap(sTOc, clientIn);
+            sTOc.compact();
+        } else {
+            // invalidate TLS1.2 session. TLS 1.3 doesn't care
+            session.invalidate();
+        }
+        return session;
+    }
+
+    private void createSSLEngines() {
+        /*
+         * Configure the serverEngine to act as a server in the SSL/TLS
+         * handshake.
+         */
+        serverEngine = sslc.createSSLEngine();
+        serverEngine.setUseClientMode(false);
+
+        /*
+         * Similar to above, but using client mode instead.
+         */
+        clientEngine = sslc.createSSLEngine("client", 80);
+        clientEngine.setUseClientMode(true);
+    }
+}

--- a/test/micro/org/openjdk/bench/java/security/TestCertificates.java
+++ b/test/micro/org/openjdk/bench/java/security/TestCertificates.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.java.security;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
+/**
+ * This class contains a 3-certificate chain for use in TLS tests.
+ * The method {@link #getKeyStore()} returns a keystore with a single entry
+ * containing one server+one intermediate CA certificate.
+ * Server's CN and subjectAltName are both set to "client"
+ *
+ * The method {@link #getTrustStore()} returns a keystore with a single entry
+ * containing the root CA certificate used for signing the intermediate CA.
+ */
+class TestCertificates {
+
+    // "/C=US/ST=CA/O=Test Root CA, Inc."
+    // basicConstraints=critical, CA:true
+    // subjectKeyIdentifier    = hash
+    // authorityKeyIdentifier  = keyid:always
+    // keyUsage                = keyCertSign
+    private static final String ROOT_CA_CERT =
+            "-----BEGIN CERTIFICATE-----\n" +
+            "MIIB0jCCAXigAwIBAgIUE+wUdx22foJXSQzD3hpCNCqITLEwCgYIKoZIzj0EAwIw\n" +
+            "NzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRswGQYDVQQKDBJUZXN0IFJvb3Qg\n" +
+            "Q0EsIEluYy4wIBcNMjIwNDEyMDcxMzMzWhgPMjEyMjAzMTkwNzEzMzNaMDcxCzAJ\n" +
+            "BgNVBAYTAlVTMQswCQYDVQQIDAJDQTEbMBkGA1UECgwSVGVzdCBSb290IENBLCBJ\n" +
+            "bmMuMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKye/mwO0V0WLr71tf8auFEz\n" +
+            "EmqhaYWauaP17Fb33fRAeG8aVp9c4B0isv/VgcqSTRMG0SJjbx7ttSYwR/JNhqNg\n" +
+            "MF4wDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUpfGt4bjadmVzWeXAiSMp9pLU\n" +
+            "RMkwHwYDVR0jBBgwFoAUpfGt4bjadmVzWeXAiSMp9pLURMkwCwYDVR0PBAQDAgIE\n" +
+            "MAoGCCqGSM49BAMCA0gAMEUCIBF8YyD5BBuhkFNV/3rNmvvMuvWUAECJ8rrUg8kr\n" +
+            "J8zpAiEAzbZQsC/IZ0wVNd4lqHn6/Ih5v7vhCgkg95KCP1NhBnU=\n" +
+            "-----END CERTIFICATE-----";
+
+    // "/C=US/ST=CA/O=Test Intermediate CA, Inc."
+    // basicConstraints=critical, CA:true, pathlen:0
+    // subjectKeyIdentifier    = hash
+    // authorityKeyIdentifier  = keyid:always
+    // keyUsage                = keyCertSign
+    private static final String CA_CERT =
+            "-----BEGIN CERTIFICATE-----\n" +
+            "MIIB3TCCAYOgAwIBAgIUQ+lTbsDcIQ1UUg0RGdpJB6JMXpcwCgYIKoZIzj0EAwIw\n" +
+            "NzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRswGQYDVQQKDBJUZXN0IFJvb3Qg\n" +
+            "Q0EsIEluYy4wIBcNMjIwNDEyMDcxMzM0WhgPMjEyMjAzMTkwNzEzMzRaMD8xCzAJ\n" +
+            "BgNVBAYTAlVTMQswCQYDVQQIDAJDQTEjMCEGA1UECgwaVGVzdCBJbnRlcm1lZGlh\n" +
+            "dGUgQ0EsIEluYy4wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQ7DsKCSQkP5oT2\n" +
+            "Wx0gf40N+H/F75w1YmPm6dp2wiQ6JPMN/4En87Ylx0ISJkeXJLxrbLvu2xZ+aonM\n" +
+            "kckNh/ERo2MwYTASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBTqP6hB5Ibr\n" +
+            "aivot/zWSMKr8ZkCVzAfBgNVHSMEGDAWgBSl8a3huNp2ZXNZ5cCJIyn2ktREyTAL\n" +
+            "BgNVHQ8EBAMCAgQwCgYIKoZIzj0EAwIDSAAwRQIhAM0vCIV938aqGAEmELIA8Kc4\n" +
+            "X+kOc4LGE0R7sMiBAbXuAiBlbNVaskKYRHIEGHEtIWet6Ufi3w9NMrycEbBZ+v5o\n" +
+            "gA==\n" +
+            "-----END CERTIFICATE-----";
+
+    // "/C=US/ST=CA/O=Test Server/CN=client"
+    // subjectKeyIdentifier    = hash
+    // authorityKeyIdentifier  = keyid:always
+    // keyUsage                = digitalSignature
+    // subjectAltName          = DNS:client
+    private static final String SERVER_CERT =
+            "-----BEGIN CERTIFICATE-----\n" +
+            "MIIB5TCCAYygAwIBAgIUNWe754lZoDc6wNs9Vsev/h9TMicwCgYIKoZIzj0EAwIw\n" +
+            "PzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMSMwIQYDVQQKDBpUZXN0IEludGVy\n" +
+            "bWVkaWF0ZSBDQSwgSW5jLjAgFw0yMjA0MTIwNzEzMzRaGA8yMTIyMDMxOTA3MTMz\n" +
+            "NFowQTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRQwEgYDVQQKDAtUZXN0IFNl\n" +
+            "cnZlcjEPMA0GA1UEAwwGY2xpZW50MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n" +
+            "o6zUz5QmzmfHL2xRifvaJenggck/Dlu6KC4v4rGXug69R7tWKWuRUsbSFLy29Rii\n" +
+            "F7V1wjFhsyGAzNyKf/KlmaNiMGAwHQYDVR0OBBYEFHz32VSnXBF4WdLDOe7e3hF9\n" +
+            "yDxmMB8GA1UdIwQYMBaAFOo/qEHkhutqK+i3/NZIwqvxmQJXMAsGA1UdDwQEAwIH\n" +
+            "gDARBgNVHREECjAIggZjbGllbnQwCgYIKoZIzj0EAwIDRwAwRAIgWsCn2LIElgVs\n" +
+            "VihcQznvBemWneEcmnp/Bw+lwk86KQ8CIA3loL7P/0/Ft/xXtClxJfyxEoZ/Az1n\n" +
+            "HTTjbe6ZnN0Y\n" +
+            "-----END CERTIFICATE-----";
+
+    private static final String serverkey =
+            //"-----BEGIN PRIVATE KEY-----\n" +
+            "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgKb9cKLH++BgA9CL1\n" +
+            "cdCLHpD0poPJ/uAkafGXDJBR67ChRANCAASjrNTPlCbOZ8cvbFGJ+9ol6eCByT8O\n" +
+            "W7ooLi/isZe6Dr1Hu1Ypa5FSxtIUvLb1GKIXtXXCMWGzIYDM3Ip/8qWZ";
+            // + "\n-----END PRIVATE KEY-----";
+
+    private TestCertificates() {}
+
+    public static KeyStore getKeyStore() throws GeneralSecurityException, IOException {
+        KeyStore result = KeyStore.getInstance("JKS");
+        result.load(null, null);
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        Certificate serverCert = cf.generateCertificate(
+                new ByteArrayInputStream(
+                        TestCertificates.SERVER_CERT.getBytes(StandardCharsets.ISO_8859_1)));
+        Certificate caCert = cf.generateCertificate(
+                new ByteArrayInputStream(
+                        CA_CERT.getBytes(StandardCharsets.ISO_8859_1)));
+        KeyFactory kf = KeyFactory.getInstance("EC");
+        PKCS8EncodedKeySpec ks = new PKCS8EncodedKeySpec(
+                Base64.getMimeDecoder().decode(serverkey));
+        Key key = kf.generatePrivate(ks);
+        Certificate[] chain = {serverCert, caCert};
+
+        result.setKeyEntry("server", key, new char[0], chain);
+        return result;
+    }
+
+    public static KeyStore getTrustStore() throws GeneralSecurityException, IOException {
+        KeyStore result = KeyStore.getInstance("JKS");
+        result.load(null, null);
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        Certificate rootcaCert = cf.generateCertificate(
+                new ByteArrayInputStream(
+                        ROOT_CA_CERT.getBytes(StandardCharsets.ISO_8859_1)));
+
+        result.setCertificateEntry("testca", rootcaCert);
+        return result;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284694](https://bugs.openjdk.org/browse/JDK-8284694): Avoid evaluating SSLAlgorithmConstraints twice


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/446/head:pull/446` \
`$ git checkout pull/446`

Update a local copy of the PR: \
`$ git checkout pull/446` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 446`

View PR using the GUI difftool: \
`$ git pr show -t 446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/446.diff">https://git.openjdk.java.net/jdk17u-dev/pull/446.diff</a>

</details>
