### PR TITLE
8275170: Some jtreg sound tests should be marked with sound keyword

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -11,11 +11,15 @@
 #
 # A "headful" test requires a graphical environment to meaningfully
 # run. Tests that are not headful are "headless".
+# A test flagged with key sound needs audio devices on the system, this
+# may be accompanied by the headful keyword since audio device access 
+# is often linked to access to desktop resources and headful systems are
+# also more likely to have audio devices (ie meaning both input and output)
 # A test flagged with key "printer" requires a printer to succeed, else
 # throws a PrinterException or the like.
 # A test flagged with cgroups uses cgroups.
 
-keys=2d dnd headful i18n intermittent printer randomness jfr cgroups
+keys=2d dnd headful sound i18n intermittent printer randomness jfr cgroups
 
 # Tests that must run in othervm mode
 othervm.dirs=java/awt java/beans javax/accessibility javax/imageio javax/sound javax/swing javax/print \

--- a/test/jdk/javax/sound/midi/Devices/ClosedReceiver.java
+++ b/test/jdk/javax/sound/midi/Devices/ClosedReceiver.java
@@ -32,6 +32,7 @@ import javax.sound.midi.Synthesizer;
 
 /**
  * @test
+ * @key sound
  * @bug 4616517
  * @summary Receiver.send() does not work properly
  */

