### PR TITLE
8282351: jpackage does not work if class file has `$$` in the name on windows

### DIFF
--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixFragmentBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,9 @@
 package jdk.jpackage.internal;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -32,6 +35,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.stream.XMLStreamWriter;
 import jdk.jpackage.internal.IOUtils.XmlConsumer;
 import jdk.jpackage.internal.OverridableResource.Source;
 import static jdk.jpackage.internal.OverridableResource.createResource;
@@ -131,7 +137,9 @@ abstract class WixFragmentBuilder {
             xml.writeNamespace("util",
                     "http://schemas.microsoft.com/wix/UtilExtension");
 
-            xmlConsumer.accept(xml);
+            xmlConsumer.accept((XMLStreamWriter) Proxy.newProxyInstance(
+                    XMLStreamWriter.class.getClassLoader(), new Class<?>[]{
+                XMLStreamWriter.class}, new WixPreprocessorEscaper(xml)));
 
             xml.writeEndElement(); // <Wix>
         });
@@ -145,6 +153,58 @@ abstract class WixFragmentBuilder {
         }
         private final OverridableResource resource;
         private final String saveAsName;
+    }
+
+    private static class WixPreprocessorEscaper implements InvocationHandler {
+
+        WixPreprocessorEscaper(XMLStreamWriter target) {
+            this.target = target;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws
+                Throwable {
+            switch (method.getName()) {
+                case "writeAttribute" -> {
+                    Object newArgs[] = new Object[args.length];
+                    for (int i = 0; i < args.length - 1; ++i) {
+                        newArgs[i] = args[i];
+                    }
+                    newArgs[args.length - 1] = escape(
+                            (CharSequence) args[args.length - 1]);
+                    return method.invoke(target, newArgs);
+                }
+                case "writeCData" -> {
+                    target.writeCData(escape((CharSequence) args[0]));
+                    return null;
+                }
+                case "writeCharacters" -> {
+                    if (args.length == 3) {
+                        // writeCharacters(char[] text, int start, int len)
+                        target.writeCharacters(escape(String.copyValueOf(
+                                (char[]) args[0], (int) args[1], (int) args[2])));
+                    } else {
+                        target.writeCharacters(escape((CharSequence) args[0]));
+                    }
+                    return null;
+                }
+            }
+            return method.invoke(target, args);
+        }
+
+        private String escape(CharSequence str) {
+            Matcher m = dollarPattern.matcher(str);
+            StringBuilder sb = new StringBuilder();
+            while (m.find()) {
+                m.appendReplacement(sb, "\\$\\$");
+            }
+            m.appendTail(sb);
+            return sb.toString();
+        }
+
+        // Match '$', but don't match $(var.foo)
+        private final Pattern dollarPattern = Pattern.compile("\\$(?!\\([^)]*\\))");
+        private final XMLStreamWriter target;
     }
 
     private DottedVersion wixVersion;

--- a/test/jdk/tools/jpackage/windows/Win8282351Test.java
+++ b/test/jdk/tools/jpackage/windows/Win8282351Test.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import jdk.jpackage.test.PackageTest;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.PackageType;
+import jdk.jpackage.test.RunnablePackageTest.Action;
+import jdk.jpackage.test.TKit;
+
+/**
+ * Test packaging of files with paths containing multiple dollar ($$, $$$)
+ * character sequences.
+ */
+
+/*
+ * @test
+ * @summary Test case for JDK-8248254
+ * @library ../helpers
+ * @build jdk.jpackage.test.*
+ * @build Win8282351Test
+ * @requires (os.family == "windows")
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @run main/othervm/timeout=360 -Xmx512m  jdk.jpackage.test.Main
+ *  --jpt-run=Win8282351Test
+ */
+public class Win8282351Test {
+
+    @Test
+    public void test() throws IOException {
+        Path appimageOutput = TKit.createTempDirectory("appimage");
+
+        JPackageCommand appImageCmd = JPackageCommand.helloAppImage()
+                .setFakeRuntime().setArgumentValue("--dest", appimageOutput);
+
+        String[] filesWithDollarCharsInNames = new String[]{
+            "Pane$$anon$$greater$1.class",
+            "$",
+            "$$",
+            "$$$",
+            "$$$$",
+            "$$$$$",
+            "foo$.class",
+            "1$b$$a$$$r$$$$.class"
+        };
+
+        String[] dirsWithDollarCharsInNames = new String[]{
+            Path.of("foo", String.join("/", filesWithDollarCharsInNames)).toString()
+        };
+
+        String name = appImageCmd.name() + "$-$$-$$$";
+
+        new PackageTest()
+                .addRunOnceInitializer(() -> {
+                    appImageCmd.execute();
+                    for (var path : filesWithDollarCharsInNames) {
+                        createImageFile(appImageCmd, Path.of(path));
+                    }
+
+                    for (var path : dirsWithDollarCharsInNames) {
+                        Files.createDirectories(
+                                appImageCmd.outputBundle().resolve(path));
+                    }
+                })
+                .addInitializer(cmd -> {
+                    cmd.setArgumentValue("--name", name);
+                    cmd.addArguments("--app-image", appImageCmd.outputBundle());
+                    cmd.removeArgumentWithValue("--input");
+                    cmd.addArgument("--win-menu");
+                    cmd.addArgument("--win-shortcut");
+                })
+                .addInstallVerifier(cmd -> {
+                    for (var path : filesWithDollarCharsInNames) {
+                        verifyImageFile(appImageCmd, Path.of(path));
+                    }
+
+                    for (var path : dirsWithDollarCharsInNames) {
+                        TKit.assertDirectoryExists(
+                                appImageCmd.outputBundle().resolve(path));
+                    }
+                }).run(Action.CREATE_AND_UNPACK);
+    }
+
+    private static void createImageFile(JPackageCommand cmd, Path name) throws
+            IOException {
+        Files.writeString(cmd.outputBundle().resolve(name), name.toString());
+    }
+
+    private static void verifyImageFile(JPackageCommand cmd, Path name) throws
+            IOException {
+        TKit.assertEquals(name.toString(), Files.readString(
+                (cmd.outputBundle().resolve(name))), String.format(
+                "Test contents of [%s] image file are euqal to [%s]", name, name));
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282351](https://bugs.openjdk.org/browse/JDK-8282351): jpackage does not work if class file has `$$` in the name on windows


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/597/head:pull/597` \
`$ git checkout pull/597`

Update a local copy of the PR: \
`$ git checkout pull/597` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 597`

View PR using the GUI difftool: \
`$ git pr show -t 597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/597.diff">https://git.openjdk.org/jdk17u-dev/pull/597.diff</a>

</details>
