### PR TITLE
8286452: The array length of testSmallConstArray should be small and const

### DIFF
--- a/test/micro/org/openjdk/bench/vm/gc/Alloc.java
+++ b/test/micro/org/openjdk/bench/vm/gc/Alloc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,14 @@ import java.util.concurrent.TimeUnit;
 public class Alloc {
 
     public static final int LENGTH = 400;
-    public static final int ARR_LEN = 100;
-    public int largeLen = 100;
-    public int smalllen = 6;
+    public static final int largeConstLen = 100;
+    public static final int smallConstLen = 6;
+    public int largeVariableLen = 100;
+    public int smallVariableLen = 6;
 
     @Benchmark
     public void testLargeConstArray(Blackhole bh) throws Exception {
-        int localArrlen = ARR_LEN;
+        int localArrlen = largeConstLen;
         for (int i = 0; i < LENGTH; i++) {
             Object[] tmp = new Object[localArrlen];
             bh.consume(tmp);
@@ -53,7 +54,7 @@ public class Alloc {
 
     @Benchmark
     public void testLargeVariableArray(Blackhole bh) throws Exception {
-        int localArrlen = largeLen;
+        int localArrlen = largeVariableLen;
         for (int i = 0; i < LENGTH; i++) {
             Object[] tmp = new Object[localArrlen];
             bh.consume(tmp);
@@ -62,7 +63,7 @@ public class Alloc {
 
     @Benchmark
     public void testSmallConstArray(Blackhole bh) throws Exception {
-        int localArrlen = largeLen;
+        int localArrlen = smallConstLen;
         for (int i = 0; i < LENGTH; i++) {
             Object[] tmp = new Object[localArrlen];
             bh.consume(tmp);
@@ -82,7 +83,7 @@ public class Alloc {
 
     @Benchmark
     public void testSmallVariableArray(Blackhole bh) throws Exception {
-        int localArrlen = smalllen;
+        int localArrlen = smallVariableLen;
         for (int i = 0; i < LENGTH; i++) {
             Object[] tmp = new Object[localArrlen];
             bh.consume(tmp);


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286452](https://bugs.openjdk.org/browse/JDK-8286452): The array length of testSmallConstArray should be small and const


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/735/head:pull/735` \
`$ git checkout pull/735`

Update a local copy of the PR: \
`$ git checkout pull/735` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 735`

View PR using the GUI difftool: \
`$ git pr show -t 735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/735.diff">https://git.openjdk.org/jdk17u-dev/pull/735.diff</a>

</details>
