### PR TITLE
8029633: Raw inner class constructor ref should not perform diamond inference

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3656,7 +3656,9 @@ public class Resolve {
                 List<Type> typeargtypes, MethodResolutionPhase maxPhase) {
             super(referenceTree, names.init, site, argtypes, typeargtypes, maxPhase);
             if (site.isRaw()) {
-                this.site = new ClassType(site.getEnclosingType(), site.tsym.type.getTypeArguments(), site.tsym, site.getMetadata());
+                this.site = new ClassType(site.getEnclosingType(),
+                        !(site.tsym.isInner() && site.getEnclosingType().isRaw()) ?
+                                site.tsym.type.getTypeArguments() : List.nil(), site.tsym, site.getMetadata());
                 needsInference = true;
             }
         }

--- a/test/langtools/tools/javac/lambda/methodReference/MethodRefNewInnerRawTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/MethodRefNewInnerRawTest.java
@@ -1,0 +1,24 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8029633
+ * @summary Raw inner class constructor ref should not perform diamond inference
+ * @compile/fail/ref=MethodRefNewInnerRawTest.out -Werror -Xlint:unchecked -XDrawDiagnostics MethodRefNewInnerRawTest.java
+ */
+
+import java.util.function.*;
+
+class MethodRefNewInnerRawTest<T> {
+    class Inner1 {}
+    class Inner2<U> {}
+
+    Supplier<MethodRefNewInnerRawTest.Inner1> s1 = MethodRefNewInnerRawTest.Inner1::new;
+    Supplier<MethodRefNewInnerRawTest.Inner2> s2 = MethodRefNewInnerRawTest.Inner2::new;
+    Supplier<MethodRefNewInnerRawTest<T>.Inner1> s3 = MethodRefNewInnerRawTest.Inner1::new;
+    Supplier<MethodRefNewInnerRawTest<T>.Inner2<String>> s4 = MethodRefNewInnerRawTest.Inner2::new;
+
+    static class Outer {
+        class Inner3<U> {}
+
+        Supplier<Outer.Inner3<String>> s5 = Outer.Inner3::new;
+    }
+}

--- a/test/langtools/tools/javac/lambda/methodReference/MethodRefNewInnerRawTest.out
+++ b/test/langtools/tools/javac/lambda/methodReference/MethodRefNewInnerRawTest.out
@@ -1,0 +1,5 @@
+MethodRefNewInnerRawTest.java:16:55: compiler.warn.prob.found.req: (compiler.misc.unchecked.assign), MethodRefNewInnerRawTest.Inner1, MethodRefNewInnerRawTest<T>.Inner1
+MethodRefNewInnerRawTest.java:17:63: compiler.warn.prob.found.req: (compiler.misc.unchecked.assign), MethodRefNewInnerRawTest.Inner2, MethodRefNewInnerRawTest<T>.Inner2<java.lang.String>
+- compiler.err.warnings.and.werror
+1 error
+2 warnings


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8029633](https://bugs.openjdk.org/browse/JDK-8029633): Raw inner class constructor ref should not perform diamond inference
 * [JDK-8296508](https://bugs.openjdk.org/browse/JDK-8296508): Raw inner class constructor ref should not perform diamond inference (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/835/head:pull/835` \
`$ git checkout pull/835`

Update a local copy of the PR: \
`$ git checkout pull/835` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 835`

View PR using the GUI difftool: \
`$ git pr show -t 835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/835.diff">https://git.openjdk.org/jdk17u-dev/pull/835.diff</a>

</details>
