### PR TITLE
8282143: Objects.requireNonNull should be ForceInline

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,6 +203,7 @@ public final class Objects {
      * @return {@code obj} if not {@code null}
      * @throws NullPointerException if {@code obj} is {@code null}
      */
+    @ForceInline
     public static <T> T requireNonNull(T obj) {
         if (obj == null)
             throw new NullPointerException();
@@ -228,6 +229,7 @@ public final class Objects {
      * @return {@code obj} if not {@code null}
      * @throws NullPointerException if {@code obj} is {@code null}
      */
+    @ForceInline
     public static <T> T requireNonNull(T obj, String message) {
         if (obj == null)
             throw new NullPointerException(message);


### PR DESCRIPTION
This is a backport of 8282143 (openjdk/jdk#7543).

This is not only critical for sake of escape analyzis, but also for resolve the issue of significant performance drops due to `checkcast`s being used whenever the return-result of the method is not ignored.

Original author: @merykitty

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8282143](https://bugs.openjdk.org/browse/JDK-8282143): Objects.requireNonNull should be ForceInline


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1079/head:pull/1079` \
`$ git checkout pull/1079`

Update a local copy of the PR: \
`$ git checkout pull/1079` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1079`

View PR using the GUI difftool: \
`$ git pr show -t 1079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1079.diff">https://git.openjdk.org/jdk17u-dev/pull/1079.diff</a>

</details>
