### PR TITLE
8277429: Conflicting jpackage static library name

### DIFF
--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -95,9 +95,9 @@ ifeq ($(call isTargetOs, linux), true)
   JPACKAGE_LIBAPPLAUNCHER_INCLUDES := $(addprefix -I, $(JPACKAGE_LIBAPPLAUNCHER_SRC))
 
   $(eval $(call SetupJdkLibrary, BUILD_JPACKAGE_LIBAPPLAUNCHER, \
-      NAME := jpackageapplauncher, \
+      NAME := jpackageapplauncheraux, \
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
-      SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjpackageapplauncher, \
+      SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjpackageapplauncheraux, \
       SRC := $(JPACKAGE_LIBAPPLAUNCHER_SRC), \
       EXCLUDE_FILES := LinuxLauncher.c LinuxPackage.c, \
       TOOLCHAIN := TOOLCHAIN_LINK_CXX, \

--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxAppImageBuilder.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxAppImageBuilder.java
@@ -101,7 +101,7 @@ public class LinuxAppImageBuilder extends AbstractAppImageBuilder {
     private void createLauncherLib() throws IOException {
         Path path = appLayout.pathGroup().getPath(
                 ApplicationLayout.PathRole.LINUX_APPLAUNCHER_LIB);
-        try (InputStream resource = getResourceAsStream("libjpackageapplauncher.so")) {
+        try (InputStream resource = getResourceAsStream("libjpackageapplauncheraux.so")) {
             writeEntry(resource, path);
         }
 


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277429](https://bugs.openjdk.org/browse/JDK-8277429): Conflicting jpackage static library name


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/560/head:pull/560` \
`$ git checkout pull/560`

Update a local copy of the PR: \
`$ git checkout pull/560` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 560`

View PR using the GUI difftool: \
`$ git pr show -t 560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/560.diff">https://git.openjdk.org/jdk17u-dev/pull/560.diff</a>

</details>
