### PR TITLE
8274597: Some of the dnd tests time out and fail intermittently

### DIFF
--- a/test/jdk/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
+++ b/test/jdk/java/awt/dnd/AcceptDropMultipleTimes/AcceptDropMultipleTimes.java
@@ -35,22 +35,44 @@
 
 import test.java.awt.regtesthelpers.Util;
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.datatransfer.*;
-import java.awt.dnd.*;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
 import java.awt.event.InputEvent;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.imageio.ImageIO;
+import javax.swing.SwingUtilities;
 
 public class AcceptDropMultipleTimes {
 
     private static final int FRAME_SIZE = 100;
-    private static final int FRAME_LOCATION = 100;
+    private static CountDownLatch dropCompleteLatch = new CountDownLatch(1);
 
     private static volatile Frame f;
 
     private static void initAndShowUI() {
         f = new Frame("Test frame");
-        f.setBounds(FRAME_LOCATION, FRAME_LOCATION, FRAME_SIZE, FRAME_SIZE);
+        f.setSize(FRAME_SIZE, FRAME_SIZE);
+        f.setLocationRelativeTo(null);
+        f.setUndecorated(true);
 
         final DraggablePanel dragSource = new DraggablePanel();
         dragSource.setBackground(Color.yellow);
@@ -63,11 +85,12 @@ public class AcceptDropMultipleTimes {
                 dtde.acceptDrop(DnDConstants.ACTION_MOVE);
 
                 dtde.dropComplete(true);
+                dropCompleteLatch.countDown();
             }
         });
         dragSource.setDropTarget(dt);
         f.add(dragSource);
-
+        f.setAlwaysOnTop(true);
         f.setVisible(true);
     }
 
@@ -77,19 +100,37 @@ public class AcceptDropMultipleTimes {
             SwingUtilities.invokeAndWait(() -> initAndShowUI());
 
             Robot r = new Robot();
+            r.setAutoDelay(50);
             Util.waitForIdle(r);
+            final AtomicReference<Point> frameLoc = new AtomicReference<>();
+            SwingUtilities.invokeAndWait(() -> frameLoc.set(f.getLocationOnScreen()));
+            Point loc = frameLoc.get();
             Util.drag(r,
-                    new Point(FRAME_LOCATION + FRAME_SIZE / 3, FRAME_LOCATION + FRAME_SIZE / 3),
-                    new Point(FRAME_LOCATION + FRAME_SIZE / 3 * 2, FRAME_LOCATION + FRAME_SIZE / 3 * 2),
-                    InputEvent.BUTTON1_MASK);
+                    new Point(loc.x + FRAME_SIZE / 3, loc.y + FRAME_SIZE / 3),
+                    new Point(loc.x + FRAME_SIZE / 3 * 2, loc.y + FRAME_SIZE / 3 * 2),
+                    InputEvent.BUTTON1_DOWN_MASK);
             Util.waitForIdle(r);
+            if(!dropCompleteLatch.await(10, TimeUnit.SECONDS)) {
+                captureScreen(r);
+                throw new RuntimeException("Waited too long, but the drop is not completed");
+            }
         } finally {
             if (f != null) {
                 f.dispose();
             }
         }
     }
