### PR TITLE
8270609: [TESTBUG] java/awt/print/Dialog/DialogCopies.java does not show instruction

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogCopies.java
+++ b/test/jdk/java/awt/print/Dialog/DialogCopies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,40 +21,73 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 6357858
  * @summary Job must reports the number of copies set in the dialog.
  * @run main/manual DialogCopies
  */
 
-import java.awt.print.*;
+import java.awt.Frame;
+import java.awt.TextArea;
+import java.awt.BorderLayout;
+import java.awt.print.PrinterJob;
 
 public class DialogCopies {
 
-  static String[] instructions = {
-     "This test assumes and requires that you have a printer installed",
-     "When the dialog appears, increment the number of copies then press OK.",
-     "The test will throw an exception if you fail to do this, since",
-     "it cannot distinguish that from a failure",
-     ""
-  };
+    private static Frame createInstructionUI() {
+        final String instruction = """
+                This test requires that you have a printer.
 
-  public static void main(String[] args) {
+                Press Cancel if your system has only virtual printers such as
+                Microsoft Print to PDF or Microsoft XPS Document Writer since
+                they don't allow setting copies to anything but 1.
 
-      for (int i=0;i<instructions.length;i++) {
-         System.out.println(instructions[i]);
-      }
+                If a real printer is installed, select it from the drop-down
+                list in the Print dialog and increase the number of copies,
+                then press OK button.""";
 
-      PrinterJob job = PrinterJob.getPrinterJob();
-      if (job.getPrintService() == null || !job.printDialog()) {
-         return;
-      }
+        TextArea instructionTextArea = new TextArea(instruction);
+        instructionTextArea.setEditable(false);
 
-      System.out.println("Job copies is " + job.getCopies());
+        Frame instructionFrame = new Frame();
+        instructionFrame.add(instructionTextArea, BorderLayout.CENTER);
+        instructionFrame.pack();
+        instructionFrame.setLocationRelativeTo(null);
+        instructionFrame.setVisible(true);
+        return instructionFrame;
+    }
 
-      if (job.getCopies() == 1) {
-            throw new RuntimeException("Copies not incremented");
-      }
-   }
+    public static void showPrintDialog() {
+        PrinterJob job = PrinterJob.getPrinterJob();
+        if (job.getPrintService() == null) {
+            System.out.println("Looks like printer is not configured. Please install printer " +
+                    " and re-run the test case.");
+            return;
+        }
+        checkNoOfCopies(job, job.printDialog());
+    }
+
+    public static void checkNoOfCopies(PrinterJob job, boolean pdReturnValue) {
+        if (pdReturnValue) {
+            System.out.println("User has selected OK/Print button on the PrintDialog");
+            int copies = job.getCopies();
+            if (copies <= 1) {
+                throw new RuntimeException("Expected the number of copies to be more than 1 but got " + copies);
+            } else {
+                System.out.println("Total number of copies : " + copies);
+            }
+        } else {
+            System.out.println("User has selected Cancel button on the PrintDialog.");
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        Frame frame = createInstructionUI();
+        try {
+            showPrintDialog();
+        } finally {
+            frame.dispose();
+        }
+    }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270609](https://bugs.openjdk.org/browse/JDK-8270609): [TESTBUG] java/awt/print/Dialog/DialogCopies.java does not show instruction


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/680/head:pull/680` \
`$ git checkout pull/680`

Update a local copy of the PR: \
`$ git checkout pull/680` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 680`

View PR using the GUI difftool: \
`$ git pr show -t 680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/680.diff">https://git.openjdk.org/jdk17u-dev/pull/680.diff</a>

</details>
