### PR TITLE
8293657: sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 failed with "SSLHandshakeException: Remote host terminated the handshake"

### DIFF
--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -925,9 +925,6 @@ public final class ConnectorBootstrap {
     private static class HostAwareSslSocketFactory extends SslRMIServerSocketFactory {
 
         private final String bindAddress;
-        private final String[] enabledCipherSuites;
-        private final String[] enabledProtocols;
-        private final boolean needClientAuth;
         private final SSLContext context;
 
         private HostAwareSslSocketFactory(String[] enabledCipherSuites,
@@ -942,11 +939,9 @@ public final class ConnectorBootstrap {
                                           String[] enabledProtocols,
                                           boolean sslNeedClientAuth,
                                           String bindAddress) throws IllegalArgumentException {
-            this.context = ctx;
+            super(ctx, enabledCipherSuites, enabledProtocols, sslNeedClientAuth);
             this.bindAddress = bindAddress;
-            this.enabledProtocols = enabledProtocols;
-            this.enabledCipherSuites = enabledCipherSuites;
-            this.needClientAuth = sslNeedClientAuth;
+            this.context = ctx;
             checkValues(ctx, enabledCipherSuites, enabledProtocols);
         }
 
@@ -956,14 +951,15 @@ public final class ConnectorBootstrap {
                 try {
                     InetAddress addr = InetAddress.getByName(bindAddress);
                     return new SslServerSocket(port, 0, addr, context,
-                                               enabledCipherSuites, enabledProtocols, needClientAuth);
+                            this.getEnabledCipherSuites(), this.getEnabledProtocols(),
+                            this.getNeedClientAuth());
                 } catch (UnknownHostException e) {
                     return new SslServerSocket(port, context,
-                                               enabledCipherSuites, enabledProtocols, needClientAuth);
+                            this.getEnabledCipherSuites(), this.getEnabledProtocols(), this.getNeedClientAuth());
                 }
             } else {
                 return new SslServerSocket(port, context,
-                                           enabledCipherSuites, enabledProtocols, needClientAuth);
+                        this.getEnabledCipherSuites(), this.getEnabledProtocols(), this.getNeedClientAuth());
             }
         }
 

--- a/test/jdk/sun/management/jmxremote/bootstrap/management_ssltest07_ok.properties.in
+++ b/test/jdk/sun/management/jmxremote/bootstrap/management_ssltest07_ok.properties.in
@@ -1,5 +1,5 @@
-com.sun.management.jmxremote.ssl.enabled.cipher.suites=TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+com.sun.management.jmxremote.ssl.enabled.cipher.suites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
 com.sun.management.jmxremote.ssl.enabled.protocols=SSLv2Hello,SSLv3,TLSv1
 com.sun.management.jmxremote.ssl.need.client.auth=true
 com.sun.management.jmxremote.authenticate=false
-javax.rmi.ssl.client.enabledCipherSuites=TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+javax.rmi.ssl.client.enabledCipherSuites=TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

Cannot remove import of BufferedInputStream. Still needed as "8280010: Remove double buffering of InputStream for Properties.load" is not in 17.

Should I alternatively backport the part of 8280010 for this file?


Skipped patch to ProblemList. Test is not ProblemListed in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293657](https://bugs.openjdk.org/browse/JDK-8293657): sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1 failed with "SSLHandshakeException: Remote host terminated the handshake"


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/817/head:pull/817` \
`$ git checkout pull/817`

Update a local copy of the PR: \
`$ git checkout pull/817` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 817`

View PR using the GUI difftool: \
`$ git pr show -t 817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/817.diff">https://git.openjdk.org/jdk17u-dev/pull/817.diff</a>

</details>
