### PR TITLE
8065097: [macosx] javax/swing/Popup/TaskbarPositionTest.java fails because Popup is one pixel off

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -730,7 +730,6 @@ javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/PopupFactory/6276087/NonOpaquePopupMenuTest.java 8065099,8208565 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all
-javax/swing/Popup/TaskbarPositionTest.java 8065097 macosx-all,linux-all
 javax/swing/JEditorPane/6917744/bug6917744.java 8213124 macosx-all
 javax/swing/JRootPane/4670486/bug4670486.java 8042381 macosx-all
 javax/swing/JButton/8151303/PressedIconTest.java 8266246 macosx-aarch64


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8065097](https://bugs.openjdk.org/browse/JDK-8065097): [macosx] javax/swing/Popup/TaskbarPositionTest.java fails because Popup is one pixel off


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/990/head:pull/990` \
`$ git checkout pull/990`

Update a local copy of the PR: \
`$ git checkout pull/990` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 990`

View PR using the GUI difftool: \
`$ git pr show -t 990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/990.diff">https://git.openjdk.org/jdk17u-dev/pull/990.diff</a>

</details>
