### PR TITLE
8283719: java/util/logging/CheckZombieLockTest.java failing intermittently

### DIFF
--- a/test/jdk/java/util/logging/CheckZombieLockTest.java
+++ b/test/jdk/java/util/logging/CheckZombieLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,8 @@ import java.util.UUID;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import static java.nio.file.StandardOpenOption.*;
+
 public class CheckZombieLockTest {
 
     private static final String WRITABLE_DIR = "writable-lockfile-dir";
@@ -241,10 +243,9 @@ public class CheckZombieLockTest {
             }
 
             if (supportsLocking) {
-                FileChannel fc = FileChannel.open(Paths.get(lock.getAbsolutePath()),
-                    StandardOpenOption.CREATE_NEW, StandardOpenOption.APPEND,
-                    StandardOpenOption.WRITE);
-                try {
+                handler2 = null;
+                try (FileChannel fc = FileChannel.open(lock.toPath(), CREATE_NEW, APPEND, WRITE)) {
+
                     if (fc.tryLock() != null) {
                         System.out.println("locked: " + lock);
                         handler2 = createFileHandler(writableDir);
@@ -261,6 +262,7 @@ public class CheckZombieLockTest {
                         throw new RuntimeException("Failed to lock: " + lock);
                     }
                 } finally {
+                    if (handler2 != null) handler2.close();
                     delete(lock);
                 }
             }
@@ -320,17 +322,12 @@ public class CheckZombieLockTest {
 
         // try to determine whether file locking is supported
         final String uniqueFileName = UUID.randomUUID().toString()+".lck";
-        try {
-            FileChannel fc = FileChannel.open(Paths.get(writableDir.getAbsolutePath(),
-                    uniqueFileName),
-                    StandardOpenOption.CREATE_NEW, StandardOpenOption.APPEND,
-                    StandardOpenOption.DELETE_ON_CLOSE);
+        try (FileChannel fc = FileChannel.open(Paths.get(writableDir.getAbsolutePath(),
+                    uniqueFileName), CREATE_NEW, APPEND, DELETE_ON_CLOSE)) {
             try {
                 fc.tryLock();
-            } catch(IOException x) {
+            } catch (IOException x) {
                 supportsLocking = false;
-            } finally {
-                fc.close();
             }
         } catch (IOException t) {
             // should not happen


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283719](https://bugs.openjdk.org/browse/JDK-8283719): java/util/logging/CheckZombieLockTest.java failing intermittently


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1072/head:pull/1072` \
`$ git checkout pull/1072`

Update a local copy of the PR: \
`$ git checkout pull/1072` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1072`

View PR using the GUI difftool: \
`$ git pr show -t 1072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1072.diff">https://git.openjdk.org/jdk17u-dev/pull/1072.diff</a>

</details>
