### PR TITLE
8294840: langtools OptionalDependencyTest.java use File.pathSeparator

### DIFF
--- a/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
+++ b/test/langtools/tools/jdeps/optionalDependency/OptionalDependencyTest.java
@@ -30,6 +30,7 @@
  * @summary Tests optional dependency handling
  */
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
@@ -71,7 +72,7 @@ public class OptionalDependencyTest {
      */
     @Test
     public void optionalDependenceNotResolved() {
-        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar" + File.pathSeparator + "m3.jar",
                                                   "--inverse",
                                                   "--package", "p2", "m1.jar");
         int rc = jdepsRunner.run(true);
@@ -83,7 +84,7 @@ public class OptionalDependencyTest {
      */
     @Test
     public void optionalDependenceResolved() {
-        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar:m3.jar",
+        JdepsRunner jdepsRunner = new JdepsRunner("--module-path", "m2.jar" + File.pathSeparator + "m3.jar",
                                                   "--inverse", "--add-modules", "m3",
                                                   "--package", "p2", "m1.jar");
         int rc = jdepsRunner.run(true);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294840](https://bugs.openjdk.org/browse/JDK-8294840): langtools OptionalDependencyTest.java use File.pathSeparator


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/833/head:pull/833` \
`$ git checkout pull/833`

Update a local copy of the PR: \
`$ git checkout pull/833` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 833`

View PR using the GUI difftool: \
`$ git pr show -t 833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/833.diff">https://git.openjdk.org/jdk17u-dev/pull/833.diff</a>

</details>
