### PR TITLE
8276837: [macos]: Error when signing the additional launcher

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
@@ -190,14 +190,24 @@ public class IOUtils {
     static void exec(ProcessBuilder pb, boolean testForPresenceOnly,
             PrintStream consumer, boolean writeOutputToFile, long timeout)
             throws IOException {
+        exec(pb, testForPresenceOnly, consumer, writeOutputToFile,
+                Executor.INFINITE_TIMEOUT, false);
+    }
+
+    static void exec(ProcessBuilder pb, boolean testForPresenceOnly,
+            PrintStream consumer, boolean writeOutputToFile,
+            long timeout, boolean quiet) throws IOException {
         List<String> output = new ArrayList<>();
-        Executor exec = Executor.of(pb).setWriteOutputToFile(writeOutputToFile)
-                .setTimeout(timeout).setOutputConsumer(lines -> {
-            lines.forEach(output::add);
-            if (consumer != null) {
-                output.forEach(consumer::println);
-            }
-        });
+        Executor exec = Executor.of(pb)
+                .setWriteOutputToFile(writeOutputToFile)
+                .setTimeout(timeout)
+                .setQuiet(quiet)
+                .setOutputConsumer(lines -> {
+                    lines.forEach(output::add);
+                    if (consumer != null) {
+                        output.forEach(consumer::println);
+                    }
+                });
 
         if (testForPresenceOnly) {
             exec.execute();

--- a/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningAppImageTest.java
@@ -24,6 +24,7 @@
 import java.nio.file.Path;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.AdditionalLauncher;
 
 /**
  * Tests generation of app image with --mac-sign and related arguments. Test will
@@ -65,10 +66,16 @@ public class SigningAppImageTest {
         cmd.addArguments("--mac-sign", "--mac-signing-key-user-name",
                 SigningBase.DEV_NAME, "--mac-signing-keychain",
                 SigningBase.KEYCHAIN);
+
+        AdditionalLauncher testAL = new AdditionalLauncher("testAL");
+        testAL.applyTo(cmd);
         cmd.executeAndAssertHelloAppImageCreated();
 
         Path launcherPath = cmd.appLauncherPath();
         SigningBase.verifyCodesign(launcherPath, true);
+
+        Path testALPath = launcherPath.getParent().resolve("testAL");
+        SigningBase.verifyCodesign(testALPath, true);
 
         Path appImage = cmd.outputBundle();
         SigningBase.verifyCodesign(appImage, true);


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276837](https://bugs.openjdk.org/browse/JDK-8276837): [macos]: Error when signing the additional launcher


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/562/head:pull/562` \
`$ git checkout pull/562`

Update a local copy of the PR: \
`$ git checkout pull/562` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 562`

View PR using the GUI difftool: \
`$ git pr show -t 562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/562.diff">https://git.openjdk.org/jdk17u-dev/pull/562.diff</a>

</details>
