### PR TITLE
8280391: NMT: Correct NMT tag on CollectedHeap

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public:
 //   ShenandoahHeap
 //   ZCollectedHeap
 //
-class CollectedHeap : public CHeapObj<mtInternal> {
+class CollectedHeap : public CHeapObj<mtGC> {
   friend class VMStructs;
   friend class JVMCIVMStructs;
   friend class IsGCActiveMark; // Block structured external access to _is_gc_active


### PR DESCRIPTION
Clean backport to improve NMT reporting.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1` -- some unrelated failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280391](https://bugs.openjdk.org/browse/JDK-8280391): NMT: Correct NMT tag on CollectedHeap


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/883/head:pull/883` \
`$ git checkout pull/883`

Update a local copy of the PR: \
`$ git checkout pull/883` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 883`

View PR using the GUI difftool: \
`$ git pr show -t 883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/883.diff">https://git.openjdk.org/jdk17u-dev/pull/883.diff</a>

</details>
