### PR TITLE
8277576: ProblemList runtime/ErrorHandling/CreateCoredumpOnCrash.java on macosx-X64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -66,6 +66,8 @@ compiler/c2/Test8004741.java 8235801 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 
+compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java 8277503 linux-aarch64
+
 
 #############################################################################
 
@@ -80,6 +82,8 @@ gc/stress/gclocker/TestGCLockerWithParallel.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
+
+applications/jcstress/acqrel.java 8277434 linux-aarch64
 
 #############################################################################
 
@@ -97,6 +101,7 @@ runtime/os/TestTracePageSizes.java#compiler-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#with-Serial 8267460 linux-aarch64
+runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 
 #############################################################################
 


### PR DESCRIPTION
I had to resolve, but marking as clean as it is only the ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8277576](https://bugs.openjdk.org/browse/JDK-8277576): ProblemList runtime/ErrorHandling/CreateCoredumpOnCrash.java on macosx-X64
 * [JDK-8277577](https://bugs.openjdk.org/browse/JDK-8277577): ProblemList compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java on linux-aarch64
 * [JDK-8277578](https://bugs.openjdk.org/browse/JDK-8277578): ProblemList applications/jcstress/acqrel.java on linux-aarch64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/674/head:pull/674` \
`$ git checkout pull/674`

Update a local copy of the PR: \
`$ git checkout pull/674` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 674`

View PR using the GUI difftool: \
`$ git pr show -t 674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/674.diff">https://git.openjdk.org/jdk17u-dev/pull/674.diff</a>

</details>
