### PR TITLE
8279662: serviceability/sa/ClhsdbScanOops.java can fail due to unexpected GC

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbScanOops.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbScanOops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.ArrayList;
 import jdk.test.lib.Utils;
 import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
 import jtreg.SkippedException;
 
 public class ClhsdbScanOops {
@@ -71,35 +72,54 @@ public class ClhsdbScanOops {
             Map<String, List<String>> expStrMap = new HashMap<>();
             Map<String, List<String>> unExpStrMap = new HashMap<>();
 
-            String startAddress = null;
-            String endAddress = null;
-            String[] snippets = null;
+            String startAddress;
+            String endAddress;
+            String[] snippets;
+            String[] words;
+            String cmd;
 
+            // Run scanoops on the old gen
+            if (gc.contains("UseParallelGC")) {
+                snippets = universeOutput.split("PSOldGen \\[  ");
+            } else {
+                snippets = universeOutput.split("old  \\[");
+            }
+            words = snippets[1].split(",");
+            // Get the addresses for Old gen
+            startAddress = words[0].replace("[", "");
+            endAddress = words[1];
+            cmd = "scanoops " + startAddress + " " + endAddress;
+            String output1 = test.run(theApp.getPid(), List.of(cmd), null, null);
+
+            // Run scanoops on the eden gen
             if (gc.contains("UseParallelGC")) {
                 snippets = universeOutput.split("eden =  ");
             } else {
                 snippets = universeOutput.split("eden \\[");
             }
-            String[] words = snippets[1].split(",");
-            // Get the addresses from Eden
+            words = snippets[1].split(",");
+            // Get the addresses for Eden gen
             startAddress = words[0].replace("[", "");
             endAddress = words[1];
-            String cmd = "scanoops " + startAddress + " " + endAddress;
-            cmds.add(cmd);
+            cmd = "scanoops " + startAddress + " " + endAddress;
+            String output2 = test.run(theApp.getPid(), List.of(cmd), null, null);
 
-            expStrMap.put(cmd, List.of
-                ("java/lang/Object", "java/lang/Class", "java/lang/Thread",
-                 "java/lang/String", "\\[B", "\\[I"));
+            // Look for expected types in the combined eden and old gens
+            OutputAnalyzer out = new OutputAnalyzer(output1 + output2);
+            List<String> expectStrs = List.of(
+                    "java/lang/Object", "java/lang/Class", "java/lang/Thread",
+                    "java/lang/String", "\\[B", "\\[I");
+            for (String expectStr : expectStrs) {
+                out.shouldMatch(expectStr);
+            }
 
-            // Test the 'type' option also
-            // scanoops <start addr> <end addr> java/lang/String
+            // Test the 'type' option also:
+            //   scanoops <start addr> <end addr> java/lang/String
             // Ensure that only the java/lang/String oops are printed.
             cmd = cmd + " java/lang/String";
-            cmds.add(cmd);
             expStrMap.put(cmd, List.of("java/lang/String"));
-            unExpStrMap.put(cmd, List.of("java/lang/Thread"));
-
-            test.run(theApp.getPid(), cmds, expStrMap, unExpStrMap);
+            unExpStrMap.put(cmd, List.of("java/lang/Thread", "java/lang/Class", "java/lang/Object"));
+            test.run(theApp.getPid(), List.of(cmd), expStrMap, unExpStrMap);
         } catch (SkippedException e) {
             throw e;
         } catch (Exception ex) {


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279662](https://bugs.openjdk.org/browse/JDK-8279662): serviceability/sa/ClhsdbScanOops.java can fail due to unexpected GC


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/692/head:pull/692` \
`$ git checkout pull/692`

Update a local copy of the PR: \
`$ git checkout pull/692` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 692`

View PR using the GUI difftool: \
`$ git pr show -t 692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/692.diff">https://git.openjdk.org/jdk17u-dev/pull/692.diff</a>

</details>
