### PR TITLE
8269571: NMT should print total malloc bytes and invocation count

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -60,6 +60,15 @@ size_t MemoryCounter::peak_size() const {
 }
 #endif
 
+// Total malloc invocation count
+size_t MallocMemorySnapshot::total_count() const {
+  size_t amount = 0;
+  for (int index = 0; index < mt_number_of_types; index ++) {
+    amount += _malloc[index].malloc_count();
+  }
+  return amount;
+}
+
 // Total malloc'd memory amount
 size_t MallocMemorySnapshot::total() const {
   size_t amount = 0;

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -153,6 +153,8 @@ class MallocMemorySnapshot : public ResourceObj {
     return &_tracking_header;
   }
 
+  // Total malloc invocation count
+  size_t total_count() const;
   // Total malloc'd memory amount
   size_t total() const;
   // Total malloc'd memory used by arenas

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -98,10 +98,12 @@ void MemReporterBase::print_virtual_memory_region(const char* type, address base
 
 void MemSummaryReporter::report() {
   outputStream* out = output();
-  size_t total_reserved_amount = _malloc_snapshot->total() +
-    _vm_snapshot->total_reserved();
-  size_t total_committed_amount = _malloc_snapshot->total() +
-    _vm_snapshot->total_committed();
+  const size_t total_malloced_bytes = _malloc_snapshot->total();
+  const size_t total_mmap_reserved_bytes = _vm_snapshot->total_reserved();
+  const size_t total_mmap_committed_bytes = _vm_snapshot->total_committed();
+
+  size_t total_reserved_amount = total_malloced_bytes + total_mmap_reserved_bytes;
+  size_t total_committed_amount = total_malloced_bytes + total_mmap_committed_bytes;
 
   // Overall total
   out->print_cr("\nNative Memory Tracking:\n");
@@ -113,7 +115,14 @@ void MemSummaryReporter::report() {
 
   out->print("Total: ");
   print_total(total_reserved_amount, total_committed_amount);
-  out->print("\n");
+  out->cr();
+  out->print_cr("       malloc: " SIZE_FORMAT "%s #" SIZE_FORMAT,
+                amount_in_current_scale(total_malloced_bytes), current_scale(),
+                _malloc_snapshot->total_count());
+  out->print("       mmap:   ");
+  print_total(total_mmap_reserved_bytes, total_mmap_committed_bytes);
+  out->cr();
+  out->cr();
 
   // Summary by memory type
   for (int index = 0; index < mt_number_of_types; index ++) {


### PR DESCRIPTION
Hi all,

Backported as part of an ongoing effort to modernize jdk17 NMT.

This pull request contains a backport of commit [3ad20fcd](https://github.com/openjdk/jdk/commit/3ad20fcdfa35796c190ccbaf26872b0fe30d8c76) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 30 Jun 2021 and was reviewed by Zhengyu Gu and Xin Liu.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269571](https://bugs.openjdk.org/browse/JDK-8269571): NMT should print total malloc bytes and invocation count


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/821/head:pull/821` \
`$ git checkout pull/821`

Update a local copy of the PR: \
`$ git checkout pull/821` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 821`

View PR using the GUI difftool: \
`$ git pr show -t 821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/821.diff">https://git.openjdk.org/jdk17u-dev/pull/821.diff</a>

</details>
