### PR TITLE
8296958: [JVMCI] add API for retrieving ConstantValue attributes

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -647,6 +647,16 @@ C2V_VMENTRY_NULL(jobject, resolvePossiblyCachedConstantInPool, (JNIEnv* env, job
   return JVMCIENV->get_jobject(JVMCIENV->get_object_constant(obj));
 C2V_END
 
+C2V_VMENTRY_NULL(jobject, getUncachedStringInPool, (JNIEnv* env, jobject, jobject jvmci_constant_pool, jint index))
+  constantPoolHandle cp(THREAD, JVMCIENV->asConstantPool(jvmci_constant_pool));
+  constantTag tag = cp->tag_at(index);
+  if (!tag.is_string()) {
+    JVMCI_THROW_MSG_NULL(IllegalArgumentException, err_msg("Unexpected constant pool tag at index %d: %d", index, tag.value()));
+  }
+  oop obj = cp->uncached_string_at(index, CHECK_NULL);
+  return JVMCIENV->get_jobject(JVMCIENV->get_object_constant(obj));
+C2V_END
+
 C2V_VMENTRY_0(jint, lookupNameAndTypeRefIndexInPool, (JNIEnv* env, jobject, jobject jvmci_constant_pool, jint index))
   constantPoolHandle cp(THREAD, JVMCIENV->asConstantPool(jvmci_constant_pool));
   return cp->name_and_type_ref_index_at(index);
@@ -2690,6 +2700,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "lookupMethodInPool",                           CC "(" HS_CONSTANT_POOL "IB)" HS_RESOLVED_METHOD,                                     FN_PTR(lookupMethodInPool)},
   {CC "constantPoolRemapInstructionOperandFromCache", CC "(" HS_CONSTANT_POOL "I)I",                                                        FN_PTR(constantPoolRemapInstructionOperandFromCache)},
   {CC "resolvePossiblyCachedConstantInPool",          CC "(" HS_CONSTANT_POOL "I)" JAVACONSTANT,                                            FN_PTR(resolvePossiblyCachedConstantInPool)},
+  {CC "getUncachedStringInPool",                      CC "(" HS_CONSTANT_POOL "I)" JAVACONSTANT,                                            FN_PTR(getUncachedStringInPool)},
   {CC "resolveTypeInPool",                            CC "(" HS_CONSTANT_POOL "I)" HS_RESOLVED_KLASS,                                       FN_PTR(resolveTypeInPool)},
   {CC "resolveFieldInPool",                           CC "(" HS_CONSTANT_POOL "I" HS_RESOLVED_METHOD "B[I)" HS_RESOLVED_KLASS,              FN_PTR(resolveFieldInPool)},
   {CC "resolveInvokeDynamicInPool",                   CC "(" HS_CONSTANT_POOL "I)V",                                                        FN_PTR(resolveInvokeDynamicInPool)},

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -211,6 +211,14 @@ final class CompilerToVM {
     native HotSpotResolvedJavaType lookupClass(Class<?> javaClass);
 
     /**
+     * Resolves the entry at index {@code cpi} in {@code constantPool} to an interned String object.
+     *
+     * The behavior of this method is undefined if {@code cpi} does not denote an
+     * {@code JVM_CONSTANT_String}.
+     */
+    native JavaConstant getUncachedStringInPool(HotSpotConstantPool constantPool, int cpi);
+
+    /**
      * Resolves the entry at index {@code cpi} in {@code constantPool} to an object, looking in the
      * constant pool cache first.
      *

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -518,6 +518,27 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
         return UNSAFE.getInt(getMetaspaceConstantPool() + config().constantPoolFlagsOffset);
     }
 
+    /**
+     * Gets the {@link JavaConstant} for the {@code ConstantValue} attribute of a field.
+     */
+    JavaConstant getStaticFieldConstantValue(int cpi) {
+        final JvmConstant tag = getTagAt(cpi);
+        switch (tag.name) {
+            case "Integer":
+                return JavaConstant.forInt(getIntAt(cpi));
+            case "Long":
+                return JavaConstant.forLong(getLongAt(cpi));
+            case "Float":
+                return JavaConstant.forFloat(getFloatAt(cpi));
+            case "Double":
+                return JavaConstant.forDouble(getDoubleAt(cpi));
+            case "String":
+                return compilerToVM().getUncachedStringInPool(this, cpi);
+            default:
+                throw new IllegalArgumentException("Illegal entry for a ConstantValue attribute:" + tag);
+        }
+    }
+
     @Override
     public Object lookupConstant(int cpi) {
         assert cpi != 0;

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaFieldImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedJavaFieldImpl.java
@@ -214,4 +214,9 @@ class HotSpotResolvedJavaFieldImpl implements HotSpotResolvedJavaField {
         }
         return runtime().reflection.getFieldAnnotation(this, annotationClass);
     }
+
+    @Override
+    public JavaConstant getConstantValue() {
+        return holder.createFieldInfo(index).getConstantValue();
+    }
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -684,6 +684,10 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
             return readFieldSlot(config().fieldInfoSignatureIndexOffset);
         }
 
+        private int getConstantValueIndex() {
+            return readFieldSlot(config().fieldInfoConstantValueIndexOffset);
+        }
+
         public int getOffset() {
             HotSpotVMConfig config = config();
             final int lowPacked = readFieldSlot(config.fieldInfoLowPackedOffset);
@@ -717,6 +721,19 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
         public String getSignature() {
             final int signatureIndex = getSignatureIndex();
             return isInternal() ? config().symbolAt(signatureIndex) : getConstantPool().lookupUtf8(signatureIndex);
+        }
+
+        /**
+         * Gets the {@link JavaConstant} for the {@code ConstantValue} attribute of this field.
+         *
+         * @return {@code null} if this field has no {@code ConstantValue} attribute
+         */
+        public JavaConstant getConstantValue() {
+            int cvIndex = getConstantValueIndex();
+            if (cvIndex == 0) {
+                return null;
+            }
+            return constantPool.getStaticFieldConstantValue(cvIndex);
         }
 
         public JavaType getType() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -120,6 +120,7 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int fieldInfoAccessFlagsOffset = getConstant("FieldInfo::access_flags_offset", Integer.class);
     final int fieldInfoNameIndexOffset = getConstant("FieldInfo::name_index_offset", Integer.class);
     final int fieldInfoSignatureIndexOffset = getConstant("FieldInfo::signature_index_offset", Integer.class);
+    final int fieldInfoConstantValueIndexOffset = getConstant("FieldInfo::initval_index_offset", Integer.class);
     final int fieldInfoLowPackedOffset = getConstant("FieldInfo::low_packed_offset", Integer.class);
     final int fieldInfoHighPackedOffset = getConstant("FieldInfo::high_packed_offset", Integer.class);
     final int fieldInfoFieldSlots = getConstant("FieldInfo::field_slots", Integer.class);

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaField.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.meta/src/jdk/vm/ci/meta/ResolvedJavaField.java
@@ -63,4 +63,15 @@ public interface ResolvedJavaField extends JavaField, ModifiersProvider, Annotat
      */
     @Override
     ResolvedJavaType getDeclaringClass();
+
+    /**
+     * Gets the value of the {@code ConstantValue} attribute ({@jvms 4.7.2}) associated with this
+     * field.
+     *
+     * @return {@code null} if this field has no {@code ConstantValue} attribute
+     * @throws UnsupportedOperationException if this operation is not supported
+     */
+    default JavaConstant getConstantValue() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
  * @test
  * @requires vm.jvmci
  * @library ../../../../../
- * @ignore 8249621
  * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
+ *          jdk.internal.vm.ci/jdk.vm.ci.common
  *          java.base/jdk.internal.misc
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.runtime.test.TestResolvedJavaField
  */
@@ -37,6 +37,8 @@ package jdk.vm.ci.runtime.test;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -46,6 +48,7 @@ import java.io.PrintStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
@@ -54,6 +57,9 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
+import jdk.vm.ci.common.JVMCIError;
+import jdk.vm.ci.meta.ConstantReflectionProvider;
+import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.ResolvedJavaField;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
@@ -106,6 +112,54 @@ public class TestResolvedJavaField extends FieldUniverse {
         }
     }
 
+    @Test
+    public void getDeclaringClassTest() {
+        for (Map.Entry<Field, ResolvedJavaField> e : fields.entrySet()) {
+            ResolvedJavaField field = e.getValue();
+            ResolvedJavaType actual = field.getDeclaringClass();
+            ResolvedJavaType expect = metaAccess.lookupJavaType(e.getKey().getDeclaringClass());
+            assertEquals(field.toString(), expect, actual);
+        }
+    }
+
+    @Test
+    public void getOffsetTest() {
+        for (Map.Entry<Field, ResolvedJavaField> e : fields.entrySet()) {
+            Field javaField = e.getKey();
+            ResolvedJavaField field = e.getValue();
+            int actual = field.getOffset();
+            long expect = field.isStatic() ? unsafe.staticFieldOffset(javaField) : unsafe.objectFieldOffset(javaField);
+            assertEquals(field.toString(), expect, actual);
+        }
+    }
+
+    @Test
+    public void isFinalTest() {
+        for (Map.Entry<Field, ResolvedJavaField> e : fields.entrySet()) {
+            ResolvedJavaField field = e.getValue();
+            boolean actual = field.isFinal();
+            boolean expect = Modifier.isFinal(e.getKey().getModifiers());
+            assertEquals(field.toString(), expect, actual);
+        }
+    }
+
+    @Test
+    public void isInternalTest() {
+        for (Class<?> c : classes) {
+            ResolvedJavaType type = metaAccess.lookupJavaType(c);
+            for (ResolvedJavaField field : type.getInstanceFields(false)) {
+                if (field.isInternal()) {
+                    try {
+                        c.getDeclaredField(field.getName());
+                        throw new AssertionError("got reflection object for internal field: " + field);
+                    } catch (NoSuchFieldException e) {
+                        // expected
+                    }
+                }
+            }
+        }
+    }
+
     private Method findTestMethod(Method apiMethod) {
         String testName = apiMethod.getName() + "Test";
         for (Method m : getClass().getDeclaredMethods()) {
@@ -118,10 +172,6 @@ public class TestResolvedJavaField extends FieldUniverse {
 
     // @formatter:off
     private static final String[] untestedApiMethods = {
-        "getDeclaringClass",
-        "getOffset",
-        "isInternal",
-        "isFinal"
     };
     // @formatter:on
 
@@ -220,6 +270,70 @@ public class TestResolvedJavaField extends FieldUniverse {
             field.toString();
             field.getAnnotations();
         }
+    }
+
+    @Test
+    public void getConstantValueTest() {
+        ConstantReflectionProvider cr = constantReflection;
+        Map<String, JavaConstant> expects = Map.of(
+                        "INT", JavaConstant.forInt(42),
+                        "SHORT", JavaConstant.forInt(43),
+                        "CHAR", JavaConstant.forInt(44),
+                        "BYTE", JavaConstant.forInt(45),
+                        "FLOAT", JavaConstant.forFloat(46.46F),
+                        "LONG", JavaConstant.forLong(47L),
+                        "DOUBLE", JavaConstant.forDouble(48.48D));
+        ResolvedJavaType type = metaAccess.lookupJavaType(FieldsWithConstantValueAttributes.class);
+        for (ResolvedJavaField field : type.getStaticFields()) {
+            JavaConstant actual = field.getConstantValue();
+            String name = field.getName();
+            if (name.endsWith("2")) {
+                assertNull(field.toString(), actual);
+            } else if (name.equals("STRING")) {
+                JavaConstant expect = cr.forString("STRING_VALUE");
+                assertEquals(field.toString(), expect, actual);
+
+                // String ConstantValues are interned so should not
+                // be identical to a newly allocated String
+                expect = cr.forString(new String("STRING_VALUE"));
+                assertNotEquals(field.toString(), expect, actual);
+            } else {
+                JavaConstant expect = expects.get(name);
+                assertEquals(field.toString(), expect, actual);
+            }
+        }
+    }
+}
+
+class FieldsWithConstantValueAttributes {
+    public static final String STRING = "STRING_VALUE";
+    public static final int INT = 42;
+    public static final short SHORT = 43;
+    public static final char CHAR = 44;
+    public static final byte BYTE = 45;
+    public static final float FLOAT = 46.46F;
+    public static final long LONG = 47L;
+    public static final double DOUBLE = 48.48D;
+
+    public static final String STRING2;
+    public static final int INT2;
+    public static final short SHORT2;
+    public static final char CHAR2;
+    public static final byte BYTE2;
+    public static final float FLOAT2;
+    public static final long LONG2;
+    public static final double DOUBLE2;
+
+    static {
+        JVMCIError.shouldNotReachHere("should not be initialized");
+        STRING2 = STRING;
+        INT2 = INT;
+        SHORT2 = SHORT;
+        BYTE2 = BYTE;
+        CHAR2 = CHAR;
+        FLOAT2 = FLOAT;
+        LONG2 = LONG;
+        DOUBLE2 = DOUBLE;
     }
 }
 


### PR DESCRIPTION
Backport not clean due to JDK-8289094 not present in 17u which isn't needed.
Adapted patch to the older API instead. Omitted hunk in `vmStructs_jvmci.cpp`
as that pertains to the virtual threads, not available in 17.

This backport is needed in order to be able to build future GraalVM based on JDK 17.

Testing: jvmci tests (including changed `TestResolvedJavaField` test), passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296958](https://bugs.openjdk.org/browse/JDK-8296958): [JVMCI] add API for retrieving ConstantValue attributes


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/932/head:pull/932` \
`$ git checkout pull/932`

Update a local copy of the PR: \
`$ git checkout pull/932` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 932`

View PR using the GUI difftool: \
`$ git pr show -t 932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/932.diff">https://git.openjdk.org/jdk17u-dev/pull/932.diff</a>

</details>
