### PR TITLE
8295116: C2: assert(dead->outcnt() == 0 && !dead->is_top()) failed: node must be dead

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -733,6 +733,7 @@ bool IfNode::is_ctrl_folds(Node* ctrl, PhaseIterGVN* igvn) {
     ctrl->in(0)->as_If()->cmpi_folds(igvn, true) &&
     // Must compare same value
     ctrl->in(0)->in(1)->in(1)->in(1) != NULL &&
+    ctrl->in(0)->in(1)->in(1)->in(1) != igvn->C->top() &&
     ctrl->in(0)->in(1)->in(1)->in(1) == in(1)->in(1)->in(1);
 }
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295116](https://bugs.openjdk.org/browse/JDK-8295116): C2: assert(dead->outcnt() == 0 && !dead->is_top()) failed: node must be dead


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1057/head:pull/1057` \
`$ git checkout pull/1057`

Update a local copy of the PR: \
`$ git checkout pull/1057` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1057`

View PR using the GUI difftool: \
`$ git pr show -t 1057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1057.diff">https://git.openjdk.org/jdk17u-dev/pull/1057.diff</a>

</details>
