### PR TITLE
8255724: [XRender] the BlitRotateClippedArea test fails on Linux in the XR pipeline

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -240,7 +240,6 @@ java/awt/font/TextLayout/TextLayoutBounds.java 8169188 generic-all
 java/awt/FontMetrics/FontCrash.java 8198336 windows-all
 java/awt/image/BufferedImage/ICMColorDataTest/ICMColorDataTest.java 8233028 generic-all
 java/awt/image/DrawImage/IncorrectAlphaSurface2SW.java 8056077 linux-all
-java/awt/image/DrawImage/BlitRotateClippedArea.java 8255724 linux-all
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8169187,8252812 macosx-all,windows-all,linux-x64
 java/awt/print/Headless/HeadlessPrinterJob.java 8196088 windows-all
 sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all

--- a/test/jdk/java/awt/image/DrawImage/BlitRotateClippedArea.java
+++ b/test/jdk/java/awt/image/DrawImage/BlitRotateClippedArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import static java.awt.Transparency.TRANSLUCENT;
 
 /**
  * @test
- * @bug 8255722
+ * @bug 8255722 8255724
  * @key headful
  */
 public class BlitRotateClippedArea {
@@ -103,10 +103,15 @@ public class BlitRotateClippedArea {
             throws IOException {
         for (int x = 0; x < gold.getWidth(); ++x) {
             for (int y = 0; y < gold.getHeight(); ++y) {
-                if (gold.getRGB(x, y) != img.getRGB(x, y)) {
-                    ImageIO.write(gold, "png", new File("gold.png"));
-                    ImageIO.write(img, "png", new File("snapshot.png"));
-                    throw new RuntimeException("Test failed.");
+                Color goldColor = new Color(gold.getRGB(x, y));
+                Color actualColor = new Color(img.getRGB(x, y));
+                if ((Math.abs(goldColor.getRed() - actualColor.getRed()) > 1) ||
+                    (Math.abs(goldColor.getGreen() - actualColor.getGreen()) > 1) ||
+                    (Math.abs(goldColor.getBlue() - actualColor.getBlue()) > 1)) {
+                     ImageIO.write(gold, "png", new File("gold.png"));
+                     ImageIO.write(img, "png", new File("snapshot.png"));
+                     throw new RuntimeException("Test failed for pixel :"
+                        + x + "/" + y);
                 }
             }
         }


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255724](https://bugs.openjdk.org/browse/JDK-8255724): [XRender] the BlitRotateClippedArea test fails on Linux in the XR pipeline


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/584/head:pull/584` \
`$ git checkout pull/584`

Update a local copy of the PR: \
`$ git checkout pull/584` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 584`

View PR using the GUI difftool: \
`$ git pr show -t 584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/584.diff">https://git.openjdk.org/jdk17u-dev/pull/584.diff</a>

</details>
