### PR TITLE
8279119: src/jdk.hotspot.agent/doc/index.html file contains references to scripts that no longer exist

### DIFF
--- a/src/jdk.hotspot.agent/doc/clhsdb.html
+++ b/src/jdk.hotspot.agent/doc/clhsdb.html
@@ -10,25 +10,16 @@ Command line HSDB
 <p>
 When debugging remote core dumps it is easier to work with command line tools instead of
 GUI tools. Command line HSDB (CLHSDB) tool is alternative to SA GUI tool HSDB.
+CLHSDB is launched from the command line using the "jhsdb clhsdb" command.
 </p>
 
 <p>
-There is also JavaScript based SA command line interface called <a href="jsdb.html">jsdb</a>.
-But, CLHSDB supports Unix shell-like (or dbx/gdb-like) command line interface with
+CLHSDB supports Unix shell-like (or dbx/gdb-like) command line interface with
 support for output redirection/appending (familiar &gt;, &gt;&gt;), command history and so on.
 Each CLHSDB command can have zero or more arguments and optionally end with output redirection
 (or append) to a file. Commands may be stored in a file and run using <b>source</b> command.
 <b>help</b> command prints usage message for all supported commands (or a specific command)
 </p>
-
-<h3>Shell/batch scripts to run command line HSDB</h3>
-
-<ul>
-<li>clhsdbproc.sh
-<li>clhsdbproc64.sh
-<li>clhsdbwindbg.bat
-<li>clhsdbwindbg64.bat
-</ul>
 
 <h3>Annotated output of CLHSDB help command</h3>
 
@@ -62,8 +53,6 @@ Available commands:
   intConstant [ name [ value ] ] <font color="red">print out hotspot integer constant(s)</font>
   jdis address <font color="red">show bytecode disassembly of a given Method*</font>
   jhisto <font color="red">show Java heap histogram</font>
-  jseval script <font color="red">evaluate a given string as JavaScript code</font>
-  jsload file <font color="red">load and evaluate a JavaScript file</font>
   jstack [-v] <font color="red">show Java stack trace of all Java threads. -v is verbose mode</font>
   livenmethods <font color="red">show all live nmethods</font>
   longConstant [ name [ value ] ] <font color="red">print out hotspot long constant(s)s</font>
@@ -92,39 +81,6 @@ Available commands:
   versioncheck [ true | false ] <font color="red">turn on/off debuggee VM version check</font>
   whatis address <font color="red">print info about any arbitrary address. alias for findpc command</font>
   where { -a | id } <font color="red">print Java stack trace of given Java thread or all Java threads (-a)</font>
-</code>
-</pre>
-
-<h3>JavaScript integration</h3>
-
-<p>Few CLHSDB commands are already implemented in JavaScript. It is possible to extend CLHSDB command set
-by implementing more commands in a JavaScript file and by loading it by <b>jsload</b> command. <b>jseval</b>
-command may be used to evaluate arbitrary JavaScript expression from a string. Any JavaScript function
-may be exposed as a CLHSDB command by registering it using JavaScript <b><code>registerCommand</code></b>
-function. This function accepts command name, usage and name of the JavaScript implementation function
-as arguments.
-</p>
-
-<h3>Simple CLHSDB command implemented in JavaScript</h3>
-
-<b>File: test.js</b>
-<pre>
-<code>
-function helloImpl(name) {
-    println("hello, " + name);
-}
-
-// register the above JavaScript function as CLHSDB command
-registerCommand("hello", "hello name", "helloImpl");
-</code>
-</pre>
----------<br>
-
-"test.js" can be loaded in CLHSDB prompt using <b>jsload</b> command using
-
-<pre>
-<code>
-hsdb&gt; jsload test.js
 </code>
 </pre>
 

--- a/src/jdk.hotspot.agent/doc/index.html
+++ b/src/jdk.hotspot.agent/doc/index.html
@@ -10,220 +10,55 @@ Using HotSpot Serviceability Agent (SA)
 <h3>HSDB GUI</h3>
 <p>
 The top-level GUI program using the HotSpot Serviceability Agent APIs is
