### PR TITLE
8275234: java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java is entered twice in ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -496,7 +496,7 @@ java/awt/im/memoryleak/InputContextMemoryLeakTest.java 8023814 linux-all
 java/awt/Frame/DisposeParentGC/DisposeParentGC.java 8079786 macosx-all
 java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java 8213120 macosx-all
 
-java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223 linux-all,windows-all
+java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223,8274106 macosx-aarch64,linux-all,windows-all
 java/awt/Window/WindowResizing/DoubleClickTitleBarTest.java 8233557 macosx-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all
 java/awt/FullScreen/8013581/bug8013581.java 8169471 macosx-all
@@ -738,7 +738,6 @@ javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 
 # Several tests which fail on some hidpi systems
-java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 8274106 macosx-aarch64
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 javax/swing/JFrame/8175301/ScaledFrameBackgroundTest.java 8274106 macosx-aarch64


### PR DESCRIPTION
I backport this as follow-up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275234](https://bugs.openjdk.org/browse/JDK-8275234): java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java is entered twice in ProblemList


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/720/head:pull/720` \
`$ git checkout pull/720`

Update a local copy of the PR: \
`$ git checkout pull/720` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 720`

View PR using the GUI difftool: \
`$ git pr show -t 720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/720.diff">https://git.openjdk.org/jdk17u-dev/pull/720.diff</a>

</details>
