### PR TITLE
8272608: java_lang_System::allow_security_manager() doesn't set its initialization flag

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4480,6 +4480,7 @@ bool java_lang_System::allow_security_manager() {
     oop base = vmClasses::System_klass()->static_field_base_raw();
     int never = base->int_field(_static_never_offset);
     allowed = (base->int_field(_static_allow_security_offset) != never);
+    initialized = true;
   }
   return allowed;
 }


### PR DESCRIPTION
Clean backport to fix the minor performance bug.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272608](https://bugs.openjdk.org/browse/JDK-8272608): java_lang_System::allow_security_manager() doesn't set its initialization flag


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/843/head:pull/843` \
`$ git checkout pull/843`

Update a local copy of the PR: \
`$ git checkout pull/843` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 843`

View PR using the GUI difftool: \
`$ git pr show -t 843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/843.diff">https://git.openjdk.org/jdk17u-dev/pull/843.diff</a>

</details>
