### PR TITLE
8279941: sun/security/pkcs11/Signature/TestDSAKeyLength.java fails when NSS version detection fails

### DIFF
--- a/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
+++ b/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class TestDSAKeyLength extends PKCS11Test {
 
     @Override
     protected boolean skipTest(Provider provider) {
-        if (isNSS(provider) && getNSSVersion() >= 3.14) {
+        if (isNSS(provider) && (getNSSVersion() == 0.0 || getNSSVersion() >= 3.14)) {
             System.out.println("Skip testing NSS " + getNSSVersion());
             return true;
         }


### PR DESCRIPTION
Clean backport to fix the test on newer Debian/Ubuntu machines. The test is executed in `tier2`, and currently fails.

Additional testing:
 - [x] Linux x86_64 fastdebug: affected test now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279941](https://bugs.openjdk.org/browse/JDK-8279941): sun/security/pkcs11/Signature/TestDSAKeyLength.java fails when NSS version detection fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/838/head:pull/838` \
`$ git checkout pull/838`

Update a local copy of the PR: \
`$ git checkout pull/838` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 838`

View PR using the GUI difftool: \
`$ git pr show -t 838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/838.diff">https://git.openjdk.org/jdk17u-dev/pull/838.diff</a>

</details>
