### PR TITLE
8280016: gc/g1/TestShrinkAuxiliaryData30 test fails on large machines

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData27.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryData27.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 package gc.g1;
 
 /**
- * @test TestShrinkAuxiliaryData30
+ * @test TestShrinkAuxiliaryData27
  * @key randomness
  * @bug 8038423 8061715 8078405
  * @summary Checks that decommitment occurs for JVM with different
@@ -36,11 +36,11 @@ package gc.g1;
  *          java.management
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
- * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData30
+ * @run main/timeout=720 gc.g1.TestShrinkAuxiliaryData27
  */
-public class TestShrinkAuxiliaryData30 {
+public class TestShrinkAuxiliaryData27 {
 
     public static void main(String[] args) throws Exception {
-        new TestShrinkAuxiliaryData(30).test();
+        new TestShrinkAuxiliaryData(27).test();
     }
 }


### PR DESCRIPTION
Clean backport to improve testing.

Additional testing:
 - [x] Affected test passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280016](https://bugs.openjdk.org/browse/JDK-8280016): gc/g1/TestShrinkAuxiliaryData30 test fails on large machines


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/908/head:pull/908` \
`$ git checkout pull/908`

Update a local copy of the PR: \
`$ git checkout pull/908` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 908`

View PR using the GUI difftool: \
`$ git pr show -t 908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/908.diff">https://git.openjdk.org/jdk17u-dev/pull/908.diff</a>

</details>
