### PR TITLE
8293828: JFR: jfr/event/oldobject/TestClassLoaderLeak.java still fails when GC cycles are not happening

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm -XX:TLABSize=2k -Xmx128m jdk.jfr.event.oldobject.TestClassLoaderLeak
+ * @run main/othervm -XX:TLABSize=2k -Xmx64m jdk.jfr.event.oldobject.TestClassLoaderLeak
  */
 public class TestClassLoaderLeak {
 


### PR DESCRIPTION
Backport for JDK-8293828

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293828](https://bugs.openjdk.org/browse/JDK-8293828): JFR: jfr/event/oldobject/TestClassLoaderLeak.java still fails when GC cycles are not happening


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/701/head:pull/701` \
`$ git checkout pull/701`

Update a local copy of the PR: \
`$ git checkout pull/701` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 701`

View PR using the GUI difftool: \
`$ git pr show -t 701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/701.diff">https://git.openjdk.org/jdk17u-dev/pull/701.diff</a>

</details>
