### PR TITLE
8276904: Optional.toString() is unnecessarily expensive

### DIFF
--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -454,7 +454,7 @@ public final class Optional<T> {
     @Override
     public String toString() {
         return value != null
-            ? String.format("Optional[%s]", value)
+            ? ("Optional[" + value + "]")
             : "Optional.empty";
     }
 }

--- a/src/java.base/share/classes/java/util/OptionalDouble.java
+++ b/src/java.base/share/classes/java/util/OptionalDouble.java
@@ -328,7 +328,7 @@ public final class OptionalDouble {
     @Override
     public String toString() {
         return isPresent
-                ? String.format("OptionalDouble[%s]", value)
+                ? ("OptionalDouble[" + value + "]")
                 : "OptionalDouble.empty";
     }
 }

--- a/src/java.base/share/classes/java/util/OptionalInt.java
+++ b/src/java.base/share/classes/java/util/OptionalInt.java
@@ -326,7 +326,7 @@ public final class OptionalInt {
     @Override
     public String toString() {
         return isPresent
-                ? String.format("OptionalInt[%s]", value)
+                ? ("OptionalInt[" + value + "]")
                 : "OptionalInt.empty";
     }
 }

--- a/src/java.base/share/classes/java/util/OptionalLong.java
+++ b/src/java.base/share/classes/java/util/OptionalLong.java
@@ -326,7 +326,7 @@ public final class OptionalLong {
     @Override
     public String toString() {
         return isPresent
-                ? String.format("OptionalLong[%s]", value)
+                ? ("OptionalLong[" + value + "]")
                 : "OptionalLong.empty";
     }
 }


### PR DESCRIPTION
Backporting trivial performance fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276904](https://bugs.openjdk.org/browse/JDK-8276904): Optional.toString() is unnecessarily expensive


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/763/head:pull/763` \
`$ git checkout pull/763`

Update a local copy of the PR: \
`$ git checkout pull/763` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 763`

View PR using the GUI difftool: \
`$ git pr show -t 763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/763.diff">https://git.openjdk.org/jdk17u-dev/pull/763.diff</a>

</details>
