### PR TITLE
8287432: C2: assert(tn->in(0) != __null) failed: must have live top node

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3519,7 +3519,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
       n->set_req(MemBarNode::Precedent, top());
       while (wq.size() > 0) {
         Node* m = wq.pop();
-        if (m->outcnt() == 0) {
+        if (m->outcnt() == 0 && m != top()) {
           for (uint j = 0; j < m->req(); j++) {
             Node* in = m->in(j);
             if (in != NULL) {

--- a/test/hotspot/jtreg/compiler/c2/TestRemoveMemBarPrecEdge.java
+++ b/test/hotspot/jtreg/compiler/c2/TestRemoveMemBarPrecEdge.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8287432
+ * @summary Test removal of precedence edge of MemBarAcquire together with other now dead input nodes which visits a
+ *          top node. This resulted in a crash before as it disconnected top from the graph which is unexpected.
+ *
+ * @run main/othervm -Xbatch compiler.c2.TestRemoveMemBarPrecEdge
+ */
+package compiler.c2;
+
+public class TestRemoveMemBarPrecEdge {
+    static boolean flag = false;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+            flag = !flag;
+        }
+    }
+
+    public static void test() {
+        // currentThread() is intrinsified and C2 emits a special AddP node with a base that is top.
+        Thread t = Thread.currentThread();
+        // getName() returns the volatile _name field. The method is inlined and we just emit a LoadN + DecodeN which
+        // is a precedence edge input into both MemBarAcquire nodes below for the volatile field _name.
+        if (flag) {
+            t.getName();
+        } else {
+            t.getName();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287432](https://bugs.openjdk.org/browse/JDK-8287432): C2: assert(tn->in(0) != __null) failed: must have live top node


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/515/head:pull/515` \
`$ git checkout pull/515`

Update a local copy of the PR: \
`$ git checkout pull/515` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 515`

View PR using the GUI difftool: \
`$ git pr show -t 515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/515.diff">https://git.openjdk.org/jdk17u-dev/pull/515.diff</a>

</details>
