### PR TITLE
8297431: [JVMCI] HotSpotJVMCIRuntime.encodeThrowable should not throw an exception

### DIFF
--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -303,12 +303,28 @@ class ExceptionTranslation: public StackObj {
     int buffer_size = 2048;
     while (true) {
       ResourceMark rm;
-      jlong buffer = (jlong) NEW_RESOURCE_ARRAY_IN_THREAD(THREAD, jbyte, buffer_size);
-      int res = encode(THREAD, runtimeKlass, buffer, buffer_size);
-      if ((_from_env != nullptr && _from_env->has_pending_exception()) || HAS_PENDING_EXCEPTION) {
-        JVMCIRuntime::fatal_exception(_from_env, "HotSpotJVMCIRuntime.encodeThrowable should not throw an exception");
+      jlong buffer = (jlong) NEW_RESOURCE_ARRAY_IN_THREAD_RETURN_NULL(THREAD, jbyte, buffer_size);
+      if (buffer == 0L) {
+        decode(THREAD, runtimeKlass, 0L);
+        return;
       }
-      if (res < 0) {
+      int res = encode(THREAD, runtimeKlass, buffer, buffer_size);
+      if (_from_env != nullptr && !_from_env->is_hotspot() && _from_env->has_pending_exception()) {
+        // Cannot get name of exception thrown by `encode` as that involves
+        // calling into libjvmci which in turn can raise another exception.
+        _from_env->clear_pending_exception();
+        decode(THREAD, runtimeKlass, -2L);
+        return;
+      } else if (HAS_PENDING_EXCEPTION) {
+        Symbol *ex_name = PENDING_EXCEPTION->klass()->name();
+        CLEAR_PENDING_EXCEPTION;
+        if (ex_name == vmSymbols::java_lang_OutOfMemoryError()) {
+          decode(THREAD, runtimeKlass, -1L);
+        } else {
+          decode(THREAD, runtimeKlass, -2L);
+        }
+        return;
+      } else if (res < 0) {
         int required_buffer_size = -res;
         if (required_buffer_size > buffer_size) {
           buffer_size = required_buffer_size;
@@ -316,7 +332,7 @@ class ExceptionTranslation: public StackObj {
       } else {
         decode(THREAD, runtimeKlass, buffer);
         if (!_to_env->has_pending_exception()) {
-          JVMCIRuntime::fatal_exception(_to_env, "HotSpotJVMCIRuntime.decodeAndThrowThrowable should throw an exception");
+          _to_env->throw_InternalError("HotSpotJVMCIRuntime.decodeAndThrowThrowable should have thrown an exception");
         }
         return;
       }

--- a/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/TranslatedException.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/TranslatedException.java
@@ -149,7 +149,6 @@ final class TranslatedException extends Exception {
      * Encodes {@code throwable} including its stack and causes as a {@linkplain GZIPOutputStream
      * compressed} byte array that can be decoded by {@link #decodeThrowable}.
      */
-    @VMEntryPoint
     static byte[] encodeThrowable(Throwable throwable) throws Throwable {
         try {
             return encodeThrowable(throwable, true);
@@ -223,7 +222,6 @@ final class TranslatedException extends Exception {
      * @param encodedThrowable an encoded exception in the format specified by
      *            {@link #encodeThrowable}
      */
-    @VMEntryPoint
     static Throwable decodeThrowable(byte[] encodedThrowable) {
         try (DataInputStream dis = new DataInputStream(new GZIPInputStream(new ByteArrayInputStream(encodedThrowable)))) {
             Throwable cause = null;


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297431](https://bugs.openjdk.org/browse/JDK-8297431): [JVMCI] HotSpotJVMCIRuntime.encodeThrowable should not throw an exception


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1033/head:pull/1033` \
`$ git checkout pull/1033`

Update a local copy of the PR: \
`$ git checkout pull/1033` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1033`

View PR using the GUI difftool: \
`$ git pr show -t 1033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1033.diff">https://git.openjdk.org/jdk17u-dev/pull/1033.diff</a>

</details>
