### PR TITLE
8284980: Test vmTestbase/nsk/stress/except/except010.java times out with -Xcomp  -XX:+DeoptimizeALot

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/except/except010.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,7 @@
  *     JDK 1.3 classic VM for Sparc may crash (core dump) due to the known bug:
  *         #4245057 (P2/S3) VM crashes when heap is exhausted
  *
+ * @requires vm.opt.DeoptimizeALot != true
  * @run main/othervm -Xms50M -Xmx200M nsk.stress.except.except010
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284980](https://bugs.openjdk.org/browse/JDK-8284980): Test vmTestbase/nsk/stress/except/except010.java times out with -Xcomp  -XX:+DeoptimizeALot


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/715/head:pull/715` \
`$ git checkout pull/715`

Update a local copy of the PR: \
`$ git checkout pull/715` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 715`

View PR using the GUI difftool: \
`$ git pr show -t 715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/715.diff">https://git.openjdk.org/jdk17u-dev/pull/715.diff</a>

</details>
