### PR TITLE
8294947: Use 64bit atomics in patch_verified_entry on x86_64

### DIFF
--- a/src/hotspot/cpu/x86/nativeInst_x86.cpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.cpp
@@ -510,12 +510,27 @@ void NativeJump::check_verified_entry_alignment(address entry, address verified_
 //
 void NativeJump::patch_verified_entry(address entry, address verified_entry, address dest) {
   // complete jump instruction (to be inserted) is in code_buffer;
+#ifdef _LP64
+  union {
+    jlong cb_long;
+    unsigned char code_buffer[8];
+  } u;
+
+  u.cb_long = *(jlong *)verified_entry;
+
+  intptr_t disp = (intptr_t)dest - ((intptr_t)verified_entry + 1 + 4);
+  guarantee(disp == (intptr_t)(int32_t)disp, "must be 32-bit offset");
+
+  u.code_buffer[0] = instruction_code;
+  *(int32_t*)(u.code_buffer + 1) = (int32_t)disp;
+
+  Atomic::store((jlong *) verified_entry, u.cb_long);
+  ICache::invalidate_range(verified_entry, 8);
+
+#else
   unsigned char code_buffer[5];
   code_buffer[0] = instruction_code;
   intptr_t disp = (intptr_t)dest - ((intptr_t)verified_entry + 1 + 4);
-#ifdef AMD64
-  guarantee(disp == (intptr_t)(int32_t)disp, "must be 32-bit offset");
-#endif // AMD64
   *(int32_t*)(code_buffer + 1) = (int32_t)disp;
 
   check_verified_entry_alignment(entry, verified_entry);
@@ -546,6 +561,7 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
   *(int32_t*)verified_entry = *(int32_t *)code_buffer;
   // Invalidate.  Opteron requires a flush after every write.
   n_jump->wrote(0);
+#endif // _LP64
 
 }
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294947](https://bugs.openjdk.org/browse/JDK-8294947): Use 64bit atomics in patch_verified_entry on x86_64


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1025/head:pull/1025` \
`$ git checkout pull/1025`

Update a local copy of the PR: \
`$ git checkout pull/1025` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1025`

View PR using the GUI difftool: \
`$ git pr show -t 1025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1025.diff">https://git.openjdk.org/jdk17u-dev/pull/1025.diff</a>

</details>
