### PR TITLE
8273629: compiler/uncommontrap/TestDeoptOOM.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/TestDeoptOOM.java
@@ -33,6 +33,19 @@
  *      compiler.uncommontrap.TestDeoptOOM
  */
 
+/*
+ * @test
+ * @bug 8273456
+ * @summary Test that ttyLock is ranked above StackWatermark_lock
+ * @requires !vm.graal.enabled & vm.gc.Z
+ * @run main/othervm -XX:-BackgroundCompilation -Xmx128M -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyStack
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::main
+ *      -XX:CompileCommand=exclude,compiler.uncommontrap.TestDeoptOOM::m9_1
+ *      -XX:+UnlockDiagnosticVMOptions
+ *      -XX:+UseZGC -XX:+LogCompilation -XX:+PrintDeoptimizationDetails -XX:+TraceDeoptimization -XX:+Verbose
+ *      compiler.uncommontrap.TestDeoptOOM
+ */
+
 package compiler.uncommontrap;
 
 public class TestDeoptOOM {


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

This change originally only fixes a test command (adding UnlockDiagnosticVMOptions)
But this test command was only added in "[273456: Do not hold ttyLock around stack walking](https://github.com/openjdk/jdk/commit/461a467f91ba19ae35d7833b7d3e74f62f52e19c)" in 18 which is not backported. 

I think this only makes sense if the whole new test command is backported including the fix. 
Test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273629](https://bugs.openjdk.org/browse/JDK-8273629): compiler/uncommontrap/TestDeoptOOM.java fails with release VMs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/604/head:pull/604` \
`$ git checkout pull/604`

Update a local copy of the PR: \
`$ git checkout pull/604` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 604`

View PR using the GUI difftool: \
`$ git pr show -t 604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/604.diff">https://git.openjdk.org/jdk17u-dev/pull/604.diff</a>

</details>
