### PR TITLE
8296960: [JVMCI] list HotSpotConstantPool.loadReferencedType to ConstantPool

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -716,6 +716,7 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
         loadReferencedType(cpi, opcode, true /* initialize */);
     }
 
+    @Override
     @SuppressWarnings("fallthrough")
     public void loadReferencedType(int cpi, int opcode, boolean initialize) {
         int index;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ConstantPool.java
@@ -47,6 +47,24 @@ public interface ConstantPool {
     void loadReferencedType(int cpi, int opcode);
 
     /**
+     * Ensures that the type referenced by the specified constant pool entry is loaded. This can be
+     * used to compile time resolve a type. It works for field, method, or type constant pool
+     * entries.
+     *
+     * @param cpi the index of the constant pool entry that references the type
+     * @param opcode the opcode of the instruction that references the type
+     * @param initialize if {@code true}, the referenced type is either guaranteed to be initialized
+     *            upon return or an initialization exception is thrown
+     */
+    default void loadReferencedType(int cpi, int opcode, boolean initialize) {
+        if (initialize) {
+            loadReferencedType(cpi, opcode);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
      * Looks up the type referenced by the constant pool entry at {@code cpi} as referenced by the
      * {@code opcode} bytecode instruction.
      *


### PR DESCRIPTION
Clean backport which is needed for JDK 17-based future GraalVM builds.

Testing: jvmci tests (passed)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296960](https://bugs.openjdk.org/browse/JDK-8296960): [JVMCI] list HotSpotConstantPool.loadReferencedType to ConstantPool


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/930/head:pull/930` \
`$ git checkout pull/930`

Update a local copy of the PR: \
`$ git checkout pull/930` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 930`

View PR using the GUI difftool: \
`$ git pr show -t 930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/930.diff">https://git.openjdk.org/jdk17u-dev/pull/930.diff</a>

</details>
