### PR TITLE
8285399: JNI exception pending in awt_GraphicsEnv.c:1432

### DIFF
--- a/src/java.desktop/unix/native/common/awt/awt.h
+++ b/src/java.desktop/unix/native/common/awt/awt.h
@@ -85,6 +85,9 @@ extern void awt_output_flush();
 
 #define AWT_LOCK_IMPL() \
     do { \
+        if ((*env)->ExceptionCheck(env)) { \
+            (*env)->ExceptionClear(env); \
+        } \
         (*env)->CallStaticVoidMethod(env, tkClass, awtLockMID); \
         if ((*env)->ExceptionCheck(env)) { \
             (*env)->ExceptionClear(env); \

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1424,10 +1424,10 @@ Java_sun_awt_X11GraphicsDevice_getDoubleBufferVisuals(JNIEnv *env,
     AWT_FLUSH_UNLOCK();
     for (i = 0; i < visScreenInfo->count; i++) {
         XdbeVisualInfo* visInfo = visScreenInfo->visinfo;
-        (*env)->CallVoidMethod(env, this, midAddVisual, (visInfo[i]).visual);
         if ((*env)->ExceptionCheck(env)) {
             break;
         }
+        (*env)->CallVoidMethod(env, this, midAddVisual, (visInfo[i]).visual);
     }
     AWT_LOCK();
     XdbeFreeVisualInfo(visScreenInfo);


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285399](https://bugs.openjdk.org/browse/JDK-8285399): JNI exception pending in awt_GraphicsEnv.c:1432


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/972/head:pull/972` \
`$ git checkout pull/972`

Update a local copy of the PR: \
`$ git checkout pull/972` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 972`

View PR using the GUI difftool: \
`$ git pr show -t 972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/972.diff">https://git.openjdk.org/jdk17u-dev/pull/972.diff</a>

</details>
