### PR TITLE
8299388: java/util/regex/NegativeArraySize.java fails on Alpine and sometimes Windows

### DIFF
--- a/test/jdk/java/util/regex/NegativeArraySize.java
+++ b/test/jdk/java/util/regex/NegativeArraySize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8223174
  * @summary Pattern.compile() can throw confusing NegativeArraySizeException
- * @requires os.maxMemory >= 5g & vm.bits == 64
+ * @requires os.maxMemory >= 6g & vm.bits == 64 & !vm.musl
  * @run testng/othervm -Xms5G -Xmx5G NegativeArraySize
  */
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299388](https://bugs.openjdk.org/browse/JDK-8299388): java/util/regex/NegativeArraySize.java fails on Alpine and sometimes Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1050/head:pull/1050` \
`$ git checkout pull/1050`

Update a local copy of the PR: \
`$ git checkout pull/1050` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1050`

View PR using the GUI difftool: \
`$ git pr show -t 1050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1050.diff">https://git.openjdk.org/jdk17u-dev/pull/1050.diff</a>

</details>
