### PR TITLE
8292880 : Enable debuggee logging in ClassUnloadEventTest

### DIFF
--- a/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
+++ b/test/jdk/com/sun/jdi/ClassUnloadEventTest.java
@@ -105,11 +105,20 @@ public class ClassUnloadEventTest {
             }
         }
         loader = null;
+
+        // Do a short delay to make sure that the debug agent is done processing all
+        // ClassPrepare events. Otherwise the debug agent might still be holding on to
+        // a reference to a class, which will prevent it from unloading during the GC.
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+        }
+
         // Trigger class unloading
         ClassUnloadCommon.triggerUnloading();
 
-        // Short delay to make sure all ClassUnloadEvents have been sent
-        // before VMDeathEvent is genareated.
+        // Do a short delay to make sure all ClassUnloadEvents have been sent
+        // before VMDeathEvent is generated.
         try {
             Thread.sleep(5000);
         } catch (InterruptedException e) {


### PR DESCRIPTION
Backport of JDK-8292880
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ Dependency #824 must be integrated first
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8292880](https://bugs.openjdk.org/browse/JDK-8292880)

### Issue
 * [JDK-8292880](https://bugs.openjdk.org/browse/JDK-8292880): Improve debuggee logging for com/sun/jdi/ClassUnloadEventTest.java ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/825/head:pull/825` \
`$ git checkout pull/825`

Update a local copy of the PR: \
`$ git checkout pull/825` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 825`

View PR using the GUI difftool: \
`$ git pr show -t 825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/825.diff">https://git.openjdk.org/jdk17u-dev/pull/825.diff</a>

</details>
