### PR TITLE
8282577: ICC_Profile.setData(int, byte[]) invalidates the profile

### DIFF
--- a/src/java.desktop/share/native/liblcms/LCMS.c
+++ b/src/java.desktop/share/native/liblcms/LCMS.c
@@ -797,34 +797,43 @@ static cmsHPROFILE _writeCookedTag(const cmsHPROFILE pfTarget,
 
     // now we have all tags moved to the new profile.
     // do some sanity checks: write it to a memory buffer and read again.
+    void* buf = NULL;
     if (cmsSaveProfileToMem(p, NULL, &pfSize)) {
-        void* buf = malloc(pfSize);
+        buf = malloc(pfSize);
         if (buf != NULL) {
             // load raw profile data into the buffer
             if (cmsSaveProfileToMem(p, buf, &pfSize)) {
                 pfSanity = cmsOpenProfileFromMem(buf, pfSize);
             }
-            free(buf);
         }
     }
+
+    cmsCloseProfile(p); // No longer needed.
 
     if (pfSanity == NULL) {
         // for some reason, we failed to save and read the updated profile
         // It likely indicates that the profile is not correct, so we report
         // a failure here.
-        cmsCloseProfile(p);
-        p =  NULL;
+        free(buf);
+        return NULL;
     } else {
         // do final check whether we can read and handle the target tag.
         const void* pTag = cmsReadTag(pfSanity, sig);
         if (pTag == NULL) {
             // the tag can not be cooked
-            cmsCloseProfile(p);
-            p = NULL;
+            free(buf);
+            cmsCloseProfile(pfSanity);
+            return NULL;
         }
+        // The profile we used for sanity checking needs to be returned
+        // since the one we updated is raw - not cooked.
+        // Except we want to re-open it since the call to cmsReadTag()
+        // means we may not get back the same bytes as we set.
+        // Whilst this may change later anyway, we can at least prevent
+        // it from happening immediately.
         cmsCloseProfile(pfSanity);
-        pfSanity = NULL;
+        pfSanity = cmsOpenProfileFromMem(buf, pfSize);
+        free(buf);
+        return pfSanity;
     }
-
-    return p;
 }

--- a/test/jdk/java/awt/color/ICC_ColorSpace/SetTagDataValidation.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/SetTagDataValidation.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8282577
+ * @summary Verify setting data for a tag doesn't invalidate the profile.
+ */
+
+import java.awt.color.ColorSpace;
+import java.awt.color.ICC_ColorSpace;
+import java.awt.color.ICC_Profile;
+
+public final class SetTagDataValidation {
+
+    public static void main(String[] args) throws Exception {
+
+        ICC_Profile srgb = ICC_Profile.getInstance(ColorSpace.CS_sRGB);
+        // Create a new profile, using the srgb data but private to us.
+        ICC_Profile icc = ICC_Profile.getInstance(srgb.getData());
+
+        // Get data for some tag, which one isn't important so long as it exists
+        int tag = ICC_Profile.icSigBlueColorantTag;
+        byte[] tagData = icc.getData(tag);
+        if (tagData == null) {
+            throw new RuntimeException("No data for tag");
+        }
+        // Set the data to be the SAME data which ought to be a harmless no-op
+        icc.setData(tag, tagData);
+
+        // Perform a color conversion - from rgb to rgb but it doesn't matter
+        // we just need to verify the op is applied and results are sane.
+
+        ColorSpace cs = new ICC_ColorSpace(icc);
+        float[] in = new float[3];
+        in[0] = 0.4f;
+        in[1] = 0.5f;
+        in[2] = 0.6f;
+
+        // the toRGB op previously threw an exception - or crashed
+        float[] out = cs.toRGB(in);
+        // If we get this far let's validate the results.
+        if (out == null || out.length !=3) {
+            throw new RuntimeException("out array invalid");
+        }
+        for (int i=0;i<out.length;i++) {
+           System.out.println(out[i]);
+        }
+        for (int i=0;i<out.length;i++) {
+           if ((Math.abs(in[i]-out[i]) > 0.01)) {
+               throw new RuntimeException("Inaccurate no-op conversion");
+           }
+        }
+    }
+}

--- a/test/jdk/java/awt/color/ICC_Profile/MTGetData.java
+++ b/test/jdk/java/awt/color/ICC_Profile/MTGetData.java
@@ -23,6 +23,7 @@
 
 import java.awt.color.ColorSpace;
 import java.awt.color.ICC_Profile;
+import java.awt.color.CMMException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -103,6 +104,7 @@ public final class MTGetData {
                     icc.setData(tag, data2);
                 }
             } catch (IllegalArgumentException ignored) {
+                System.err.println("Ignoring " + ignored);
             } catch (Throwable throwable) {
                 throwable.printStackTrace();
                 failed = true;


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282577](https://bugs.openjdk.org/browse/JDK-8282577): ICC_Profile.setData(int, byte[]) invalidates the profile


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/970/head:pull/970` \
`$ git checkout pull/970`

Update a local copy of the PR: \
`$ git checkout pull/970` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 970`

View PR using the GUI difftool: \
`$ git pr show -t 970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/970.diff">https://git.openjdk.org/jdk17u-dev/pull/970.diff</a>

</details>
