### PR TITLE
8280554: resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java can fail if GC is triggered

### DIFF
--- a/test/hotspot/jtreg/resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,6 @@ public class ClhsdbRegionDetailsScanOopsForG1 {
             expStrMap.put("g1regiondetails", List.of(
                 "Region",
                 "Eden",
-                "Survivor",
                 "StartsHumongous",
                 "ContinuesHumongous",
                 "Free"));

--- a/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeStringArray.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeStringArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,8 @@
 
 import jdk.test.lib.apps.LingeredApp;
 
+import java.lang.ref.Reference;
+
 public class LingeredAppWithLargeStringArray extends LingeredApp {
     public static void main(String args[]) {
         String[] hugeArray = new String[Integer.MAX_VALUE/8];
@@ -31,5 +33,6 @@ public class LingeredAppWithLargeStringArray extends LingeredApp {
             hugeArray[i] = new String(smallArray[i%3]);
         }
         LingeredApp.main(args);
+        Reference.reachabilityFence(hugeArray);
     }
  }


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280554](https://bugs.openjdk.org/browse/JDK-8280554): resourcehogs/serviceability/sa/ClhsdbRegionDetailsScanOopsForG1.java can fail if GC is triggered


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/712/head:pull/712` \
`$ git checkout pull/712`

Update a local copy of the PR: \
`$ git checkout pull/712` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 712`

View PR using the GUI difftool: \
`$ git pr show -t 712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/712.diff">https://git.openjdk.org/jdk17u-dev/pull/712.diff</a>

</details>
