### PR TITLE
Backport 3f2f128af6ec2f9097af7758bfd41aeaa4354d40

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -50,17 +50,17 @@ compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 
 compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
 
-compiler/rtm/locking/TestRTMAbortRatio.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMAbortThreshold.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMAfterNonRTMDeopt.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMDeoptOnHighAbortRatio.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMDeoptOnLowAbortRatio.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMLockingCalculationDelay.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMLockingThreshold.java 8183263 generic-x64
-compiler/rtm/locking/TestRTMSpinLoopCount.java 8183263 generic-x64
-compiler/rtm/locking/TestUseRTMDeopt.java 8183263 generic-x64
-compiler/rtm/locking/TestUseRTMXendForLockBusy.java 8183263 generic-x64
-compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64
+compiler/rtm/locking/TestRTMAbortRatio.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMAbortThreshold.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMAfterNonRTMDeopt.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMDeoptOnHighAbortRatio.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMDeoptOnLowAbortRatio.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMLockingCalculationDelay.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMLockingThreshold.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestRTMSpinLoopCount.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestUseRTMDeopt.java 8183263 generic-x64,generic-i586
+compiler/rtm/locking/TestUseRTMXendForLockBusy.java 8183263 generic-x64,generic-i586
+compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64,generic-i586
 
 compiler/c2/Test8004741.java 8235801 generic-all
 


### PR DESCRIPTION
Problemlist should be extended so that existing compiler/rtm entries include x86 (32-bit) intel builds as well, as these are also affected.