### PR TITLE
8279398: jdk/jfr/api/recording/time/TestTimeMultiple.java failed with "RuntimeException: getStopTime() > afterStop"

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -269,9 +269,12 @@ public final class MetadataRepository {
         if (staleMetadata) {
             storeDescriptorInJVM();
         }
-        awaitUniqueTimestamp();
         jvm.setOutput(filename);
-        long nanos = jvm.getChunkStartNanos();
+        // Each chunk needs a unique start timestamp and
+        // if the clock resolution is low, two chunks may
+        // get the same timestamp. Utils.getChunkStartNanos()
+        // ensures the timestamp is unique for the next chunk
+        long chunkStart = Utils.getChunkStartNanos();
         if (filename != null) {
             RepositoryFiles.notifyNewFile();
         }
@@ -282,29 +285,7 @@ public final class MetadataRepository {
             }
             unregistered = false;
         }
-        return Utils.epochNanosToInstant(nanos);
-    }
-
-    // Each chunk needs a unique start timestamp and
-    // if the clock resolution is low, two chunks may
-    // get the same timestamp.
-    private void awaitUniqueTimestamp() {
-        if (outputChange == null) {
-            outputChange = Instant.now();
-            return;
-        }
-        while (true) {
-            Instant time = Instant.now();
-            if (!time.equals(outputChange)) {
-                outputChange = time;
-                return;
-            }
-            try {
-                Thread.sleep(0, 100);
-            } catch (InterruptedException iex) {
-                // ignore
-            }
-        }
+        return Utils.epochNanosToInstant(chunkStart);
     }
 
     private void unregisterUnloaded() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -249,7 +249,7 @@ public final class PlatformRecorder {
             }
             currentChunk = newChunk;
             jvm.beginRecording();
-            startNanos = jvm.getChunkStartNanos();
+            startNanos = Utils.getChunkStartNanos();
             startTime = Utils.epochNanosToInstant(startNanos);
             if (currentChunk != null) {
                 currentChunk.setStartTime(startTime);
@@ -270,7 +270,7 @@ public final class PlatformRecorder {
                 startTime = MetadataRepository.getInstance().setOutput(p);
                 newChunk.setStartTime(startTime);
             }
-            startNanos = jvm.getChunkStartNanos();
+            startNanos = Utils.getChunkStartNanos();
             startTime = Utils.epochNanosToInstant(startNanos);
             recording.setStartTime(startTime);
             recording.setState(RecordingState.RUNNING);
@@ -317,7 +317,7 @@ public final class PlatformRecorder {
             }
         }
         OldObjectSample.emit(recording);
-        recording.setFinalStartnanos(jvm.getChunkStartNanos());
+        recording.setFinalStartnanos(Utils.getChunkStartNanos());
 
         if (endPhysical) {
             RequestEngine.doChunkEnd();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,6 +96,7 @@ public final class Utils {
      * The possible data race is benign and is worth of not introducing any contention here.
      */
     private static Metrics[] metrics;
+    private static Instant lastTimestamp;
 
     public static void checkAccessFlightRecorder() throws SecurityException {
         @SuppressWarnings("removal")
@@ -840,5 +841,31 @@ public final class Utils {
 
     public static long timeToNanos(Instant timestamp) {
         return timestamp.getEpochSecond() * 1_000_000_000L + timestamp.getNano();
+    }
+
+    public static long getChunkStartNanos() {
+        long nanos = JVM.getJVM().getChunkStartNanos();
+        // JVM::getChunkStartNanos() may return a bumped timestamp, +1 ns or +2 ns.
+        // Spin here to give Instant.now() a chance to catch up.
+        awaitUniqueTimestamp();
+        return nanos;
+    }
+
+    private static void awaitUniqueTimestamp() {
+        if (lastTimestamp == null) {
+            lastTimestamp = Instant.now(); // lazy initialization
+        }
+        while (true) {
+            Instant time = Instant.now();
+            if (!time.equals(lastTimestamp)) {
+                lastTimestamp = time;
+                return;
+            }
+            try {
+                Thread.sleep(0, 100);
+            } catch (InterruptedException iex) {
+                // ignore
+            }
+        }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279398](https://bugs.openjdk.org/browse/JDK-8279398): jdk/jfr/api/recording/time/TestTimeMultiple.java failed with "RuntimeException: getStopTime() > afterStop"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/688/head:pull/688` \
`$ git checkout pull/688`

Update a local copy of the PR: \
`$ git checkout pull/688` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 688`

View PR using the GUI difftool: \
`$ git pr show -t 688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/688.diff">https://git.openjdk.org/jdk17u-dev/pull/688.diff</a>

</details>
