### PR TITLE
8273881: Metaspace: test repeated deallocations

### DIFF
--- a/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
@@ -739,3 +739,50 @@ TEST_VM(metaspace, MetaspaceArena_growth_boot_nc_not_inplace) {
                          word_size_for_level(CHUNK_LEVEL_4M), false);
 }
 */
+
+// Test that repeated allocation-deallocation cycles with the same block size
+//  do not increase metaspace usage after the initial allocation (the deallocated
+//  block should be reused by the next allocation).
+static void test_repeatedly_allocate_and_deallocate(bool is_topmost) {
+  if (Settings::handle_deallocations()) {
+    // Test various sizes, including (important) the max. possible block size = 1 root chunk
+    for (size_t blocksize = Metaspace::max_allocation_word_size(); blocksize >= 1; blocksize /= 2) {
+      size_t used1 = 0, used2 = 0, committed1 = 0, committed2 = 0;
+      MetaWord* p = NULL, *p2 = NULL;
+
+      MetaspaceGtestContext context;
+      MetaspaceArenaTestHelper helper(context, Metaspace::StandardMetaspaceType, false);
+
+      // First allocation
+      helper.allocate_from_arena_with_tests_expect_success(&p, blocksize);
+      if (!is_topmost) {
+        // another one on top, size does not matter.
+        helper.allocate_from_arena_with_tests_expect_success(0x10);
+      }
+
+      // Measure
+      helper.usage_numbers_with_test(&used1, &committed1, NULL);
+
+      // Dealloc, alloc several times with the same size.
+      for (int i = 0; i < 5; i ++) {
+        helper.deallocate_with_tests(p, blocksize);
+        helper.allocate_from_arena_with_tests_expect_success(&p2, blocksize);
+        // We should get the same pointer back.
+        EXPECT_EQ(p2, p);
+      }
+
+      // Measure again
+      helper.usage_numbers_with_test(&used2, &committed2, NULL);
+      EXPECT_EQ(used2, used1);
+      EXPECT_EQ(committed1, committed2);
+    }
+  }
+}
+
+TEST_VM(metaspace, MetaspaceArena_test_repeatedly_allocate_and_deallocate_top_allocation) {
+  test_repeatedly_allocate_and_deallocate(true);
+}
+
+TEST_VM(metaspace, MetaspaceArena_test_repeatedly_allocate_and_deallocate_nontop_allocation) {
+  test_repeatedly_allocate_and_deallocate(false);
+}


### PR DESCRIPTION
I backport this for parity with 17.0.5-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273881](https://bugs.openjdk.org/browse/JDK-8273881): Metaspace: test repeated deallocations


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/689/head:pull/689` \
`$ git checkout pull/689`

Update a local copy of the PR: \
`$ git checkout pull/689` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 689`

View PR using the GUI difftool: \
`$ git pr show -t 689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/689.diff">https://git.openjdk.org/jdk17u-dev/pull/689.diff</a>

</details>
