### PR TITLE
8287917: System.loadLibrary does not work on Big Sur if JDK is built with macOS SDK 10.15 and earlier

### DIFF
--- a/src/java.base/macosx/classes/jdk/internal/loader/ClassLoaderHelper.java
+++ b/src/java.base/macosx/classes/jdk/internal/loader/ClassLoaderHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,8 @@ class ClassLoaderHelper {
         try {
             major = Integer.parseInt(i < 0 ? osVersion : osVersion.substring(0, i));
         } catch (NumberFormatException e) {}
-        hasDynamicLoaderCache = major >= 11;
+        // SDK 10.15 and earlier always reports 10.16 instead of 11.x.x
+        hasDynamicLoaderCache = major >= 11 || osVersion.equals("10.16");
     }
 
     private ClassLoaderHelper() {}

--- a/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
+++ b/test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import java.nio.file.Paths;
 
 public class LibraryFromCache {
     public static void main(String[] args) throws IOException {
+        System.out.println("os.version = " + System.getProperty("os.version"));
+
         String libname = args[0];
         if (!systemHasLibrary(libname)) {
             System.out.println("Test skipped. Library " + libname + " not found");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fe807217](https://github.com/openjdk/jdk/commit/fe807217a79753f84c00432e7451c17baa6645c5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Yoshiki Sato on 15 Jun 2022 and was reviewed by Mandy Chung.

It applies cleanly to current jdk17u-dev head. The test it modifies passes after the patch.

Running the test was a little unusual. I needed to build the native component by hand and explicitly pass an argument to `jtreg`:

```
 $  pushd test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache
 $  cc  exeLibraryCache.c -o LibraryCache
 $  popd
 $  $JT_HOME/bin/jtreg -jdk:build/macosx-x86_64-server-release/images/jdk  \
 -nativepath:test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache  \
test/jdk/java/lang/RuntimeTests/loadLibrary/exeLibraryCache/LibraryFromCache.java
```

test system is macOS Big Sur (11.5.2)  with local SDK version 10.14.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287917](https://bugs.openjdk.org/browse/JDK-8287917): System.loadLibrary does not work on Big Sur if JDK is built with macOS SDK 10.15 and earlier


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/506/head:pull/506` \
`$ git checkout pull/506`

Update a local copy of the PR: \
`$ git checkout pull/506` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 506`

View PR using the GUI difftool: \
`$ git pr show -t 506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/506.diff">https://git.openjdk.org/jdk17u-dev/pull/506.diff</a>

</details>
