### PR TITLE
8277411: C2 fast_unlock intrinsic on AArch64 has unnecessary ownership check

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3913,19 +3913,15 @@ encode %{
     __ bind(object_has_monitor);
     STATIC_ASSERT(markWord::monitor_value <= INT_MAX);
     __ add(tmp, tmp, -(int)markWord::monitor_value); // monitor
-    __ ldr(rscratch1, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
     __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
 
     Label notRecursive;
-    __ cmp(rscratch1, rthread);
-    __ br(Assembler::NE, cont);
-
     __ cbz(disp_hdr, notRecursive);
 
     // Recursive lock
     __ sub(disp_hdr, disp_hdr, 1u);
     __ str(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
-    // flag == EQ was set in the ownership check above
+    __ cmp(disp_hdr, disp_hdr); // Sets flags for result
     __ b(cont);
 
     __ bind(notRecursive);


### PR DESCRIPTION
Original patch applies cleanly.

Testing: jtreg tier1, tier2, applications/jcstress on 64-core machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277411](https://bugs.openjdk.org/browse/JDK-8277411): C2 fast_unlock intrinsic on AArch64 has unnecessary ownership check


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/660/head:pull/660` \
`$ git checkout pull/660`

Update a local copy of the PR: \
`$ git checkout pull/660` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 660`

View PR using the GUI difftool: \
`$ git pr show -t 660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/660.diff">https://git.openjdk.org/jdk17u-dev/pull/660.diff</a>

</details>
