### PR TITLE
8277866: gc/epsilon/TestMemoryMXBeans.java failed with wrong initial heap size

### DIFF
--- a/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
+++ b/test/hotspot/jtreg/gc/epsilon/TestMemoryMXBeans.java
@@ -36,7 +36,7 @@ package gc.epsilon;
  *                   gc.epsilon.TestMemoryMXBeans
  *                   -1 256
  *
- * @run main/othervm -Xmx256m -Xmx256m
+ * @run main/othervm -Xms256m -Xmx256m
  *                   -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC
  *                   gc.epsilon.TestMemoryMXBeans
  *                   256 256


### PR DESCRIPTION
Clean backport to improve test reliability.

Additional testing
  - [x] Linux x86_64 fastdebug, `gc/epsilon`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277866](https://bugs.openjdk.org/browse/JDK-8277866): gc/epsilon/TestMemoryMXBeans.java failed with wrong initial heap size


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/892/head:pull/892` \
`$ git checkout pull/892`

Update a local copy of the PR: \
`$ git checkout pull/892` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 892`

View PR using the GUI difftool: \
`$ git pr show -t 892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/892.diff">https://git.openjdk.org/jdk17u-dev/pull/892.diff</a>

</details>
