### PR TITLE
8272815: jpackage --type rpm produces an error: Invalid or unsupported type: [null]

### DIFF
--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/ErrorTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/ErrorTest.java
@@ -32,7 +32,7 @@ import jdk.jpackage.test.TKit;
 
 /*
  * @test
- * @summary jpackage application version testing
+ * @summary Test jpackage output for erroneous input
  * @library ../../../../helpers
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
@@ -44,7 +44,7 @@ import jdk.jpackage.test.TKit;
 
 /*
  * @test
- * @summary jpackage application version testing
+ * @summary Test jpackage output for erroneous input
  * @library ../../../../helpers
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
@@ -96,7 +96,7 @@ public final class ErrorTest {
             {"Hello",
                     new String[]{"--type", "invalid-type"},
                     null,
-                    "Invalid or unsupported type:"},
+                    "Invalid or unsupported type: [invalid-type]"},
             // no --input
             {"Hello",
                     null,


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272815](https://bugs.openjdk.org/browse/JDK-8272815): jpackage --type rpm produces an error: Invalid or unsupported type: [null]


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/551/head:pull/551` \
`$ git checkout pull/551`

Update a local copy of the PR: \
`$ git checkout pull/551` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 551`

View PR using the GUI difftool: \
`$ git pr show -t 551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/551.diff">https://git.openjdk.org/jdk17u-dev/pull/551.diff</a>

</details>
