### PR TITLE
8284950: CgroupV1 detection code should consider memory.swappiness

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -136,17 +136,37 @@ jlong CgroupV1Subsystem::memory_and_swap_limit_in_bytes() {
       const char* matchline = "hierarchical_memsw_limit";
       const char* format = "%s " JULONG_FORMAT;
       GET_CONTAINER_INFO_LINE(julong, _memory->controller(), "/memory.stat", matchline,
-                             "Hierarchical Memory and Swap Limit is : " JULONG_FORMAT, format, hier_memlimit)
-      if (hier_memlimit >= _unlimited_memory) {
+                             "Hierarchical Memory and Swap Limit is : " JULONG_FORMAT, format, hier_memswlimit)
+      if (hier_memswlimit >= _unlimited_memory) {
         log_trace(os, container)("Hierarchical Memory and Swap Limit is: Unlimited");
       } else {
-        return (jlong)hier_memlimit;
+        jlong swappiness = read_mem_swappiness();
+        if (swappiness == 0) {
+            const char* matchmemline = "hierarchical_memory_limit";
+            GET_CONTAINER_INFO_LINE(julong, _memory->controller(), "/memory.stat", matchmemline,
+                             "Hierarchical Memory Limit is : " JULONG_FORMAT, format, hier_memlimit)
+            log_trace(os, container)("Memory and Swap Limit has been reset to " JULONG_FORMAT " because swappiness is 0", hier_memlimit);
+            return (jlong)hier_memlimit;
+        }
+        return (jlong)hier_memswlimit;
       }
     }
     return (jlong)-1;
   } else {
+    jlong swappiness = read_mem_swappiness();
+    if (swappiness == 0) {
+      jlong memlimit = read_memory_limit_in_bytes();
+      log_trace(os, container)("Memory and Swap Limit has been reset to " JULONG_FORMAT " because swappiness is 0", memlimit);
+      return memlimit;
+    }
     return (jlong)memswlimit;
   }
+}
+
+jlong CgroupV1Subsystem::read_mem_swappiness() {
+  GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.swappiness",
+                     "Swappiness is: " JULONG_FORMAT, JULONG_FORMAT, swappiness);
+  return swappiness;
 }
 
 jlong CgroupV1Subsystem::memory_soft_limit_in_bytes() {

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -108,6 +108,8 @@ class CgroupV1Subsystem: public CgroupSubsystem {
 
     char * pids_max_val();
 
+    jlong read_mem_swappiness();
+
   public:
     CgroupV1Subsystem(CgroupV1Controller* cpuset,
                       CgroupV1Controller* cpu,

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -150,8 +150,9 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
     }
 
     private static boolean getSwapEnabled(CgroupV1MemorySubSystemController controller) {
-         long retval = getLongValue(controller, "memory.memsw.limit_in_bytes");
-         return retval > 0;
+        long memswBytes = getLongValue(controller, "memory.memsw.limit_in_bytes");
+        long swappiness = getLongValue(controller, "memory.swappiness");
+        return (memswBytes > 0 && swappiness > 0);
      }
 
 

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.lib.containers.docker.DockerRunOptions;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.internal.platform.Metrics;
+
+/*
+ * @test
+ * @key cgroups
+ * @requires os.family == "linux"
+ * @modules java.base/jdk.internal.platform
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox PrintContainerInfo CheckOperatingSystemMXBean
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar sun.hotspot.WhiteBox
+ * @run main TestMemoryWithCgroupV1
+ */
+public class TestMemoryWithCgroupV1 {
+
+    private static final String imageName = Common.imageName("memory");
+
+    public static void main(String[] args) throws Exception {
+        // If cgroups is not configured, report success.
+        Metrics metrics = Metrics.systemMetrics();
+        if (metrics == null) {
+            System.out.println("TEST PASSED!!!");
+            return;
+        }
+        if ("cgroupv1".equals(metrics.getProvider())) {
+            if (!DockerTestUtils.canTestDocker()) {
+                return;
+            }
+
+            Common.prepareWhiteBox();
+            DockerTestUtils.buildJdkContainerImage(imageName);
+
+            try {
+                testMemoryLimitWithSwappiness("100M", "150M", "100.00M",
+                        Integer.toString(((int) Math.pow(2, 20)) * 150),
+                        Integer.toString(((int) Math.pow(2, 20)) * 100));
+                testOSBeanSwappinessMemory("200m", "250m", "0", "0");
+            } finally {
+                DockerTestUtils.removeDockerImage(imageName);
+            }
+        } else {
+            System.out.println("Memory swappiness not supported with cgroups v2. Test skipped.");
+        }
+        System.out.println("TEST PASSED!!!");
+    }
+
+    private static void testMemoryLimitWithSwappiness(String dockerMemLimit, String dockerSwapMemLimit,
+            String expectedLimit, String expectedReadLimit, String expectedResetLimit)
+            throws Exception {
+        Common.logNewTestCase("Test print_container_info()");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo").addJavaOpts("-XshowSettings:system");
+        opts.addDockerOpts("--memory", dockerMemLimit, "--memory-swappiness", "0", "--memory-swap", dockerSwapMemLimit);
+        Common.addWhiteBoxOpts(opts);
+
+        OutputAnalyzer out = Common.run(opts);
+        out.shouldContain("Memory and Swap Limit is: " + expectedReadLimit)
+                .shouldContain(
+                        "Memory and Swap Limit has been reset to " + expectedResetLimit + " because swappiness is 0")
+                .shouldContain("Memory & Swap Limit: " + expectedLimit);
+    }
+
+    private static void testOSBeanSwappinessMemory(String memoryAllocation, String swapAllocation,
+            String swappiness, String expectedSwap) throws Exception {
+        Common.logNewTestCase("Check OperatingSystemMXBean");
+        DockerRunOptions opts = Common.newOpts(imageName, "CheckOperatingSystemMXBean")
+                .addDockerOpts(
+                        "--memory", memoryAllocation,
+                        "--memory-swappiness", swappiness,
+                        "--memory-swap", swapAllocation)
+                // CheckOperatingSystemMXBean uses Metrics (jdk.internal.platform) for
+                // diagnostics
+                .addJavaOpts("--add-exports")
+                .addJavaOpts("java.base/jdk.internal.platform=ALL-UNNAMED");
+        OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
+        // in case of warnings like : "Your kernel does not support swap limit
+        // capabilities or the cgroup is not mounted. Memory limited without swap."
+        // the getTotalSwapSpaceSize and getFreeSwapSpaceSize return the system
+        // values as the container setup isn't supported in that case.
+        try {
+            out.shouldContain("OperatingSystemMXBean.getTotalSwapSpaceSize: " + expectedSwap);
+        } catch (RuntimeException ex) {
+            out.shouldMatch("OperatingSystemMXBean.getTotalSwapSpaceSize: [0-9]+");
+        }
+    }
+
+}


### PR DESCRIPTION
Backport 46d208fb1ce9a3d45bee2afda824f15c84a5e4d2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284950](https://bugs.openjdk.org/browse/JDK-8284950): CgroupV1 detection code should consider memory.swappiness


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/641/head:pull/641` \
`$ git checkout pull/641`

Update a local copy of the PR: \
`$ git checkout pull/641` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 641`

View PR using the GUI difftool: \
`$ git pr show -t 641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/641.diff">https://git.openjdk.org/jdk17u-dev/pull/641.diff</a>

</details>
