### PR TITLE
8279032: compiler/loopopts/TestSkeletonPredicateNegation.java times out with -XX:TieredStopAtLevel < 4

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestSkeletonPredicateNegation.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSkeletonPredicateNegation.java
@@ -24,6 +24,7 @@
 
 /**
  * @test
+ * @requires vm.compiler2.enabled
  * @bug 8273277
  * @summary Skeleton predicates sometimes need to be negated
  * @run main compiler.loopopts.TestSkeletonPredicateNegation


### PR DESCRIPTION
clean backport

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279032](https://bugs.openjdk.org/browse/JDK-8279032): compiler/loopopts/TestSkeletonPredicateNegation.java times out with -XX:TieredStopAtLevel < 4


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/631/head:pull/631` \
`$ git checkout pull/631`

Update a local copy of the PR: \
`$ git checkout pull/631` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 631`

View PR using the GUI difftool: \
`$ git pr show -t 631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/631.diff">https://git.openjdk.org/jdk17u-dev/pull/631.diff</a>

</details>
