### PR TITLE
8293531: C2: some vectorapi tests fail assert "Not monotonic" with flag -XX:TypeProfileLevel=222

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1740,7 +1740,7 @@ PhaseCCP::~PhaseCCP() {
 
 #ifdef ASSERT
 static bool ccp_type_widens(const Type* t, const Type* t0) {
-  assert(t->meet(t0) == t, "Not monotonic");
+  assert(t->meet(t0) == t->remove_speculative(), "Not monotonic");
   switch (t->base() == t0->base() ? t->base() : Type::Top) {
   case Type::Int:
     assert(t0->isa_int()->_widen <= t->isa_int()->_widen, "widen increases");


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293531](https://bugs.openjdk.org/browse/JDK-8293531): C2: some vectorapi tests fail assert "Not monotonic" with flag -XX:TypeProfileLevel=222


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1009/head:pull/1009` \
`$ git checkout pull/1009`

Update a local copy of the PR: \
`$ git checkout pull/1009` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1009`

View PR using the GUI difftool: \
`$ git pr show -t 1009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1009.diff">https://git.openjdk.org/jdk17u-dev/pull/1009.diff</a>

</details>
