### PR TITLE
8286625: C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1317,7 +1317,8 @@ static bool skeleton_follow_inputs(Node* n, int op) {
           op == Op_MulI ||
           op == Op_SubL ||
           op == Op_SubI ||
-          op == Op_ConvI2L);
+          op == Op_ConvI2L ||
+          op == Op_CastII);
 }
 
 bool PhaseIdealLoop::skeleton_predicate_has_opaque(IfNode* iff) {
@@ -2838,6 +2839,9 @@ int PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
           Node* max_value = new SubINode(opaque_stride, cl->stride());
           register_new_node(max_value, predicate_proj);
           max_value = new AddINode(opaque_init, max_value);
+          register_new_node(max_value, predicate_proj);
+          // init + (current stride - initial stride) is within the loop so narrow its type by leveraging the type of the iv Phi
+          max_value = new CastIINode(max_value, loop->_head->as_CountedLoop()->phi()->bottom_type());
           register_new_node(max_value, predicate_proj);
           predicate_proj = add_range_check_predicate(loop, cl, predicate_proj, scale_con, int_offset, int_limit, stride_con, max_value);
           assert(skeleton_predicate_has_opaque(predicate_proj->in(0)->as_If()), "unexpected");

--- a/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestOverUnrolling2.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8286625
+ * @key stress
+ * @summary C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+StressIGVN -XX:StressSeed=4232417824 TestOverUnrolling2
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+StressIGVN TestOverUnrolling2
+ */
+
+public class TestOverUnrolling2 {
+   public static void main(String[] args) {
+        final byte[] large = new byte[1000];
+        final byte[] src = new byte[16];
+        for (int i = 0; i < 20_000; i++) {
+            test_helper(large, large);
+            test(src);
+        }
+   }
+
+    private static void test(byte[] src) {
+        byte[] array = new byte[16];
+        test_helper(src, array);
+    }
+
+    private static void test_helper(byte[] src, byte[] array) {
+        for (int i = 0; i < src.length; i++) {
+            array[array.length - 1 - i] = src[i];
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286625](https://bugs.openjdk.org/browse/JDK-8286625): C2 fails with assert(!n->is_Store() && !n->is_LoadStore()) failed: no node with a side effect


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/514/head:pull/514` \
`$ git checkout pull/514`

Update a local copy of the PR: \
`$ git checkout pull/514` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 514`

View PR using the GUI difftool: \
`$ git pr show -t 514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/514.diff">https://git.openjdk.org/jdk17u-dev/pull/514.diff</a>

</details>
