### PR TITLE
8282528: AArch64: Incorrect replicate2L_zero rule

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -3103,16 +3103,14 @@ instruct replicate2L(vecX dst, iRegL src)
   ins_pipe(vdup_reg_reg128);
 %}
 
-instruct replicate2L_zero(vecX dst, immI0 zero)
+instruct replicate2L_imm(vecX dst, immL con)
 %{
   predicate(UseSVE == 0 && n->as_Vector()->length() == 2);
-  match(Set dst (ReplicateI zero));
+  match(Set dst (ReplicateL con));
   ins_cost(INSN_COST);
-  format %{ "movi  $dst, $zero\t# vector (4I)" %}
+  format %{ "movi  $dst, $con\t# vector (2L)" %}
   ins_encode %{
-    __ eor(as_FloatRegister($dst$$reg), __ T16B,
-           as_FloatRegister($dst$$reg),
-           as_FloatRegister($dst$$reg));
+    __ mov(as_FloatRegister($dst$$reg), __ T2D, $con$$constant);
   %}
   ins_pipe(vmovi_reg_imm128);
 %}
@@ -3124,8 +3122,7 @@ instruct replicate2F(vecD dst, vRegF src)
   ins_cost(INSN_COST);
   format %{ "dup  $dst, $src\t# vector (2F)" %}
   ins_encode %{
-    __ dup(as_FloatRegister($dst$$reg), __ T2S,
-           as_FloatRegister($src$$reg));
+    __ dup(as_FloatRegister($dst$$reg), __ T2S, as_FloatRegister($src$$reg));
   %}
   ins_pipe(vdup_reg_freg64);
 %}
@@ -3137,8 +3134,7 @@ instruct replicate4F(vecX dst, vRegF src)
   ins_cost(INSN_COST);
   format %{ "dup  $dst, $src\t# vector (4F)" %}
   ins_encode %{
-    __ dup(as_FloatRegister($dst$$reg), __ T4S,
-           as_FloatRegister($src$$reg));
+    __ dup(as_FloatRegister($dst$$reg), __ T4S, as_FloatRegister($src$$reg));
   %}
   ins_pipe(vdup_reg_freg128);
 %}
@@ -3150,8 +3146,7 @@ instruct replicate2D(vecX dst, vRegD src)
   ins_cost(INSN_COST);
   format %{ "dup  $dst, $src\t# vector (2D)" %}
   ins_encode %{
-    __ dup(as_FloatRegister($dst$$reg), __ T2D,
-           as_FloatRegister($src$$reg));
+    __ dup(as_FloatRegister($dst$$reg), __ T2D, as_FloatRegister($src$$reg));
   %}
   ins_pipe(vdup_reg_dreg128);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -1463,55 +1463,54 @@ VFABD(fabd, fabd, 2, F, D, S, 64)
 VFABD(fabd, fabd, 4, F, X, S, 128)
 VFABD(fabd, fabd, 2, D, X, D, 128)
 dnl
