### PR TITLE
8275535: Retrying a failed authentication on multiple LDAP servers can lead to users blocked

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtxFactory.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapCtxFactory.java
@@ -189,6 +189,10 @@ public final class LdapCtxFactory implements ObjectFactory, InitialContextFactor
                     ctx = getLdapCtxFromUrl(
                             r.getDomainName(), url, new LdapURL(u), env);
                     return ctx;
+                } catch (AuthenticationException e) {
+                    // do not retry on a different endpoint to avoid blocking
+                    // the user if authentication credentials are wrong.
+                    throw e;
                 } catch (NamingException e) {
                     // try the next element
                     lastException = e;
@@ -241,6 +245,10 @@ public final class LdapCtxFactory implements ObjectFactory, InitialContextFactor
         for (String u : urls) {
             try {
                 return getUsingURL(u, env);
+            } catch (AuthenticationException e) {
+                // do not retry on a different URL to avoid blocking
+                // the user if authentication credentials are wrong.
+                throw e;
             } catch (NamingException e) {
                 ex = e;
             }


### PR DESCRIPTION
Backport [8275535](https://bugs.openjdk.org/browse/JDK-8275535).

Fixes authentication issue introduced by [8160768](https://bugs.openjdk.org/browse/JDK-8160768).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8275535](https://bugs.openjdk.org/browse/JDK-8275535): Retrying a failed authentication on multiple LDAP servers can lead to users blocked
 * [JDK-8276959](https://bugs.openjdk.org/browse/JDK-8276959): Retrying a failed authentication on multiple LDAP servers can lead to users blocked (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/654/head:pull/654` \
`$ git checkout pull/654`

Update a local copy of the PR: \
`$ git checkout pull/654` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 654`

View PR using the GUI difftool: \
`$ git pr show -t 654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/654.diff">https://git.openjdk.org/jdk17u-dev/pull/654.diff</a>

</details>