--- a/test/jdk/javax/sound/midi/Devices/InitializationHang.java
+++ b/test/jdk/javax/sound/midi/Devices/InitializationHang.java
@@ -28,6 +28,7 @@ import javax.sound.midi.MidiUnavailableException;
 
 /**
  * @test
+ * @key sound
  * @bug 8068412
  */
 public final class InitializationHang {

--- a/test/jdk/javax/sound/midi/Devices/MidiDeviceGetReceivers.java
+++ b/test/jdk/javax/sound/midi/Devices/MidiDeviceGetReceivers.java
@@ -31,6 +31,7 @@ import javax.sound.midi.Transmitter;
 
 /**
  * @test
+ * @key sound
  * @bug 4931387
  * @summary Add methods to MidiDevice to get list of Transmitters and Receivers
  */

--- a/test/jdk/javax/sound/midi/Devices/MidiIO.java
+++ b/test/jdk/javax/sound/midi/Devices/MidiIO.java
@@ -27,6 +27,7 @@ import javax.sound.midi.MidiUnavailableException;
 
 /**
  * @test
+ * @key sound
  * @bug 4356787
  * @summary MIDI device I/O is not working
  */

--- a/test/jdk/javax/sound/midi/Devices/MidiOutGetMicrosecondPositionBug.java
+++ b/test/jdk/javax/sound/midi/Devices/MidiOutGetMicrosecondPositionBug.java
@@ -28,6 +28,7 @@ import javax.sound.midi.Synthesizer;
 
 /**
  * @test
+ * @key sound
  * @bug 4903786
  * @summary MIDI OUT does not implement getMicrosecondPosition() consistently
  */

--- a/test/jdk/javax/sound/midi/Devices/OpenClose.java
+++ b/test/jdk/javax/sound/midi/Devices/OpenClose.java
@@ -31,6 +31,7 @@ import javax.sound.midi.Transmitter;
 
 /**
  * @test
+ * @key sound
  * @bug 4616517
  * @summary Receiver.send() does not work properly. Tests open/close behaviour
  *          of MidiDevices. For this test, it is essential that the MidiDevice

--- a/test/jdk/javax/sound/midi/Devices/ReceiverTransmitterAvailable.java
+++ b/test/jdk/javax/sound/midi/Devices/ReceiverTransmitterAvailable.java
@@ -29,6 +29,7 @@ import javax.sound.midi.Transmitter;
 
 /**
  * @test
+ * @key sound
  * @bug 4616517
  * @summary Receiver.send() does not work properly
  */

--- a/test/jdk/javax/sound/midi/Devices/Reopen.java
+++ b/test/jdk/javax/sound/midi/Devices/Reopen.java
@@ -28,6 +28,7 @@ import javax.sound.midi.Synthesizer;
 
 /**
  * @test
+ * @key sound
  * @bug 4914667
  * @summary Closing and reopening MIDI IN device on Linux throws
  *          MidiUnavailableException

--- a/test/jdk/javax/sound/midi/MidiSystem/DefaultDevices.java
+++ b/test/jdk/javax/sound/midi/MidiSystem/DefaultDevices.java
@@ -39,6 +39,7 @@ import com.sun.media.sound.JDK13Services;
  * @bug 4776511
  * @bug 4934509
  * @bug 4938236
+ * @key sound
  * @modules java.desktop/com.sun.media.sound
  * @run main/timeout=600 DefaultDevices
  * @summary RFE: Setting the default MixerProvider

--- a/test/jdk/javax/sound/midi/MidiSystem/GetSequencer.java
+++ b/test/jdk/javax/sound/midi/MidiSystem/GetSequencer.java
@@ -30,6 +30,7 @@ import javax.sound.midi.Transmitter;
 
 /**
  * @test
+ * @key sound
  * @bug 4931400
  * @summary Clarify default connections in default sequencer
  */

--- a/test/jdk/javax/sound/midi/Sequence/GetMicrosecondLength.java
+++ b/test/jdk/javax/sound/midi/Sequence/GetMicrosecondLength.java
@@ -30,6 +30,7 @@ import javax.sound.midi.Track;
 
 /**
  * @test
+ * @key sound
  * @bug 4929955
  * @summary Sequence.getMicrosecondLength() returns wrong value
  */

--- a/test/jdk/javax/sound/midi/Sequencer/LoopIAE.java
+++ b/test/jdk/javax/sound/midi/Sequencer/LoopIAE.java
@@ -32,6 +32,7 @@ import javax.sound.midi.Track;
 
 /**
  * @test
+ * @key sound
  * @bug 5025549
  * @summary Verify that setLoopEndPoint throws IAE
  */

--- a/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
+++ b/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
@@ -36,7 +36,7 @@ import javax.sound.midi.Track;
  * @test
  * @bug 4347135
  * @summary MIDI MetaMessage callback inconsistent
- * @key intermittent
+ * @key intermittent sound
  * @run main/othervm MetaCallback
  */
 public class MetaCallback implements MetaEventListener {

--- a/test/jdk/javax/sound/midi/Sequencer/Recording.java
+++ b/test/jdk/javax/sound/midi/Sequencer/Recording.java
@@ -34,7 +34,7 @@ import javax.sound.midi.Track;
 /**
  * @test
  * @bug 4932841
- * @key intermittent
+ * @key intermittent sound
  * @summary Sequencer's recording feature does not work
  */
 public class Recording {

--- a/test/jdk/javax/sound/midi/Sequencer/SeqRecordDoesNotCopy.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SeqRecordDoesNotCopy.java
@@ -33,6 +33,7 @@ import javax.sound.midi.Track;
 
 /**
  * @test
+ * @key sound
  * @bug 5048381
  * @summary Sequencer doesn't create distinct messages when recording events.
  */

--- a/test/jdk/javax/sound/midi/Sequencer/SeqRecordsRealTimeEvents.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SeqRecordsRealTimeEvents.java
@@ -33,6 +33,7 @@ import javax.sound.midi.Track;
 
 /**
  * @test
+ * @key sound
  * @bug 5048381
  * @summary Sequencer records real time messages into the sequence
  */

--- a/test/jdk/javax/sound/midi/Sequencer/SeqStartRecording.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SeqStartRecording.java
@@ -27,6 +27,7 @@ import javax.sound.midi.Sequencer;
 
 /**
  * @test
+ * @key sound
  * @bug 5001943
  * @summary Sequencer.startRecording throws unexpected NPE
  */

--- a/test/jdk/javax/sound/midi/Sequencer/SequencerCacheValues.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SequencerCacheValues.java
@@ -28,6 +28,7 @@ import javax.sound.midi.Sequencer;
 
 /**
  * @test
+ * @key sound
  * @bug 4716740
  * @summary default sequencer does not set the tempo factor
  */

--- a/test/jdk/javax/sound/midi/Sequencer/SequencerImplicitSynthOpen.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SequencerImplicitSynthOpen.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key sound
  * @bug 6660470
  * @summary Tests that sequencer correctly opens/closes (implicitly) devices
  * @author Alex Menkov

--- a/test/jdk/javax/sound/midi/Sequencer/SequencerSetMuteSolo.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SequencerSetMuteSolo.java
@@ -33,6 +33,7 @@ import javax.sound.midi.Sequencer;
 
 /**
  * @test
+ * @key sound
  * @bug 4713900
  * @summary default Sequencer allows to set Mute for invalid track
  */

--- a/test/jdk/javax/sound/midi/Sequencer/SequencerState.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SequencerState.java
@@ -34,6 +34,7 @@ import javax.sound.midi.Sequencer;
 
 /**
  * @test
+ * @key sound
  * @bug 4913027
  * @summary several Sequencer methods should specify behaviour on closed Sequencer
  */

--- a/test/jdk/javax/sound/midi/Sequencer/SetTickPosition.java
+++ b/test/jdk/javax/sound/midi/Sequencer/SetTickPosition.java
@@ -30,8 +30,9 @@ import javax.sound.midi.Track;
 
 /**
  * @test
+ * @key sound
  * @bug 4493775
- * @summary Sequncer method, setTickPosition(long) doesnot set the Tick position
+ * @summary Sequencer method, setTickPosition(long) does not set the Tick position
  */
 public class SetTickPosition {
         private static boolean testPassed = true;

--- a/test/jdk/javax/sound/midi/Sequencer/TickLength.java
+++ b/test/jdk/javax/sound/midi/Sequencer/TickLength.java
@@ -33,6 +33,7 @@ import javax.sound.midi.Track;
 
 /**
  * @test
+ * @key sound
  * @bug 4427890
  * @run main/othervm TickLength
  * @summary Sequencer.getTickLength() and Sequence.getTickLength() report the

--- a/test/jdk/javax/sound/midi/Soundbanks/ExtraCharInSoundbank.java
+++ b/test/jdk/javax/sound/midi/Soundbanks/ExtraCharInSoundbank.java
@@ -30,6 +30,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4429762
  * @summary Some instrument names in some soundbanks include bad extra characters
  */

--- a/test/jdk/javax/sound/sampled/AudioSystem/DefaultMixers.java
+++ b/test/jdk/javax/sound/sampled/AudioSystem/DefaultMixers.java
@@ -38,6 +38,7 @@ import com.sun.media.sound.JDK13Services;
 
 /**
  * @test
+ * @key sound
  * @bug 4776511
  * @summary RFE: Setting the default MixerProvider. Test the retrieving of lines
  *          with defaut mixer properties.

--- a/test/jdk/javax/sound/sampled/Clip/ClipCloseLoss.java
+++ b/test/jdk/javax/sound/sampled/Clip/ClipCloseLoss.java
@@ -33,6 +33,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4946913 8178403
  * @summary DirectClip doesn't kill the thread correctly, sometimes
  * @run main/othervm ClipCloseLoss

--- a/test/jdk/javax/sound/sampled/Clip/ClipFlushCrash.java
+++ b/test/jdk/javax/sound/sampled/Clip/ClipFlushCrash.java
@@ -33,6 +33,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4946945
  * @summary Crash in javasound while running TicTacToe demo applet tiger b26
  */

--- a/test/jdk/javax/sound/sampled/Clip/Drain/ClipDrain.java
+++ b/test/jdk/javax/sound/sampled/Clip/Drain/ClipDrain.java
@@ -29,6 +29,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4732218
  * @summary Clip.drain does not actually block until all I/O is complete as
  *          documented.

--- a/test/jdk/javax/sound/sampled/Clip/Duration/ClipDuration.java
+++ b/test/jdk/javax/sound/sampled/Clip/Duration/ClipDuration.java
@@ -33,6 +33,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4237703
  * @summary Check that Clip.getMicrosecondLength() returns correct value.
  */

--- a/test/jdk/javax/sound/sampled/Clip/Endpoint/ClipSetEndPoint.java
+++ b/test/jdk/javax/sound/sampled/Clip/Endpoint/ClipSetEndPoint.java
@@ -33,6 +33,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4385928
  * @summary Verify that an endpoint -1 in Clip does not throw an exception
  */

--- a/test/jdk/javax/sound/sampled/Controls/FloatControl/FloatControlBug.java
+++ b/test/jdk/javax/sound/sampled/Controls/FloatControl/FloatControlBug.java
@@ -34,6 +34,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4385654
  * @summary Check that the MASTER_GAIN control has a valid precision
  */

--- a/test/jdk/javax/sound/sampled/DataLine/DataLineInfoNegBufferSize.java
+++ b/test/jdk/javax/sound/sampled/DataLine/DataLineInfoNegBufferSize.java
@@ -30,6 +30,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 5021234
  * @summary Using -2 for buffer size will fail retrieval of lines
  */

--- a/test/jdk/javax/sound/sampled/DataLine/DataLine_ArrayIndexOutOfBounds.java
+++ b/test/jdk/javax/sound/sampled/DataLine/DataLine_ArrayIndexOutOfBounds.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key sound
  * @bug 7088367
  * @summary SourceDataLine.write and TargetDataLine.read don't throw ArrayIndexOutOfBoundsException
  * @author Alex Menkov

--- a/test/jdk/javax/sound/sampled/DataLine/LineDefFormat.java
+++ b/test/jdk/javax/sound/sampled/DataLine/LineDefFormat.java
@@ -31,6 +31,7 @@ import javax.sound.sampled.TargetDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 5053380
  * @summary Verify that getting a line initializes it with the format in
  *          DataLine.Info

--- a/test/jdk/javax/sound/sampled/Lines/16and32KHz/Has16and32KHz.java
+++ b/test/jdk/javax/sound/sampled/Lines/16and32KHz/Has16and32KHz.java
@@ -32,6 +32,7 @@ import javax.sound.sampled.TargetDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4479441
  * @summary Verify that the lines report 16KHz and 32KHz capability
  */

--- a/test/jdk/javax/sound/sampled/Lines/BufferSizeCheck.java
+++ b/test/jdk/javax/sound/sampled/Lines/BufferSizeCheck.java
@@ -30,6 +30,7 @@ import javax.sound.sampled.SourceDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4661602
  * @summary Buffersize is checked when re-opening line
  */

--- a/test/jdk/javax/sound/sampled/Lines/ChangingBuffer.java
+++ b/test/jdk/javax/sound/sampled/Lines/ChangingBuffer.java
@@ -30,6 +30,7 @@ import javax.sound.sampled.SourceDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4515126
  * @summary Verify that the buffer passed to SourceDataLine.write() and
  *          Clip.open() will not be changed

--- a/test/jdk/javax/sound/sampled/Lines/ClickInPlay/Test4218609.java
+++ b/test/jdk/javax/sound/sampled/Lines/ClickInPlay/Test4218609.java
@@ -31,6 +31,7 @@ import java.awt.event.ActionListener;
 
 /**
  * @test
+ * @key sound
  * @bug 4218609
  * @summary A soft audio click is heard when playing some audio file
  * @build ClickInPlay

--- a/test/jdk/javax/sound/sampled/Lines/ClipOpenException.java
+++ b/test/jdk/javax/sound/sampled/Lines/ClipOpenException.java
@@ -33,6 +33,7 @@ import javax.sound.sampled.TargetDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4679187
  * @summary Clip.open() throws unexpected Exceptions. verifies that clip,
  *          sourcedataline and targetdataline throw IllegalArgumentExcepotion if

--- a/test/jdk/javax/sound/sampled/Lines/FrameSize/FrameSizeTest.java
+++ b/test/jdk/javax/sound/sampled/Lines/FrameSize/FrameSizeTest.java
@@ -29,6 +29,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4469409
  * @summary Check that the frame size in the formats returned by lines is
  *          correct

--- a/test/jdk/javax/sound/sampled/Lines/SDLwrite.java
+++ b/test/jdk/javax/sound/sampled/Lines/SDLwrite.java
@@ -30,6 +30,7 @@ import javax.sound.sampled.SourceDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4680710
  * @summary SourceDataLine.write() behavior is not correct for not open or not
  *          started lines

--- a/test/jdk/javax/sound/sampled/Lines/SourceDataLineDefaultBufferSizeCrash.java
+++ b/test/jdk/javax/sound/sampled/Lines/SourceDataLineDefaultBufferSizeCrash.java
@@ -30,6 +30,7 @@ import javax.sound.sampled.SourceDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4681384
  * @summary SourceDataLine.write() causes Unexpected Signal 11 in native code
  *          outside the VM

--- a/test/jdk/javax/sound/sampled/Lines/StopStart.java
+++ b/test/jdk/javax/sound/sampled/Lines/StopStart.java
@@ -34,6 +34,7 @@ import javax.sound.sampled.SourceDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4828556
  * @summary stopping and starting sampled audio plays small chunk in infinite
  *          loop

--- a/test/jdk/javax/sound/sampled/LinuxBlock/PlaySine.java
+++ b/test/jdk/javax/sound/sampled/LinuxBlock/PlaySine.java
@@ -34,6 +34,7 @@ import javax.sound.sampled.SourceDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4834461
  * @summary Applet hang when you load it during sound card is in use
  * @run main/manual PlaySine

--- a/test/jdk/javax/sound/sampled/LinuxCrash/ClipLinuxCrash.java
+++ b/test/jdk/javax/sound/sampled/LinuxCrash/ClipLinuxCrash.java
@@ -34,6 +34,7 @@ import javax.sound.sampled.LineListener;
 
 /**
  * @test
+ * @key sound
  * @bug 4498848
  * @summary Sound causes crashes on Linux (part 1)
  */

--- a/test/jdk/javax/sound/sampled/LinuxCrash/ClipLinuxCrash2.java
+++ b/test/jdk/javax/sound/sampled/LinuxCrash/ClipLinuxCrash2.java
@@ -36,6 +36,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4498848
  * @summary Sound causes crashes on Linux (part 3)
  */

--- a/test/jdk/javax/sound/sampled/LinuxCrash/SDLLinuxCrash.java
+++ b/test/jdk/javax/sound/sampled/LinuxCrash/SDLLinuxCrash.java
@@ -32,6 +32,7 @@ import javax.sound.sampled.SourceDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4498848
  * @summary Sound causes crashes on Linux (part 2)
  */

--- a/test/jdk/javax/sound/sampled/Mixers/BogusMixers.java
+++ b/test/jdk/javax/sound/sampled/Mixers/BogusMixers.java
@@ -28,6 +28,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4667064
  * @summary Java Sound provides bogus SourceDataLine and TargetDataLine
  */

--- a/test/jdk/javax/sound/sampled/Mixers/BothEndiansAndSigns.java
+++ b/test/jdk/javax/sound/sampled/Mixers/BothEndiansAndSigns.java
@@ -29,6 +29,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4936397
  * @summary Verify that there'll for a given endianness, there's also the little
  *          endian version

--- a/test/jdk/javax/sound/sampled/Mixers/DirectSoundRepeatingBuffer/Test4997635.java
+++ b/test/jdk/javax/sound/sampled/Mixers/DirectSoundRepeatingBuffer/Test4997635.java
@@ -31,6 +31,7 @@ import java.awt.event.ActionListener;
 
 /**
  * @test
+ * @key sound
  * @bug 4997635
  * @summary Win: SourceDataLine playback loops endlessly unless you manually
  *          stop()

--- a/test/jdk/javax/sound/sampled/Mixers/DirectSoundUnderrunSilence/Test5032020.java
+++ b/test/jdk/javax/sound/sampled/Mixers/DirectSoundUnderrunSilence/Test5032020.java
@@ -31,6 +31,7 @@ import java.awt.event.ActionListener;
 
 /**
  * @test
+ * @key sound
  * @bug 5032020
  * @summary Win: Direct Audio is silent after underrun
  * @build DirectSoundUnderrunSilence

--- a/test/jdk/javax/sound/sampled/Mixers/NoSimpleInputDevice.java
+++ b/test/jdk/javax/sound/sampled/Mixers/NoSimpleInputDevice.java
@@ -26,6 +26,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4936397
  * @summary Verify that there'll be either SimpleInputDevice OR DirectAudioDevice
  */

--- a/test/jdk/javax/sound/sampled/Mixers/PhantomMixers.java
+++ b/test/jdk/javax/sound/sampled/Mixers/PhantomMixers.java
@@ -30,6 +30,7 @@ import javax.sound.sampled.TargetDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4794104
  * @summary mixers are always present, independent of available soundcards
  * @run main/manual PhantomMixers

--- a/test/jdk/javax/sound/sampled/Mixers/PlugHwMonoAnd8bitAvailable.java
+++ b/test/jdk/javax/sound/sampled/Mixers/PlugHwMonoAnd8bitAvailable.java
@@ -29,6 +29,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 5013897
  * @summary Verify that plughw: provides mono and 8-bit lines
  */

--- a/test/jdk/javax/sound/sampled/Mixers/UnexpectedIAE.java
+++ b/test/jdk/javax/sound/sampled/Mixers/UnexpectedIAE.java
@@ -28,6 +28,7 @@ import javax.sound.sampled.Mixer;
 
 /**
  * @test
+ * @key sound
  * @bug 4964288
  * @summary Unexpected IAE raised while getting TargetDataLine
  */

--- a/test/jdk/javax/sound/sampled/Recording/TargetDataLineFlush.java
+++ b/test/jdk/javax/sound/sampled/Recording/TargetDataLineFlush.java
@@ -30,6 +30,7 @@ import javax.sound.sampled.TargetDataLine;
 
 /**
  * @test
+ * @key sound
  * @bug 4836433
  * @summary Windows: TargetDataLine.flush() does not work. Since this test has
  *          some real-time variance, I disabled it by making it a manual test.

--- a/test/jdk/javax/sound/sampled/spi/MixerProvider/ExpectedNPEOnNull.java
+++ b/test/jdk/javax/sound/sampled/spi/MixerProvider/ExpectedNPEOnNull.java
@@ -29,6 +29,7 @@ import static java.util.ServiceLoader.load;
 
 /**
  * @test
+ * @key sound
  * @bug 8135100
  * @author Sergey Bylokhov
  */


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275170](https://bugs.openjdk.org/browse/JDK-8275170): Some jtreg sound tests should be marked with sound keyword


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/736/head:pull/736` \
`$ git checkout pull/736`

Update a local copy of the PR: \
`$ git checkout pull/736` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 736`

View PR using the GUI difftool: \
`$ git pr show -t 736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/736.diff">https://git.openjdk.org/jdk17u-dev/pull/736.diff</a>

</details>
