### PR TITLE
8280166: Extend java/lang/instrument/GetObjectSizeIntrinsicsTest.java test cases

### DIFF
--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2020, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,6 +264,39 @@
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest
  */
 
+/*
+ * @test
+ * @summary Test for fInst.getObjectSize with large arrays
+ * @library /test/lib
+ * @requires vm.bits == 64
+ * @requires vm.debug
+ * @requires os.maxMemory >= 10G
+ *
+ * @build sun.hotspot.WhiteBox
+ * @run build GetObjectSizeIntrinsicsTest
+ * @run shell MakeJAR.sh basicAgent
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ *
+ * @run main/othervm -Xmx8g
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -XX:ObjectAlignmentInBytes=32
+ *                   -Xint
+ *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
+ *
+ * @run main/othervm -Xmx8g
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -XX:ObjectAlignmentInBytes=32
+ *                   -Xbatch -XX:TieredStopAtLevel=1
+ *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
+ *
+ * @run main/othervm -Xmx8g
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
+ *                   -XX:ObjectAlignmentInBytes=32
+ *                   -Xbatch -XX:-TieredCompilation
+ *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
+ */
+
 import java.util.*;
 
 import jdk.test.lib.Platform;
@@ -271,18 +304,26 @@ import sun.hotspot.WhiteBox;
 
 public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase {
 
-    static final Boolean compressedOops = WhiteBox.getWhiteBox().getBooleanVMFlag("UseCompressedOops");
-    static final int REF_SIZE = (compressedOops == null || compressedOops == true) ?  4 : 8;
+    static final Boolean COMPRESSED_OOPS = WhiteBox.getWhiteBox().getBooleanVMFlag("UseCompressedOops");
+    static final long REF_SIZE = (COMPRESSED_OOPS == null || COMPRESSED_OOPS == true) ? 4 : 8;
 
     static final Long align = WhiteBox.getWhiteBox().getIntxVMFlag("ObjectAlignmentInBytes");
     static final int OBJ_ALIGN = (align == null ? 8 : align.intValue());
 
-    public GetObjectSizeIntrinsicsTest(String name) {
+    static final int SMALL_ARRAY_SIZE = 1024;
+
+    // With int[] arrays, this overflows 4G boundary
+    static final int LARGE_ARRAY_SIZE = 1024*1024*1024 + 1024;
+
+    final String mode;
+
+    public GetObjectSizeIntrinsicsTest(String name, String mode) {
         super(name);
+        this.mode = mode;
     }
 
     public static void main(String[] args)throws Throwable {
-        new GetObjectSizeIntrinsicsTest(args[0]).runTest();
+        new GetObjectSizeIntrinsicsTest(args[0], (args.length >= 2 ? args[1] : "")).runTest();
     }
 
     public static final int ITERS = 200_000;
@@ -312,30 +353,35 @@ public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase 
         testSize_localObject();
         testSize_fieldObject();
 
-        testSize_newSmallByteArray();
-        testSize_localSmallByteArray();
-        testSize_fieldSmallByteArray();
+        testSize_newSmallIntArray();
+        testSize_localSmallIntArray();
+        testSize_fieldSmallIntArray();
 
         testSize_newSmallObjArray();
         testSize_localSmallObjArray();
         testSize_fieldSmallObjArray();
 
+        if (mode.equals("large")) {
+            testSize_localLargeIntArray();
+            testSize_localLargeObjArray();
+        }
+
         testNulls();
     }
 
-    private static int roundUp(int v, int a) {
+    private static long roundUp(long v, long a) {
         return (v + a - 1) / a * a;
     }
 
     private void testSize_newObject() {
-        int expected = roundUp(Platform.is64bit() ? 16 : 8, OBJ_ALIGN);
+        long expected = roundUp(Platform.is64bit() ? 16 : 8, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(new Object()));
         }
     }
 
     private void testSize_localObject() {
-        int expected = roundUp(Platform.is64bit() ? 16 : 8, OBJ_ALIGN);
+        long expected = roundUp(Platform.is64bit() ? 16 : 8, OBJ_ALIGN);
         Object o = new Object();
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(o));
@@ -345,57 +391,73 @@ public class GetObjectSizeIntrinsicsTest extends ASimpleInstrumentationTestCase 
     static Object staticO = new Object();
 
     private void testSize_fieldObject() {
-        int expected = roundUp(Platform.is64bit() ? 16 : 8, OBJ_ALIGN);
+        long expected = roundUp(Platform.is64bit() ? 16 : 8, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(staticO));
         }
     }
 
