### PR TITLE
8295419: JFR: Change name of jdk.JitRestart

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -494,7 +494,7 @@
     <Field type="ulong" contentType="bytes" name="used" label="Used" />
   </Event>
 
-  <Event name="JitRestart" category="Java Virtual Machine, Compiler" label="JIT Restart" stackTrace="false" startTime="false" thread="true">
+  <Event name="JITRestart" category="Java Virtual Machine, Compiler" label="JIT Restart" stackTrace="false" startTime="false" thread="true">
     <Field type="int" contentType="bytes" name="freedMemory" label="Freed Memory" />
     <Field type="ulong" contentType="bytes" name="codeCacheMaxCapacity" label="Code Cache Maximum Capacity" />
   </Event>

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -432,7 +432,7 @@ void NMethodSweeper::sweep_code_cache() {
     CompileBroker::set_should_compile_new_jobs(CompileBroker::run_compilation);
     log.debug("restart compiler");
     log_sweep("restart_compiler");
-    EventJitRestart event;
+    EventJITRestart event;
     event.set_freedMemory(freed_memory);
     event.set_codeCacheMaxCapacity(CodeCache::max_capacity());
     event.commit();

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -521,7 +521,7 @@
       <setting name="enabled" control="compiler-enabled-failure">false</setting>
     </event>
 
-    <event name="jdk.JitRestart">
+    <event name="jdk.JITRestart">
       <setting name="enabled" control="compiler-enabled">true</setting>
     </event>
 

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -521,7 +521,7 @@
       <setting name="enabled" control="compiler-enabled-failure">false</setting>
     </event>
 
-    <event name="jdk.JitRestart">
+    <event name="jdk.JITRestart">
       <setting name="enabled" control="compiler-enabled">true</setting>
     </event>
 

--- a/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestJitRestart.java
@@ -66,7 +66,7 @@ public class TestJitRestart {
     private static boolean testWithBlobType(BlobType btype, long availableSize) throws Exception {
         Recording r = new Recording();
         r.enable(EventNames.CodeCacheFull);
-        r.enable(EventNames.JitRestart);
+        r.enable(EventNames.JITRestart);
         r.start();
         long addr = WHITE_BOX.allocateCodeBlob(availableSize, btype.id);
         WHITE_BOX.freeCodeBlob(addr);
@@ -79,7 +79,7 @@ public class TestJitRestart {
 
         for (RecordedEvent evt: events) {
             System.out.println(evt);
-            if (evt.getEventType().getName().equals("jdk.JitRestart")) {
+            if (evt.getEventType().getName().equals("jdk.JITRestart")) {
                 Events.assertField(evt, "codeCacheMaxCapacity").notEqual(0L);
                 Events.assertField(evt, "freedMemory").notEqual(0L);
                 return true;

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -169,7 +169,7 @@ public class EventNames {
     public final static String ObjectAllocationOutsideTLAB = PREFIX + "ObjectAllocationOutsideTLAB";
     public final static String ObjectAllocationSample = PREFIX + "ObjectAllocationSample";
     public final static String Deoptimization = PREFIX + "Deoptimization";
-    public final static String JitRestart = PREFIX + "JitRestart";
+    public final static String JITRestart = PREFIX + "JITRestart";
 
     // OS
     public final static String OSInformation = PREFIX + "OSInformation";


### PR DESCRIPTION
Another cpp file had to be modified in jdk17u-dev compared to jdk/jdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295419](https://bugs.openjdk.org/browse/JDK-8295419): JFR: Change name of jdk.JitRestart


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - Committer)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/888/head:pull/888` \
`$ git checkout pull/888`

Update a local copy of the PR: \
`$ git checkout pull/888` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 888`

View PR using the GUI difftool: \
`$ git pr show -t 888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/888.diff">https://git.openjdk.org/jdk17u-dev/pull/888.diff</a>

</details>
