### PR TITLE
8283606: Tests may fail with zh locale on MacOS

### DIFF
--- a/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/TestEmptyBootstrapMethodsAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,8 @@ public class TestEmptyBootstrapMethodsAttr {
         // ======= execute test case #1
         // Expect a lack of main method, this implies that the class loaded correctly
         // with an empty bootstrap_methods and did not generate a ClassFormatError.
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(className);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-Duser.language=en", "-Duser.country=US", className);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
         output.shouldContain("Main method not found in class " + className);
@@ -63,7 +64,8 @@ public class TestEmptyBootstrapMethodsAttr {
         // ======= execute test case #2
         // Expect a lack of main method, this implies that the class loaded correctly
         // with an empty bootstrap_methods and did not generate ClassFormatError.
-        pb = ProcessTools.createJavaProcessBuilder(className);
+        pb = ProcessTools.createJavaProcessBuilder(
+                "-Duser.language=en", "-Duser.country=US", className);
         output = new OutputAnalyzer(pb.start());
         output.shouldNotContain("java.lang.ClassFormatError");
         output.shouldContain("Main method not found in class " + className);

--- a/test/langtools/jdk/javadoc/tool/6964914/TestStdDoclet.java
+++ b/test/langtools/jdk/javadoc/tool/6964914/TestStdDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,8 @@ public class TestStdDoclet {
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(javadoc.getPath());
         cmdArgs.addAll(Arrays.asList(
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
                 "-classpath", ".", // insulates us from ambient classpath
                 "-Xdoclint:none",
                 "-package",

--- a/test/langtools/jdk/javadoc/tool/6964914/TestUserDoclet.java
+++ b/test/langtools/jdk/javadoc/tool/6964914/TestUserDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,8 @@ public class TestUserDoclet implements Doclet {
         List<String> cmdArgs = new ArrayList<>();
         cmdArgs.add(javadoc.getPath());
         cmdArgs.addAll(Arrays.asList(
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
                 "-doclet", thisClassName,
                 "-docletpath", testClasses.getPath(),
                 new File(testSrc, thisClassName + ".java").getPath()

--- a/test/langtools/jdk/javadoc/tool/EnsureNewOldDoclet.java
+++ b/test/langtools/jdk/javadoc/tool/EnsureNewOldDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,8 @@ public class EnsureNewOldDoclet extends TestRunner {
     // outcome: new tool and new doclet
     @Test
     public void testDefault() throws Exception {
-        setArgs("-classpath", ".", // insulates us from ambient classpath
+        setArgs("-J-Duser.language=en", "-J-Duser.country=US",
+                "-classpath", ".", // insulates us from ambient classpath
                   testSrc.toString());
         Task.Result tr = task.run(Task.Expect.SUCCESS);
         List<String> err = tr.getOutputLines(Task.OutputKind.STDERR);
@@ -117,7 +118,9 @@ public class EnsureNewOldDoclet extends TestRunner {
     // outcome: new doclet and new taglet should register
     @Test
     public void testNewDocletNewTaglet() throws Exception {
-        setArgs("-classpath", ".", // ambient classpath insulation
+        setArgs("-J-Duser.language=en",
+                "-J-Duser.country=US",
+                "-classpath", ".", // ambient classpath insulation
                 "-doclet",
                 NEW_STDDOCLET,
                 "-taglet",

--- a/test/langtools/jdk/javadoc/tool/testLocaleOption/TestLocaleOption.java
+++ b/test/langtools/jdk/javadoc/tool/testLocaleOption/TestLocaleOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,6 +242,9 @@ public class TestLocaleOption extends TestRunner {
             options.add("-J-Duser.language=" + defaultLocale.getLanguage());
             options.add("-J-Duser.country=" + defaultLocale.getCountry());
             options.add("-J-Duser.variant=" + defaultLocale.getVariant());
+        } else {
+            options.add("-J-Duser.language=en");
+            options.add("-J-Duser.country=us");
         }
         if (localeOption != null) {
             options.addAll(List.of("-locale", localeOption.toString()));

--- a/test/langtools/tools/javac/T8132562/ClassPathWithDoubleQuotesTest.java
+++ b/test/langtools/tools/javac/T8132562/ClassPathWithDoubleQuotesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,7 +125,7 @@ public class ClassPathWithDoubleQuotesTest extends TestRunner {
                 "and for which they are a legal filename character");
         List<String> log = new JavacTask(tb, Task.Mode.EXEC)
                 .envVar("CLASSPATH", "Ztest/jarOut/J.jar" + File.pathSeparator + "test/srcZ")
-                .options("-XDrawDiagnostics")
+                .options("-XDrawDiagnostics", "-J-Duser.language=en", "-J-Duser.country=US")
                 .files("test/src/A.java").run(Task.Expect.FAIL)
                 .writeAll()
                 .getOutputLines(Task.OutputKind.STDERR);
@@ -138,7 +138,7 @@ public class ClassPathWithDoubleQuotesTest extends TestRunner {
         System.err.println("invoking javac EXEC mode with double quotes in the CLASSPATH env variable");
         List<String> log2 = new JavacTask(tb, Task.Mode.EXEC)
                     .envVar("CLASSPATH", "\"test/jarOut/J.jar" + File.pathSeparator + "test/src\"")
-                    .options("-Xlint:path", "-XDrawDiagnostics")
+                    .options("-Xlint:path", "-XDrawDiagnostics", "-J-Duser.language=en", "-J-Duser.country=US")
                     .files("test/src/A.java").run(Task.Expect.FAIL)
                     .writeAll()
                     .getOutputLines(Task.OutputKind.STDERR);

--- a/test/langtools/tools/javac/options/smokeTests/OptionSmokeTest.java
+++ b/test/langtools/tools/javac/options/smokeTests/OptionSmokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -206,6 +206,7 @@ public class OptionSmokeTest extends TestRunner {
         List<String> log = new JavacTask(tb, Task.Mode.EXEC)
                 .envVar("JDK_JAVAC_OPTIONS",
                         String.format("--add-exports jdk.compiler%scom.sun.tools.javac.jvm=\"ALL-UNNAMED", fileSeparator))
+                .options("-J-Duser.language=en", "-J-Duser.country=US")
                 .files(findJavaFiles(src))
                 .run(Task.Expect.FAIL)
                 .writeAll()

--- a/test/langtools/tools/javac/platform/PlatformProviderTest.java
+++ b/test/langtools/tools/javac/platform/PlatformProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,7 +131,8 @@ public class PlatformProviderTest implements PlatformProvider {
         Task.Result result =
                 new JavacTask(tb, Task.Mode.EXEC)
                   .outdir(".")
-                  .options("-J--class-path=" + System.getProperty("test.classes"),
+                  .options("-J-Duser.language=en", "-J-Duser.country=US",
+                           "-J--class-path=" + System.getProperty("test.classes"),
                            "-J--add-exports=jdk.compiler/com.sun.tools.javac.platform=ALL-UNNAMED",
                            "-J--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
                            "--release",

--- a/test/langtools/tools/jdeps/MultiReleaseJar.java
+++ b/test/langtools/tools/jdeps/MultiReleaseJar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,10 +80,10 @@ public class MultiReleaseJar {
 
     @Test
     public void basic() throws Exception {
-        Result r = run("jdeps --multi-release 9  -v missing.jar");
+        Result r = run("jdeps -J-Duser.language=en -J-Duser.country=US --multi-release 9  -v missing.jar");
         checkResult(r, false, "Warning: Path does not exist: missing.jar");
 
-        r = run("jdeps -v Version.jar");
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US -v Version.jar");
         checkResult(r, false, "--multi-release option is not set");
 
         r = run("jdeps --multi-release base  -v Version.jar");
@@ -115,10 +115,10 @@ public class MultiReleaseJar {
             "9/test.NonPublic"
         );
 
-        r = run("jdeps --multi-release 8  -v Version.jar");
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US --multi-release 8  -v Version.jar");
         checkResult(r, false, "Error: invalid argument for option: 8");
 
-        r = run("jdeps --multi-release 9.1  -v Version.jar");
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US --multi-release 9.1  -v Version.jar");
         checkResult(r, false, "Error: invalid argument for option: 9.1");
 
         runJdeps("Main.class");
@@ -127,10 +127,10 @@ public class MultiReleaseJar {
 
 
     private void runJdeps(String path) throws Exception {
-        Result r = run("jdeps -v -R -cp Version.jar " + path);
+        Result r = run("jdeps -J-Duser.language=en -J-Duser.country=US -v -R -cp Version.jar " + path);
         checkResult(r, false, "--multi-release option is not set");
 
-        r = run("jdeps -v -R -cp Version.jar --module-path Foo.jar -multi-release 9 " + path);
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US -v -R -cp Version.jar --module-path Foo.jar -multi-release 9 " + path);
         checkResult(r, false,
             "Error: unknown option: -multi-release",
             "Usage: jdeps <options> <path",
@@ -208,7 +208,7 @@ public class MultiReleaseJar {
             "p.Foo"
         );
 
-        r = run("jdeps -v -R -cp Version.jar --module-path  Foo.jar --multi-release 9.1 " + path);
+        r = run("jdeps -J-Duser.language=en -J-Duser.country=US -v -R -cp Version.jar --module-path  Foo.jar --multi-release 9.1 " + path);
         checkResult(r, false, "Error: invalid argument for option: 9.1");
 
         // Version_9.jar does not have any version 10 entry


### PR DESCRIPTION
I would like to backport JDK-8283606 to JDK17u. This fix can be applied cleanly.
I tried to run these tests on Japanese Windows 10, and all tests are passed.

But, I am not a author, so need a sponsor.

Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283606](https://bugs.openjdk.org/browse/JDK-8283606): Tests may fail with zh locale on MacOS


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/963/head:pull/963` \
`$ git checkout pull/963`

Update a local copy of the PR: \
`$ git checkout pull/963` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 963`

View PR using the GUI difftool: \
`$ git pr show -t 963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/963.diff">https://git.openjdk.org/jdk17u-dev/pull/963.diff</a>

</details>
