### PR TITLE
8271956: AArch64: C1 build failed after JDK-8270947

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -37,6 +37,7 @@
 #include "gc/shared/tlab_globals.hpp"
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/interpreter.hpp"
+#include "compiler/compileTask.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271956](https://bugs.openjdk.org/browse/JDK-8271956): AArch64: C1 build failed after JDK-8270947


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/797/head:pull/797` \
`$ git checkout pull/797`

Update a local copy of the PR: \
`$ git checkout pull/797` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 797`

View PR using the GUI difftool: \
`$ git pr show -t 797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/797.diff">https://git.openjdk.org/jdk17u-dev/pull/797.diff</a>

</details>
