### PR TITLE
8286707: JFR: Don't commit JFR internal jdk.JavaMonitorWait events

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunkRotation.cpp
@@ -38,7 +38,7 @@ static jobject install_chunk_monitor(JavaThread* thread) {
   // read static field
   HandleMark hm(thread);
   static const char klass[] = "jdk/jfr/internal/JVM";
-  static const char field[] = "FILE_DELTA_CHANGE";
+  static const char field[] = "CHUNK_ROTATION_MONITOR";
   static const char signature[] = "Ljava/lang/Object;";
   JavaValue result(T_OBJECT);
   JfrJavaArguments field_args(&result, klass, field, signature, thread);

--- a/src/hotspot/share/jfr/support/jfrIntrinsics.hpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.hpp
@@ -37,6 +37,7 @@
   template(jdk_jfr_internal_JVM,                                      "jdk/jfr/internal/JVM")                     \
   template(jdk_jfr_internal_handlers_EventHandler_signature,          "Ljdk/jfr/internal/handlers/EventHandler;") \
   template(eventHandler_name,                                         "eventHandler")                             \
+  template(jfr_chunk_rotation_monitor,                                "jdk/jfr/internal/JVM$ChunkRotationMonitor")   \
 
 #define JFR_INTRINSICS(do_intrinsic, do_class, do_name, do_signature, do_alias)                              \
   do_intrinsic(_counterTime,        jdk_jfr_internal_JVM, counterTime_name, void_long_signature, F_SN)       \

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -1416,6 +1416,12 @@ bool ObjectMonitor::check_owner(TRAPS) {
              "current thread is not owner", false);
 }
 
+static inline bool is_excluded(const Klass* monitor_klass) {
+  assert(monitor_klass != nullptr, "invariant");
+  NOT_JFR_RETURN_(false);
+  JFR_ONLY(return vmSymbols::jfr_chunk_rotation_monitor() == monitor_klass->name());
+}
+
 static void post_monitor_wait_event(EventJavaMonitorWait* event,
                                     ObjectMonitor* monitor,
                                     jlong notifier_tid,
@@ -1423,7 +1429,11 @@ static void post_monitor_wait_event(EventJavaMonitorWait* event,
                                     bool timedout) {
   assert(event != NULL, "invariant");
   assert(monitor != NULL, "invariant");
-  event->set_monitorClass(monitor->object()->klass());
+  const Klass* monitor_klass = monitor->object()->klass();
+  if (is_excluded(monitor_klass)) {
+    return;
+  }
+  event->set_monitorClass(monitor_klass);
   event->set_timeout(timeout);
   // Set an address that is 'unique enough', such that events close in
   // time and with the same address are likely (but not guaranteed) to

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -38,10 +38,16 @@ import jdk.jfr.internal.handlers.EventHandler;
 public final class JVM {
     private static final JVM jvm = new JVM();
 
-    // JVM signals file changes by doing Object#notify on this object
-    static final Object FILE_DELTA_CHANGE = new Object();
-
     static final long RESERVED_CLASS_ID_LIMIT = 500;
+
+    private static class ChunkRotationMonitor {}
+
+    /*
+     * The JVM uses the chunk rotation monitor to notify Java that a rotation is warranted.
+     * The monitor type is used to exclude jdk.JavaMonitorWait events from being generated
+     * when Object.wait() is called on this monitor.
+     */
+    static final Object CHUNK_ROTATION_MONITOR = new ChunkRotationMonitor();
 
     private volatile boolean nativeOK;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -523,8 +523,8 @@ public final class PlatformRecorder {
 
     private void takeNap(long duration) {
         try {
-            synchronized (JVM.FILE_DELTA_CHANGE) {
-                JVM.FILE_DELTA_CHANGE.wait(duration < 10 ? 10 : duration);
+            synchronized (JVM.CHUNK_ROTATION_MONITOR) {
+                JVM.CHUNK_ROTATION_MONITOR.wait(duration < 10 ? 10 : duration);
             }
         } catch (InterruptedException e) {
             // Ignore

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RequestEngine.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RequestEngine.java
@@ -291,8 +291,8 @@ public final class RequestEngine {
         boolean needNotify = interval < flushInterval;
         flushInterval = interval;
         if (needNotify) {
-            synchronized (JVM.FILE_DELTA_CHANGE) {
-                JVM.FILE_DELTA_CHANGE.notifyAll();
+            synchronized (JVM.CHUNK_ROTATION_MONITOR) {
+                JVM.CHUNK_ROTATION_MONITOR.notifyAll();
             }
         }
     }


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

I had to resolve jfrIntrinsics.hpp due to context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286707](https://bugs.openjdk.org/browse/JDK-8286707): JFR: Don't commit JFR internal jdk.JavaMonitorWait events


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1044/head:pull/1044` \
`$ git checkout pull/1044`

Update a local copy of the PR: \
`$ git checkout pull/1044` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1044`

View PR using the GUI difftool: \
`$ git pr show -t 1044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1044.diff">https://git.openjdk.org/jdk17u-dev/pull/1044.diff</a>

</details>
