### PR TITLE
8290209: jcup.md missing additional text

### DIFF
--- a/src/java.xml/share/legal/jcup.md
+++ b/src/java.xml/share/legal/jcup.md
@@ -1,8 +1,8 @@
 ## CUP Parser Generator for Java v 0.11b
 
 ### CUP Parser Generator License
-<pre>
 
+```
 Copyright 1996-2015 by Scott Hudson, Frank Flannery, C. Scott Ananian, Michael Petter
 
 Permission to use, copy, modify, and distribute this software and its
@@ -20,5 +20,12 @@ any special, indirect or consequential damages or any damages whatsoever
 resulting from loss of use, data or profits, whether in an action of
 contract, negligence or other tortious action, arising out of or in
 connection with the use or performance of this software.
+```
+---
+```
+This is an open source license. It is also GPL-Compatible (see entry for
+"Standard ML of New Jersey"). The portions of CUP output which are hard-coded
+into the CUP source code are (naturally) covered by this same license, as is
+the CUP runtime code linked with the generated parser.
+```
 
-</pre>


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290209](https://bugs.openjdk.org/browse/JDK-8290209): jcup.md missing additional text


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/673/head:pull/673` \
`$ git checkout pull/673`

Update a local copy of the PR: \
`$ git checkout pull/673` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 673`

View PR using the GUI difftool: \
`$ git pr show -t 673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/673.diff">https://git.openjdk.org/jdk17u-dev/pull/673.diff</a>

</details>
