### PR TITLE
8210558: serviceability/sa/TestJhsdbJstackLock.java fails to find '^\s+- waiting to lock <0x[0-9a-f]+> \(a java\.lang\.Class ...'

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,19 @@ public class LingeredAppWithLock extends LingeredApp {
         classLock2.start();
         objectLock.start();
         primitiveLock.start();
+
+        // Wait until all threads have reached their blocked or timed wait state
+        while ((classLock1.getState() != Thread.State.BLOCKED &&
+                classLock1.getState() != Thread.State.TIMED_WAITING) ||
+               (classLock2.getState() != Thread.State.BLOCKED &&
+                classLock2.getState() != Thread.State.TIMED_WAITING) ||
+               (objectLock.getState() != Thread.State.TIMED_WAITING) ||
+               (primitiveLock.getState() != Thread.State.TIMED_WAITING)) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ex) {
+            }
+        }
 
         LingeredApp.main(args);
     }


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210558](https://bugs.openjdk.org/browse/JDK-8210558): serviceability/sa/TestJhsdbJstackLock.java fails to find '^\s+- waiting to lock <0x[0-9a-f]+> \(a java\.lang\.Class ...'


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/710/head:pull/710` \
`$ git checkout pull/710`

Update a local copy of the PR: \
`$ git checkout pull/710` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 710`

View PR using the GUI difftool: \
`$ git pr show -t 710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/710.diff">https://git.openjdk.org/jdk17u-dev/pull/710.diff</a>

</details>
