### PR TITLE
8279351: [TESTBUG] SADebugDTest.java does not handle "Address already in use" error

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/sadebugd/SADebugDTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8163805 8224252 8196751
+ * @bug 8163805 8224252 8196751 8279351
  * @summary Checks that the jshdb debugd utility successfully starts
  *          and tries to attach to a running process
  * @requires vm.hasSA
@@ -71,6 +71,16 @@ public class SADebugDTest {
         }
     }
 
+    private static boolean checkOutput(final String line, final boolean useRmiPort, final int rmiPort) {
+        if (!useRmiPort && line.contains(GOLDEN)) {
+            testResult = true;
+        } else if (useRmiPort && line.contains(RMI_CONNECTOR_IS_BOUND + rmiPort)) {
+            testResult = true;
+        } else if (line.contains(ADDRESS_ALREADY_IN_USE)) {
+            portInUse = true;
+        }
+        return (line.contains(GOLDEN) || portInUse);
+    }
 
     private static void testWithPid(final boolean useRmiPort, final boolean useRegistryPort, final boolean useHostName) throws Exception {
         LingeredApp app = null;
@@ -95,9 +105,8 @@ public class SADebugDTest {
                     jhsdbLauncher.addToolArg(Integer.toString(registryPort));
                 }
 
-                int rmiPort = -1;
+                final int rmiPort = useRmiPort ? Utils.findUnreservedFreePort(REGISTRY_DEFAULT_PORT, registryPort) : -1;
                 if (useRmiPort) {
-                    rmiPort = Utils.findUnreservedFreePort(REGISTRY_DEFAULT_PORT, registryPort);
                     jhsdbLauncher.addToolArg("--rmiport");
                     jhsdbLauncher.addToolArg(Integer.toString(rmiPort));
                 }
@@ -107,28 +116,16 @@ public class SADebugDTest {
                 }
                 ProcessBuilder pb = SATestUtils.createProcessBuilder(jhsdbLauncher);
 
-                final int finalRmiPort = rmiPort;
-
                 // The startProcess will block until the 'golden' string appears in either process' stdout or stderr
                 // In case of timeout startProcess kills the debugd process
-                Process debugd = startProcess("debugd", pb, null,
-                        l -> {
-                            if (!useRmiPort && l.contains(GOLDEN)) {
-                                testResult = true;
-                            } else if (useRmiPort && l.contains(RMI_CONNECTOR_IS_BOUND + finalRmiPort)) {
-                                testResult = true;
-                            } else if (l.contains(ADDRESS_ALREADY_IN_USE)) {
-                                portInUse = true;
-                            }
-                            return (l.contains(GOLDEN) || portInUse);
-                        }, 20, TimeUnit.SECONDS);
+                Process debugd = startProcess("debugd", pb, null, l -> checkOutput(l, useRmiPort, rmiPort), 20, TimeUnit.SECONDS);
 
                 // If we are here, this means we have received the golden line and the test has passed
                 // The debugd remains running, we have to kill it
                 debugd.destroy();
                 debugd.waitFor();
 
-                if (!testResult) {
+                if (!testResult && !portInUse) {
                     throw new RuntimeException("Expected message \"" +
                             RMI_CONNECTOR_IS_BOUND + rmiPort + "\" is not found in the output.");
                 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279351](https://bugs.openjdk.org/browse/JDK-8279351): [TESTBUG] SADebugDTest.java does not handle "Address already in use" error


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1061/head:pull/1061` \
`$ git checkout pull/1061`

Update a local copy of the PR: \
`$ git checkout pull/1061` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1061`

View PR using the GUI difftool: \
`$ git pr show -t 1061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1061.diff">https://git.openjdk.org/jdk17u-dev/pull/1061.diff</a>

</details>
