### PR TITLE
8289257: Some custom loader tests failed due to symbol refcount not decremented

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class HelloUnload {
         }
 
         URLClassLoader urlClassLoader =
-            new URLClassLoader("HelloClassLoader", urls, null);
+            new URLClassLoader("HelloClassLoader" + System.currentTimeMillis(), urls, null);
         Class c = Class.forName(className, true, urlClassLoader);
         System.out.println(c);
         System.out.println(c.getClassLoader());

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -63,7 +63,7 @@ public class HelloUnload {
         }
 
         URLClassLoader urlClassLoader =
-            new URLClassLoader("HelloClassLoader" + System.currentTimeMillis(), urls, null);
+            new URLClassLoader("HelloClassLoader", urls, null);
         Class c = Class.forName(className, true, urlClassLoader);
         System.out.println(c);
         System.out.println(c.getClassLoader());
@@ -86,22 +86,11 @@ public class HelloUnload {
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
 
         if (doUnload) {
-            String loaderName = urlClassLoader.getName();
-            int loadedRefcount = wb.getSymbolRefcount(loaderName);
-            System.out.println("Refcount of symbol " + loaderName + " is " + loadedRefcount);
-
             urlClassLoader = null; c = null; o = null;
             ClassUnloadCommon.triggerUnloading();
             System.out.println("Is CustomLoadee alive? " + wb.isClassAlive(className));
             ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
 
-            int unloadedRefcount = wb.getSymbolRefcount(loaderName);
-            System.out.println("Refcount of symbol " + loaderName + " is " + unloadedRefcount);
-
-            // refcount of a permanent symbol will not be decremented
-            if (loadedRefcount != 65535) {
-                ClassUnloadCommon.failIf(unloadedRefcount != (loadedRefcount - 1), "Refcount must be decremented");
-            }
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

Dropped change to problem list. Tests were not problem listed in 17. Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289257](https://bugs.openjdk.org/browse/JDK-8289257): Some custom loader tests failed due to symbol refcount not decremented


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/756/head:pull/756` \
`$ git checkout pull/756`

Update a local copy of the PR: \
`$ git checkout pull/756` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 756`

View PR using the GUI difftool: \
`$ git pr show -t 756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/756.diff">https://git.openjdk.org/jdk17u-dev/pull/756.diff</a>

</details>
