### PR TITLE
Backport 7b029ea6ba1d44d361fdf980816732d8454b8194

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -651,7 +651,6 @@ sun/security/tools/keytool/ListKeychainStore.sh                 8156889 macosx-a
 
 sun/security/tools/jarsigner/warnings/BadKeyUsageTest.java      8026393 generic-all
 
-javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java       8212096 generic-all
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64
 
 sun/security/provider/KeyStore/DKSTest.sh                       8180266 windows-all

--- a/test/jdk/javax/net/ssl/SSLEngine/LargePacket.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/LargePacket.java
@@ -38,6 +38,7 @@
  */
 
 import javax.net.ssl.*;
+import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.net.*;
 
@@ -93,10 +94,10 @@ public class LargePacket extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -136,13 +137,13 @@ public class LargePacket extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // close the socket channel.
         sc.close();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorer.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorer.java
@@ -145,10 +145,10 @@ public class SSLEngineExplorer extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -195,13 +195,13 @@ public class SSLEngineExplorer extends SSLEngineService {
         ssle.setEnabledProtocols(supportedProtocols);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // close the socket channel.
         sc.close();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java
@@ -154,10 +154,10 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -209,13 +209,13 @@ public class SSLEngineExplorerMatchedSNI extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java
@@ -148,10 +148,10 @@ public class SSLEngineExplorerUnmatchedSNI extends SSLEngineService {
 
         try {
             // handshaking
-            handshaking(ssle, sc, buffer);
+            ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
             // receive application data
-            receive(ssle, sc);
+            receive(ssle, sc, peerNetData);
 
             // send out application data
             deliver(ssle, sc);
@@ -213,13 +213,13 @@ public class SSLEngineExplorerUnmatchedSNI extends SSLEngineService {
 
         try {
             // handshaking
-            handshaking(ssle, sc, null);
+            ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
             // send out application data
             deliver(ssle, sc);
 
             // receive application data
-            receive(ssle, sc);
+            receive(ssle, sc, peerNetData);
 
             // check server name indication
             ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java
@@ -136,10 +136,10 @@ public class SSLEngineExplorerWithCli extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -190,13 +190,13 @@ public class SSLEngineExplorerWithCli extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();

--- a/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java
+++ b/test/jdk/javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java
@@ -145,10 +145,10 @@ public class SSLEngineExplorerWithSrv extends SSLEngineService {
         ssle.setSSLParameters(params);
 
         // handshaking
-        handshaking(ssle, sc, buffer);
+        ByteBuffer peerNetData = handshaking(ssle, sc, buffer);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // send out application data
         deliver(ssle, sc);
@@ -193,13 +193,13 @@ public class SSLEngineExplorerWithSrv extends SSLEngineService {
         }
 
         // handshaking
-        handshaking(ssle, sc, null);
+        ByteBuffer peerNetData = handshaking(ssle, sc, null);
 
         // send out application data
         deliver(ssle, sc);
 
         // receive application data
-        receive(ssle, sc);
+        receive(ssle, sc, peerNetData);
 
         // check server name indication
         ExtendedSSLSession session = (ExtendedSSLSession)ssle.getSession();


### PR DESCRIPTION
Clean backport.

On our systems, LargePackage.java fails more than half of the time, and SSLEngineExplorerWithSrv.java fails occassionally. This change seems to stabilize those tests.