### PR TITLE
8288651: CDS test HelloUnload.java should not use literal string as ClassLoader name

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class HelloUnload {
         }
 
         URLClassLoader urlClassLoader =
-            new URLClassLoader("HelloClassLoader", urls, null);
+            new URLClassLoader("HelloClassLoader" + System.currentTimeMillis(), urls, null);
         Class c = Class.forName(className, true, urlClassLoader);
         System.out.println(c);
         System.out.println(c.getClassLoader());


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288651](https://bugs.openjdk.org/browse/JDK-8288651): CDS test HelloUnload.java should not use literal string as ClassLoader name


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/744/head:pull/744` \
`$ git checkout pull/744`

Update a local copy of the PR: \
`$ git checkout pull/744` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 744`

View PR using the GUI difftool: \
`$ git pr show -t 744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/744.diff">https://git.openjdk.org/jdk17u-dev/pull/744.diff</a>

</details>
