### PR TITLE
8258512: serviceability/sa/TestJmapCore.java timed out on macOS 10.13.6

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -26,7 +26,7 @@
  * @summary Test verifies that jhsdb jmap could generate heap dump from core when heap is full
  * @requires vm.hasSA
  * @library /test/lib
- * @run driver/timeout=240 TestJmapCore run heap
+ * @run driver/timeout=480 TestJmapCore run heap
  */
 
 import java.io.File;


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258512](https://bugs.openjdk.org/browse/JDK-8258512): serviceability/sa/TestJmapCore.java timed out on macOS 10.13.6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1012/head:pull/1012` \
`$ git checkout pull/1012`

Update a local copy of the PR: \
`$ git checkout pull/1012` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1012`

View PR using the GUI difftool: \
`$ git pr show -t 1012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1012.diff">https://git.openjdk.org/jdk17u-dev/pull/1012.diff</a>

</details>
