### PR TITLE
8288985: P11TlsKeyMaterialGenerator should work with ChaCha20-Poly1305

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11SecretKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,7 @@ final class P11SecretKeyFactory extends SecretKeyFactorySpi {
         addKeyType("AES",      CKK_AES);
         addKeyType("Blowfish", CKK_BLOWFISH);
         addKeyType("ChaCha20", CKK_CHACHA20);
+        addKeyType("ChaCha20-Poly1305", CKK_CHACHA20);
 
         // we don't implement RC2 or IDEA, but we want to be able to generate
         // keys for those SSL/TLS ciphersuites.

--- a/test/jdk/sun/security/pkcs11/tls/TestKeyMaterialChaCha20.java
+++ b/test/jdk/sun/security/pkcs11/tls/TestKeyMaterialChaCha20.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288985
+ * @summary Tests that P11TlsKeyMaterialGenerator works with ChaCha20-Poly1305
+ * @library /test/lib ..
+ * @modules java.base/sun.security.internal.spec
+ *          jdk.crypto.cryptoki
+ * @run main/othervm TestKeyMaterialChaCha20
+ */
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.security.Provider;
+import java.security.NoSuchAlgorithmException;
+import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
+import sun.security.internal.spec.TlsMasterSecretParameterSpec;
+import sun.security.internal.spec.TlsKeyMaterialParameterSpec;
+
+
+public class TestKeyMaterialChaCha20 extends PKCS11Test {
+
+    public static void main(String[] args) throws Exception {
+        main(new TestKeyMaterialChaCha20(), args);
+    }
+
+    @Override
+    public void main(Provider provider) throws Exception {
+        KeyGenerator kg1, kg2, kg3;
+        try {
+            kg1 = KeyGenerator.getInstance("SunTlsRsaPremasterSecret", provider);
+        } catch (Exception e) {
+            System.out.println("Skipping, SunTlsRsaPremasterSecret KeyGenerator not supported");
+            return;
+        }
+        try {
+            kg2 = KeyGenerator.getInstance("SunTls12MasterSecret", provider);
+        } catch (Exception e) {
+            System.out.println("Skipping, SunTls12MasterSecret KeyGenerator not supported");
+            return;
+        }
+        try {
+            kg3 = KeyGenerator.getInstance("SunTls12KeyMaterial", provider);
+        } catch (Exception e) {
+            System.out.println("Skipping, SunTls12KeyMaterial KeyGenerator not supported");
+            return;
+        }
+
+        kg1.init(new TlsRsaPremasterSecretParameterSpec(0x0303, 0x0303));
+        SecretKey preMasterSecret = kg1.generateKey();
+
+        TlsMasterSecretParameterSpec spec = new TlsMasterSecretParameterSpec(
+            preMasterSecret,
+            3, 3,
+            new byte[32],
+            new byte[32],
+            "SHA-256", 32, 64);
+        kg2.init(spec);
+        SecretKey masterSecret = kg2.generateKey();
+
+        TlsKeyMaterialParameterSpec params = new TlsKeyMaterialParameterSpec(
+            masterSecret, 3, 3,
+            new byte[32],
+            new byte[32],
+            "ChaCha20-Poly1305", 32, 32,
+            12, 0,
+            "SHA-256", 32, 64);
+        kg3.init(params);
+        kg3.generateKey();
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b6bd190d](https://github.com/openjdk/jdk/commit/b6bd190d8d10fdb177f9fb100c9f44c9f57a3cb5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Zdenek Zambersky on 29 Jun 2022 and was reviewed by Valerie Peng.

The patch applies cleanly. The test fails on an unpatched install of 17.0.4 and passes on a patched build.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288985](https://bugs.openjdk.org/browse/JDK-8288985): P11TlsKeyMaterialGenerator should work with ChaCha20-Poly1305


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/650/head:pull/650` \
`$ git checkout pull/650`

Update a local copy of the PR: \
`$ git checkout pull/650` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 650`

View PR using the GUI difftool: \
`$ git pr show -t 650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/650.diff">https://git.openjdk.org/jdk17u-dev/pull/650.diff</a>

</details>