-called <b>HSDB</b>, the "HotSpot Debugger". To run it, type "hsdbproc.sh" 
-or "hsdbwindbg.bat" or 64-bit variants (on Unix, Windows platforms 
-respectively). More info. on HSDB GUI are in <a href="hsdb.html">hsdb.html</a>.
+called <b>HSDB</b>, the "HotSpot Debugger". To run it, type "jhsdb hsdb".
+More info on HSDB GUI are in <a href="hsdb.html">hsdb.html</a>. Also
+see the "jhsdb" man page.
 </p>
 
 <h3>SA Modes</h3>
 <p>
-There are three modes for the SA debugger: 
+There are three modes for the SA debugger:
 <ul>
-<li>attaching to a local process,
-<li>opening a core file, and 
-<li>attaching to a remote "debug server". 
+<li>attaching to a local process
+<li>opening a core file
+<li>attaching to a remote "debug server"
 </ul>
 <p>
-The remote case requires two programs to be running on the remote machine:
-the rmiregistry (see the script "start-rmiregistry.sh" in this directory;
-run this in the background) and the debug server (see the script
-"start-debug-server-proc.sh"), in that order. start-rmiregistry.sh takes no
-arguments; start-debug-server-proc.sh (or -windbg.bat) takes as argument 
-the process ID or the executable and core file names to allow remote debugging
-of. 
+The remote case requires running the debug server on the remote machine. This
+is done by running "jhsdb debugd", and also adding arguments specifying the core
+file or process to debug. Once this is done you can connect remotely
+to the debug server by running various other "jhsdb" subcommands, and specifying
+which debug server to connect to. See the "jhsdb" man page for details.
 </p>
 
 <h3>Command line HSDB</h3>
 <p>
-There is also a command line HSDB variant.  More details on the command line interface can be found in:
-<ul>
+There is also a command line HSDB variant. It is launched using "jhsdb clhsdb".
+More details on the command line interface can be found in the "jhsdb" man page and also in:<ul>
 <li><a href="clhsdb.html">clhsdb.html</a>
-</ul> 
+</ul>
 </p>
 
-<h3>Other command line tools</h3>
+<h3>Compilation Replay</h3>
 <p>
-The following table lists all SA command line tools. &lt;xxx&gt;windbg.bat 
-files are for Windows. .sh files are for Solaris. &lt;xxx&gt;64.sh are for 
-64 bit debugees.
-</p>
-
-<table border="1">
-<tr>
-<th>
-Tool
-</th>
-<th>
-Description
-</th>
-</tr>
-
-<tr>
-<td>
-dumpflagsproc.sh,
-dumpflagsproc64.sh,
-dumpflagswindbg.bat
-dumpflagswindbg64.bat
-</td>
-<td>
-dumps name and value of all -XX JVM command line arguments passed
-to debuggee. 
-</td>
-</tr>
-
-<tr>
-<td>
-<a name="dumpsysprops"></a>
-dumpsyspropsproc.sh,
-dumpsyspropsproc64.sh,
-dumpsyspropswindbg.bat
-dumpsyspropswindbg64.bat
-</td>
-<td>
-This prints name and value of Java level System properties.
-</td>
-</tr>
-
-<tr>
-<td>
-<a name="heapdump"></a>
-heapdumpproc.sh,
-heapdumpproc64.sh,
-heapdumpwindbg.bat
-heapdumpwindbg64.bat
-</td>
-<td>
-Dumps heap in a file in hprof binary format.
-</td>
-</tr>
-
-<tr>
-<td>
-<a name="heapsum"></a>
-heapsumproc.sh,
-heapsumproc64.sh,
-heapsumwindbg.bat
-heapsumwindbg64.bat
-</td>
-<td>
-Prints summary information on Java heap.
-</td>
-</tr>
-
-
-<tr>
-<td>
-jcoreproc.sh,
-jcoreproc64.sh,
-jcorewindbg.bat
-jcorewindbg64.bat
-</td>
-<td>
-This can retrieve .class files from the debuggee.
-set the environment variable <b>JCORE_PACKAGES</b> to comman separated list of
-packages whose classes have to be retrieved from the core file.
-</td>
-</tr>
-
-<tr>
-<tr>
-<td>
-jstackproc.sh,
-jstackproc64.sh,
-jstackwindbg.bat
-jstackwindbg64.bat
-</td>
-<td>
-used to get java stack trace for all java threads.
-</td>
-</tr>
-
-<tr>
-<td>
-jhistoproc.sh,
-jhistoproc64.sh,
-jhistowindbg.bat
-jhistowindbg64.bat
-</td>
-<td>
-used to get object histogram of java heap.
-</td>
-</tr>
-
-<tr>
-<td>
-permstatproc.sh,
-permstatproc64.sh,
-permstatwindbg.bat
-permstatwindbg64.bat
-</td>
-<td>
-To gather statistics on perm. generation.
-</td>
-</tr>
-
-<a name="mixed_pstack"></a>
-<tr>
-<tr>
-<td>
-pstackproc.sh,
-pstackproc64.sh,
-pstackwindbg.bat
-pstackwindbg64.bat
-</td>
-<td>
-This is cross platform mixed mode pstack utility. This works on any (non-java as well) process, core dump. For java process and core dumps, this prints both java and C/C++ frames. 
-</td>
-</tr>
-
-<tr>
-<td>
-pmapproc.sh,
-pmapproc64.sh,
-pmapwindbg.bat
-pmapwindbg64.bat
-</td>
-<td>
-This is cross platform Solaris pmap-like utility. 
-</td>
-</tr>
-
-<td>
-start-debug-server-proc.sh,
-start-debug-server-proc64.sh,
-start-debug-server-windbg.bat,
-start-debug-server-windbg64.bat,
-start-rmiregistry.bat,
-start-rmiregistry64.bat,
-start-rmiregistry.sh
-start-rmiregistry64.sh
-</td>
-<td>
-These scripts are used to run SA remotely. 
-</td>
-</tr>
-</table>
-
-<h3>C2 Compilation Replay</h3>
-<p>
-When a java process crashes in compiled method, usually a core file is saved.
-The C2 replay function can reproduce the compiling process in the core.
-<a href="c2replay.html">c2replay.html</a>
+When a java process crashes in a compiled method, usually a core file is saved.
+The compiler replay function can reproduce the compiling process in the core.
+See <a href="cireplay.html">cireplay.html</a>
 
 <h3>Debugging transported core dumps</h3>
 <p>
 When a core dump is moved from the machine where it was produced to a
