### PR TITLE
8293535: jdk/javadoc/doclet/testJavaFX/TestJavaFxMode.java fail with jfx

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFxMode.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFxMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,13 +77,16 @@ public class TestJavaFxMode extends JavadocTester {
         checkExit(Exit.OK);
         checkOrder("pkg/A.html",
                 "Property Summary",
-                "javafx.beans.property.Property", "<a href=\"#propProperty\">prop</a>",
-                "Field Summary",
-                "javafx.beans.property.Property", "<a href=\"#prop\">prop</a></span>",
-                "Method Summary",
-                "<a href=\"#getProp()\">getProp</a>", "Gets the value of the property prop.",
                 """
-                    <a href="#propProperty()">propProperty</a>""", "Sets the value of the property prop.");
+                    <a href="#propProperty" class="member-name-link">prop</a>""",
+                "Field Summary",
+                """
+                    <a href="#prop" class="member-name-link">prop</a>""",
+                "Method Summary",
+                """
+                    <a href="#getProp()" class="member-name-link">getProp</a>""",
+                """
+                    <a href="#propProperty()" class="member-name-link">propProperty</a>""");
     }
 
     void createTestClass(Path src) throws Exception {


### PR DESCRIPTION
Hi,

I request the backport for jdk17u-dev. The patch applies clean. This backport is only a test change, no risk and fixes the test failure.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293535](https://bugs.openjdk.org/browse/JDK-8293535): jdk/javadoc/doclet/testJavaFX/TestJavaFxMode.java fail with jfx


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/922/head:pull/922` \
`$ git checkout pull/922`

Update a local copy of the PR: \
`$ git checkout pull/922` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 922`

View PR using the GUI difftool: \
`$ git pr show -t 922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/922.diff">https://git.openjdk.org/jdk17u-dev/pull/922.diff</a>

</details>
