### PR TITLE
8283803: Remove jtreg tag manual=yesno for java/awt/print/PrinterJob/PrintGlyphVectorTest.java and fix test

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Toolkit;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.Timer;
+
+import static javax.swing.SwingUtilities.invokeAndWait;
+import static javax.swing.SwingUtilities.isEventDispatchThread;
+
+public class PassFailJFrame {
+
+    private static final String TITLE = "Test Instruction Frame";
+    private static final long TEST_TIMEOUT = 5;
+    private static final int ROWS = 10;
+    private static final int COLUMNS = 40;
+
+    private static final List<Frame> frameList = new ArrayList<>();
+    private static final Timer timer = new Timer(0, null);
+    private static final CountDownLatch latch = new CountDownLatch(1);
+
+    private static volatile boolean failed;
+    private static volatile boolean timeout;
+    private static volatile String testFailedReason;
+    private static JFrame frame;
+
+    public enum Position {HORIZONTAL, VERTICAL}
+
+    public PassFailJFrame(String instructions) throws InterruptedException,
+            InvocationTargetException {
+        this(instructions, TEST_TIMEOUT);
+    }
+
+    public PassFailJFrame(String instructions, long testTimeOut) throws
+            InterruptedException, InvocationTargetException {
+        this(TITLE, instructions, testTimeOut);
+    }
+
+    public PassFailJFrame(String title, String instructions,
+                          long testTimeOut) throws InterruptedException,
+            InvocationTargetException {
+        this(title, instructions, testTimeOut, ROWS, COLUMNS);
+    }
+
+    /**
+     * Constructs a JFrame with a given title & serves as test instructional
+     * frame where the user follows the specified test instruction in order
+     * to test the test case & mark the test pass or fail. If the expected
+     * result is seen then the user click on the 'Pass' button else click
+     * on the 'Fail' button and the reason for the failure should be
+     * specified in the JDialog JTextArea.
+     *
+     * @param title        title of the Frame.
+     * @param instructions the instruction for the tester on how to test
+     *                     and what is expected (pass) and what is not
+     *                     expected (fail).
+     * @param testTimeOut  test timeout where time is specified in minutes.
+     * @param rows         number of visible rows of the JTextArea where the
+     *                     instruction is show.
+     * @param columns      Number of columns of the instructional
+     *                     JTextArea
+     * @throws InterruptedException      exception thrown when thread is
+     *                                   interrupted
+     * @throws InvocationTargetException if an exception is thrown while
+     *                                   creating the test instruction frame on
+     *                                   EDT
+     */
+    public PassFailJFrame(String title, String instructions, long testTimeOut,
+                          int rows, int columns) throws InterruptedException,
+            InvocationTargetException {
+        if (isEventDispatchThread()) {
+            createUI(title, instructions, testTimeOut, rows, columns);
+        } else {
+            invokeAndWait(() -> createUI(title, instructions, testTimeOut,
+                    rows, columns));
+        }
+    }
+
+    private static void createUI(String title, String instructions,
+                                 long testTimeOut, int rows, int columns) {
+        frame = new JFrame(title);
+        frame.setLayout(new BorderLayout());
+        JTextArea instructionsText = new JTextArea(instructions, rows, columns);
+        instructionsText.setEditable(false);
+        instructionsText.setLineWrap(true);
+
+        long tTimeout = TimeUnit.MINUTES.toMillis(testTimeOut);
+
+        final JLabel testTimeoutLabel = new JLabel(String.format("Test " +
+                "timeout: %s", convertMillisToTimeStr(tTimeout)), JLabel.CENTER);
+        final long startTime = System.currentTimeMillis();
+        timer.setDelay(1000);
+        timer.addActionListener((e) -> {
+            long leftTime = tTimeout - (System.currentTimeMillis() - startTime);
+            if ((leftTime < 0) || failed) {
+                timer.stop();
+                testFailedReason = "Failure Reason:\n"
+                        + "Timeout User did not perform testing.";
+                timeout = true;
+                latch.countDown();
+            }
+            testTimeoutLabel.setText(String.format("Test timeout: %s", convertMillisToTimeStr(leftTime)));
+        });
+        timer.start();
+        frame.add(testTimeoutLabel, BorderLayout.NORTH);
+        frame.add(new JScrollPane(instructionsText), BorderLayout.CENTER);
+
+        JButton btnPass = new JButton("Pass");
+        btnPass.addActionListener((e) -> {
+            latch.countDown();
+            timer.stop();
+        });
+
+        JButton btnFail = new JButton("Fail");
+        btnFail.addActionListener((e) -> {
+            getFailureReason();
+            timer.stop();
+        });
+
+        JPanel buttonsPanel = new JPanel();
+        buttonsPanel.add(btnPass);
+        buttonsPanel.add(btnFail);
+
+        frame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                super.windowClosing(e);
+                testFailedReason = "Failure Reason:\n"
+                        + "User closed the instruction Frame";
+                failed = true;
+                latch.countDown();
+            }
+        });
+
+        frame.add(buttonsPanel, BorderLayout.SOUTH);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frameList.add(frame);
+    }
+
+    private static String convertMillisToTimeStr(long millis) {
+        if (millis < 0) {
+            return "00:00:00";
+        }
+        long hours = millis / 3_600_000;
+        long minutes = (millis - hours * 3_600_000) / 60_000;
+        long seconds = (millis - hours * 3_600_000 - minutes * 60_000) / 1_000;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
+    /**
+     * Wait for the user decision i,e user selects pass or fail button.
+     * If user does not select pass or fail button then the test waits for
+     * the specified timeoutMinutes period and the test gets timeout.
+     * Note: This method should be called from main() thread
+     *
+     * @throws InterruptedException      exception thrown when thread is
+     *                                   interrupted
+     * @throws InvocationTargetException if an exception is thrown while
+     *                                   disposing of frames on EDT
+     */
+    public void awaitAndCheck() throws InterruptedException, InvocationTargetException {
+        if (isEventDispatchThread()) {
+            throw new IllegalStateException("awaitAndCheck() should not be called on EDT");
+        }
+        latch.await();
+        invokeAndWait(PassFailJFrame::disposeFrames);
+
+        if (timeout) {
+            throw new RuntimeException(testFailedReason);
+        }
+
+        if (failed) {
+            throw new RuntimeException("Test failed! : " + testFailedReason);
+        }
+
+        System.out.println("Test passed!");
+    }
+
+    /**
+     * Dispose all the frame(s) i,e both the test instruction frame as
+     * well as the frame that is added via addTestFrame(Frame frame)
+     */
+    private static synchronized void disposeFrames() {
+        for (Frame f : frameList) {
+            f.dispose();
+        }
+    }
+
+    /**
+     * Read the test failure reason and add the reason to the test result
+     * example in the jtreg .jtr file.
+     */
+    private static void getFailureReason() {
+        final JDialog dialog = new JDialog(frame, "Test Failure ", true);
+        dialog.setTitle("Failure reason");
+        JPanel jPanel = new JPanel(new BorderLayout());
+        JTextArea jTextArea = new JTextArea(5, 20);
+
+        JButton okButton = new JButton("OK");
+        okButton.addActionListener((ae) -> {
+            testFailedReason = "Failure Reason:\n" + jTextArea.getText();
+            dialog.setVisible(false);
+        });
+
+        jPanel.add(new JScrollPane(jTextArea), BorderLayout.CENTER);
+
+        JPanel okayBtnPanel = new JPanel();
+        okayBtnPanel.add(okButton);
+
+        jPanel.add(okayBtnPanel, BorderLayout.SOUTH);
+        dialog.add(jPanel);
+        dialog.setLocationRelativeTo(frame);
+        dialog.pack();
+        dialog.setVisible(true);
+
+        failed = true;
+        dialog.dispose();
+        latch.countDown();
+    }
+
+    /**
+     * Position the instruction frame with testFrame ( testcase created
+     * frame) by the specified position
+     * Note: This method should be invoked from the method that creates
+     * testFrame
+     *
+     * @param testFrame test frame that the test is created
+     * @param position  position can be either HORIZONTAL (both test
+     *                  instruction frame and test frame as arranged side by
+     *                  side or VERTICAL ( both test instruction frame and
+     *                  test frame as arranged up and down)
+     */
+    public static void positionTestFrame(Frame testFrame, Position position) {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        if (position.equals(Position.HORIZONTAL)) {
+            int newX = ((screenSize.width / 2) - frame.getWidth());
+            frame.setLocation(newX, frame.getY());
+
+            testFrame.setLocation((frame.getLocation().x + frame.getWidth() + 5), frame.getY());
+        } else if (position.equals(Position.VERTICAL)) {
+            int newY = ((screenSize.height / 2) - frame.getHeight());
+            frame.setLocation(frame.getX(), newY);
+
+            testFrame.setLocation(frame.getX(),
+                    (frame.getLocation().y + frame.getHeight() + 5));
+        }
+    }
+
+    /**
+     * Add the testFrame to the frameList so that test instruction frame
+     * and testFrame and any other frame used in this test is disposed
+     * via disposeFrames()
+     *
+     * @param testFrame testFrame that needs to be disposed
+     */
+    public static synchronized void addTestFrame(Frame testFrame) {
+        frameList.add(testFrame);
+    }
+
+    /**
+     * Forcibly pass the test.
+     * <p>The sample usage:
+     * <pre><code>
+     *      PrinterJob pj = PrinterJob.getPrinterJob();
+     *      if (pj == null || pj.getPrintService() == null) {
+     *          System.out.println(""Printer not configured or available.");
+     *          PassFailJFrame.forcePass();
+     *      }
+     * </code></pre>
+     */
+    public static void forcePass() {
+        latch.countDown();
+    }
+
+    /**
+     *  Forcibly fail the test.
+     */
+    public static void forceFail() {
+        failed = true;
+        latch.countDown();
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

I include all of PassFailJFrame.java in this change.
It was added by "8284535: Fix PrintLatinCJKTest.java test that is failing with Parse Exception"
which is not in 17. The changed test needs this helper file to compile.
The backport of the test itself is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8283803](https://bugs.openjdk.org/browse/JDK-8283803): Remove jtreg tag manual=yesno for java/awt/print/PrinterJob/PrintGlyphVectorTest.java and fix test
 * [JDK-8284898](https://bugs.openjdk.org/browse/JDK-8284898): Enhance PassFailJFrame


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/596/head:pull/596` \
`$ git checkout pull/596`

Update a local copy of the PR: \
`$ git checkout pull/596` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 596`

View PR using the GUI difftool: \
`$ git pr show -t 596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/596.diff">https://git.openjdk.org/jdk17u-dev/pull/596.diff</a>

</details>
