### PR TITLE
8282047: Enhance StringDecode/Encode microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/StringDecode.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringDecode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,17 +22,7 @@
  */
 package org.openjdk.bench.java.lang;
 
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Param;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.nio.charset.Charset;
@@ -40,28 +30,30 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3)
-@Warmup(iterations = 5, time = 2)
+@Fork(value = 2)
+@Warmup(iterations = 5, time = 3)
 @Measurement(iterations = 5, time = 3)
 @State(Scope.Thread)
 public class StringDecode {
 
-    @Param({"US-ASCII", "ISO-8859-1", "UTF-8", "MS932", "ISO-8859-6", "ISO-2022-KR"})
+    // Reduced by default to only UTF-8, previous coverage:
+    // @Param({"US-ASCII", "ISO-8859-1", "UTF-8", "MS932", "ISO-8859-6", "ISO-2022-KR"})
+    @Param({"UTF-8"})
     private String charsetName;
 
     private Charset charset;
     private byte[] asciiString;
+    private byte[] longAsciiString;
     private byte[] utf16String;
-    private byte[] longUtf16String;
+    private byte[] longUtf16EndString;
     private byte[] longUtf16StartString;
-    private byte[] longLatin1String;
+    private byte[] longUtf16OnlyString;
+    private byte[] latin1String;
+    private byte[] longLatin1EndString;
+    private byte[] longLatin1StartString;
+    private byte[] longLatin1OnlyString;
 
-    @Setup
-    public void setup() {
-        charset = Charset.forName(charsetName);
-        asciiString = "ascii string".getBytes(charset);
-        utf16String = "UTF-\uFF11\uFF16 string".getBytes(charset);
-        longUtf16String = """
+    private static final String LOREM = """
              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ac sem eu
              urna egestas placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.
              Nulla nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et
@@ -70,90 +62,145 @@ public class StringDecode {
              per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla
              sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida
              efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.
-             Suspendisse potenti.
+             Suspendisse potenti.""";
+    private static final String UTF16_STRING = "\uFF11".repeat(31);
+    private static final String LATIN1_STRING = "\u00B6".repeat(31);
 
-             Phasellus vel nisi iaculis, accumsan quam sed, bibendum eros. Sed venenatis
-             nulla tortor, et eleifend urna sodales id. Nullam tempus ac metus sit amet
-             sollicitudin. Nam sed ex diam. Praesent vitae eros et neque condimentum
-             consectetur eget non tortor. Praesent bibendum vel felis nec dignissim.
-             Maecenas a enim diam. Suspendisse quis ligula at nisi accumsan lacinia id
-             hendrerit sapien. \uFF11Donec aliquam mattis lectus eu ultrices. Duis eu nisl\uFF11
-             euismod, blandit mauris vel, \uFF11placerat urna. Etiam malesuada enim purus,
-             tristique mollis odio blandit quis.\uFF11 Vivamus posuere. \uFF11
-             \uFF11
-            """.getBytes(charset);
-        longUtf16StartString = """
-             \uFF11
-             Lorem ipsum dolor sit amet, \uFF11consectetur adipiscing elit. Aliquam ac sem eu
-             urna egestas \uFF11placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.
-             Nulla \uFF11nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et
-             sapien in \uFF11magna porta ultricies. \uFF11Sed vel pellentesque nibh. Pellentesque dictum
-             dignissim diam eu ultricies. Class aptent taciti sociosqu ad litora torquent
-             per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla
-             sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida
-             efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.
-             Suspendisse potenti.
-
-             Phasellus vel nisi iaculis, accumsan quam sed, bibendum eros. Sed venenatis
-             nulla tortor, et eleifend urna sodales id. Nullam tempus ac metus sit amet
-             sollicitudin. Nam sed ex diam. Praesent vitae eros et neque condimentum
-             consectetur eget non tortor. Praesent bibendum vel felis nec dignissim.
-             Maecenas a enim diam. Suspendisse quis ligula at nisi accumsan lacinia id
-             hendrerit sapien. Donec aliquam mattis lectus eu ultrices. Duis eu nisl
-             euismod, blandit mauris vel, placerat urna. Etiam malesuada enim purus,
-             tristique mollis odio blandit quis. Vivamus posuere.
-            """.getBytes(charset);
-
-        longLatin1String = """
-             a\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             b\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             c\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             d\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             e\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             f\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             g\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             h\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             i\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6
-             j\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6\u00F6
-             k\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6\u00F6
-             l\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6\u00F6
-             m\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00F6\u00B6\u00F6\u00F6
-            """.getBytes(charset);
+    @Setup
+    public void setup() {
+        charset = Charset.forName(charsetName);
+        asciiString = LOREM.substring(0, 32).getBytes(charset);
+        longAsciiString = LOREM.repeat(200).getBytes(charset);
+        utf16String = "UTF-\uFF11\uFF16 string".getBytes(charset);
+        longUtf16EndString = LOREM.repeat(4).concat(UTF16_STRING).getBytes(charset);
+        longUtf16StartString = UTF16_STRING.concat(LOREM.repeat(4)).getBytes(charset);
+        longUtf16OnlyString = UTF16_STRING.repeat(10).getBytes(charset);
+        latin1String = LATIN1_STRING.getBytes(charset);
+        longLatin1EndString = LOREM.repeat(4).concat(LATIN1_STRING).getBytes(charset);
+        longLatin1StartString = LATIN1_STRING.concat(LOREM.repeat(4)).getBytes(charset);
+        longLatin1OnlyString = LATIN1_STRING.repeat(10).getBytes(charset);
     }
 
     @Benchmark
-    public String decodeAsciiCharsetName() throws Exception {
-        return new String(asciiString, charsetName);
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void decodeAsciiShort(Blackhole bh) throws Exception {
+        bh.consume(new String(asciiString, charset));
+        bh.consume(new String(longAsciiString, 0, 15, charset));
+        bh.consume(new String(asciiString, 0, 3, charset));
+        bh.consume(new String(longAsciiString, 512, 512 + 7, charset));
     }
 
     @Benchmark
-    public String decodeAscii() throws Exception {
-        return new String(asciiString, charset);
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void decodeAsciiLong(Blackhole bh) throws Exception {
+        bh.consume(new String(longAsciiString, charset));
+        bh.consume(new String(longAsciiString, 0, 1024 + 31, charset));
     }
 
     @Benchmark
-    public String decodeLatin1Long() throws Exception {
-        return new String(longLatin1String, charset);
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void decodeLatin1Short(Blackhole bh) throws Exception {
+        bh.consume(new String(latin1String, charset));
+        bh.consume(new String(latin1String, 0, 15, charset));
+        bh.consume(new String(latin1String, 0, 3, charset));
+        bh.consume(new String(longLatin1OnlyString, 512, 512 + 7, charset));
     }
 
     @Benchmark
-    public String decodeUTF16Short() throws Exception {
-        return new String(utf16String, charset);
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public String decodeLatin1LongStart() throws Exception {
+        return new String(longLatin1StartString, charset);
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public String decodeLatin1LongEnd() throws Exception {
+        return new String(longLatin1EndString, charset);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public String decodeLatin1LongOnly() throws Exception {
+        return new String(longLatin1OnlyString, charset);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void decodeLatin1Mixed(Blackhole bh) throws Exception {
+        bh.consume(new String(longLatin1EndString, charset));
+        bh.consume(new String(longLatin1StartString, charset));
+        bh.consume(new String(latin1String, charset));
+        bh.consume(new String(longLatin1OnlyString, charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void decodeUTF16Short(Blackhole bh) throws Exception {
+        bh.consume(new String(utf16String, charset));
+        bh.consume(new String(utf16String, 0, 15, charset));
+        bh.consume(new String(utf16String, 0, 3, charset));
+        bh.consume(new String(utf16String, 0, 7, charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public String decodeUTF16LongEnd() throws Exception {
-        return new String(longUtf16String, charset);
+        return new String(longUtf16EndString, charset);
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public String decodeUTF16LongStart() throws Exception {
         return new String(longUtf16StartString, charset);
     }
 
     @Benchmark
-    public void decodeUTF16LongMixed(Blackhole bh) throws Exception {
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public String decodeUTF16LongOnly() throws Exception {
+        return new String(longUtf16OnlyString, charset);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void decodeUTF16Mixed(Blackhole bh) throws Exception {
         bh.consume(new String(longUtf16StartString, charset));
-        bh.consume(new String(longUtf16String, charset));
+        bh.consume(new String(longUtf16EndString, charset));
+        bh.consume(new String(utf16String, charset));
+        bh.consume(new String(longUtf16OnlyString, charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void decodeAllMixed(Blackhole bh) throws Exception {
+        bh.consume(new String(utf16String, charset));
+        bh.consume(new String(longUtf16EndString, charset));
+        bh.consume(new String(utf16String, 0, 15, charset));
+        bh.consume(new String(longUtf16StartString, charset));
+        bh.consume(new String(asciiString, 0, 3, charset));
+        bh.consume(new String(longUtf16OnlyString, charset));
+        bh.consume(new String(latin1String, charset));
+        bh.consume(new String(longLatin1EndString, charset));
+        bh.consume(new String(longLatin1StartString, charset));
+        bh.consume(new String(latin1String, 0, 7, charset));
+        bh.consume(new String(longLatin1OnlyString, charset));
+        bh.consume(new String(asciiString, charset));
+        bh.consume(new String(longAsciiString, charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void decodeShortMixed(Blackhole bh) throws Exception {
+        bh.consume(new String(utf16String, 0, 15, charset));
+        bh.consume(new String(latin1String, 0, 15, charset));
+        bh.consume(new String(asciiString, charset));
+        bh.consume(new String(utf16String, charset));
+        bh.consume(new String(latin1String, 0, 3, charset));
+        bh.consume(new String(asciiString, 0, 3, charset));
+        bh.consume(new String(utf16String, 0, 7, charset));
+        bh.consume(new String(latin1String, charset));
+        bh.consume(new String(asciiString, 0, 7, charset));
+        bh.consume(new String(utf16String, 0, 3, charset));
+        bh.consume(new String(latin1String, 0, 7, charset));
+        bh.consume(new String(asciiString, 0, 15, charset));
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/StringEncode.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringEncode.java
@@ -30,97 +30,197 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3)
-@Warmup(iterations = 5, time = 2)
+@Fork(value = 2)
+@Warmup(iterations = 5, time = 3)
 @Measurement(iterations = 5, time = 3)
 @State(Scope.Thread)
 public class StringEncode {
 
-    @Param({"US-ASCII", "ISO-8859-1", "UTF-8", "MS932", "ISO-8859-6"})
+    // Reduced by default to only UTF-8, previous coverage:
+    // @Param({"US-ASCII", "ISO-8859-1", "UTF-8", "MS932", "ISO-8859-6", "ISO-2022-KR"})
+    @Param({"UTF-8"})
     private String charsetName;
+
     private Charset charset;
     private String asciiString;
+    private String asciiString3;
+    private String asciiString7;
+    private String asciiString15;
+    private String longAsciiString;
+    private String longAsciiString1055;
     private String utf16String;
-    private String longUtf16String;
+    private String utf16String3;
+    private String utf16String7;
+    private String utf16String15;
+    private String longUtf16EndString;
     private String longUtf16StartString;
+    private String longUtf16OnlyString;
+    private String latin1String;
+    private String latin1String3;
+    private String latin1String7;
+    private String latin1String15;
+    private String longLatin1EndString;
+    private String longLatin1StartString;
+    private String longLatin1OnlyString;
+
+    private static final String LOREM = """
+             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ac sem eu
+             urna egestas placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.
+             Nulla nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et
+             sapien in magna porta ultricies. Sed vel pellentesque nibh. Pellentesque dictum
+             dignissim diam eu ultricies. Class aptent taciti sociosqu ad litora torquent
+             per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla
+             sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida
+             efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.
+             Suspendisse potenti.""";
+    private static final String UTF16_STRING = "\uFF11".repeat(31);
+    private static final String LATIN1_STRING = "\u00B6".repeat(31);
 
     @Setup
     public void setup() {
         charset = Charset.forName(charsetName);
-        asciiString = "ascii string";
-        utf16String = "UTF-\uFF11\uFF16 string";
-        longUtf16String = """
-                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ac sem eu
-                 urna egestas placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.
-                 Nulla nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et
-                 sapien in magna porta ultricies. Sed vel pellentesque nibh. Pellentesque dictum
-                 dignissim diam eu ultricies. Class aptent taciti sociosqu ad litora torquent
-                 per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla
-                 sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida
-                 efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.
-                 Suspendisse potenti.
-
-                 Phasellus vel nisi iaculis, accumsan quam sed, bibendum eros. Sed venenatis
-                 nulla tortor, et eleifend urna sodales id. Nullam tempus ac metus sit amet
-                 sollicitudin. Nam sed ex diam. Praesent vitae eros et neque condimentum
-                 consectetur eget non tortor. Praesent bibendum vel felis nec dignissim.
-                 Maecenas a enim diam. Suspendisse quis ligula at nisi accumsan lacinia id
-                 hendrerit sapien. Donec aliquam mattis lectus eu ultrices. Duis eu nisl
-                 euismod, blandit mauris vel, placerat urna. Etiam malesuada enim purus,
-                 tristique mollis odio blandit quis. Vivamus posuere.
-                 \uFF11
-                """;
-        longUtf16StartString = """
-                 \uFF11
-                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ac sem eu
-                 urna egestas placerat. Etiam finibus ipsum nulla, non mattis dolor cursus a.
-                 Nulla nec nisl consectetur, lacinia neque id, accumsan ante. Curabitur et
-                 sapien in magna porta ultricies. Sed vel pellentesque nibh. Pellentesque dictum
-                 dignissim diam eu ultricies. Class aptent taciti sociosqu ad litora torquent
-                 per conubia nostra, per inceptos himenaeos. Suspendisse erat diam, fringilla
-                 sed massa sed, posuere viverra orci. Suspendisse tempor libero non gravida
-                 efficitur. Vivamus lacinia risus non orci viverra, at consectetur odio laoreet.
-                 Suspendisse potenti.
-
-                 Phasellus vel nisi iaculis, accumsan quam sed, bibendum eros. Sed venenatis
-                 nulla tortor, et eleifend urna sodales id. Nullam tempus ac metus sit amet
-                 sollicitudin. Nam sed ex diam. Praesent vitae eros et neque condimentum
-                 consectetur eget non tortor. Praesent bibendum vel felis nec dignissim.
-                 Maecenas a enim diam. Suspendisse quis ligula at nisi accumsan lacinia id
-                 hendrerit sapien. Donec aliquam mattis lectus eu ultrices. Duis eu nisl
-                 euismod, blandit mauris vel, placerat urna. Etiam malesuada enim purus,
-                 tristique mollis odio blandit quis. Vivamus posuere.
-                """;
+        asciiString = LOREM.substring(0, 32);
+        asciiString3 = LOREM.substring(0, 3);
+        asciiString7 = LOREM.substring(0, 7);
+        asciiString15 = LOREM.substring(0, 15);
+        longAsciiString = LOREM.repeat(200);
+        longAsciiString1055 = longAsciiString.substring(0, 1055);
+        utf16String = UTF16_STRING;
+        utf16String3 = UTF16_STRING.substring(0, 3);
+        utf16String7 = UTF16_STRING.substring(0, 7);
+        utf16String15 = UTF16_STRING.substring(0, 15);
+        longUtf16EndString = LOREM.repeat(4).concat(UTF16_STRING);
+        longUtf16StartString = UTF16_STRING.concat(LOREM.repeat(4));
+        longUtf16OnlyString = UTF16_STRING.repeat(10);
+        latin1String = LATIN1_STRING;
+        latin1String3 = LATIN1_STRING.substring(0, 3);
+        latin1String7 = LATIN1_STRING.substring(0, 7);
+        latin1String15 = LATIN1_STRING.substring(0, 15);
+        longLatin1EndString = LOREM.repeat(4).concat(LATIN1_STRING);
+        longLatin1StartString = LATIN1_STRING.concat(LOREM.repeat(4));
+        longLatin1OnlyString = LATIN1_STRING.repeat(10);
     }
 
     @Benchmark
-    public byte[] encodeAsciiCharsetName() throws Exception {
-        return asciiString.getBytes(charset);
-    }
-
-    @Benchmark
-    public byte[] encodeAscii() throws Exception {
-        return asciiString.getBytes(charset);
-    }
-
-    @Benchmark
-    public void encodeMix(Blackhole bh) throws Exception {
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void encodeAsciiShort(Blackhole bh) throws Exception {
         bh.consume(asciiString.getBytes(charset));
+        bh.consume(asciiString3.getBytes(charset));
+        bh.consume(asciiString15.getBytes(charset));
+        bh.consume(asciiString7.getBytes(charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void encodeAsciiLong(Blackhole bh) throws Exception {
+        bh.consume(longAsciiString.getBytes(charset));
+        bh.consume(longAsciiString1055.getBytes(charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void encodeUTF16Short(Blackhole bh) throws Exception {
         bh.consume(utf16String.getBytes(charset));
+        bh.consume(utf16String3.getBytes(charset));
+        bh.consume(utf16String15.getBytes(charset));
+        bh.consume(utf16String7.getBytes(charset));
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public byte[] encodeUTF16LongEnd() throws Exception {
-        return longUtf16String.getBytes(charset);
+        return longUtf16EndString.getBytes(charset);
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public byte[] encodeUTF16LongStart() throws Exception {
         return longUtf16StartString.getBytes(charset);
     }
 
     @Benchmark
-    public byte[] encodeUTF16() throws Exception {
-        return utf16String.getBytes(charset);
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public byte[] encodeUTF16LongOnly() throws Exception {
+        return longUtf16OnlyString.getBytes(charset);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void encodeUTF16Mixed(Blackhole bh) throws Exception {
+        bh.consume(utf16String.getBytes(charset));
+        bh.consume(longUtf16StartString.getBytes(charset));
+        bh.consume(longUtf16EndString.getBytes(charset));
+        bh.consume(longUtf16OnlyString.getBytes(charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void encodeLatin1Short(Blackhole bh) throws Exception {
+        bh.consume(latin1String.getBytes(charset));
+        bh.consume(latin1String3.getBytes(charset));
+        bh.consume(latin1String15.getBytes(charset));
+        bh.consume(latin1String7.getBytes(charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public byte[] encodeLatin1LongOnly() throws Exception {
+        return longLatin1OnlyString.getBytes(charset);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public byte[] encodeLatin1LongStart() throws Exception {
+        return longLatin1StartString.getBytes(charset);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public byte[] encodeLatin1LongEnd() throws Exception {
+        return longLatin1EndString.getBytes(charset);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void encodeLatin1Mixed(Blackhole bh) throws Exception {
+        bh.consume(longLatin1EndString.getBytes(charset));
+        bh.consume(longLatin1StartString.getBytes(charset));
+        bh.consume(longLatin1OnlyString.getBytes(charset));
+        bh.consume(latin1String.getBytes(charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void encodeAllMixed(Blackhole bh) throws Exception {
+        bh.consume(utf16String.getBytes(charset));
+        bh.consume(longUtf16StartString.getBytes(charset));
+        bh.consume(asciiString7.getBytes(charset));
+        bh.consume(longUtf16EndString.getBytes(charset));
+        bh.consume(latin1String3.getBytes(charset));
+        bh.consume(longUtf16OnlyString.getBytes(charset));
+        bh.consume(longLatin1EndString.getBytes(charset));
+        bh.consume(longLatin1StartString.getBytes(charset));
+        bh.consume(utf16String15.getBytes(charset));
+        bh.consume(longLatin1OnlyString.getBytes(charset));
+        bh.consume(latin1String.getBytes(charset));
+        bh.consume(asciiString.getBytes(charset));
+        bh.consume(longAsciiString.getBytes(charset));
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void encodeShortMixed(Blackhole bh) throws Exception {
+        bh.consume(utf16String3.getBytes(charset));
+        bh.consume(latin1String7.getBytes(charset));
+        bh.consume(asciiString15.getBytes(charset));
+        bh.consume(utf16String.getBytes(charset));
+        bh.consume(latin1String3.getBytes(charset));
+        bh.consume(asciiString7.getBytes(charset));
+        bh.consume(utf16String15.getBytes(charset));
+        bh.consume(latin1String.getBytes(charset));
+        bh.consume(asciiString3.getBytes(charset));
+        bh.consume(utf16String7.getBytes(charset));
+        bh.consume(latin1String15.getBytes(charset));
+        bh.consume(asciiString.getBytes(charset));
     }
 }


### PR DESCRIPTION
This change is a backport of "8282047: Enhance StringDecode/Encode microbenchmarks" commit - a benchmarks update as a part of subsequent [JDK-8281146](https://bugs.openjdk.org/browse/JDK-8281146) change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282047](https://bugs.openjdk.org/browse/JDK-8282047): Enhance StringDecode/Encode microbenchmarks


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/666/head:pull/666` \
`$ git checkout pull/666`

Update a local copy of the PR: \
`$ git checkout pull/666` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 666`

View PR using the GUI difftool: \
`$ git pr show -t 666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/666.diff">https://git.openjdk.org/jdk17u-dev/pull/666.diff</a>

</details>
