### PR TITLE
8298459: Fix msys2 linking and handling out of tree build directory for source zip creation

### DIFF
--- a/make/ZipSource.gmk
+++ b/make/ZipSource.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ include JavaCompilation.gmk
 include Modules.gmk
 
 SRC_ZIP_WORK_DIR := $(SUPPORT_OUTPUTDIR)/src
+$(if $(filter $(TOPDIR)/%, $(SUPPORT_OUTPUTDIR)), $(eval SRC_ZIP_BASE := $(TOPDIR)), $(eval SRC_ZIP_BASE := $(SUPPORT_OUTPUTDIR)))
 
 # Hook to include the corresponding custom file, if present.
 $(eval $(call IncludeCustomExtension, ZipSource.gmk))
@@ -45,10 +46,10 @@ ALL_MODULES := $(FindAllModules)
 # again to create src.zip.
 $(foreach m, $(ALL_MODULES), \
   $(foreach d, $(call FindModuleSrcDirs, $m), \
-    $(eval $d_TARGET := $(SRC_ZIP_WORK_DIR)/$(patsubst $(TOPDIR)/%,%,$d)/$m) \
+    $(eval $d_TARGET := $(SRC_ZIP_WORK_DIR)/$(patsubst $(TOPDIR)/%,%,$(patsubst $(SUPPORT_OUTPUTDIR)/%,%,$d))/$m) \
     $(if $(SRC_GENERATED), , \
       $(eval $$($d_TARGET): $d ; \
-          $$(if $(filter $(TOPDIR)/%, $d), $$(link-file-relative), $$(link-file-absolute)) \
+          $$(if $(filter $(SRC_ZIP_BASE)/%, $d), $$(link-file-relative), $$(link-file-absolute)) \
       ) \
     ) \
     $(eval SRC_ZIP_SRCS += $$($d_TARGET)) \

--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -307,17 +307,36 @@ endef
 # There are two versions, either creating a relative or an absolute link. Be
 # careful when using this on Windows since the symlink created is only valid in
 # the unix emulation environment.
-define link-file-relative
+# In msys2 we use mklink /J because its ln would perform a deep copy of the target.
+# This inhibits performance and can lead to issues with long paths. With mklink /J
+# relative linking does not work, so we handle the link as absolute path.
+ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
+  define link-file-relative
+	$(call MakeTargetDir)
+	$(RM) '$(call DecodeSpace, $@)'
+	cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
+  endef
+else
+  define link-file-relative
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
 	$(LN) -s '$(call DecodeSpace, $(call RelativePath, $<, $(@D)))' '$(call DecodeSpace, $@)'
-endef
+  endef
+endif
 
-define link-file-absolute
+ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys2)
+  define link-file-absolute
+	$(call MakeTargetDir)
+	$(RM) '$(call DecodeSpace, $@)'
+	cmd //c "mklink /J $(call FixPath, $(call DecodeSpace, $@)) $(call FixPath, $(call DecodeSpace, $<))"
+  endef
+else
+  define link-file-absolute
 	$(call MakeTargetDir)
 	$(RM) '$(call DecodeSpace, $@)'
 	$(LN) -s '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'
-endef
+  endef
+endif
 
 ################################################################################
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8298459](https://bugs.openjdk.org/browse/JDK-8298459), commit [d624debe](https://github.com/openjdk/jdk20/commit/d624debe23f60d778d7be43f28d06e9454057217) from the [openjdk/jdk20](https://git.openjdk.org/jdk20) repository.

The commit being backported was authored by Christoph Langer on 11 Dec 2022 and was reviewed by Erik Joelsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298459](https://bugs.openjdk.org/browse/JDK-8298459): Fix msys2 linking and handling out of tree build directory for source zip creation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/950/head:pull/950` \
`$ git checkout pull/950`

Update a local copy of the PR: \
`$ git checkout pull/950` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 950`

View PR using the GUI difftool: \
`$ git pr show -t 950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/950.diff">https://git.openjdk.org/jdk17u-dev/pull/950.diff</a>

</details>
