### PR TITLE
8287073: NPE from CgroupV2Subsystem.getInstance()

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemFactory.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -110,9 +111,9 @@ public class CgroupSubsystemFactory {
         Map<String, CgroupInfo> infos = result.getInfos();
         if (result.isCgroupV2()) {
             // For unified it doesn't matter which controller we pick.
-            CgroupInfo anyController = infos.get(MEMORY_CTRL);
-            CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(anyController);
-            return subsystem != null ? new CgroupMetrics(subsystem) : null;
+            CgroupInfo anyController = infos.values().iterator().next();
+            CgroupSubsystem subsystem = CgroupV2Subsystem.getInstance(Objects.requireNonNull(anyController));
+            return new CgroupMetrics(subsystem);
         } else {
             CgroupV1Subsystem subsystem = CgroupV1Subsystem.getInstance(infos);
             return subsystem != null ? new CgroupV1MetricsImpl(subsystem) : null;


### PR DESCRIPTION
Clean backport. Issue present in 17u too and low risk fix. Regression test in JDK-8287663 which I intend to backport too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287073](https://bugs.openjdk.org/browse/JDK-8287073): NPE from CgroupV2Subsystem.getInstance()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk17u-dev pull/456/head:pull/456` \
`$ git checkout pull/456`

Update a local copy of the PR: \
`$ git checkout pull/456` \
`$ git pull https://git.openjdk.java.net/jdk17u-dev pull/456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 456`

View PR using the GUI difftool: \
`$ git pr show -t 456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk17u-dev/pull/456.diff">https://git.openjdk.java.net/jdk17u-dev/pull/456.diff</a>

</details>
