### PR TITLE
8272417: ZGC: fastdebug build crashes when printing ClassLoaderData

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -968,11 +968,13 @@ void ClassLoaderData::print_on(outputStream* out) const {
   out->print_cr(" - keep alive          %d", _keep_alive);
   out->print   (" - claim               ");
   switch(_claim) {
-    case _claim_none:       out->print_cr("none"); break;
-    case _claim_finalizable:out->print_cr("finalizable"); break;
-    case _claim_strong:     out->print_cr("strong"); break;
-    case _claim_other:      out->print_cr("other"); break;
-    default:                ShouldNotReachHere();
+    case _claim_none:                       out->print_cr("none"); break;
+    case _claim_finalizable:                out->print_cr("finalizable"); break;
+    case _claim_strong:                     out->print_cr("strong"); break;
+    case _claim_other:                      out->print_cr("other"); break;
+    case _claim_other | _claim_finalizable: out->print_cr("other and finalizable"); break;
+    case _claim_other | _claim_strong:      out->print_cr("other and strong"); break;
+    default:                                ShouldNotReachHere();
   }
   out->print_cr(" - handles             %d", _handles.count());
   out->print_cr(" - dependency count    %d", _dependency_count);


### PR DESCRIPTION
Hi! Here is backport of 8272417 that fixes a crash in ClassLoaderData logging that takes place for debug build. The patch is applied cleanly

Verification (amd64 / Ubuntu 20.04)
```
alex@alex-VirtualBox:~/8272417$ echo "public class A { public static void main(String... args) { System.gc(); } }" > A.java
alex@alex-VirtualBox:~/8272417$ ./build/linux-x86_64-server-fastdebug/images/jdk/bin/java -XX:+UseZGC -XX:+VerifyAfterGC -Xlog:gc*=trace A.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272417](https://bugs.openjdk.org/browse/JDK-8272417): ZGC: fastdebug build crashes when printing ClassLoaderData


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/643/head:pull/643` \
`$ git checkout pull/643`

Update a local copy of the PR: \
`$ git checkout pull/643` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 643`

View PR using the GUI difftool: \
`$ git pr show -t 643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/643.diff">https://git.openjdk.org/jdk17u-dev/pull/643.diff</a>

</details>
