### PR TITLE
8294837: unify Windows 2019 version check in os_windows and java_props_md

### DIFF
--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -558,7 +558,7 @@ GetJavaProperties(JNIEnv* env)
                         /* Windows server 2022 build number is 20348 */
                         if (buildNumber > 20347) {
                             sprops.os_name = "Windows Server 2022";
-                        } else if (buildNumber > 17676) {
+                        } else if (buildNumber > 17762) {
                             sprops.os_name = "Windows Server 2019";
                         } else {
                             sprops.os_name = "Windows Server 2016";


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294837](https://bugs.openjdk.org/browse/JDK-8294837): unify Windows 2019 version check in os_windows and java_props_md


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/775/head:pull/775` \
`$ git checkout pull/775`

Update a local copy of the PR: \
`$ git checkout pull/775` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 775`

View PR using the GUI difftool: \
`$ git pr show -t 775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/775.diff">https://git.openjdk.org/jdk17u-dev/pull/775.diff</a>

</details>
