### PR TITLE
8288445: AArch64: C2 compilation fails with guarantee(!true || (true && (shift != 0))) failed: impossible encoding

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4295,6 +4295,16 @@ operand immI_65535()
   interface(CONST_INTER);
 %}
 
+operand immI_positive()
+%{
+  predicate(n->get_int() > 0);
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 operand immL_255()
 %{
   predicate(n->get_long() == 255L);

--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -4428,7 +4428,7 @@ instruct vsll16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsra8B_imm(vecD dst, vecD src, immI shift) %{
+instruct vsra8B_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4 ||
             n->as_Vector()->length() == 8);
   match(Set dst (RShiftVB src (RShiftCntV shift)));
@@ -4443,7 +4443,7 @@ instruct vsra8B_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsra16B_imm(vecX dst, vecX src, immI shift) %{
+instruct vsra16B_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 16);
   match(Set dst (RShiftVB src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4457,7 +4457,7 @@ instruct vsra16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrl8B_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrl8B_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4 ||
             n->as_Vector()->length() == 8);
   match(Set dst (URShiftVB src (RShiftCntV shift)));
@@ -4477,7 +4477,7 @@ instruct vsrl8B_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrl16B_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrl16B_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 16);
   match(Set dst (URShiftVB src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4632,7 +4632,7 @@ instruct vsll8S_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsra4S_imm(vecD dst, vecD src, immI shift) %{
+instruct vsra4S_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2 ||
             n->as_Vector()->length() == 4);
   match(Set dst (RShiftVS src (RShiftCntV shift)));
@@ -4647,7 +4647,7 @@ instruct vsra4S_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsra8S_imm(vecX dst, vecX src, immI shift) %{
+instruct vsra8S_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (RShiftVS src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4661,7 +4661,7 @@ instruct vsra8S_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrl4S_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrl4S_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2 ||
             n->as_Vector()->length() == 4);
   match(Set dst (URShiftVS src (RShiftCntV shift)));
@@ -4681,7 +4681,7 @@ instruct vsrl4S_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrl8S_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrl8S_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (URShiftVS src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4820,7 +4820,7 @@ instruct vsll4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsra2I_imm(vecD dst, vecD src, immI shift) %{
+instruct vsra2I_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (RShiftVI src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4833,7 +4833,7 @@ instruct vsra2I_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsra4I_imm(vecX dst, vecX src, immI shift) %{
+instruct vsra4I_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (RShiftVI src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4846,7 +4846,7 @@ instruct vsra4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrl2I_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrl2I_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (URShiftVI src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4859,7 +4859,7 @@ instruct vsrl2I_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrl4I_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrl4I_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (URShiftVI src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4932,7 +4932,7 @@ instruct vsll2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsra2L_imm(vecX dst, vecX src, immI shift) %{
+instruct vsra2L_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (RShiftVL src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4945,7 +4945,7 @@ instruct vsra2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrl2L_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrl2L_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (URShiftVL src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4958,7 +4958,7 @@ instruct vsrl2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsraa8B_imm(vecD dst, vecD src, immI shift) %{
+instruct vsraa8B_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (AddVB dst (RShiftVB src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -4972,7 +4972,7 @@ instruct vsraa8B_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsraa16B_imm(vecX dst, vecX src, immI shift) %{
+instruct vsraa16B_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 16);
   match(Set dst (AddVB dst (RShiftVB src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -4986,7 +4986,7 @@ instruct vsraa16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsraa4S_imm(vecD dst, vecD src, immI shift) %{
+instruct vsraa4S_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (AddVS dst (RShiftVS src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5000,7 +5000,7 @@ instruct vsraa4S_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsraa8S_imm(vecX dst, vecX src, immI shift) %{
+instruct vsraa8S_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (AddVS dst (RShiftVS src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5014,7 +5014,7 @@ instruct vsraa8S_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsraa2I_imm(vecD dst, vecD src, immI shift) %{
+instruct vsraa2I_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (AddVI dst (RShiftVI src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5027,7 +5027,7 @@ instruct vsraa2I_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsraa4I_imm(vecX dst, vecX src, immI shift) %{
+instruct vsraa4I_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (AddVI dst (RShiftVI src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5040,7 +5040,7 @@ instruct vsraa4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsraa2L_imm(vecX dst, vecX src, immI shift) %{
+instruct vsraa2L_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (AddVL dst (RShiftVL src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5053,7 +5053,7 @@ instruct vsraa2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrla8B_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrla8B_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (AddVB dst (URShiftVB src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5068,7 +5068,7 @@ instruct vsrla8B_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrla16B_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrla16B_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 16);
   match(Set dst (AddVB dst (URShiftVB src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5083,7 +5083,7 @@ instruct vsrla16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrla4S_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrla4S_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (AddVS dst (URShiftVS src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5098,7 +5098,7 @@ instruct vsrla4S_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrla8S_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrla8S_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (AddVS dst (URShiftVS src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5113,7 +5113,7 @@ instruct vsrla8S_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrla2I_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrla2I_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (AddVI dst (URShiftVI src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5126,7 +5126,7 @@ instruct vsrla2I_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrla4I_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrla4I_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (AddVI dst (URShiftVI src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5139,7 +5139,7 @@ instruct vsrla4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrla2L_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrla2L_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (AddVL dst (URShiftVL src (RShiftCntV shift))));
   ins_cost(INSN_COST);

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -1992,7 +1992,7 @@ instruct vsll$3$4_imm`'(vec$6 dst, vec$6 src, immI shift) %{
   ins_pipe(vshift`'ifelse($6, D, 64, 128)_imm);
 %}')dnl
 define(`VSRA_IMM', `
-instruct vsra$3$4_imm`'(vec$6 dst, vec$6 src, immI shift) %{
+instruct vsra$3$4_imm`'(vec$6 dst, vec$6 src, immI_positive shift) %{
   predicate(ifelse($3$4, 8B, n->as_Vector()->length() == 4 ||`
             ',
   $3$4, 4S, n->as_Vector()->length() == 2 ||`
@@ -2017,7 +2017,7 @@ instruct vsra$3$4_imm`'(vec$6 dst, vec$6 src, immI shift) %{
 %}')dnl
 dnl
 define(`VSRL_IMM', `
-instruct vsrl$3$4_imm`'(vec$6 dst, vec$6 src, immI shift) %{
+instruct vsrl$3$4_imm`'(vec$6 dst, vec$6 src, immI_positive shift) %{
   predicate(ifelse($3$4, 8B, n->as_Vector()->length() == 4 ||`
             ',
   $3$4, 4S, n->as_Vector()->length() == 2 ||`
@@ -2052,7 +2052,7 @@ instruct vsrl$3$4_imm`'(vec$6 dst, vec$6 src, immI shift) %{
 %}')dnl
 dnl
 define(`VSRLA_IMM', `
-instruct vsrla$3$4_imm`'(vec$6 dst, vec$6 src, immI shift) %{
+instruct vsrla$3$4_imm`'(vec$6 dst, vec$6 src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == $3);
   match(Set dst (AddV$4 dst (URShiftV$4 src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -2076,7 +2076,7 @@ instruct vsrla$3$4_imm`'(vec$6 dst, vec$6 src, immI shift) %{
 %}')dnl
 dnl
 define(`VSRAA_IMM', `
-instruct vsraa$3$4_imm`'(vec$6 dst, vec$6 src, immI shift) %{
+instruct vsraa$3$4_imm`'(vec$6 dst, vec$6 src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == $3);
   match(Set dst (AddV$4 dst (RShiftV$4 src (RShiftCntV shift))));
   ins_cost(INSN_COST);

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288445
+ * @summary Test shift by 0
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ * compiler.codegen.ShiftByZero
+ */
+
+package compiler.codegen;
+
+public class ShiftByZero {
+
+    public static final int N = 64;
+
+    public static int[] i32 = new int[N];
+
+    public static void bMeth() {
+        int shift = i32[0];
+        // This loop is to confuse the optimizer, so that "shift" is
+        // optimized to 0 only after loop vectorization.
+        for (int i8 = 279; i8 > 1; --i8) {
+            shift <<= 6;
+        }
+        // low 6 bits of shift are 0, so shift can be
+        // simplified to constant 0
+        {
+            for (int i = 0; i < N; ++i) {
+                i32[i] += i32[i] >>= shift;
+            }
+            for (int i = 0; i < N; ++i) {
+                i32[i] += i32[i] >>>= shift;
+            }
+            for (int i = 0; i < N; ++i) {
+                i32[i] >>>= shift;
+            }
+            for (int i = 0; i < N; ++i) {
+                i32[i] >>= shift;
+            }
+            for (int i = 0; i < N; ++i) {
+                i32[i] <<= shift;
+            }
+        }
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 20_000; i++) {
+            bMeth();
+        }
+    }
+}


### PR DESCRIPTION
Backport b4490386fe348250e88347526172c1c27ef01eba
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288445](https://bugs.openjdk.org/browse/JDK-8288445): AArch64: C2 compilation fails with guarantee(!true || (true && (shift != 0))) failed: impossible encoding


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/640/head:pull/640` \
`$ git checkout pull/640`

Update a local copy of the PR: \
`$ git checkout pull/640` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 640`

View PR using the GUI difftool: \
`$ git pr show -t 640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/640.diff">https://git.openjdk.org/jdk17u-dev/pull/640.diff</a>

</details>
