### PR TITLE
8286122: [macos]: App bundle cannot upload to Mac App Store due to info.plist embedded in java exe

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DeployParams.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/DeployParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -146,6 +145,7 @@ public class DeployParams {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void validate() throws PackagerException {
         boolean hasModule = (bundlerArguments.get(
                 Arguments.CLIOptions.MODULE.getId()) != null);
@@ -161,6 +161,8 @@ public class DeployParams {
                 Arguments.CLIOptions.INPUT.getId()) != null);
         boolean hasModulePath = (bundlerArguments.get(
                 Arguments.CLIOptions.MODULE_PATH.getId()) != null);
+        boolean hasMacAppStore = (bundlerArguments.get(
+                Arguments.CLIOptions.MAC_APP_STORE.getId()) != null);
         boolean runtimeInstaller = !isTargetAppImage() &&
                 !hasAppImage && !hasModule && !hasMain && hasRuntimeImage;
 
@@ -271,6 +273,45 @@ public class DeployParams {
             if (!(Files.exists(Path.of(icon)))) {
                 throw new PackagerException("ERR_IconFileNotExit",
                         Path.of(icon).toAbsolutePath().toString());
+            }
+        }
+
+
+        if (hasMacAppStore) {
+            // Validate jlink-options if mac-app-store is set
+            Object jlinkOptions = bundlerArguments.get(
+                    Arguments.CLIOptions.JLINK_OPTIONS.getId());
+            if (jlinkOptions instanceof List) {
+                List<String> options = (List<String>) jlinkOptions;
+                if (!options.contains("--strip-native-commands")) {
+                    throw new PackagerException(
+                            "ERR_MissingJLinkOptMacAppStore",
+                            "--strip-native-commands");
+                }
+            }
+
+            // Validate runtime if mac-app-store is set. Predefined runtime
+            // should not contain "bin" folder.
+            runtime = (String)bundlerArguments.get(
+                    Arguments.CLIOptions.PREDEFINED_RUNTIME_IMAGE.getId());
+            if (runtime != null) {
+                // Should exist from check above if not null
+                Path topImage = Path.of(runtime);
+
+                // On Mac topImage can be runtime root or runtime home.
+                Path runtimeHome = topImage.resolve("Contents/Home");
+                if (Files.isDirectory(runtimeHome)) {
+                    // topImage references runtime root, adjust it to pick data
+                    // from runtime home
+                    topImage = runtimeHome;
+                }
+
+                Path runtimeBin = topImage.resolve("bin");
+                if (Files.isDirectory(runtimeBin)) {
+                    throw new PackagerException(
+                            "ERR_MacAppStoreRuntimeBinExists",
+                            topImage.toAbsolutePath().toString());
+                }
             }
         }
     }

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources.properties
@@ -109,3 +109,5 @@ ERR_NoEntryPoint=Error: creating application image requires --main-jar or --modu
 ERR_InputNotDirectory=Error: Input directory specified is not a directory: {0}
 ERR_CannotReadInputDir=Error: No permission to read from input directory: {0}
 ERR_CannotParseOptions=Error: Processing @filename option: {0}
