### PR TITLE
8282555: Missing memory edge when spilling MoveF2I, MoveD2L etc

### DIFF
--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -1700,6 +1700,14 @@ void PhaseChaitin::fixup_spills() {
           if( cisc->oper_input_base() > 1 && mach->oper_input_base() <= 1 ) {
             assert( cisc->oper_input_base() == 2, "Only adding one edge");
             cisc->ins_req(1,src);         // Requires a memory edge
+          } else {
+            // There is no space reserved for a memory edge before the inputs for
+            // instructions which have "stackSlotX" parameter instead of "memory".
+            // For example, "MoveF2I_stack_reg". We always need a memory edge from
+            // src to cisc, else we might schedule cisc before src, loading from a
+            // spill location before storing the spill.
+            assert(cisc->memory_operand() == nullptr, "no memory operand, only stack");
+            cisc->add_prec(src);
           }
           block->map_node(cisc, j);          // Insert into basic block
           n->subsume_by(cisc, C); // Correct graph

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
@@ -35,6 +35,21 @@
  *      HeapByteBufferTest
  */
 
+/**
+ * @test
+ * @bug 8282555
+ * @summary intermittent, check that spilling MoveF2I etc produce memory edge
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ *
+ * @run main/othervm -Djdk.test.lib.random.seed=42
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+OptoScheduling
+ *      HeapByteBufferTest
+ * @run main/othervm
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+OptoScheduling
+ *      HeapByteBufferTest
+ */
+
 public class HeapByteBufferTest extends ByteBufferTest {
 
     public HeapByteBufferTest(long iterations, boolean direct) {


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282555](https://bugs.openjdk.org/browse/JDK-8282555): Missing memory edge when spilling MoveF2I, MoveD2L etc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/485/head:pull/485` \
`$ git checkout pull/485`

Update a local copy of the PR: \
`$ git checkout pull/485` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 485`

View PR using the GUI difftool: \
`$ git pr show -t 485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/485.diff">https://git.openjdk.org/jdk17u-dev/pull/485.diff</a>

</details>
