### PR TITLE
8283723: Update Visual Studio 2022 to version 17.1.0 for Oracle builds on Windows

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -278,7 +278,7 @@
 </tr>
 <tr class="odd">
 <td style="text-align: left;">Windows</td>
-<td style="text-align: left;">Microsoft Visual Studio 2019 update 16.7.2</td>
+<td style="text-align: left;">Microsoft Visual Studio 2022 update 17.1.0</td>
 </tr>
 </tbody>
 </table>

--- a/doc/building.md
+++ b/doc/building.md
@@ -323,7 +323,7 @@ issues.
  ------------------ -------------------------------------------------------
  Linux              gcc 10.2.0
  macOS              Apple Xcode 10.1 (using clang 10.0.0)
- Windows            Microsoft Visual Studio 2019 update 16.7.2
+ Windows            Microsoft Visual Studio 2022 update 17.1.0
 
 All compilers are expected to be able to compile to the C99 language standard,
 as some C99 features are used in the source code. Microsoft Visual Studio

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1049,7 +1049,7 @@ var getJibProfilesDependencies = function (input, common) {
     var devkit_platform_revisions = {
         linux_x64: "gcc10.3.0-OL6.4+1.0",
         macosx: "Xcode12.4+1.0",
-        windows_x64: "VS2019-16.9.3+1.0",
+        windows_x64: "VS2022-17.1.0+1.0",
         linux_aarch64: "gcc10.3.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
         linux_ppc64le: "gcc8.2.0-Fedora27+1.0",

--- a/make/devkit/createWindowsDevkit.sh
+++ b/make/devkit/createWindowsDevkit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -28,14 +28,19 @@
 # suitable for building OpenJDK and OracleJDK. Needs to run in Cygwin or WSL.
 # erik.joelsson@oracle.com
 
-VS_VERSION="2019"
-VS_VERSION_NUM_NODOT="160"
+usage_and_exit() {
+    echo "Usage: createWindowsDevkit.sh <2019 | 2022>"
+    exit 1
+}
+
+if [ ! $# = 1 ]; then
+    usage_and_exit
+fi
+
+VS_VERSION="$1"
+
 VS_DLL_VERSION="140"
 SDK_VERSION="10"
-SDK_FULL_VERSION="10.0.17763.0"
-MSVC_DIR="Microsoft.VC142.CRT"
-MSVC_FULL_VERSION="14.12.27508"
-REDIST_FULL_VERSION="14.20.27508"
 
 SCRIPT_DIR="$(cd "$(dirname $0)" > /dev/null && pwd)"
 BUILD_DIR="${SCRIPT_DIR}/../../build/devkit"
@@ -66,13 +71,33 @@ fi
 
 # Work around the insanely named ProgramFiles(x86) env variable
 PROGRAMFILES_X86="$($WINDOWS_PATH_TO_UNIX_PATH "$(cmd.exe /c set | sed -n 's/^ProgramFiles(x86)=//p' | tr -d '\r')")"
+PROGRAMFILES="$($WINDOWS_PATH_TO_UNIX_PATH "$PROGRAMFILES")"
+
+case $VS_VERSION in
+    2019)
+        MSVC_PROGRAMFILES_DIR="${PROGRAMFILES_X86}"
+        MSVC_CRT_DIR="Microsoft.VC142.CRT"
+        VS_VERSION_NUM_NODOT="160"
+        ;;
+
+    2022)
+        MSVC_PROGRAMFILES_DIR="${PROGRAMFILES}"
+        MSVC_CRT_DIR="Microsoft.VC143.CRT"
+        VS_VERSION_NUM_NODOT="170"
+        ;;
+    *)
+        echo "Unexpected VS version: $VS_VERSION"
+        usage_and_exit
+        ;;
+esac
+
 
 # Find Visual Studio installation dir
 VSNNNCOMNTOOLS=`cmd.exe /c echo %VS${VS_VERSION_NUM_NODOT}COMNTOOLS% | tr -d '\r'`
 if [ -d "$VSNNNCOMNTOOLS" ]; then
     VS_INSTALL_DIR="$($WINDOWS_PATH_TO_UNIX_PATH "$VSNNNCOMNTOOLS/../..")"
 else
-    VS_INSTALL_DIR="${PROGRAMFILES_X86}/Microsoft Visual Studio/2019"
+    VS_INSTALL_DIR="${MSVC_PROGRAMFILES_DIR}/Microsoft Visual Studio/$VS_VERSION"
     VS_INSTALL_DIR="$(ls -d "${VS_INSTALL_DIR}/"{Community,Professional,Enterprise} 2>/dev/null | head -n1)"
 fi
 echo "VS_INSTALL_DIR: $VS_INSTALL_DIR"
@@ -101,9 +126,9 @@ DEVKIT_BUNDLE="${DEVKIT_ROOT}.tar.gz"
 
 echo "Creating devkit in $DEVKIT_ROOT"
 
-MSVCR_DLL=${MSVC_DIR}/vcruntime${VS_DLL_VERSION}.dll
-VCRUNTIME_1_DLL=${MSVC_DIR}/vcruntime${VS_DLL_VERSION}_1.dll
-MSVCP_DLL=${MSVC_DIR}/msvcp${VS_DLL_VERSION}.dll
+MSVCR_DLL=${MSVC_CRT_DIR}/vcruntime${VS_DLL_VERSION}.dll
+VCRUNTIME_1_DLL=${MSVC_CRT_DIR}/vcruntime${VS_DLL_VERSION}_1.dll
+MSVCP_DLL=${MSVC_CRT_DIR}/msvcp${VS_DLL_VERSION}.dll
 
 ################################################################################
 # Copy Visual Studio files


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

I had to resolve the jib-profiles.js file. The context differs in used gcc versions.

I deliberately omitted deleting the createWindowsDevkit2017.sh.
It still might be useful to people building with that environment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283723](https://bugs.openjdk.org/browse/JDK-8283723): Update Visual Studio 2022 to version 17.1.0 for Oracle builds on Windows


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/585/head:pull/585` \
`$ git checkout pull/585`

Update a local copy of the PR: \
`$ git checkout pull/585` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 585`

View PR using the GUI difftool: \
`$ git pr show -t 585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/585.diff">https://git.openjdk.org/jdk17u-dev/pull/585.diff</a>

</details>
