### PR TITLE
8291459: JVM crash with GenerateOopMap::error_work(char const*, __va_list_tag*)

### DIFF
--- a/src/hotspot/share/oops/generateOopMap.cpp
+++ b/src/hotspot/share/oops/generateOopMap.cpp
@@ -547,7 +547,13 @@ bool GenerateOopMap::jump_targets_do(BytecodeStream *bcs, jmpFct_t jmpFct, int *
     case Bytecodes::_ifnull:
     case Bytecodes::_ifnonnull:
       (*jmpFct)(this, bcs->dest(), data);
-      (*jmpFct)(this, bci + 3, data);
+      // Class files verified by the old verifier can have a conditional branch
+      // as their last bytecode, provided the conditional branch is unreachable
+      // during execution.  Check if this instruction is the method's last bytecode
+      // and, if so, don't call the jmpFct.
+      if (bci + 3 < method()->code_size()) {
+        (*jmpFct)(this, bci + 3, data);
+      }
       break;
 
     case Bytecodes::_goto:

--- a/test/hotspot/jtreg/runtime/GenerateOopMap/TestGenerateOopMapCrash.java
+++ b/test/hotspot/jtreg/runtime/GenerateOopMap/TestGenerateOopMapCrash.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8291459
+ * @summary Test that GenerateOopMap does not crash if last bytecode is a conditional branch
+ * @library /test/lib /
+ * @requires vm.flagless
+ * @compile if_icmpleIsLastOpcode.jasm
+ * @run driver TestGenerateOopMapCrash
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+// This test was copied from compiler test TestLinkageErrorInGenerateOopMap.java.
+public class TestGenerateOopMapCrash {
+
+    public static void main(String args[]) throws Exception {
+        if (args.length == 0) {
+            // Spawn new VM instance to execute test
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                    "-XX:-TieredCompilation",
+                    "-XX:CompileCommand=dontinline,if_icmpleIsLastOpcode.m*",
+                    "-Xmx64m",
+                    TestGenerateOopMapCrash.class.getName(),
+                    "run");
+            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            output.shouldHaveExitValue(0);
+        } else {
+            // Execute test
+            if_icmpleIsLastOpcode.test();
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/GenerateOopMap/if_icmpleIsLastOpcode.jasm
+++ b/test/hotspot/jtreg/runtime/GenerateOopMap/if_icmpleIsLastOpcode.jasm
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+// Old class file with a method whose last bytecode is an unreachable
+// conditional branch.
+public class if_icmpleIsLastOpcode version 49:0 {
+    public static Method m1:"()I" stack 1 locals 0 {
+        iconst_0;
+        ireturn;
+    }
+
+    public static Method m2:"(I)V" stack 1 locals 1 {
+        return;
+    }
+
+    public static Method test:"()V" stack 2 locals 1 {
+        iconst_0;
+        istore_0;
+        Loop: stack_frame_type append;
+        locals_map int;
+        iload_0;
+        invokestatic Method if_icmpleIsLastOpcode."m1":"()I";
+        invokestatic Method if_icmpleIsLastOpcode."m2":"(I)V";
+        iinc 0, 1;
+        ldc 100000;
+        if_icmple Loop;
+        return;
+        ldc 100000;
+        if_icmple Loop;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291459](https://bugs.openjdk.org/browse/JDK-8291459): JVM crash with GenerateOopMap::error_work(char const*, __va_list_tag*)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/757/head:pull/757` \
`$ git checkout pull/757`

Update a local copy of the PR: \
`$ git checkout pull/757` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 757`

View PR using the GUI difftool: \
`$ git pr show -t 757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/757.diff">https://git.openjdk.org/jdk17u-dev/pull/757.diff</a>

</details>
