### PR TITLE
8289471: Issue in Initialization of keys in ErrorMsg.java and XPATHErrorResources.java

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java
@@ -33,7 +33,7 @@ import jdk.xml.internal.SecuritySupport;
  * @author G. Todd Miller
  * @author Erwin Bolwidt <ejb@klomp.org>
  * @author Morten Jorgensen
- * @LastModified: Jan 2022
+ * @LastModified: Jul 2022
  */
 public final class ErrorMsg {
 
@@ -169,7 +169,7 @@ public final class ErrorMsg {
     public static final String OUTLINE_ERR_METHOD_TOO_BIG =
                                             "OUTLINE_ERR_METHOD_TOO_BIG";
 
-    public static final String DESERIALIZE_TRANSLET_ERR = "DESERIALIZE_TEMPLATES_ERR";
+    public static final String DESERIALIZE_TRANSLET_ERR = "DESERIALIZE_TRANSLET_ERR";
 
     public static final String XPATH_LIMIT = "XPATH_LIMIT";
     public static final String XPATH_GROUP_LIMIT = "XPATH_GROUP_LIMIT";

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/res/XPATHErrorResources.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/res/XPATHErrorResources.java
@@ -31,7 +31,7 @@ import java.util.ListResourceBundle;
   * Also you need to  update the count of messages(MAX_CODE)or
  * the count of warnings(MAX_WARNING) [ Information purpose only]
  * @xsl.usage advanced
- * @LastModified: Apr 2022
+ * @LastModified: Jul 2022
  */
 public class XPATHErrorResources extends ListResourceBundle
 {
@@ -322,8 +322,8 @@ public static final String ER_IGNORABLE_WHITESPACE_NOT_HANDLED =
   public static final String ER_SECUREPROCESSING_FEATURE = "ER_SECUREPROCESSING_FEATURE";
   public static final String ER_NULL_XPATH_FUNCTION_RESOLVER = "ER_NULL_XPATH_FUNCTION_RESOLVER";
   public static final String ER_NULL_XPATH_VARIABLE_RESOLVER = "ER_NULL_XPATH_VARIABLE_RESOLVER";
-  public static final String ER_XPATH_GROUP_LIMIT = "XPATH_GROUP_LIMIT";
-  public static final String ER_XPATH_OPERATOR_LIMIT = "XPATH_OPERATOR_LIMIT";
+  public static final String ER_XPATH_GROUP_LIMIT = "ER_XPATH_GROUP_LIMIT";
+  public static final String ER_XPATH_OPERATOR_LIMIT = "ER_XPATH_OPERATOR_LIMIT";
 
   //END: Keys needed for exception messages of  JAXP 1.3 XPath API implementation
 


### PR DESCRIPTION
OpenJDK PR : https://github.com/openjdk/jdk/pull/9369
OpenJDK bug : https://bugs.openjdk.org/browse/JDK-8289471

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289471](https://bugs.openjdk.org/browse/JDK-8289471): Issue in Initialization of keys in ErrorMsg.java and XPATHErrorResources.java


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/598/head:pull/598` \
`$ git checkout pull/598`

Update a local copy of the PR: \
`$ git checkout pull/598` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 598`

View PR using the GUI difftool: \
`$ git pr show -t 598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/598.diff">https://git.openjdk.org/jdk17u-dev/pull/598.diff</a>

</details>
