### PR TITLE
8290374: Shenandoah: Remove inaccurate comment on SBS::load_reference_barrier()

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2015, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,13 +84,8 @@ inline oop ShenandoahBarrierSet::load_reference_barrier(oop obj) {
       _heap->in_collection_set(obj)) { // Subsumes NULL-check
     assert(obj != NULL, "cset check must have subsumed NULL-check");
     oop fwd = resolve_forwarded_not_null(obj);
-    // TODO: It should not be necessary to check evac-in-progress here.
-    // We do it for mark-compact, which may have forwarded objects,
-    // and objects in cset and gets here via runtime barriers.
-    // We can probably fix this as soon as mark-compact has its own
-    // marking phase.
     if (obj == fwd && _heap->is_evacuation_in_progress()) {
-       Thread* t = Thread::current();
+      Thread* t = Thread::current();
       ShenandoahEvacOOMScope oom_evac_scope(t);
       return _heap->evacuate_object(obj, t);
     }


### PR DESCRIPTION
Clean backport, provides the grounds for more clean backports.

Additional testing:
 - [x] Linux x86_64 fastdebug, `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290374](https://bugs.openjdk.org/browse/JDK-8290374): Shenandoah: Remove inaccurate comment on SBS::load_reference_barrier()


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/894/head:pull/894` \
`$ git checkout pull/894`

Update a local copy of the PR: \
`$ git checkout pull/894` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 894`

View PR using the GUI difftool: \
`$ git pr show -t 894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/894.diff">https://git.openjdk.org/jdk17u-dev/pull/894.diff</a>

</details>
