### PR TITLE
8287463: JFR: Disable TestDevNull.java on Windows

### DIFF
--- a/test/jdk/jdk/jfr/api/recording/dump/TestDumpDevNull.java
+++ b/test/jdk/jdk/jfr/api/recording/dump/TestDumpDevNull.java
@@ -24,14 +24,13 @@
 package jdk.jfr.api.recording.dump;
 
 import java.nio.file.Path;
-
 import jdk.jfr.Recording;
 
 /**
  * @test
  * @summary Tests that it's possible to dump to /dev/null without a livelock
  * @key jfr
- * @requires vm.hasJFR
+ * @requires vm.hasJFR & (os.family != "windows")
  * @library /test/lib
  * @run main/othervm -Xlog:jfr jdk.jfr.api.recording.dump.TestDumpDevNull
  */


### PR DESCRIPTION
I'd like to backport JDK-8287463 to 17u.
This test-only fix disables jdk/jfr/api/recording/dump/TestDumpDevNull.java test on Windows.
Without this fix the test fails with "java.nio.file.NoSuchFileException: \dev\null".
The test is added by JDK-8282947 which is already backported to 17u.
The patch applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287463](https://bugs.openjdk.org/browse/JDK-8287463): JFR: Disable TestDevNull.java on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/649/head:pull/649` \
`$ git checkout pull/649`

Update a local copy of the PR: \
`$ git checkout pull/649` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 649`

View PR using the GUI difftool: \
`$ git pr show -t 649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/649.diff">https://git.openjdk.org/jdk17u-dev/pull/649.diff</a>

</details>
