### PR TITLE
8284535: Fix PrintLatinCJKTest.java test that is failing with Parse Exception

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,57 +21,74 @@
  * questions.
  */
 
-/**
+/*
  * @test
- * @bug 800535 8022536
+ * @bug 8008535 8022536
+ * @library ../../regtesthelpers
+ * @build PassFailJFrame
  * @summary JDK7 Printing: CJK and Latin Text in string overlap
- * @run main/manual=yesno PrintLatinCJKTest
+ * @run main/manual PrintLatinCJKTest
  */
 
+import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.Graphics;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.print.PageFormat;
-import java.awt.print.Pageable;
 import java.awt.print.Printable;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
+import java.lang.reflect.InvocationTargetException;
 import javax.swing.JButton;
 import javax.swing.JFrame;
-import javax.swing.JTextArea;
 
-import javax.swing.SwingUtilities;
+import static javax.swing.SwingUtilities.invokeAndWait;
 
-public class PrintLatinCJKTest implements Printable, ActionListener {
+public class PrintLatinCJKTest implements Printable {
 
-    static PrintLatinCJKTest testInstance = new PrintLatinCJKTest();
-    private PageFormat pf;
+    private static PrintLatinCJKTest testInstance = new PrintLatinCJKTest();
+    private static JFrame frame;
+    private static final String info = """
+            You need a printer for this test. If you have none, let
+            the test pass. If there is a printer, press Print, send
+            the output to the printer, and examine it. It should have
+            text looking like this : \u4e00\u4e01\u4e02\u4e03\u4e04English
 
-    static String info =
-       "To test 8022536, if a remote printer is the system default,"+
-       "it should show in the dialog as the selected printer.\n"+
-       "You need a printer for this test. If you have none, let "+
-       "the test pass. If there is a printer, press Print, send "+
-       "the output to the printer, and examine it. It should have "+
-       "text looking like this : \u4e00\u4e01\u4e02\u4e03\u4e04English.";
+            To test 8022536, if a remote printer is the system default,
+            it should show in the dialog as the selected printer.
+            """;
 
-    public static void showFrame() {
-         JFrame f = new JFrame();
-         JTextArea jta = new JTextArea(info, 4, 30);
-         jta.setLineWrap(true);
-         jta.setWrapStyleWord(true);
-         f.add("Center", jta);
-         JButton b = new JButton("Print");
-         b.addActionListener(testInstance);
-         f.add("South", b);
-         f.pack();
-         f.setVisible(true);
+    public static void showFrame() throws InterruptedException, InvocationTargetException {
+        invokeAndWait( () -> {
+            frame = new JFrame("Test Frame");
+            JButton b = new JButton("Print");
+            b.addActionListener((ae) -> {
+                try {
+                    PrinterJob job = PrinterJob.getPrinterJob();
+                    job.setPrintable(testInstance);
+                    if (job.printDialog()) {
+                        job.print();
+                    }
+                } catch (PrinterException ex) {
+                    ex.printStackTrace();
+                }
+            });
+            frame.getContentPane().add(b, BorderLayout.SOUTH);
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+
+            // add the test frame to dispose
+            PassFailJFrame.addTestFrame(frame);
+
+            // Arrange the test instruction frame and test frame side by side
+            PassFailJFrame.positionTestFrame(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+        });
     }
 
+    @Override
     public int print(Graphics g, PageFormat pf, int pageIndex)
                          throws PrinterException {
-
         if (pageIndex > 0) {
             return Printable.NO_SUCH_PAGE;
         }
@@ -81,24 +98,12 @@ public class PrintLatinCJKTest implements Printable, ActionListener {
         return Printable.PAGE_EXISTS;
     }
 
-    public void actionPerformed(ActionEvent e) {
-        try {
-            PrinterJob job = PrinterJob.getPrinterJob();
-            job.setPrintable(testInstance);
-            if (job.printDialog()) {
-                job.print();
-            }
-        } catch (PrinterException ex) {
-            ex.printStackTrace();
-        }
-    }
-
-    public static void main(String[] args) {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                showFrame();
-            }
-        });
+    public static void main(String[] args) throws InterruptedException, InvocationTargetException {
+        PassFailJFrame passFailJFrame = new PassFailJFrame("Test Instruction" +
+                "Frame", info, 10, 40, 5);
+        showFrame();
+        passFailJFrame.awaitAndCheck();
     }
 }
+
+


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

test/jdk/java/awt/regtesthelpers/PassFailJFrame.java was already backported in JDK-8283803

As this is a pure omit of a file I will mark this as /clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8284535](https://bugs.openjdk.org/browse/JDK-8284535): Fix PrintLatinCJKTest.java test that is failing with Parse Exception
 * [JDK-8283712](https://bugs.openjdk.org/browse/JDK-8283712): Create a manual test framework class


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/618/head:pull/618` \
`$ git checkout pull/618`

Update a local copy of the PR: \
`$ git checkout pull/618` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 618`

View PR using the GUI difftool: \
`$ git pr show -t 618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/618.diff">https://git.openjdk.org/jdk17u-dev/pull/618.diff</a>

</details>
