### PR TITLE
Backport f1dd559e20342b892d0c1ed0314e5bba451bc5d3

### DIFF
--- a/test/jdk/java/util/Currency/PropertiesTest.sh
+++ b/test/jdk/java/util/Currency/PropertiesTest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ case "$OS" in
     PS=";"
     FS="/"
     ;;
-  CYGWIN* )
+  CYGWIN*|MSYS*|MINGW* )
     PS=";"
     FS="/"
     TESTJAVA=`cygpath -u ${TESTJAVA}`


### PR DESCRIPTION
Clean backport of [JDK-8287896](https://bugs.openjdk.org/browse/JDK-8287896): PropertiesTest.sh fail on msys2