### PR TITLE
8294578: [PPC64] C2: Missing is_oop information when using disjoint compressed oops mode

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -6834,6 +6834,9 @@ instruct decodeN_Disjoint_notNull_Ex(iRegPdst dst, iRegNsrc src) %{
     n2->_opnds[2] = op_dst;
     n2->_bottom_type = _bottom_type;
 
+    assert(ra_->is_oop(this) == true, "A decodeN node must produce an oop!");
+    ra_->set_oop(n2, true);
+
     ra_->set_pair(n1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
     ra_->set_pair(n2->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
 


### PR DESCRIPTION
Clean backport of JDK-8294578.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294578](https://bugs.openjdk.org/browse/JDK-8294578): [PPC64] C2: Missing is_oop information when using disjoint compressed oops mode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/769/head:pull/769` \
`$ git checkout pull/769`

Update a local copy of the PR: \
`$ git checkout pull/769` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 769`

View PR using the GUI difftool: \
`$ git pr show -t 769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/769.diff">https://git.openjdk.org/jdk17u-dev/pull/769.diff</a>

</details>
