### PR TITLE
8273459: Update code segment alignment to 64 bytes

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1171,7 +1171,16 @@ void MacroAssembler::addpd(XMMRegister dst, AddressLiteral src) {
   }
 }
 
+// See 8273459.  Function for ensuring 64-byte alignment, intended for stubs only.
+// Stub code is generated once and never copied.
+// NMethods can't use this because they get copied and we can't force alignment > 32 bytes.
+void MacroAssembler::align64() {
+  align(64, (unsigned long long) pc());
+}
+
 void MacroAssembler::align(int modulus) {
+  // 8273459: Ensure alignment is possible with current segment alignment
+  assert(modulus <= CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
   align(modulus, offset());
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -194,6 +194,7 @@ class MacroAssembler: public Assembler {
   void incrementq(AddressLiteral dst);
 
   // Alignment
+  void align64();
   void align(int modulus);
   void align(int modulus, int target);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -2998,7 +2998,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   address generate_upper_word_mask() {
-    __ align(64);
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "upper_word_mask");
     address start = __ pc();
     __ emit_data(0x00000000, relocInfo::none, 0);
@@ -3009,7 +3009,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   address generate_shuffle_byte_flip_mask() {
-    __ align(64);
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "shuffle_byte_flip_mask");
     address start = __ pc();
     __ emit_data(0x0c0d0e0f, relocInfo::none, 0);
@@ -3068,7 +3068,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   address generate_pshuffle_byte_flip_mask() {
-    __ align(64);
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "pshuffle_byte_flip_mask");
     address start = __ pc();
     __ emit_data(0x00010203, relocInfo::none, 0);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4194,7 +4194,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   address generate_upper_word_mask() {
-    __ align(64);
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "upper_word_mask");
     address start = __ pc();
     __ emit_data64(0x0000000000000000, relocInfo::none);
@@ -4203,7 +4203,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   address generate_shuffle_byte_flip_mask() {
-    __ align(64);
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "shuffle_byte_flip_mask");
     address start = __ pc();
     __ emit_data64(0x08090a0b0c0d0e0f, relocInfo::none);
@@ -4248,7 +4248,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   address generate_pshuffle_byte_flip_mask() {
-    __ align(64);
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "pshuffle_byte_flip_mask");
     address start = __ pc();
     __ emit_data64(0x0405060700010203, relocInfo::none);
@@ -4370,7 +4370,7 @@ class StubGenerator: public StubCodeGenerator {
 
   // This mask is used for incrementing counter value(linc0, linc4, etc.)
   address counter_mask_addr() {
-    __ align(64);
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "counter_mask_addr");
     address start = __ pc();
     __ emit_data64(0x08090a0b0c0d0e0f, relocInfo::none);//lbswapmask
@@ -5289,7 +5289,7 @@ address generate_avx_ghash_processBlocks() {
 
   address base64_shuffle_addr()
   {
-    __ align(64, (unsigned long long)__ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "shuffle_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
@@ -5349,7 +5349,7 @@ address generate_avx_ghash_processBlocks() {
 
   address base64_encoding_table_addr()
   {
-    __ align(64, (unsigned long long)__ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "encoding_table_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0, "Alignment problem (0x%08llx)", (unsigned long long)start);
@@ -5756,7 +5756,7 @@ address generate_avx_ghash_processBlocks() {
 
   // base64 AVX512vbmi tables
   address base64_vbmi_lookup_lo_addr() {
-    __ align(64, (unsigned long long) __ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "lookup_lo_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
@@ -5773,7 +5773,7 @@ address generate_avx_ghash_processBlocks() {
   }
 
   address base64_vbmi_lookup_hi_addr() {
-    __ align(64, (unsigned long long) __ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "lookup_hi_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
@@ -5789,7 +5789,7 @@ address generate_avx_ghash_processBlocks() {
     return start;
   }
   address base64_vbmi_lookup_lo_url_addr() {
-    __ align(64, (unsigned long long) __ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "lookup_lo_base64url");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
@@ -5806,7 +5806,7 @@ address generate_avx_ghash_processBlocks() {
   }
 
   address base64_vbmi_lookup_hi_url_addr() {
-    __ align(64, (unsigned long long) __ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "lookup_hi_base64url");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
@@ -5823,7 +5823,7 @@ address generate_avx_ghash_processBlocks() {
   }
 
   address base64_vbmi_pack_vec_addr() {
-    __ align(64, (unsigned long long) __ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "pack_vec_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
@@ -5840,7 +5840,7 @@ address generate_avx_ghash_processBlocks() {
   }
 
   address base64_vbmi_join_0_1_addr() {
-    __ align(64, (unsigned long long) __ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "join_0_1_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
@@ -5857,7 +5857,7 @@ address generate_avx_ghash_processBlocks() {
   }
 
   address base64_vbmi_join_1_2_addr() {
-    __ align(64, (unsigned long long) __ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "join_1_2_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,
@@ -5874,7 +5874,7 @@ address generate_avx_ghash_processBlocks() {
   }
 
   address base64_vbmi_join_2_3_addr() {
-    __ align(64, (unsigned long long) __ pc());
+    __ align64();
     StubCodeMark mark(this, "StubRoutines", "join_2_3_base64");
     address start = __ pc();
     assert(((unsigned long long)start & 0x3f) == 0,


### PR DESCRIPTION
One of 3 dependent backports for Base64 that are required to get the real bugfix cleanly integrated.  The next one will be for align32(), then followed by the buffer overrun bugfix required for Base64 decoding to work properly.

Depends on PR #860 and #861 .

Risk: I view the risk of this backport to be minimal. This code has been in use for many months with no bugs reported.

Testing: x86_64 build, affected tests, tier1

Thanks,
--Scott

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #861 must be integrated first

### Issue
 * [JDK-8273459](https://bugs.openjdk.org/browse/JDK-8273459): Update code segment alignment to 64 bytes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/862/head:pull/862` \
`$ git checkout pull/862`

Update a local copy of the PR: \
`$ git checkout pull/862` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 862`

View PR using the GUI difftool: \
`$ git pr show -t 862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/862.diff">https://git.openjdk.org/jdk17u-dev/pull/862.diff</a>

</details>
