### PR TITLE
8286263: compiler/c1/TestPinnedIntrinsics.java failed with "RuntimeException: testCurrentTimeMillis failed with -3"

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestPinnedIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/c1/TestPinnedIntrinsics.java
@@ -24,10 +24,9 @@
 /*
  * @test
  * @bug 8184271
- * @summary Test correct scheduling of System.nanoTime and System.currentTimeMillis C1 intrinsics.
+ * @summary Test correct scheduling of System.nanoTime C1 intrinsic.
  * @run main/othervm -XX:TieredStopAtLevel=1 -Xbatch
  *                   -XX:CompileCommand=dontinline,compiler.c1.TestPinnedIntrinsics::checkNanoTime
- *                   -XX:CompileCommand=dontinline,compiler.c1.TestPinnedIntrinsics::checkCurrentTimeMillis
  *                   compiler.c1.TestPinnedIntrinsics
  */
 
@@ -47,22 +46,9 @@ public class TestPinnedIntrinsics {
         }
     }
 
-    private static void testCurrentTimeMillis() {
-        long start = System.currentTimeMillis();
-        long end = System.currentTimeMillis();
-        checkCurrentTimeMillis(end - start);
-    }
-
-    private static void checkCurrentTimeMillis(long diff) {
-        if (diff < 0) {
-            throw new RuntimeException("testCurrentTimeMillis failed with " + diff);
-        }
-    }
-
     public static void main(String[] args) {
         for (int i = 0; i < 100_000; ++i) {
             testNanoTime();
-            testCurrentTimeMillis();
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286263](https://bugs.openjdk.org/browse/JDK-8286263): compiler/c1/TestPinnedIntrinsics.java failed with "RuntimeException: testCurrentTimeMillis failed with -3"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/699/head:pull/699` \
`$ git checkout pull/699`

Update a local copy of the PR: \
`$ git checkout pull/699` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 699`

View PR using the GUI difftool: \
`$ git pr show -t 699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/699.diff">https://git.openjdk.org/jdk17u-dev/pull/699.diff</a>

</details>
