### PR TITLE
8284690: [macos] VoiceOver : Getting java.lang.IllegalArgumentException: Invalid location on Editable JComboBox

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibleText.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibleText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,7 +288,9 @@ class CAccessibleText {
                 final AccessibleEditableText aet = ac.getAccessibleEditableText();
                 if (aet == null) return null;
 
-                return aet.getTextRange(location, location + length);
+                int currentLength = aet.getCharCount();
+                return aet.getTextRange(Math.min(currentLength, location),
+                        Math.min(currentLength, location + length));
             }
         }, c);
     }


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [ebfa27b9](https://github.com/openjdk/jdk/commit/ebfa27b9f06aee8ceceabc564a78a351903ce9a1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Alexander Zuev on 25 May 2022 and was reviewed by Sergey Bylokhov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284690](https://bugs.openjdk.org/browse/JDK-8284690): [macos] VoiceOver : Getting java.lang.IllegalArgumentException: Invalid location on Editable JComboBox


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/480/head:pull/480` \
`$ git checkout pull/480`

Update a local copy of the PR: \
`$ git checkout pull/480` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 480`

View PR using the GUI difftool: \
`$ git pr show -t 480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/480.diff">https://git.openjdk.org/jdk17u-dev/pull/480.diff</a>

</details>
