### PR TITLE
8299520: TestPrintXML.java output error messages in case compare fails

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestPrintXML.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintXML.java
@@ -123,6 +123,8 @@ public class TestPrintXML {
             Map<String, Object> xmlMap = (Map<String, Object>) xmlObject;
             List<ValueDescriptor> fields = re.getFields();
             if (fields.size() != xmlMap.size()) {
+                System.err.println("Size of fields of recorded object (" + fields.size() +
+                                   ") and reference (" + xmlMap.size() + ") differ");
                 return false;
             }
             for (ValueDescriptor v : fields) {
@@ -138,6 +140,7 @@ public class TestPrintXML {
                     expectedValue = re.getDuration(name);
                 }
                 if (!compare(expectedValue, xmlValue)) {
+                    System.err.println("Expcted value " + expectedValue + " differs from " + xmlValue);
                     return false;
                 }
             }
@@ -147,10 +150,14 @@ public class TestPrintXML {
             Object[] array = (Object[]) eventObject;
             Object[] xmlArray = (Object[]) xmlObject;
             if (array.length != xmlArray.length) {
+                System.err.println("Array length " + array.length + " differs from length " +
+                                   xmlArray.length);
                 return false;
             }
             for (int i = 0; i < array.length; i++) {
                 if (!compare(array[i], xmlArray[i])) {
+                    System.err.println("Array element " + i + "(" + array[i] +
+                                       ") differs from element " + xmlArray[i]);
                     return false;
                 }
             }
@@ -158,7 +165,11 @@ public class TestPrintXML {
         }
         String s1 = String.valueOf(eventObject);
         String s2 = (String) xmlObject;
-        return s1.equals(s2);
+        boolean res = s1.equals(s2);
+        if (! res) {
+            System.err.println("Event object string " + s1 + " differs from " + s2);
+        }
+        return res;
     }
 
     static class XMLEvent {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299520](https://bugs.openjdk.org/browse/JDK-8299520): TestPrintXML.java output error messages in case compare fails


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1055/head:pull/1055` \
`$ git checkout pull/1055`

Update a local copy of the PR: \
`$ git checkout pull/1055` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1055`

View PR using the GUI difftool: \
`$ git pr show -t 1055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1055.diff">https://git.openjdk.org/jdk17u-dev/pull/1055.diff</a>

</details>
