### PR TITLE
8297569: URLPermission constructor throws IllegalArgumentException: Invalid characters in hostname after JDK-8294378

### DIFF
--- a/src/java.base/share/classes/java/net/HostPortrange.java
+++ b/src/java.base/share/classes/java/net/HostPortrange.java
@@ -149,9 +149,6 @@ class HostPortrange {
                         // regular domain name
                         hoststr = toLowerCase(hoststr);
                     }
-                } else {
-                    // regular domain name
-                    hoststr = toLowerCase(hoststr);
                 }
             }
             hostname = hoststr;

--- a/src/java.base/share/classes/java/net/URLPermission.java
+++ b/src/java.base/share/classes/java/net/URLPermission.java
@@ -494,7 +494,7 @@ public final class URLPermission extends Permission {
             auth = authpath.substring(0, delim);
             this.path = authpath.substring(delim);
         }
-        this.authority = new Authority(scheme, auth);
+        this.authority = new Authority(scheme, auth.toLowerCase(Locale.ROOT));
     }
 
     private String actions() {

--- a/test/jdk/java/net/URLPermission/URLPermissionTest.java
+++ b/test/jdk/java/net/URLPermission/URLPermissionTest.java
@@ -402,7 +402,9 @@ public class URLPermissionTest {
     static Test[] createTests = {
         createtest("http://user@foo.com/a/b/c"),
         createtest("http://user:pass@foo.com/a/b/c"),
-        createtest("http://user:@foo.com/a/b/c")
+        createtest("http://user:@foo.com/a/b/c"),
+        createtest("http://foo_bar"),
+        createtest("http://foo_bar:12345")
     };
 
     static boolean failed = false;


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297569](https://bugs.openjdk.org/browse/JDK-8297569): URLPermission constructor throws IllegalArgumentException: Invalid characters in hostname after JDK-8294378


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1032/head:pull/1032` \
`$ git checkout pull/1032`

Update a local copy of the PR: \
`$ git checkout pull/1032` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1032`

View PR using the GUI difftool: \
`$ git pr show -t 1032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1032.diff">https://git.openjdk.org/jdk17u-dev/pull/1032.diff</a>

</details>
