### PR TITLE
8284067: jpackage'd launcher reports non-zero exit codes with error prompt

### DIFF
--- a/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
+++ b/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 #include <io.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <windows.h>
 
 #include "AppLauncher.h"
@@ -180,11 +181,7 @@ void launchApp() {
                                                         GetExitCodeProcess));
         }
 
-        if (exitCode != 0) {
-            JP_THROW(tstrings::any() << "Child process exited with code "
-                                                                << exitCode);
-        }
-
+        exit(exitCode);
         return;
     }
 

--- a/test/jdk/tools/jpackage/apps/Hello.java
+++ b/test/jdk/tools/jpackage/apps/Hello.java
@@ -70,6 +70,8 @@ public class Hello implements OpenFilesHandler {
                 lock.wait();
             }
         }
+
+        System.exit(Integer.getInteger("jpackage.test.exitCode", 0));
     }
 
     private static List<String> printArgs(String[] args) {

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
@@ -370,6 +370,8 @@ public final class HelloApp {
                 params.put(name, value);
             } else if ("jpackage.test.appOutput".equals(name)) {
                 outputFilePath = Path.of(value);
+            } else if ("jpackage.test.exitCode".equals(name)) {
+                expectedExitCode = Integer.parseInt(value);
             }
             return this;
         }
@@ -421,8 +423,8 @@ public final class HelloApp {
             final int attempts = 3;
             final int waitBetweenAttemptsSeconds = 5;
             getExecutor(launcherArgs.toArray(new String[0])).dumpOutput().setRemovePath(
-                    removePath).executeAndRepeatUntilExitCode(0, attempts,
-                            waitBetweenAttemptsSeconds);
+                    removePath).executeAndRepeatUntilExitCode(expectedExitCode,
+                            attempts, waitBetweenAttemptsSeconds);
             verifyOutputFile(outputFilePath, appArgs, params);
         }
 
@@ -468,6 +470,7 @@ public final class HelloApp {
 
         private final Path launcherPath;
         private Path outputFilePath;
+        private int expectedExitCode;
         private final List<String> defaultLauncherArgs;
         private final Map<String, String> params;
     }

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,6 +347,17 @@ public final class BasicTest {
         // Verify output of jpackage command.
         cmd.assertImageCreated();
         HelloApp.executeLauncherAndVerifyOutput(cmd);
+    }
+
+    @Test
+    @Parameter("1")
+    @Parameter("123")
+    public void testExitCode(int exitCode) {
+        JPackageCommand cmd = JPackageCommand
+                .helloAppImage()
+                .addArguments("--java-options", String.format(
+                        "-Djpackage.test.exitCode=%d", exitCode));
+        cmd.executeAndAssertHelloAppImageCreated();
     }
 
     private static Executor getJPackageToolProvider() {


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284067](https://bugs.openjdk.org/browse/JDK-8284067): jpackage'd launcher reports non-zero exit codes with error prompt


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/593/head:pull/593` \
`$ git checkout pull/593`

Update a local copy of the PR: \
`$ git checkout pull/593` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 593`

View PR using the GUI difftool: \
`$ git pr show -t 593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/593.diff">https://git.openjdk.org/jdk17u-dev/pull/593.diff</a>

</details>
