### PR TITLE
8293965: Code signing warnings after JDK-8293550

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1211,11 +1211,15 @@ define SetupNativeCompilationBody
 		    $$($1_MT) -nologo -manifest $$($1_MANIFEST) -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" -outputresource:$$@;#1
                   endif
                 endif
-                # On macosx, optionally run codesign on every binary
+                # On macosx, optionally run codesign on every binary.
+                # Remove signature explicitly first to avoid warnings if the linker
+                # added a default adhoc signature.
                 ifeq ($(MACOSX_CODESIGN_MODE), hardened)
+		  $(CODESIGN) --remove-signature $$@
 		  $(CODESIGN) -f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp --options runtime \
 		      --entitlements $$(call GetEntitlementsFile, $$@) $$@
                 else ifeq ($(MACOSX_CODESIGN_MODE), debug)
+		  $(CODESIGN) --remove-signature $$@
 		  $(CODESIGN) -f -s - --entitlements $$(call GetEntitlementsFile, $$@) $$@
                 endif
   endif


### PR DESCRIPTION
Clean backport follow-on to [JDK-8293550](https://bugs.openjdk.org/browse/JDK-8293550) 17u backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293965](https://bugs.openjdk.org/browse/JDK-8293965): Code signing warnings after JDK-8293550


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/946/head:pull/946` \
`$ git checkout pull/946`

Update a local copy of the PR: \
`$ git checkout pull/946` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 946`

View PR using the GUI difftool: \
`$ git pr show -t 946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/946.diff">https://git.openjdk.org/jdk17u-dev/pull/946.diff</a>

</details>
