### PR TITLE
8288854: getLocalGraphicsEnvironment() on for multi-screen setups throws exception NPE

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
@@ -232,7 +232,7 @@ public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
             throw new AWTError("no screen devices");
         }
         int index = getDefaultScreenNum();
-        mainScreen = 0 < index && index < screens.length ? index : 0;
+        mainScreen = 0 < index && index < numScreens ? index : 0;
 
         for (int id = 0; id < numScreens; ++id) {
             devices.put(id, old.containsKey(id) ? old.remove(id) :


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [cfc9a881](https://github.com/openjdk/jdk/commit/cfc9a881afd300bd7c1ce784287d1669308e89fc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Sergey Bylokhov on 2 Jul 2022 and was reviewed by Alexander Zvegintsev and Alexey Ivanov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288854](https://bugs.openjdk.org/browse/JDK-8288854): getLocalGraphicsEnvironment() on for multi-screen setups throws exception NPE


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/994/head:pull/994` \
`$ git checkout pull/994`

Update a local copy of the PR: \
`$ git checkout pull/994` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 994`

View PR using the GUI difftool: \
`$ git pr show -t 994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/994.diff">https://git.openjdk.org/jdk17u-dev/pull/994.diff</a>

</details>
