### PR TITLE
8287609: macOS: SIGSEGV at [CoreFoundation] CFArrayGetCount / sun.font.CFont.getTableBytesNative

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
@@ -379,6 +379,9 @@ JNI_COCOA_ENTER(env);
     CTFontRef ctfont = (CTFontRef)nsFont;
     CFArrayRef tagsArray =
         CTFontCopyAvailableTables(ctfont, kCTFontTableOptionNoOptions);
+    if (tagsArray == NULL) {
+        return NULL;
+    }
     CFIndex numTags = CFArrayGetCount(tagsArray);
     for (i=0; i<numTags; i++) {
         if (tag ==


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287609](https://bugs.openjdk.org/browse/JDK-8287609): macOS: SIGSEGV at [CoreFoundation] CFArrayGetCount / sun.font.CFont.getTableBytesNative


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/534/head:pull/534` \
`$ git checkout pull/534`

Update a local copy of the PR: \
`$ git checkout pull/534` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 534`

View PR using the GUI difftool: \
`$ git pr show -t 534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/534.diff">https://git.openjdk.org/jdk17u-dev/pull/534.diff</a>

</details>
