### PR TITLE
8277346: ProblemList 7 serviceability/sa tests on macosx-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -117,10 +117,13 @@ serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 w
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 serviceability/jvmti/CompiledMethodLoad/Zombie.java 8245877 linux-aarch64
 
-serviceability/sa/ClhsdbCDSCore.java 8269982 macosx-aarch64
-serviceability/sa/ClhsdbFindPC.java#id1 8269982 macosx-aarch64
-serviceability/sa/ClhsdbFindPC.java#id3 8269982 macosx-aarch64
-serviceability/sa/ClhsdbPstack.java#id1 8269982 macosx-aarch64
+serviceability/sa/ClhsdbCDSCore.java 8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id1 8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id3 8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbPmap.java#id1 8267433 macosx-x64
+serviceability/sa/ClhsdbPstack.java#id1 8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/TestJmapCore.java 8267433 macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
 
 #############################################################################
 


### PR DESCRIPTION
Backport JDK-8277346 to jdk17u.

This patch can not apply to jdk17u-dev cleanly. There are 2 changes:
1. drop 'runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java' because it doesn't exist in jdk17u
2. rename tag ids. 

Since jdk17u misses JDK-8273928, I have to reference individual tests using default test ids, starting with 0. eg.
'ClhsdbPmap.java#core' maps to 'ClhsdbPmap.java#id1' because it is the second tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8277346](https://bugs.openjdk.org/browse/JDK-8277346): ProblemList 7 serviceability/sa tests on macosx-x64
 * [JDK-8277351](https://bugs.openjdk.org/browse/JDK-8277351): ProblemList runtime/jni/checked/TestPrimitiveArrayCriticalWithBadParam.java on macosx-x64


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/790/head:pull/790` \
`$ git checkout pull/790`

Update a local copy of the PR: \
`$ git checkout pull/790` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 790`

View PR using the GUI difftool: \
`$ git pr show -t 790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/790.diff">https://git.openjdk.org/jdk17u-dev/pull/790.diff</a>

</details>
