### PR TITLE
8289197: [17u] Push of backport of 8286177 did not remove assertion

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -110,8 +110,6 @@ bool SuperWord::transform_loop(IdealLoopTree* lpt, bool do_optimization) {
     return false; // skip malformed counted loop
   }
 
-  assert(!lpt->has_reduction_nodes() || cl->is_reduction_loop(),
-         "non-reduction loop contains reduction nodes");
   bool post_loop_allowed = (PostLoopMultiversioning && Matcher::has_predicated_vectors() && cl->is_post_loop());
   if (post_loop_allowed) {
     if (cl->is_reduction_loop()) {


### PR DESCRIPTION
When I pushed 8286177, I missed removing the assertion that was 
addressed by that change.  This is corrected by this follow up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289197](https://bugs.openjdk.org/browse/JDK-8289197): [17u] Push of backport of 8286177 did not remove assertion


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/509/head:pull/509` \
`$ git checkout pull/509`

Update a local copy of the PR: \
`$ git checkout pull/509` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 509`

View PR using the GUI difftool: \
`$ git pr show -t 509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/509.diff">https://git.openjdk.org/jdk17u-dev/pull/509.diff</a>

</details>
