### PR TITLE
8284892: java/net/httpclient/http2/TLSConnection.java fails intermittently

### DIFF
--- a/test/jdk/java/net/httpclient/http2/TLSConnection.java
+++ b/test/jdk/java/net/httpclient/http2/TLSConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,12 +166,13 @@ public class TLSConnection {
                 System.out.println(new String(body));
             }
 
+            sslSession = t.getSSLSession();
+
             try (OutputStream os = t.getResponseBody()) {
                 t.sendResponseHeaders(200, BODY.length);
                 os.write(BODY);
             }
 
-            sslSession = t.getSSLSession();
         }
 
         SSLSession getSSLSession() {


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284892](https://bugs.openjdk.org/browse/JDK-8284892): java/net/httpclient/http2/TLSConnection.java fails intermittently


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/696/head:pull/696` \
`$ git checkout pull/696`

Update a local copy of the PR: \
`$ git checkout pull/696` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 696`

View PR using the GUI difftool: \
`$ git pr show -t 696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/696.diff">https://git.openjdk.org/jdk17u-dev/pull/696.diff</a>

</details>
