### PR TITLE
8290020: Deadlock in leakprofiler::emit_events during shutdown

### DIFF
--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -92,8 +92,8 @@ bool Jfr::is_excluded(Thread* t) {
   return t != NULL && t->jfr_thread_local()->is_excluded();
 }
 
-void Jfr::on_vm_shutdown(bool exception_handler) {
-  if (JfrRecorder::is_recording()) {
+void Jfr::on_vm_shutdown(bool exception_handler, bool halt) {
+  if (!halt && JfrRecorder::is_recording()) {
     JfrEmergencyDump::on_vm_shutdown(exception_handler);
   }
 }

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -48,7 +48,7 @@ class Jfr : AllStatic {
   static void on_unloading_classes();
   static void on_thread_start(Thread* thread);
   static void on_thread_exit(Thread* thread);
-  static void on_vm_shutdown(bool exception_handler = false);
+  static void on_vm_shutdown(bool exception_handler = false, bool halt = false);
   static bool on_flight_recorder_option(const JavaVMOption** option, char* delimiter);
   static bool on_start_flight_recording_option(const JavaVMOption** option, char* delimiter);
   static void on_vm_error_report(outputStream* st);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -436,7 +436,7 @@ JVM_END
 
 
 JVM_ENTRY_NO_ENV(void, JVM_Halt(jint code))
-  before_exit(thread);
+  before_exit(thread, true);
   vm_exit(code);
 JVM_END
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -404,7 +404,7 @@ void print_statistics() {
 // Note: before_exit() can be executed only once, if more than one threads
 //       are trying to shutdown the VM at the same time, only one thread
 //       can run before_exit() and all other threads must wait.
-void before_exit(JavaThread* thread) {
+void before_exit(JavaThread* thread, bool halt) {
   #define BEFORE_EXIT_NOT_RUN 0
   #define BEFORE_EXIT_RUNNING 1
   #define BEFORE_EXIT_DONE    2
@@ -451,7 +451,7 @@ void before_exit(JavaThread* thread) {
     event.commit();
   }
 
-  JFR_ONLY(Jfr::on_vm_shutdown();)
+  JFR_ONLY(Jfr::on_vm_shutdown(false, halt);)
 
   // Stop the WatcherThread. We do this before disenrolling various
   // PeriodicTasks to reduce the likelihood of races.

--- a/src/hotspot/share/runtime/java.hpp
+++ b/src/hotspot/share/runtime/java.hpp
@@ -33,7 +33,7 @@ class JavaThread;
 class Symbol;
 
 // Execute code before all handles are released and thread is killed; prologue to vm_exit
-extern void before_exit(JavaThread * thread);
+extern void before_exit(JavaThread * thread, bool halt = false);
 
 // Forced VM exit (i.e, internal error or JVM_Exit)
 extern void vm_exit(int code);

--- a/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
+++ b/test/jdk/jdk/jfr/jvm/TestDumpOnCrash.java
@@ -74,22 +74,24 @@ public class TestDumpOnCrash {
     }
 
     public static void main(String[] args) throws Exception {
-        test(CrasherIllegalAccess.class, "", true);
-        test(CrasherIllegalAccess.class, "", false);
-        test(CrasherHalt.class, "", true);
-        test(CrasherHalt.class, "", false);
+        test(CrasherIllegalAccess.class, "", true, null, true);
+        test(CrasherIllegalAccess.class, "", false, null, true);
+
+        // JDK-8290020 disables dumps when calling halt, so expect no dump.
+        test(CrasherHalt.class, "", true, null, false);
+        test(CrasherHalt.class, "", false, null, false);
 
         // Test is excluded until 8219680 is fixed
         // @ignore 8219680
-        // test(CrasherSig.class, "FPE", true);
+        // test(CrasherSig.class, "FPE", true, true);
     }
 
-    private static void test(Class<?> crasher, String signal, boolean disk) throws Exception {
+    private static void test(Class<?> crasher, String signal, boolean disk, String dumppath, boolean expectDump) throws Exception {
         // The JVM may be in a state it can't recover from, so try three times
         // before concluding functionality is not working.
         for (int attempt = 0; attempt < ATTEMPTS; attempt++) {
             try {
-                verify(runProcess(crasher, signal, disk));
+                verify(runProcess(crasher, signal, disk), dumppath, expectDump);
                 return;
             } catch (Exception e) {
                 System.out.println("Attempt " + attempt + ". Verification failed:");
@@ -125,18 +127,22 @@ public class TestDumpOnCrash {
         return p.pid();
     }
 
-    private static void verify(long pid) throws IOException {
+    private static void verify(long pid, String dumppath, boolean expectDump) throws IOException {
         String fileName = "hs_err_pid" + pid + ".jfr";
         Path file = Paths.get(fileName).toAbsolutePath().normalize();
 
-        Asserts.assertTrue(Files.exists(file), "No emergency jfr recording file " + file + " exists");
-        Asserts.assertNotEquals(Files.size(file), 0L, "File length 0. Should at least be some bytes");
-        System.out.printf("File size=%d%n", Files.size(file));
+        if (expectDump) {
+            Asserts.assertTrue(Files.exists(file), "No emergency jfr recording file " + file + " exists");
+            Asserts.assertNotEquals(Files.size(file), 0L, "File length 0. Should at least be some bytes");
+            System.out.printf("File size=%d%n", Files.size(file));
 
-        List<RecordedEvent> events = RecordingFile.readAllEvents(file);
-        Asserts.assertFalse(events.isEmpty(), "No event found");
-        System.out.printf("Found event %s%n", events.get(0).getEventType().getName());
+            List<RecordedEvent> events = RecordingFile.readAllEvents(file);
+            Asserts.assertFalse(events.isEmpty(), "No event found");
+            System.out.printf("Found event %s%n", events.get(0).getEventType().getName());
 
-        Files.delete(file);
+            Files.delete(file);
+        } else {
+            Asserts.assertFalse(Files.exists(file), "Emergency jfr recording file " + file + " exists but wasn't expected");
+        }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

I had to resolve TestDumpOnCrash.java because "8275375: [REDO] JDK-8271949 dumppath in -XX:FlightRecorderOptions does not affect" is not in 17.
I decided to add also the dumppath argument, it will simplify later backports, also of 8271949.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290020](https://bugs.openjdk.org/browse/JDK-8290020): Deadlock in leakprofiler::emit_events during shutdown


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/568/head:pull/568` \
`$ git checkout pull/568`

Update a local copy of the PR: \
`$ git checkout pull/568` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 568`

View PR using the GUI difftool: \
`$ git pr show -t 568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/568.diff">https://git.openjdk.org/jdk17u-dev/pull/568.diff</a>

</details>
