### PR TITLE
8288781: C1: LIR_OpVisitState::maxNumberOfOperands too small

### DIFF
--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -2315,7 +2315,7 @@ class LIR_OpVisitState: public StackObj {
   typedef enum { inputMode, firstMode = inputMode, tempMode, outputMode, numModes, invalidMode = -1 } OprMode;
 
   enum {
-    maxNumberOfOperands = 20,
+    maxNumberOfOperands = 21,
     maxNumberOfInfos = 4
   };
 

--- a/test/hotspot/jtreg/compiler/c1/TestManyMethodParameters.java
+++ b/test/hotspot/jtreg/compiler/c1/TestManyMethodParameters.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8288781
+ * @summary Test if a call with 8 integer + 13 float = 21 parameters can can be compiled.
+ *          On ppc all parameters can be passed in registers.
+ * @author Richard Reingruber
+ *
+ * @run main/othervm -Xbatch -XX:CompileCommand=dontinline,*::*dontinline* compiler.c1.TestManyMethodParameters
+ */
+
+package compiler.c1;
+
+public class TestManyMethodParameters {
+    public static void main(String[] args) {
+        for (int i = 30_000; i >= 0; i--) {
+            double sum = testMethod_01_dontinline();
+            if (sum != 127) {
+                throw new Error("Wrong sum: " + sum);
+            }
+        }
+    }
+
+    public static double testMethod_01_dontinline() {
+        return testMethod_01_manyArgs(1, 2, 3, 4, 5, 6, 7, 8,
+                                      1.0d, 2.0d, 3.0d, 4.0d, 5.0d, 6.0d, 7.0d, 8.0d, 9.0d, 10.0d, 11.0d, 12.0d, 13.0d);
+    }
+
+    public static double testMethod_01_manyArgs(long l1, long l2, long l3, long l4, long l5, long l6, long l7, long l8,
+                                                double d1, double d2, double d3, double d4, double d5, double d6, double d7,
+                                                double d8, double d9, double d10, double d11, double d12, double d13) {
+        return l1+l2+l3+l4+l5+l6+l7+l8+d1+d2+d3+d4+d5+d6+d7+d8+d9+d10+d11+d12+d13;
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3f5e48a4](https://github.com/openjdk/jdk19/commit/3f5e48a44ee77d07dea3d2c4ae52aaf19b8dc7cb) from the [openjdk/jdk19](https://git.openjdk.org/jdk19) repository.

The commit being backported was authored by Richard Reingruber on 23 Jun 2022 and was reviewed by Aleksey Shipilev, Martin Doerr and Tobias Hartmann.

The fix passed CI testing which includes JCK and JTREG tests on the standard platforms and also on Linux/PPC64le.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288781](https://bugs.openjdk.org/browse/JDK-8288781): C1: LIR_OpVisitState::maxNumberOfOperands too small


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/567/head:pull/567` \
`$ git checkout pull/567`

Update a local copy of the PR: \
`$ git checkout pull/567` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 567`

View PR using the GUI difftool: \
`$ git pr show -t 567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/567.diff">https://git.openjdk.org/jdk17u-dev/pull/567.diff</a>

</details>
