### PR TITLE
8280944: Enable Unix domain sockets in Windows Selector notification mechanism

### DIFF
--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -33,6 +33,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.StandardSocketOptions;
+import java.net.UnixDomainSocketAddress;
 import java.nio.*;
 import java.nio.channels.*;
 import java.nio.file.Files;
@@ -44,6 +45,7 @@ import java.security.PrivilegedActionException;
 import java.security.SecureRandom;
 import java.util.Random;
 
+import static java.net.StandardProtocolFamily.UNIX;
 
 /**
  * A simple Pipe implementation based on a socket connection.
@@ -67,12 +69,14 @@ class PipeImpl
     {
 
         private final SelectorProvider sp;
+        private final boolean preferUnixDomain;
         private IOException ioe;
         SourceChannelImpl source;
         SinkChannelImpl sink;
 
-        private Initializer(SelectorProvider sp) {
+        private Initializer(SelectorProvider sp, boolean preferUnixDomain) {
             this.sp = sp;
+            this.preferUnixDomain = preferUnixDomain;
         }
 
         @Override
@@ -120,7 +124,7 @@ class PipeImpl
                         // Bind ServerSocketChannel to a port on the loopback
                         // address
                         if (ssc == null || !ssc.isOpen()) {
-                            ssc = createListener();
+                            ssc = createListener(preferUnixDomain);
                             sa = ssc.getLocalAddress();
                         }
 
@@ -162,6 +166,9 @@ class PipeImpl
                     try {
                         if (ssc != null)
                             ssc.close();
+                        if (sa instanceof UnixDomainSocketAddress uaddr) {
+                            Files.deleteIfExists(uaddr.getPath());
+                        }
                     } catch (IOException e2) {}
                 }
             }
@@ -169,21 +176,24 @@ class PipeImpl
     }
 
     /**
-     * Creates a Pipe implementation that supports buffering.
+     * Creates a (TCP) Pipe implementation that supports buffering.
      */
     PipeImpl(SelectorProvider sp) throws IOException {
-        this(sp, true);
+        this(sp, true, false);
     }
 
     /**
-     * Creates Pipe implementation that supports optionally buffering.
+     * Creates Pipe implementation that supports optionally buffering
+     * and is TCP by default, but if Unix domain is supported and
+     * preferAfUnix is true, then Unix domain sockets are used.
      *
-     * @implNote Uses a loopback connection. When buffering is
-     * disabled then it sets TCP_NODELAY on the sink channel.
+     * @param preferAfUnix use Unix domain sockets if supported
+     *
+     * @param buffering if false set TCP_NODELAY on TCP sockets
      */
     @SuppressWarnings("removal")
-    PipeImpl(SelectorProvider sp, boolean buffering) throws IOException {
-        Initializer initializer = new Initializer(sp);
+    PipeImpl(SelectorProvider sp, boolean preferAfUnix, boolean buffering) throws IOException {
+        Initializer initializer = new Initializer(sp, preferAfUnix);
         try {
             AccessController.doPrivileged(initializer);
             SinkChannelImpl sink = initializer.sink;
@@ -205,8 +215,19 @@ class PipeImpl
         return sink;
     }
 
-    private static ServerSocketChannel createListener() throws IOException {
-        ServerSocketChannel listener = ServerSocketChannel.open();
+    private static ServerSocketChannel createListener(boolean preferUnixDomain) throws IOException {
+        ServerSocketChannel listener = null;
+        if (preferUnixDomain && UnixDomainSockets.isSupported()) {
+            try {
+                listener = ServerSocketChannel.open(UNIX);
+                listener.bind(null);
+                return listener;
+            } catch (IOException | UnsupportedOperationException e) {
+                if (listener != null)
+                    listener.close();
+            }
+        }
+        listener = ServerSocketChannel.open();
         InetAddress lb = InetAddress.getLoopbackAddress();
         listener.bind(new InetSocketAddress(lb, 0));
         return listener;

--- a/src/java.base/windows/classes/sun/nio/ch/WEPollSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WEPollSelectorImpl.java
@@ -75,7 +75,7 @@ class WEPollSelectorImpl extends SelectorImpl {
 
         // wakeup support
         try {
-            this.pipe = new PipeImpl(sp, /*buffering*/ false);
+            this.pipe = new PipeImpl(sp, /* AF_UNIX */ true, /*buffering*/ false);
         } catch (IOException ioe) {
             WEPoll.freePollArray(pollArrayAddress);
             WEPoll.close(eph);

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsSelectorImpl.java
@@ -139,7 +139,7 @@ class WindowsSelectorImpl extends SelectorImpl {
     WindowsSelectorImpl(SelectorProvider sp) throws IOException {
         super(sp);
         pollWrapper = new PollArrayWrapper(INIT_CAP);
-        wakeupPipe = new PipeImpl(sp, false);
+        wakeupPipe = new PipeImpl(sp, /* AF_UNIX */ true, /*buffering*/ false);
         wakeupSourceFd = ((SelChImpl)wakeupPipe.source()).getFDVal();
         wakeupSinkFd = ((SelChImpl)wakeupPipe.sink()).getFDVal();
         pollWrapper.addWakeupSocket(wakeupSourceFd, 0);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8280944](https://bugs.openjdk.java.net/browse/JDK-8280944), commit [87ab0994](https://github.com/openjdk/jdk/commit/87ab0994ded3b535a160bb87b6540bd072042c44) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

Since [JDK-8280233](https://bugs.openjdk.org/browse/JDK-8280233) was brought to jdk17u, @dfuch suggested to bring this one along.

The commit being backported was authored by Michael McMahon on 2 Feb 2022 and was reviewed by Daniel Fuchs and Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280944](https://bugs.openjdk.org/browse/JDK-8280944): Enable Unix domain sockets in Windows Selector notification mechanism


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/625/head:pull/625` \
`$ git checkout pull/625`

Update a local copy of the PR: \
`$ git checkout pull/625` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 625`

View PR using the GUI difftool: \
`$ git pr show -t 625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/625.diff">https://git.openjdk.org/jdk17u-dev/pull/625.diff</a>

</details>
