### PR TITLE
8286266: [macos] Voice over moving JTable column to be the first column JVM crashes

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 @interface TableAccessibility : CommonComponentAccessibility <NSAccessibilityTable>
 {
     NSMutableDictionary<NSNumber*, id> *rowCache;
+    BOOL cacheValid;
 }
 
 - (BOOL)isAccessibleChildSelectedFromIndex:(int)index;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableAccessibility.m
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,6 +130,15 @@ static jmethodID sjm_getAccessibleName = NULL;
     if (rowCache == nil) {
         int rowCount = [self accessibilityRowCount];
         rowCache = [[NSMutableDictionary<NSNumber*, id> dictionaryWithCapacity:rowCount] retain];
+        cacheValid = YES;
+    }
+
+    if (!cacheValid) {
+        for (NSNumber *key in [rowCache allKeys]) {
+            [[rowCache objectForKey:key] release];
+            [rowCache removeObjectForKey:key];
+        }
+        cacheValid = YES;
     }
 
     id row = [rowCache objectForKey:[NSNumber numberWithUnsignedInteger:index]];
@@ -223,11 +232,7 @@ static jmethodID sjm_getAccessibleName = NULL;
 }
 
 - (void)clearCache {
-    for (NSNumber *key in [rowCache allKeys]) {
-        [[rowCache objectForKey:key] release];
-    }
-    [rowCache release];
-    rowCache = nil;
+    cacheValid = NO;
 }
 
 @end

--- a/test/jdk/java/awt/a11y/AccessibleJTableTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJTableTest.java
@@ -76,6 +76,27 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
         super.createUI(panel, "AccessibleJTableTest");
     }
 
+    public void  createUIDraggable() {
+        INSTRUCTIONS = "INSTRUCTIONS:\n"
+                + "Check that table is properly updated when column order is changed.\n\n"
+                + "Turn screen reader on, and Tab to the table.\n"
+                + "Using arrow keys navigate to the last cell in the first row in the table."
+                + "Screen reader should announce it as \"Column 3 row 1\"\n\n"
+                + "Using mouse drag the header of the last culumn so the last column becomes the first one."
+                + "Wait for the screen reader to finish announcing new position in table.\n\n"
+                + "If new position in table corresponds to the new table layout ctrl+tab further "
+                + "and press PASS, otherwise press FAIL.\n";
+
+        JTable table = new JTable(data, columnNames);
+        JPanel panel = new JPanel();
+        panel.setLayout(new FlowLayout());
+        JScrollPane scrollPane = new JScrollPane(table);
+        panel.add(scrollPane);
+        panel.setFocusable(false);
+        exceptionString = "AccessibleJTable test failed!";
+        super.createUI(panel, "AccessibleJTableTest");
+    }
+
     public void  createUINamed() {
         INSTRUCTIONS = "INSTRUCTIONS:\n"
                 + "Check a11y of named JTable.\n\n"
@@ -161,6 +182,13 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
 
         countDownLatch = test.createCountDownLatch();
         SwingUtilities.invokeAndWait(test::createUI);
+        countDownLatch.await(15, TimeUnit.MINUTES);
+        if (!testResult) {
+            throw new RuntimeException(exceptionString);
+        }
+
+        countDownLatch = test.createCountDownLatch();
+        SwingUtilities.invokeAndWait(test::createUIDraggable);
         countDownLatch.await(15, TimeUnit.MINUTES);
         if (!testResult) {
             throw new RuntimeException(exceptionString);


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286266](https://bugs.openjdk.org/browse/JDK-8286266): [macos] Voice over moving JTable column to be the first column JVM crashes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/525/head:pull/525` \
`$ git checkout pull/525`

Update a local copy of the PR: \
`$ git checkout pull/525` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 525`

View PR using the GUI difftool: \
`$ git pr show -t 525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/525.diff">https://git.openjdk.org/jdk17u-dev/pull/525.diff</a>

</details>
