### PR TITLE
8293891: gc/g1/mixedgc/TestOldGenCollectionUsage.java (still) assumes that GCs take 1ms minimum

### DIFF
--- a/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
+++ b/test/hotspot/jtreg/gc/g1/mixedgc/TestOldGenCollectionUsage.java
@@ -118,9 +118,6 @@ public class TestOldGenCollectionUsage {
         if (collectionCount <= 0) {
             throw new RuntimeException("Collection count <= 0");
         }
-        if (collectionTime <= 0) {
-            throw new RuntimeException("Collector has not run");
-        }
 
         MixedGCProvoker.provokeMixedGC(liveOldObjects);
 


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293891](https://bugs.openjdk.org/browse/JDK-8293891): gc/g1/mixedgc/TestOldGenCollectionUsage.java (still) assumes that GCs take 1ms minimum


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/816/head:pull/816` \
`$ git checkout pull/816`

Update a local copy of the PR: \
`$ git checkout pull/816` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 816`

View PR using the GUI difftool: \
`$ git pr show -t 816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/816.diff">https://git.openjdk.org/jdk17u-dev/pull/816.diff</a>

</details>