+ERR_MissingJLinkOptMacAppStore=Error: --mac-app-store argument requires a {0} option for --jlink-options argument
+ERR_MacAppStoreRuntimeBinExists=Error: Runtime image "{0}" should not contain "bin" folder. Use --strip-native-commands jlink option when generating runtime image used with --mac-app-store argument.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_de.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_de.properties
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+#
+
+param.copyright.default=Copyright (C) {0,date,YYYY}
+param.description.default=Kein Wert
+param.vendor.default=Unbekannt
+
+message.using-default-resource=Standardpackageressource {0} {1} wird verwendet (durch Hinzuf\u00FCgen von {2} zu resource-dir ist eine Anpassung m\u00F6glich).
+message.no-default-resource=Keine Standardpackageressource {0} {1} (durch Hinzuf\u00FCgen von {2} zu resource-dir ist eine Anpassung m\u00F6glich).
+message.using-custom-resource-from-file=Benutzerdefinierte Packageressource {0} wird verwendet (aus Datei {1} geladen).
+message.using-custom-resource=Benutzerdefinierte Packageressource {0} wird verwendet (aus {1} geladen).
+message.creating-app-bundle=Anwendungspackage {0} wird in {1} erstellt
+message.app-image-dir-does-not-exist=Angegebenes Anwendungsimageverzeichnis {0}: {1} ist nicht vorhanden
+message.app-image-dir-does-not-exist.advice=Best\u00E4tigen Sie, dass der Wert f\u00FCr {0} vorhanden ist
+message.runtime-image-dir-does-not-exist=Angegebenes Laufzeitimageverzeichnis {0}: {1} ist nicht vorhanden
+message.runtime-image-dir-does-not-exist.advice=Best\u00E4tigen Sie, dass der Wert f\u00FCr {0} vorhanden ist
+message.resource-dir-does-not-exist=Angegebenes Ressourcenverzeichnis {0}: {1} ist nicht vorhanden
+message.debug-working-directory=Arbeitsverzeichnis f\u00FCr Debug beibehalten: {0}
+message.bundle-created={0}-Package wurde erfolgreich erstellt
+message.module-version=Version "{0}" aus Modul "{1}" wird als Anwendungsversion verwendet
+message.module-class=Klasse "{0}" aus Modul "{1}" wird als Anwendungshauptklasse verwendet
+
+error.version-string-empty="Version darf keine leere Zeichenfolge sein"
+error.version-string-zero-length-component="Version [{0}] enth\u00E4lt eine Komponente mit einer Nulll\u00E4nge"
+error.version-string-invalid-component="Version [{0}] enth\u00E4lt ung\u00FCltige Komponente [{1}]"
+
+error.cannot-create-output-dir=Zielverzeichnis {0} kann nicht erstellt werden
+error.cannot-write-to-output-dir=Zielverzeichnis {0} ist schreibgesch\u00FCtzt
+error.root-exists=Fehler: Anwendungszielverzeichnis {0} ist bereits vorhanden
+error.no-main-class-with-main-jar=Es wurde keine Hauptklasse angegeben oder in der JAR-Datei {0} gefunden
+error.no-main-class-with-main-jar.advice=Geben Sie eine Hauptklasse an, oder stellen Sie sicher, dass die JAR-Datei {0} eine Hauptklasse im Manifest angibt
+error.no-main-class=Es wurde keine Hauptklasse angegeben oder in den angegebenen Anwendungsressourcen gefunden
+error.no-main-class.advice=Geben Sie eine Anwendungsklasse an, oder stellen Sie sicher, dass die appResources eine JAR-Datei mit einer Anwendungsklasse im Manifest enthalten
+error.main-jar-does-not-exist=Die konfigurierte Haupt-JAR-Datei ist im Eingabeverzeichnis nicht vorhanden {0}
+error.main-jar-does-not-exist.advice=Die Haupt-JAR-Datei muss relativ zum Eingabeverzeichnis (nicht als absoluter Pfad) angegeben werden und muss in diesem Verzeichnis vorhanden sein
+error.no-module-in-path="{0}-Modul im Modulpfad nicht gefunden"
+error.not-path-parameter="Ung\u00FCltiger Wert f\u00FCr Parameter {0}: {1}"
+error.no-input-parameter="--input-Parameter f\u00FCr nicht modulare Anwendung fehlt"
+error.no-main-jar-parameter="--main-jar-Parameter f\u00FCr nicht modulare Anwendung fehlt"
+
+error.no-content-types-for-file-association=F\u00FCr Dateiverkn\u00FCpfungsnummer {0} wurden keine MIME-Typen angegeben
+error.no-content-types-for-file-association.advice=Geben Sie einen MIME-Typ f\u00FCr Dateiverkn\u00FCpfungsnummer {0} an
+error.too-many-content-types-for-file-association=F\u00FCr Dateiverkn\u00FCpfungsnummer {0} wurde mehr als ein MIME-Typ angegeben
+error.too-many-content-types-for-file-association.advice=Geben Sie nur einen MIME-Typ f\u00FCr Dateiverkn\u00FCpfungsnummer {0} an
+
+error.tool-not-found={0} kann nicht gefunden werden. Grund: {1}
+error.tool-not-found.advice=Installieren Sie {0}
+error.tool-old-version={0} {1} oder eine neuere Version kann nicht gefunden werden
+error.tool-old-version.advice=Installieren Sie {0} {1} oder eine neuere Version
+error.jlink.failed=jlink nicht erfolgreich mit: {0}
+error.blocked.option=jlink-Option [{0}] ist in --jlink-options nicht zul\u00E4ssig
+error.no.name=Name nicht mit --name angegeben. Es kann auch kein Name aus app-image abgeleitet werden
+
+warning.no.jdk.modules.found=Warnung: Keine JDK-Module gefunden
+warning.foreign-app-image=Warnung: app-image-Verzeichnis ({0}) wurde von jpackage nicht generiert.
+warning.invalid-app-image=Warnung: .jpackage.xml kann in app-image-Verzeichnis ({0}) nicht geparst werden
+
+MSG_BundlerFailed=Fehler: Bundler "{1}" ({0}) konnte kein Package generieren
+MSG_BundlerConfigException=Bundler {0} aufgrund eines Konfigurationsproblems \u00FCbersprungen: {1} \nEmpfehlung zur Behebung: {2}
+MSG_BundlerConfigExceptionNoAdvice=Bundler {0} aufgrund eines Konfigurationsproblems \u00FCbersprungen: {1}
+MSG_BundlerRuntimeException=Bundler {0} nicht erfolgreich. Grund: {1}
+MSG_BundlerFailed=Fehler: Bundler "{1}" ({0}) konnte kein Package generieren
+
+ERR_NoMainClass=Fehler: Hauptanwendungsklasse fehlt
+ERR_UnsupportedOption=Fehler: Option [{0}] ist auf dieser Plattform ung\u00FCltig
+ERR_InvalidTypeOption=Fehler: Option [{0}] ist nicht g\u00FCltig mit Typ [{1}]
+ERR_NoInstallerEntryPoint=Fehler: Option [{0}] ist nicht g\u00FCltig ohne Einstiegspunktoption --module oder --main-jar
+ERR_MutuallyExclusiveOptions="Fehler: Optionen [{0}] und [{1}] schlie\u00DFen sich gegenseitig aus
+
+ERR_MissingArgument=Fehler: Fehlendes Argument: {0}
+ERR_MissingAppResources=Fehler: Keine Anwendungs-JAR-Dateien gefunden
+ERR_AppImageNotExist=Fehler: Anwendungsimageverzeichnis "{0}" ist nicht vorhanden
+ERR_NoAddLauncherName=Fehler: F\u00FCr Option --add-launcher m\u00FCssen ein Name und ein Dateipfad angegeben werden (--add-launcher <Name>=<Dateipfad>)
+ERR_NoUniqueName=Fehler: F\u00FCr --add-launcher <Name>=<Dateipfad> ist ein eindeutiger Name erforderlich
+ERR_NoJreInstallerName=Fehler: F\u00FCr JRE-Installationsprogramme ist ein Namensparameter erforderlich
+ERR_InvalidAppName=Fehler: Ung\u00FCltiger Anwendungsname: {0}
+ERR_InvalidSLName=Fehler: Ung\u00FCltiger Name f\u00FCr hinzuzuf\u00FCgenden Launcher: {0}
+ERR_IconFileNotExit=Fehler: Die angegebene Symboldatei [{0}] ist nicht vorhanden
+ERR_LicenseFileNotExit=Fehler: Die angegebene Lizenzdatei ist nicht vorhanden
+ERR_BuildRootInvalid=Fehler: Das tempor\u00E4re Verzeichnis ({0}) darf nicht vorhanden oder muss leer sein
+ERR_InvalidOption=Fehler: Ung\u00FCltige Option: [{0}]
+ERR_InvalidInstallerType=Fehler: Ung\u00FCltiger oder nicht unterst\u00FCtzter Typ: [{0}]
+ERR_BothMainJarAndModule=Fehler: Die Optionen --main-jar und --module d\u00FCrfen nicht beide vorhanden sein
+ERR_NoEntryPoint=Fehler: F\u00FCr das Erstellen des Anwendungsimages muss entweder die Option --main-jar oder die Option --module angegeben werden
+ERR_InputNotDirectory=Fehler: Das angegebene Eingabeverzeichnis ist kein Verzeichnis: {0}
+ERR_CannotReadInputDir=Fehler: Keine Berechtigung zum Lesen aus Eingabeverzeichnis vorhanden: {0}
+ERR_CannotParseOptions=Fehler: Option @filename wird verarbeitet: {0}
+ERR_MissingJLinkOptMacAppStore=Error: --mac-app-store argument requires a {0} option for --jlink-options argument
+ERR_MacAppStoreRuntimeBinExists=Error: Runtime image "{0}" should not contain "bin" folder. Use --strip-native-commands jlink option when generating runtime image used with --mac-app-store argument.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_ja.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_ja.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -108,3 +108,5 @@ ERR_NoEntryPoint=\u30A8\u30E9\u30FC: \u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\
 ERR_InputNotDirectory=\u30A8\u30E9\u30FC: \u6307\u5B9A\u3055\u308C\u305F\u5165\u529B\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u306F\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u3067\u306F\u3042\u308A\u307E\u305B\u3093: {0}
 ERR_CannotReadInputDir=\u30A8\u30E9\u30FC: \u5165\u529B\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u304B\u3089\u8AAD\u307F\u53D6\u308B\u6A29\u9650\u304C\u3042\u308A\u307E\u305B\u3093: {0}
 ERR_CannotParseOptions=\u30A8\u30E9\u30FC: @filename\u30AA\u30D7\u30B7\u30E7\u30F3\u306E\u51E6\u7406: {0}
