### PR TITLE
8270155: ARM32: Improve register dump in hs_err

### DIFF
--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -468,9 +468,8 @@ void os::print_register_info(outputStream *st, const void *context) {
   st->print_cr("Register to memory mapping:");
   st->cr();
   for (int r = 0; r < ARM_REGS_IN_CONTEXT; r++) {
-    st->print_cr("  %-3s = " INTPTR_FORMAT, as_Register(r)->name(), reg_area[r]);
+    st->print("  %-3s = ", as_Register(r)->name());
     print_location(st, reg_area[r]);
-    st->cr();
   }
   st->cr();
 }


### PR DESCRIPTION
Clean backport to improve ARM32 error handling.

Additional testing:
 - [x] Linux ARM32 fastdebug `make bootcycle-images`
 - [x] Ad-hoc Linux ARM32 fastdebug crashes, eyeballing hs-errs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270155](https://bugs.openjdk.org/browse/JDK-8270155): ARM32: Improve register dump in hs_err


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/926/head:pull/926` \
`$ git checkout pull/926`

Update a local copy of the PR: \
`$ git checkout pull/926` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 926`

View PR using the GUI difftool: \
`$ git pr show -t 926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/926.diff">https://git.openjdk.org/jdk17u-dev/pull/926.diff</a>

</details>
