### PR TITLE
8286313: [macos] Voice over reads the boolean value as null in the JTable

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableRowAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TableRowAccessibility.m
@@ -123,7 +123,14 @@ static jclass sjc_CAccessibility = NULL;
             if ([accessibilityName isEqualToString:@""]) {
                 accessibilityName = [cell accessibilityLabel];
             } else {
-                accessibilityName = [accessibilityName stringByAppendingFormat:@", %@", [cell accessibilityLabel]];
+                NSString *label = [cell accessibilityLabel];
+                if (label == nil) {
+                    id val = [cell accessibilityValue];
+                    if (val != nil) {
+                        label = [NSString stringWithFormat:@"%@", val];
+                    }
+                }
+                accessibilityName = [accessibilityName stringByAppendingFormat:@", %@", label];
             }
         }
         return accessibilityName;


### PR DESCRIPTION
Clean backport.

Original commit: https://github.com/openjdk/jdk/commit/8353a33350eca859842bc6b92bc9a38a60c11e26

JBS: https://bugs.openjdk.org/browse/JDK-8286313


Tested locally. After the change, checkboxes can be read with VoiceOver. Before the change, they were read as `null`. (_However checkboxes are read as `1` or `0` like numbers. Not sure if that's the best user experience, but this is a backport : /_)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286313](https://bugs.openjdk.org/browse/JDK-8286313): [macos] Voice over reads the boolean value as null in the JTable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/810/head:pull/810` \
`$ git checkout pull/810`

Update a local copy of the PR: \
`$ git checkout pull/810` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 810`

View PR using the GUI difftool: \
`$ git pr show -t 810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/810.diff">https://git.openjdk.org/jdk17u-dev/pull/810.diff</a>

</details>
