### PR TITLE
8287895: Some langtools tests fail on msys2

### DIFF
--- a/test/langtools/tools/javac/Paths/Util.sh
+++ b/test/langtools/tools/javac/Paths/Util.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 jimage="${TESTJAVA+${TESTJAVA}/bin/}jimage${EXE_SUFFIX}"
 
 case `uname -s` in
-  Windows*|CYGWIN*)
+  Windows*|CYGWIN*|MSYS*|MINGW*)
     WindowsOnly() { "$@"; }
     UnixOnly() { :; }
     PS=";" ;;


### PR DESCRIPTION
clean backport of [JDK-8287895](https://bugs.openjdk.org/browse/JDK-8287895): Some langtools tests fail on msys2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287895](https://bugs.openjdk.org/browse/JDK-8287895): Some langtools tests fail on msys2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/543/head:pull/543` \
`$ git checkout pull/543`

Update a local copy of the PR: \
`$ git checkout pull/543` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 543`

View PR using the GUI difftool: \
`$ git pr show -t 543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/543.diff">https://git.openjdk.org/jdk17u-dev/pull/543.diff</a>

</details>
