### PR TITLE
8292899: CustomTzIDCheckDST.java testcase failed on AIX platform

### DIFF
--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -379,12 +379,11 @@ mapPlatformToJavaTimezone(const char *java_home_dir, const char *tz) {
     size_t tz_len = 0;
 
     /* On AIX, the TZ environment variable may end with a comma
-     * followed by modifier fields. These are ignored here. */
-    temp_tz = strchr(tz, ',');
-    tz_len = (temp_tz == NULL) ? strlen(tz) : temp_tz - tz;
-    tz_buf = (char *)malloc(tz_len + 1);
-    memcpy(tz_buf, tz, tz_len);
-    tz_buf[tz_len] = 0;
+     * followed by modifier fields until early AIX6.1.
+     * This restriction has been removed from AIX7. */
+
+    tz_buf = strdup(tz);
+    tz_len = strlen(tz_buf);
 
     /* Open tzmappings file, with buffer overrun check */
     if ((strlen(java_home_dir) + 15) > PATH_MAX) {
@@ -553,11 +552,22 @@ getGMTOffsetID()
     }
 #endif
 
+#if defined(_AIX)
+    // strftime() with "%z" does not return ISO 8601 format by AIX default.
+    // XPG_SUS_ENV=ON environment variable is required.
+    // But Hotspot does not support XPG_SUS_ENV=ON.
+    // Ignore daylight saving settings to calculate current time difference
+    localtm.tm_isdst = 0;
+    int gmt_off = (int)(difftime(mktime(&localtm), mktime(&gmt)) / 60.0);
+    sprintf(buf, (const char *)"GMT%c%02.2d:%02.2d",
+            gmt_off < 0 ? '-' : '+' , abs(gmt_off / 60), gmt_off % 60);
+#else
     if (strftime(offset, 6, "%z", &localtm) != 5) {
         return strdup("GMT");
     }
 
     sprintf(buf, (const char *)"GMT%c%c%c:%c%c", offset[0], offset[1], offset[2],
         offset[3], offset[4]);
+#endif
     return strdup(buf);
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292899](https://bugs.openjdk.org/browse/JDK-8292899): CustomTzIDCheckDST.java testcase failed on AIX platform


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/841/head:pull/841` \
`$ git checkout pull/841`

Update a local copy of the PR: \
`$ git checkout pull/841` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 841`

View PR using the GUI difftool: \
`$ git pr show -t 841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/841.diff">https://git.openjdk.org/jdk17u-dev/pull/841.diff</a>

</details>
