### PR TITLE
8300106: Currency.getSymbol(Locale) returns incorrect symbol for en_SL and hr_HR

### DIFF
--- a/make/data/cldr/common/main/en_SL.xml
+++ b/make/data/cldr/common/main/en_SL.xml
@@ -39,7 +39,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 	</dates>
 	<numbers>
 		<currencies>
-			<currency type="SLL">
+			<currency type="SLE">
 				<symbol>Le</symbol>
 			</currency>
 		</currencies>

--- a/make/data/cldr/common/main/hr.xml
+++ b/make/data/cldr/common/main/hr.xml
@@ -6751,7 +6751,7 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 				<displayName count="one">euro</displayName>
 				<displayName count="few">eura</displayName>
 				<displayName count="other">eura</displayName>
-				<symbol>EUR</symbol>
+				<symbol>€</symbol>
 				<symbol alt="narrow" draft="contributed">€</symbol>
 			</currency>
 			<currency type="FIM">


### PR DESCRIPTION
This issue isn't applicable to JDK versions with CLDR upgraded to v42 (JDK-8284840).

Backport of some changes from CLDR v42
 - changes in en_SL.xml that replaces "SSL->Le" entry with "SLE->Le" entry. This resolves the regression after JDK-8283277 that changed  the currency code from SLL to SLE.
 - changes in hr.xml that replaces the EUR symbol with the euro sign

The test attached to the bug report fails without the patch and passes with the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300106](https://bugs.openjdk.org/browse/JDK-8300106): Currency.getSymbol(Locale) returns incorrect symbol for en_SL and hr_HR


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1065/head:pull/1065` \
`$ git checkout pull/1065`

Update a local copy of the PR: \
`$ git checkout pull/1065` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1065/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1065`

View PR using the GUI difftool: \
`$ git pr show -t 1065`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1065.diff">https://git.openjdk.org/jdk17u-dev/pull/1065.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1065#issuecomment-1381555966)