### PR TITLE
8275569: Add linux-aarch64 to test-make profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -564,7 +564,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             "ANT_HOME": input.get("ant", "home_path")
         }
     };
-    [ "linux-x64", "macosx-x64", "windows-x64"]
+    [ "linux-x64", "macosx-x64", "windows-x64", "linux-aarch64"]
         .forEach(function (name) {
             var maketestName = name + "-testmake";
             profiles[maketestName] = concatObjects(profiles[name], testmakeBase);


### PR DESCRIPTION
Clean backport

Original commit: https://github.com/openjdk/jdk/commit/af14650127de47058b958be411503584c0ba6323
JBS: https://bugs.openjdk.org/browse/JDK-8275569

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275569](https://bugs.openjdk.org/browse/JDK-8275569): Add linux-aarch64 to test-make profiles


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/850/head:pull/850` \
`$ git checkout pull/850`

Update a local copy of the PR: \
`$ git checkout pull/850` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 850`

View PR using the GUI difftool: \
`$ git pr show -t 850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/850.diff">https://git.openjdk.org/jdk17u-dev/pull/850.diff</a>

</details>
