### PR TITLE
8295413: com/sun/jdi/EATests.java fails with compiler flag -XX:+StressReflectiveCode

### DIFF
--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -299,6 +299,7 @@ public class EATests extends TestScaffold {
         public final boolean DeoptimizeObjectsALot;
         public final boolean DoEscapeAnalysis;
         public final boolean ZGCIsSelected;
+        public final boolean StressReflectiveCode;
 
         public TargetVMOptions(EATests env, ClassType testCaseBaseTargetClass) {
             Value val;
@@ -313,6 +314,8 @@ public class EATests extends TestScaffold {
             UseJVMCICompiler = ((PrimitiveValue) val).booleanValue();
             val = testCaseBaseTargetClass.getValue(testCaseBaseTargetClass.fieldByName("ZGCIsSelected"));
             ZGCIsSelected = ((PrimitiveValue) val).booleanValue();
+            val = testCaseBaseTargetClass.getValue(testCaseBaseTargetClass.fieldByName("StressReflectiveCode"));
+            StressReflectiveCode = ((PrimitiveValue) val).booleanValue();
         }
 
     }
@@ -424,6 +427,12 @@ abstract class EATestCaseBaseDebugger  extends EATestCaseBaseShared {
     public static final String XYVAL_NAME = XYVal.class.getName();
 
     public abstract void runTestCase() throws Exception;
+
+    @Override
+    public boolean shouldSkip() {
+        // Skip if StressReflectiveCode because it effectively disables escape analysis
+        return super.shouldSkip() || env.targetVMOptions.StressReflectiveCode;
+    }
 
     public void run(EATests env) {
         this.env = env;
@@ -796,6 +805,7 @@ abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runn
     public static final long BiasedLockingBulkRebiasThreshold = WB.getIntxVMFlag("BiasedLockingBulkRebiasThreshold");
     public static final long BiasedLockingBulkRevokeThreshold = WB.getIntxVMFlag("BiasedLockingBulkRevokeThreshold");
     public static final boolean ZGCIsSelected = GC.Z.isSelected();
+    public static final boolean StressReflectiveCode = unbox(WB.getBooleanVMFlag("StressReflectiveCode"), false);
 
     public String testMethodName;
     public int testMethodDepth;
@@ -826,6 +836,12 @@ abstract class EATestCaseBaseTarget extends EATestCaseBaseShared implements Runn
 
     public static final    Long CONST_2_OBJ     = Long.valueOf(2);
     public static final    Long CONST_3_OBJ     = Long.valueOf(3);
+
+    @Override
+    public boolean shouldSkip() {
+        // Skip if StressReflectiveCode because it effectively disables escape analysis
+        return super.shouldSkip() || StressReflectiveCode;
+    }
 
     /**
      * Main driver of a test case.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [08d3ef4f](https://github.com/openjdk/jdk/commit/08d3ef4fe60460d94b0a2db0b6671adc56a6653c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Richard Reingruber on 24 Oct 2022 and was reviewed by Leonid Mesnik, Vladimir Kozlov and Serguei Spitsyn.

Applies cleanly. This is just a test fix, so there's hardly any risk.

Tested on Linux x86_64 with fastdebug and release builds.

```
make test TEST=test/jdk/com/sun/jdi/EATests.java TEST_VM_OPTS="-XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode"
```

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295413](https://bugs.openjdk.org/browse/JDK-8295413): com/sun/jdi/EATests.java fails with compiler flag -XX:+StressReflectiveCode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1042/head:pull/1042` \
`$ git checkout pull/1042`

Update a local copy of the PR: \
`$ git checkout pull/1042` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1042`

View PR using the GUI difftool: \
`$ git pr show -t 1042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1042.diff">https://git.openjdk.org/jdk17u-dev/pull/1042.diff</a>

</details>
