### PR TITLE
8299424: containers/docker/TestMemoryWithCgroupV1.java fails on SLES12 ppc64le when testing Memory and Swap Limit

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -85,10 +85,14 @@ public class TestMemoryWithCgroupV1 {
         // capabilities or the cgroup is not mounted. Memory limited without swap."
         // we only have Memory and Swap Limit is: <huge integer> in the output
         try {
-            out.shouldContain("Memory and Swap Limit is: " + expectedReadLimit)
-                .shouldContain(
+            if (out.getOutput().contains("memory_and_swap_limit_in_bytes: not supported")) {
+                System.out.println("memory_and_swap_limit_in_bytes not supported, avoiding Memory and Swap Limit check");
+            } else {
+                out.shouldContain("Memory and Swap Limit is: " + expectedReadLimit)
+                    .shouldContain(
                         "Memory and Swap Limit has been reset to " + expectedResetLimit + " because swappiness is 0")
-                .shouldContain("Memory & Swap Limit: " + expectedLimit);
+                    .shouldContain("Memory & Swap Limit: " + expectedLimit);
+            }
         } catch (RuntimeException ex) {
             System.out.println("Expected Memory and Swap Limit output missing.");
             System.out.println("You may need to add 'cgroup_enable=memory swapaccount=1' to the Linux kernel boot parameters.");


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299424](https://bugs.openjdk.org/browse/JDK-8299424): containers/docker/TestMemoryWithCgroupV1.java fails on SLES12 ppc64le when testing Memory and Swap Limit


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1054/head:pull/1054` \
`$ git checkout pull/1054`

Update a local copy of the PR: \
`$ git checkout pull/1054` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1054`

View PR using the GUI difftool: \
`$ git pr show -t 1054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1054.diff">https://git.openjdk.org/jdk17u-dev/pull/1054.diff</a>

</details>
