### PR TITLE
8299158: Improve MD5 intrinsic on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3265,19 +3265,19 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(rscratch4, r1, rscratch2);           \
     __ ldrw(rscratch1, Address(buf, k*4));       \
     __ eorw(rscratch3, rscratch3, r4);           \
-    __ addw(rscratch3, rscratch3, rscratch1);    \
+    __ addw(rscratch4, rscratch4, rscratch1);    \
     __ addw(rscratch3, rscratch3, rscratch4);    \
     __ rorw(rscratch2, rscratch3, 32 - s);       \
     __ addw(r1, rscratch2, r2);
 
 #define GG(r1, r2, r3, r4, k, s, t)              \
-    __ eorw(rscratch2, r2, r3);                  \
+    __ andw(rscratch3, r2, r4);                  \
+    __ bicw(rscratch4, r3, r4);                  \
     __ ldrw(rscratch1, Address(buf, k*4));       \
-    __ andw(rscratch3, rscratch2, r4);           \
     __ movw(rscratch2, t);                       \
-    __ eorw(rscratch3, rscratch3, r3);           \
+    __ orrw(rscratch3, rscratch3, rscratch4);    \
     __ addw(rscratch4, r1, rscratch2);           \
-    __ addw(rscratch3, rscratch3, rscratch1);    \
+    __ addw(rscratch4, rscratch4, rscratch1);    \
     __ addw(rscratch3, rscratch3, rscratch4);    \
     __ rorw(rscratch2, rscratch3, 32 - s);       \
     __ addw(r1, rscratch2, r2);
@@ -3288,7 +3288,7 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(rscratch4, r1, rscratch2);           \
     __ ldrw(rscratch1, Address(buf, k*4));       \
     __ eorw(rscratch3, rscratch3, r2);           \
-    __ addw(rscratch3, rscratch3, rscratch1);    \
+    __ addw(rscratch4, rscratch4, rscratch1);    \
     __ addw(rscratch3, rscratch3, rscratch4);    \
     __ rorw(rscratch2, rscratch3, 32 - s);       \
     __ addw(r1, rscratch2, r2);
@@ -3299,7 +3299,7 @@ class StubGenerator: public StubCodeGenerator {
     __ addw(rscratch4, r1, rscratch3);           \
     __ ldrw(rscratch1, Address(buf, k*4));       \
     __ eorw(rscratch3, rscratch2, r3);           \
-    __ addw(rscratch3, rscratch3, rscratch1);    \
+    __ addw(rscratch4, rscratch4, rscratch1);    \
     __ addw(rscratch3, rscratch3, rscratch4);    \
     __ rorw(rscratch2, rscratch3, 32 - s);       \
     __ addw(r1, rscratch2, r2);


### PR DESCRIPTION
This change is nearly clean. 17u uses macro and tip uses functions.

TestMD5Intrinsics and TestMD5MultiBlockIntrinsics are tested with [the patch](https://github.com/openjdk/jdk/pull/10954).

Similar performance improvement is observed.

baseline
```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt     Score   Error   Units
MessageDigests.digest                   md5        64     DEFAULT  thrpt   50  2987.994 ? 3.246  ops/ms
MessageDigests.digest                   md5      1024     DEFAULT  thrpt   50   370.344 ? 0.683  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   50    24.773 ? 0.038  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   50  2543.829 ? 3.060  ops/ms
MessageDigests.getAndDigest             md5      1024     DEFAULT  thrpt   50   364.196 ? 0.319  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   50    24.741 ? 0.021  ops/ms
```

optimized
```
Benchmark                    (digesterName)  (length)  (provider)   Mode  Cnt     Score   Error   Units
MessageDigests.digest                   md5        64     DEFAULT  thrpt   50  3671.576 ? 2.780  ops/ms
MessageDigests.digest                   md5      1024     DEFAULT  thrpt   50   462.163 ? 0.724  ops/ms
MessageDigests.digest                   md5     16384     DEFAULT  thrpt   50    31.137 ? 0.058  ops/ms
MessageDigests.getAndDigest             md5        64     DEFAULT  thrpt   50  3015.830 ? 4.608  ops/ms
MessageDigests.getAndDigest             md5      1024     DEFAULT  thrpt   50   453.550 ? 0.263  ops/ms
MessageDigests.getAndDigest             md5     16384     DEFAULT  thrpt   50    31.039 ? 0.006  ops/ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299158](https://bugs.openjdk.org/browse/JDK-8299158): Improve MD5 intrinsic on AArch64


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1037/head:pull/1037` \
`$ git checkout pull/1037`

Update a local copy of the PR: \
`$ git checkout pull/1037` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1037`

View PR using the GUI difftool: \
`$ git pr show -t 1037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1037.diff">https://git.openjdk.org/jdk17u-dev/pull/1037.diff</a>

</details>
