### PR TITLE
8268779: ZGC: runtime/InternalApi/ThreadCpuTimesDeadlock.java#id1 failed with "OutOfMemoryError: Java heap space"

### DIFF
--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -493,6 +493,11 @@ void ZDriver::run_service() {
     // Run GC
     gc(request);
 
+    if (should_terminate()) {
+      // Abort
+      break;
+    }
+
     // Notify GC completed
     _gc_cycle_port.ack();
 


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268779](https://bugs.openjdk.org/browse/JDK-8268779): ZGC: runtime/InternalApi/ThreadCpuTimesDeadlock.java#id1 failed with "OutOfMemoryError: Java heap space"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/684/head:pull/684` \
`$ git checkout pull/684`

Update a local copy of the PR: \
`$ git checkout pull/684` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 684`

View PR using the GUI difftool: \
`$ git pr show -t 684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/684.diff">https://git.openjdk.org/jdk17u-dev/pull/684.diff</a>

</details>
