### PR TITLE
8296548: Improve MD5 intrinsic for x86_64

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86_md5.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_md5.cpp
@@ -66,16 +66,18 @@ void MacroAssembler::fast_md5(Register buf, Address state, Address ofs, Address 
   movl(rdx, Address(rdi, 12));
 
 #define FF(r1, r2, r3, r4, k, s, t)              \
+  addl(r1, t);                                   \
   movl(rsi, r3);                                 \
   addl(r1, Address(buf, k*4));                   \
   xorl(rsi, r4);                                 \
   andl(rsi, r2);                                 \
   xorl(rsi, r4);                                 \
-  leal(r1, Address(r1, rsi, Address::times_1, t)); \
+  addl(r1, rsi);                                 \
   roll(r1, s);                                   \
   addl(r1, r2);
 
 #define GG(r1, r2, r3, r4, k, s, t)              \
+  addl(r1, t);                                   \
   movl(rsi, r4);                                 \
   movl(rdi, r4);                                 \
   addl(r1, Address(buf, k*4));                   \
@@ -83,26 +85,28 @@ void MacroAssembler::fast_md5(Register buf, Address state, Address ofs, Address 
   andl(rdi, r2);                                 \
   andl(rsi, r3);                                 \
   orl(rsi, rdi);                                 \
-  leal(r1, Address(r1, rsi, Address::times_1, t)); \
+  addl(r1, rsi);                                 \
   roll(r1, s);                                   \
   addl(r1, r2);
 
 #define HH(r1, r2, r3, r4, k, s, t)              \
+  addl(r1, t);                                   \
   movl(rsi, r3);                                 \
   addl(r1, Address(buf, k*4));                   \
   xorl(rsi, r4);                                 \
   xorl(rsi, r2);                                 \
-  leal(r1, Address(r1, rsi, Address::times_1, t)); \
+  addl(r1, rsi);                                 \
   roll(r1, s);                                   \
   addl(r1, r2);
 
 #define II(r1, r2, r3, r4, k, s, t)              \
+  addl(r1, t);                                   \
   movl(rsi, r4);                                 \
   notl(rsi);                                     \
   addl(r1, Address(buf, k*4));                   \
   orl(rsi, r2);                                  \
   xorl(rsi, r3);                                 \
-  leal(r1, Address(r1, rsi, Address::times_1, t)); \
+  addl(r1, rsi);                                 \
   roll(r1, s);                                   \
   addl(r1, r2);
 


### PR DESCRIPTION
This is a clean backport to improve the performance of MD5 intrinsic.

The change has been tested with TestMD5Intrinsics and TestMD5MultiBlockIntrinsics (with the patch [f43bb9f](https://github.com/openjdk/jdk/commit/f43bb9feaa03008bad9708a4d7ed850d2532e102)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296548](https://bugs.openjdk.org/browse/JDK-8296548): Improve MD5 intrinsic for x86_64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/954/head:pull/954` \
`$ git checkout pull/954`

Update a local copy of the PR: \
`$ git checkout pull/954` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 954`

View PR using the GUI difftool: \
`$ git pr show -t 954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/954.diff">https://git.openjdk.org/jdk17u-dev/pull/954.diff</a>

</details>
