### PR TITLE
8271344: Windows product version issue

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/MsiVersion.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/MsiVersion.java
@@ -25,6 +25,7 @@
 package jdk.jpackage.internal;
 
 import java.math.BigInteger;
+import java.text.MessageFormat;
 
 
 final class MsiVersion {
@@ -42,9 +43,11 @@ final class MsiVersion {
         DottedVersion ver = new DottedVersion(value);
 
         BigInteger[] components = ver.getComponents();
-        if (components.length > 3) {
-            throw new IllegalArgumentException(I18N.getString(
-                    "error.msi-product-version-too-many-components"));
+
+        if (components.length < 2 || components.length > 4) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    I18N.getString("error.msi-product-version-components"),
+                    value));
         }
 
         if (BigInteger.valueOf(255).compareTo(components[0]) < 0) {

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/WinResources.properties
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/WinResources.properties
@@ -42,8 +42,8 @@ resource.installdirnotemptydlg-wix-file=Not empty install directory dialog WiX p
 
 error.no-wix-tools=Can not find WiX tools (light.exe, candle.exe)
 error.no-wix-tools.advice=Download WiX 3.0 or later from https://wixtoolset.org and add it to the PATH.
-error.version-string-wrong-format.advice=Set value of --app-version parameter according to these rules: https://msdn.microsoft.com/en-us/library/aa370859%28v\=VS.85%29.aspx
-error.msi-product-version-too-many-components=Version sting may have between 1 and 3 components: 1, 1.2, 1.2.3.
+error.version-string-wrong-format.advice=Set value of --app-version parameter to a valid Windows Installer ProductVersion.
+error.msi-product-version-components=Version string [{0}] must have between 2 and 4 components.
 error.msi-product-version-major-out-of-range=Major version must be in the range [0, 255]
 error.msi-product-version-build-out-of-range=Build part of version must be in the range [0, 65535]
 error.msi-product-version-minor-out-of-range=Minor version must be in the range [0, 255]

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/WinResources_ja.properties
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/WinResources_ja.properties
@@ -42,8 +42,8 @@ resource.installdirnotemptydlg-wix-file=Not empty install directory dialog WiX p
 
 error.no-wix-tools=WiX\u30C4\u30FC\u30EB(light.exe\u3001candle.exe)\u304C\u898B\u3064\u304B\u308A\u307E\u305B\u3093
 error.no-wix-tools.advice=WiX 3.0\u4EE5\u964D\u3092https://wixtoolset.org\u304B\u3089\u30C0\u30A6\u30F3\u30ED\u30FC\u30C9\u3057\u3001PATH\u306B\u8FFD\u52A0\u3057\u307E\u3059\u3002
-error.version-string-wrong-format.advice=--app-version\u30D1\u30E9\u30E1\u30FC\u30BF\u306E\u5024\u3092\u6B21\u306E\u898F\u5247\u306B\u5F93\u3063\u3066\u8A2D\u5B9A\u3057\u307E\u3059: https://msdn.microsoft.com/en-us/library/aa370859%28v=VS.85%29.aspx
-error.msi-product-version-too-many-components=\u30D0\u30FC\u30B8\u30E7\u30F3\u6587\u5B57\u5217\u306B\u306F\u30011\u30011.2\u30011.2.3\u306A\u30691\u304B\u30893\u306E\u69CB\u6210\u8981\u7D20\u3092\u4F7F\u7528\u3067\u304D\u307E\u3059\u3002
+error.version-string-wrong-format.advice=Set value of --app-version parameter to a valid Windows Installer ProductVersion.
+error.msi-product-version-components=Version string [{0}] must have between 2 and 4 components.
 error.msi-product-version-major-out-of-range=\u30E1\u30B8\u30E3\u30FC\u30FB\u30D0\u30FC\u30B8\u30E7\u30F3\u306F\u7BC4\u56F2[0, 255]\u5185\u3067\u3042\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059
 error.msi-product-version-build-out-of-range=\u30D0\u30FC\u30B8\u30E7\u30F3\u306E\u30D3\u30EB\u30C9\u90E8\u5206\u306F\u7BC4\u56F2[0, 65535]\u5185\u3067\u3042\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059
 error.msi-product-version-minor-out-of-range=\u30DE\u30A4\u30CA\u30FC\u30FB\u30D0\u30FC\u30B8\u30E7\u30F3\u306F\u7BC4\u56F2[0, 255]\u5185\u3067\u3042\u308B\u5FC5\u8981\u304C\u3042\u308A\u307E\u3059

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/WinResources_zh_CN.properties
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/resources/WinResources_zh_CN.properties
@@ -42,8 +42,8 @@ resource.installdirnotemptydlg-wix-file=Not empty install directory dialog WiX p
 
 error.no-wix-tools=\u627E\u4E0D\u5230 WiX \u5DE5\u5177 (light.exe, candle.exe)
 error.no-wix-tools.advice=\u4ECE https://wixtoolset.org \u4E0B\u8F7D WiX 3.0 \u6216\u66F4\u9AD8\u7248\u672C\uFF0C\u7136\u540E\u5C06\u5176\u6DFB\u52A0\u5230 PATH\u3002
-error.version-string-wrong-format.advice=\u6839\u636E\u4EE5\u4E0B\u89C4\u5219\u8BBE\u7F6E --app-version \u53C2\u6570\u7684\u503C\uFF1Ahttps://msdn.microsoft.com/en-us/library/aa370859%28v=VS.85%29.aspx
-error.msi-product-version-too-many-components=\u7248\u672C\u5B57\u7B26\u4E32\u53EF\u4EE5\u5305\u542B 1 \u5230 3 \u4E2A\u7EC4\u4EF6\uFF1A1\u30011.2\u30011.2.3\u3002
+error.version-string-wrong-format.advice=Set value of --app-version parameter to a valid Windows Installer ProductVersion.
+error.msi-product-version-components=Version string [{0}] must have between 2 and 4 components.
 error.msi-product-version-major-out-of-range=\u4E3B\u7248\u672C\u5FC5\u987B\u4F4D\u4E8E [0, 255] \u8303\u56F4\u4E2D
 error.msi-product-version-build-out-of-range=\u7248\u672C\u7684\u5DE5\u4F5C\u7248\u672C\u90E8\u5206\u5FC5\u987B\u4F4D\u4E8E [0, 65535] \u8303\u56F4\u4E2D
 error.msi-product-version-minor-out-of-range=\u6B21\u7248\u672C\u5FC5\u987B\u4F4D\u4E8E [0, 255] \u8303\u56F4\u4E2D

--- a/test/jdk/tools/jpackage/junit/jdk/jpackage/internal/PlatformVersionTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk/jpackage/internal/PlatformVersionTest.java
@@ -51,20 +51,20 @@ public class PlatformVersionTest {
     public static List<Object[]> data() {
         List<Object[]> data = new ArrayList<>();
         addTo(data, WIN_MSI_PRODUCT_VERSION_PARSER, true,
-            "255",
-            "0",
+            "0.0",
             "255.255",
+            "0.0.0",
             "255.255.65535",
-            "1.0",
-            "1",
-            "01.02.6"
+            "0.0.0.0",
+            "255.255.65535.999999"
         );
 
         addTo(data, WIN_MSI_PRODUCT_VERSION_PARSER, false,
-            "256",
+            "0",
+            "256.01",
             "255.256",
             "255.255.65536",
-            "1.2.3.4"
+            "1.2.3.4.5"
         );
 
         addTo(data, MAC_CFBUNDLE_VERSION_PARSER, true,


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271344](https://bugs.openjdk.org/browse/JDK-8271344): Windows product version issue


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/558/head:pull/558` \
`$ git checkout pull/558`

Update a local copy of the PR: \
`$ git checkout pull/558` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 558`

View PR using the GUI difftool: \
`$ git pr show -t 558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/558.diff">https://git.openjdk.org/jdk17u-dev/pull/558.diff</a>

</details>
