### PR TITLE
8285398: Cache the results of constraint checks

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -44,6 +44,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
+++ b/src/java.base/share/classes/sun/security/util/DisabledAlgorithmConstraints.java
@@ -27,6 +27,7 @@ package sun.security.util;
 
 import sun.security.validator.Validator;
 
+import java.lang.ref.SoftReference;
 import java.security.AlgorithmParameters;
 import java.security.CryptoPrimitive;
 import java.security.Key;
@@ -43,7 +44,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -53,6 +53,7 @@ import java.util.Set;
 import java.util.Collection;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
@@ -100,6 +101,8 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
 
     private final Set<String> disabledAlgorithms;
     private final Constraints algorithmConstraints;
+    private volatile SoftReference<Map<String, Boolean>> cacheRef =
+            new SoftReference<>(null);
 
     public static DisabledAlgorithmConstraints certPathConstraints() {
         return CertPathHolder.CONSTRAINTS;
@@ -157,7 +160,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
                     " or empty.");
         }
 
-        if (!checkAlgorithm(disabledAlgorithms, algorithm, decomposer)) {
+        if (!cachedCheckAlgorithm(algorithm)) {
             return false;
         }
 
@@ -240,7 +243,7 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
         // Check if named curves in the key are disabled.
         for (Key key : cp.getKeys()) {
             for (String curve : getNamedCurveFromKey(key)) {
-                if (!checkAlgorithm(disabledAlgorithms, curve, decomposer)) {
+                if (!cachedCheckAlgorithm(curve)) {
                     throw new CertPathValidatorException(
                             "Algorithm constraints check failed on disabled " +
                                     "algorithm: " + curve,
@@ -959,6 +962,25 @@ public class DisabledAlgorithmConstraints extends AbstractAlgorithmConstraints {
 
             return true;
         }
+    }
+
+    private boolean cachedCheckAlgorithm(String algorithm) {
+        Map<String, Boolean> cache;
+        if ((cache = cacheRef.get()) == null) {
+            synchronized (this) {
+                if ((cache = cacheRef.get()) == null) {
+                    cache = new ConcurrentHashMap<>();
+                    cacheRef = new SoftReference<>(cache);
+                }
+            }
+        }
+        Boolean result = cache.get(algorithm);
+        if (result != null) {
+            return result;
+        }
+        result = checkAlgorithm(disabledAlgorithms, algorithm, decomposer);
+        cache.put(algorithm, result);
+        return result;
     }
 
     /*


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

I had to resiolve the new imports and the chunk for permits() that differs in indentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285398](https://bugs.openjdk.org/browse/JDK-8285398): Cache the results of constraint checks


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [9b36f549](https://git.openjdk.org/jdk17u-dev/pull/450/files/9b36f54961c006cf06618691588f17e7228832a5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/450/head:pull/450` \
`$ git checkout pull/450`

Update a local copy of the PR: \
`$ git checkout pull/450` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 450`

View PR using the GUI difftool: \
`$ git pr show -t 450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/450.diff">https://git.openjdk.org/jdk17u-dev/pull/450.diff</a>

</details>
