### PR TITLE
Backport 2baf498eb5bcdd12b2b969222414a43bdf5eb256

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/nativeAndMH.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/meth/stress/jni/nativeAndMH/nativeAndMH.cpp
@@ -56,7 +56,8 @@ Java_vm_mlvm_meth_stress_jni_nativeAndMH_Test_native01(
 
     NSK_JNI_VERIFY(pEnv, NULL != (objectClass = pEnv->FindClass("java/lang/Object")));
 
-    NSK_JNI_VERIFY(pEnv, NULL != (arguments = pEnv->NewObjectArray(ARGS_COUNT, objectClass, NULL)));
+    if (!NSK_JNI_VERIFY(pEnv, NULL != (arguments = pEnv->NewObjectArray(ARGS_COUNT, objectClass, NULL))))
+        return NULL;
 
     NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 0, a1));
     NSK_JNI_VERIFY_VOID(pEnv, pEnv->SetObjectArrayElement(arguments, 1, a2));


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.