### PR TITLE
8280896: java/nio/file/Files/probeContentType/Basic.java fails on Windows 11

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ public class Basic {
                 new ExType("doc", List.of("application/msword")),
                 new ExType("docx", List.of("application/vnd.openxmlformats-officedocument.wordprocessingml.document")),
                 new ExType("gz", List.of("application/gzip", "application/x-gzip")),
-                new ExType("jar", List.of("application/java-archive", "application/x-java-archive")),
+                new ExType("jar", List.of("application/java-archive", "application/x-java-archive", "application/jar")),
                 new ExType("jpg", List.of("image/jpeg")),
                 new ExType("js", List.of("text/javascript", "application/javascript")),
                 new ExType("json", List.of("application/json")),


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280896](https://bugs.openjdk.org/browse/JDK-8280896): java/nio/file/Files/probeContentType/Basic.java fails on Windows 11


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1070/head:pull/1070` \
`$ git checkout pull/1070`

Update a local copy of the PR: \
`$ git checkout pull/1070` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1070`

View PR using the GUI difftool: \
`$ git pr show -t 1070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1070.diff">https://git.openjdk.org/jdk17u-dev/pull/1070.diff</a>

</details>
