### PR TITLE
8285835: SIGSEGV in PhaseIdealLoop::build_loop_late_post_work

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -240,7 +240,9 @@ bool ConnectionGraph::compute_escape() {
   // 3. Adjust scalar_replaceable state of nonescaping objects and push
   //    scalar replaceable allocations on alloc_worklist for processing
   //    in split_unique_types().
+  GrowableArray<JavaObjectNode*> jobj_worklist;
   int non_escaped_length = non_escaped_allocs_worklist.length();
+  bool found_nsr_alloc = false;
   for (int next = 0; next < non_escaped_length; next++) {
     JavaObjectNode* ptn = non_escaped_allocs_worklist.at(next);
     bool noescape = (ptn->escape_state() == PointsToNode::NoEscape);
@@ -251,8 +253,22 @@ bool ConnectionGraph::compute_escape() {
     if (noescape && ptn->scalar_replaceable()) {
       adjust_scalar_replaceable_state(ptn);
       if (ptn->scalar_replaceable()) {
-        alloc_worklist.append(ptn->ideal_node());
+        jobj_worklist.push(ptn);
+      } else {
+        found_nsr_alloc = true;
       }
+    }
+  }
+
+  // Propagate NSR (Not Scalar Replaceable) state.
+  if (found_nsr_alloc) {
+    find_scalar_replaceable_allocs(jobj_worklist);
+  }
+
+  for (int next = 0; next < jobj_worklist.length(); ++next) {
+    JavaObjectNode* jobj = jobj_worklist.at(next);
+    if (jobj->scalar_replaceable()) {
+      alloc_worklist.append(jobj->ideal_node());
     }
   }
 
@@ -1840,15 +1856,19 @@ void ConnectionGraph::adjust_scalar_replaceable_state(JavaObjectNode* jobj) {
         jobj->set_scalar_replaceable(false);
         return;
       }
-      // 2. An object is not scalar replaceable if the field into which it is
-      // stored has multiple bases one of which is null.
-      if (field->base_count() > 1) {
-        for (BaseIterator i(field); i.has_next(); i.next()) {
-          PointsToNode* base = i.get();
-          if (base == null_obj) {
-            jobj->set_scalar_replaceable(false);
-            return;
-          }
+      for (BaseIterator i(field); i.has_next(); i.next()) {
+        PointsToNode* base = i.get();
+        // 2. An object is not scalar replaceable if the field into which it is
+       // stored has multiple bases one of which is null.
+        if ((base == null_obj) && (field->base_count() > 1)) {
+          set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA "is stored into field with potentially null base"));
+          return;
+        }
+        // 2.5. An object is not scalar replaceable if the field into which it is
+        // stored has NSR base.
+        if (!base->scalar_replaceable()) {
+          set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA "is stored into field with NSR base"));
+          return;
         }
       }
     }
