### PR TITLE
8276546: [IR Framework] Whitelist and ignore CompileThreshold

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -122,6 +122,7 @@ public class TestFramework {
                     "BackgroundCompilation",
                     "Xbatch",
                     "TieredCompilation",
+                    "CompileThreshold",
                     "Xmixed",
                     "server",
                     "Xlog",

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -37,6 +37,7 @@ import jdk.test.lib.process.ProcessTools;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * This class prepares, creates, and runs the "test" VM with verification of proper termination. The class also stores
@@ -97,9 +98,10 @@ public class TestVMProcess {
         cmds.add("-Xbootclasspath/a:.");
         cmds.add("-XX:+UnlockDiagnosticVMOptions");
         cmds.add("-XX:+WhiteBoxAPI");
-        String[] jtregVMFlags = Utils.getTestJavaOpts();
+        // Ignore CompileCommand flags which have an impact on the profiling information.
+        List<String> jtregVMFlags = Arrays.stream(Utils.getTestJavaOpts()).filter(s -> !s.contains("CompileThreshold")).collect(Collectors.toList());
         if (!PREFER_COMMAND_LINE_FLAGS) {
-            cmds.addAll(Arrays.asList(jtregVMFlags));
+            cmds.addAll(jtregVMFlags);
         }
         // Add server property flag that enables test VM to print encoding for IR verification last and debug messages.
         cmds.add(socket.getPortPropertyFlag());
@@ -111,7 +113,7 @@ public class TestVMProcess {
 
         if (PREFER_COMMAND_LINE_FLAGS) {
             // Prefer flags set via the command line over the ones set by scenarios.
-            cmds.addAll(Arrays.asList(jtregVMFlags));
+            cmds.addAll(jtregVMFlags);
         }
 
         if (WARMUP_ITERATIONS < 0 && defaultWarmup != -1) {

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompileThreshold.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestCompileThreshold.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package ir_framework.tests;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.ir_framework.driver.IRViolationException;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8276546
+ * @requires vm.debug == true & vm.compMode != "Xint" & vm.compMode != "Xcomp" & vm.compiler1.enabled & vm.compiler2.enabled & vm.flagless
+ * @summary Test that CompileThreshold flag is ignored when passed as Java/VM option to the framework.
+ *          Normally, the framework should be called with driver.
+ * @library /test/lib /testlibrary_tests /
+ * @run main/othervm -XX:CompileThreshold=12 -XX:+UseG1GC ir_framework.tests.TestCompileThreshold
+ */
+
+public class TestCompileThreshold {
+    public int iFld = 0;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            // CompileThreshold=12 passed to the JTreg test is ignored even though we prefer command line flags.
+            // CompileThreshold=10 is user defined and passed directly to the framework and thus not ignored.
+            // InterpreterProfilePercentage=0 ensures that we compile exactly after 10 invocations.
+            TestFramework.runWithFlags("-XX:CompileThreshold=10", "-XX:InterpreterProfilePercentage=0",
+                                       "-XX:-TieredCompilation", "-DTest=testWithCompileThreshold",
+                                       "-DPreferCommandLineFlags=true");
+        } catch (IRViolationException e) {
+            Asserts.assertTrue(e.getExceptionInfo().contains("Failed IR Rules (1)"), "exactly one rule failed");
+            Asserts.assertTrue(e.getExceptionInfo().contains("testWithCompileThreshold()"),
+                               "testWithCompileThreshold() failed");
+        }
+
+        try {
+            TestFramework.runWithFlags("-XX:InterpreterProfilePercentage=0", "-XX:-TieredCompilation",
+                                       "-DTest=testWithoutCompileThreshold");
+        } catch (IRViolationException e) {
+            Asserts.assertTrue(e.getExceptionInfo().contains("Failed IR Rules (1)"), "exactly one rule failed");
+            Asserts.assertTrue(e.getExceptionInfo().contains("testWithoutCompileThreshold()"),
+                               "testWithoutCompileThreshold() failed");
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.CALL, "1"}) // fails
+    public void testWithCompileThreshold() {
+        iFld++;
+    }
+
+    @Run(test = "testWithCompileThreshold")
+    @Warmup(20)
+    public void runTestWithCompileThreshold(RunInfo info) {
+        if (iFld == 10) {
+            TestFramework.assertNotCompiled(info.getTest());
+        } else if (iFld == 11) {
+            // CompileThreshold=10 is passed directly as a flag to the framework.
+            // Therefore, testWithCompileThreshold() must be compiled by now.
+            TestFramework.assertCompiled(info.getTest());
+        }
+        testWithCompileThreshold();
+    }
+
+
+    @Test
+    @IR(counts = {IRNode.CALL, "1"}) // fails
+    public void testWithoutCompileThreshold() {
+        iFld++;
+    }
+
+    @Run(test = "testWithoutCompileThreshold")
+    @Warmup(20)
+    public void runTestWithoutCompileThreshold(RunInfo info) {
+        testWithCompileThreshold();
+        if (info.isWarmUp()) {
+            // CompileThreshold=12 is passed to the JTreg test but not directly to the framework.
+            // Therefore, it is ignored and we do not trigger a compilation until the framework does.
+            TestFramework.assertNotCompiled(info.getTest());
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276546](https://bugs.openjdk.org/browse/JDK-8276546): [IR Framework] Whitelist and ignore CompileThreshold


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/523/head:pull/523` \
`$ git checkout pull/523`

Update a local copy of the PR: \
`$ git checkout pull/523` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 523`

View PR using the GUI difftool: \
`$ git pr show -t 523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/523.diff">https://git.openjdk.org/jdk17u-dev/pull/523.diff</a>

</details>
