### PR TITLE
8285794: AsyncGetCallTrace might acquire a lock via JavaThread::thread_from_jni_environment

### DIFF
--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -529,7 +529,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
   JavaThread* thread;
 
   if (trace->env_id == NULL || raw_thread == NULL || !raw_thread->is_Java_thread() ||
-     (thread = ((JavaThread*)raw_thread))->is_exiting()) {
+      (thread = ((JavaThread*)raw_thread))->is_exiting()) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -522,12 +522,14 @@ static void forte_fill_call_trace_given_top(JavaThread* thd,
 extern "C" {
 JNIEXPORT
 void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
+
+  // Can't use thread_from_jni_environment as it may also perform a VM exit check that is unsafe to
+  // do from this context.
+  Thread* raw_thread = Thread::current_or_null_safe();
   JavaThread* thread;
 
-  if (trace->env_id == NULL ||
-    (thread = JavaThread::thread_from_jni_environment(trace->env_id)) == NULL ||
-    thread->is_exiting()) {
-
+  if (trace->env_id == NULL || raw_thread == NULL || !raw_thread->is_Java_thread() ||
+     (thread = ((JavaThread*)raw_thread))->is_exiting()) {
     // bad env_id, thread has exited or thread is exiting
     trace->num_frames = ticks_thread_exit; // -8
     return;
@@ -539,7 +541,8 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  assert(JavaThread::current() == thread,
+  // This is safe now as the thread has not terminated and so no VM exit check occurs.
+  assert(thread == JavaThread::thread_from_jni_environment(trace->env_id),
          "AsyncGetCallTrace must be called by the current interrupted thread");
 
   if (!JvmtiExport::should_post_class_load()) {


### PR DESCRIPTION
Fixes the minor possibility of ASGCT acquiring a lock.

Tested using my jdk profiling tester.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285794](https://bugs.openjdk.org/browse/JDK-8285794): AsyncGetCallTrace might acquire a lock via JavaThread::thread_from_jni_environment


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [ebe5bc25](https://git.openjdk.org/jdk17u-dev/pull/725/files/ebe5bc25594d288f990d3415a3ab0e2cc4513597)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/725/head:pull/725` \
`$ git checkout pull/725`

Update a local copy of the PR: \
`$ git checkout pull/725` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 725`

View PR using the GUI difftool: \
`$ git pr show -t 725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/725.diff">https://git.openjdk.org/jdk17u-dev/pull/725.diff</a>

</details>
