### PR TITLE
8231490: Ugly racy writes to ZipUtils.defaultBuf

### DIFF
--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -424,7 +424,9 @@ public class Inflater {
                 needDict = true;
             }
             if (input != null) {
-                input.position(inputPos + read);
+                if (read > 0) {
+                    input.position(inputPos + read);
+                }
             } else {
                 this.inputPos = inputPos + read;
             }


### PR DESCRIPTION
Clean backport to fix a minor data race.

Additional testing:
 - [x] Linux x86_64 fastdebug, `java/nio/zipfs`, `java/util/zip`, `java/util/jar`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8231490](https://bugs.openjdk.org/browse/JDK-8231490): Ugly racy writes to ZipUtils.defaultBuf


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/891/head:pull/891` \
`$ git checkout pull/891`

Update a local copy of the PR: \
`$ git checkout pull/891` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 891`

View PR using the GUI difftool: \
`$ git pr show -t 891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/891.diff">https://git.openjdk.org/jdk17u-dev/pull/891.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/891#issuecomment-1318553248)