### PR TITLE
Backport 61698bd137fc8ffad6a63b57b73df699712527b9

### DIFF
--- a/src/hotspot/share/interpreter/interpreter.hpp
+++ b/src/hotspot/share/interpreter/interpreter.hpp
@@ -46,10 +46,10 @@ class InterpreterCodelet: public Stub {
   friend class VMStructs;
   friend class CodeCacheDumper; // possible extension [do not remove]
  private:
-  int         _size;                             // the size in bytes
-  const char* _description;                      // a description of the codelet, for debugging & printing
-  Bytecodes::Code _bytecode;                     // associated bytecode if any
   NOT_PRODUCT(CodeStrings _strings;)              // Comments for annotating assembler output.
+  const char*     _description;           // A description of the codelet, for debugging & printing
+  int             _size;                  // The codelet size in bytes
+  Bytecodes::Code _bytecode;              // Associated bytecode, if any
 
  public:
   // Initialization/finalization


### PR DESCRIPTION
Original patch does not apply because of different NOT_PRODUCT fields of InterpreterCodelet. Repeated exactly the meaningful part: moving 3 fields in a new order after the NOT_PRODUCT part. Comments and white space 'after' are just like in the original diff.

Testing: tier1, tier2 on aarch64.