### PR TITLE
8274160: java/awt/Window/ShapedAndTranslucentWindows/Common.java delay is too high

### DIFF
--- a/test/jdk/java/awt/Window/ShapedAndTranslucentWindows/Common.java
+++ b/test/jdk/java/awt/Window/ShapedAndTranslucentWindows/Common.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public abstract class Common {
     static final int STATIC_BLOCKS = 30;
     static final Color BG_COLOR = Color.BLUE;
     static final Color FG_COLOR = Color.RED;
-    static final int delay = 55000;
+    static final int delay = 1000;
     static final SecureRandom random = new SecureRandom();
     static final int dl = 100;
     static final Class[] WINDOWS_TO_TEST = { Window.class, Frame.class, Dialog.class };


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274160](https://bugs.openjdk.org/browse/JDK-8274160): java/awt/Window/ShapedAndTranslucentWindows/Common.java delay is too high


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/682/head:pull/682` \
`$ git checkout pull/682`

Update a local copy of the PR: \
`$ git checkout pull/682` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 682`

View PR using the GUI difftool: \
`$ git pr show -t 682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/682.diff">https://git.openjdk.org/jdk17u-dev/pull/682.diff</a>

</details>
