### PR TITLE
8292778: EncodingSupport_md.c convertUtf8ToPlatformString wrong placing of free

### DIFF
--- a/src/java.instrument/windows/native/libinstrument/EncodingSupport_md.c
+++ b/src/java.instrument/windows/native/libinstrument/EncodingSupport_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,8 +76,8 @@ convertUft8ToPlatformString(char* utf8_str, int utf8_len, char* platform_str, in
                 if (plen >= 0) {
                     platform_str[plen] = '\0';
                 }
-                free(wstr);
             }
+            free(wstr);
         }
     }
     return plen;


### PR DESCRIPTION
backport of 8292778, adjust copyrigth headers

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292778](https://bugs.openjdk.org/browse/JDK-8292778): EncodingSupport_md.c convertUtf8ToPlatformString wrong placing of free


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/809/head:pull/809` \
`$ git checkout pull/809`

Update a local copy of the PR: \
`$ git checkout pull/809` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 809`

View PR using the GUI difftool: \
`$ git pr show -t 809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/809.diff">https://git.openjdk.org/jdk17u-dev/pull/809.diff</a>

</details>
