### PR TITLE
8211002: test/jdk/java/lang/Math/PowTests.java skips testing for non-corner-case values

### DIFF
--- a/test/jdk/java/lang/Math/PowTests.java
+++ b/test/jdk/java/lang/Math/PowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,15 @@ public class PowTests {
         failures += Tests.test("Math.pow(double, double)", input1, input2,
                                Math.pow(input1, input2), expected);
         return failures;
+    }
+
+    static int testStrictVsNonstrictPowCase(double input1, double input2) {
+        double smResult = StrictMath.pow(input1, input2);
+        double mResult = Math.pow(input1, input2);
+        return Tests.testUlpDiff(
+            "StrictMath.pow(double, double) vs Math.pow(double, double)",
+            input1, input2, mResult, smResult, 2.0
+        );
     }
 
     /*
@@ -206,8 +215,10 @@ public class PowTests {
                     assert y != 0.0;
                     failures += testStrictPowCase(x, y, f3(x, y));
                     failures += testNonstrictPowCase(x, y, f3ns(x, y));
+                    failures += testStrictVsNonstrictPowCase(x, y);
                     continue;
                 } else {
+                    failures += testStrictVsNonstrictPowCase(x, y);
                     // go to next iteration
                     expected = NaN;
                     continue;


### PR DESCRIPTION
I backport this for parity with 11.0.17-oracle. (Yes!)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211002](https://bugs.openjdk.org/browse/JDK-8211002): test/jdk/java/lang/Math/PowTests.java skips testing for non-corner-case values


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/491/head:pull/491` \
`$ git checkout pull/491`

Update a local copy of the PR: \
`$ git checkout pull/491` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 491`

View PR using the GUI difftool: \
`$ git pr show -t 491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/491.diff">https://git.openjdk.org/jdk17u-dev/pull/491.diff</a>

</details>
