### PR TITLE
8284165: Add pid to process reaper thread name

### DIFF
--- a/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/ProcessHandleImpl.java
@@ -144,33 +144,40 @@ final class ProcessHandleImpl implements ProcessHandle {
                 processReaperExecutor.execute(new Runnable() {
                     // Use inner class to avoid lambda stack overhead
                     public void run() {
-                        int exitValue = waitForProcessExit0(pid, shouldReap);
-                        if (exitValue == NOT_A_CHILD) {
-                            // pid not alive or not a child of this process
-                            // If it is alive wait for it to terminate
-                            long sleep = 300;     // initial milliseconds to sleep
-                            int incr = 30;        // increment to the sleep time
+                        String threadName = Thread.currentThread().getName();
+                        Thread.currentThread().setName("process reaper (pid " + pid + ")");
+                        try {
+                            int exitValue = waitForProcessExit0(pid, shouldReap);
+                            if (exitValue == NOT_A_CHILD) {
+                                // pid not alive or not a child of this process
+                                // If it is alive wait for it to terminate
+                                long sleep = 300;     // initial milliseconds to sleep
+                                int incr = 30;        // increment to the sleep time
 
-                            long startTime = isAlive0(pid);
-                            long origStart = startTime;
-                            while (startTime >= 0) {
-                                try {
-                                    Thread.sleep(Math.min(sleep, 5000L)); // no more than 5 sec
-                                    sleep += incr;
-                                } catch (InterruptedException ie) {
-                                    // ignore and retry
+                                long startTime = isAlive0(pid);
+                                long origStart = startTime;
+                                while (startTime >= 0) {
+                                    try {
+                                        Thread.sleep(Math.min(sleep, 5000L)); // no more than 5 sec
+                                        sleep += incr;
+                                    } catch (InterruptedException ie) {
+                                        // ignore and retry
+                                    }
+                                    startTime = isAlive0(pid);  // recheck if it is alive
+                                    if (startTime > 0 && origStart > 0 && startTime != origStart) {
+                                        // start time changed (and is not zero), pid is not the same process
+                                        break;
+                                    }
                                 }
-                                startTime = isAlive0(pid);  // recheck if it is alive
-                                if (startTime > 0 && origStart > 0 && startTime != origStart) {
-                                    // start time changed (and is not zero), pid is not the same process
-                                    break;
-                                }
+                                exitValue = 0;
                             }
-                            exitValue = 0;
+                            newCompletion.complete(exitValue);
+                            // remove from cache afterwards
+                            completions.remove(pid, newCompletion);
+                        } finally {
+                            // Restore thread name
+                            Thread.currentThread().setName(threadName);
                         }
-                        newCompletion.complete(exitValue);
-                        // remove from cache afterwards
-                        completions.remove(pid, newCompletion);
                     }
                 });
             }

--- a/test/jdk/java/util/concurrent/Phaser/Basic.java
+++ b/test/jdk/java/util/concurrent/Phaser/Basic.java
@@ -440,7 +440,7 @@ public class Basic {
             if ("Finalizer".equals(name)
                 && info.getLockName().startsWith("java.lang.ref.ReferenceQueue$Lock"))
                 continue;
-            if ("process reaper".equals(name))
+            if (name.startsWith("process reaper"))
                 continue;
             if (name != null && name.startsWith("ForkJoinPool.commonPool-worker"))
                 continue;


### PR DESCRIPTION
I'd like to downport this patch since it is a small improvement that comes in very handy when analyzing mass-fork scenarios.

Does not apply cleanly: Original patch modifies [test/jdk/java/lang/ProcessBuilder/ProcessReaperCCL.java](https://github.com/openjdk/jdk/commit/9561b5e041c4cc70319e60953819c521c1e68d6c#diff-447b6da42c627f901f46bbe517abd2db37364b2536bd740c036830535c8a1e83) but that test does not exist in 17u yet. Left the hunk out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284165](https://bugs.openjdk.org/browse/JDK-8284165): Add pid to process reaper thread name


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1046/head:pull/1046` \
`$ git checkout pull/1046`

Update a local copy of the PR: \
`$ git checkout pull/1046` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1046`

View PR using the GUI difftool: \
`$ git pr show -t 1046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1046.diff">https://git.openjdk.org/jdk17u-dev/pull/1046.diff</a>

</details>
