### PR TITLE
8287349: AArch64: Merge LDR instructions to improve C1 OSR performance

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -283,10 +283,9 @@ void LIR_Assembler::osr_entry() {
         __ bind(L);
       }
 #endif
-      __ ldr(r19, Address(OSR_buf, slot_offset + 0));
+      __ ldp(r19, r20, Address(OSR_buf, slot_offset));
       __ str(r19, frame_map()->address_for_monitor_lock(i));
-      __ ldr(r19, Address(OSR_buf, slot_offset + 1*BytesPerWord));
-      __ str(r19, frame_map()->address_for_monitor_object(i));
+      __ str(r20, frame_map()->address_for_monitor_object(i));
     }
   }
 }


### PR DESCRIPTION
Straightforward replacement to pair load-store instructions, applies cleanly.

Testing: jtreg tier1, tier2 on linux-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287349](https://bugs.openjdk.org/browse/JDK-8287349): AArch64: Merge LDR instructions to improve C1 OSR performance


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/661/head:pull/661` \
`$ git checkout pull/661`

Update a local copy of the PR: \
`$ git checkout pull/661` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 661`

View PR using the GUI difftool: \
`$ git pr show -t 661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/661.diff">https://git.openjdk.org/jdk17u-dev/pull/661.diff</a>

</details>
