### PR TITLE
8275320: NMT should perform buffer overrun checks

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -704,18 +704,19 @@ void* os::malloc(size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
 
   // NMT support
   NMT_TrackingLevel level = MemTracker::tracking_level();
-  size_t            nmt_header_size = MemTracker::malloc_header_size(level);
+  const size_t nmt_overhead =
+      MemTracker::malloc_header_size(level) + MemTracker::malloc_footer_size(level);
 
   // Check for overflow.
-  if (size + nmt_header_size < size) {
+  if (size + nmt_overhead < size) {
     return NULL;
   }
 
 #ifndef ASSERT
-  const size_t alloc_size = size + nmt_header_size;
+  const size_t alloc_size = size + nmt_overhead;
 #else
-  const size_t alloc_size = GuardedMemory::get_total_size(size + nmt_header_size);
-  if (size + nmt_header_size > alloc_size) { // Check for rollover.
+  const size_t alloc_size = GuardedMemory::get_total_size(size + nmt_overhead);
+  if (size + nmt_overhead > alloc_size) { // Check for rollover.
     return NULL;
   }
 #endif
@@ -733,7 +734,7 @@ void* os::malloc(size_t size, MEMFLAGS memflags, const NativeCallStack& stack) {
     return NULL;
   }
   // Wrap memory with guard
-  GuardedMemory guarded(ptr, size + nmt_header_size);
+  GuardedMemory guarded(ptr, size + nmt_overhead);
   ptr = guarded.get_user_ptr();
 
   if ((intptr_t)ptr == (intptr_t)MallocCatchPtr) {
@@ -781,8 +782,9 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
    // NMT support
   NMT_TrackingLevel level = MemTracker::tracking_level();
   void* membase = MemTracker::record_free(memblock, level);
-  size_t  nmt_header_size = MemTracker::malloc_header_size(level);
-  void* ptr = ::realloc(membase, size + nmt_header_size);
+  const size_t nmt_overhead =
+      MemTracker::malloc_header_size(level) + MemTracker::malloc_footer_size(level);
+  void* ptr = ::realloc(membase, size + nmt_overhead);
   return MemTracker::record_malloc(ptr, size, memflags, stack, level);
 #else
   if (memblock == NULL) {
@@ -801,7 +803,10 @@ void* os::realloc(void *memblock, size_t size, MEMFLAGS memflags, const NativeCa
   if (ptr != NULL ) {
     GuardedMemory guarded(MemTracker::malloc_base(memblock));
     // Guard's user data contains NMT header
-    size_t memblock_size = guarded.get_user_size() - MemTracker::malloc_header_size(memblock);
+    NMT_TrackingLevel level = MemTracker::tracking_level();
+    const size_t nmt_overhead =
+        MemTracker::malloc_header_size(level) + MemTracker::malloc_footer_size(level);
+    size_t memblock_size = guarded.get_user_size() - nmt_overhead;
     memcpy(ptr, memblock, MIN2(size, memblock_size));
     if (paranoid) {
       verify_memory(MemTracker::malloc_base(ptr));

--- a/src/hotspot/share/services/mallocSiteTable.cpp
+++ b/src/hotspot/share/services/mallocSiteTable.cpp
@@ -39,7 +39,6 @@ volatile int MallocSiteTable::_access_count = 0;
 // Tracking hashtable contention
 NOT_PRODUCT(int MallocSiteTable::_peak_count = 0;)
 
-
 /*
  * Initialize malloc site table.
  * Hashtable entry is malloc'd, so it can cause infinite recursion.
@@ -49,7 +48,6 @@ NOT_PRODUCT(int MallocSiteTable::_peak_count = 0;)
  * time, it is in single-threaded mode from JVM perspective.
  */
 bool MallocSiteTable::initialize() {
-  assert((size_t)table_size <= MAX_MALLOCSITE_TABLE_SIZE, "Hashtable overflow");
 
   // Fake the call stack for hashtable entry allocation
   assert(NMT_TrackingStackDepth > 1, "At least one tracking stack");

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -114,6 +114,9 @@ class MallocSiteTable : AllStatic {
     table_size = (table_base_size * NMT_TrackingStackDepth - 1)
   };
 
+  // The table must not be wider than the maximum value the bucket_idx field
+  // in the malloc header can hold.
+  STATIC_ASSERT(table_size <= MAX_MALLOCSITE_TABLE_SIZE);
 
   // This is a very special lock, that allows multiple shared accesses (sharedLock), but
   // once exclusive access (exclusiveLock) is requested, all shared accesses are

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -23,10 +23,13 @@
  */
 #include "precompiled.hpp"
 
+#include "runtime/os.hpp"
 #include "services/mallocSiteTable.hpp"
 #include "services/mallocTracker.hpp"
 #include "services/mallocTracker.inline.hpp"
 #include "services/memTracker.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/ostream.hpp"
 
 size_t MallocMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(MallocMemorySnapshot, size_t)];
 
@@ -103,15 +106,118 @@ void MallocMemorySummary::initialize() {
   ::new ((void*)_snapshot)MallocMemorySnapshot();
 }
 
-void MallocHeader::release() const {
+void MallocHeader::mark_block_as_dead() {
+  _canary = _header_canary_dead_mark;
+  NOT_LP64(_alt_canary = _header_alt_canary_dead_mark);
+  set_footer(_footer_canary_dead_mark);
+}
+
+void MallocHeader::release() {
   // Tracking already shutdown, no housekeeping is needed anymore
   if (MemTracker::tracking_level() <= NMT_minimal) return;
+
+  check_block_integrity();
 
   MallocMemorySummary::record_free(size(), flags());
   MallocMemorySummary::record_free_malloc_header(sizeof(MallocHeader));
   if (MemTracker::tracking_level() == NMT_detail) {
     MallocSiteTable::deallocation_at(size(), _bucket_idx, _pos_idx);
   }
+
+  mark_block_as_dead();
+}
+
+void MallocHeader::print_block_on_error(outputStream* st, address bad_address) const {
+  assert(bad_address >= (address)this, "sanity");
+
+  // This function prints block information, including hex dump, in case of a detected
+  // corruption. The hex dump should show both block header and corruption site
+  // (which may or may not be close together or identical). Plus some surrounding area.
+  //
+  // Note that we use os::print_hex_dump(), which is able to cope with unmapped
+  // memory (it uses SafeFetch).
+
+  st->print_cr("NMT Block at " PTR_FORMAT ", corruption at: " PTR_FORMAT ": ",
+               p2i(this), p2i(bad_address));
+  static const size_t min_dump_length = 256;
+  address from1 = align_down((address)this, sizeof(void*)) - (min_dump_length / 2);
+  address to1 = from1 + min_dump_length;
+  address from2 = align_down(bad_address, sizeof(void*)) - (min_dump_length / 2);
+  address to2 = from2 + min_dump_length;
+  if (from2 > to1) {
+    // Dump gets too large, split up in two sections.
+    os::print_hex_dump(st, from1, to1, 1);
+    st->print_cr("...");
+    os::print_hex_dump(st, from2, to2, 1);
+  } else {
+    // print one hex dump
+    os::print_hex_dump(st, from1, to2, 1);
+  }
+}
+
+// Check block integrity. If block is broken, print out a report
+// to tty (optionally with hex dump surrounding the broken block),
+// then trigger a fatal error.
+void MallocHeader::check_block_integrity() const {
+
+#define PREFIX "NMT corruption: "
+  // Note: if you modify the error messages here, make sure you
+  // adapt the associated gtests too.
+
+  // Weed out obviously wrong block addresses of NULL or very low
+  // values. Note that we should not call this for ::free(NULL),
+  // which should be handled by os::free() above us.
+  if (((size_t)p2i(this)) < K) {
+    fatal(PREFIX "Block at " PTR_FORMAT ": invalid block address", p2i(this));
+  }
+
+  // From here on we assume the block pointer to be valid. We could
+  // use SafeFetch but since this is a hot path we don't. If we are
+  // wrong, we will crash when accessing the canary, which hopefully
+  // generates distinct crash report.
+
+  // Weed out obviously unaligned addresses. NMT blocks, being the result of
+  // malloc calls, should adhere to malloc() alignment. Malloc alignment is
+  // specified by the standard by this requirement:
+  // "malloc returns a pointer which is suitably aligned for any built-in type"
+  // For us it means that it is *at least* 64-bit on all of our 32-bit and
+  // 64-bit platforms since we have native 64-bit types. It very probably is
+  // larger than that, since there exist scalar types larger than 64bit. Here,
+  // we test the smallest alignment we know.
+  // Should we ever start using std::max_align_t, this would be one place to
+  // fix up.
+  if (!is_aligned(this, sizeof(uint64_t))) {
+    print_block_on_error(tty, (address)this);
+    fatal(PREFIX "Block at " PTR_FORMAT ": block address is unaligned", p2i(this));
+  }
+
+  // Check header canary
+  if (_canary != _header_canary_life_mark) {
+    print_block_on_error(tty, (address)this);
+    fatal(PREFIX "Block at " PTR_FORMAT ": header canary broken.", p2i(this));
+  }
+
+#ifndef _LP64
+  // On 32-bit we have a second canary, check that one too.
+  if (_alt_canary != _header_alt_canary_life_mark) {
+    print_block_on_error(tty, (address)this);
+    fatal(PREFIX "Block at " PTR_FORMAT ": header alternate canary broken.", p2i(this));
+  }
+#endif
+
+  // Does block size seems reasonable?
+  if (_size >= max_reasonable_malloc_size) {
+    print_block_on_error(tty, (address)this);
+    fatal(PREFIX "Block at " PTR_FORMAT ": header looks invalid (weirdly large block size)", p2i(this));
+  }
+
+  // Check footer canary
+  if (get_footer() != _footer_canary_life_mark) {
+    print_block_on_error(tty, footer_address());
+    fatal(PREFIX "Block at " PTR_FORMAT ": footer canary broken at " PTR_FORMAT " (buffer overflow?)",
+          p2i(this), p2i(footer_address()));
+  }
+#undef PREFIX
 }
 
 bool MallocHeader::record_malloc_site(const NativeCallStack& stack, size_t size,

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -239,31 +239,99 @@ class MallocMemorySummary : AllStatic {
 
 /*
  * Malloc tracking header.
- * To satisfy malloc alignment requirement, NMT uses 2 machine words for tracking purpose,
- * which ensures 8-bytes alignment on 32-bit systems and 16-bytes on 64-bit systems (Product build).
+ *
+ * If NMT is active (state >= minimal), we need to track allocations. A simple and cheap way to
+ * do this is by using malloc headers.
+ *
+ * The user allocation is preceded by a header and is immediately followed by a (possibly unaligned)
+ *  footer canary:
+ *
+ * +--------------+-------------  ....  ------------------+-----+
+ * |    header    |               user                    | can |
+ * |              |             allocation                | ary |
+ * +--------------+-------------  ....  ------------------+-----+
+ *     16 bytes              user size                      2 byte
+ *
+ * Alignment:
+ *
+ * The start of the user allocation needs to adhere to malloc alignment. We assume 128 bits
+ * on both 64-bit/32-bit to be enough for that. So the malloc header is 16 bytes long on both
+ * 32-bit and 64-bit.
+ *
+ * Layout on 64-bit:
+ *
+ *     0        1        2        3        4        5        6        7
+ * +--------+--------+--------+--------+--------+--------+--------+--------+
+ * |                            64-bit size                                |  ...
+ * +--------+--------+--------+--------+--------+--------+--------+--------+
+ *
+ *           8        9        10       11       12       13       14       15          16 ++
+ *       +--------+--------+--------+--------+--------+--------+--------+--------+  ------------------------
+ *  ...  |   bucket idx    |     pos idx     | flags  | unused |     canary      |  ... User payload ....
+ *       +--------+--------+--------+--------+--------+--------+--------+--------+  ------------------------
+ *
+ * Layout on 32-bit:
+ *
+ *     0        1        2        3        4        5        6        7
+ * +--------+--------+--------+--------+--------+--------+--------+--------+
+ * |            alt. canary            |           32-bit size             |  ...
+ * +--------+--------+--------+--------+--------+--------+--------+--------+
+ *
+ *           8        9        10       11       12       13       14       15          16 ++
+ *       +--------+--------+--------+--------+--------+--------+--------+--------+  ------------------------
+ *  ...  |   bucket idx    |     pos idx     | flags  | unused |     canary      |  ... User payload ....
+ *       +--------+--------+--------+--------+--------+--------+--------+--------+  ------------------------
+ *
+ * Notes:
+ * - We have a canary in the two bytes directly preceding the user payload. That allows us to
+ *   catch negative buffer overflows.
+ * - On 32-bit, due to the smaller size_t, we have some bits to spare. So we also have a second
+ *   canary at the very start of the malloc header (generously sized 32 bits).
+ * - The footer canary consists of two bytes. Since the footer location may be unaligned to 16 bits,
+ *   the bytes are stored individually.
  */
 
 class MallocHeader {
-#ifdef _LP64
-  size_t           _size      : 64;
-  size_t           _flags     : 8;
-  size_t           _pos_idx   : 16;
-  size_t           _bucket_idx: 40;
-#define MAX_MALLOCSITE_TABLE_SIZE right_n_bits(40)
-#define MAX_BUCKET_LENGTH         right_n_bits(16)
-#else
-  size_t           _size      : 32;
-  size_t           _flags     : 8;
-  size_t           _pos_idx   : 8;
-  size_t           _bucket_idx: 16;
-#define MAX_MALLOCSITE_TABLE_SIZE  right_n_bits(16)
-#define MAX_BUCKET_LENGTH          right_n_bits(8)
-#endif  // _LP64
+
+  NOT_LP64(uint32_t _alt_canary);
+  size_t _size;
+  uint16_t _bucket_idx;
+  uint16_t _pos_idx;
+  uint8_t _flags;
+  uint8_t _unused;
+  uint16_t _canary;
+
+#define MAX_MALLOCSITE_TABLE_SIZE (USHRT_MAX - 1)
+#define MAX_BUCKET_LENGTH         (USHRT_MAX - 1)
+
+  static const uint16_t _header_canary_life_mark = 0xE99E;
+  static const uint16_t _header_canary_dead_mark = 0xD99D;
+  static const uint16_t _footer_canary_life_mark = 0xE88E;
+  static const uint16_t _footer_canary_dead_mark = 0xD88D;
+  NOT_LP64(static const uint32_t _header_alt_canary_life_mark = 0xE99EE99E;)
+  NOT_LP64(static const uint32_t _header_alt_canary_dead_mark = 0xD88DD88D;)
+
+  // We discount sizes larger than these
+  static const size_t max_reasonable_malloc_size = LP64_ONLY(256 * G) NOT_LP64(3500 * M);
+
+  // Check block integrity. If block is broken, print out a report
+  // to tty (optionally with hex dump surrounding the broken block),
+  // then trigger a fatal error.
+  void check_block_integrity() const;
+  void print_block_on_error(outputStream* st, address bad_address) const;
+  void mark_block_as_dead();
+
+  static uint16_t build_footer(uint8_t b1, uint8_t b2) { return ((uint16_t)b1 << 8) | (uint16_t)b2; }
+
+  uint8_t* footer_address() const   { return ((address)this) + sizeof(MallocHeader) + _size; }
+  uint16_t get_footer() const       { return build_footer(footer_address()[0], footer_address()[1]); }
+  void set_footer(uint16_t v)       { footer_address()[0] = v >> 8; footer_address()[1] = (uint8_t)v; }
 
  public:
+
   MallocHeader(size_t size, MEMFLAGS flags, const NativeCallStack& stack, NMT_TrackingLevel level) {
-    assert(sizeof(MallocHeader) == sizeof(void*) * 2,
-      "Wrong header size");
+
+    assert(size < max_reasonable_malloc_size, "Too large allocation size?");
 
     if (level == NMT_minimal) {
       return;
@@ -277,10 +345,17 @@ class MallocHeader {
       if (record_malloc_site(stack, size, &bucket_idx, &pos_idx, flags)) {
         assert(bucket_idx <= MAX_MALLOCSITE_TABLE_SIZE, "Overflow bucket index");
         assert(pos_idx <= MAX_BUCKET_LENGTH, "Overflow bucket position index");
-        _bucket_idx = bucket_idx;
-        _pos_idx = pos_idx;
+        _bucket_idx = (uint16_t)bucket_idx;
+        _pos_idx = (uint16_t)pos_idx;
       }
     }
+
+    _unused = 0;
+    _canary = _header_canary_life_mark;
+    // On 32-bit we have some bits more, use them for a second canary
+    // guarding the start of the header.
+    NOT_LP64(_alt_canary = _header_alt_canary_life_mark;)
+    set_footer(_footer_canary_life_mark); // set after initializing _size
 
     MallocMemorySummary::record_malloc(size, flags);
     MallocMemorySummary::record_new_malloc_header(sizeof(MallocHeader));
@@ -290,8 +365,8 @@ class MallocHeader {
   inline MEMFLAGS flags() const { return (MEMFLAGS)_flags; }
   bool get_stack(NativeCallStack& stack) const;
 
-  // Cleanup tracking information before the memory is released.
-  void release() const;
+  // Cleanup tracking information and mark block as dead before the memory is released.
+  void release();
 
  private:
   inline void set_size(size_t size) {
@@ -300,6 +375,9 @@ class MallocHeader {
   bool record_malloc_site(const NativeCallStack& stack, size_t size,
     size_t* bucket_idx, size_t* pos_idx, MEMFLAGS flags) const;
 };
+
+// This needs to be true on both 64-bit and 32-bit platforms
+STATIC_ASSERT(sizeof(MallocHeader) == (sizeof(uint64_t) * 2));
 
 
 // Main class called from MemTracker to track malloc activities
@@ -313,6 +391,11 @@ class MallocTracker : AllStatic {
   // malloc tracking header size for specific tracking level
   static inline size_t malloc_header_size(NMT_TrackingLevel level) {
     return (level == NMT_off) ? 0 : sizeof(MallocHeader);
+  }
+
+  // malloc tracking footer size for specific tracking level
+  static inline size_t malloc_footer_size(NMT_TrackingLevel level) {
+    return (level == NMT_off) ? 0 : sizeof(uint16_t);
   }
 
   // Parameter name convention:
@@ -347,11 +430,6 @@ class MallocTracker : AllStatic {
   static inline MEMFLAGS get_flags(void* memblock) {
     MallocHeader* header = malloc_header(memblock);
     return header->flags();
-  }
-
-  // Get header size
-  static inline size_t get_header_size(void* memblock) {
-    return (memblock == NULL) ? 0 : sizeof(MallocHeader);
   }
 
   static inline void record_new_arena(MEMFLAGS flags) {

--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -58,6 +58,7 @@ class MemTracker : AllStatic {
     const NativeCallStack& stack, NMT_TrackingLevel level) { return mem_base; }
   static inline size_t malloc_header_size(NMT_TrackingLevel level) { return 0; }
   static inline size_t malloc_header_size(void* memblock) { return 0; }
+  static inline size_t malloc_footer_size(NMT_TrackingLevel level) { return 0; }
   static inline void* malloc_base(void* memblock) { return memblock; }
   static inline void* record_free(void* memblock, NMT_TrackingLevel level) { return memblock; }
 
@@ -157,11 +158,9 @@ class MemTracker : AllStatic {
     return MallocTracker::malloc_header_size(level);
   }
 
-  static size_t malloc_header_size(void* memblock) {
-    if (tracking_level() != NMT_off) {
-      return MallocTracker::get_header_size(memblock);
-    }
-    return 0;
+  // malloc tracking footer size for specific tracking level
+  static inline size_t malloc_footer_size(NMT_TrackingLevel level) {
+    return MallocTracker::malloc_footer_size(level);
   }
 
   // To malloc base address, which is the starting address

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -237,7 +237,6 @@ void report_vm_error(const char* file, int line, const char* error_msg)
 
 
 static void print_error_for_unit_test(const char* message, const char* detail_fmt, va_list detail_args) {
-#ifdef ASSERT
   if (ExecutingUnitTests) {
     char detail_msg[256];
     if (detail_fmt != NULL) {
@@ -262,7 +261,6 @@ static void print_error_for_unit_test(const char* message, const char* detail_fm
       va_end(detail_args_copy);
     }
   }
-#endif // ASSERT
 }
 
 void report_vm_error(const char* file, int line, const char* error_msg, const char* detail_fmt, ...)

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/os.hpp"
+#include "services/memTracker.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/ostream.hpp"
+#include "unittest.hpp"
+#include "testutils.hpp"
+
+#if INCLUDE_NMT
+
+// This prefix shows up on any c heap corruption NMT detects. If unsure which assert will
+// come, just use this one.
+#define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT corruption"
+
+
+
+#define DEFINE_TEST(test_function, expected_assertion_message)                            \
+  TEST_VM_FATAL_ERROR_MSG(NMT, test_function, ".*" expected_assertion_message ".*") {     \
+    if (MemTracker::tracking_level() > NMT_off) {                                         \
+      tty->print_cr("NMT overwrite death test, please ignore subsequent error dump.");    \
+      test_function ();                                                                   \
+    } else {                                                                              \
+      /* overflow detection requires NMT to be on. If off, fake assert. */                \
+      guarantee(false,                                                                    \
+                "fake message ignore this - " expected_assertion_message);                \
+    }                                                                                     \
+  }
+
+///////
+
+static void test_overwrite_front() {
+  address p = (address) os::malloc(1, mtTest);
+  *(p - 1) = 'a';
+  os::free(p);
+}
+
+DEFINE_TEST(test_overwrite_front, "header canary broken")
+
+///////
+
+static void test_overwrite_back() {
+  address p = (address) os::malloc(1, mtTest);
+  *(p + 1) = 'a';
+  os::free(p);
+}
+
+DEFINE_TEST(test_overwrite_back, "footer canary broken")
+
+///////
+
+// A overwrite farther away from the NMT header; the report should show the hex dump split up
+// in two parts, containing both header and corruption site.
+static void test_overwrite_back_long(size_t distance) {
+  address p = (address) os::malloc(distance, mtTest);
+  *(p + distance) = 'a';
+  os::free(p);
+}
+static void test_overwrite_back_long_aligned_distance()   { test_overwrite_back_long(0x2000); }
+DEFINE_TEST(test_overwrite_back_long_aligned_distance, "footer canary broken")
+static void test_overwrite_back_long_unaligned_distance() { test_overwrite_back_long(0x2001); }
+DEFINE_TEST(test_overwrite_back_long_unaligned_distance, "footer canary broken")
+
+///////
+
+static void test_double_free() {
+  address p = (address) os::malloc(1, mtTest);
+  os::free(p);
+  // Now a double free. Note that this is susceptible to concurrency issues should
+  // a concurrent thread have done a malloc and gotten the same address after the
+  // first free. To decrease chance of this happening, we repeat the double free
+  // several times.
+  for (int i = 0; i < 100; i ++) {
+    os::free(p);
+  }
+}
+
+// What assertion message we will see depends on whether the VM wipes the memory-to-be-freed
+// on the first free(), and whether the libc uses the freed memory to store bookkeeping information.
+// If the death marker in the header is still intact after the first free, we will recognize this as
+// double free; if it got wiped, we should at least see a broken header canary.
+// The message would be either
+// - "header canary broken" or
+// - "header canary dead (double free?)".
+// However, since gtest regex expressions do not support unions (a|b), I search for a reasonable
+// subset here.
+DEFINE_TEST(test_double_free, "header canary")
+
+///////
+
+static void test_invalid_block_address() {
+  // very low, like the result of an overflow or of accessing a NULL this pointer
+  os::free((void*)0x100);
+}
+DEFINE_TEST(test_invalid_block_address, "invalid block address")
+
+///////
+
+static void test_unaliged_block_address() {
+  address p = (address) os::malloc(1, mtTest);
+  os::free(p + 6);
+}
+DEFINE_TEST(test_unaliged_block_address, "block address is unaligned");
+
+///////
+
+// Test that we notice block corruption on realloc too
+static void test_corruption_on_realloc(size_t s1, size_t s2) {
+  address p1 = (address) os::malloc(s1, mtTest);
+  *(p1 + s1) = 'a';
+  address p2 = (address) os::realloc(p1, s2, mtTest);
+
+  // Still here?
+  tty->print_cr("NMT did not detect corruption on os::realloc?");
+  // Note: don't use ASSERT here, that does not work as expected in death tests. Just
+  // let the test run its course, it should notice something is amiss.
+}
+static void test_corruption_on_realloc_growing()    { test_corruption_on_realloc(0x10, 0x11); }
+DEFINE_TEST(test_corruption_on_realloc_growing, COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX);
+static void test_corruption_on_realloc_shrinking()  { test_corruption_on_realloc(0x11, 0x10); }
+DEFINE_TEST(test_corruption_on_realloc_shrinking, COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX);
+
+///////
+
+// realloc is the trickiest of the bunch. Test that realloc works and correctly takes over
+// NMT header and footer to the resized block. We just test that nothing crashes - if the
+// header/footer get corrupted, NMT heap corruption checker will trigger alert on os::free()).
+TEST_VM(NMT, test_realloc) {
+  // We test both directions (growing and shrinking) and a small range for each to cover all
+  // size alignment variants. Should not matter, but this should be cheap.
+  for (size_t s1 = 0xF0; s1 < 0x110; s1 ++) {
+    for (size_t s2 = 0x100; s2 > 0xF0; s2 --) {
+      address p1 = (address) os::malloc(s1, mtTest);
+      ASSERT_NOT_NULL(p1);
+      GtestUtils::mark_range(p1, s1);       // mark payload range...
+      address p2 = (address) os::realloc(p1, s2, mtTest);
+      ASSERT_NOT_NULL(p2);
+      ASSERT_RANGE_IS_MARKED(p2, MIN2(s1, s2))        // ... and check that it survived the resize
+         << s1 << "->" << s2 << std::endl;
+      os::free(p2);                         // <- if NMT headers/footers got corrupted this asserts
+    }
+  }
+}
+
+#ifndef ASSERT
+// JDK 17 only to safeguard the size overflow check done with JDK-8286519. Head will receive more
+// thorough tests with JDK-8295865; if that gets ever downported to 17, this test can be removed.
+TEST_VM(NMT, test_malloc_size_arg_overflow) {
+  void* p = os::malloc(SIZE_MAX, mtTest);
+  ASSERT_NULL(p);
+  p = os::malloc(SIZE_MAX - 16, mtTest);
+  ASSERT_NULL(p);
+}
+#endif
+
+#endif // INCLUDE_NMT

--- a/test/hotspot/gtest/testutils.cpp
+++ b/test/hotspot/gtest/testutils.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "runtime/os.hpp"
+#include "utilities/align.hpp"
+#include "utilities/ostream.hpp"
+
+#include "testutils.hpp"
+#include "unittest.hpp"
+
+#include <string.h>
+
+// Note: these could be made more suitable for covering large ranges (e.g. just mark one byte per page).
+
+void GtestUtils::mark_range_with(void* p, size_t s, uint8_t mark) {
+  if (p != NULL && s > 0) {
+    ::memset(p, mark, s);
+  }
+}
+
+bool GtestUtils::check_range(const void* p, size_t s, uint8_t expected) {
+  if (p == NULL || s == 0) {
+    return true;
+  }
+
+  const char* first_wrong = NULL;
+  char* p2 = (char*)p;
+  const char* const end = p2 + s;
+  while (p2 < end) {
+    if (*p2 != (char)expected) {
+      first_wrong = p2;
+      break;
+    }
+    p2 ++;
+  }
+
+  if (first_wrong != NULL) {
+    tty->print_cr("check_range [" PTR_FORMAT ".." PTR_FORMAT "), 0x%X, : wrong pattern around " PTR_FORMAT,
+                  p2i(p), p2i(p) + s, expected, p2i(first_wrong));
+    // Note: We deliberately print the surroundings too without bounds check. Might be interesting,
+    // and os::print_hex_dump uses SafeFetch, so this is fine without bounds checks.
+    os::print_hex_dump(tty, (address)(align_down(p2, 0x10) - 0x10),
+                            (address)(align_up(end, 0x10) + 0x10), 1);
+  }
+
+  return first_wrong == NULL;
+}

--- a/test/hotspot/gtest/testutils.hpp
+++ b/test/hotspot/gtest/testutils.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef TESTUTILS_HPP
+#define TESTUTILS_HPP
+
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "unittest.hpp"
+
+class GtestUtils : public AllStatic {
+public:
+
+  // Fill range with a byte mark.
+  // Tolerates p == NULL or s == 0.
+  static void mark_range_with(void* p, size_t s, uint8_t mark);
+
+  // Given a memory range, check that the whole range is filled with the expected byte.
+  // If not, hex dump around first non-matching address and return false.
+  // If p == NULL or size == 0, returns true.
+  static bool check_range(const void* p, size_t s, uint8_t expected);
+
+  // Convenience method with a predefined byte mark.
+  static void mark_range(void* p, size_t s)           { mark_range_with(p, s, 32); }
+  static bool check_range(const void* p, size_t s)    { return check_range(p, s, 32); }
+
+};
+
+#define ASSERT_RANGE_IS_MARKED_WITH(p, size, mark)  ASSERT_TRUE(GtestUtils::check_range(p, size, mark))
+#define ASSERT_RANGE_IS_MARKED(p, size)             ASSERT_TRUE(GtestUtils::check_range(p, size))
+
+// Convenience asserts
+#define ASSERT_NOT_NULL(p)  ASSERT_NE(p2i(p), 0)
+#define ASSERT_NULL(p)      ASSERT_EQ(p2i(p), 0)
+
+#define ASSERT_ALIGN(p, n) ASSERT_TRUE(is_aligned(p, n))
+
+#endif // TESTUTILS_HPP

--- a/test/hotspot/gtest/unittest.hpp
+++ b/test/hotspot/gtest/unittest.hpp
@@ -153,4 +153,21 @@
     TEST_VM_ASSERT_MSG is only available in debug builds
 #endif
 
+#define TEST_VM_FATAL_ERROR_MSG(category, name, msg)                \
+  static void test_  ## category ## _ ## name ## _();               \
+                                                                    \
+  static void child_ ## category ## _ ## name ## _() {              \
+    ::testing::GTEST_FLAG(throw_on_failure) = true;                 \
+    test_ ## category ## _ ## name ## _();                          \
+    exit(0);                                                        \
+  }                                                                 \
+                                                                    \
+  TEST(category, CONCAT(name, _vm_assert)) {                        \
+    ASSERT_EXIT(child_ ## category ## _ ## name ## _(),             \
+                ::testing::ExitedWithCode(1),                       \
+                msg);                            \
+  }                                                                 \
+                                                                    \
+  void test_ ## category ## _ ## name ## _()
+
 #endif // UNITTEST_HPP


### PR DESCRIPTION
Not a clean downport:

- testutils.cpp/.hpp does not exist yet. I took this over (it is just a bunch of test helpers for gtests)
- os.cpp, in os::malloc, the size overflow check added with the downport of JDK-8286519 needed to be reformulated.

I also added a small, JDK17 only gtest to test for size argument overflow. Ideally that should have been done with JDK-8286519. It is release only since in debug we will get an assert which is fine but I did not feel like adding a death test for it. 

Note that in head, I am in the process of fixing https://bugs.openjdk.org/browse/JDK-8295865, and that will introduce much more thorough regression tests. Should we ever downport JDK-8295865 to 17, the test introduced here can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8275320](https://bugs.openjdk.org/browse/JDK-8275320): NMT should perform buffer overrun checks
 * [JDK-8275320](https://bugs.openjdk.org/browse/JDK-8275320): NMT should perform buffer overrun checks
 * [JDK-8275301](https://bugs.openjdk.org/browse/JDK-8275301): Unify C-heap buffer overrun checks into NMT


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/842/head:pull/842` \
`$ git checkout pull/842`

Update a local copy of the PR: \
`$ git checkout pull/842` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 842`

View PR using the GUI difftool: \
`$ git pr show -t 842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/842.diff">https://git.openjdk.org/jdk17u-dev/pull/842.diff</a>

</details>
