### PR TITLE
Backport 21de4e55b8fa2ba138338ec82c159897ab3d4233

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestFarJump.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestFarJump.java
@@ -74,9 +74,9 @@ public class TestFarJump {
             }
             int dump = (int)Long.parseLong(match, 16);
             int encoding = Integer.reverseBytes(dump);
-            if (isADRP(encoding)) {
-                return true;
-            }
+            // Check the first instruction only. The raw pointer can be confused with the encoded adrp instruction:
+            // emit_exception_handler() = far_call() + should_not_reach_here() = ADRP + ADD + BLR + DCPS1 + raw_pointer
+            return isADRP(encoding);
         }
         return false;
     }


### PR DESCRIPTION
The backport of [JDK-8280872](https://bugs.openjdk.org/browse/JDK-8280872) introduces a test. The test has a bug causing intermittent failures.
This is a backport of the bug fix.