### PR TITLE
8289799: Build warning in methodData.cpp memset zero-length parameter

### DIFF
--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1242,7 +1242,9 @@ void MethodData::initialize() {
   int extra_size = extra_data_count * DataLayout::compute_size_in_bytes(0);
 
   // Let's zero the space for the extra data
-  Copy::zero_to_bytes(((address)_data) + data_size, extra_size);
+  if (extra_size > 0) {
+    Copy::zero_to_bytes(((address)_data) + data_size, extra_size);
+  }
 
   // Add a cell to record information about modified arguments.
   // Set up _args_modified array after traps cells so that


### PR DESCRIPTION
Trival clean backport, prevents gcc warnings on Fedora 12 GCC 8.3

The commit being backported was authored by Thomas Stuefe on 7 Jul 2022 and was reviewed by Jie Fu and Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289799](https://bugs.openjdk.org/browse/JDK-8289799): Build warning in methodData.cpp memset zero-length parameter


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/535/head:pull/535` \
`$ git checkout pull/535`

Update a local copy of the PR: \
`$ git checkout pull/535` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 535`

View PR using the GUI difftool: \
`$ git pr show -t 535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/535.diff">https://git.openjdk.org/jdk17u-dev/pull/535.diff</a>

</details>
