### PR TITLE
8297241: Update sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java

### DIFF
--- a/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
+++ b/test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
@@ -63,7 +63,10 @@ public class OnScreenRenderingResizeTest {
     private static Frame frame;
 
     private static void createAndShowGUI() {
-        frame = new Frame();
+        frame = new Frame() {
+            public void paint(Graphics g) {}
+            public void update(Graphics g) {}
+        };
         frame.setBackground(bgColor);
         frame.setUndecorated(true);
         frame.setAlwaysOnTop(true);
@@ -148,6 +151,9 @@ public class OnScreenRenderingResizeTest {
                         incH = -incH;
                     }
                     frame.setSize(w, h);
+                    if (robot != null) {
+                        robot.waitForIdle();
+                    }
                     cnt = 0;
                 }
                 // try to put the device into non-default state, for example,


### PR DESCRIPTION
Backport for
[JDK-8297153](https://bugs.openjdk.org/browse/JDK-8297153) sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java fails again
[JDK-8297241](https://bugs.openjdk.org/browse/JDK-8297241) Update sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java

Original commit: https://github.com/openjdk/jdk/commit/3c0949824e06f2b3d44f1bde9d2292a7627b0197

Clean backport.
Fixing unstable test.
Checked on mac and linux by running:
make run-test TEST="test/jdk/sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8297241](https://bugs.openjdk.org/browse/JDK-8297241): Update sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java
 * [JDK-8297153](https://bugs.openjdk.org/browse/JDK-8297153): sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java fails again


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/919/head:pull/919` \
`$ git checkout pull/919`

Update a local copy of the PR: \
`$ git checkout pull/919` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 919`

View PR using the GUI difftool: \
`$ git pr show -t 919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/919.diff">https://git.openjdk.org/jdk17u-dev/pull/919.diff</a>

</details>
