### PR TITLE
8274296: Update or Problem List tests which may fail with uiScale=2 on macOS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -737,6 +737,12 @@ javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 
+# Several tests which fail on some hidpi systems
+java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 8274106 macosx-aarch64
+java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
+java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
+javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64
+
 sanity/client/SwingSet/src/ToolTipDemoTest.java 8225012 windows-all,macosx-all
 sanity/client/SwingSet/src/ScrollPaneDemoTest.java 8225013 linux-all
 sanity/client/SwingSet/src/ButtonDemoScreenshotTest.java 8265770 macosx-all

--- a/test/jdk/java/awt/Dialog/SiblingChildOrder/SiblingChildOrderTest.java
+++ b/test/jdk/java/awt/Dialog/SiblingChildOrder/SiblingChildOrderTest.java
@@ -26,7 +26,7 @@
  * @bug 8190230 8196360
  * @summary [macosx] Order of overlapping of modal dialogs is wrong
  * @key headful
- * @run main SiblingChildOrderTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 SiblingChildOrderTest
  */
 
 import java.awt.Color;

--- a/test/jdk/java/awt/Paint/PaintNativeOnUpdate.java
+++ b/test/jdk/java/awt/Paint/PaintNativeOnUpdate.java
@@ -36,7 +36,7 @@ import java.awt.Point;
  * @library /lib/client
  * @build ExtendedRobot
  * @author Sergey Bylokhov
- * @run main PaintNativeOnUpdate
+ * @run main/othervm -Dsun.java2d.uiScale=1 PaintNativeOnUpdate
  */
 public final class PaintNativeOnUpdate extends Label {
 

--- a/test/jdk/java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java
+++ b/test/jdk/java/awt/Window/BackgroundIsNotUpdated/BackgroundIsNotUpdated.java
@@ -37,7 +37,7 @@ import java.awt.Window;
  * @author Sergey Bylokhov
  * @library /lib/client
  * @build ExtendedRobot
- * @run main BackgroundIsNotUpdated
+ * @run main/othervm -Dsun.java2d.uiScale=1 BackgroundIsNotUpdated
  */
 public final class BackgroundIsNotUpdated extends Window {
 

--- a/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
+++ b/test/jdk/java/awt/Window/MultiWindowApp/ChildAlwaysOnTopTest.java
@@ -28,7 +28,7 @@
  *          certain scenarios
  * @bug 8021961
  * @author Semyon Sadetsky
- * @run main ChildAlwaysOnTopTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 ChildAlwaysOnTopTest
  */
 
 import javax.swing.*;

--- a/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
+++ b/test/jdk/java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java
@@ -27,7 +27,7 @@
  * @bug 6683728
  * @summary Tests that a JApplet in a translucent JFrame works properly
  * @compile -XDignore.symbol.file=true TranslucentJAppletTest.java
- * @run main TranslucentJAppletTest
+ * @run main/othervm -Dsun.java2d.uiScale=1 TranslucentJAppletTest
  */
 
 import java.awt.*;

--- a/test/jdk/javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java
@@ -36,7 +36,7 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @key headful
  * @bug 8172269 8244557
  * @summary Tests JTabbedPane background for SCROLL_TAB_LAYOUT
- * @run main TestBackgroundScrollPolicy
+ * @run main/othervm -Dsun.java2d.uiScale=1 TestBackgroundScrollPolicy
  */
 
 public class TestBackgroundScrollPolicy {

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -28,7 +28,7 @@
  * @build Util
  * @author Romain Guy
  * @summary Tests PRESSED and MOUSE_OVER and FOCUSED state for buttons with Synth.
- * @run main bug6276188
+ * @run main/othervm -Dsun.java2d.uiScale=1 bug6276188
  */
 import java.awt.*;
 import java.awt.image.*;


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.
Omitted the hunk for TestNimbusBGColor.java because JDK-8058704 is not in 17.
Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274296](https://bugs.openjdk.org/browse/JDK-8274296): Update or Problem List tests which may fail with uiScale=2 on macOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/704/head:pull/704` \
`$ git checkout pull/704`

Update a local copy of the PR: \
`$ git checkout pull/704` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 704`

View PR using the GUI difftool: \
`$ git pr show -t 704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/704.diff">https://git.openjdk.org/jdk17u-dev/pull/704.diff</a>

</details>
