### PR TITLE
8298457: Instructions in a11y manual tests need to be updated

### DIFF
--- a/test/jdk/java/awt/a11y/AccessibleActionsTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleActionsTest.java
@@ -57,7 +57,7 @@ public class AccessibleActionsTest extends AccessibleComponentTest {
             + "Check a11y actions.\n\n"
             + "Turn screen reader on, and Tab to the label.\n\n"
             + "Perform the VO action \"Press\" (VO+space)\n"
-            + "Perform the VO action \"Show menu\" (VO+m)\n\n"
+            + "Perform the VO action \"Show menu\" (Shift+VO+m)\n\n"
             + "If after the first action the text of the label has changed, and after the second action the menu appears  tab further and press PASS, otherwise press FAIL.";
 
     exceptionString = "AccessibleAction test failed!";
@@ -67,7 +67,7 @@ public class AccessibleActionsTest extends AccessibleComponentTest {
   void createTree() {
     INSTRUCTIONS = "INSTRUCTIONS:\n"
             + "Check a11y actions.\n\n"
-            + "Turn screen reader on, and Tab to the label.\n\n"
+            + "Turn screen reader on, and Tab to the tree.\n\n"
             + "Perform the VO action \"Press\" (VO+space) on tree nodes\n\n"
             + "If after press the tree node is expanded  tab further and press PASS, otherwise press FAIL.";
 

--- a/test/jdk/java/awt/a11y/AccessibleJTabbedPaneTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJTabbedPaneTest.java
@@ -52,7 +52,7 @@ public class AccessibleJTabbedPaneTest extends AccessibleComponentTest {
         INSTRUCTIONS = "INSTRUCTIONS:\n"
                 + "Check a11y of JTabbedPane.\n\n"
                 + "Turn screen reader on, and tab to the JTabbedPane.\n"
-                + "Use page up and page down arrow buttons to move through the tabs.\n\n"
+                + "Use the left and right arrow buttons to move through the tabs.\n\n"
                 + "If you can hear selected tab names tab further and press PASS, otherwise press FAIL.\n";
 
         JTabbedPane tabbedPane = new JTabbedPane();

--- a/test/jdk/java/awt/a11y/AccessibleTextTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleTextTest.java
@@ -58,8 +58,8 @@ public class AccessibleTextTest extends AccessibleComponentTest {
                 + "Check a11y of JLabel.\n\n"
                 + "Turn screen reader on.\n"
                 + "On MacOS, use the VO navigation keys to read the label text;\n"
-                + "ON Windows with JAWS, use window virtualization (insert+alt+w and arrows) to read the label text;\n"
-                + "ON Windows with NVDA, use the browse cursor (insert+num4 or insert+num6) to read the label text;\n\n"
+                + "On Windows with JAWS, use JAWS cursor (num_minus and arrows) to read the label text;\n"
+                + "On Windows with NVDA, use the object navigation (insert+num4 or insert+num6) to read the label text;\n\n"
                 + "If you can hear text from label tab further and press PASS, otherwise press FAIL.";
 
         JLabel label = new JLabel("this is a label");


### PR DESCRIPTION
Test instructions: 
- Accessible Actions Test; 
- AccessibleJTabbedPaneTest; 
- Accessible Text Test. 
contain inaccurate indications of actions in different screen readers.
These changes were committed to the [JDK](https://git.openjdk.org/jdk/pull/11607), but could not be applied automatically.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298457](https://bugs.openjdk.org/browse/JDK-8298457): Instructions in a11y manual tests need to be updated


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/948/head:pull/948` \
`$ git checkout pull/948`

Update a local copy of the PR: \
`$ git checkout pull/948` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 948`

View PR using the GUI difftool: \
`$ git pr show -t 948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/948.diff">https://git.openjdk.org/jdk17u-dev/pull/948.diff</a>

</details>
