### PR TITLE
Backport a3406a1d8ab4228b06b4f2978f87275093c39468

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestContext.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/MetaspaceTestContext.java
@@ -1,9 +1,7 @@
 
 import sun.hotspot.WhiteBox;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 
 public class MetaspaceTestContext {
 
@@ -139,6 +137,9 @@ public class MetaspaceTestContext {
 
         long usageMeasured = usedWords();
         long committedMeasured = committedWords();
+
+        System.out.println("context used words " + usageMeasured + ", committed words " + committedMeasured
+                + ".");
 
         if (usageMeasured > committedMeasured) {
             throw new RuntimeException("Weirdness.");


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.