### PR TITLE
8293659: Improve UnsatisfiedLinkError error message to include dlopen error details

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
+++ b/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java
@@ -385,7 +385,21 @@ public final class NativeLibraries {
                 throw new InternalError("Native library " + name + " has been loaded");
             }
 
-            return load(this, name, isBuiltin, isJNI, loadLibraryOnlyIfPresent);
+            return load(this, name, isBuiltin, isJNI, throwExceptionIfFail());
+        }
+
+        @SuppressWarnings("removal")
+        private boolean throwExceptionIfFail() {
+            if (loadLibraryOnlyIfPresent) return true;
+
+            // If the file exists but fails to load, UnsatisfiedLinkException thrown by the VM
+            // will include the error message from dlopen to provide diagnostic information
+            return AccessController.doPrivileged(new PrivilegedAction<>() {
+                public Boolean run() {
+                    File file = new File(name);
+                    return file.exists();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
backport of 8293659

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293659](https://bugs.openjdk.org/browse/JDK-8293659): Improve UnsatisfiedLinkError error message to include dlopen error details


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/812/head:pull/812` \
`$ git checkout pull/812`

Update a local copy of the PR: \
`$ git checkout pull/812` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 812`

View PR using the GUI difftool: \
`$ git pr show -t 812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/812.diff">https://git.openjdk.org/jdk17u-dev/pull/812.diff</a>

</details>
