### PR TITLE
8298526: JFR: Generate missing filename for time-bound recordings

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -144,6 +144,11 @@ final class DCmdStart extends AbstractDCmd {
         recording.setSettings(s);
         SafePath safePath = null;
 
+        // Generate dump filename if user has specified a time-bound recording
+        if (duration != null && path == null) {
+            path = resolvePath(recording, null).toString();
+        }
+
         if (path != null) {
             try {
                 if (dumpOnExit == null) {

--- a/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package jdk.jfr.startupargs;
 
 import java.time.Duration;
 
+import jdk.jfr.FlightRecorder;
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
 import jdk.test.lib.Asserts;
@@ -41,21 +42,38 @@ import jdk.test.lib.process.ProcessTools;
  * @run main jdk.jfr.startupargs.TestStartDuration
  */
 public class TestStartDuration {
+    public static final String RECORDING_NAME = "TestStartDuration";
+    public static final String WAIT_FOR_RUNNING = "wait-for-running";
+    public static final String WAIT_FOR_CLOSED = "wait-for-closed";
 
     public static class TestValues {
         public static void main(String[] args) throws Exception {
-            Recording r = StartupHelper.getRecording("TestStartDuration");
-            Asserts.assertEquals(r.getDuration(), Duration.parse(args[0]));
-            if (args.length > 1 && args[1].equals("wait")) {
-                CommonHelper.waitForRecordingState(r, RecordingState.STOPPED);
+            String action = args[0];
+            Duration duration = Duration.parse(args[1]);
+            if (action.equals(WAIT_FOR_RUNNING)) {
+                Recording r = StartupHelper.getRecording("TestStartDuration");
+                Asserts.assertEquals(r.getDuration(), duration);
+                CommonHelper.waitForRecordingState(r, RecordingState.RUNNING);
+                return;
             }
+            if (action.equals(WAIT_FOR_CLOSED)) {
+                while (!FlightRecorder.getFlightRecorder().getRecordings().isEmpty()) {
+                    Thread.sleep(200);
+                    System.out.println("A recording still running");
+                }
+                return;
+            }
+            System.out.println("Unknown action: " + action);
+            System.exit(1);
         }
     }
 
-    private static void testDurationInRange(String duration, Duration durationString, boolean wait) throws Exception {
+    private static void testDurationInRange(String durationText, Duration duration, String action) throws Exception {
         ProcessBuilder pb = ProcessTools.createTestJvm(
-            "-XX:StartFlightRecording:name=TestStartDuration,duration=" + duration, TestValues.class.getName(),
-            durationString.toString(), wait ? "wait" : "");
+            "-XX:StartFlightRecording:name=" + RECORDING_NAME + ",duration=" + durationText,
+            TestValues.class.getName(),
+            action,
+            duration.toString());
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
 
         out.shouldHaveExitValue(0);
@@ -84,12 +102,13 @@ public class TestStartDuration {
     }
 
     public static void main(String[] args) throws Exception {
-        testDurationInRange("1s", Duration.ofSeconds(1), true);
-        testDurationInRange("1234003005ns", Duration.ofNanos(1234003005L), true);
-        testDurationInRange("1034ms", Duration.ofMillis(1034), false);
-        testDurationInRange("32m", Duration.ofMinutes(32), false);
-        testDurationInRange("65h", Duration.ofHours(65), false);
-        testDurationInRange("354d", Duration.ofDays(354), false);
+        testDurationInRange("1s", Duration.ofSeconds(1), WAIT_FOR_CLOSED);
+        testDurationInRange("1234003005ns", Duration.ofNanos(1234003005L), WAIT_FOR_CLOSED);
+        testDurationInRange("1034ms", Duration.ofMillis(1034), WAIT_FOR_CLOSED);
+        testDurationInRange("3500s", Duration.ofSeconds(3500), WAIT_FOR_RUNNING);
+        testDurationInRange("59m", Duration.ofMinutes(59), WAIT_FOR_RUNNING);
+        testDurationInRange("65h", Duration.ofHours(65), WAIT_FOR_RUNNING);
+        testDurationInRange("354d", Duration.ofDays(354), WAIT_FOR_RUNNING);
 
         // additional test for corner values, verify that JVM accepts following durations
         testDurationInRangeAccept("1000000000ns");


### PR DESCRIPTION
Backport de8153cab76606350eb0ecc4302b23c52f0565a6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298526](https://bugs.openjdk.org/browse/JDK-8298526): JFR: Generate missing filename for time-bound recordings


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/992/head:pull/992` \
`$ git checkout pull/992`

Update a local copy of the PR: \
`$ git checkout pull/992` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 992`

View PR using the GUI difftool: \
`$ git pr show -t 992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/992.diff">https://git.openjdk.org/jdk17u-dev/pull/992.diff</a>

</details>
