### PR TITLE
8296485: BuildEEBasicConstraints.java test fails with SunCertPathBuilderException

### DIFF
--- a/test/jdk/java/security/cert/CertPathBuilder/targetConstraints/BuildEEBasicConstraints.java
+++ b/test/jdk/java/security/cert/CertPathBuilder/targetConstraints/BuildEEBasicConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,9 +45,12 @@ import java.security.cert.PKIXCertPathBuilderResult;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.security.cert.X509CertSelector;
+import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+
 import jdk.test.lib.security.CertUtils;
 
 public final class BuildEEBasicConstraints {
@@ -65,6 +68,11 @@ public final class BuildEEBasicConstraints {
         PKIXBuilderParameters params = new PKIXBuilderParameters
             (Collections.singleton(anchor), sel);
         params.setRevocationEnabled(false);
+
+        // Certs expired on 7th Nov 2022
+        params.setDate(DateFormat.getDateInstance(DateFormat.MEDIUM,
+                Locale.US).parse("June 01, 2022"));
+
         X509Certificate eeCert = CertUtils.getCertFromFile("ee.cer");
         X509Certificate caCert = CertUtils.getCertFromFile("ca.cer");
         ArrayList<X509Certificate> certs = new ArrayList<X509Certificate>();


### PR DESCRIPTION
Backport for [JDK-8296485](https://bugs.openjdk.org/browse/JDK-8296485) BuildEEBasicConstraints.java test fails with SunCertPathBuilderException

Clean backport, test fix, low risk.
Test fails before the fix passes after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296485](https://bugs.openjdk.org/browse/JDK-8296485): BuildEEBasicConstraints.java test fails with SunCertPathBuilderException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/865/head:pull/865` \
`$ git checkout pull/865`

Update a local copy of the PR: \
`$ git checkout pull/865` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 865`

View PR using the GUI difftool: \
`$ git pr show -t 865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/865.diff">https://git.openjdk.org/jdk17u-dev/pull/865.diff</a>

</details>
