### PR TITLE
8297264: C2: Cast node is not processed again in CCP and keeps a wrong too narrow type which is later replaced by top

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1871,6 +1871,30 @@ void PhaseCCP::analyze() {
             }
           }
         }
+        push_cast_ii(worklist, n, m);
+      }
+    }
+  }
+}
+
+void PhaseCCP::push_if_not_bottom_type(Unique_Node_List& worklist, Node* n) const {
+  if (n->bottom_type() != type(n)) {
+    worklist.push(n);
+  }
+}
+
+// CastII::Value() optimizes CmpI/If patterns if the right input of the CmpI has a constant type. If the CastII input is
+// the same node as the left input into the CmpI node, the type of the CastII node can be improved accordingly. Add the
+// CastII node back to the worklist to re-apply Value() to either not miss this optimization or to undo it because it
+// cannot be applied anymore. We could have optimized the type of the CastII before but now the type of the right input
+// of the CmpI (i.e. 'parent') is no longer constant. The type of the CastII must be widened in this case.
+void PhaseCCP::push_cast_ii(Unique_Node_List& worklist, const Node* parent, const Node* use) const {
+  if (use->Opcode() == Op_CmpI && use->in(2) == parent) {
+    Node* other_cmp_input = use->in(1);
+    for (DUIterator_Fast imax, i = other_cmp_input->fast_outs(imax); i < imax; i++) {
+      Node* cast_ii = other_cmp_input->fast_out(i);
+      if (cast_ii->is_CastII()) {
+        push_if_not_bottom_type(worklist, cast_ii);
       }
     }
   }
@@ -1956,7 +1980,6 @@ Node *PhaseCCP::transform( Node *n ) {
   assert(new_root->is_Root(), "transformed root node must be a root node");
   return new_root;
 }
-
 
 //------------------------------transform_once---------------------------------
 // For PhaseCCP, transformation is IDENTITY unless Node computed a constant.

--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -568,6 +568,8 @@ class PhaseCCP : public PhaseIterGVN {
   Unique_Node_List _root_and_safepoints;
   // Non-recursive.  Use analysis to transform single Node.
   virtual Node *transform_once( Node *n );
+  void push_if_not_bottom_type(Unique_Node_List& worklist, Node* n) const;
+  void push_cast_ii(Unique_Node_List& worklist, const Node* parent, const Node* use) const;
 
 public:
   PhaseCCP( PhaseIterGVN *igvn ); // Compute conditional constants

--- a/test/hotspot/jtreg/compiler/ccp/TestCastIIWrongTypeCCP.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestCastIIWrongTypeCCP.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8297264
+ * @summary Test that CastII nodes are added to the CCP worklist if they could have been
+ *          optimized due to a CmpI/If pattern.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.ccp.TestCastIIWrongTypeCCP::*
+ *                   compiler.ccp.TestCastIIWrongTypeCCP
+ */
+package compiler.ccp;
+
+public class TestCastIIWrongTypeCCP {
+
+    static int x;
+
+    public static void main(String[] args) {
+        test();
+    }
+
+    static void test() {
+        int iArr[] = new int[400];
+        int i = 0;
+        do {
+            for (int i5 = 1; i5 < 4; i5++) {
+                for (int i9 = 2; i9 > i5; i9 -= 3) {
+                    if (x != 0) {
+                        A.unloaded(); // unloaded UCT
+                    }
+                    x = 1;
+                    iArr[5] = 1;
+                }
+            }
+            i++;
+        } while (i < 10000);
+    }
+}
+
+class A {
+    public static void unloaded() {
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

I had to place the call to push_cast_ii by hand.
In head, PhaseCCP::analyze() is refactored. 
I also took push_if_not_bottom_type() from head
to make it as similar as possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297264](https://bugs.openjdk.org/browse/JDK-8297264): C2: Cast node is not processed again in CCP and keeps a wrong too narrow type which is later replaced by top


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1078/head:pull/1078` \
`$ git checkout pull/1078`

Update a local copy of the PR: \
`$ git checkout pull/1078` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1078`

View PR using the GUI difftool: \
`$ git pr show -t 1078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1078.diff">https://git.openjdk.org/jdk17u-dev/pull/1078.diff</a>

</details>
