### PR TITLE
8288377: [REDO] DST not applying properly with zone id offset set with TZ env variable

### DIFF
--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -525,58 +525,39 @@ findJavaTZ_md(const char *java_home_dir)
 /**
  * Returns a GMT-offset-based zone ID. (e.g., "GMT-08:00")
  */
+char *
+getGMTOffsetID()
+{
+    char buf[32];
+    char offset[6];
+    struct tm localtm;
+    time_t clock = time(NULL);
+    if (localtime_r(&clock, &localtm) == NULL) {
+        return strdup("GMT");
+    }
 
 #if defined(MACOSX)
-
-char *
-getGMTOffsetID()
-{
-    time_t offset;
-    char sign, buf[32];
-    struct tm local_tm;
-    time_t clock;
-
-    clock = time(NULL);
-    if (localtime_r(&clock, &local_tm) == NULL) {
+    time_t gmt_offset;
+    gmt_offset = (time_t)localtm.tm_gmtoff;
+    if (gmt_offset == 0) {
         return strdup("GMT");
     }
-    offset = (time_t)local_tm.tm_gmtoff;
-    if (offset == 0) {
-        return strdup("GMT");
-    }
-    if (offset > 0) {
-        sign = '+';
-    } else {
-        offset = -offset;
-        sign = '-';
-    }
-    sprintf(buf, (const char *)"GMT%c%02d:%02d",
-            sign, (int)(offset/3600), (int)((offset%3600)/60));
-    return strdup(buf);
-}
-
 #else
-
-char *
-getGMTOffsetID()
-{
-    time_t offset;
-    char sign, buf[32];
-    offset = timezone;
-
-    if (offset == 0) {
+    struct tm gmt;
+    if (gmtime_r(&clock, &gmt) == NULL) {
         return strdup("GMT");
     }
 
-    /* Note that the time offset direction is opposite. */
-    if (offset > 0) {
-        sign = '-';
-    } else {
-        offset = -offset;
-        sign = '+';
+    if(localtm.tm_hour == gmt.tm_hour && localtm.tm_min == gmt.tm_min) {
+        return strdup("GMT");
     }
-    sprintf(buf, (const char *)"GMT%c%02d:%02d",
-            sign, (int)(offset/3600), (int)((offset%3600)/60));
+#endif
+
+    if (strftime(offset, 6, "%z", &localtm) != 5) {
+        return strdup("GMT");
+    }
+
+    sprintf(buf, (const char *)"GMT%c%c%c:%c%c", offset[0], offset[1], offset[2],
+        offset[3], offset[4]);
     return strdup(buf);
 }
-#endif /* MACOSX */

--- a/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
+++ b/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8285838
+ * @library /test/lib
+ * @summary This test will ensure that daylight savings rules are followed
+ * appropriately when setting a custom timezone ID via the TZ env variable.
+ * @requires os.family != "windows"
+ * @run main/othervm CustomTzIDCheckDST
+ */
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.SimpleTimeZone;
+import java.time.DayOfWeek;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+public class CustomTzIDCheckDST {
+    private static String CUSTOM_TZ = "MEZ-1MESZ,M3.5.0,M10.5.0";
+    public static void main(String args[]) throws Throwable {
+        if (args.length == 0) {
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(List.of("CustomTzIDCheckDST", "runTZTest"));
+            pb.environment().put("TZ", CUSTOM_TZ);
+            OutputAnalyzer output = ProcessTools.executeProcess(pb);
+            output.shouldHaveExitValue(0);
+        } else {
+            runTZTest();
+        }
+    }
+
+    /* TZ code will always be set to "MEZ-1MESZ,M3.5.0,M10.5.0".
+     * This ensures the transition periods for Daylights Savings should be at March's last
+     * Sunday and October's last Sunday.
+     */
+    private static void runTZTest() {
+        Date time = new Date();
+        if (new SimpleTimeZone(3600000, "MEZ-1MESZ", Calendar.MARCH, -1, Calendar.SUNDAY, 0,
+                Calendar.OCTOBER, -1, Calendar.SUNDAY, 0).inDaylightTime(time)) {
+            // We are in Daylight savings period.
+            if (time.toString().endsWith("GMT+02:00 " + Integer.toString(time.getYear() + 1900)))
+                return;
+        } else {
+            if (time.toString().endsWith("GMT+01:00 " + Integer.toString(time.getYear() + 1900)))
+                return;
+        }
+
+        // Reaching here means time zone did not match up as expected.
+        throw new RuntimeException("Got unexpected timezone information: " + time);
+    }
+
+    private static ZonedDateTime getLastSundayOfMonth(ZonedDateTime date) {
+        return date.with(TemporalAdjusters.lastInMonth(DayOfWeek.SUNDAY));
+    }
+}


### PR DESCRIPTION
Backport changes from JDK-8288377

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288377](https://bugs.openjdk.org/browse/JDK-8288377): [REDO] DST not applying properly with zone id offset set with TZ env variable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/662/head:pull/662` \
`$ git checkout pull/662`

Update a local copy of the PR: \
`$ git checkout pull/662` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 662`

View PR using the GUI difftool: \
`$ git pr show -t 662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/662.diff">https://git.openjdk.org/jdk17u-dev/pull/662.diff</a>

</details>
