### PR TITLE
8257534: misc tests failed with "NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,12 +203,7 @@ public final class GarbageUtils {
           *
           * It is Important that the impl is not inlined.
           */
-
-         public static int eatMemory(ExecutionController stresser, GarbageProducer gp, long initialFactor, long minMemoryChunk, long factor, OOM_TYPE type) {
-            try {
-               // Using a methodhandle invoke of eatMemoryImpl to prevent inlining of it
-               MethodHandles.Lookup lookup = MethodHandles.lookup();
-               MethodType mt = MethodType.methodType(
+          private static MethodType mt = MethodType.methodType(
                      int.class,
                      ExecutionController.class,
                      GarbageProducer.class,
@@ -216,6 +211,11 @@ public final class GarbageUtils {
                      long.class,
                      long.class,
                      OOM_TYPE.class);
+
+         public static int eatMemory(ExecutionController stresser, GarbageProducer gp, long initialFactor, long minMemoryChunk, long factor, OOM_TYPE type) {
+            try {
+               // Using a methodhandle invoke of eatMemoryImpl to prevent inlining of it
+               MethodHandles.Lookup lookup = MethodHandles.lookup();
                MethodHandle eat = lookup.findStatic(GarbageUtils.class, "eatMemoryImpl", mt);
                return (int) eat.invoke(stresser, gp, initialFactor, minMemoryChunk, factor, type);
             } catch (OutOfMemoryError e) {


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257534](https://bugs.openjdk.org/browse/JDK-8257534): misc tests failed with "NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/605/head:pull/605` \
`$ git checkout pull/605`

Update a local copy of the PR: \
`$ git checkout pull/605` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 605`

View PR using the GUI difftool: \
`$ git pr show -t 605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/605.diff">https://git.openjdk.org/jdk17u-dev/pull/605.diff</a>

</details>
