### PR TITLE
8294740: Add cgroups keyword to TestDockerBasic.java

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8293540
  * @summary Verify that -XshowSettings:system works
+ * @key cgroups
  * @requires docker.support
  * @library /test/lib
  * @run main/timeout=360 TestDockerBasic


### PR DESCRIPTION
Clean backport. Just adds a `@cgroups` tag to a test added with #785.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294740](https://bugs.openjdk.org/browse/JDK-8294740): Add cgroups keyword to TestDockerBasic.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/795/head:pull/795` \
`$ git checkout pull/795`

Update a local copy of the PR: \
`$ git checkout pull/795` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 795`

View PR using the GUI difftool: \
`$ git pr show -t 795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/795.diff">https://git.openjdk.org/jdk17u-dev/pull/795.diff</a>

</details>
