### PR TITLE
8297656: AArch64: Enable AES/GCM Intrinsics

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -266,7 +266,7 @@ void VM_Version::initialize() {
       UseAES = true;
     }
     if (FLAG_IS_DEFAULT(UseAESCTRIntrinsics)) {
-      FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);
+      FLAG_SET_DEFAULT(UseAESCTRIntrinsics, true);
     }
   } else {
     if (UseAES) {


### PR DESCRIPTION
These have been in mainline for more than a year. Time to enable them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297656](https://bugs.openjdk.org/browse/JDK-8297656): AArch64: Enable AES/GCM Intrinsics


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/935/head:pull/935` \
`$ git checkout pull/935`

Update a local copy of the PR: \
`$ git checkout pull/935` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 935`

View PR using the GUI difftool: \
`$ git pr show -t 935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/935.diff">https://git.openjdk.org/jdk17u-dev/pull/935.diff</a>

</details>