-difference machine, it may not always be possible for SA to debug the same.
-More info. on debugging on transported core dumps is in
+different machine, it may not always be possible for SA to debug it.
+More info on debugging on transported core dumps is in
 <a href="transported_core.html">transported_core.html</a>.
 </p>
 
 <h3>SA Bugs</h3>
 <p>
 Not all of the possible states of target VMs have been tested (or
-supportable) with SA. For example, the SA will probably not work at all 
-if it freezes the target VM during certain phases of GC. When filing bugs
-a pointer to a core file (see gcore(1)) which the SA can not handle well 
+are supportable) with SA. For example, the SA will probably not work at all
+if it freezes the target VM during certain phases of GC. When filing bugs,
+a pointer to a core file (see gcore(1)) which the SA can not handle well
 is best.
 </p>
 

--- a/src/jdk.hotspot.agent/doc/index.html
+++ b/src/jdk.hotspot.agent/doc/index.html
@@ -35,13 +35,9 @@ of.
 
 <h3>Command line HSDB</h3>
 <p>
-There are also command line HSDB variants ("clhsdbproc.sh" or "clhsdbwindbg.bat"
-or 64-bit variants). There is also a JavaScript based command line interface
-called "jsdbproc.sh" [or "jsdbwindbg.bat" or 64-bit variants]. More details on 
-command line interfaces can be found in 
+There is also a command line HSDB variant.  More details on the command line interface can be found in:
 <ul>
 <li><a href="clhsdb.html">clhsdb.html</a>
-<li><a href="jsdb.html">jsdb.html</a>
 </ul> 
 </p>
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279119](https://bugs.openjdk.org/browse/JDK-8279119): src/jdk.hotspot.agent/doc/index.html file contains references to scripts that no longer exist


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/984/head:pull/984` \
`$ git checkout pull/984`

Update a local copy of the PR: \
`$ git checkout pull/984` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 984`

View PR using the GUI difftool: \
`$ git pr show -t 984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/984.diff">https://git.openjdk.org/jdk17u-dev/pull/984.diff</a>

</details>