-
+    private static void captureScreen(Robot r) {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        try {
+            ImageIO.write(
+                    r.createScreenCapture(new Rectangle(0, 0, screenSize.width, screenSize.height)),
+                    "png",
+                    new File("FailedScreenImage.png")
+                         );
+        } catch (IOException ignore) {
+        }
+    }
     private static class DraggablePanel extends Panel implements DragGestureListener {
 
         public DraggablePanel() {

--- a/test/jdk/java/awt/dnd/DropTargetEnterExitTest/ExtraDragEnterTest.java
+++ b/test/jdk/java/awt/dnd/DropTargetEnterExitTest/ExtraDragEnterTest.java
@@ -35,8 +35,13 @@
 
 import test.java.awt.regtesthelpers.Util;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
 import java.awt.datatransfer.StringSelection;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DragGestureEvent;
@@ -47,23 +52,27 @@ import java.awt.dnd.DropTargetAdapter;
 import java.awt.dnd.DropTargetDragEvent;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.event.InputEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.swing.SwingUtilities;
 
 public class ExtraDragEnterTest {
 
     private static final int FRAME_SIZE = 100;
-    private static final int FRAME_LOCATION = 100;
 
     private static AtomicInteger dragEnterCalled = new AtomicInteger(0);
 
     private static volatile Panel mainPanel;
     private static volatile Frame f;
+    private static CountDownLatch dropCompleteLatch = new CountDownLatch(1);
 
     private static void initAndShowUI() {
         f = new Frame("Test frame");
-        f.setBounds(FRAME_LOCATION,FRAME_LOCATION,FRAME_SIZE,FRAME_SIZE);
+        f.setLocationRelativeTo(null);
+        f.setSize(FRAME_SIZE,FRAME_SIZE);
         mainPanel = new Panel();
-        mainPanel.setBounds(0, 0, FRAME_SIZE, FRAME_SIZE);
+        mainPanel.setSize(FRAME_SIZE, FRAME_SIZE);
         mainPanel.setBackground(Color.black);
         mainPanel.setLayout(new GridLayout(2, 1));
 
@@ -75,7 +84,10 @@ public class ExtraDragEnterTest {
         Panel dropTarget = new Panel();
         dropTarget.setBackground(Color.red);
         DropTarget dt = new DropTarget(dropTarget, new DropTargetAdapter() {
-            @Override public void drop(DropTargetDropEvent dtde) { }
+            @Override public void drop(DropTargetDropEvent dtde) {
+                System.out.println("Drop complete");
+                dropCompleteLatch.countDown();
+            }
 
             @Override
             public void dragEnter(DropTargetDragEvent dtde) {
@@ -86,6 +98,7 @@ public class ExtraDragEnterTest {
         mainPanel.add(dropTarget);
 
         f.add(mainPanel);
+        f.setAlwaysOnTop(true);
         f.setVisible(true);
     }
 
@@ -112,6 +125,9 @@ public class ExtraDragEnterTest {
             int called = dragEnterCalled.get();
             if (called != 1) {
                 throw new RuntimeException("Failed. Drag enter called " + called + " times. Expected 1" );
+            }
+            if(!dropCompleteLatch.await(10, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Waited too long, but the drop is not completed");
             }
         } finally {
             if (f != null) {

--- a/test/jdk/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
+++ b/test/jdk/java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java
@@ -35,8 +35,12 @@
 
 import test.java.awt.regtesthelpers.Util;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
 import java.awt.datatransfer.StringSelection;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DragGestureEvent;
@@ -48,15 +52,17 @@ import java.awt.dnd.DropTargetDragEvent;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.dnd.DropTargetEvent;
 import java.awt.event.InputEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.SwingUtilities;
 
 public class MissedDragExitTest {
 
     private static final int FRAME_SIZE = 100;
     private static final int FRAME_LOCATION = 100;
 
-    private static volatile boolean dragExitCalled = false;
-
     private static volatile Frame f;
+    private static CountDownLatch dragLatch = new CountDownLatch(2);
 
     private static void initAndShowUI() {
         f = new Frame("Test frame");
@@ -70,21 +76,30 @@ public class MissedDragExitTest {
 
             @Override
             public void dragExit(DropTargetEvent dte) {
-                dragExitCalled = true;
+                System.out.println("Drag Exit");
+                dragLatch.countDown();
             }
 
             @Override
             public void dragOver(DropTargetDragEvent dtde) {
-                Panel newDropTarget = new Panel();
-                newDropTarget.setDropTarget(new DropTarget());
-                newDropTarget.setBackground(Color.red);
-                newDropTarget.setBounds(0, 0, FRAME_SIZE, FRAME_SIZE);
-                dragSource.add(newDropTarget);
+                Panel newDropTargetPanel = new Panel();
+                final DropTarget dropTarget = new DropTarget(null,new DropTargetAdapter() {
+                    @Override
+                    public void drop(DropTargetDropEvent dtde) {
+                        System.out.println("Drop complete");
+                        dragLatch.countDown();
+                    }
+                });
+                newDropTargetPanel.setDropTarget(dropTarget);
+                newDropTargetPanel.setBackground(Color.red);
+                newDropTargetPanel.setSize(FRAME_SIZE, FRAME_SIZE);
+                dragSource.add(newDropTargetPanel);
             }
         });
         dragSource.setDropTarget(dt);
         f.add(dragSource);
 
+        f.setAlwaysOnTop(true);
         f.setVisible(true);
     }
 
@@ -105,8 +120,7 @@ public class MissedDragExitTest {
                     new Point(FRAME_LOCATION + FRAME_SIZE / 3 * 2, FRAME_LOCATION + FRAME_SIZE / 3 * 2),
                     InputEvent.BUTTON1_DOWN_MASK);
             Util.waitForIdle(r);
-
-            if (!dragExitCalled) {
+            if(!dragLatch.await(10, TimeUnit.SECONDS)) {
                 throw new RuntimeException("Failed. Drag exit was not called" );
             }
         } finally {

--- a/test/jdk/java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java
+++ b/test/jdk/java/awt/dnd/MissingDragExitEventTest/MissingDragExitEventTest.java
@@ -32,9 +32,14 @@
  * @author Sergey Bylokhov
  */
 
+import test.java.awt.regtesthelpers.Util;
+
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.dnd.DnDConstants;
 import java.awt.dnd.DropTarget;
 import java.awt.dnd.DropTargetAdapter;
@@ -44,12 +49,15 @@ import java.awt.dnd.DropTargetEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
-
-import test.java.awt.regtesthelpers.Util;
 
 public class MissingDragExitEventTest {
 
@@ -59,23 +67,26 @@ public class MissingDragExitEventTest {
     private static boolean MOUSE_ENTERED;
     private static boolean MOUSE_EXIT_TD;
     private static boolean MOUSE_EXIT;
-    private static int SIZE = 300;
+    private static int SIZE = 100;
+    private static CountDownLatch dropCompleteLatch = new CountDownLatch(1);
 
     private static void initAndShowUI() {
         frame = new JFrame("Test frame");
-
+        frame.setUndecorated(true);
         frame.setSize(SIZE, SIZE);
         frame.setLocationRelativeTo(null);
         final JTextArea jta = new JTextArea();
         jta.setBackground(Color.RED);
         frame.add(jta);
         jta.setText("1234567890");
-        jta.setFont(jta.getFont().deriveFont(150f));
+        jta.setFont(jta.getFont().deriveFont(50f));
         jta.setDragEnabled(true);
         jta.selectAll();
         jta.setDropTarget(new DropTarget(jta, DnDConstants.ACTION_COPY,
                                          new TestdropTargetListener()));
         jta.addMouseListener(new TestMouseAdapter());
+        frame.pack();
+        frame.setAlwaysOnTop(true);
         frame.setVisible(true);
     }
 
@@ -92,25 +103,36 @@ public class MissingDragExitEventTest {
                     initAndShowUI();
                 }
             });
-
-            final Point inside = new Point(frame.getLocationOnScreen());
-            inside.translate(20, SIZE / 2);
+            final AtomicReference<Point> insidePoint = new AtomicReference<>();
+            SwingUtilities.invokeAndWait(() -> insidePoint.set(frame.getLocationOnScreen()));
+            final Point inside = insidePoint.get();
+            inside.translate(2,20);
             final Point outer = new Point(inside);
-            outer.translate(-40, 0);
+            outer.translate(-20, 0);
             r.mouseMove(inside.x, inside.y);
-            r.mousePress(InputEvent.BUTTON1_MASK);
+            r.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             try {
                 for (int i = 0; i < 3; ++i) {
                     Util.mouseMove(r, inside, outer);
                     Util.mouseMove(r, outer, inside);
                 }
             } finally {
-                r.mouseRelease(InputEvent.BUTTON1_MASK);
+                r.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             }
-            sleep(r);
 
-            if (FAILED || !MOUSE_ENTERED || !MOUSE_ENTERED_DT || !MOUSE_EXIT
-                    || !MOUSE_EXIT_TD) {
+            if (!dropCompleteLatch.await(10, TimeUnit.SECONDS)) {
+                captureScreen(r);
+                throw new RuntimeException(
+                        "Waited too long, but the drop is not completed");
+            }
+            if (FAILED || !MOUSE_ENTERED || !MOUSE_ENTERED_DT || !MOUSE_EXIT ||
+                !MOUSE_EXIT_TD) {
+                System.out.println(
+                        "Events, FAILED = " + FAILED + ", MOUSE_ENTERED = " +
+                        MOUSE_ENTERED + ", MOUSE_ENTERED_DT = " +
+                        MOUSE_ENTERED_DT + ", MOUSE_EXIT = " + MOUSE_EXIT +
+                        ", MOUSE_EXIT_TD = " + MOUSE_EXIT_TD);
+                captureScreen(r);
                 throw new RuntimeException("Failed");
             }
         } finally {
@@ -120,12 +142,14 @@ public class MissingDragExitEventTest {
         }
     }
 
-    private static void sleep(Robot robot) {
+    private static void captureScreen(Robot r) {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
         try {
-            Thread.sleep(10000);
-        } catch (InterruptedException ignored) {
+            ImageIO.write(r.createScreenCapture(
+                    new Rectangle(0, 0, screenSize.width, screenSize.height)),
+                          "png", new File("FailedScreenImage.png"));
+        } catch (IOException ignore) {
         }
-        robot.waitForIdle();
     }
 
     static class TestdropTargetListener extends DropTargetAdapter {
@@ -140,10 +164,6 @@ public class MissingDragExitEventTest {
             }
             inside = true;
             MOUSE_ENTERED_DT = true;
-            try {
-                Thread.sleep(10000); // we should have time to leave a component
-            } catch (InterruptedException ignored) {
-            }
         }
 
         @Override
@@ -162,6 +182,7 @@ public class MissingDragExitEventTest {
             }
             inside = false;
             MOUSE_EXIT_TD = true;
+            System.out.println("Drag exit");
         }
 
         @Override
@@ -171,6 +192,8 @@ public class MissingDragExitEventTest {
                 Thread.dumpStack();
             }
             inside = false;
+            System.out.println("Drop complete");
+            dropCompleteLatch.countDown();
         }
     }
 
@@ -190,6 +213,7 @@ public class MissingDragExitEventTest {
 
         @Override
         public void mouseExited(final MouseEvent e) {
+            System.out.println( "Mouse exit");
             if (!inside) {
                 FAILED = true;
                 Thread.dumpStack();


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8274597](https://bugs.openjdk.org/browse/JDK-8274597): Some of the dnd tests time out and fail intermittently
 * [JDK-8028998](https://bugs.openjdk.org/browse/JDK-8028998): [TEST_BUG] [macosx] java/awt/dnd/DropTargetEnterExitTest/MissedDragExitTest.java failed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/483/head:pull/483` \
`$ git checkout pull/483`

Update a local copy of the PR: \
`$ git checkout pull/483` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 483`

View PR using the GUI difftool: \
`$ git pr show -t 483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/483.diff">https://git.openjdk.org/jdk17u-dev/pull/483.diff</a>

</details>
