### PR TITLE
8274903: Zero: Support AsyncGetCallTrace

### DIFF
--- a/src/hotspot/os_cpu/linux_zero/thread_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/thread_linux_zero.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,16 +96,10 @@
  public:
   bool pd_get_top_frame_for_signal_handler(frame* fr_addr,
                                            void* ucontext,
-                                           bool isInJava) {
-    ShouldNotCallThis();
-    return false; // silence compile warning
-  }
+                                           bool isInJava);
 
   bool pd_get_top_frame_for_profiling(frame* fr_addr,
                                       void* ucontext,
-                                      bool isInJava) {
-    ShouldNotCallThis();
-    return false; // silence compile warning
-  }
+                                      bool isInJava);
 
 #endif // OS_CPU_LINUX_ZERO_THREAD_LINUX_ZERO_HPP

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -313,6 +313,46 @@ static bool find_initial_Java_frame(JavaThread* thread,
   // or something called by a JRT_LEAF method.
 
   frame candidate = *fr;
+
+#ifdef ZERO
+  // Zero has no frames with code blobs, so the generic code fails.
+  // Instead, try to do Zero-specific search for Java frame.
+
+  {
+    RegisterMap map(thread, false, false);
+
+    while (true) {
+      // Cannot walk this frame? Cannot do anything anymore.
+      if (!candidate.safe_for_sender(thread)) {
+        return false;
+      }
+
+      if (candidate.is_entry_frame()) {
+        // jcw is NULL if the java call wrapper could not be found
+        JavaCallWrapper* jcw = candidate.entry_frame_call_wrapper_if_safe(thread);
+        // If initial frame is frame from StubGenerator and there is no
+        // previous anchor, there are no java frames associated with a method
+        if (jcw == NULL || jcw->is_first_frame()) {
+          return false;
+        }
+      }
+
+      // If we find a decipherable interpreted frame, this is our initial frame.
+      if (candidate.is_interpreted_frame()) {
+        if (is_decipherable_interpreted_frame(thread, &candidate, method_p, bci_p)) {
+          *initial_frame_p = candidate;
+          return true;
+        }
+      }
+
+      // Walk some more.
+      candidate = candidate.sender(&map);
+    }
+
+    // No dice, report no initial frames.
+    return false;
+  }
+#endif
 
   // If the starting frame we were given has no codeBlob associated with
   // it see if we can find such a frame because only frames with codeBlobs


### PR DESCRIPTION
Clean backport to improve Zero maintenance.

Additional testing:
 - [x] Linux x86_64 Zero, eyeballing JMH `-prof async` results
 - [x] Linux x86_64 Zero fastdebug `make bootcycle-images`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274903](https://bugs.openjdk.org/browse/JDK-8274903): Zero: Support AsyncGetCallTrace


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/885/head:pull/885` \
`$ git checkout pull/885`

Update a local copy of the PR: \
`$ git checkout pull/885` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 885`

View PR using the GUI difftool: \
`$ git pr show -t 885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/885.diff">https://git.openjdk.org/jdk17u-dev/pull/885.diff</a>

</details>
