### PR TITLE
8277485: Zero: Fix _fast_{i,f}access_0 bytecodes handling

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2815,7 +2815,7 @@ run:
         UPDATE_PC_AND_TOS_AND_CONTINUE(4, 1);
       }
 
-      CASE(_fast_faccess_0): {
+      CASE(_fast_iaccess_0): {
         u2 index = Bytes::get_native_u2(pc+2);
         ConstantPoolCacheEntry* cache = cp->entry_at(index);
         int field_offset = cache->f2_as_index();
@@ -2830,7 +2830,7 @@ run:
         UPDATE_PC_AND_TOS_AND_CONTINUE(4, 1);
       }
 
-      CASE(_fast_iaccess_0): {
+      CASE(_fast_faccess_0): {
         u2 index = Bytes::get_native_u2(pc+2);
         ConstantPoolCacheEntry* cache = cp->entry_at(index);
         int field_offset = cache->f2_as_index();


### PR DESCRIPTION
Clean follow up for JDK-8008243.

Additional testing:
 - [x] Linux x86_64 Zero fastdebug `make bootcycle-images`
 - [x] Linux x86_32 Zero fastdebug `make bootcycle-images`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277485](https://bugs.openjdk.org/browse/JDK-8277485): Zero: Fix _fast_{i,f}access_0 bytecodes handling


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/925/head:pull/925` \
`$ git checkout pull/925`

Update a local copy of the PR: \
`$ git checkout pull/925` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 925`

View PR using the GUI difftool: \
`$ git pr show -t 925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/925.diff">https://git.openjdk.org/jdk17u-dev/pull/925.diff</a>

</details>
