### PR TITLE
8278233: [macos] tools/jpackage tests timeout due to /usr/bin/osascript

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
@@ -191,7 +191,7 @@ public class IOUtils {
             PrintStream consumer, boolean writeOutputToFile, long timeout)
             throws IOException {
         exec(pb, testForPresenceOnly, consumer, writeOutputToFile,
-                Executor.INFINITE_TIMEOUT, false);
+                timeout, false);
     }
 
     static void exec(ProcessBuilder pb, boolean testForPresenceOnly,


### PR DESCRIPTION
Clean except for ProblemList.  Test are not problemlisted in 17.  Marking as /clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278233](https://bugs.openjdk.org/browse/JDK-8278233): [macos] tools/jpackage tests timeout due to /usr/bin/osascript


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/577/head:pull/577` \
`$ git checkout pull/577`

Update a local copy of the PR: \
`$ git checkout pull/577` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 577`

View PR using the GUI difftool: \
`$ git pr show -t 577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/577.diff">https://git.openjdk.org/jdk17u-dev/pull/577.diff</a>

</details>
