### PR TITLE
8287125: [macos] Multiple jpackage tests fail/timeout on same host

### DIFF
--- a/test/jdk/tools/jpackage/share/ArgumentsTest.java
+++ b/test/jdk/tools/jpackage/share/ArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ import jdk.jpackage.test.Annotations.Parameter;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile ArgumentsTest.java
- * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=ArgumentsTest
  */
 public class ArgumentsTest {

--- a/test/jdk/tools/jpackage/share/MultiNameTwoPhaseTest.java
+++ b/test/jdk/tools/jpackage/share/MultiNameTwoPhaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import jdk.jpackage.test.JPackageCommand;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile MultiNameTwoPhaseTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=MultiNameTwoPhaseTest
  */
 

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ import static jdk.jpackage.tests.MainClassTest.Script.MainClassType.*;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile MainClassTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=jdk.jpackage.tests.MainClassTest
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287125](https://bugs.openjdk.org/browse/JDK-8287125): [macos] Multiple jpackage tests fail/timeout on same host


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/569/head:pull/569` \
`$ git checkout pull/569`

Update a local copy of the PR: \
`$ git checkout pull/569` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 569`

View PR using the GUI difftool: \
`$ git pr show -t 569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/569.diff">https://git.openjdk.org/jdk17u-dev/pull/569.diff</a>

</details>
