### PR TITLE
Backport d1e3ca4ee35bf4c2ce9b6dae2518f533f36a98dd

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -498,7 +498,6 @@ java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java 8
 
 java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223 linux-all,windows-all
 java/awt/Window/WindowResizing/DoubleClickTitleBarTest.java 8233557 macosx-all
-java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java 8233558 macosx-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all
 java/awt/FullScreen/8013581/bug8013581.java 8169471 macosx-all
 java/awt/event/MouseEvent/RobotLWTest/RobotLWTest.java 8233568 macosx-all

--- a/test/jdk/java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java
+++ b/test/jdk/java/awt/Window/WindowOwnedByEmbeddedFrameTest/WindowOwnedByEmbeddedFrameTest.java
@@ -26,7 +26,7 @@
  * @bug 8130655
  * @summary Tests that window owned by EmbeddedFrame can receive keyboard input
  * @requires (os.family == "mac")
- * @modules java.desktop/sun.awt
+ * @modules java.desktop/sun.awt java.desktop/sun.lwawt.macosx:open
  * @library ../../regtesthelpers
  * @build Util
  * @run main WindowOwnedByEmbeddedFrameTest


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.