### PR TITLE
8296136: Use correct register in aarch64_enc_fast_unlock()

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3916,7 +3916,7 @@ encode %{
 
     // Handle existing monitor.
     __ ldr(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
-    __ tbnz(disp_hdr, exact_log2(markWord::monitor_value), object_has_monitor);
+    __ tbnz(tmp, exact_log2(markWord::monitor_value), object_has_monitor);
 
     // Check if it is still a light weight lock, this is is true if we
     // see the stack address of the basicLock in the markWord of the


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

Omitted riskv part. Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296136](https://bugs.openjdk.org/browse/JDK-8296136): Use correct register in aarch64_enc_fast_unlock()


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1005/head:pull/1005` \
`$ git checkout pull/1005`

Update a local copy of the PR: \
`$ git checkout pull/1005` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1005`

View PR using the GUI difftool: \
`$ git pr show -t 1005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1005.diff">https://git.openjdk.org/jdk17u-dev/pull/1005.diff</a>

</details>
