### PR TITLE
8274639: Provide a way to disable warnings for cross-modular links

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -452,6 +452,14 @@ doclet.usage.linkoffline.parameters=\
 doclet.usage.linkoffline.description=\
     Link to docs at <url1> using package list at <url2>
 
+# L10N: do not localize the option parameters: warn info
+doclet.usage.link-modularity-mismatch.parameters=\
+    (warn|info)
+doclet.usage.link-modularity-mismatch.description=\
+    Report external documentation with wrong modularity with either\n\
+    a warning or informational message. The default behaviour is to\n\
+    report a warning.
+
 doclet.usage.link-platform-properties.parameters=\
     <url>
 doclet.usage.link-platform-properties.description=\

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseOptions.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -164,6 +165,20 @@ public abstract class BaseOptions {
      */
     // A list of pairs containing urls and package list
     private final List<Utils.Pair<String, String>> linkOfflineList = new ArrayList<>();
+
+    /**
+     * An enum of policies for handling modularity mismatches in external documentation.
+     */
+    public enum ModularityMismatchPolicy {
+        INFO,
+        WARN
+    }
+
+    /**
+     * Argument for command-line option {@code --link-modularity-mismatch}.
+     * Describes how to handle external documentation with non-matching modularity.
+     */
+    private ModularityMismatchPolicy linkModularityMismatch = ModularityMismatchPolicy.WARN;
 
     /**
      * Location of alternative platform link properties file.
@@ -397,6 +412,23 @@ public abstract class BaseOptions {
                     }
                 },
 
+                new Option(resources, "--link-modularity-mismatch", 1) {
+                    @Override
+                    public boolean process(String opt, List<String> args) {
+                        String s = args.get(0);
+                        switch (s) {
+                            case "warn", "info" ->
+                                    linkModularityMismatch = ModularityMismatchPolicy.valueOf(s.toUpperCase(Locale.ROOT));
+                            default -> {
+                                reporter.print(ERROR, resources.getText(
+                                        "doclet.Option_invalid", s, "--link-modularity-mismatch"));
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                },
+
                 new Option(resources, "--link-platform-properties", 1) {
                     @Override
                     public boolean process(String opt, List<String> args) {
@@ -458,16 +490,13 @@ public abstract class BaseOptions {
                     public boolean process(String opt,  List<String> args) {
                         String o = args.get(0);
                         switch (o) {
-                            case "summary":
-                                summarizeOverriddenMethods = true;
-                                break;
-                            case "detail":
-                                summarizeOverriddenMethods = false;
-                                break;
-                            default:
+                            case "summary" -> summarizeOverriddenMethods = true;
+                            case "detail"  -> summarizeOverriddenMethods = false;
+                            default -> {
                                 reporter.print(ERROR,
                                         resources.getText("doclet.Option_invalid",o, "--override-methods"));
                                 return false;
+                            }
                         }
                         return true;
                     }
@@ -811,6 +840,14 @@ public abstract class BaseOptions {
      */
     List<Utils.Pair<String, String>> linkOfflineList() {
         return linkOfflineList;
+    }
+
+    /**
+     * Argument for command-line option {@code --link-modularity-mismatch}.
+     * Describes how to handle external documentation with non-matching modularity.
+     */
+    public ModularityMismatchPolicy linkModularityMismatch() {
+        return linkModularityMismatch;
     }
 
     /**


### PR DESCRIPTION
Hi! Here is backport of [JDK-8274639](https://bugs.openjdk.org/browse/JDK-8274639). The patch adds the ability to disable Link Modularity Mismatch warnings and so projects using cross-modular links can be compiled with -Werror flag.

Original patch applied cleanly.

Verification (amd64/20.04LTS): test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOptionWithModule.java
Regression (amd64/20.04LTS): test/langtools/jdk/javadoc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request to be approved

### Issues
 * [JDK-8274639](https://bugs.openjdk.org/browse/JDK-8274639): Provide a way to disable warnings for cross-modular links
 * [JDK-8294354](https://bugs.openjdk.org/browse/JDK-8294354): Provide a way to disable warnings for cross-modular links (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/723/head:pull/723` \
`$ git checkout pull/723`

Update a local copy of the PR: \
`$ git checkout pull/723` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 723`

View PR using the GUI difftool: \
`$ git pr show -t 723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/723.diff">https://git.openjdk.org/jdk17u-dev/pull/723.diff</a>

</details>
