### PR TITLE
Backport 8a3cca09ba427282f2712bec7298b85bbacf076b

### DIFF
--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -45,6 +45,10 @@ class VM_Cleanup: public VM_Operation {
  public:
   VMOp_Type type() const { return VMOp_Cleanup; }
   void doit() {};
+  virtual bool skip_thread_oop_barriers() const {
+    // None of the safepoint cleanup tasks read oops in the Java threads.
+    return true;
+  }
 };
 
 class VM_ClearICs: public VM_Operation {


### PR DESCRIPTION
Clean backport of performance enhancement for GCs that do concurrent thread roots (in JDK 17u those are Shenandoah and Z). On my machine, with Shenandoah running 20K threads, the safepoint cleanup time for "Cleanup" VM ops dropped from 2ms to nearly zero. The follow-up would be [JDK-8280817](https://bugs.openjdk.org/browse/JDK-8280817), which would extend this to other "empty" ops

Additional testing:
 - [x] Ad-hoc benchmarks
 - [x] Linux x86_64 fastdebug `tier1`, `tier2` 
 - [x] Linux x86_64 fastdebug `tier1`, `tier2`  with `-XX:+DeoptimizeALot`
 - [ ] Linux x86_64 fastdebug `tier1`, `tier2`  with `-XX:+UseShenandoahGC`