### PR TITLE
8290004: [PPC64] JfrGetCallTrace: assert(_pc != nullptr) failed: must have PC

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
@@ -30,7 +30,7 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
 
-  intptr_t* sp = last_Java_sp();
+  intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
   address pc = _anchor.last_Java_pc();
 
   // Last_Java_pc ist not set, if we come here from compiled code.

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -31,7 +31,7 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
 
-  intptr_t* sp = last_Java_sp();
+  intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
   address pc = _anchor.last_Java_pc();
 
   // Last_Java_pc ist not set, if we come here from compiled code.


### PR DESCRIPTION
Clean backport of the memory barrier addition. Omitted cleanup which would require other changes which are not in 17u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290004](https://bugs.openjdk.org/browse/JDK-8290004): [PPC64] JfrGetCallTrace: assert(_pc != nullptr) failed: must have PC


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - Committer)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/545/head:pull/545` \
`$ git checkout pull/545`

Update a local copy of the PR: \
`$ git checkout pull/545` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 545`

View PR using the GUI difftool: \
`$ git pr show -t 545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/545.diff">https://git.openjdk.org/jdk17u-dev/pull/545.diff</a>

</details>
