### PR TITLE
8293578: Duplicate ldc generated by javac

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -862,7 +862,7 @@ public class Attr extends JCTree.Visitor {
             Type itype = attribExpr(variable.init, env, type);
             if (variable.isImplicitlyTyped()) {
                 //fixup local variable type
-                type = variable.type = variable.sym.type = chk.checkLocalVarType(variable, itype.baseType(), variable.name);
+                type = variable.type = variable.sym.type = chk.checkLocalVarType(variable, itype, variable.name);
             }
             if (itype.constValue() != null) {
                 return coerce(itype, type).constValue();
@@ -1314,7 +1314,7 @@ public class Attr extends JCTree.Visitor {
                     attribExpr(tree.init, initEnv, v.type);
                     if (tree.isImplicitlyTyped()) {
                         //fixup local variable type
-                        v.type = chk.checkLocalVarType(tree, tree.init.type.baseType(), tree.name);
+                        v.type = chk.checkLocalVarType(tree, tree.init.type, tree.name);
                     }
                 }
                 if (tree.isImplicitlyTyped()) {
@@ -2594,7 +2594,7 @@ public class Attr extends JCTree.Visitor {
                     argtypes.isEmpty()) {
                 // as a special case, x.getClass() has type Class<? extends |X|>
                 return new ClassType(restype.getEnclosingType(),
-                        List.of(new WildcardType(types.erasure(qualifierType),
+                        List.of(new WildcardType(types.erasure(qualifierType.baseType()),
                                 BoundKind.EXTENDS,
                                 syms.boundClass)),
                         restype.tsym,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -985,7 +985,7 @@ public class Check {
         }
 
         //upward project the initializer type
-        return types.upward(t, types.captures(t));
+        return types.upward(t, types.captures(t)).baseType();
     }
 
     Type checkMethod(final Type mtype,

--- a/test/langtools/tools/javac/lvti/ConstantTypes.java
+++ b/test/langtools/tools/javac/lvti/ConstantTypes.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8293578
+ * @summary Ensure constant types are removed correctly for <string>.getClass().
+ * @compile ConstantTypes.java
+ * @run main ConstantTypes
+ */
+
+import java.util.Objects;
+
+public class ConstantTypes {
+    public static void main(String... args) throws Throwable {
+        new ConstantTypes().testStringCreation1();
+        new ConstantTypes().testStringCreation2();
+        new ConstantTypes().testStringCreation3();
+        new ConstantTypes().testStringCreation4();
+        new ConstantTypes().testStringFolding();
+    }
+
+    private void testStringCreation1() throws Throwable {
+        var testC = "incorrect".getClass();
+        var testV = testC.getConstructor(String.class)
+                         .newInstance("correct");
+        String actual = testV;
+        String expected = "correct";
+        if (!Objects.equals(actual, expected)) {
+            throw new AssertionError("Unexpected result: " + actual);
+        }
+    }
+
+    private void testStringCreation2() throws Throwable {
+        var test = "incorrect".getClass()
+                              .getConstructor(String.class)
+                              .newInstance("correct");
+        String actual = test;
+        String expected = "correct";
+        if (!Objects.equals(actual, expected)) {
+            throw new AssertionError("Unexpected result: " + actual);
+        }
+    }
+
+    private void testStringCreation3() throws Throwable {
+        final var testC = "incorrect";
+        var testV = testC.getClass()
+                         .getConstructor(String.class)
+                         .newInstance("correct");
+        String actual = testV;
+        String expected = "correct";
+        if (!Objects.equals(actual, expected)) {
+            throw new AssertionError("Unexpected result: " + actual);
+        }
+    }
+
+    private void testStringCreation4() throws Throwable {
+        var testC = "incorrect";
+        var testV = testC.getClass()
+                         .getConstructor(String.class)
+                         .newInstance("correct");
+        String actual = testV;
+        String expected = "correct";
+        if (!Objects.equals(actual, expected)) {
+            throw new AssertionError("Unexpected result: " + actual);
+        }
+    }
+
+    private void testStringFolding() {
+        final var v1 = "1";
+        final var v2 = "2";
+        String actual = v1 + v2;
+        String expected = "12";
+        if (actual != expected) { //intentional reference comparison
+            throw new AssertionError("Value not interned!");
+        }
+    }
+
+}


### PR DESCRIPTION
Backport for 8293578

Backport for parity with 17.0.6-oracle
Clean backport, tests pass.

Tested by manually running ConstantTypes.java, also ran jtreg tier1, tier2, jck_compiler and jck_runtime - all fine

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293578](https://bugs.openjdk.org/browse/JDK-8293578): Duplicate ldc generated by javac


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/758/head:pull/758` \
`$ git checkout pull/758`

Update a local copy of the PR: \
`$ git checkout pull/758` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 758`

View PR using the GUI difftool: \
`$ git pr show -t 758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/758.diff">https://git.openjdk.org/jdk17u-dev/pull/758.diff</a>

</details>
