### PR TITLE
8291599: Assertion in PhaseIdealLoop::skeleton_predicate_has_opaque after JDK-8289127

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1304,7 +1304,8 @@ void PhaseIdealLoop::copy_skeleton_predicates_to_main_loop_helper(Node* predicat
   }
 }
 
-static bool skeleton_follow_inputs(Node* n, int op) {
+static bool skeleton_follow_inputs(Node* n) {
+  int op = n->Opcode();
   return (n->is_Bool() ||
           n->is_Cmp() ||
           op == Op_AndL ||
@@ -1322,31 +1323,27 @@ static bool skeleton_follow_inputs(Node* n, int op) {
           op == Op_CastII);
 }
 
+bool PhaseIdealLoop::subgraph_has_opaque(Node* n) {
+  if (n->Opcode() == Op_OpaqueLoopInit || n->Opcode() == Op_OpaqueLoopStride) {
+    return true;
+  }
+  if (!skeleton_follow_inputs(n)) {
+    return false;
+  }
+  uint init;
+  uint stride;
+  count_opaque_loop_nodes(n, init, stride);
+  return init != 0 || stride != 0;
+}
+
+
 bool PhaseIdealLoop::skeleton_predicate_has_opaque(IfNode* iff) {
+  uint init;
+  uint stride;
+  count_opaque_loop_nodes(iff->in(1)->in(1), init, stride);
+#ifdef ASSERT
   ResourceMark rm;
   Unique_Node_List wq;
-  wq.push(iff->in(1)->in(1));
-  uint init = 0;
-  uint stride = 0;
-  for (uint i = 0; i < wq.size(); i++) {
-    Node* n = wq.at(i);
-    int op = n->Opcode();
-    if (skeleton_follow_inputs(n, op)) {
-      for (uint j = 1; j < n->req(); j++) {
-        Node* m = n->in(j);
-        if (m != NULL) {
-          wq.push(m);
-        }
-      }
-      continue;
-    }
-    if (n->Opcode() == Op_OpaqueLoopInit) {
-      init++;
-    } else if (n->Opcode() == Op_OpaqueLoopStride) {
-      stride++;
-    }
-  }
-#ifdef ASSERT
   wq.clear();
   wq.push(iff->in(1)->in(1));
   uint verif_init = 0;
@@ -1375,6 +1372,31 @@ bool PhaseIdealLoop::skeleton_predicate_has_opaque(IfNode* iff) {
   return init != 0;
 }
 
+void PhaseIdealLoop::count_opaque_loop_nodes(Node* n, uint& init, uint& stride) {
+  init = 0;
+  stride = 0;
+  ResourceMark rm;
+  Unique_Node_List wq;
+  wq.push(n);
+  for (uint i = 0; i < wq.size(); i++) {
+    Node* n = wq.at(i);
+    if (skeleton_follow_inputs(n)) {
+      for (uint j = 1; j < n->req(); j++) {
+        Node* m = n->in(j);
+        if (m != NULL) {
+          wq.push(m);
+        }
+      }
+      continue;
+    }
+    if (n->Opcode() == Op_OpaqueLoopInit) {
+      init++;
+    } else if (n->Opcode() == Op_OpaqueLoopStride) {
+      stride++;
+    }
+  }
+}
+
 // Clone the skeleton predicate bool for a main or unswitched loop:
 // Main loop: Set new_init and new_stride nodes as new inputs.
 // Unswitched loop: new_init and new_stride are both NULL. Clone OpaqueLoopInit and OpaqueLoopStride instead.
@@ -1394,8 +1416,7 @@ Node* PhaseIdealLoop::clone_skeleton_predicate_bool(Node* iff, Node* new_init, N
     Node* n = to_clone.node();
     uint i = to_clone.index();
     Node* m = n->in(i);
-    int op = m->Opcode();
-    if (skeleton_follow_inputs(m, op)) {
+    if (skeleton_follow_inputs(m)) {
       to_clone.push(m, 1);
       continue;
     }
@@ -1404,6 +1425,7 @@ Node* PhaseIdealLoop::clone_skeleton_predicate_bool(Node* iff, Node* new_init, N
         n = n->clone();
         register_new_node(n, control);
       }
+      int op = m->Opcode();
       if (op == Op_OpaqueLoopInit) {
         if (is_unswitched_loop && m->_idx < current && new_init == NULL) {
           new_init = m->clone();

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -924,6 +924,8 @@ private:
                                                        IdealLoopTree* outer_loop, Node* input_proj);
   Node* clone_skeleton_predicate_bool(Node* iff, Node* new_init, Node* new_stride, Node* control);
   static bool skeleton_predicate_has_opaque(IfNode* iff);
+  static void count_opaque_loop_nodes(Node* n, uint& init, uint& stride);
+  static bool subgraph_has_opaque(Node* n);
   static void get_skeleton_predicates(Node* predicate, Unique_Node_List& list, bool get_opaque = false);
   void update_main_loop_skeleton_predicates(Node* ctrl, CountedLoopNode* loop_head, Node* init, int stride_con);
   void copy_skeleton_predicates_to_post_loop(LoopNode* main_loop_head, CountedLoopNode* post_loop_head, Node* init, Node* stride);

--- a/src/hotspot/share/opto/split_if.cpp
+++ b/src/hotspot/share/opto/split_if.cpp
@@ -200,7 +200,7 @@ bool PhaseIdealLoop::split_up( Node *n, Node *blk1, Node *blk2 ) {
       return true;
     }
   }
-  if (n->Opcode() == Op_OpaqueLoopStride || n->Opcode() == Op_OpaqueLoopInit) {
+  if (subgraph_has_opaque(n)) {
     Unique_Node_List wq;
     wq.push(n);
     for (uint i = 0; i < wq.size(); i++) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestPhiInSkeletonPredicateExpression.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPhiInSkeletonPredicateExpression.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8291599
+ * @summary Assertion in PhaseIdealLoop::skeleton_predicate_has_opaque after JDK-8289127
+ * @requires vm.compiler2.enabled
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:LoopMaxUnroll=0 TestPhiInSkeletonPredicateExpression
+ */
+
+public class TestPhiInSkeletonPredicateExpression {
+    private static int[] array1;
+    private static int[] array2;
+    private static int off;
+    private static volatile int barrier;
+
+    public static void main(String[] args) {
+        int[] array = new int[2000];
+        array1 = array;
+        array2 = array;
+        for (int i = 0; i < 20_000; i++) {
+            test1(1000, false);
+            test1(1000, true);
+            test2(1000, false);
+            test2(1000, true);
+        }
+    }
+
+    private static int test1(int stop, boolean flag) {
+        int v = 0;
+
+        for (int j = 1; j < 10; j *= 2) {
+            int[] array;
+            if (flag) {
+                if (array1 == null) {
+
+                }
+                array = array1;
+                barrier = 0x42;
+            } else {
+                if (array2 == null) {
+
+                }
+                array = array2;
+                barrier = 0x42;
+            }
+
+            int i = 0;
+            do {
+                synchronized (new Object()) {
+                }
+                v += array[i + off];
+                i++;
+            } while (i < stop);
+        }
+        return v;
+    }
+
+    private static int test2(int stop, boolean flag) {
+        int v = 0;
+
+        int[] array;
+        if (flag) {
+            if (array1 == null) {
+
+            }
+            array = array1;
+            barrier = 0x42;
+        } else {
+            if (array2 == null) {
+
+            }
+            array = array2;
+            barrier = 0x42;
+        }
+
+        int i = 0;
+        do {
+            synchronized (new Object()) {
+            }
+            v += array[i + off];
+            i++;
+        } while (i < stop);
+        return v;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291599](https://bugs.openjdk.org/browse/JDK-8291599): Assertion in PhaseIdealLoop::skeleton_predicate_has_opaque after JDK-8289127


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/770/head:pull/770` \
`$ git checkout pull/770`

Update a local copy of the PR: \
`$ git checkout pull/770` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 770`

View PR using the GUI difftool: \
`$ git pr show -t 770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/770.diff">https://git.openjdk.org/jdk17u-dev/pull/770.diff</a>

</details>
