### PR TITLE
8280555: serviceability/sa/TestObjectMonitorIterate.java is failing due to ObjectMonitor referencing a null Object

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestObjectMonitorIterate.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestObjectMonitorIterate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -59,8 +59,12 @@ public class TestObjectMonitorIterate {
 
             while (itr.hasNext()) {
                 ObjectMonitor mon = (ObjectMonitor)itr.next();
-                Oop oop = heap.newOop(mon.object());
-                System.out.println("Monitor found: " + oop.getKlass().getName().asString());
+                if (mon.object() == null) {
+                    System.out.println("Monitor found: object is null");
+                } else {
+                    Oop oop = heap.newOop(mon.object());
+                    System.out.println("Monitor found: " + oop.getKlass().getName().asString());
+                }
             }
         } finally {
             agent.detach();


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280555](https://bugs.openjdk.org/browse/JDK-8280555): serviceability/sa/TestObjectMonitorIterate.java is failing due to ObjectMonitor referencing a null Object


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/691/head:pull/691` \
`$ git checkout pull/691`

Update a local copy of the PR: \
`$ git checkout pull/691` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 691`

View PR using the GUI difftool: \
`$ git pr show -t 691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/691.diff">https://git.openjdk.org/jdk17u-dev/pull/691.diff</a>

</details>
