### PR TITLE
8280234: AArch64 "core" variant does not build after JDK-8270947

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -29,6 +29,7 @@
 #include "jvm.h"
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
+#include "ci/ciEnv.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"


### PR DESCRIPTION
I backport this as follow up of 8270947

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280234](https://bugs.openjdk.org/browse/JDK-8280234): AArch64 "core" variant does not build after JDK-8270947


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/796/head:pull/796` \
`$ git checkout pull/796`

Update a local copy of the PR: \
`$ git checkout pull/796` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 796`

View PR using the GUI difftool: \
`$ git pr show -t 796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/796.diff">https://git.openjdk.org/jdk17u-dev/pull/796.diff</a>

</details>