+ERR_MissingJLinkOptMacAppStore=Error: --mac-app-store argument requires a {0} option for --jlink-options argument
+ERR_MacAppStoreRuntimeBinExists=Error: Runtime image "{0}" should not contain "bin" folder. Use --strip-native-commands jlink option when generating runtime image used with --mac-app-store argument.

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_zh_CN.properties
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/resources/MainResources_zh_CN.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -108,3 +108,5 @@ ERR_NoEntryPoint=\u9519\u8BEF\uFF1A\u521B\u5EFA\u5E94\u7528\u7A0B\u5E8F\u6620\u5
 ERR_InputNotDirectory=\u9519\u8BEF\uFF1A\u6307\u5B9A\u7684\u8F93\u5165\u76EE\u5F55\u4E0D\u662F\u76EE\u5F55\uFF1A{0}
 ERR_CannotReadInputDir=\u9519\u8BEF\uFF1A\u65E0\u6743\u4ECE\u8F93\u5165\u76EE\u5F55\u8BFB\u53D6\uFF1A{0}
 ERR_CannotParseOptions=\u9519\u8BEF\uFF1A\u6B63\u5728\u5904\u7406 @filename \u9009\u9879\uFF1A{0}
+ERR_MissingJLinkOptMacAppStore=Error: --mac-app-store argument requires a {0} option for --jlink-options argument
+ERR_MacAppStoreRuntimeBinExists=Error: Runtime image "{0}" should not contain "bin" folder. Use --strip-native-commands jlink option when generating runtime image used with --mac-app-store argument.

