### PR TITLE
8270156: Add "randomness" and "stress" keys to JTreg tests which use StressGCM, StressLCM and/or StressIGVN

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestStressOptions.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestStressOptions.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8252219 8256535
  * @requires vm.compiler2.enabled
  * @summary Tests that different combinations of stress options and
@@ -53,4 +54,3 @@ public class TestStressOptions {
         System.out.println("Passed");
     }
 }
-

--- a/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7179138_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Skip Balk.  All Rights Reserved.
+ * Copyright 2012, 2021, Skip Balk.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @key stress randomness
  * @bug 7179138 8271341
  * @summary Incorrect result with String concatenation optimization
  *

--- a/test/hotspot/jtreg/compiler/c2/TestJumpTable.java
+++ b/test/hotspot/jtreg/compiler/c2/TestJumpTable.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key stress randomness
  * @bug 8229855 8238812
  * @summary Test jump table with key value that gets out of bounds after loop unrolling.
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/debug/TestGenerateStressSeed.java
+++ b/test/hotspot/jtreg/compiler/debug/TestGenerateStressSeed.java
@@ -29,6 +29,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8252219 8256535
  * @requires vm.compiler2.enabled
  * @summary Tests that using a stress option without -XX:StressSeed=N generates

--- a/test/hotspot/jtreg/compiler/debug/TestStressCM.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressCM.java
@@ -29,6 +29,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8253765
  * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Tests that, when compiling with StressLCM or StressGCM, using the

--- a/test/hotspot/jtreg/compiler/debug/TestStressIGVNAndCCP.java
+++ b/test/hotspot/jtreg/compiler/debug/TestStressIGVNAndCCP.java
@@ -29,6 +29,7 @@ import jdk.test.lib.Asserts;
 
 /*
  * @test
+ * @key stress randomness
  * @bug 8252219 8256535
  * @requires vm.debug == true & vm.compiler2.enabled
  * @summary Tests that stress compilations with the same seed yield the same

--- a/test/hotspot/jtreg/compiler/exceptions/TestSpilling.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestSpilling.java
@@ -25,6 +25,7 @@ package compiler.exceptions;
 
 /**
  * @test
+ * @key stress randomness
  * @bug 8263227
  * @summary Tests that users of return values from exception-throwing method
  *          calls are not duplicated in the call's exception path. The second

--- a/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLostDependencyOnZeroTripGuard.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @key stress randomness
  * @bug 8263971
  * @summary C2 crashes with SIGFPE with -XX:+StressGCM and -XX:+StressIGVN
  *


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270156](https://bugs.openjdk.org/browse/JDK-8270156): Add "randomness" and "stress" keys to JTreg tests which use StressGCM, StressLCM and/or StressIGVN


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1011/head:pull/1011` \
`$ git checkout pull/1011`

Update a local copy of the PR: \
`$ git checkout pull/1011` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1011`

View PR using the GUI difftool: \
`$ git pr show -t 1011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1011.diff">https://git.openjdk.org/jdk17u-dev/pull/1011.diff</a>

</details>
