### PR TITLE
8290920: sspi_bridge.dll not built if BUILD_CRYPTO is false

### DIFF
--- a/make/modules/java.security.jgss/Lib.gmk
+++ b/make/modules/java.security.jgss/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,19 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJ2GSS, \
 
 TARGETS += $(BUILD_LIBJ2GSS)
 
+ifeq ($(call isTargetOs, windows), true)
+  $(eval $(call SetupJdkLibrary, BUILD_LIBSSPI_BRIDGE, \
+      NAME := sspi_bridge, \
+      OPTIMIZATION := LOW, \
+      CFLAGS := $(CFLAGS_JDKLIB) \
+          -I$(TOPDIR)/src/java.security.jgss/share/native/libj2gss, \
+      LDFLAGS := $(LDFLAGS_JDKLIB) \
+          $(call SET_SHARED_LIBRARY_ORIGIN) \
+  ))
+
+  TARGETS += $(BUILD_LIBSSPI_BRIDGE)
+endif
+
 ################################################################################
 
 ifneq ($(BUILD_CRYPTO), false)
@@ -57,17 +70,6 @@ ifneq ($(BUILD_CRYPTO), false)
     ))
 
     TARGETS += $(BUILD_LIBW2K_LSA_AUTH)
-
-    $(eval $(call SetupJdkLibrary, BUILD_LIBSSPI_BRIDGE, \
-        NAME := sspi_bridge, \
-        OPTIMIZATION := LOW, \
-        CFLAGS := $(CFLAGS_JDKLIB) \
-            -I$(TOPDIR)/src/java.security.jgss/share/native/libj2gss, \
-        LDFLAGS := $(LDFLAGS_JDKLIB) \
-            $(call SET_SHARED_LIBRARY_ORIGIN) \
-    ))
-
-    TARGETS += $(BUILD_LIBSSPI_BRIDGE)
   endif
 
   ifeq ($(call isTargetOs, macosx), true)


### PR DESCRIPTION
I backport this for parity with 17.0.6-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290920](https://bugs.openjdk.org/browse/JDK-8290920): sspi_bridge.dll not built if BUILD_CRYPTO is false


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/857/head:pull/857` \
`$ git checkout pull/857`

Update a local copy of the PR: \
`$ git checkout pull/857` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 857`

View PR using the GUI difftool: \
`$ git pr show -t 857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/857.diff">https://git.openjdk.org/jdk17u-dev/pull/857.diff</a>

</details>
