### PR TITLE
8272776: NullPointerException not reported

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -341,9 +341,8 @@ public class TransPatterns extends TreeTranslator {
             JCCase lastCase = cases.last();
 
             if (hasTotalPattern && !hasNullCase) {
-                JCCase last = lastCase;
-                if (last.labels.stream().noneMatch(l -> l.hasTag(Tag.DEFAULTCASELABEL))) {
-                    last.labels = last.labels.prepend(makeLit(syms.botType, null));
+                if (cases.stream().flatMap(c -> c.labels.stream()).noneMatch(l -> l.hasTag(Tag.DEFAULTCASELABEL))) {
+                    lastCase.labels = lastCase.labels.prepend(makeLit(syms.botType, null));
                     hasNullCase = true;
                 }
             }

--- a/test/langtools/tools/javac/patterns/NullSwitch.java
+++ b/test/langtools/tools/javac/patterns/NullSwitch.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8262891
+ * @bug 8262891 8272776
  * @summary Check null handling for non-pattern switches.
  * @compile --enable-preview -source ${jdk.version} NullSwitch.java
  * @run main/othervm --enable-preview NullSwitch
@@ -57,6 +57,9 @@ public class NullSwitch {
         assertEquals(0, matchingSwitch12(""));
         assertEquals(2, matchingSwitch12(null));
         assertEquals(1, matchingSwitch12(0.0));
+        assertEquals(0, matchingSwitch13(""));
+        assertEquals(1, matchingSwitch13(0.0));
+        assertEquals(2, matchingSwitch13(null));
     }
 
     private int matchingSwitch1(Object obj) {
@@ -153,6 +156,17 @@ public class NullSwitch {
             switch (obj) {
                 case String s: return 0;
                 default: return 1;
+            }
+        } catch (NullPointerException ex) {
+            return 2;
+        }
+    }
+
+    private int matchingSwitch13(Object obj) {
+        try {
+            switch (obj) {
+                default: return 1;
+                case String s: return 0;
             }
         } catch (NullPointerException ex) {
             return 2;


### PR DESCRIPTION
Hi! Here is backport of [8272776](https://bugs.openjdk.org/browse/JDK-8272776) fixing absent NPE in the case of null switch with default. Original patch is applied cleanly

Verification (amd64 / 20.04 LTS): test/langtools/tools/javac/patterns/NullSwitch.java (updated)
Regression (amd64 / 20.04 LTS): test/langtools/tools/javac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272776](https://bugs.openjdk.org/browse/JDK-8272776): NullPointerException not reported


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/667/head:pull/667` \
`$ git checkout pull/667`

Update a local copy of the PR: \
`$ git checkout pull/667` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/667/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 667`

View PR using the GUI difftool: \
`$ git pr show -t 667`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/667.diff">https://git.openjdk.org/jdk17u-dev/pull/667.diff</a>

</details>
