### PR TITLE
8274029: Remove jtreg tag manual=yesno for  java/awt/print/Dialog/DialogOrient.java

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogOrient.java
+++ b/test/jdk/java/awt/print/Dialog/DialogOrient.java
@@ -25,7 +25,7 @@
   @test
   @bug 6594374
   @summary  Confirm that the orientation is as specified.
-  @run main/manual=yesno DialogOrient
+  @run main/manual DialogOrient
 */
 
 import java.awt.*;


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274029](https://bugs.openjdk.org/browse/JDK-8274029): Remove jtreg tag manual=yesno for  java/awt/print/Dialog/DialogOrient.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/873/head:pull/873` \
`$ git checkout pull/873`

Update a local copy of the PR: \
`$ git checkout pull/873` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 873`

View PR using the GUI difftool: \
`$ git pr show -t 873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/873.diff">https://git.openjdk.org/jdk17u-dev/pull/873.diff</a>

</details>
