### PR TITLE
8178698: javax/sound/midi/Sequencer/MetaCallback.java failed with timeout

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -685,7 +685,6 @@ javax/sound/sampled/Clip/Drain/ClipDrain.java          7062792 generic-all
 javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
 
 javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,macosx-aarch64
-javax/sound/midi/Sequencer/MetaCallback.java 8178698 linux-all
 javax/sound/midi/Sequencer/Looping.java 8136897 generic-all
 
 ############################################################################

--- a/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
+++ b/test/jdk/javax/sound/midi/Sequencer/MetaCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,16 @@ import javax.sound.midi.Sequence;
 import javax.sound.midi.Sequencer;
 import javax.sound.midi.ShortMessage;
 import javax.sound.midi.Track;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @test
  * @bug 4347135
  * @summary MIDI MetaMessage callback inconsistent
  * @key intermittent sound
- * @run main/othervm MetaCallback
+ * @run main/othervm/timeout=120 MetaCallback
  */
 public class MetaCallback implements MetaEventListener {
 
@@ -59,11 +62,15 @@ public class MetaCallback implements MetaEventListener {
 
     public static int TOTAL_COUNT = 100;
 
-    int metaCount = 0;
-    boolean finished = false;
+    volatile int metaCount = 0;
+    volatile boolean finished = false;
+    // On M1 Mac sometimes system notifies listener about the same message twice
+    static List<MetaMessage> received = Collections.synchronizedList(new ArrayList<>());
+    long startTimeMs;
 
     MetaCallback() throws Exception {
 
+        startTimeMs = System.currentTimeMillis();
         sequencer=MidiSystem.getSequencer();
         sequence=new Sequence(Sequence.PPQ,240);
         track=sequence.createTrack();
@@ -101,13 +108,28 @@ public class MetaCallback implements MetaEventListener {
         }
     }
     void start() {sequencer.start();}
-    void stop() {sequencer.stop();}
+    void stop() {
+        sequencer.stop();
+        sequencer.close();
+    }
 
     public void meta(MetaMessage msg) {
         System.out.println(""+metaCount+": got "+msg);
         if (msg.getType() == 0x2F) {
             finished = true;
         } else if (msg.getData().length > 0 && msg.getType() == 1) {
+            if (!received.contains(msg)) {
+                received.add(msg);
+            } else {
+                // Add some additional debug output for the case of duplicate meta message
+                // The test will fail anyway at the end
+                System.out.println("Duplicate message received after getting "
+                        + received.size() + " messages.");
+                System.out.println("Sequencer in use: " + sequencer);
+                System.out.println("Time from test start: " +
+                        (System.currentTimeMillis() - startTimeMs) + "ms");
+                Thread.dumpStack();
+            }
             metaCount++;
         }
     }


### PR DESCRIPTION
Backport for [JDK-8178698](https://bugs.openjdk.org/browse/JDK-8178698) javax/sound/midi/Sequencer/MetaCallback.java failed with timeout https://github.com/openjdk/jdk/commit/43ce047f9f417a1d8afa83a3d2c2429a478975db

Clean backport
Test update, low risk.
Test passes on mac & linux using make run-test TEST="test/jdk/javax/sound/midi/Sequencer/MetaCallback.java"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8178698](https://bugs.openjdk.org/browse/JDK-8178698): javax/sound/midi/Sequencer/MetaCallback.java failed with timeout


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/902/head:pull/902` \
`$ git checkout pull/902`

Update a local copy of the PR: \
`$ git checkout pull/902` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 902`

View PR using the GUI difftool: \
`$ git pr show -t 902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/902.diff">https://git.openjdk.org/jdk17u-dev/pull/902.diff</a>

</details>
