### PR TITLE
8268297: jdk/jfr/api/consumer/streaming/TestLatestEvent.java times out

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp
@@ -47,6 +47,8 @@ static jlong nanos_now() {
   const jlong now = seconds * 1000000000 + nanos;
   if (now > last) {
     last = now;
+  } else {
+    ++last;
   }
   return last;
 }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -818,7 +818,6 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    gener
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-x64
 
 ############################################################################
 


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

I had to resolve ProblemList because of context.  Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268297](https://bugs.openjdk.org/browse/JDK-8268297): jdk/jfr/api/consumer/streaming/TestLatestEvent.java times out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/687/head:pull/687` \
`$ git checkout pull/687`

Update a local copy of the PR: \
`$ git checkout pull/687` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 687`

View PR using the GUI difftool: \
`$ git pr show -t 687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/687.diff">https://git.openjdk.org/jdk17u-dev/pull/687.diff</a>

</details>
