### PR TITLE
8274563: jfr/event/oldobject/TestClassLoaderLeak.java fails when GC cycles are not happening

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -40,10 +40,9 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc != "Serial"
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestClassLoaderLeak
+ * @run main/othervm -XX:TLABSize=2k -Xmx128m jdk.jfr.event.oldobject.TestClassLoaderLeak
  */
 public class TestClassLoaderLeak {
 


### PR DESCRIPTION
Clean backport to fix a test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274563](https://bugs.openjdk.org/browse/JDK-8274563): jfr/event/oldobject/TestClassLoaderLeak.java fails when GC cycles are not happening


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/663/head:pull/663` \
`$ git checkout pull/663`

Update a local copy of the PR: \
`$ git checkout pull/663` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 663`

View PR using the GUI difftool: \
`$ git pr show -t 663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/663.diff">https://git.openjdk.org/jdk17u-dev/pull/663.diff</a>

</details>
