### PR TITLE
8296733: JFR: File Read event for RandomAccessFile::write(byte[]) is incorrect

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/RandomAccessFileInstrumentor.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/RandomAccessFileInstrumentor.java
@@ -156,7 +156,7 @@ final class RandomAccessFileInstrumentor {
             write(b);
             bytesWritten = b.length;
         } finally {
-            long duration = EventHandler.timestamp();
+            long duration = EventHandler.timestamp() - start;
             if (handler.shouldCommit(duration)) {
                 handler.write(start, duration, path, bytesWritten);
             }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit ced88a2f from the openjdk/jdk repository.

The commit being backported was authored by Erik Gahlin on 11 Nov 2022 and was reviewed by Christoph Langer and Markus Grönlund.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296733](https://bugs.openjdk.org/browse/JDK-8296733): JFR: File Read event for RandomAccessFile::write(byte[]) is incorrect


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/895/head:pull/895` \
`$ git checkout pull/895`

Update a local copy of the PR: \
`$ git checkout pull/895` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 895`

View PR using the GUI difftool: \
`$ git pr show -t 895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/895.diff">https://git.openjdk.org/jdk17u-dev/pull/895.diff</a>

</details>
