### PR TITLE
8271471: [IR Framework] Rare occurrence of "<!-- safepoint while printing -->" in PrintIdeal/PrintOptoAssembly can let tests fail

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestIRMatching.java
@@ -42,7 +42,7 @@ import java.util.regex.Pattern;
  * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler1.enabled & vm.compiler2.enabled & vm.flagless
  * @summary Test IR matcher with different default IR node regexes. Use -DPrintIREncoding.
  *          Normally, the framework should be called with driver.
- * @library /test/lib /
+ * @library /test/lib /testlibrary_tests /
  * @build sun.hotspot.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
  * @run main/othervm/timeout=240 -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
@@ -231,7 +231,7 @@ public class TestIRMatching {
 
         try {
             runWithArgumentsFail(CompilationOutputOfFails.class);
-            shouldNotReach();
+            Utils.shouldHaveThrownException();
         } catch (IRViolationException e) {
             try {
                 boolean failed = false;
@@ -328,7 +328,7 @@ public class TestIRMatching {
     private static void runCheck(String[] args , Constraint... constraints) {
         try {
             new TestFramework(constraints[0].getKlass()).addFlags(args).start(); // All constraints have the same class.
-            shouldNotReach();
+            Utils.shouldHaveThrownException();
         } catch (IRViolationException e) {
             checkConstraints(e, constraints);
         } catch (Exception e) {
@@ -339,7 +339,7 @@ public class TestIRMatching {
     private static void runCheck(Constraint... constraints) {
         try {
             TestFramework.run(constraints[0].getKlass()); // All constraints have the same class.
-            shouldNotReach();
+            Utils.shouldHaveThrownException();
         } catch (IRViolationException e) {
             checkConstraints(e, constraints);
         } catch (Exception e) {
@@ -364,7 +364,7 @@ public class TestIRMatching {
     private static void runFailOnTestsArgs(Constraint constraint, String... args) {
         try {
             new TestFramework(constraint.getKlass()).addFlags(args).start(); // All constraints have the same class.
-            shouldNotReach();
+            Utils.shouldHaveThrownException();
         } catch (IRViolationException e) {
             try {
                 constraint.checkConstraint(e);
@@ -374,10 +374,6 @@ public class TestIRMatching {
         } catch (Exception e) {
             addException(e);
         }
-    }
-
-    public static void shouldNotReach() {
-        throw new ShouldNotReachException("Framework did not fail but it should have!");
     }
 
     public static void findIrIds(String output, String method, int... numbers) {
@@ -1448,12 +1444,6 @@ class MyClassEmptySub extends MyClassEmpty {}
 class MyClassSub extends MyClass {
     int iFld;
     static int iFldStatic;
-}
-
-class ShouldNotReachException extends RuntimeException {
-    ShouldNotReachException(String s) {
-        super(s);
-    }
 }
 
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestRunTests.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestRunTests.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
  * @test
  * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler1.enabled & vm.compiler2.enabled & vm.flagless
  * @summary Test different custom run tests.
- * @library /test/lib /
+ * @library /test/lib /testlibrary_tests /
  * @run driver ir_framework.tests.TestRunTests
  */
 
@@ -44,7 +44,7 @@ public class TestRunTests {
         TestFramework.run();
         try {
             TestFramework.run(BadStandalone.class);
-            throw new RuntimeException("Should not reach");
+            Utils.shouldHaveThrownException();
         } catch (IRViolationException e) {
             String[] matches = { "test(int)", "test2(int)", "Failed IR Rules (2)"};
             Arrays.stream(matches).forEach(m -> Asserts.assertTrue(e.getExceptionInfo().contains(m)));

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
@@ -31,7 +31,7 @@ import jdk.test.lib.Asserts;
  * @test
  * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
  * @summary Test scenarios with the framework.
- * @library /test/lib /
+ * @library /test/lib /testlibrary_tests /
  * @run driver ir_framework.tests.TestScenarios
  */
 
@@ -44,15 +44,27 @@ public class TestScenarios {
         Scenario s3dup = new Scenario(3, "-XX:TLABRefillWasteFraction=53");
         try {
             new TestFramework().addScenarios(sDefault, s1, s2, s3).start();
-            Asserts.fail("Should not reach");
+            if (Utils.notAllBailedOut(sDefault, s1, s3)) {
+                // Not all scenarios had a bailout which means that at least one exception should have been thrown.
+                Asserts.fail("Should have thrown an exception");
+            }
         } catch (TestRunException e) {
-            Asserts.assertTrue(e.getMessage().contains("The following scenarios have failed: #0, #1, #3"), e.getMessage());
+            if (!e.getMessage().contains("The following scenarios have failed: #0, #1, #3")) {
+                // Was there a bailout in a scenario? If not fail.
+                Asserts.assertTrue(Utils.anyBailedOut(sDefault, s1, s3), e.getMessage());
+            }
         }
         try {
             new TestFramework().addScenarios(s1, s2, s3).start();
-            Asserts.fail("Should not reach");
+            if (Utils.notAllBailedOut(s1, s3)) {
+                // Not all scenarios had a bailout which means that at least one exception should have been thrown.
+                Asserts.fail("Should have thrown an exception");
+            }
         } catch (TestRunException e) {
-            Asserts.assertTrue(e.getMessage().contains("The following scenarios have failed: #1, #3"), e.getMessage());
+            if (!e.getMessage().contains("The following scenarios have failed: #1, #3")) {
+                // Was there a bailout in a scenario? If not fail.
+                Asserts.assertTrue(Utils.anyBailedOut(sDefault, s1, s3), e.getMessage());
+            }
         }
         new TestFramework(ScenarioTest.class).addScenarios(s1, s2, s3).start();
         try {
@@ -71,7 +83,6 @@ public class TestScenarios {
         } catch (Exception e) {
             Asserts.fail("Should not catch other exceptions");
         }
-
     }
 
     @Test

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/Utils.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/Utils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package ir_framework.tests;
+
+import compiler.lib.ir_framework.Scenario;
+import compiler.lib.ir_framework.driver.IRMatcher;
+import compiler.lib.ir_framework.driver.TestVMProcess;
+import jdk.test.lib.Asserts;
+
+import java.util.Arrays;
+
+public class Utils {
+    public static void shouldHaveThrownException() {
+        // Do not throw an exception if we hit a safepoint while printing which could possibly let the IR matching fail.
+        // This happens very rarely. If there is a problem with the test, then we will catch that on the next test invocation.
+        if (!TestVMProcess.getLastTestVMOutput().contains(IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE)) {
+            Asserts.fail("Should have thrown exception");
+        }
+    }
+
+    /**
+     * Is there at least one scenario which hit a safepoint while printing (i.e. a bailout)?
+     */
+    public static boolean anyBailedOut(Scenario... scenarios) {
+        return Arrays.stream(scenarios).anyMatch(s -> s.getTestVMOutput().contains(IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE));
+    }
+
+    /**
+     * Is there at least one scenario which did not hit a safepoint while printing (i.e. a bailout)?
+     */
+    public static boolean notAllBailedOut(Scenario... scenarios) {
+        return Arrays.stream(scenarios).anyMatch(s -> !s.getTestVMOutput().contains(IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE));
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271471](https://bugs.openjdk.org/browse/JDK-8271471): [IR Framework] Rare occurrence of "<!-- safepoint while printing -->" in PrintIdeal/PrintOptoAssembly can let tests fail


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/969/head:pull/969` \
`$ git checkout pull/969`

Update a local copy of the PR: \
`$ git checkout pull/969` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 969`

View PR using the GUI difftool: \
`$ git pr show -t 969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/969.diff">https://git.openjdk.org/jdk17u-dev/pull/969.diff</a>

</details>
