### PR TITLE
8267138: Stray suffix when starting gtests via GTestWrapper.java

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -83,7 +83,7 @@ public class GTestWrapper {
         command.add("-jdk");
         command.add(Utils.TEST_JDK);
         command.add("--gtest_output=xml:" + resultFile);
-        command.add("--gtest_catch_exceptions=0" + resultFile);
+        command.add("--gtest_catch_exceptions=0");
         for (String a : args) {
             command.add(a);
         }


### PR DESCRIPTION
Hi all,

Backported since the underlying issue is suspected of causing rare windows gtests errors in JDK17.

This pull request contains a backport of commit [b565459f](https://github.com/openjdk/jdk/commit/b565459f83b749a01d7d873a01bb7dbdf55745de) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 25 Jun 2021 and was reviewed by Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267138](https://bugs.openjdk.org/browse/JDK-8267138): Stray suffix when starting gtests via GTestWrapper.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/822/head:pull/822` \
`$ git checkout pull/822`

Update a local copy of the PR: \
`$ git checkout pull/822` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 822`

View PR using the GUI difftool: \
`$ git pr show -t 822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/822.diff">https://git.openjdk.org/jdk17u-dev/pull/822.diff</a>

</details>
