### PR TITLE
8297309: Memory leak in ShenandoahFullGC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -66,6 +66,10 @@ ShenandoahFullGC::ShenandoahFullGC() :
   _gc_timer(ShenandoahHeap::heap()->gc_timer()),
   _preserved_marks(new PreservedMarksSet(true)) {}
 
+ShenandoahFullGC::~ShenandoahFullGC() {
+  delete _preserved_marks;
+}
+
 bool ShenandoahFullGC::collect(GCCause::Cause cause) {
   vmop_entry_full(cause);
   // Always success

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.hpp
@@ -66,6 +66,7 @@ private:
 
 public:
   ShenandoahFullGC();
+  ~ShenandoahFullGC();
   bool collect(GCCause::Cause cause);
 
 private:


### PR DESCRIPTION
Clean backport to fix a trivial memory leak in Shenandoah.

Additional testing:
 - [x] Linux x86_64 fastdebug, `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297309](https://bugs.openjdk.org/browse/JDK-8297309): Memory leak in ShenandoahFullGC


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/938/head:pull/938` \
`$ git checkout pull/938`

Update a local copy of the PR: \
`$ git checkout pull/938` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 938`

View PR using the GUI difftool: \
`$ git pr show -t 938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/938.diff">https://git.openjdk.org/jdk17u-dev/pull/938.diff</a>

</details>
