### PR TITLE
8296924: C2: assert(is_valid_AArch64_address(dest.target())) failed: bad address

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3440,7 +3440,8 @@ encode %{
         __ mov_metadata(dst_reg, (Metadata*)con);
       } else {
         assert(rtype == relocInfo::none, "unexpected reloc type");
-        if (con < (address)(uintptr_t)os::vm_page_size()) {
+        if (! __ is_valid_AArch64_address(con) ||
+            con < (address)(uintptr_t)os::vm_page_size()) {
           __ mov(dst_reg, con);
         } else {
           uint64_t offset;

--- a/test/hotspot/jtreg/compiler/unsafe/TestBadBaseAddress.java
+++ b/test/hotspot/jtreg/compiler/unsafe/TestBadBaseAddress.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8296924
+ * @summary Tests compilation of an unreachable unsafe access with a bad base address.
+ * @modules java.base/jdk.internal.misc:+open
+ * @run main/othervm -XX:CompileCommand=compileonly,TestBadBaseAddress::test -XX:-TieredCompilation -Xcomp TestBadBaseAddress
+ */
+
+import java.lang.reflect.*;
+import sun.misc.*;
+
+public class TestBadBaseAddress {
+    private static Unsafe unsafe;
+
+    static {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            unsafe = (Unsafe)field.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void test(boolean b) {
+        if (b) {
+            unsafe.putLong(-1, 42);
+        }
+    }
+
+    public static void main(String[] args) {
+        test(false);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296924](https://bugs.openjdk.org/browse/JDK-8296924): C2: assert(is_valid_AArch64_address(dest.target())) failed: bad address


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1034/head:pull/1034` \
`$ git checkout pull/1034`

Update a local copy of the PR: \
`$ git checkout pull/1034` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1034`

View PR using the GUI difftool: \
`$ git pr show -t 1034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1034.diff">https://git.openjdk.org/jdk17u-dev/pull/1034.diff</a>

</details>