--- a/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Annotations.Test;
+
+/**
+ * Tests generation of app image with --mac-app-store and --jlink-options. jpackage should able
+ * to generate app image if "--strip-native-commands" is specified for --jlink-options and should
+ * fail if it is not specified.
+ */
+
+/*
+ * @test
+ * @summary jpackage with --mac-app-store and --jlink-options
+ * @library ../helpers
+ * @library /test/lib
+ * @build jdk.jpackage.test.*
+ * @build MacAppStoreJLinkOptionsTest
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @requires (os.family == "mac")
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=MacAppStoreJLinkOptionsTest
+ */
+public class MacAppStoreJLinkOptionsTest {
+
+    @Test
+    public static void testWithStripNativeCommands() throws Exception {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-app-store", "--jlink-options",
+                "--strip-debug --no-man-pages --no-header-files --strip-native-commands");
+
+        cmd.executeAndAssertHelloAppImageCreated();
+    }
+
+    @Test
+    public static void testWithoutStripNativeCommands() throws Exception {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-app-store", "--jlink-options",
+                "--strip-debug --no-man-pages --no-header-files");
+
+        cmd.execute(1);
+    }
+}

--- a/test/jdk/tools/jpackage/macosx/MacAppStoreRuntimeTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreRuntimeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Executor;
+import jdk.jpackage.test.TKit;
+import jdk.jpackage.test.JavaTool;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Annotations.Parameter;
+
+
+/**
+ * Tests generation of app image with --mac-app-store and --runtime-image. jpackage should able
+ * to generate app image if runtime image does not have "bin" folder and fail otherwise.
+ */
+
+/*
+ * @test
+ * @summary jpackage with --mac-app-store and --runtime-image
+ * @library ../helpers
+ * @library /test/lib
+ * @build jdk.jpackage.test.*
+ * @build MacAppStoreRuntimeTest
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @requires (os.family == "mac")
+ * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ *  --jpt-run=MacAppStoreRuntimeTest
+ */
+public class MacAppStoreRuntimeTest {
+
+    private static String getRuntimeImage(boolean stripNativeCommands) throws IOException {
+        final Path workDir = TKit.createTempDirectory("runtime").resolve("data");
+        final Path jlinkOutputDir = workDir.resolve("temp.runtime");
+        Files.createDirectories(jlinkOutputDir.getParent());
+
+        // List of modules required for test app.
+        final var modules = new String[] {
+            "java.base",
+            "java.desktop"
+        };
+
+        List<String> jlinkArgs = new ArrayList<>();
+        jlinkArgs.add("--output");
+        jlinkArgs.add(jlinkOutputDir.toString());
+        jlinkArgs.add("--add-modules");
+        jlinkArgs.add(String.join(",", modules));
+        jlinkArgs.add("--strip-debug");
+        jlinkArgs.add("--no-header-files");
+        jlinkArgs.add("--no-man-pages");
+        if (stripNativeCommands) {
+            jlinkArgs.add("--strip-native-commands");
+        }
+
+        new Executor()
+                .setToolProvider(JavaTool.JLINK)
+                .dumpOutput()
+                .addArguments(jlinkArgs)
+                .execute();
+
+        return jlinkOutputDir.toString();
+    }
+
+    @Test
+    @Parameter("true")
+    @Parameter("false")
+    public static void test(boolean stripNativeCommands) throws Exception {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+        cmd.addArguments("--mac-app-store", "--runtime-image", getRuntimeImage(stripNativeCommands));
+
+        if (stripNativeCommands) {
+            cmd.executeAndAssertHelloAppImageCreated();
+        } else {
+            cmd.execute(1);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

The localization file "de" patched by the original change is not in 17.
It was added in "8283805: [REDO] JDK 19 L10n resource files update - msgdrop 10"
I had a look at backporting that change, too. I think the localization updates are
a nice to have for the LTS. But it is a big change and does not apply well. Each new/removed entry would
have to be checked. So I decided not to do it.
Instead, I inlcude the de file for jpackage in this change, along with the two 
new Strings. This file matches the jpackage in 17 as there were no other addions to 
the ja and zh files between 17 and 8283805.

I had to adapt the copyright in the ja and zh files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286122](https://bugs.openjdk.org/browse/JDK-8286122): [macos]: App bundle cannot upload to Mac App Store due to info.plist embedded in java exe


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/565/head:pull/565` \
`$ git checkout pull/565`

Update a local copy of the PR: \
`$ git checkout pull/565` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 565`

View PR using the GUI difftool: \
`$ git pr show -t 565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/565.diff">https://git.openjdk.org/jdk17u-dev/pull/565.diff</a>

</details>
