### PR TITLE
8212961: [TESTBUG] vmTestbase/nsk/stress/jni/ native code cleanup

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnihelper.h
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnihelper.h
@@ -41,3 +41,11 @@ static void* c_malloc(JNIEnv* env, size_t size) {
         env->FatalError("Unexpected JNI Exception. TEST FAIL.");\
     }\
 }
+
+// Checks return code for JNI calls that don't raise exceptions
+// and generate fatal error
+#define CHECK(jniCall) do { \
+  if ((jniCall) != 0) { \
+    env->FatalError("Error invoking JNI method: " #jniCall); \
+  } \
+} while (0)

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress001.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,214 +33,221 @@ extern "C" {
 #define DIGESTLENGTH 16
 
 typedef struct {
-    const char **str;
-    char **checkstr;
+  const char **str;
+  char **checkstr;
 } CHAR_ARRAY;
 
 typedef struct {
-    const jchar **str;
-    char **checkstr;
-    int *size;
+  const jchar **str;
+  char **checkstr;
+  int *size;
 } JCHAR_ARRAY;
 
 JNIEXPORT jstring JNICALL
 Java_nsk_stress_jni_JNIter001_jnistress (JNIEnv *env, jobject jobj, jstring jstr,
-                    jint nstr, jint printperiod) {
+                                         jint nstr, jint printperiod) {
 
-    int i,j;
-    size_t k;
-    static CHAR_ARRAY *element;
-    unsigned char digest[DIGESTLENGTH];
-    static int allocs=0;
-    static size_t strsize=0;
-    static unsigned int compared=1;
+  int i, j;
+  size_t k;
+  static CHAR_ARRAY *element;
+  unsigned char digest[DIGESTLENGTH];
+  static int allocs = 0;
+  static size_t strsize = 0;
+  static unsigned int compared = 1;
 
-    const char *clsName = "nsk/stress/jni/JNIter001";
-    const char *name="setpass";
-    const char *sig="(Z)V";
-    const char *halt="halt";
-    const char *haltSig="()V";
-    jstring tmpstr;
-    jclass clazz;
-    jmethodID methodID;
+  const char *clsName = "nsk/stress/jni/JNIter001";
+  const char *name = "setpass";
+  const char *sig = "(Z)V";
+  const char *halt = "halt";
+  const char *haltSig = "()V";
+  jstring tmpstr;
+  jclass clazz;
+  jmethodID methodID;
 
-    env->MonitorEnter(jobj); CE
-    if (!allocs) {
-        element = (CHAR_ARRAY *)c_malloc(env, sizeof(CHAR_ARRAY));
-        element->str = (const char **)c_malloc(env, nstr*sizeof(const char *));
-        element->checkstr = (char **)c_malloc(env, nstr*sizeof(char *));
-        for (j=0;j<nstr;j++)
-            element->checkstr[j] = (char *)c_malloc(env, DIGESTLENGTH*sizeof(char));
-    }
-    for (j=0;j<DIGESTLENGTH;j++) {
-        digest[j]=0;
-    }
-    element->str[allocs] = env->GetStringUTFChars(jstr,0); CE
-    if (strlen(element->str[allocs]) !=
-        (size_t) env->GetStringUTFLength(jstr))
-        printf("Length is wrong in string No. %d\n",allocs);
-    else
-        strsize += strlen(element->str[allocs])+1;
-    for (k = 0; k < strlen(element->str[allocs]); k++) {
-       digest[k % DIGESTLENGTH] += element->str[allocs][k];
-    }
-    memcpy(element->checkstr[allocs],digest,DIGESTLENGTH);
-    allocs++;
-    if (allocs % printperiod == 0) {
-        printf("Check string for thread %s is ", element->str[allocs-1]);
-        for (j=0;j<DIGESTLENGTH;j++)
-            printf("%02x", digest[j]);
-        printf("\n");
-    }
-    if (allocs == nstr) {
-        printf("JNI UTF8 strings memory=%zd\n", strsize);
-        tmpstr=env->NewStringUTF(element->str[allocs-1]); CE
-        for (j=0; j<nstr; j++) {
+  CHECK(env->MonitorEnter(jobj));
 
-            for (i=0;i<DIGESTLENGTH;i++) {
-                digest[i]=0;
-            }
-            for (k=0; k < strlen(element->str[j]); k++) {
-                digest[k % DIGESTLENGTH] += element->str[j][k];
-            }
-            if (memcmp(digest,element->checkstr[j],DIGESTLENGTH) == 0) {
-                env->ReleaseStringUTFChars(jstr,element->str[j]); CE
-                element->str[j] = NULL;
-                element->checkstr[j] = NULL;
-            }
-            else {
-                compared=0;
-                printf("The element No. %d has been corrupted %s vs %s\n",j, element->str[j],element->checkstr[j]);
-                printf("Digest string  is %s [", element->str[j]);
-                for (i=0;i<DIGESTLENGTH;i++)
-                    printf("ch[%d]=%02x", i, digest[i]);
-                printf("Digest end\n");
-            }
+  if (!allocs) {
+    element = (CHAR_ARRAY *)c_malloc(env, sizeof(CHAR_ARRAY));
+    element->str = (const char **)c_malloc(env, nstr * sizeof(const char*));
+    element->checkstr = (char **)c_malloc(env, nstr * sizeof(char*));
+    for (j = 0; j < nstr; j++) {
+      element->checkstr[j] = (char *)c_malloc(env, DIGESTLENGTH * sizeof(char));
+    }
+  }
+  for (j = 0; j < DIGESTLENGTH; j++) {
+    digest[j] = 0;
+  }
+  element->str[allocs] = env->GetStringUTFChars(jstr, 0); CE
+  if (strlen(element->str[allocs]) != (size_t) env->GetStringUTFLength(jstr)) {
+    printf("Length is wrong in string No. %d\n", allocs);
+  } else {
+    strsize += strlen(element->str[allocs]) + 1;
+  }
+  for (k = 0; k < strlen(element->str[allocs]); k++) {
+    digest[k % DIGESTLENGTH] += element->str[allocs][k];
+  }
+  memcpy(element->checkstr[allocs], digest, DIGESTLENGTH);
+  allocs++;
+  if (allocs % printperiod == 0) {
+    printf("Check string for thread %s is ", element->str[allocs - 1]);
+    for (j = 0; j < DIGESTLENGTH; j++) {
+      printf("%02x", digest[j]);
+    }
+    printf("\n");
+  }
+  if (allocs == nstr) {
+    printf("JNI UTF8 strings memory = %zd\n", strsize);
+    tmpstr = env->NewStringUTF(element->str[allocs - 1]); CE
+    for (j = 0; j < nstr; j++) {
+
+      for (i = 0; i < DIGESTLENGTH; i++) {
+        digest[i] = 0;
+      }
+      for (k = 0; k < strlen(element->str[j]); k++) {
+        digest[k % DIGESTLENGTH] += element->str[j][k];
+      }
+      if (memcmp(digest, element->checkstr[j], DIGESTLENGTH) == 0) {
+        env->ReleaseStringUTFChars(jstr, element->str[j]); CE
+        element->str[j] = NULL;
+        element->checkstr[j] = NULL;
+      } else {
+        compared = 0;
+        printf("The element No. %d has been corrupted %s vs %s\n", j,
+               element->str[j], element->checkstr[j]);
+        printf("Digest string  is %s [", element->str[j]);
+        for (i = 0; i < DIGESTLENGTH; i++) {
+          printf("ch[%d] = %02x", i, digest[i]);
         }
-        allocs=0;
-        strsize = 0;
-        for (j=0;j<nstr;j++)
-            free(element->checkstr[j]);
-        free(element->checkstr);
-        free((void *)(element->str));
-        free(element);
-        clazz=env->FindClass(clsName); CE
-        if (!compared) {
-            methodID=env->GetStaticMethodID(clazz, name, sig); CE
-            env->CallStaticVoidMethod(clazz, methodID, JNI_FALSE); CE
-        }
-        //methodID=env->GetStaticMethodID(clazz, halt, haltSig); CE
-        //env->CallStaticVoidMethod(clazz, methodID); CE
-        return(tmpstr);
+        printf("Digest end\n");
+      }
     }
-    env->MonitorExit(jobj); CE
-    return (env->NewStringUTF(element->str[allocs-1]));
+    allocs = 0;
+    strsize = 0;
+    for (j = 0; j < nstr; j++) {
+      free(element->checkstr[j]);
+    }
+    free(element->checkstr);
+    free((void *)(element->str));
+    free(element);
+    clazz = env->FindClass(clsName); CE
+    if (!compared) {
+      methodID = env->GetStaticMethodID(clazz, name, sig); CE
+      env->CallStaticVoidMethod(clazz, methodID, JNI_FALSE); CE
+    }
+    //methodID = env->GetStaticMethodID(clazz, halt, haltSig); CE
+    //env->CallStaticVoidMethod(clazz, methodID); CE
+    return tmpstr;
+  }
+  CHECK(env->MonitorExit(jobj));
+  return (env->NewStringUTF(element->str[allocs - 1]));
 }
 
 JNIEXPORT jstring JNICALL
 Java_nsk_stress_jni_JNIter001_jnistress1(JNIEnv *env, jobject jobj, jstring jstr,
-                    jint nstr, jint printperiod) {
+                                         jint nstr, jint printperiod) {
 
-    int i,j;
-    static JCHAR_ARRAY *javachars;
-    unsigned char digest[DIGESTLENGTH];
-    static int index=0;
-    static long len=0;
-    static unsigned int equal=1;
-    char *elem;
-    int elem_len = -1;
+  int i, j;
+  static JCHAR_ARRAY *javachars;
+  unsigned char digest[DIGESTLENGTH];
+  static int index = 0;
+  static long len = 0;
+  static unsigned int equal = 1;
+  char *elem;
+  int elem_len = -1;
 
-    const char *clsName = "nsk/stress/jni/JNIter001";
-    const char *name="setpass";
-    const char *sig="(Z)V";
-    const char *halt="halt";
-    const char *haltSig="()V";
-    jstring tmpstr;
-    jclass clazz;
-    jmethodID methodID;
+  const char *clsName = "nsk/stress/jni/JNIter001";
+  const char *name = "setpass";
+  const char *sig = "(Z)V";
+  const char *halt = "halt";
+  const char *haltSig = "()V";
+  jstring tmpstr;
+  jclass clazz;
+  jmethodID methodID;
 
-    env->MonitorEnter(jobj); CE
-    if (!index) {
-        javachars = (JCHAR_ARRAY *)c_malloc(env, sizeof(JCHAR_ARRAY));
-        javachars->str = (const jchar **)c_malloc(env, nstr*sizeof(const jchar *));
-        javachars->checkstr = (char **)c_malloc(env, nstr*sizeof(char *));
-        javachars->size = (int *)c_malloc(env, nstr*sizeof(int));
-        for (j=0;j<nstr;j++)
-            javachars->checkstr[j] = (char *)c_malloc(env, DIGESTLENGTH*sizeof(char));
+  CHECK(env->MonitorEnter(jobj));
+  if (!index) {
+    javachars = (JCHAR_ARRAY *)c_malloc(env, sizeof(JCHAR_ARRAY));
+    javachars->str = (const jchar **)c_malloc(env, nstr * sizeof(const jchar*));
+    javachars->checkstr = (char **)c_malloc(env, nstr * sizeof(char*));
+    javachars->size = (int *)c_malloc(env, nstr * sizeof(int));
+    for (j = 0; j < nstr; j++) {
+      javachars->checkstr[j] = (char *)c_malloc(env, DIGESTLENGTH * sizeof(char));
     }
-    for (j=0;j<DIGESTLENGTH;j++) {
-        digest[j]=0;
-    }
-    javachars->str[index] = env->GetStringChars(jstr,0); CE
-    javachars->size[index] = env->GetStringUTFLength(jstr); CE
-    elem_len = javachars->size[index];
-    len += elem_len;
-    elem = (char*) c_malloc(env, elem_len*sizeof(char));
-    for (j=0; j < elem_len; j++) {
-        elem[j] = (char) javachars->str[index][j];
-    }
+  }
+  for (j = 0; j < DIGESTLENGTH; j++) {
+    digest[j] = 0;
+  }
+  javachars->str[index] = env->GetStringChars(jstr, 0); CE
+  javachars->size[index] = env->GetStringUTFLength(jstr); CE
+  elem_len = javachars->size[index];
+  len += elem_len;
+  elem = (char*) c_malloc(env, elem_len * sizeof(char));
+  for (j = 0; j < elem_len; j++) {
+    elem[j] = (char) javachars->str[index][j];
+  }
 
-    //memcpy(digest, elem, javachars->size[index]);
-    for (j=0;j<elem_len; j++) {
-        digest[j % DIGESTLENGTH]+=elem[j];
+  //memcpy(digest, elem, javachars->size[index]);
+  for (j = 0; j < elem_len; j++) {
+    digest[j % DIGESTLENGTH] += elem[j];
+  }
+  memcpy(javachars->checkstr[index++], digest, DIGESTLENGTH);
+  if (index % printperiod == 0) {
+    printf("Check string sum for thread %.*s is ", elem_len, elem);
+    for (j = 0; j < DIGESTLENGTH; j++) {
+      printf("%02x", digest[j]);
     }
-    memcpy(javachars->checkstr[index++],digest,DIGESTLENGTH);
-    if (index % printperiod == 0) {
-        printf("Check string sum for thread %.*s is ", elem_len, elem);
-        for (j=0;j<DIGESTLENGTH;j++)
-            printf("%02x", digest[j]);
-        printf("\n");
-    }
-    free(elem);
-    if (index == nstr) {
-        printf("JNI Unicode strings memory=%ld\n",len);
-        tmpstr=env->NewString(javachars->str[index-1],elem_len); CE
-        for (j=0; j<nstr; j++) {
-            elem = (char*) c_malloc(env, javachars->size[j]*sizeof(char));
-            for (i=0; i < javachars->size[j]; i++) {
-                elem[i] = (char) javachars->str[j][i];
-            }
-            //memcpy(digest, elem, javachars->size[j]);
-            for (i=0;i<DIGESTLENGTH;i++) {
-                digest[i]=0;
-            }
-            for (i=0;i<javachars->size[j]; i++) {
-                digest[i % DIGESTLENGTH]+=elem[i];
-            }
-            free(elem);
-            if (memcmp(digest,javachars->checkstr[j],javachars->size[j]) == 0) {
-                env->ReleaseStringChars(jstr,javachars->str[j]); CE
-                javachars->str[j] = NULL;
-                javachars->checkstr[j] = NULL;
-                javachars->size[j] = 0;
-            }
-            else {
-                equal=0;
-                printf("The Unicode element No. %d has been corrupted\n",j);
-                for (i=0;i<DIGESTLENGTH;i++) {
-                    printf("digest[%d]=%02x checkstr[%d]=%02x\n",i,digest[i],i,javachars->checkstr[j][i]);
-                }
-            }
+    printf("\n");
+  }
+  free(elem);
+  if (index == nstr) {
+    printf("JNI Unicode strings memory = %ld\n", len);
+    tmpstr = env->NewString(javachars->str[index - 1], elem_len); CE
+    for (j = 0; j < nstr; j++) {
+      elem = (char*) c_malloc(env, javachars->size[j] * sizeof(char));
+      for (i = 0; i < javachars->size[j]; i++) {
+        elem[i] = (char) javachars->str[j][i];
+      }
+      //memcpy(digest, elem, javachars->size[j]);
+      for (i = 0; i < DIGESTLENGTH; i++) {
+        digest[i] = 0;
+      }
+      for (i = 0; i < javachars->size[j]; i++) {
+        digest[i % DIGESTLENGTH] += elem[i];
+      }
+      free(elem);
+      if (memcmp(digest, javachars->checkstr[j], javachars->size[j]) == 0) {
+        env->ReleaseStringChars(jstr, javachars->str[j]); CE
+        javachars->str[j] = NULL;
+        javachars->checkstr[j] = NULL;
+        javachars->size[j] = 0;
+      } else {
+        equal = 0;
+        printf("The Unicode element No. %d has been corrupted\n", j);
+        for (i = 0; i < DIGESTLENGTH; i++) {
+          printf("digest[%d] = %02x checkstr[%d] = %02x\n", i, digest[i], i, javachars->checkstr[j][i]);
         }
-        index=0;
-        len = 0;
-        for (j=0;j<nstr;j++)
-            free(javachars->checkstr[j]);
-        free(javachars->checkstr);
-        free((void *)(javachars->str));
-        free(javachars->size);
-        free(javachars);
-        clazz=env->FindClass(clsName); CE
-        if (!equal) {
-            methodID=env->GetStaticMethodID(clazz, name, sig); CE
-            env->CallStaticVoidMethod(clazz, methodID, JNI_FALSE); CE
-        }
-        //methodID=env->GetStaticMethodID(clazz, halt, haltSig); CE
-        //env->CallStaticVoidMethod(clazz, methodID); CE
-        return(tmpstr);
+      }
     }
-    env->MonitorExit(jobj); CE
-    return(env->NewString(javachars->str[index-1],elem_len));
+    index = 0;
+    len = 0;
+    for (j = 0; j < nstr; j++) {
+      free(javachars->checkstr[j]);
+    }
+    free(javachars->checkstr);
+    free((void *)(javachars->str));
+    free(javachars->size);
+    free(javachars);
+    clazz = env->FindClass(clsName); CE
+    if (!equal) {
+      methodID = env->GetStaticMethodID(clazz, name, sig); CE
+      env->CallStaticVoidMethod(clazz, methodID, JNI_FALSE); CE
+    }
+    //methodID = env->GetStaticMethodID(clazz, halt, haltSig); CE
+    //env->CallStaticVoidMethod(clazz, methodID); CE
+    return tmpstr;
+  }
+  CHECK(env->MonitorExit(jobj));
+  return env->NewString(javachars->str[index - 1], elem_len);
 }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress002.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,70 +31,63 @@ jobject NewObjectWrapper(JNIEnv *env, jclass clazz, jmethodID methodID, ...) {
   va_list ap;
   jobject tmp;
 
-  va_start(ap,methodID);
-  tmp=env->NewObjectV(clazz, methodID, ap);
+  va_start(ap, methodID);
+  tmp = env->NewObjectV(clazz, methodID, ap);
   va_end(ap);
   return(tmp);
 }
 
 JNIEXPORT jobjectArray JNICALL
 Java_nsk_stress_jni_JNIter002_jniobjects (JNIEnv *env, jobject jobj, jstring jstr, jint intgr,
-              jlong lng, jcharArray jChArr, jfloat flt, jdouble dbl) {
+                                          jlong lng, jcharArray jChArr, jfloat flt, jdouble dbl) {
 
   static int classCount = 0;
   jobjectArray obj;
   jobject element;
   jclass clazz, clazzUp;
   jmethodID methodID;
-  const char *classname="nsk/stress/jni/objectsJNI";
-  const char *name="<init>";
-  const char *sig="(Ljava/lang/String;IJ[CFD)V";
-  const char *upperClassName="nsk/stress/jni/jnistress002";
-  const char *fieldName="jniStringAllocSize";
-  const char *fieldSig="I";
-  const char *setpass="halt";
-  const char *setpassSig="()V";
+  jfieldID fieldID;
+  const char *classname = "nsk/stress/jni/objectsJNI";
+  const char *name = "<init>";
+  const char *sig = "(Ljava/lang/String;IJ[CFD)V";
+  const char *upperClassName = "nsk/stress/jni/jnistress002";
+  const char *fieldName = "jniStringAllocSize";
+  const char *fieldSig = "I";
+  const char *setpass = "halt";
+  const char *setpassSig = "()V";
   jvalue paramArr [6];
 
-  env->MonitorEnter(jobj); CE
+  CHECK(env->MonitorEnter(jobj));
   ++classCount;
-  env->MonitorExit(jobj); CE
-  paramArr[0].l=jstr;
-  paramArr[1].i=intgr;
-  paramArr[2].j=lng;
-  paramArr[3].l=jChArr;
-  paramArr[4].f=flt;
-  paramArr[5].d=dbl;
+  CHECK(env->MonitorExit(jobj));
+  paramArr[0].l = jstr;
+  paramArr[1].i = intgr;
+  paramArr[2].j = lng;
+  paramArr[3].l = jChArr;
+  paramArr[4].f = flt;
+  paramArr[5].d = dbl;
 
-  clazz=env->FindClass(classname); CE
-  obj=env->NewObjectArray((jsize)3,clazz,
-                 env->AllocObject(clazz)); CE
-  if (obj == NULL) {
-    fprintf(stderr,"Can not construct the object Array for  %s\n", classname);
-    return(NULL);
-  }
+  clazz = env->FindClass(classname); CE
+  element = env->AllocObject(clazz); CE
+  obj = env->NewObjectArray((jsize)3, clazz, element); CE
 
-  methodID=env->GetMethodID(clazz,name,sig); CE
-  if (methodID == NULL) {
-    fprintf(stderr,"Can not get the ID of <init> for %s\n", classname);
-    return(NULL);
-  }
+  methodID = env->GetMethodID(clazz, name, sig); CE
 
-  element=env->NewObject(clazz,methodID,
-                jstr, intgr, lng, jChArr, flt, dbl); CE
-  env->SetObjectArrayElement(obj,0,element); CE
-  element=env->NewObjectA(clazz,methodID,paramArr); CE
-  env->SetObjectArrayElement(obj,1,element); CE
+  element = env->NewObject(clazz, methodID,
+                           jstr, intgr, lng, jChArr, flt, dbl); CE
+  env->SetObjectArrayElement(obj, 0, element); CE
+  element = env->NewObjectA(clazz, methodID, paramArr); CE
+  env->SetObjectArrayElement(obj, 1, element); CE
   element= NewObjectWrapper(env, clazz, methodID,
-                jstr, intgr, lng, jChArr, flt, dbl); CE
-  env->SetObjectArrayElement(obj,2,element); CE
+                            jstr, intgr, lng, jChArr, flt, dbl); CE
+  env->SetObjectArrayElement(obj, 2, element); CE
 
-  clazzUp=env->FindClass(upperClassName); CE
-  if (classCount == env->GetStaticIntField(clazzUp,
-      env->GetStaticFieldID(clazzUp,fieldName,fieldSig))) {
-    classname="nsk/stress/jni/JNIter002";
-    clazz=env->FindClass(classname); CE
-    methodID=env->GetStaticMethodID(clazz, setpass, setpassSig); CE
+  clazzUp = env->FindClass(upperClassName); CE
+  fieldID = env->GetStaticFieldID(clazzUp, fieldName, fieldSig); CE
+  if (classCount == env->GetStaticIntField(clazzUp, fieldID)) {
+    classname = "nsk/stress/jni/JNIter002";
+    clazz = env->FindClass(classname); CE
+    methodID = env->GetStaticMethodID(clazz, setpass, setpassSig); CE
     env->CallStaticVoidMethod(clazz, methodID); CE
   }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress003.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,111 +40,112 @@ extern "C" {
 JNIEXPORT jobjectArray JNICALL
 Java_nsk_stress_jni_JNIter003_jniInitArrays (JNIEnv *env, jobject jobj, jint size) {
 
-    jarray *arrayArray;
-    jboolean *boolBuf;
-    jbyte *byteBuf;
-    jchar *charBuf;
-    jshort *shortBuf;
-    jint *intBuf;
-    jlong *longBuf;
-    jfloat *floatBuf;
-    jdouble *doubleBuf;
-    jobjectArray objectsArray;
+  jarray *arrayArray;
+  jboolean *boolBuf;
+  jbyte *byteBuf;
+  jchar *charBuf;
+  jshort *shortBuf;
+  jint *intBuf;
+  jlong *longBuf;
+  jfloat *floatBuf;
+  jdouble *doubleBuf;
+  jobjectArray objectsArray;
 
-    int i;
-    int SIZE=size;
-    const char *classname="java/lang/Object";
-    jclass clazz = env->FindClass(classname); CE
-    objectsArray = env->NewObjectArray(8,clazz, env->AllocObject(clazz));
+  int i;
+  int SIZE = size;
+  const char *classname = "java/lang/Object";
+  jclass clazz = env->FindClass(classname); CE
+  jobject obj = env->AllocObject(clazz); CE
+  objectsArray = env->NewObjectArray(8, clazz, obj); CE
 
-    arrayArray=(jarray *)malloc(8*sizeof(jarray)); CE
-    arrayArray[BOOL]=env->NewBooleanArray(SIZE); CE
-    arrayArray[BYTE]=env->NewByteArray(SIZE); CE
-    arrayArray[CHAR]=env->NewCharArray(SIZE); CE
-    arrayArray[SHORT]=env->NewShortArray(SIZE); CE
-    arrayArray[INT]=env->NewIntArray(SIZE); CE
-    arrayArray[LONG]=env->NewLongArray(SIZE); CE
-    arrayArray[FLOAT]=env->NewFloatArray(SIZE); CE
-    arrayArray[DOUBLE]=env->NewDoubleArray(SIZE); CE
+  arrayArray = (jarray *)c_malloc(env, 8*sizeof(jarray));
+  arrayArray[BOOL] = env->NewBooleanArray(SIZE); CE
+  arrayArray[BYTE] = env->NewByteArray(SIZE); CE
+  arrayArray[CHAR] = env->NewCharArray(SIZE); CE
+  arrayArray[SHORT] = env->NewShortArray(SIZE); CE
+  arrayArray[INT] = env->NewIntArray(SIZE); CE
+  arrayArray[LONG] = env->NewLongArray(SIZE); CE
+  arrayArray[FLOAT] = env->NewFloatArray(SIZE); CE
+  arrayArray[DOUBLE] = env->NewDoubleArray(SIZE); CE
 
-    for (i=0;i<8;i++)
-    { env->SetObjectArrayElement(objectsArray,i,arrayArray[i]); CE }
+  for (i = 0; i < 8; i++) {
+    env->SetObjectArrayElement(objectsArray, i,arrayArray[i]); CE
+  }
 
-    boolBuf=(jboolean *)malloc(SIZE*sizeof(jboolean));
-    byteBuf=(jbyte *)malloc(SIZE*sizeof(jbyte));
-    charBuf=(jchar *)malloc(SIZE*sizeof(jchar));
-    shortBuf=(jshort *)malloc(SIZE*sizeof(jshort));
-    intBuf=(jint *)malloc(SIZE*sizeof(jint));
-    longBuf=(jlong *)malloc(SIZE*sizeof(jlong));
-    floatBuf=(jfloat *)malloc(SIZE*sizeof(jfloat));
-    doubleBuf=(jdouble *)malloc(SIZE*sizeof(jdouble));
+  boolBuf = (jboolean *)c_malloc(env, SIZE * sizeof(jboolean));
+  byteBuf = (jbyte *)c_malloc(env, SIZE * sizeof(jbyte));
+  charBuf = (jchar *)c_malloc(env, SIZE * sizeof(jchar));
+  shortBuf = (jshort *)c_malloc(env, SIZE * sizeof(jshort));
+  intBuf = (jint *)c_malloc(env, SIZE * sizeof(jint));
+  longBuf = (jlong *)c_malloc(env, SIZE * sizeof(jlong));
+  floatBuf = (jfloat *)c_malloc(env, SIZE * sizeof(jfloat));
+  doubleBuf = (jdouble *)c_malloc(env, SIZE * sizeof(jdouble));
 
-    for (i=0;i<SIZE;i++) {
-    if (i%2 == 0) boolBuf[i]=JNI_TRUE;
-    else boolBuf[i]=JNI_FALSE;
+  for (i = 0; i < SIZE; i++) {
+    boolBuf[i] = (i % 2 == 0) ? JNI_TRUE : JNI_FALSE;
     /*
-      byteBuf[i]=(jbyte)random();
-      charBuf[i]=(jchar)random();
-      shortBuf[i]=(jshort)random();
-      intBuf[i]=(jint)random();
-      longBuf[i]=(jlong)random();
-      floatBuf[i]=(jfloat)((random()));
-      doubleBuf[i]=(jdouble)((random()));
+      byteBuf[i] = (jbyte)random();
+      charBuf[i] = (jchar)random();
+      shortBuf[i] = (jshort)random();
+      intBuf[i] = (jint)random();
+      longBuf[i] = (jlong)random();
+      floatBuf[i] = (jfloat)((random()));
+      doubleBuf[i] = (jdouble)((random()));
     */
-    byteBuf[i]=(jbyte)109;
-    charBuf[i]=(jchar)214;
-    shortBuf[i]=(jshort)9223;
-    intBuf[i]=(jint)872634;
-    longBuf[i]=(jlong)276458276;
-    floatBuf[i]=(jfloat)235.4576284;
-    doubleBuf[i]=(jdouble)98275.716253567;
-    }
-    env->SetBooleanArrayRegion((jbooleanArray) arrayArray[BOOL],0,i,boolBuf); CE
-    env->SetByteArrayRegion((jbyteArray) arrayArray[BYTE],0,i,byteBuf); CE
-    env->SetCharArrayRegion((jcharArray) arrayArray[CHAR],0,i,charBuf); CE
-    env->SetShortArrayRegion((jshortArray) arrayArray[SHORT],0,i,shortBuf); CE
-    env->SetIntArrayRegion((jintArray) arrayArray[INT],0,i,intBuf); CE
-    env->SetLongArrayRegion((jlongArray) arrayArray[LONG],0,i,longBuf); CE
-    env->SetFloatArrayRegion((jfloatArray) arrayArray[FLOAT],0,i,floatBuf); CE
-    env->SetDoubleArrayRegion((jdoubleArray) arrayArray[DOUBLE],0,i,doubleBuf); CE
+    byteBuf[i] = (jbyte)109;
+    charBuf[i] = (jchar)214;
+    shortBuf[i] = (jshort)9223;
+    intBuf[i] = (jint)872634;
+    longBuf[i] = (jlong)276458276;
+    floatBuf[i] = (jfloat)235.4576284;
+    doubleBuf[i] = (jdouble)98275.716253567;
+  }
+  env->SetBooleanArrayRegion((jbooleanArray) arrayArray[BOOL], 0, i, boolBuf); CE
+  env->SetByteArrayRegion((jbyteArray) arrayArray[BYTE], 0, i, byteBuf); CE
+  env->SetCharArrayRegion((jcharArray) arrayArray[CHAR], 0, i, charBuf); CE
+  env->SetShortArrayRegion((jshortArray) arrayArray[SHORT], 0, i, shortBuf); CE
+  env->SetIntArrayRegion((jintArray) arrayArray[INT], 0, i, intBuf); CE
+  env->SetLongArrayRegion((jlongArray) arrayArray[LONG], 0, i, longBuf); CE
+  env->SetFloatArrayRegion((jfloatArray) arrayArray[FLOAT], 0, i, floatBuf); CE
+  env->SetDoubleArrayRegion((jdoubleArray) arrayArray[DOUBLE], 0, i, doubleBuf); CE
 
-    free(doubleBuf);
-    free(floatBuf);
-    free(longBuf);
-    free(intBuf);
-    free(shortBuf);
-    free(byteBuf);
-    free(charBuf);
-    free(boolBuf);
-    free(arrayArray);
+  free(doubleBuf);
+  free(floatBuf);
+  free(longBuf);
+  free(intBuf);
+  free(shortBuf);
+  free(byteBuf);
+  free(charBuf);
+  free(boolBuf);
+  free(arrayArray);
 
-    return objectsArray;
+  return objectsArray;
 }
 
 JNIEXPORT jboolean JNICALL
 Java_nsk_stress_jni_JNIter003_jniBodyChangeArray (JNIEnv *env, jobject jobj,
-                jobjectArray orig, jobjectArray clone, jint limit) {
+                                                  jobjectArray orig, jobjectArray clone, jint limit) {
 
-#define SWAP(param1, param2) tmparr=param2; param2=param1; param1=tmparr;
+#define SWAP(param1, param2) tmparr = param2; param2 = param1; param1 = tmparr;
 #define SIZE(type) env->GetArrayLength(arrayClone[type])
 
-    static volatile long count=0;
-    jarray *arrayOrig, *arrayClone;
-    jboolean *boolOrig, *boolClone;
-    jbyte *byteOrig, *byteClone;
-    jchar *charOrig, *charClone;
-    jshort *shortOrig, *shortClone;
-    jint *intOrig, *intClone;
-    jlong *longOrig, *longClone;
-    jfloat *floatOrig, *floatClone;
-    jdouble *doubleOrig, *doubleClone;
-    int i;
+  static volatile long count = 0;
+  jarray *arrayOrig, *arrayClone;
+  jboolean *boolOrig, *boolClone;
+  jbyte *byteOrig, *byteClone;
+  jchar *charOrig, *charClone;
+  jshort *shortOrig, *shortClone;
+  jint *intOrig, *intClone;
+  jlong *longOrig, *longClone;
+  jfloat *floatOrig, *floatClone;
+  jdouble *doubleOrig, *doubleClone;
+  int i;
 
-    if ((orig == NULL) || (clone == NULL)) {
-    fprintf(stderr,"JNI received a NULL array from Java\n");
+  if ((orig == NULL) || (clone == NULL)) {
+    fprintf(stderr, "JNI received a NULL array from Java\n");
     return JNI_FALSE;
-    }
-    if (count == limit) {
+  }
+  if (count == limit) {
     jclass clazz;
     const char *classname = "nsk/stress/jni/JNIter003";
     const char *setdone = "halt";
@@ -152,113 +153,113 @@ Java_nsk_stress_jni_JNIter003_jniBodyChangeArray (JNIEnv *env, jobject jobj,
     jmethodID jmethod;
 
     fprintf(stderr, "Count and limit are: %ld\t%d cons.\n", count, limit);
-    clazz=env->FindClass(classname); CE
-        jmethod=env->GetMethodID(clazz, setdone, setdonesig); CE
-        env->CallVoidMethod(jobj, jmethod); CE
+    clazz = env->FindClass(classname); CE
+    jmethod = env->GetMethodID(clazz, setdone, setdonesig); CE
+    env->CallVoidMethod(jobj, jmethod); CE
 
     return JNI_TRUE;
-    }
-    env->MonitorEnter(jobj); CE
-    ++count;
-    env->MonitorExit(jobj); CE
-    arrayOrig=(jarray *)malloc(8*sizeof(jarray));
-    arrayClone=(jarray *)malloc(8*sizeof(jarray));
-    for (i=0;i<8;i++) {
-    arrayOrig[i]=(jarray) env->GetObjectArrayElement(orig,i); CE
-    arrayClone[i]=(jarray) env->GetObjectArrayElement(clone,i); CE
-    }
+  }
+  CHECK(env->MonitorEnter(jobj));
+  ++count;
+  CHECK(env->MonitorExit(jobj));
+  arrayOrig = (jarray *)c_malloc(env, 8 * sizeof(jarray));
+  arrayClone = (jarray *)c_malloc(env, 8 * sizeof(jarray));
+  for (i = 0; i < 8; i++) {
+    arrayOrig[i] = (jarray) env->GetObjectArrayElement(orig, i); CE
+    arrayClone[i] = (jarray) env->GetObjectArrayElement(clone, i); CE
+  }
 
-    /* Take the elements from Java arrays into native buffers */
-    /* Use Get<Type>ArrayElements */
-    boolOrig = env->GetBooleanArrayElements((jbooleanArray) arrayOrig[BOOL],0); CE
-    byteOrig = env->GetByteArrayElements((jbyteArray) arrayOrig[BYTE],0); CE
-    charOrig = env->GetCharArrayElements((jcharArray) arrayOrig[CHAR],0); CE
-    shortOrig = env->GetShortArrayElements((jshortArray) arrayOrig[SHORT],0); CE
-    intOrig = env->GetIntArrayElements((jintArray) arrayOrig[INT],0); CE
-    longOrig = env->GetLongArrayElements((jlongArray) arrayOrig[LONG],0); CE
-    floatOrig = env->GetFloatArrayElements((jfloatArray) arrayOrig[FLOAT],0); CE
-    doubleOrig = env->GetDoubleArrayElements((jdoubleArray) arrayOrig[DOUBLE],0); CE
+  /* Take the elements from Java arrays into native buffers */
+  /* Use Get<Type>ArrayElements */
+  boolOrig = env->GetBooleanArrayElements((jbooleanArray) arrayOrig[BOOL], 0); CE
+  byteOrig = env->GetByteArrayElements((jbyteArray) arrayOrig[BYTE], 0); CE
+  charOrig = env->GetCharArrayElements((jcharArray) arrayOrig[CHAR], 0); CE
+  shortOrig = env->GetShortArrayElements((jshortArray) arrayOrig[SHORT], 0); CE
+  intOrig = env->GetIntArrayElements((jintArray) arrayOrig[INT], 0); CE
+  longOrig = env->GetLongArrayElements((jlongArray) arrayOrig[LONG], 0); CE
+  floatOrig = env->GetFloatArrayElements((jfloatArray) arrayOrig[FLOAT], 0); CE
+  doubleOrig = env->GetDoubleArrayElements((jdoubleArray) arrayOrig[DOUBLE], 0); CE
 
-    /* Alloc some memory for cloned arrays buffers */
-    boolClone=(jboolean *)malloc(SIZE(BOOL)*sizeof(jboolean));
-    byteClone=(jbyte *)malloc(SIZE(BYTE)*sizeof(jbyte));
-    charClone=(jchar *)malloc(SIZE(CHAR)*sizeof(jchar));
-    shortClone=(jshort *)malloc(SIZE(SHORT)*sizeof(jshort));
-    intClone=(jint *)malloc(SIZE(INT)*sizeof(jint));
-    longClone=(jlong *)malloc(SIZE(LONG)*sizeof(jlong));
-    floatClone=(jfloat *)malloc(SIZE(FLOAT)*sizeof(jfloat));
-    doubleClone=(jdouble *)malloc(SIZE(DOUBLE)*sizeof(jdouble));
+  /* Alloc some memory for cloned arrays buffers */
+  boolClone = (jboolean *)c_malloc(env, SIZE(BOOL) * sizeof(jboolean));
+  byteClone = (jbyte *)c_malloc(env, SIZE(BYTE) * sizeof(jbyte));
+  charClone = (jchar *)c_malloc(env, SIZE(CHAR) * sizeof(jchar));
+  shortClone = (jshort *)c_malloc(env, SIZE(SHORT) * sizeof(jshort));
+  intClone = (jint *)c_malloc(env, SIZE(INT) * sizeof(jint));
+  longClone = (jlong *)c_malloc(env, SIZE(LONG) * sizeof(jlong));
+  floatClone = (jfloat *)c_malloc(env, SIZE(FLOAT) * sizeof(jfloat));
+  doubleClone = (jdouble *)c_malloc(env, SIZE(DOUBLE) * sizeof(jdouble));
 
   /* Take the elements from cloned Java arrays into native buffers */
   /* Use Get<Type>ArrayRegion */
-    env->GetBooleanArrayRegion((jbooleanArray) arrayClone[BOOL],0,SIZE(BOOL),boolClone); CE
-    env->GetByteArrayRegion((jbyteArray) arrayClone[BYTE],0,SIZE(BYTE),byteClone); CE
-    env->GetCharArrayRegion((jcharArray) arrayClone[CHAR],0,SIZE(CHAR),charClone); CE
-    env->GetShortArrayRegion((jshortArray) arrayClone[SHORT],0,SIZE(SHORT),shortClone); CE
-    env->GetIntArrayRegion((jintArray) arrayClone[INT],0,SIZE(INT),intClone); CE
-    env->GetLongArrayRegion((jlongArray) arrayClone[LONG],0,SIZE(LONG),longClone); CE
-    env->GetFloatArrayRegion((jfloatArray) arrayClone[FLOAT],0,SIZE(FLOAT),floatClone); CE
-    env->GetDoubleArrayRegion((jdoubleArray) arrayClone[DOUBLE],0,SIZE(DOUBLE),doubleClone); CE
+  env->GetBooleanArrayRegion((jbooleanArray) arrayClone[BOOL], 0, SIZE(BOOL), boolClone); CE
+  env->GetByteArrayRegion((jbyteArray) arrayClone[BYTE], 0, SIZE(BYTE), byteClone); CE
+  env->GetCharArrayRegion((jcharArray) arrayClone[CHAR], 0, SIZE(CHAR), charClone); CE
+  env->GetShortArrayRegion((jshortArray) arrayClone[SHORT], 0, SIZE(SHORT), shortClone); CE
+  env->GetIntArrayRegion((jintArray) arrayClone[INT], 0, SIZE(INT), intClone); CE
+  env->GetLongArrayRegion((jlongArray) arrayClone[LONG], 0, SIZE(LONG), longClone); CE
+  env->GetFloatArrayRegion((jfloatArray) arrayClone[FLOAT], 0, SIZE(FLOAT), floatClone); CE
+  env->GetDoubleArrayRegion((jdoubleArray) arrayClone[DOUBLE], 0, SIZE(DOUBLE), doubleClone); CE
 
   /* In this code section I should make some changes for elements into both */
   /* (original and cloned) arrays and than copied new values back to Java */
 
-/*
-Can't change the pointer into the Java structure.  It's illegal JNI.
-    SWAP(boolOrig,boolClone)
-    SWAP(byteOrig,byteClone)
-    SWAP(charOrig,charClone)
-    SWAP(shortOrig,shortClone)
-    SWAP(intOrig,intClone)
-    SWAP(longOrig,longClone)
-    SWAP(floatOrig,floatClone)
-    SWAP(doubleOrig,doubleClone)
-*/
+  /*
+    Can't change the pointer into the Java structure.  It's illegal JNI.
+    SWAP(boolOrig, boolClone)
+    SWAP(byteOrig, byteClone)
+    SWAP(charOrig, charClone)
+    SWAP(shortOrig, shortClone)
+    SWAP(intOrig, intClone)
+    SWAP(longOrig, longClone)
+    SWAP(floatOrig, floatClone)
+    SWAP(doubleOrig, doubleClone)
+  */
 
-    /* Coping new values of elements back to Java and releasing native buffers */
-    /* Use Set<Type>ArrayRegion */
-/*
-Use Orig pointers to get the original effect of the test.
-    env->SetBooleanArrayRegion(arrayClone[BOOL],0,SIZE(BOOL),boolClone);
-    env->SetByteArrayRegion(arrayClone[BYTE],0,SIZE(BYTE),byteClone);
-    env->SetCharArrayRegion(arrayClone[CHAR],0,SIZE(CHAR),charClone);
-    env->SetShortArrayRegion(arrayClone[SHORT],0,SIZE(SHORT),shortClone);
-    env->SetIntArrayRegion(arrayClone[INT],0,SIZE(INT),intClone);
-    env->SetLongArrayRegion(arrayClone[LONG],0,SIZE(LONG),longClone);
-    env->SetFloatArrayRegion(arrayClone[FLOAT],0,SIZE(FLOAT),floatClone);
-    env->SetDoubleArrayRegion(arrayClone[DOUBLE],0,SIZE(DOUBLE),doubleClone);
-*/
-    env->SetBooleanArrayRegion((jbooleanArray) arrayClone[BOOL],0,SIZE(BOOL),boolOrig); CE
-    env->SetByteArrayRegion((jbyteArray) arrayClone[BYTE],0,SIZE(BYTE),byteOrig); CE
-    env->SetCharArrayRegion((jcharArray) arrayClone[CHAR],0,SIZE(CHAR),charOrig); CE
-    env->SetShortArrayRegion((jshortArray) arrayClone[SHORT],0,SIZE(SHORT),shortOrig); CE
-    env->SetIntArrayRegion((jintArray) arrayClone[INT],0,SIZE(INT),intOrig); CE
-    env->SetLongArrayRegion((jlongArray) arrayClone[LONG],0,SIZE(LONG),longOrig); CE
-    env->SetFloatArrayRegion((jfloatArray) arrayClone[FLOAT],0,SIZE(FLOAT),floatOrig); CE
-    env->SetDoubleArrayRegion((jdoubleArray) arrayClone[DOUBLE],0,SIZE(DOUBLE),doubleOrig); CE
+  /* Coping new values of elements back to Java and releasing native buffers */
+  /* Use Set<Type>ArrayRegion */
+  /*
+    Use Orig pointers to get the original effect of the test.
+    env->SetBooleanArrayRegion(arrayClone[BOOL], 0,SIZE(BOOL), boolClone);
+    env->SetByteArrayRegion(arrayClone[BYTE], 0,SIZE(BYTE), byteClone);
+    env->SetCharArrayRegion(arrayClone[CHAR], 0,SIZE(CHAR), charClone);
+    env->SetShortArrayRegion(arrayClone[SHORT], 0,SIZE(SHORT), shortClone);
+    env->SetIntArrayRegion(arrayClone[INT], 0,SIZE(INT), intClone);
+    env->SetLongArrayRegion(arrayClone[LONG], 0,SIZE(LONG), longClone);
+    env->SetFloatArrayRegion(arrayClone[FLOAT], 0,SIZE(FLOAT), floatClone);
+    env->SetDoubleArrayRegion(arrayClone[DOUBLE], 0,SIZE(DOUBLE), doubleClone);
+  */
+  env->SetBooleanArrayRegion((jbooleanArray) arrayClone[BOOL], 0, SIZE(BOOL), boolOrig); CE
+  env->SetByteArrayRegion((jbyteArray) arrayClone[BYTE], 0, SIZE(BYTE), byteOrig); CE
+  env->SetCharArrayRegion((jcharArray) arrayClone[CHAR], 0, SIZE(CHAR), charOrig); CE
+  env->SetShortArrayRegion((jshortArray) arrayClone[SHORT], 0, SIZE(SHORT), shortOrig); CE
+  env->SetIntArrayRegion((jintArray) arrayClone[INT], 0, SIZE(INT), intOrig); CE
+  env->SetLongArrayRegion((jlongArray) arrayClone[LONG], 0, SIZE(LONG), longOrig); CE
+  env->SetFloatArrayRegion((jfloatArray) arrayClone[FLOAT], 0, SIZE(FLOAT), floatOrig); CE
+  env->SetDoubleArrayRegion((jdoubleArray) arrayClone[DOUBLE], 0, SIZE(DOUBLE), doubleOrig); CE
 
-    /* Use Release<Type>ArrayElements */
-    env->ReleaseDoubleArrayElements((jdoubleArray) arrayOrig[DOUBLE],doubleOrig,0); CE
-    env->ReleaseFloatArrayElements((jfloatArray) arrayOrig[FLOAT],floatOrig,0); CE
-    env->ReleaseLongArrayElements((jlongArray) arrayOrig[LONG],longOrig,0); CE
-    env->ReleaseIntArrayElements((jintArray) arrayOrig[INT],intOrig,0); CE
-    env->ReleaseShortArrayElements((jshortArray) arrayOrig[SHORT],shortOrig,0); CE
-    env->ReleaseCharArrayElements((jcharArray) arrayOrig[CHAR],charOrig,0); CE
-    env->ReleaseByteArrayElements((jbyteArray) arrayOrig[BYTE],byteOrig,0); CE
-    env->ReleaseBooleanArrayElements((jbooleanArray) arrayOrig[BOOL],boolOrig,0); CE
-    free(arrayOrig);
+  /* Use Release<Type>ArrayElements */
+  env->ReleaseDoubleArrayElements((jdoubleArray) arrayOrig[DOUBLE], doubleOrig, 0); CE
+  env->ReleaseFloatArrayElements((jfloatArray) arrayOrig[FLOAT], floatOrig, 0); CE
+  env->ReleaseLongArrayElements((jlongArray) arrayOrig[LONG], longOrig, 0); CE
+  env->ReleaseIntArrayElements((jintArray) arrayOrig[INT], intOrig, 0); CE
+  env->ReleaseShortArrayElements((jshortArray) arrayOrig[SHORT], shortOrig, 0); CE
+  env->ReleaseCharArrayElements((jcharArray) arrayOrig[CHAR], charOrig, 0); CE
+  env->ReleaseByteArrayElements((jbyteArray) arrayOrig[BYTE], byteOrig, 0); CE
+  env->ReleaseBooleanArrayElements((jbooleanArray) arrayOrig[BOOL], boolOrig, 0); CE
+  free(arrayOrig);
 
-    free(doubleClone);
-    free(floatClone);
-    free(longClone);
-    free(intClone);
-    free(shortClone);
-    free(byteClone);
-    free(charClone);
-    free(boolClone);
-    free(arrayClone);
+  free(doubleClone);
+  free(floatClone);
+  free(longClone);
+  free(intClone);
+  free(shortClone);
+  free(byteClone);
+  free(charClone);
+  free(boolClone);
+  free(arrayClone);
 
-    return JNI_TRUE;
+  return JNI_TRUE;
 }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress004.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,139 +34,125 @@ extern "C" {
 JNIEXPORT jcharArray JNICALL
 Java_nsk_stress_jni_JNIter004_CheckSum (JNIEnv *env, jobject jobj, jstring jstr) {
 
-    unsigned char digest[DIGESTLENGTH];
-    jchar *tmp;
-    static jint upper = 0;
-    jcharArray jArr;
-    int i;
-    const jchar *critstr;
-    char *str;
-    jint len=env->GetStringUTFLength(jstr); CE
+  unsigned char digest[DIGESTLENGTH];
+  jchar *tmp;
+  static jint upper = 0;
+  jcharArray jArr;
+  int i;
+  const jchar *critstr;
+  char *str;
+  jint len = env->GetStringUTFLength(jstr); CE
 
-    for (i=0;i<DIGESTLENGTH;i++) {
-      digest[i]=0;
-    }
-    str=(char *)malloc(len*sizeof(char));
-/*     const char *threadName=env->GetStringUTFChars(jstr, 0); */
+  for (i = 0; i < DIGESTLENGTH; i++) {
+    digest[i] = 0;
+  }
+  str = (char *)c_malloc(env, len * sizeof(char));
+  /*     const char *threadName = env->GetStringUTFChars(jstr, 0); */
 
-    env->MonitorEnter(jobj); CE
-    if (upper == 0) tmp = (jchar *) malloc(DIGESTLENGTH*sizeof(char));
-    if (env->ExceptionOccurred()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-    }
-    critstr=env->GetStringCritical(jstr, 0); CE
-    for (i=0;i<len;i++)
+  CHECK(env->MonitorEnter(jobj));
+  if (upper == 0) {
+    tmp = (jchar *) c_malloc(env, DIGESTLENGTH * sizeof(char));
+  }
+  critstr = env->GetStringCritical(jstr, 0); CE
+  for (i = 0; i < len; i++) {
     str[i] = (char) critstr[i];
-    env->ReleaseStringCritical(jstr,critstr); CE
-    for (i=0;i<len;i++) {
-        digest[i % DIGESTLENGTH]+=str[i];
-    }
-    free(str);
-
-    if (env->ExceptionOccurred()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-    }
-    memcpy(tmp,digest,DIGESTLENGTH);
-    jArr=env->NewCharArray(DIGESTLENGTH/sizeof(jchar)); CE
-    len=env->GetArrayLength(jArr); CE
-    env->SetCharArrayRegion(jArr,0,len,tmp); CE
-/*     ++upper; */
-    env->MonitorExit(jobj); CE
-    return jArr;
+  }
+  env->ReleaseStringCritical(jstr, critstr); CE
+  for (i = 0; i < len; i++) {
+    digest[i % DIGESTLENGTH] += str[i];
+  }
+  free(str);
+  memcpy(tmp, digest, DIGESTLENGTH);
+  jArr = env->NewCharArray(DIGESTLENGTH / sizeof(jchar)); CE
+  len = env->GetArrayLength(jArr); CE
+  env->SetCharArrayRegion(jArr, 0, len, tmp); CE
+  /*     ++upper; */
+  CHECK(env->MonitorExit(jobj));
+  return jArr;
 }
 
 JNIEXPORT jboolean JNICALL
 Java_nsk_stress_jni_JNIter004_CheckCompare (JNIEnv *env, jobject jobj, jstring jstr,
-            jcharArray cArr, jint limit) {
+                                            jcharArray cArr, jint limit) {
 
-    unsigned char digest[DIGESTLENGTH];
-    jchar *tmp;
-/*     jcharArray jArr; */
-    const jchar *critstr;
-    jint strlen;
-    char *str;
-    jboolean ret=JNI_TRUE;
-    int i;
-    static jint upper = 0;
-    jint len;
-    jchar *ch;
+  unsigned char digest[DIGESTLENGTH];
+  jchar *tmp;
+  /*     jcharArray jArr; */
+  const jchar *critstr;
+  jint strlen;
+  char *str;
+  jboolean ret = JNI_TRUE;
+  int i;
+  static jint upper = 0;
+  jint len;
+  jchar *ch;
 
-    for (i=0;i<DIGESTLENGTH;i++) {
-      digest[i]=0;
-    }
-    strlen =  env->GetStringUTFLength(jstr); CE
-    str = (char *)malloc(strlen*sizeof(char));
+  for (i = 0; i < DIGESTLENGTH; i++) {
+    digest[i] = 0;
+  }
+  strlen =  env->GetStringUTFLength(jstr); CE
+  str = (char *)c_malloc(env, strlen * sizeof(char));
 
-    len =env->GetArrayLength(cArr); CE
+  len =env->GetArrayLength(cArr); CE
 
-    env->MonitorEnter(jobj); CE
-    if (upper>limit) {
-    env->MonitorExit(jobj); CE
+  CHECK(env->MonitorEnter(jobj));
+  if (upper > limit) {
+    CHECK(env->MonitorExit(jobj));
     return JNI_FALSE;
-    }
-    tmp=(jchar *)malloc(DIGESTLENGTH*sizeof(char));
-    if (env->ExceptionOccurred()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-    }
-    critstr=env->GetStringCritical(jstr, 0); CE
-    for (i=0;i<strlen;i++)
+  }
+  tmp = (jchar *)c_malloc(env, DIGESTLENGTH * sizeof(char));
+  critstr = env->GetStringCritical(jstr, 0); CE
+  for (i = 0; i < strlen; i++) {
     str[i] = (char) critstr[i];
-    env->ReleaseStringCritical(jstr,critstr); CE
-    for (i=0;i<strlen; i++) {
-      digest[i % DIGESTLENGTH]+=str[i % DIGESTLENGTH];
-    }
+  }
+  env->ReleaseStringCritical(jstr, critstr); CE
+  for (i = 0; i < strlen; i++) {
+    digest[i % DIGESTLENGTH] += str[i % DIGESTLENGTH];
+  }
+  free(str);
+  memcpy(tmp, digest, DIGESTLENGTH);
 
-    free(str);
+  /*     jArr = env->NewCharArray(DIGESTLENGTH/sizeof(jchar)); */
+  /*     len = env->GetArrayLength(jArr); */
+  /*     env->SetCharArrayRegion(jArr, 0, len, tmp); */
+  /*     ++upper; */
+  /*     env->MonitorExit(jobj); */
 
-    if (env->ExceptionOccurred()) {
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-    }
-    memcpy(tmp,digest,DIGESTLENGTH);
+  /* Compare  */
+  /*     env->MonitorEnter(jobj); */
 
-/*     jArr=env->NewCharArray(DIGESTLENGTH/sizeof(jchar)); */
-/*     len=env->GetArrayLength(jArr); */
-/*     env->SetCharArrayRegion(jArr,0,len,tmp); */
-/*     ++upper; */
-/*     env->MonitorExit(jobj); */
+  ch = (jchar *)env->GetPrimitiveArrayCritical(cArr, 0); CE
 
-/* Compare  */
-/*     env->MonitorEnter(jobj); */
-
-    ch=(jchar *)env->GetPrimitiveArrayCritical(cArr,0); CE
-
-    printf("Comparing: ");
-    for (i=0;i<len;i++)
+  printf("Comparing: ");
+  for (i = 0; i < len; i++) {
     if (ch[i] != tmp[i]) {
-        printf("Error in %d\n",i);
-        printf("ch[%d]=%02x tmp[%d]=%02x\n",i,ch[i],i,tmp[i]);
-        ret=JNI_FALSE;
+      printf("Error in %d\n", i);
+      printf("ch[%d] = %02x tmp[%d] = %02x\n", i, ch[i], i, tmp[i]);
+      ret = JNI_FALSE;
+    } else {
+      printf("ch[%d] = %02x tmp[%d] = %02x\n", i, ch[i], i, tmp[i]);
     }
-    else {
-        printf("ch[%d]=%02x tmp[%d]=%02x\n",i,ch[i],i,tmp[i]);
-    }
-    printf("\n");
-    env->ReleasePrimitiveArrayCritical(cArr,ch,0); CE
-    ++upper;
-    if (!(upper % 500))
-    fprintf(stderr,"There are %d elements now.\n", upper);
-    if (upper == limit) {
+  }
+  printf("\n");
+  env->ReleasePrimitiveArrayCritical(cArr, ch, 0); CE
+  ++upper;
+  if ((upper % 500) == 0) {
+    fprintf(stderr, "There are %d elements now.\n", upper);
+  }
+  if (upper == limit) {
     jclass clazz;
     jmethodID methodID;
-    char *name = (char*) "halt";
-    char *sig = (char*) "()V";
+    const char* name = "halt";
+    const char* sig = "()V";
 
-    clazz=env->GetObjectClass(jobj); CE
-    methodID=env->GetStaticMethodID(clazz, name, sig); CE
+    clazz = env->GetObjectClass(jobj); CE
+    methodID = env->GetStaticMethodID(clazz, name, sig); CE
     env->CallStaticVoidMethod(clazz, methodID); CE
     free(tmp);
-    ret=JNI_TRUE;
-    }
-    env->MonitorExit(jobj); CE
-    return ret;
+    ret = JNI_TRUE;
+  }
+  CHECK(env->MonitorExit(jobj));
+  return ret;
 }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress005.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,92 +24,86 @@
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "jnihelper.h"
 
 extern "C" {
 
-#define CHECK_EXCEPTION     { if (env->ExceptionOccurred()) { fprintf(stderr, "Unexpected exception:\n"); env->ExceptionDescribe(); env->ExceptionClear(); exit(97); } }
-
 JNIEXPORT void JNICALL
 Java_nsk_stress_jni_JNIter005_except (JNIEnv *env, jobject jobj, jthrowable tobj) {
-    jclass clazz;
-    static int Exceptcalls=0;
-    const char *name;
-    const char *mess;
-    jmethodID jmethod;
-    const char *iter = "nsk/stress/jni/JNIter005";
-//    const char *inc = "nsk/stress/jni/jnistress005/incCount";
-    const char *incSig = "()V";
-    const char *fldName = "counts";
-    const char *fldSig = "I";
+  jclass clazz;
+  static int Exceptcalls = 0;
+  const char *name;
+  const char *mess;
+  jmethodID jmethod;
+  const char *iter = "nsk/stress/jni/JNIter005";
+  //    const char *inc = "nsk/stress/jni/jnistress005/incCount";
+  const char *incSig = "()V";
+  const char *fldName = "counts";
+  const char *fldSig = "I";
 
-/*     incClazz = env->FindClass(iter); */
-/*     CHECK_EXCEPTION */
-/*     jmethod=env->GetStaticMethodID(incClazz, inc, incSig); */
-/*     CHECK_EXCEPTION */
-/*     env->CallStaticVoidMethod(incClazz, jmethod); */
-/*     CHECK_EXCEPTION */
-/*     jfld = env->GetFieldID(incClazz, fldName, fldSig); */
-/*     printf("JNI: Count is %d\n", env->GetIntField(jobj, jfld)); */
-/*     CHECK_EXCEPTION */
+  /*     incClazz = env->FindClass(iter); */
+  /*     jmethod = env->GetStaticMethodID(incClazz, inc, incSig); */
+  /*     env->CallStaticVoidMethod(incClazz, jmethod); */
+  /*     jfld = env->GetFieldID(incClazz, fldName, fldSig); */
+  /*     printf("JNI: Count is %d\n", env->GetIntField(jobj, jfld)); */
 
-    env->MonitorEnter(jobj);
-    CHECK_EXCEPTION
-    if (!env->Throw(tobj)) {
-    if (env->ExceptionOccurred())
-        if (Exceptcalls % 1000 == 0)
-        fprintf(stderr, "NATIVE: Throw has been catched in native\n");
+  CHECK(env->MonitorEnter(jobj));
+
+  if (env->Throw(tobj) == 0) {
+    if (env->ExceptionOccurred()) {
+      if (Exceptcalls % 1000 == 0) {
+        fprintf(stderr, "NATIVE: Throw has been caught in native\n");
+      }
+    }
     env->ExceptionClear();
     ++Exceptcalls;
-    } else fprintf(stderr, "Throw failed\n");
+  } else {
+    fprintf(stderr, "Throw failed\n");
+  }
 
-    env->MonitorExit(jobj);
-    CHECK_EXCEPTION
+  CHECK(env->MonitorExit(jobj));
 
-    switch (Exceptcalls % 23) {
-      case 0: name="java/lang/ArithmeticException"; break;
-      case 1: name="java/lang/ArrayIndexOutOfBoundsException"; break;
-      case 2: name="java/lang/ArrayStoreException"; break;
-      case 3: name="java/lang/ClassCastException"; break;
-      case 4: name="java/lang/ClassNotFoundException"; break;
-      case 5: name="java/lang/CloneNotSupportedException"; break;
-      case 6: name="java/lang/IllegalAccessException"; break;
-      case 7: name="java/lang/IllegalArgumentException"; break;
-      case 8: name="java/lang/IllegalMonitorStateException"; break;
-      case 9: name="java/lang/IllegalStateException"; break;
-      case 10: name="java/lang/IllegalThreadStateException"; break;
-      case 11: name="java/lang/IndexOutOfBoundsException"; break;
-      case 12: name="java/lang/InstantiationException"; break;
-      case 13: name="java/lang/InterruptedException"; break;
-      case 14: name="java/lang/NegativeArraySizeException"; break;
-      case 15: name="java/lang/NoSuchFieldException"; break;
-      case 16: name="java/lang/NoSuchMethodException"; break;
-      case 17: name="java/lang/NullPointerException"; break;
-      case 18: name="java/lang/NumberFormatException"; break;
-      case 19: name="java/lang/RuntimeException"; break;
-      case 20: name="java/lang/SecurityException"; break;
-      case 21: name="java/lang/StringIndexOutOfBoundsException"; break;
-      case 22: name="java/lang/UnsupportedOperationException"; break;
-      default: name="java/lang/Exception";
-    }
-    mess=name;
+  switch (Exceptcalls % 23) {
+  case 0: name = "java/lang/ArithmeticException"; break;
+  case 1: name = "java/lang/ArrayIndexOutOfBoundsException"; break;
+  case 2: name = "java/lang/ArrayStoreException"; break;
+  case 3: name = "java/lang/ClassCastException"; break;
+  case 4: name = "java/lang/ClassNotFoundException"; break;
+  case 5: name = "java/lang/CloneNotSupportedException"; break;
+  case 6: name = "java/lang/IllegalAccessException"; break;
+  case 7: name = "java/lang/IllegalArgumentException"; break;
+  case 8: name = "java/lang/IllegalMonitorStateException"; break;
+  case 9: name = "java/lang/IllegalStateException"; break;
+  case 10: name = "java/lang/IllegalThreadStateException"; break;
+  case 11: name = "java/lang/IndexOutOfBoundsException"; break;
+  case 12: name = "java/lang/InstantiationException"; break;
+  case 13: name = "java/lang/InterruptedException"; break;
+  case 14: name = "java/lang/NegativeArraySizeException"; break;
+  case 15: name = "java/lang/NoSuchFieldException"; break;
+  case 16: name = "java/lang/NoSuchMethodException"; break;
+  case 17: name = "java/lang/NullPointerException"; break;
+  case 18: name = "java/lang/NumberFormatException"; break;
+  case 19: name = "java/lang/RuntimeException"; break;
+  case 20: name = "java/lang/SecurityException"; break;
+  case 21: name = "java/lang/StringIndexOutOfBoundsException"; break;
+  case 22: name = "java/lang/UnsupportedOperationException"; break;
+  default: name = "java/lang/Exception";
+  }
+  mess = name;
 
-    CHECK_EXCEPTION
-    clazz = env->FindClass(name);
-    CHECK_EXCEPTION
-    if (env->ThrowNew(clazz, mess)) {
-      const char *pass = "setpass";
-      const char *passSig = "(Z)V";
-      jclass incClazz;
-      fprintf(stderr, "ThrowNew failed\n");
-      CHECK_EXCEPTION;
-      incClazz = env->FindClass(iter);
-      CHECK_EXCEPTION;
-      jmethod=env->GetStaticMethodID(incClazz, pass, passSig);
-      CHECK_EXCEPTION
-      env->CallStaticVoidMethod(incClazz, jmethod, JNI_FALSE);
-      CHECK_EXCEPTION
-    }
-/*     printf("JNI: count %d\n", Exceptcalls); */
+  clazz = env->FindClass(name); CE
+  if (env->ThrowNew(clazz, mess) != 0) {
+    const char *pass = "setpass";
+    const char *passSig = "(Z)V";
+    jclass incClazz;
+    fprintf(stderr, "ThrowNew failed\n");
+    CE;
+    // ThrowNew failed but didn't itself raise an exception
+    incClazz = env->FindClass(iter); CE
+    jmethod=env->GetStaticMethodID(incClazz, pass, passSig); CE
+    env->CallStaticVoidMethod(incClazz, jmethod, JNI_FALSE); CE
+  }
+  /*     printf("JNI: count %d\n", Exceptcalls); */
 }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress006.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,58 +31,59 @@ extern "C" {
 JNIEXPORT jboolean JNICALL
 Java_nsk_stress_jni_JNIter006_refs (JNIEnv *env, jobject jobj, jobject tobj, jint LIMIT) {
 
-    static jobject *globRefsArray = 0;
-    static int upper = 0;
+  static jobject *globRefsArray = 0;
+  static int upper = 0;
 
-    jclass clazz;
-    jmethodID jmethod;
-    jboolean res=JNI_FALSE;
-    const char *classname = "nsk/stress/jni/JNIter006";
-    const char *getmethodname="get_i";
-    const char *setmethodname="set_i";
-    const char *getsig="()I";
-    const char *setsig="(I)V";
-    const char *setdone = "halt";
-    const char *setdonesig = "()V";
-    int i = 0;
+  jclass clazz;
+  jmethodID jmethod;
+  jboolean res = JNI_FALSE;
+  const char *classname = "nsk/stress/jni/JNIter006";
+  const char *getmethodname = "get_i";
+  const char *setmethodname = "set_i";
+  const char *getsig = "()I";
+  const char *setsig = "(I)V";
+  const char *setdone = "halt";
+  const char *setdonesig = "()V";
+  int i = 0;
 
-    if (upper >= LIMIT) return JNI_TRUE;
+  if (upper >= LIMIT) {
+    return JNI_TRUE;
+  }
 
-    if (upper == 0) {
-        globRefsArray=(jobject*)(malloc(LIMIT*sizeof(jobject)));
-    }
+  if (upper == 0) {
+    globRefsArray = (jobject*)c_malloc(env, LIMIT * sizeof(jobject));
+  }
 
-    globRefsArray[upper]=env->NewGlobalRef(tobj); CE
-    if (env->IsSameObject(tobj, globRefsArray[upper])) {
+  globRefsArray[upper] = env->NewGlobalRef(tobj); CE
+  if (env->IsSameObject(tobj, globRefsArray[upper])) {
     env->DeleteLocalRef(tobj); CE
-    clazz=env->GetObjectClass(globRefsArray[upper]); CE
-    }
-    else {
-    fprintf(stderr,"Objects are different\n");
-    env->MonitorExit(jobj); CE
+    clazz = env->GetObjectClass(globRefsArray[upper]); CE
+  } else {
+    fprintf(stderr, "Objects are different\n");
+    CHECK(env->MonitorExit(jobj));
     return res;
-    }
-    jmethod=env->GetStaticMethodID(clazz, setmethodname, setsig); CE
-    env->CallStaticVoidMethod(clazz, jmethod, (jint)upper); CE
-    env->MonitorEnter(jobj); CE
-    ++upper;
-    res=JNI_TRUE;
-    env->MonitorExit(jobj); CE
-/* If upper == LIMIT than flush ref's array and set */
-/* 'done' flag in JNIter006 class to JNI_TRUE */
-    if (upper == LIMIT) {
-    fprintf(stderr,"\n\tTotal memory allocated: %zd bytes\n",
-        LIMIT*sizeof(jobject));
-    clazz=env->FindClass(classname); CE
-    jmethod=env->GetMethodID(clazz, setdone, setdonesig); CE
+  }
+  jmethod = env->GetStaticMethodID(clazz, setmethodname, setsig); CE
+  env->CallStaticVoidMethod(clazz, jmethod, (jint)upper); CE
+  CHECK(env->MonitorEnter(jobj));
+  ++upper;
+  res = JNI_TRUE;
+  CHECK(env->MonitorExit(jobj));
+  /* If upper == LIMIT than flush ref's array and set */
+  /* 'done' flag in JNIter006 class to JNI_TRUE */
+  if (upper == LIMIT) {
+    fprintf(stderr, "\n\tTotal memory allocated: %zd bytes\n",
+            LIMIT * sizeof(jobject));
+    clazz = env->FindClass(classname); CE
+    jmethod = env->GetMethodID(clazz, setdone, setdonesig); CE
     env->CallVoidMethod(jobj, jmethod); CE
 
-    for (i=0;i<LIMIT;i++) {
-        env->DeleteGlobalRef(globRefsArray[i]); CE
+    for (i = 0; i < LIMIT; i++) {
+      env->DeleteGlobalRef(globRefsArray[i]); CE
     }
-        free(globRefsArray);
-    }
-    return res;
+    free(globRefsArray);
+  }
+  return res;
 }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/libjnistress007.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,20 +29,20 @@ extern "C" {
 
 JNIEXPORT void JNICALL
 Java_nsk_stress_jni_JNIter007_incCount (JNIEnv *env, jobject jobj, jstring name) {
-    jclass clazz;
-    jfieldID fld;
-    jint value;
-    const char *str = env->GetStringUTFChars(name, 0); CE
+  jclass clazz;
+  jfieldID fld;
+  jint value;
+  const char *str = env->GetStringUTFChars(name, 0); CE
 
-    if (env->MonitorEnter(jobj))
-        printf("Error in monitor lock\n");
-    clazz = env->GetObjectClass(jobj); CE
-    fld = env->GetStaticFieldID(clazz, "nativeCount", "I"); CE
-    value = env->GetStaticIntField(clazz, fld); CE
-    env->SetStaticIntField(clazz, fld, (jint)(++value)); CE
-    env->MonitorExit(jobj); CE
-    if (value % 1000 == 0)
-        printf("in %s Count after %u\n", str, value);
+  CHECK(env->MonitorEnter(jobj));
+  clazz = env->GetObjectClass(jobj); CE
+  fld = env->GetStaticFieldID(clazz, "nativeCount", "I"); CE
+  value = env->GetStaticIntField(clazz, fld); CE
+  env->SetStaticIntField(clazz, fld, (jint)(++value)); CE
+  CHECK(env->MonitorExit(jobj));
+  if (value % 1000 == 0) {
+    printf("in %s Count after %u\n", str, value);
+  }
 }
 
 }


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8212961](https://bugs.openjdk.org/browse/JDK-8212961): [TESTBUG] vmTestbase/nsk/stress/jni/ native code cleanup


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1010/head:pull/1010` \
`$ git checkout pull/1010`

Update a local copy of the PR: \
`$ git checkout pull/1010` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1010`

View PR using the GUI difftool: \
`$ git pr show -t 1010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1010.diff">https://git.openjdk.org/jdk17u-dev/pull/1010.diff</a>

</details>
