### PR TITLE
8289044: ARM32: missing LIR_Assembler::cmove metadata type support

### DIFF
--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -1483,6 +1483,9 @@ void LIR_Assembler::cmove(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, L
           __ mov_double(result->as_double_reg(), c->as_jdouble(), acond);
 #endif // __SOFTFP__
           break;
+        case T_METADATA:
+          __ mov_metadata(result->as_register(), c->as_metadata(), acond);
+          break;
         default:
           ShouldNotReachHere();
       }


### PR DESCRIPTION
I'd like to backport this changeset to fix ARM32 jtreg fails:

- jdk/java/text/BreakIterator/Bug7104012.java
- runtime/logging/MonitorMismatchTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289044](https://bugs.openjdk.org/browse/JDK-8289044): ARM32: missing LIR_Assembler::cmove metadata type support


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/651/head:pull/651` \
`$ git checkout pull/651`

Update a local copy of the PR: \
`$ git checkout pull/651` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 651`

View PR using the GUI difftool: \
`$ git pr show -t 651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/651.diff">https://git.openjdk.org/jdk17u-dev/pull/651.diff</a>

</details>
