### PR TITLE
8270086: ARM32-softfp: Do not load CONSTANT_double using the condy helper methods in the interpreter

### DIFF
--- a/src/hotspot/cpu/arm/templateTable_arm.cpp
+++ b/src/hotspot/cpu/arm/templateTable_arm.cpp
@@ -490,29 +490,30 @@ void TemplateTable::ldc2_w() {
   __ add(Rtemp, Rtags, tags_offset);
   __ ldrb(Rtemp, Address(Rtemp, Rindex));
 
-  Label Condy, exit;
-#ifdef __ABI_HARD__
-  Label NotDouble;
+  Label Done, NotLong, NotDouble;
   __ cmp(Rtemp, JVM_CONSTANT_Double);
   __ b(NotDouble, ne);
+#ifdef __SOFTFP__
+  __ ldr(R0_tos_lo, Address(Rbase, base_offset + 0 * wordSize));
+  __ ldr(R1_tos_hi, Address(Rbase, base_offset + 1 * wordSize));
+#else // !__SOFTFP__
   __ ldr_double(D0_tos, Address(Rbase, base_offset));
-
+#endif // __SOFTFP__
   __ push(dtos);
-  __ b(exit);
+  __ b(Done);
   __ bind(NotDouble);
-#endif
 
   __ cmp(Rtemp, JVM_CONSTANT_Long);
-  __ b(Condy, ne);
+  __ b(NotLong, ne);
   __ ldr(R0_tos_lo, Address(Rbase, base_offset + 0 * wordSize));
   __ ldr(R1_tos_hi, Address(Rbase, base_offset + 1 * wordSize));
   __ push(ltos);
-  __ b(exit);
+  __ b(Done);
+  __ bind(NotLong);
 
-  __ bind(Condy);
-  condy_helper(exit);
+  condy_helper(Done);
 
-  __ bind(exit);
+  __ bind(Done);
 }
 
 


### PR DESCRIPTION
Clean backport to improve ARM32 reliability.

Additional testing:
 - [x] Linux ARM32 fastdebug `make bootcycle-images`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270086](https://bugs.openjdk.org/browse/JDK-8270086): ARM32-softfp: Do not load CONSTANT_double using the condy helper methods in the interpreter


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/927/head:pull/927` \
`$ git checkout pull/927`

Update a local copy of the PR: \
`$ git checkout pull/927` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 927`

View PR using the GUI difftool: \
`$ git pr show -t 927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/927.diff">https://git.openjdk.org/jdk17u-dev/pull/927.diff</a>

</details>
