### PR TITLE
8251466: test/java/io/File/GetXSpace.java fails on Windows with mapped network drives.

### DIFF
--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FilePermission;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -108,8 +107,8 @@ public class GetXSpace {
 
         Space(String total, String free, String name) {
             try {
-                this.total = Long.valueOf(total) * KSIZE;
-                this.free = Long.valueOf(free) * KSIZE;
+                this.total = Long.parseLong(total) * KSIZE;
+                this.free = Long.parseLong(free) * KSIZE;
             } catch (NumberFormatException x) {
                 throw new RuntimeException("the regex should have caught this", x);
             }
@@ -157,7 +156,7 @@ public class GetXSpace {
                     }
                     al.add(new Space(m.group(2), m.group(3), name));;
                 }
-                j = m.end() + 1;
+                j = m.end();
             } else {
                 throw new RuntimeException("unrecognized df output format: "
                                            + "charAt(" + j + ") = '"
@@ -227,7 +226,7 @@ public class GetXSpace {
                 // On Linux, ignore the NSFE if the path is one of the
                 // /run/user/$UID mounts created by pam_systemd(8) as it
                 // might be deleted during the test
-                if (!Platform.isLinux() || s.name().indexOf("/run/user") == -1)
+                if (!Platform.isLinux() || !s.name().contains("/run/user"))
                     throw new RuntimeException(nsfe);
             } catch (IOException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8251466](https://bugs.openjdk.org/browse/JDK-8251466): test/java/io/File/GetXSpace.java fails on Windows with mapped network drives.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/781/head:pull/781` \
`$ git checkout pull/781`

Update a local copy of the PR: \
`$ git checkout pull/781` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 781`

View PR using the GUI difftool: \
`$ git pr show -t 781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/781.diff">https://git.openjdk.org/jdk17u-dev/pull/781.diff</a>

</details>
