### PR TITLE
Backport 3ff085e2967508ad312c9d32fa908807aefe69ee

### DIFF
--- a/src/hotspot/share/memory/metaspace/chunkManager.cpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.cpp
@@ -316,24 +316,11 @@ void ChunkManager::purge() {
 
   const size_t reserved_before = _vslist->reserved_words();
   const size_t committed_before = _vslist->committed_words();
-  int num_nodes_purged = 0;
 
-  // We purge to return unused memory to the Operating System. We do this in
-  //  two independent steps.
-
-  // 1) We purge the virtual space list: any memory mappings which are
-  //   completely deserted can be potentially unmapped. We iterate over the list
-  //   of mappings (VirtualSpaceList::purge) and delete every node whose memory
-  //   only contains free chunks. Deleting that node includes unmapping its memory,
-  //   so all chunk vanish automatically.
-  //   Of course we need to remove the chunk headers of those vanished chunks from
-  //   the ChunkManager freelist.
-  num_nodes_purged = _vslist->purge(&_chunks);
-  InternalStats::inc_num_purges();
-
-  // 2) Since (1) is rather ineffective - it is rare that a whole node only contains
-  //   free chunks - we now iterate over all remaining free chunks and
-  //   and uncommit those which can be uncommitted (>= commit granule size).
+  // We return unused memory to the Operating System: we iterate over all
+  //  free chunks and uncommit the backing memory of those large enough to
+  //  contain one or multiple commit granules (chunks larger than a granule
+  //  always cover a whole number of granules and start at a granule boundary).
   if (Settings::uncommit_free_chunks()) {
     const chunklevel_t max_level =
         chunklevel::level_fitting_word_size(Settings::commit_granule_words());
@@ -365,7 +352,6 @@ void ChunkManager::purge() {
       ls.print("committed: ");
       print_word_size_delta(&ls, committed_before, committed_after);
       ls.cr();
-      ls.print_cr("full nodes purged: %d", num_nodes_purged);
     }
   }
   DEBUG_ONLY(_vslist->verify_locked());

--- a/src/hotspot/share/memory/metaspace/internalStats.hpp
+++ b/src/hotspot/share/memory/metaspace/internalStats.hpp
@@ -92,9 +92,6 @@ class InternalStats : public AllStatic {
   /* Number of chunk in place enlargements */       \
   x(num_chunks_enlarged)                            \
                                                     \
-  /* Number of times we did a purge */              \
-  x(num_purges)                                     \
-                                                    \
   /* Number of times we read inconsistent stats. */ \
   x(num_inconsistent_stats)                         \
 

--- a/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
+++ b/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
@@ -481,16 +481,6 @@ RootChunkAreaLUT::~RootChunkAreaLUT() {
   FREE_C_HEAP_ARRAY(RootChunkArea, _arr);
 }
 
-// Returns true if all areas in this area table are free (only contain free chunks).
-bool RootChunkAreaLUT::is_free() const {
-  for (int i = 0; i < _num; i++) {
-    if (!_arr[i].is_free()) {
-      return false;
-    }
-  }
-  return true;
-}
-
 #ifdef ASSERT
 
 void RootChunkAreaLUT::verify() const {

--- a/src/hotspot/share/memory/metaspace/rootChunkArea.hpp
+++ b/src/hotspot/share/memory/metaspace/rootChunkArea.hpp
@@ -107,10 +107,6 @@ public:
   size_t word_size() const      { return chunklevel::MAX_CHUNK_WORD_SIZE; }
   const MetaWord* end() const   { return _base + word_size(); }
 
-  // Direct access to the first chunk (use with care)
-  Metachunk* first_chunk()              { return _first_chunk; }
-  const Metachunk* first_chunk() const  { return _first_chunk; }
-
   // Returns true if this root chunk area is completely free:
   //  In that case, it should only contain one chunk (maximally merged, so a root chunk)
   //  and it should be free.
@@ -182,19 +178,11 @@ public:
     return _arr + idx;
   }
 
-  // Access area by its index
-  int number_of_areas() const                               { return _num; }
-  RootChunkArea* get_area_by_index(int index)               { assert(index >= 0 && index < _num, "oob"); return _arr + index; }
-  const RootChunkArea* get_area_by_index(int index) const   { assert(index >= 0 && index < _num, "oob"); return _arr + index; }
-
   /// range ///
 
   const MetaWord* base() const  { return _base; }
   size_t word_size() const      { return _num * chunklevel::MAX_CHUNK_WORD_SIZE; }
   const MetaWord* end() const   { return _base + word_size(); }
-
-  // Returns true if all areas in this area table are free (only contain free chunks).
-  bool is_free() const;
 
   DEBUG_ONLY(void verify() const;)
 

--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.hpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.hpp
@@ -48,10 +48,6 @@ class FreeChunkListVector;
 //  managing a single contiguous memory region. The first node of
 //  this list is the current node and used for allocation of new
 //  root chunks.
-//
-// Beyond access to those nodes and the ability to grow new nodes
-//  (if expandable) it allows for purging: purging this list means
-//  removing and unmapping all memory regions which are unused.
 
 class VirtualSpaceList : public CHeapObj<mtClass> {
 
@@ -100,11 +96,6 @@ public:
   // May return NULL if vslist would need to be expanded to hold the new root node but
   // the list cannot be expanded (in practice this means we reached CompressedClassSpaceSize).
   Metachunk* allocate_root_chunk();
-
-  // Attempts to purge nodes. This will remove and delete nodes which only contain free chunks.
-  // The free chunks are removed from the freelists before the nodes are deleted.
-  // Return number of purged nodes.
-  int purge(FreeChunkListVector* freelists);
 
   //// Statistics ////
 

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -369,48 +369,6 @@ bool VirtualSpaceNode::attempt_enlarge_chunk(Metachunk* c, FreeChunkListVector* 
   return rc;
 }
 
-// Attempts to purge the node:
-//
-// If all chunks living in this node are free, they will all be removed from
-//  the freelist they currently reside in. Then, the node will be deleted.
-//
-// Returns true if the node has been deleted, false if not.
-// !! If this returns true, do not access the node from this point on. !!
-bool VirtualSpaceNode::attempt_purge(FreeChunkListVector* freelists) {
-  assert_lock_strong(Metaspace_lock);
-
-  if (!_owns_rs) {
-    // We do not allow purging of nodes if we do not own the
-    // underlying ReservedSpace (CompressClassSpace case).
-    return false;
-  }
-
-  // First find out if all areas are empty. Since empty chunks collapse to root chunk
-  // size, if all chunks in this node are free root chunks we are good to go.
-  if (!_root_chunk_area_lut.is_free()) {
-    return false;
-  }
-
-  UL(debug, ": purging.");
-
-  // Okay, we can purge. Before we can do this, we need to remove all chunks from the freelist.
-  for (int narea = 0; narea < _root_chunk_area_lut.number_of_areas(); narea++) {
-    RootChunkArea* ra = _root_chunk_area_lut.get_area_by_index(narea);
-    Metachunk* c = ra->first_chunk();
-    if (c != NULL) {
-      UL2(trace, "removing chunk from to-be-purged node: "
-          METACHUNK_FULL_FORMAT ".", METACHUNK_FULL_FORMAT_ARGS(c));
-      assert(c->is_free() && c->is_root_chunk(), "Sanity");
-      freelists->remove(c);
-    }
-  }
-
-  // Now, delete the node, then right away return since this object is invalid.
-  delete this;
-
-  return true;
-}
-
 void VirtualSpaceNode::print_on(outputStream* st) const {
   size_t scale = K;
 

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.hpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.hpp
@@ -208,15 +208,6 @@ public:
   // On success, true is returned, false otherwise.
   bool attempt_enlarge_chunk(Metachunk* c, FreeChunkListVector* freelists);
 
-  // Attempts to purge the node:
-  //
-  // If all chunks living in this node are free, they will all be removed from
-  //  the freelist they currently reside in. Then, the node will be deleted.
-  //
-  // Returns true if the node has been deleted, false if not.
-  // !! If this returns true, do not access the node from this point on. !!
-  bool attempt_purge(FreeChunkListVector* freelists);
-
   // Attempts to uncommit free areas according to the rules set in settings.
   // Returns number of words uncommitted.
   size_t uncommit_free_areas();


### PR DESCRIPTION
I'd like to downport this, since it is a prerequisite for downporting [JDK-8275704](https://bugs.openjdk.org/browse/JDK-8275704)
"Metaspace::contains() should be threadsafe".