### PR TITLE
8283199: Linux os::cpu_microcode_revision() stalls cold startup

### DIFF
--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -459,11 +459,26 @@ bool os::supports_sse() {
 }
 
 juint os::cpu_microcode_revision() {
+  // Note: this code runs on startup, and therefore should not be slow,
+  // see JDK-8283200.
+
   juint result = 0;
-  char data[2048] = {0}; // lines should fit in 2K buf
-  size_t len = sizeof(data);
-  FILE *fp = fopen("/proc/cpuinfo", "r");
+
+  // Attempt 1 (faster): Read the microcode version off the sysfs.
+  FILE *fp = fopen("/sys/devices/system/cpu/cpu0/microcode/version", "r");
   if (fp) {
+    int read = fscanf(fp, "%x", &result);
+    fclose(fp);
+    if (read > 0) {
+      return result;
+    }
+  }
+
+  // Attempt 2 (slower): Read the microcode version off the procfs.
+  fp = fopen("/proc/cpuinfo", "r");
+  if (fp) {
+    char data[2048] = {0}; // lines should fit in 2K buf
+    size_t len = sizeof(data);
     while (!feof(fp)) {
       if (fgets(data, len, fp)) {
         if (strstr(data, "microcode") != NULL) {
@@ -475,6 +490,7 @@ juint os::cpu_microcode_revision() {
     }
     fclose(fp);
   }
+
   return result;
 }
 


### PR DESCRIPTION
Unclean backport to fix the startup time regression.

The backport is not clean, because [JDK-8238161](https://bugs.openjdk.org/browse/JDK-8238161) is not present in JDK 17, and thus we have `fopen` instead of `os::fopen` in these hunks. I changed the code back to `fopen` to be consistent with the rest of JDK 17.

Verified the startup time improves, using the scripts from the issue.

```
# Before
real	0m0.042s
real	0m0.043s
real	0m0.043s

# After
real	0m0.025s
real	0m0.024s
real	0m0.024s
```

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283199](https://bugs.openjdk.org/browse/JDK-8283199): Linux os::cpu_microcode_revision() stalls cold startup


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/820/head:pull/820` \
`$ git checkout pull/820`

Update a local copy of the PR: \
`$ git checkout pull/820` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 820`

View PR using the GUI difftool: \
`$ git pr show -t 820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/820.diff">https://git.openjdk.org/jdk17u-dev/pull/820.diff</a>

</details>
