### PR TITLE
8242115: C2 SATB barriers are not safepoint-safe

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.hpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.hpp
@@ -84,7 +84,13 @@ protected:
 
   virtual Node* load_at_resolved(C2Access& access, const Type* val_type) const;
 
- public:
+#ifdef ASSERT
+  bool has_cas_in_use_chain(Node* x) const;
+  void verify_pre_load(Node* marking_check_if, Unique_Node_List& loads /*output*/) const;
+  void verify_no_safepoints(Compile* compile, Node* marking_load, const Unique_Node_List& loads) const;
+#endif
+
+public:
   virtual bool is_gc_barrier_node(Node* node) const;
   virtual void eliminate_gc_barrier(PhaseMacroExpand* macro, Node* node) const;
   virtual Node* step_over_gc_barrier(Node* c) const;

--- a/src/hotspot/share/opto/idealKit.cpp
+++ b/src/hotspot/share/opto/idealKit.cpp
@@ -352,13 +352,14 @@ Node* IdealKit::load(Node* ctl,
                      BasicType bt,
                      int adr_idx,
                      bool require_atomic_access,
-                     MemNode::MemOrd mo) {
+                     MemNode::MemOrd mo,
+                     LoadNode::ControlDependency control_dependency) {
 
   assert(adr_idx != Compile::AliasIdxTop, "use other make_load factory" );
   const TypePtr* adr_type = NULL; // debug-mode-only argument
   debug_only(adr_type = C->get_adr_type(adr_idx));
   Node* mem = memory(adr_idx);
-  Node* ld = LoadNode::make(_gvn, ctl, mem, adr, adr_type, t, bt, mo, LoadNode::DependsOnlyOnTest, require_atomic_access);
+  Node* ld = LoadNode::make(_gvn, ctl, mem, adr, adr_type, t, bt, mo, control_dependency, require_atomic_access);
   return transform(ld);
 }
 

--- a/src/hotspot/share/opto/idealKit.hpp
+++ b/src/hotspot/share/opto/idealKit.hpp
@@ -220,7 +220,9 @@ class IdealKit: public StackObj {
              const Type* t,
              BasicType bt,
              int adr_idx,
-             bool require_atomic_access = false, MemNode::MemOrd mo = MemNode::unordered);
+             bool require_atomic_access = false,
+             MemNode::MemOrd mo = MemNode::unordered,
+             LoadNode::ControlDependency control_dependency = LoadNode::DependsOnlyOnTest);
 
   // Return the new StoreXNode
   Node* store(Node* ctl,

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -823,7 +823,7 @@ const TypePtr* MemNode::calculate_adr_type(const Type* t, const TypePtr* cross_c
 //=============================================================================
 // Should LoadNode::Ideal() attempt to remove control edges?
 bool LoadNode::can_remove_control() const {
-  return true;
+  return !has_pinned_control_dependency();
 }
 uint LoadNode::size_of() const { return sizeof(*this); }
 bool LoadNode::cmp( const Node &n ) const
@@ -841,7 +841,17 @@ void LoadNode::dump_spec(outputStream *st) const {
     st->print(" #"); _type->dump_on(st);
   }
   if (!depends_only_on_test()) {
-    st->print(" (does not depend only on test)");
+    st->print(" (does not depend only on test, ");
+    if (control_dependency() == UnknownControl) {
+      st->print("unknown control");
+    } else if (control_dependency() == Pinned) {
+      st->print("pinned");
+    } else if (adr_type() == TypeRawPtr::BOTTOM) {
+      st->print("raw access");
+    } else {
+      st->print("unknown reason");
+    }
+    st->print(")");
   }
 }
 #endif
@@ -1186,6 +1196,9 @@ bool LoadNode::is_instance_field_load_with_local_phi(Node* ctrl) {
 //------------------------------Identity---------------------------------------
 // Loads are identity if previous store is to same address
 Node* LoadNode::Identity(PhaseGVN* phase) {
+  if (has_pinned_control_dependency()) {
+    return this;
+  }
   // If the previous store-maker is the right kind of Store, and the store is
   // to the same address, then we are equal to the value stored.
   Node* mem = in(Memory);
@@ -1683,6 +1696,9 @@ AllocateNode* LoadNode::is_new_object_mark_load(PhaseGVN *phase) const {
 // If the offset is constant and the base is an object allocation,
 // try to hook me up to the exact initializing store.
 Node *LoadNode::Ideal(PhaseGVN *phase, bool can_reshape) {
+  if (has_pinned_control_dependency()) {
+    return NULL;
+  }
   Node* p = MemNode::Ideal_common(phase, can_reshape);
   if (p)  return (p == NodeSentinel) ? NULL : p;
 

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -286,7 +286,9 @@ public:
   Node* convert_to_reinterpret_load(PhaseGVN& gvn, const Type* rt);
 
   void pin() { _control_dependency = Pinned; }
-  bool has_unknown_control_dependency() const { return _control_dependency == UnknownControl; }
+  ControlDependency control_dependency() const { return _control_dependency; }
+  bool has_unknown_control_dependency() const  { return _control_dependency == UnknownControl; }
+  bool has_pinned_control_dependency() const   { return _control_dependency == Pinned; }
 
 #ifndef PRODUCT
   virtual void dump_spec(outputStream *st) const;


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

I had to resolve memnode.hpp and added control_dependency()
which is called by this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8242115](https://bugs.openjdk.org/browse/JDK-8242115): C2 SATB barriers are not safepoint-safe


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/999/head:pull/999` \
`$ git checkout pull/999`

Update a local copy of the PR: \
`$ git checkout pull/999` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 999`

View PR using the GUI difftool: \
`$ git pr show -t 999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/999.diff">https://git.openjdk.org/jdk17u-dev/pull/999.diff</a>

</details>
