### PR TITLE
8288005: HotSpot build with disabled PCH fails for Windows AArch64

### DIFF
--- a/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
+++ b/src/hotspot/os_cpu/windows_aarch64/vm_version_windows_aarch64.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "logging/log.hpp"
 #include "runtime/os.hpp"
 #include "runtime/vm_version.hpp"
 


### PR DESCRIPTION
This backport fixes non-PCH builds on Windows AArch64 which helps Windows AArch64 builds reproducibility on VS2019+.

This is a clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288005](https://bugs.openjdk.org/browse/JDK-8288005): HotSpot build with disabled PCH fails for Windows AArch64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/956/head:pull/956` \
`$ git checkout pull/956`

Update a local copy of the PR: \
`$ git checkout pull/956` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 956`

View PR using the GUI difftool: \
`$ git pr show -t 956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/956.diff">https://git.openjdk.org/jdk17u-dev/pull/956.diff</a>

</details>
