### PR TITLE
8278609: [macos] accessibility frame is misplaced on a secondary monitor on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/CommonComponentAccessibility.m
@@ -792,7 +792,7 @@ static jobject sAccessibilityClass = NULL;
     (*env)->DeleteLocalRef(env, axComponent);
     point.y += size.height;
 
-    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+    point.y = [[[NSScreen screens] objectAtIndex:0] frame].size.height - point.y;
 
     return NSMakeRect(point.x, point.y, size.width, size.height);
 }
@@ -990,7 +990,7 @@ static jobject sAccessibilityClass = NULL;
     point.y += size.height;
 
     // Now make it into Cocoa screen coords.
-    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+    point.y = [[[NSScreen screens] objectAtIndex:0] frame].size.height - point.y;
 
     return point;
 }
@@ -1098,7 +1098,7 @@ static jobject sAccessibilityClass = NULL;
                                  "(Ljava/awt/Container;FF)Ljavax/accessibility/Accessible;", nil);
 
     // Make it into java screen coords
-    point.y = [[[[self view] window] screen] frame].size.height - point.y;
+    point.y = [[[NSScreen screens] objectAtIndex:0] frame].size.height - point.y;
 
     jobject jparent = fComponent;
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ad128284](https://github.com/openjdk/jdk/commit/ad1282842c5eefdad151afe6f4db97a09d643546) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Aleksandr Veselov on 20 Dec 2021 and was reviewed by Anton Tarasov and Alexander Zuev. I'd like to backport this for Oracle JDK17 parity.

A few notes on testing. There are no tests in the patch. The JBS bug says only this in terms of reproducing the issue:

>  When an app is displayed on a secondary monitor whose vertical resolution differs from the primary monitor, accessibility outline frame gets misplaced while navigating UI elements.
> This can be easily reproduced with SwingSet2, for instance. 

I built and ran https://github.com/xjrga/swingset2 on macOS 11.5.2 (20G95) with an external display with a deliberately different resolution from the mac's internal panel, but I could not reproduce the original issue.

The patch itself backports clean. I ran swingset2 afterwards and noticed no obvious difference (but all the various widgets worked fine)

If anyone wants to suggest any further specific manual tests I could perform to reproduce the original issue or validate the fix I'm happy to try them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278609](https://bugs.openjdk.org/browse/JDK-8278609): [macos] accessibility frame is misplaced on a secondary monitor on macOS ⚠️ Issue is not open.


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/520/head:pull/520` \
`$ git checkout pull/520`

Update a local copy of the PR: \
`$ git checkout pull/520` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 520`

View PR using the GUI difftool: \
`$ git pr show -t 520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/520.diff">https://git.openjdk.org/jdk17u-dev/pull/520.diff</a>

</details>
