### PR TITLE
8280233: Temporarily disable Unix domain sockets in Windows PipeImpl

### DIFF
--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.UnixDomainSocketAddress;
-import java.net.StandardProtocolFamily;
 import java.net.StandardSocketOptions;
 import java.nio.*;
 import java.nio.channels.*;
@@ -164,10 +162,6 @@ class PipeImpl
                     try {
                         if (ssc != null)
                             ssc.close();
-                        if (sa instanceof UnixDomainSocketAddress) {
-                            Path path = ((UnixDomainSocketAddress) sa).getPath();
-                            Files.deleteIfExists(path);
-                        }
                     } catch (IOException e2) {}
                 }
             }
@@ -184,8 +178,7 @@ class PipeImpl
     /**
      * Creates Pipe implementation that supports optionally buffering.
      *
-     * @implNote The pipe uses Unix domain sockets where possible. It uses a
-     * loopback connection on older editions of Windows. When buffering is
+     * @implNote Uses a loopback connection. When buffering is
      * disabled then it sets TCP_NODELAY on the sink channel.
      */
     @SuppressWarnings("removal")
@@ -212,23 +205,8 @@ class PipeImpl
         return sink;
     }
 
-    private static volatile boolean noUnixDomainSockets;
-
     private static ServerSocketChannel createListener() throws IOException {
-        ServerSocketChannel listener = null;
-        if (!noUnixDomainSockets) {
-            try {
-                listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
-                return listener.bind(null);
-            } catch (UnsupportedOperationException | IOException e) {
-                // IOException is most likely to be caused by the temporary directory
-                // name being too long. Possibly should log this.
-                noUnixDomainSockets = true;
-                if (listener != null)
-                    listener.close();
-            }
-        }
-        listener = ServerSocketChannel.open();
+        ServerSocketChannel listener = ServerSocketChannel.open();
         InetAddress lb = InetAddress.getLoopbackAddress();
         listener.bind(new InetSocketAddress(lb, 0));
         return listener;


### PR DESCRIPTION
Hi!

Here is a backport that disables using of Unix domain socket in Pipe implementation for Windows and switches it back to TCP socket on the loopback. That fixes occasional hangings caused by an error in Winsock2 library. The original patch is applied cleanly.

Verification (Microsoft Windows 10 Pro Build 19044): [WSARecvHanger.java](https://bugs.openjdk.org/secure/attachment/97583/WSARecvHanger.java)
Regression (Microsoft Windows 10 Pro Build 19044): test\jdk\java\nio\channels

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280233](https://bugs.openjdk.org/browse/JDK-8280233): Temporarily disable Unix domain sockets in Windows PipeImpl


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/548/head:pull/548` \
`$ git checkout pull/548`

Update a local copy of the PR: \
`$ git checkout pull/548` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 548`

View PR using the GUI difftool: \
`$ git pr show -t 548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/548.diff">https://git.openjdk.org/jdk17u-dev/pull/548.diff</a>

</details>
