### PR TITLE
8244670: convert clhsdb "whatis" command from javascript to java

### DIFF
--- a/src/jdk.hotspot.agent/doc/clhsdb.html
+++ b/src/jdk.hotspot.agent/doc/clhsdb.html
@@ -90,7 +90,7 @@ Available commands:
   vmstructsdump <font color="red">dump hotspot type library in text</font>
   verbose true | false <font color="red">turn on/off verbose mode</font>
   versioncheck [ true | false ] <font color="red">turn on/off debuggee VM version check</font>
-  whatis address <font color="red">print info about any arbitrary address</font>
+  whatis address <font color="red">print info about any arbitrary address. alias for findpc command</font>
   where { -a | id } <font color="red">print Java stack trace of given Java thread or all Java threads (-a)</font>
 </code>
 </pre>

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -613,6 +613,18 @@ public class CommandProcessor {
                 }
             }
         },
+        // "whatis" is just an alias for "findpc". It's kept around for compatiblity reasons.
+        new Command("whatis", "whatis address", false) {
+            public void doit(Tokens t) {
+                if (t.countTokens() != 1) {
+                    usage();
+                } else {
+                    Address a = VM.getVM().getDebugger().parseAddress(t.nextToken());
+                    PointerLocation loc = PointerFinder.find(a);
+                    loc.printOn(out);
+                }
+            }
+        },
         new Command("symbol", "symbol address", false) {
             public void doit(Tokens t) {
                 if (t.countTokens() != 1) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -182,6 +182,15 @@ public class ClhsdbFindPC {
                                           methodAddr));
             runTest(withCore, cmds, expStrMap);
 
+            // Rerun above findpc command, but this time using "whatis", which is an alias for "findpc".
+            cmdStr = "whatis " + methodAddr;
+            cmds = List.of(cmdStr);
+            expStrMap = new HashMap<>();
+            expStrMap.put(cmdStr, List.of("Method ",
+                                          "LingeredApp.steadyState",
+                                          methodAddr));
+            runTest(withCore, cmds, expStrMap);
+
             // Run findpc on a JavaThread*. We can find one in the jstack output.
             // The tid for a thread is it's JavaThread*. For example:
             //  "main" #1 prio=5 tid=0x00000080263398f0 nid=0x277e0 ...


### PR DESCRIPTION
Backport  [JDK-8244670](https://bugs.openjdk.org/browse/JDK-8244670) convert clhsdb "whatis" command from javascript to java

Clean backport, 
Parity with 17.0.6-oracle
Tested: tier1, tier2, jck's.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8244670](https://bugs.openjdk.org/browse/JDK-8244670): convert clhsdb "whatis" command from javascript to java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/849/head:pull/849` \
`$ git checkout pull/849`

Update a local copy of the PR: \
`$ git checkout pull/849` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 849`

View PR using the GUI difftool: \
`$ git pr show -t 849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/849.diff">https://git.openjdk.org/jdk17u-dev/pull/849.diff</a>

</details>
