### PR TITLE
8296945: PublicMethodsTest is slow due to dependency verification with debug builds

### DIFF
--- a/test/jdk/java/lang/reflect/PublicMethods/PublicMethodsTest.java
+++ b/test/jdk/java/lang/reflect/PublicMethods/PublicMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ import static java.util.stream.Collectors.toMap;
  * @modules jdk.compiler
  *          jdk.zipfs
  * @summary Nearly exhaustive test of Class.getMethod() and Class.getMethods()
- * @run main PublicMethodsTest
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies PublicMethodsTest
  */
 public class PublicMethodsTest {
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296945](https://bugs.openjdk.org/browse/JDK-8296945): PublicMethodsTest is slow due to dependency verification with debug builds


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/911/head:pull/911` \
`$ git checkout pull/911`

Update a local copy of the PR: \
`$ git checkout pull/911` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 911`

View PR using the GUI difftool: \
`$ git pr show -t 911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/911.diff">https://git.openjdk.org/jdk17u-dev/pull/911.diff</a>

</details>
