### PR TITLE
8292297: Fix up loading of override java.security properties file

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -85,113 +85,83 @@ public final class Security {
 
     private static void initialize() {
         props = new Properties();
-        boolean loadedProps = false;
         boolean overrideAll = false;
 
         // first load the system properties file
         // to determine the value of security.overridePropertiesFile
         File propFile = securityPropFile("java.security");
-        if (propFile.exists()) {
-            InputStream is = null;
-            try {
-                FileInputStream fis = new FileInputStream(propFile);
-                is = new BufferedInputStream(fis);
-                props.load(is);
-                loadedProps = true;
-
-                if (sdebug != null) {
-                    sdebug.println("reading security properties file: " +
-                                propFile);
-                }
-            } catch (IOException e) {
-                if (sdebug != null) {
-                    sdebug.println("unable to load security properties from " +
-                                propFile);
-                    e.printStackTrace();
-                }
-            } finally {
-                if (is != null) {
-                    try {
-                        is.close();
-                    } catch (IOException ioe) {
-                        if (sdebug != null) {
-                            sdebug.println("unable to close input stream");
-                        }
-                    }
-                }
-            }
+        boolean success = loadProps(propFile, null, false);
+        if (!success) {
+            throw new InternalError("Error loading java.security file");
         }
 
         if ("true".equalsIgnoreCase(props.getProperty
                 ("security.overridePropertiesFile"))) {
 
             String extraPropFile = System.getProperty
-                                        ("java.security.properties");
+                    ("java.security.properties");
             if (extraPropFile != null && extraPropFile.startsWith("=")) {
                 overrideAll = true;
                 extraPropFile = extraPropFile.substring(1);
             }
+            loadProps(null, extraPropFile, overrideAll);
+        }
+    }
 
-            if (overrideAll) {
-                props = new Properties();
-                if (sdebug != null) {
-                    sdebug.println
-                        ("overriding other security properties files!");
+    private static boolean loadProps(File masterFile, String extraPropFile, boolean overrideAll) {
+        InputStream is = null;
+        try {
+            if (masterFile != null && masterFile.exists()) {
+                is = new FileInputStream(masterFile);
+            } else if (extraPropFile != null) {
+                extraPropFile = PropertyExpander.expand(extraPropFile);
+                File propFile = new File(extraPropFile);
+                URL propURL;
+                if (propFile.exists()) {
+                    propURL = new URL
+                            ("file:" + propFile.getCanonicalPath());
+                } else {
+                    propURL = new URL(extraPropFile);
                 }
-            }
 
-            // now load the user-specified file so its values
-            // will win if they conflict with the earlier values
-            if (extraPropFile != null) {
-                BufferedInputStream bis = null;
-                try {
-                    URL propURL;
-
-                    extraPropFile = PropertyExpander.expand(extraPropFile);
-                    propFile = new File(extraPropFile);
-                    if (propFile.exists()) {
-                        propURL = new URL
-                                ("file:" + propFile.getCanonicalPath());
-                    } else {
-                        propURL = new URL(extraPropFile);
-                    }
-                    bis = new BufferedInputStream(propURL.openStream());
-                    props.load(bis);
-                    loadedProps = true;
-
-                    if (sdebug != null) {
-                        sdebug.println("reading security properties file: " +
-                                        propURL);
-                        if (overrideAll) {
-                            sdebug.println
-                                ("overriding other security properties files!");
-                        }
-                    }
-                } catch (Exception e) {
+                is = propURL.openStream();
+                if (overrideAll) {
+                    props = new Properties();
                     if (sdebug != null) {
                         sdebug.println
-                                ("unable to load security properties from " +
-                                extraPropFile);
-                        e.printStackTrace();
+                                ("overriding other security properties files!");
                     }
-                } finally {
-                    if (bis != null) {
-                        try {
-                            bis.close();
-                        } catch (IOException ioe) {
-                            if (sdebug != null) {
-                                sdebug.println("unable to close input stream");
-                            }
-                        }
+                }
+            } else {
+                // unexpected
+                return false;
+            }
+            props.load(is);
+            if (sdebug != null) {
+                // ExceptionInInitializerError if masterFile.getName() is
+                // called here (NPE!). Leave as is (and few lines down)
+                sdebug.println("reading security properties file: " +
+                        masterFile == null ? extraPropFile : "java.security");
+            }
+            return true;
+        } catch (IOException | PropertyExpander.ExpandException e) {
+            if (sdebug != null) {
+                sdebug.println("unable to load security properties from " +
+                        masterFile == null ? extraPropFile : "java.security");
+                e.printStackTrace();
+            }
+            return false;
+        } finally {
+            if (is != null) {
+                try {
+                    is.close();
+                } catch (IOException ioe) {
+                    if (sdebug != null) {
+                        sdebug.println("unable to close input stream");
                     }
                 }
             }
         }
-
-        if (!loadedProps) {
-            throw new InternalError("java.security file missing");
-        }
-
     }
 
     /**

--- a/test/jdk/java/security/Security/ConfigFileTest.java
+++ b/test/jdk/java/security/Security/ConfigFileTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.*;
 
+import java.security.Provider;
 import java.security.Security;
 import java.util.Arrays;
 import java.util.Optional;
@@ -35,7 +36,7 @@ import java.util.Optional;
 /*
  * @test
  * @summary Throw error if default java.security file is missing
- * @bug 8155246
+ * @bug 8155246 8292297
  * @library /test/lib
  * @run main ConfigFileTest
  */
@@ -50,39 +51,66 @@ public class ConfigFileTest {
 
         if (args.length == 1) {
             // set up is complete. Run code to exercise loading of java.security
-            System.out.println(Arrays.toString(Security.getProviders()));
+            Provider[] provs = Security.getProviders();
+            System.out.println(Arrays.toString(provs) + "NumProviders: " + provs.length);
         } else {
             Files.createDirectory(copyJdkDir);
             Path jdkTestDir = Path.of(Optional.of(System.getProperty("test.jdk"))
                             .orElseThrow(() -> new RuntimeException("Couldn't load JDK Test Dir"))
             );
 
-            copyJDKMinusJavaSecurity(jdkTestDir, copyJdkDir);
+            copyJDK(jdkTestDir, copyJdkDir);
             String extraPropsFile = Path.of(System.getProperty("test.src"), "override.props").toString();
 
             // exercise some debug flags while we're here
-            // launch JDK without java.security file being present or specified
-            exerciseSecurity(copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+            // regular JDK install - should expect success
+            exerciseSecurity(0, "java",
+                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
                     "-Djava.security.debug=all", "-Djavax.net.debug=all", "ConfigFileTest", "runner");
+
+            // given an overriding security conf file that doesn't exist, we shouldn't
+            // overwrite the properties from original/master security conf file
+            exerciseSecurity(0, "SUN version",
+                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    "-Djava.security.debug=all", "-Djavax.net.debug=all",
+                    "-Djava.security.properties==file:///" + extraPropsFile + "badFileName",
+                    "ConfigFileTest", "runner");
+
+            // test JDK launch with customized properties file
+            exerciseSecurity(0, "NumProviders: 6",
+                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    "-Djava.security.debug=all", "-Djavax.net.debug=all",
+                    "-Djava.security.properties==file:///" + extraPropsFile,
+                    "ConfigFileTest", "runner");
+
+            // delete the master conf file
+            Files.delete(Path.of(copyJdkDir.toString(), "conf",
+                    "security","java.security"));
+
+            // launch JDK without java.security file being present or specified
+            exerciseSecurity(1, "Error loading java.security file",
+                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+                    "-Djava.security.debug=all", "-Djavax.net.debug=all",
+                    "ConfigFileTest", "runner");
 
             // test the override functionality also. Should not be allowed since
             // "security.overridePropertiesFile=true" Security property is missing.
-            exerciseSecurity(copiedJava.toString(), "-cp", System.getProperty("test.classes"),
+            exerciseSecurity(1, "Error loading java.security file",
+                    copiedJava.toString(), "-cp", System.getProperty("test.classes"),
                     "-Djava.security.debug=all", "-Djavax.net.debug=all",
-                    "-Djava.security.properties==file://" + extraPropsFile, "ConfigFileTest", "runner");
+                    "-Djava.security.properties==file:///" + extraPropsFile, "ConfigFileTest", "runner");
         }
     }
 
-    private static void exerciseSecurity(String... args) throws Exception {
+    private static void exerciseSecurity(int exitCode, String output, String... args) throws Exception {
         ProcessBuilder process = new ProcessBuilder(args);
         OutputAnalyzer oa = ProcessTools.executeProcess(process);
-        oa.shouldHaveExitValue(1).shouldContain("java.security file missing");
+        oa.shouldHaveExitValue(exitCode).shouldContain(output);
     }
 
-    private static void copyJDKMinusJavaSecurity(Path src, Path dst) throws Exception {
+    private static void copyJDK(Path src, Path dst) throws Exception {
         Files.walk(src)
             .skip(1)
-            .filter(p -> !p.toString().endsWith("java.security"))
             .forEach(file -> {
                 try {
                     Files.copy(file, dst.resolve(src.relativize(file)), StandardCopyOption.COPY_ATTRIBUTES);

--- a/test/jdk/java/security/Security/override.props
+++ b/test/jdk/java/security/Security/override.props
@@ -1,7 +1,7 @@
+# exercise ServiceLoader and legacy (class load) approach
 security.provider.1=sun.security.provider.Sun
-security.provider.2=sun.security.rsa.SunRsaSign
+security.provider.2=SunRsaSign
 security.provider.3=sun.security.ssl.SunJSSE
 security.provider.4=com.sun.crypto.provider.SunJCE
-security.provider.5=sun.security.jgss.SunProvider
-security.provider.6=com.sun.security.sasl.Provider
-
+security.provider.5=SunJGSS
+security.provider.6=SunSASL


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

I had to resolve as
8280010: Remove double buffering of InputStream for Properties.load  is not in 17.
The new code comes without the double buffering, but as I understand it is 
also not needed in 17 and thus I left it as-is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292297](https://bugs.openjdk.org/browse/JDK-8292297): Fix up loading of override java.security properties file


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/996/head:pull/996` \
`$ git checkout pull/996`

Update a local copy of the PR: \
`$ git checkout pull/996` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 996`

View PR using the GUI difftool: \
`$ git pr show -t 996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/996.diff">https://git.openjdk.org/jdk17u-dev/pull/996.diff</a>

</details>