@@ -1932,6 +1952,36 @@ void ConnectionGraph::adjust_scalar_replaceable_state(JavaObjectNode* jobj) {
           // Mark all bases.
           jobj->set_scalar_replaceable(false);
           base->set_scalar_replaceable(false);
+        }
+      }
+    }
+  }
+}
+
+// Propagate NSR (Not scalar replaceable) state.
+void ConnectionGraph::find_scalar_replaceable_allocs(GrowableArray<JavaObjectNode*>& jobj_worklist) {
+  int jobj_length = jobj_worklist.length();
+  bool found_nsr_alloc = true;
+  while (found_nsr_alloc) {
+    found_nsr_alloc = false;
+    for (int next = 0; next < jobj_length; ++next) {
+      JavaObjectNode* jobj = jobj_worklist.at(next);
+      for (UseIterator i(jobj); (jobj->scalar_replaceable() && i.has_next()); i.next()) {
+        PointsToNode* use = i.get();
+        if (use->is_Field()) {
+          FieldNode* field = use->as_Field();
+          assert(field->is_oop() && field->scalar_replaceable(), "sanity");
+          assert(field->offset() != Type::OffsetBot, "sanity");
+          for (BaseIterator i(field); i.has_next(); i.next()) {
+            PointsToNode* base = i.get();
+            // An object is not scalar replaceable if the field into which
+            // it is stored has NSR base.
+            if ((base != null_obj) && !base->scalar_replaceable()) {
+              set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA "is stored into field with NSR base"));
+              found_nsr_alloc = true;
+              break;
+            }
+          }
         }
       }
     }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -1859,7 +1859,7 @@ void ConnectionGraph::adjust_scalar_replaceable_state(JavaObjectNode* jobj) {
       for (BaseIterator i(field); i.has_next(); i.next()) {
         PointsToNode* base = i.get();
         // 2. An object is not scalar replaceable if the field into which it is
-       // stored has multiple bases one of which is null.
+        // stored has multiple bases one of which is null.
         if ((base == null_obj) && (field->base_count() > 1)) {
           set_not_scalar_replaceable(jobj NOT_PRODUCT(COMMA "is stored into field with potentially null base"));
           return;

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -456,6 +456,9 @@ private:
   // Adjust scalar_replaceable state after Connection Graph is built.
   void adjust_scalar_replaceable_state(JavaObjectNode* jobj);
 
+  // Propagate NSR (Not scalar replaceable) state.
+  void find_scalar_replaceable_allocs(GrowableArray<JavaObjectNode*>& jobj_worklist);
+
   // Optimize ideal graph.
   void optimize_ideal_graph(GrowableArray<Node*>& ptr_cmp_worklist,
                             GrowableArray<Node*>& storestore_worklist);
@@ -568,6 +571,11 @@ private:
 
   // Compute the escape information
   bool compute_escape();
+
+  void set_not_scalar_replaceable(PointsToNode* ptn NOT_PRODUCT(COMMA const char* reason)) const {
+    ptn->set_scalar_replaceable(false);
+  }
+
 
 public:
   ConnectionGraph(Compile *C, PhaseIterGVN *igvn);

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestBrokenEA.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestBrokenEA.java
@@ -1,0 +1,82 @@
+/* Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8285835
+ * @summary EA does not propagate NSR (not scalar replaceable) state.
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:-UseOnStackReplacement TestBrokenEA
+ */
+
+public class TestBrokenEA {
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test1(true);
+            test1(false);
+            test2(true);
+            test2(false);
+        }
+    }
+
+    private static void test1(boolean flag) {
+        A[] array = new A[1];
+        if (flag) {
+            C c = new C();
+            B b = new B();
+            b.c = c;
+            A a = new A();
+            a.b = b;
+            array[0] = a;
+        }
+        A a = array[0];
+        if (a != null) {
+            a.b.c.f = 0x42;
+        }
+    }
+
+    private static void test2(boolean flag) {
+        A a = null;
+        if (flag) {
+            C c = new C();
+            B b = new B();
+            b.c = c;
+            a = new A();
+            a.b = b;
+        }
+        if (a != null) {
+            a.b.c.f = 0x42;
+        }
+    }
+
+    private static class A {
+        public B b;
+    }
+
+    private static class B {
+        public C c;
+    }
+
+    private static class C {
+        public int f;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.


I had to resolve one hunk in escape.cpp because head has more tracing code at that
place. Old code calls set_scalar_replaceable(false), new code
calls set_not_scalar_replaceable(...) which traces and calls the 
other method.
Instead of editing the new code, I keep the tracing call and add 
that method in escape.hpp.  But I stripped the output of the 
tracing, as it would be incomplete as long as I don't fix all
occurances.
The tracing was added by "8281548: Add escape analysis tracing flag"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285835](https://bugs.openjdk.org/browse/JDK-8285835): SIGSEGV in PhaseIdealLoop::build_loop_late_post_work


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [13987dff](https://git.openjdk.org/jdk17u-dev/pull/1023/files/13987dffe6eb4f961ab8052543fbd466f725a246)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1023/head:pull/1023` \
`$ git checkout pull/1023`

Update a local copy of the PR: \
`$ git checkout pull/1023` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1023`

View PR using the GUI difftool: \
`$ git pr show -t 1023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1023.diff">https://git.openjdk.org/jdk17u-dev/pull/1023.diff</a>

</details>
