### PR TITLE
8295414: [Aarch64] C2: assert(false) failed: bad AD file

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4922,7 +4922,7 @@ operand iRegP()
   match(iRegP_R0);
   //match(iRegP_R2);
   //match(iRegP_R4);
-  //match(iRegP_R5);
+  match(iRegP_R5);
   match(thread_RegP);
   op_cost(0);
   format %{ %}

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +25,15 @@
 /**
  * @test
  * @bug 8253566
+ * @bug 8295414
  * @summary clazz.isAssignableFrom will return false for interface implementors
  * @requires vm.compiler2.enabled
  *
  * @run main/othervm -XX:-BackgroundCompilation TestSubTypeCheckMacroTrichotomy
+ * @run main/othervm -XX:-BackgroundCompilation
+ *     -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
+ *     -XX:-TieredCompilation -XX:CompileThreshold=100 TestSubTypeCheckMacroTrichotomy
  *
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295414](https://bugs.openjdk.org/browse/JDK-8295414): [Aarch64] C2: assert(false) failed: bad AD file


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1015/head:pull/1015` \
`$ git checkout pull/1015`

Update a local copy of the PR: \
`$ git checkout pull/1015` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1015`

View PR using the GUI difftool: \
`$ git pr show -t 1015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1015.diff">https://git.openjdk.org/jdk17u-dev/pull/1015.diff</a>

</details>
