### PR TITLE
8286429: jpackageapplauncher build fails intermittently in Tier[45]

### DIFF
--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -196,9 +196,11 @@ endef
 ################################################################################
 # Create man pages for jmod to pick up. There should be a one-to-one
 # relationship between executables and man pages (even if this is not always
-# the case), so piggyback man page generation on the launcher compilation.
+# the case), so piggyback man page generation on the launcher compilation. This
+# file may be included from other places as well, so only process man pages
+# when called from <module>/Launcher.gmk.
 
-ifeq ($(call isTargetOsType, unix), true)
+ifeq ($(call isTargetOsType, unix)+$(MAKEFILE_PREFIX), true+Launcher)
   # Only build manpages on unix systems.
   # We assume all our man pages should reside in section 1.
 
@@ -242,9 +244,9 @@ ifeq ($(call isTargetOsType, unix), true)
           FILTER := $(PANDOC_TROFF_MANPAGE_FILTER), \
           POST_PROCESS := $(MAN_POST_PROCESS), \
           REPLACEMENTS := \
-		@@COPYRIGHT_YEAR@@ => $(COPYRIGHT_YEAR) ; \
-		@@VERSION_SHORT@@ => $(VERSION_SHORT) ; \
-		@@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION), \
+              @@COPYRIGHT_YEAR@@ => $(COPYRIGHT_YEAR) ; \
+              @@VERSION_SHORT@@ => $(VERSION_SHORT) ; \
+              @@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION), \
           EXTRA_DEPS := $(PANDOC_TROFF_MANPAGE_FILTER) \
               $(PANDOC_TROFF_MANPAGE_FILTER_SOURCE), \
       ))


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286429](https://bugs.openjdk.org/browse/JDK-8286429): jpackageapplauncher build fails intermittently in Tier[45]


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/471/head:pull/471` \
`$ git checkout pull/471`

Update a local copy of the PR: \
`$ git checkout pull/471` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 471`

View PR using the GUI difftool: \
`$ git pr show -t 471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/471.diff">https://git.openjdk.org/jdk17u-dev/pull/471.diff</a>

</details>
