### PR TITLE
8297590: [TESTBUG] HotSpotResolvedJavaFieldTest does not run

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/HotSpotResolvedJavaFieldTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/HotSpotResolvedJavaFieldTest.java
@@ -47,7 +47,15 @@ import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.runtime.JVMCI;
 
 /**
- * Tests {@link HotSpotResolvedJavaField} functionality.
+ *
+ * @test
+ * @requires vm.jvmci
+ * @summary Tests HotSpotResolvedJavaField functionality
+ * @library ../../../../../
+ * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
+ *          jdk.internal.vm.ci/jdk.vm.ci.runtime
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
+ * @run junit/othervm --add-opens=jdk.internal.vm.ci/jdk.vm.ci.hotspot=ALL-UNNAMED -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler jdk.vm.ci.hotspot.test.HotSpotResolvedJavaFieldTest
  */
 public class HotSpotResolvedJavaFieldTest {
 
@@ -61,7 +69,7 @@ public class HotSpotResolvedJavaFieldTest {
         Field f = null;
         try {
             Class<?> typeImpl = Class.forName("jdk.vm.ci.hotspot.HotSpotResolvedObjectTypeImpl");
-            m = typeImpl.getDeclaredMethod("createField", JavaType.class, long.class, int.class, int.class);
+            m = typeImpl.getDeclaredMethod("createField", JavaType.class, int.class, int.class, int.class);
             m.setAccessible(true);
             Class<?> fieldImpl = Class.forName("jdk.vm.ci.hotspot.HotSpotResolvedJavaFieldImpl");
             f = fieldImpl.getDeclaredField("index");


### PR DESCRIPTION
Clean backport. Test fix so that it actually runs a recently added test when running jvmci tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297590](https://bugs.openjdk.org/browse/JDK-8297590): [TESTBUG] HotSpotResolvedJavaFieldTest does not run


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/936/head:pull/936` \
`$ git checkout pull/936`

Update a local copy of the PR: \
`$ git checkout pull/936` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 936`

View PR using the GUI difftool: \
`$ git pr show -t 936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/936.diff">https://git.openjdk.org/jdk17u-dev/pull/936.diff</a>

</details>
