### PR TITLE
8286870: Memory leak with RepeatCompilation

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2319,8 +2319,9 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
       /* Repeat compilation without installing code for profiling purposes */
       int repeat_compilation_count = directive->RepeatCompilationOption;
       while (repeat_compilation_count > 0) {
+        ResourceMark rm(thread);
         task->print_ul("NO CODE INSTALLED");
-        comp->compile_method(&ci_env, target, osr_bci, false , directive);
+        comp->compile_method(&ci_env, target, osr_bci, false, directive);
         repeat_compilation_count--;
       }
     }


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286870](https://bugs.openjdk.org/browse/JDK-8286870): Memory leak with RepeatCompilation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/488/head:pull/488` \
`$ git checkout pull/488`

Update a local copy of the PR: \
`$ git checkout pull/488` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 488`

View PR using the GUI difftool: \
`$ git pr show -t 488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/488.diff">https://git.openjdk.org/jdk17u-dev/pull/488.diff</a>

</details>
