### PR TITLE
8266519: Cleanup resolve() leftovers from BarrierSet et al

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSet.hpp
+++ b/src/hotspot/share/gc/shared/barrierSet.hpp
@@ -310,10 +310,6 @@ public:
     static void clone_in_heap(oop src, oop dst, size_t size) {
       Raw::clone(src, dst, size);
     }
-
-    static oop resolve(oop obj) {
-      return Raw::resolve(obj);
-    }
   };
 };
 

--- a/src/hotspot/share/oops/access.hpp
+++ b/src/hotspot/share/oops/access.hpp
@@ -57,7 +57,6 @@
 // * atomic_xchg_at: Atomically swap a new value at an internal pointer address if previous value matched the compared value.
 // * arraycopy: Copy data from one heap array to another heap array. The ArrayAccess class has convenience functions for this.
 // * clone: Clone the contents of an object to a newly allocated object.
-// * resolve: Resolve a stable to-space invariant oop that is guaranteed not to relocate its payload until a subsequent thread transition.
 //
 // == IMPLEMENTATION ==
 // Each access goes through the following steps in a template pipeline.

--- a/src/hotspot/share/oops/access.inline.hpp
+++ b/src/hotspot/share/oops/access.inline.hpp
@@ -200,13 +200,6 @@ namespace AccessInternal {
     }
   };
 
-  template <class GCBarrierType, DecoratorSet decorators>
-  struct PostRuntimeDispatch<GCBarrierType, BARRIER_RESOLVE, decorators>: public AllStatic {
-    static oop access_barrier(oop obj) {
-      return GCBarrierType::resolve(obj);
-    }
-  };
-
   // Resolving accessors with barriers from the barrier set happens in two steps.
   // 1. Expand paths with runtime-decorators, e.g. is UseCompressedOops on or off.
   // 2. Expand paths for each BarrierSet available in the system.
@@ -353,13 +346,6 @@ namespace AccessInternal {
     func_t function = BarrierResolver<decorators, func_t, BARRIER_CLONE>::resolve_barrier();
     _clone_func = function;
     function(src, dst, size);
-  }
-
-  template <DecoratorSet decorators, typename T>
-  oop RuntimeDispatch<decorators, T, BARRIER_RESOLVE>::resolve_init(oop obj) {
-    func_t function = BarrierResolver<decorators, func_t, BARRIER_RESOLVE>::resolve_barrier();
-    _resolve_func = function;
-    return function(obj);
   }
 }
 


### PR DESCRIPTION
Clean backport to simplify GC interface for better maintainability.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`
 - [x] Linux x86_64 fastdebug `tier2`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266519](https://bugs.openjdk.org/browse/JDK-8266519): Cleanup resolve() leftovers from BarrierSet et al


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/907/head:pull/907` \
`$ git checkout pull/907`

Update a local copy of the PR: \
`$ git checkout pull/907` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 907`

View PR using the GUI difftool: \
`$ git pr show -t 907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/907.diff">https://git.openjdk.org/jdk17u-dev/pull/907.diff</a>

</details>
