### PR TITLE
8280553: resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java can fail if GC occurs

### DIFF
--- a/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeArray.java
+++ b/test/hotspot/jtreg/resourcehogs/serviceability/sa/LingeredAppWithLargeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,12 @@
 
 import jdk.test.lib.apps.LingeredApp;
 
+import java.lang.ref.Reference;
+
 public class LingeredAppWithLargeArray extends LingeredApp {
     public static void main(String args[]) {
         int[] hugeArray = new int[Integer.MAX_VALUE/2];
         LingeredApp.main(args);
+        Reference.reachabilityFence(hugeArray);
     }
  }


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280553](https://bugs.openjdk.org/browse/JDK-8280553): resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java can fail if GC occurs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1017/head:pull/1017` \
`$ git checkout pull/1017`

Update a local copy of the PR: \
`$ git checkout pull/1017` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1017`

View PR using the GUI difftool: \
`$ git pr show -t 1017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1017.diff">https://git.openjdk.org/jdk17u-dev/pull/1017.diff</a>

</details>
