### PR TITLE
8273108: RunThese24H crashes with SEGV in markWord::displaced_mark_helper() after JDK-8268276

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -6165,6 +6165,9 @@ address generate_avx_ghash_processBlocks() {
       __ cmpl(length, 63);
       __ jcc(Assembler::lessEqual, L_finalBit);
 
+      __ mov64(rax, 0x0000ffffffffffff);
+      __ kmovql(k2, rax);
+
       __ align32();
       __ BIND(L_process64Loop);
 
@@ -6186,7 +6189,7 @@ address generate_avx_ghash_processBlocks() {
       __ vpmaddwd(merged0, merge_ab_bc0, pack32_op, Assembler::AVX_512bit);
       __ vpermb(merged0, pack24bits, merged0, Assembler::AVX_512bit);
 
-      __ evmovdquq(Address(dest, dp), merged0, Assembler::AVX_512bit);
+      __ evmovdqub(Address(dest, dp), k2, merged0, true, Assembler::AVX_512bit);
 
       __ subl(length, 64);
       __ addptr(source, 64);


### PR DESCRIPTION
Clean PR for #864

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8273108](https://bugs.openjdk.org/browse/JDK-8273108): RunThese24H crashes with SEGV in markWord::displaced_mark_helper() after JDK-8268276
 * [JDK-8272809](https://bugs.openjdk.org/browse/JDK-8272809): JFR thread sampler SI_KERNEL SEGV in metaspace::VirtualSpaceList::contains


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/870/head:pull/870` \
`$ git checkout pull/870`

Update a local copy of the PR: \
`$ git checkout pull/870` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 870`

View PR using the GUI difftool: \
`$ git pr show -t 870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/870.diff">https://git.openjdk.org/jdk17u-dev/pull/870.diff</a>

</details>
