### PR TITLE
8155246: Throw error if default java.security file is missing

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -47,6 +47,9 @@ import sun.security.jca.*;
  * implementation-specific location, which is typically the properties file
  * {@code conf/security/java.security} in the Java installation directory.
  *
+ * @implNote If the properties file fails to load, the JDK implementation will
+ * throw an unspecified error when initializing the {@code Security} class.
+ *
  * @author Benjamin Renaud
  * @since 1.1
  */
@@ -186,26 +189,9 @@ public final class Security {
         }
 
         if (!loadedProps) {
-            initializeStatic();
-            if (sdebug != null) {
-                sdebug.println("unable to load security properties " +
-                        "-- using defaults");
-            }
+            throw new InternalError("java.security file missing");
         }
 
-    }
-
-    /*
-     * Initialize to default values, if <java.home>/lib/java.security
-     * is not found.
-     */
-    private static void initializeStatic() {
-        props.put("security.provider.1", "sun.security.provider.Sun");
-        props.put("security.provider.2", "sun.security.rsa.SunRsaSign");
-        props.put("security.provider.3", "sun.security.ssl.SunJSSE");
-        props.put("security.provider.4", "com.sun.crypto.provider.SunJCE");
-        props.put("security.provider.5", "sun.security.jgss.SunProvider");
-        props.put("security.provider.6", "com.sun.security.sasl.Provider");
     }
 
     /**

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -22,6 +22,9 @@
 # the command line, set the key security.overridePropertiesFile
 # to false in the master security properties file. It is set to true
 # by default.
+#
+# If this properties file fails to load, the JDK implementation will throw
+# an unspecified error when initializing the java.security.Security class.
 
 # In this file, various security properties are set for use by
 # java.security classes. This is where users can statically register

--- a/test/jdk/java/security/Security/ConfigFileTest.java
+++ b/test/jdk/java/security/Security/ConfigFileTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.*;
+
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Optional;
+
+/*
+ * @test
+ * @summary Throw error if default java.security file is missing
+ * @bug 8155246
+ * @library /test/lib
+ * @run main ConfigFileTest
+ */
+public class ConfigFileTest {
+
+    public static void main(String[] args) throws Exception {
+        Path copyJdkDir = Path.of("./jdk-8155246-tmpdir");
+        Path copiedJava = Optional.of(
+                        Path.of(copyJdkDir.toString(), "bin", "java"))
+                .orElseThrow(() -> new RuntimeException("Unable to locate new JDK")
+                );
+
+        if (args.length == 1) {
+            // set up is complete. Run code to exercise loading of java.security
+            System.out.println(Arrays.toString(Security.getProviders()));
+        } else {
+            Files.createDirectory(copyJdkDir);
+            Path jdkTestDir = Path.of(Optional.of(System.getProperty("test.jdk"))
+                            .orElseThrow(() -> new RuntimeException("Couldn't load JDK Test Dir"))
+            );
+
+            copyJDKMinusJavaSecurity(jdkTestDir, copyJdkDir);
+            String extraPropsFile = Path.of(System.getProperty("test.src"), "override.props").toString();
+
+            // exercise some debug flags while we're here
+            // launch JDK without java.security file being present or specified
+            exerciseSecurity(copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    "-Djava.security.debug=all", "-Djavax.net.debug=all", "ConfigFileTest", "runner");
+
+            // test the override functionality also. Should not be allowed since
+            // "security.overridePropertiesFile=true" Security property is missing.
+            exerciseSecurity(copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    "-Djava.security.debug=all", "-Djavax.net.debug=all",
+                    "-Djava.security.properties==file://" + extraPropsFile, "ConfigFileTest", "runner");
+        }
+    }
+
+    private static void exerciseSecurity(String... args) throws Exception {
+        ProcessBuilder process = new ProcessBuilder(args);
+        OutputAnalyzer oa = ProcessTools.executeProcess(process);
+        oa.shouldHaveExitValue(1).shouldContain("java.security file missing");
+    }
+
+    private static void copyJDKMinusJavaSecurity(Path src, Path dst) throws Exception {
+        Files.walk(src)
+            .skip(1)
+            .filter(p -> !p.toString().endsWith("java.security"))
+            .forEach(file -> {
+                try {
+                    Files.copy(file, dst.resolve(src.relativize(file)), StandardCopyOption.COPY_ATTRIBUTES);
+                } catch (IOException ioe) {
+                    throw new UncheckedIOException(ioe);
+                }
+            });
+    }
+}

--- a/test/jdk/java/security/Security/override.props
+++ b/test/jdk/java/security/Security/override.props
@@ -1,0 +1,7 @@
+security.provider.1=sun.security.provider.Sun
+security.provider.2=sun.security.rsa.SunRsaSign
+security.provider.3=sun.security.ssl.SunJSSE
+security.provider.4=com.sun.crypto.provider.SunJCE
+security.provider.5=sun.security.jgss.SunProvider
+security.provider.6=com.sun.security.sasl.Provider
+


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8155246](https://bugs.openjdk.org/browse/JDK-8155246): Throw error if default java.security file is missing
 * [JDK-8291891](https://bugs.openjdk.org/browse/JDK-8291891): Throw error if default java.security file is missing (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/973/head:pull/973` \
`$ git checkout pull/973`

Update a local copy of the PR: \
`$ git checkout pull/973` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 973`

View PR using the GUI difftool: \
`$ git pr show -t 973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/973.diff">https://git.openjdk.org/jdk17u-dev/pull/973.diff</a>

</details>
