### PR TITLE
8169468: NoResizeEventOnDMChangeTest.java fails because FS Window didn't receive all resizes!

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -496,7 +496,6 @@ java/awt/xembed/server/RunTestXEmbed.java 7034201 linux-all
 java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 8164473 linux-all
 java/awt/im/memoryleak/InputContextMemoryLeakTest.java 8023814 linux-all
 java/awt/Frame/DisposeParentGC/DisposeParentGC.java 8079786 macosx-all
-java/awt/FullScreen/NoResizeEventOnDMChangeTest/NoResizeEventOnDMChangeTest.java 8169468 macosx-all
 java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java 8213120 macosx-all
 
 java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223 linux-all,windows-all


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

I had to resolve the ProblemList, will mark as /clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8169468](https://bugs.openjdk.org/browse/JDK-8169468): NoResizeEventOnDMChangeTest.java fails because FS Window didn't receive all resizes!


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/590/head:pull/590` \
`$ git checkout pull/590`

Update a local copy of the PR: \
`$ git checkout pull/590` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 590`

View PR using the GUI difftool: \
`$ git pr show -t 590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/590.diff">https://git.openjdk.org/jdk17u-dev/pull/590.diff</a>

</details>