-define(`VREPLICATE', `
-instruct replicate$3$4$5`'(vec$6 dst, $7 ifelse($7, immI0, zero, $7, immI, con, src))
+define(`VREPLICATE_REG', `
+instruct replicate$2$3`'(vec$4 dst, $5 src)
 %{
-  predicate(ifelse($8, UseSVE == 0 && , $8,
-                   $8, , , $8`
-            ')n->as_Vector()->length() == $3);
-  match(Set dst (Replicate`'ifelse($7, immI0, I, $4) ifelse($7, immI0, zero, $7, immI, con, $7, zero, I, src)));
+  predicate(ifelse($7, UseSVE == 0 && , $7,
+                   $7, , , $7`
+            ')n->as_Vector()->length() == $2);
+  match(Set dst (Replicate$3 src));
   ins_cost(INSN_COST);
-  format %{ "$1  $dst, $ifelse($7, immI0, zero, $7, immI, con, src)`\t# vector ('ifelse($4$7, SimmI, $3H, $2, eor, 4I, $3$4)`)"' %}
+  format %{ "dup  $dst, $src\t# vector ($2$3)" %}
   ins_encode %{
-    __ $2(as_FloatRegister($dst$$reg), __ ifelse(
-            $2, eor, T16B, T$3`'$9),ifelse(
-            `$4 $7', `B immI', ` '$con$$constant & 0xff,
-            `$4 $7', `S immI', ` '$con$$constant & 0xffff,
-            `$4 $7', `I immI', ` '$con$$constant,
-            `$2', eor,`
-           as_FloatRegister($dst$$reg),
-           as_FloatRegister($dst$$reg)',
-            `$7', vRegF,`
-           as_FloatRegister($src$$reg)',
-            `$7', vRegD,`
-           as_FloatRegister($src$$reg)',
-           ` 'as_Register($src$$reg)));
+    __ dup(as_FloatRegister($dst$$reg), __ T$2$1, $6($src$$reg));
   %}
-  ins_pipe(ifelse($7, immI0, v$1_reg_imm,
-                  $7, immI,  v$1_reg_imm,
-                  $7, iRegIorL2I, v$1_reg_reg,
-                  $7, zero, vmovi_reg_imm,
-                  $7, iRegL, vdup_reg_reg,
-                  $4, F, vdup_reg_freg, vdup_reg_dreg)`'ifelse($6, X, 128, 64));
+  ins_pipe(ifelse($5, iRegIorL2I, vdup_reg_reg,
+                  $5, iRegL, vdup_reg_reg,
+                  $3, F, vdup_reg_freg, vdup_reg_dreg)`'ifelse($4, X, 128, 64));
 %}')dnl
-dnl        $1    $2    $3  $4 $5     $6 $7          $8                                $9
-VREPLICATE(dup,  dup,  8,  B, ,      D, iRegIorL2I, n->as_Vector()->length() == 4 ||, B)
-VREPLICATE(dup,  dup,  16, B, ,      X, iRegIorL2I, UseSVE == 0 && ,                  B)
-VREPLICATE(movi, mov,  8,  B, _imm,  D, immI,       n->as_Vector()->length() == 4 ||, B)
-VREPLICATE(movi, mov,  16, B, _imm,  X, immI,       UseSVE == 0 && ,                  B)
-VREPLICATE(dup,  dup,  4,  S, ,      D, iRegIorL2I, n->as_Vector()->length() == 2 ||, H)
-VREPLICATE(dup,  dup,  8,  S, ,      X, iRegIorL2I, UseSVE == 0 && ,                  H)
-VREPLICATE(movi, mov,  4,  S, _imm,  D, immI,       n->as_Vector()->length() == 2 ||, H)
-VREPLICATE(movi, mov,  8,  S,  _imm, X, immI,       UseSVE == 0 && ,                  H)
-VREPLICATE(dup,  dup,  2,  I, ,      D, iRegIorL2I, ,                                 S)
-VREPLICATE(dup,  dup,  4,  I, ,      X, iRegIorL2I, UseSVE == 0 && ,                  S)
-VREPLICATE(movi, mov,  2,  I, _imm,  D, immI,       ,                                 S)
-VREPLICATE(movi, mov,  4,  I,  _imm, X, immI,       UseSVE == 0 && ,                  S)
-VREPLICATE(dup,  dup,  2,  L, ,      X, iRegL,      UseSVE == 0 && ,                  D)
-VREPLICATE(movi, eor,  2,  L, _zero, X, immI0,      UseSVE == 0 && ,                  D)
-VREPLICATE(dup,  dup,  2,  F, ,      D, vRegF,      ,                                 S)
-VREPLICATE(dup,  dup,  4,  F, ,      X, vRegF,      UseSVE == 0 && ,                  S)
-VREPLICATE(dup,  dup,  2,  D, ,      X, vRegD,      UseSVE == 0 && ,                  D)
+define(`VREPLICATE_IMM', `
+instruct replicate$2$3_imm`'(vec$4 dst, $5 con)
+%{
+  predicate(ifelse($7, UseSVE == 0 && , $7,
+                   $7, , , $7`
+            ')n->as_Vector()->length() == $2);
+  match(Set dst (Replicate$3 con));
+  ins_cost(INSN_COST);
+  format %{ "movi  $dst, $con\t`#' vector ($2`'ifelse($3, S, H, $3))" %}
+  ins_encode %{
+    __ mov(as_FloatRegister($dst$$reg), __ T$2`'iTYPE2SIMD($3), $con$$constant`'$6);
+  %}
+  ins_pipe(vmovi_reg_imm`'ifelse($4, X, 128, 64));
+%}')dnl
+dnl            $1 $2  $3 $4 $5          $6                $7
+VREPLICATE_REG(B, 8,  B, D, iRegIorL2I, as_Register,      n->as_Vector()->length() == 4 ||)
+VREPLICATE_REG(B, 16, B, X, iRegIorL2I, as_Register,      UseSVE == 0 && )
+VREPLICATE_IMM(B, 8,  B, D, immI,       ` & 0xff',        n->as_Vector()->length() == 4 ||)
+VREPLICATE_IMM(B, 16, B, X, immI,       ` & 0xff',        UseSVE == 0 && )
+VREPLICATE_REG(H, 4,  S, D, iRegIorL2I, as_Register,      n->as_Vector()->length() == 2 ||)
+VREPLICATE_REG(H, 8,  S, X, iRegIorL2I, as_Register,      UseSVE == 0 && )
+VREPLICATE_IMM(H, 4,  S, D, immI,       ` & 0xffff',      n->as_Vector()->length() == 2 ||)
+VREPLICATE_IMM(H, 8,  S, X, immI,       ` & 0xffff',      UseSVE == 0 && )
+VREPLICATE_REG(S, 2,  I, D, iRegIorL2I, as_Register,      )
+VREPLICATE_REG(S, 4,  I, X, iRegIorL2I, as_Register,      UseSVE == 0 && )
+VREPLICATE_IMM(S, 2,  I, D, immI,       ,                 )
+VREPLICATE_IMM(S, 4,  I, X, immI,       ,                 UseSVE == 0 && )
+VREPLICATE_REG(D, 2,  L, X, iRegL,      as_Register,      UseSVE == 0 && )
+VREPLICATE_IMM(D, 2,  L, X, immL,       ,                 UseSVE == 0 && )
+VREPLICATE_REG(S, 2,  F, D, vRegF,      as_FloatRegister, )
+VREPLICATE_REG(S, 4,  F, X, vRegF,      as_FloatRegister, UseSVE == 0 && )
+VREPLICATE_REG(D, 2,  D, X, vRegD,      as_FloatRegister, UseSVE == 0 && )
 dnl
 
 // ====================REDUCTION ARITHMETIC====================================

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020 Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -311,6 +311,53 @@ bool Assembler::operand_valid_for_add_sub_immediate(int64_t imm) {
 
 bool Assembler::operand_valid_for_logical_immediate(bool is32, uint64_t imm) {
   return encode_logical_immediate(is32, imm) != 0xffffffff;
+}
+
+// Check immediate encoding for movi.
+// Return the shift amount which can be {0, 8, 16, 24} for B/H/S types. As the D type
+// movi does not have shift variant, in this case the return value is the immediate
+// after encoding.
+// Return -1 if the input imm64 can not be encoded.
+int Assembler::operand_valid_for_movi_immediate(uint64_t imm64, SIMD_Arrangement T) {
+  if (T == T1D || T == T2D) {
+     // To encode into movi, the 64-bit imm must be in the form of
+     // 'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffgggggggghhhhhhhh'
+     // and encoded in "a:b:c:d:e:f:g:h".
+     uint64_t tmp = imm64;
+     uint64_t one_byte = 0;
+     for (int i = 0; i < 8; i++) {
+       one_byte = tmp & 0xffULL;
+       if (one_byte != 0xffULL && one_byte != 0) {
+         return -1; // can not be encoded
+       }
+       tmp = tmp >> 8;
+     }
+
+     imm64 &= 0x0101010101010101ULL;
+     imm64 |= (imm64 >> 7);
+     imm64 |= (imm64 >> 14);
+     imm64 |= (imm64 >> 28);
+
+     return imm64 & 0xff;
+  }
+
+  uint32_t imm32 = imm64 & 0xffffffffULL;
+  if (T == T8B || T == T16B) {       // 8-bit variant
+    if (0 == (imm32 & ~0xff))        return 0;
+  } else if(T == T4H || T == T8H) {  // 16-bit variant
+    if (0 == (imm32 & ~0xff))        return 0;
+    if (0 == (imm32 & ~0xff00))      return 8;
+  } else if (T == T2S || T == T4S) { // 32-bit variant
+    if (0 == (imm32 & ~0xff))        return 0;
+    if (0 == (imm32 & ~0xff00))      return 8;
+    if (0 == (imm32 & ~0xff0000))    return 16;
+    if (0 == (imm32 & ~0xff000000))  return 24;
+  } else {
+    assert(false, "unsupported");
+    ShouldNotReachHere();
+  }
+
+  return -1;
 }
 
 static uint64_t doubleTo64Bits(jdouble d) {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -3254,6 +3254,7 @@ public:
   static bool operand_valid_for_logical_immediate(bool is32, uint64_t imm);
   static bool operand_valid_for_add_sub_immediate(int64_t imm);
   static bool operand_valid_for_float_immediate(double imm);
+  static int  operand_valid_for_movi_immediate(uint64_t imm64, SIMD_Arrangement T);
 
   void emit_data64(jlong data, relocInfo::relocType rtype, int format = 0);
   void emit_data64(jlong data, RelocationHolder const& rspec, int format = 0);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1509,48 +1509,43 @@ void MacroAssembler::movptr(Register r, uintptr_t imm64) {
 }
 
 // Macro to mov replicated immediate to vector register.
-//  Vd will get the following values for different arrangements in T
-//   imm32 == hex 000000gh  T8B:  Vd = ghghghghghghghgh
-//   imm32 == hex 000000gh  T16B: Vd = ghghghghghghghghghghghghghghghgh
-//   imm32 == hex 0000efgh  T4H:  Vd = efghefghefghefgh
-//   imm32 == hex 0000efgh  T8H:  Vd = efghefghefghefghefghefghefghefgh
-//   imm32 == hex abcdefgh  T2S:  Vd = abcdefghabcdefgh
-//   imm32 == hex abcdefgh  T4S:  Vd = abcdefghabcdefghabcdefghabcdefgh
-//   T1D/T2D: invalid
-void MacroAssembler::mov(FloatRegister Vd, SIMD_Arrangement T, uint32_t imm32) {
-  assert(T != T1D && T != T2D, "invalid arrangement");
-  if (T == T8B || T == T16B) {
-    assert((imm32 & ~0xff) == 0, "extraneous bits in unsigned imm32 (T8B/T16B)");
-    movi(Vd, T, imm32 & 0xff, 0);
+// imm64: only the lower 8/16/32 bits are considered for B/H/S type. That is,
+//        the upper 56/48/32 bits must be zeros for B/H/S type.
+// Vd will get the following values for different arrangements in T
+//   imm64 == hex 000000gh  T8B:  Vd = ghghghghghghghgh
+//   imm64 == hex 000000gh  T16B: Vd = ghghghghghghghghghghghghghghghgh
+//   imm64 == hex 0000efgh  T4H:  Vd = efghefghefghefgh
+//   imm64 == hex 0000efgh  T8H:  Vd = efghefghefghefghefghefghefghefgh
+//   imm64 == hex abcdefgh  T2S:  Vd = abcdefghabcdefgh
+//   imm64 == hex abcdefgh  T4S:  Vd = abcdefghabcdefghabcdefghabcdefgh
+//   imm64 == hex abcdefgh  T1D:  Vd = 00000000abcdefgh
+//   imm64 == hex abcdefgh  T2D:  Vd = 00000000abcdefgh00000000abcdefgh
+// Clobbers rscratch1
+void MacroAssembler::mov(FloatRegister Vd, SIMD_Arrangement T, uint64_t imm64) {
+  assert(T != T1Q, "unsupported");
+  if (T == T1D || T == T2D) {
+    int imm = operand_valid_for_movi_immediate(imm64, T);
+    if (-1 != imm) {
+      movi(Vd, T, imm);
+    } else {
+      mov(rscratch1, imm64);
+      dup(Vd, T, rscratch1);
+    }
     return;
   }
-  uint32_t nimm32 = ~imm32;
-  if (T == T4H || T == T8H) {
-    assert((imm32  & ~0xffff) == 0, "extraneous bits in unsigned imm32 (T4H/T8H)");
-    imm32 &= 0xffff;
-    nimm32 &= 0xffff;
-  }
-  uint32_t x = imm32;
-  int movi_cnt = 0;
-  int movn_cnt = 0;
-  while (x) { if (x & 0xff) movi_cnt++; x >>= 8; }
-  x = nimm32;
-  while (x) { if (x & 0xff) movn_cnt++; x >>= 8; }
-  if (movn_cnt < movi_cnt) imm32 = nimm32;
-  unsigned lsl = 0;
-  while (imm32 && (imm32 & 0xff) == 0) { lsl += 8; imm32 >>= 8; }
-  if (movn_cnt < movi_cnt)
-    mvni(Vd, T, imm32 & 0xff, lsl);
-  else
-    movi(Vd, T, imm32 & 0xff, lsl);
-  imm32 >>= 8; lsl += 8;
-  while (imm32) {
-    while ((imm32 & 0xff) == 0) { lsl += 8; imm32 >>= 8; }
-    if (movn_cnt < movi_cnt)
-      bici(Vd, T, imm32 & 0xff, lsl);
-    else
-      orri(Vd, T, imm32 & 0xff, lsl);
-    lsl += 8; imm32 >>= 8;
+
+#ifdef ASSERT
+  if (T == T8B || T == T16B) assert((imm64 & ~0xff) == 0, "extraneous bits (T8B/T16B)");
+  if (T == T4H || T == T8H) assert((imm64  & ~0xffff) == 0, "extraneous bits (T4H/T8H)");
+  if (T == T2S || T == T4S) assert((imm64  & ~0xffffffff) == 0, "extraneous bits (T2S/T4S)");
+#endif
+  int shift = operand_valid_for_movi_immediate(imm64, T);
+  uint32_t imm32 = imm64 & 0xffffffffULL;
+  if (shift >= 0) {
+    movi(Vd, T, (imm32 >> shift) & 0xff, shift);
+  } else {
+    movw(rscratch1, imm32);
+    dup(Vd, T, rscratch1);
   }
 }
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -525,7 +525,7 @@ public:
 
   void movptr(Register r, uintptr_t imm64);
 
-  void mov(FloatRegister Vd, SIMD_Arrangement T, uint32_t imm32);
+  void mov(FloatRegister Vd, SIMD_Arrangement T, uint64_t imm64);
 
   void mov(FloatRegister Vd, SIMD_Arrangement T, FloatRegister Vn) {
     orr(Vd, T, Vn, Vn);

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorReplicateLongSpecialImmTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorReplicateLongSpecialImmTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorSpecies;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * @test
+ * @bug 8282528
+ * @summary AArch64: Incorrect replicate2L_zero rule
+ * @library /test/lib
+ * @requires os.arch == "aarch64"
+ * @modules jdk.incubator.vector
+ * @run testng/othervm -XX:UseSVE=0 -XX:-TieredCompilation -XX:CompileThreshold=100 compiler.vectorapi.VectorReplicateLongSpecialImmTest
+ */
+public class VectorReplicateLongSpecialImmTest {
+
+    private static final VectorSpecies<Long> lspec = LongVector.SPECIES_128;
+    private static final int INVOC_COUNT = 1000;
+
+    private static void assertEquals(LongVector lv, long expected) {
+        Assert.assertEquals(lv.lane(0), expected);
+        Assert.assertEquals(lv.lane(1), expected);
+    }
+
+    @Test
+    public void testReplicateL_Imm() {
+        for (int ic = 0; ic < INVOC_COUNT * INVOC_COUNT; ic++) {
+            // On AArch64 ReplicateL will generate movi, which requires the 64-bit
+            // imm must be in the form of
+            // 'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeeeffffffffgggggggghhhhhhhh'
+            assertEquals(LongVector.broadcast(lspec, 0x0000000000000000L), 0x0000000000000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000000000FFL), 0x00000000000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000000000FF00L), 0x000000000000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000000000FFFFL), 0x000000000000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000000000FF0000L), 0x0000000000FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000000000FF00FFL), 0x0000000000FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000000000FFFF00L), 0x0000000000FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000000000FFFFFFL), 0x0000000000FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000FF000000L), 0x00000000FF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000FF0000FFL), 0x00000000FF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000FF00FF00L), 0x00000000FF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000FF00FFFFL), 0x00000000FF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000FFFF0000L), 0x00000000FFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000FFFF00FFL), 0x00000000FFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000FFFFFF00L), 0x00000000FFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00000000FFFFFFFFL), 0x00000000FFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FF00000000L), 0x000000FF00000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FF000000FFL), 0x000000FF000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FF0000FF00L), 0x000000FF0000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FF0000FFFFL), 0x000000FF0000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FF00FF0000L), 0x000000FF00FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FF00FF00FFL), 0x000000FF00FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FF00FFFF00L), 0x000000FF00FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FF00FFFFFFL), 0x000000FF00FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FFFF000000L), 0x000000FFFF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FFFF0000FFL), 0x000000FFFF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FFFF00FF00L), 0x000000FFFF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FFFF00FFFFL), 0x000000FFFF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FFFFFF0000L), 0x000000FFFFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FFFFFF00FFL), 0x000000FFFFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FFFFFFFF00L), 0x000000FFFFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x000000FFFFFFFFFFL), 0x000000FFFFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF0000000000L), 0x0000FF0000000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00000000FFL), 0x0000FF00000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF000000FF00L), 0x0000FF000000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF000000FFFFL), 0x0000FF000000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF0000FF0000L), 0x0000FF0000FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF0000FF00FFL), 0x0000FF0000FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF0000FFFF00L), 0x0000FF0000FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF0000FFFFFFL), 0x0000FF0000FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00FF000000L), 0x0000FF00FF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00FF0000FFL), 0x0000FF00FF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00FF00FF00L), 0x0000FF00FF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00FF00FFFFL), 0x0000FF00FF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00FFFF0000L), 0x0000FF00FFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00FFFF00FFL), 0x0000FF00FFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00FFFFFF00L), 0x0000FF00FFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FF00FFFFFFFFL), 0x0000FF00FFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFF00000000L), 0x0000FFFF00000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFF000000FFL), 0x0000FFFF000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFF0000FF00L), 0x0000FFFF0000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFF0000FFFFL), 0x0000FFFF0000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFF00FF0000L), 0x0000FFFF00FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFF00FF00FFL), 0x0000FFFF00FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFF00FFFF00L), 0x0000FFFF00FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFF00FFFFFFL), 0x0000FFFF00FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFFFF000000L), 0x0000FFFFFF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFFFF0000FFL), 0x0000FFFFFF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFFFF00FF00L), 0x0000FFFFFF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFFFF00FFFFL), 0x0000FFFFFF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFFFFFF0000L), 0x0000FFFFFFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFFFFFF00FFL), 0x0000FFFFFFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFFFFFFFF00L), 0x0000FFFFFFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x0000FFFFFFFFFFFFL), 0x0000FFFFFFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF000000000000L), 0x00FF000000000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000000000FFL), 0x00FF0000000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00000000FF00L), 0x00FF00000000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00000000FFFFL), 0x00FF00000000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF000000FF0000L), 0x00FF000000FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF000000FF00FFL), 0x00FF000000FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF000000FFFF00L), 0x00FF000000FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF000000FFFFFFL), 0x00FF000000FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000FF000000L), 0x00FF0000FF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000FF0000FFL), 0x00FF0000FF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000FF00FF00L), 0x00FF0000FF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000FF00FFFFL), 0x00FF0000FF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000FFFF0000L), 0x00FF0000FFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000FFFF00FFL), 0x00FF0000FFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000FFFFFF00L), 0x00FF0000FFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF0000FFFFFFFFL), 0x00FF0000FFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FF00000000L), 0x00FF00FF00000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FF000000FFL), 0x00FF00FF000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FF0000FF00L), 0x00FF00FF0000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FF0000FFFFL), 0x00FF00FF0000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FF00FF0000L), 0x00FF00FF00FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FF00FF00FFL), 0x00FF00FF00FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FF00FFFF00L), 0x00FF00FF00FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FF00FFFFFFL), 0x00FF00FF00FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FFFF000000L), 0x00FF00FFFF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FFFF0000FFL), 0x00FF00FFFF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FFFF00FF00L), 0x00FF00FFFF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FFFF00FFFFL), 0x00FF00FFFF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FFFFFF0000L), 0x00FF00FFFFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FFFFFF00FFL), 0x00FF00FFFFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FFFFFFFF00L), 0x00FF00FFFFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FF00FFFFFFFFFFL), 0x00FF00FFFFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF0000000000L), 0x00FFFF0000000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00000000FFL), 0x00FFFF00000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF000000FF00L), 0x00FFFF000000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF000000FFFFL), 0x00FFFF000000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF0000FF0000L), 0x00FFFF0000FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF0000FF00FFL), 0x00FFFF0000FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF0000FFFF00L), 0x00FFFF0000FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF0000FFFFFFL), 0x00FFFF0000FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00FF000000L), 0x00FFFF00FF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00FF0000FFL), 0x00FFFF00FF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00FF00FF00L), 0x00FFFF00FF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00FF00FFFFL), 0x00FFFF00FF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00FFFF0000L), 0x00FFFF00FFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00FFFF00FFL), 0x00FFFF00FFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00FFFFFF00L), 0x00FFFF00FFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFF00FFFFFFFFL), 0x00FFFF00FFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFF00000000L), 0x00FFFFFF00000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFF000000FFL), 0x00FFFFFF000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFF0000FF00L), 0x00FFFFFF0000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFF0000FFFFL), 0x00FFFFFF0000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFF00FF0000L), 0x00FFFFFF00FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFF00FF00FFL), 0x00FFFFFF00FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFF00FFFF00L), 0x00FFFFFF00FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFF00FFFFFFL), 0x00FFFFFF00FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFFFF000000L), 0x00FFFFFFFF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFFFF0000FFL), 0x00FFFFFFFF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFFFF00FF00L), 0x00FFFFFFFF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFFFF00FFFFL), 0x00FFFFFFFF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFFFFFF0000L), 0x00FFFFFFFFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFFFFFF00FFL), 0x00FFFFFFFFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFFFFFFFF00L), 0x00FFFFFFFFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0x00FFFFFFFFFFFFFFL), 0x00FFFFFFFFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00000000000000L), 0xFF00000000000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000000000FFL), 0xFF000000000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000000000FF00L), 0xFF0000000000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000000000FFFFL), 0xFF0000000000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00000000FF0000L), 0xFF00000000FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00000000FF00FFL), 0xFF00000000FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00000000FFFF00L), 0xFF00000000FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00000000FFFFFFL), 0xFF00000000FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000FF000000L), 0xFF000000FF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000FF0000FFL), 0xFF000000FF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000FF00FF00L), 0xFF000000FF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000FF00FFFFL), 0xFF000000FF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000FFFF0000L), 0xFF000000FFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000FFFF00FFL), 0xFF000000FFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000FFFFFF00L), 0xFF000000FFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF000000FFFFFFFFL), 0xFF000000FFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FF00000000L), 0xFF0000FF00000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FF000000FFL), 0xFF0000FF000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FF0000FF00L), 0xFF0000FF0000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FF0000FFFFL), 0xFF0000FF0000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FF00FF0000L), 0xFF0000FF00FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FF00FF00FFL), 0xFF0000FF00FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FF00FFFF00L), 0xFF0000FF00FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FF00FFFFFFL), 0xFF0000FF00FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FFFF000000L), 0xFF0000FFFF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FFFF0000FFL), 0xFF0000FFFF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FFFF00FF00L), 0xFF0000FFFF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FFFF00FFFFL), 0xFF0000FFFF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FFFFFF0000L), 0xFF0000FFFFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FFFFFF00FFL), 0xFF0000FFFFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FFFFFFFF00L), 0xFF0000FFFFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF0000FFFFFFFFFFL), 0xFF0000FFFFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF0000000000L), 0xFF00FF0000000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00000000FFL), 0xFF00FF00000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF000000FF00L), 0xFF00FF000000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF000000FFFFL), 0xFF00FF000000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF0000FF0000L), 0xFF00FF0000FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF0000FF00FFL), 0xFF00FF0000FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF0000FFFF00L), 0xFF00FF0000FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF0000FFFFFFL), 0xFF00FF0000FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00FF000000L), 0xFF00FF00FF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00FF0000FFL), 0xFF00FF00FF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00FF00FF00L), 0xFF00FF00FF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00FF00FFFFL), 0xFF00FF00FF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00FFFF0000L), 0xFF00FF00FFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00FFFF00FFL), 0xFF00FF00FFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00FFFFFF00L), 0xFF00FF00FFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FF00FFFFFFFFL), 0xFF00FF00FFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFF00000000L), 0xFF00FFFF00000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFF000000FFL), 0xFF00FFFF000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFF0000FF00L), 0xFF00FFFF0000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFF0000FFFFL), 0xFF00FFFF0000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFF00FF0000L), 0xFF00FFFF00FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFF00FF00FFL), 0xFF00FFFF00FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFF00FFFF00L), 0xFF00FFFF00FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFF00FFFFFFL), 0xFF00FFFF00FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFFFF000000L), 0xFF00FFFFFF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFFFF0000FFL), 0xFF00FFFFFF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFFFF00FF00L), 0xFF00FFFFFF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFFFF00FFFFL), 0xFF00FFFFFF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFFFFFF0000L), 0xFF00FFFFFFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFFFFFF00FFL), 0xFF00FFFFFFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFFFFFFFF00L), 0xFF00FFFFFFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFF00FFFFFFFFFFFFL), 0xFF00FFFFFFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF000000000000L), 0xFFFF000000000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000000000FFL), 0xFFFF0000000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00000000FF00L), 0xFFFF00000000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00000000FFFFL), 0xFFFF00000000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF000000FF0000L), 0xFFFF000000FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF000000FF00FFL), 0xFFFF000000FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF000000FFFF00L), 0xFFFF000000FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF000000FFFFFFL), 0xFFFF000000FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000FF000000L), 0xFFFF0000FF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000FF0000FFL), 0xFFFF0000FF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000FF00FF00L), 0xFFFF0000FF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000FF00FFFFL), 0xFFFF0000FF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000FFFF0000L), 0xFFFF0000FFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000FFFF00FFL), 0xFFFF0000FFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000FFFFFF00L), 0xFFFF0000FFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF0000FFFFFFFFL), 0xFFFF0000FFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FF00000000L), 0xFFFF00FF00000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FF000000FFL), 0xFFFF00FF000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FF0000FF00L), 0xFFFF00FF0000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FF0000FFFFL), 0xFFFF00FF0000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FF00FF0000L), 0xFFFF00FF00FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FF00FF00FFL), 0xFFFF00FF00FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FF00FFFF00L), 0xFFFF00FF00FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FF00FFFFFFL), 0xFFFF00FF00FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FFFF000000L), 0xFFFF00FFFF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FFFF0000FFL), 0xFFFF00FFFF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FFFF00FF00L), 0xFFFF00FFFF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FFFF00FFFFL), 0xFFFF00FFFF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FFFFFF0000L), 0xFFFF00FFFFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FFFFFF00FFL), 0xFFFF00FFFFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FFFFFFFF00L), 0xFFFF00FFFFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFF00FFFFFFFFFFL), 0xFFFF00FFFFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF0000000000L), 0xFFFFFF0000000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00000000FFL), 0xFFFFFF00000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF000000FF00L), 0xFFFFFF000000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF000000FFFFL), 0xFFFFFF000000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF0000FF0000L), 0xFFFFFF0000FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF0000FF00FFL), 0xFFFFFF0000FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF0000FFFF00L), 0xFFFFFF0000FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF0000FFFFFFL), 0xFFFFFF0000FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00FF000000L), 0xFFFFFF00FF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00FF0000FFL), 0xFFFFFF00FF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00FF00FF00L), 0xFFFFFF00FF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00FF00FFFFL), 0xFFFFFF00FF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00FFFF0000L), 0xFFFFFF00FFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00FFFF00FFL), 0xFFFFFF00FFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00FFFFFF00L), 0xFFFFFF00FFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFF00FFFFFFFFL), 0xFFFFFF00FFFFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFF00000000L), 0xFFFFFFFF00000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFF000000FFL), 0xFFFFFFFF000000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFF0000FF00L), 0xFFFFFFFF0000FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFF0000FFFFL), 0xFFFFFFFF0000FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFF00FF0000L), 0xFFFFFFFF00FF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFF00FF00FFL), 0xFFFFFFFF00FF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFF00FFFF00L), 0xFFFFFFFF00FFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFF00FFFFFFL), 0xFFFFFFFF00FFFFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFFFF000000L), 0xFFFFFFFFFF000000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFFFF0000FFL), 0xFFFFFFFFFF0000FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFFFF00FF00L), 0xFFFFFFFFFF00FF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFFFF00FFFFL), 0xFFFFFFFFFF00FFFFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFFFFFF0000L), 0xFFFFFFFFFFFF0000L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFFFFFF00FFL), 0xFFFFFFFFFFFF00FFL);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFFFFFFFF00L), 0xFFFFFFFFFFFFFF00L);
+            assertEquals(LongVector.broadcast(lspec, 0xFFFFFFFFFFFFFFFFL), 0xFFFFFFFFFFFFFFFFL);
+        }
+    }
+}


### PR DESCRIPTION
Another commit 9d3379b9755e9739f0b8f5c29deb1d28d0f3aa81, "8267356: AArch64: Vector API SVE codegen support", adds "UseSVE == 0" to all predicates expanded from replicate$3$4$5, but it is not backported. It causes this backport not clean.

This backport instead preserves the predicate in replicate$3$4$5 prior to commit 9d3379 and preserves one more argument in the invocations.

The predicates are expanded from replicate$3$4$5 by m4 and verified as unmodified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282528](https://bugs.openjdk.org/browse/JDK-8282528): AArch64: Incorrect replicate2L_zero rule


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/642/head:pull/642` \
`$ git checkout pull/642`

Update a local copy of the PR: \
`$ git checkout pull/642` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 642`

View PR using the GUI difftool: \
`$ git pr show -t 642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/642.diff">https://git.openjdk.org/jdk17u-dev/pull/642.diff</a>

</details>