-    private void testSize_newSmallByteArray() {
-        int expected = roundUp(1024 + 16, OBJ_ALIGN);
+    private void testSize_newSmallIntArray() {
+        long expected = roundUp(4L*SMALL_ARRAY_SIZE + 16, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
-            assertEquals(expected, fInst.getObjectSize(new byte[1024]));
+            assertEquals(expected, fInst.getObjectSize(new int[SMALL_ARRAY_SIZE]));
         }
     }
 
-    private void testSize_localSmallByteArray() {
-        byte[] arr = new byte[1024];
-        int expected = roundUp(arr.length + 16, OBJ_ALIGN);
+    private void testSize_localSmallIntArray() {
+        int[] arr = new int[SMALL_ARRAY_SIZE];
+        long expected = roundUp(4L*SMALL_ARRAY_SIZE + 16, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(arr));
         }
     }
 
-    static byte[] smallArr = new byte[1024];
+    static int[] smallArr = new int[SMALL_ARRAY_SIZE];
 
-    private void testSize_fieldSmallByteArray() {
-        int expected = roundUp(smallArr.length + 16, OBJ_ALIGN);
+    private void testSize_fieldSmallIntArray() {
+        long expected = roundUp(4L*SMALL_ARRAY_SIZE + 16, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(smallArr));
         }
     }
 
     private void testSize_newSmallObjArray() {
-        int expected = roundUp(1024*REF_SIZE + 16, OBJ_ALIGN);
+        long expected = roundUp(REF_SIZE*SMALL_ARRAY_SIZE + 16, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
-            assertEquals(expected, fInst.getObjectSize(new Object[1024]));
+            assertEquals(expected, fInst.getObjectSize(new Object[SMALL_ARRAY_SIZE]));
         }
     }
 
     private void testSize_localSmallObjArray() {
-        Object[] arr = new Object[1024];
-        int expected = roundUp(arr.length*REF_SIZE + 16, OBJ_ALIGN);
+        Object[] arr = new Object[SMALL_ARRAY_SIZE];
+        long expected = roundUp(REF_SIZE*SMALL_ARRAY_SIZE + 16, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(arr));
         }
     }
 
-    static Object[] smallObjArr = new Object[1024];
+    static Object[] smallObjArr = new Object[SMALL_ARRAY_SIZE];
 
     private void testSize_fieldSmallObjArray() {
-        int expected = roundUp(smallArr.length*REF_SIZE + 16, OBJ_ALIGN);
+        long expected = roundUp(REF_SIZE*SMALL_ARRAY_SIZE + 16, OBJ_ALIGN);
         for (int c = 0; c < ITERS; c++) {
             assertEquals(expected, fInst.getObjectSize(smallObjArr));
+        }
+    }
+
+    private void testSize_localLargeIntArray() {
+        int[] arr = new int[LARGE_ARRAY_SIZE];
+        long expected = roundUp(4L*LARGE_ARRAY_SIZE + 16, OBJ_ALIGN);
+        for (int c = 0; c < ITERS; c++) {
+            assertEquals(expected, fInst.getObjectSize(arr));
+        }
+    }
+
+    private void testSize_localLargeObjArray() {
+        Object[] arr = new Object[LARGE_ARRAY_SIZE];
+        long expected = roundUp(REF_SIZE*LARGE_ARRAY_SIZE + 16, OBJ_ALIGN);
+        for (int c = 0; c < ITERS; c++) {
+            assertEquals(expected, fInst.getObjectSize(arr));
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280166](https://bugs.openjdk.org/browse/JDK-8280166): Extend java/lang/instrument/GetObjectSizeIntrinsicsTest.java test cases


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1013/head:pull/1013` \
`$ git checkout pull/1013`

Update a local copy of the PR: \
`$ git checkout pull/1013` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1013`

View PR using the GUI difftool: \
`$ git pr show -t 1013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1013.diff">https://git.openjdk.org/jdk17u-dev/pull/1013.diff</a>

</details>
