### PR TITLE
8282143: Objects.requireNonNull should be ForceInline

### DIFF
--- a/src/java.base/share/classes/java/util/Objects.java
+++ b/src/java.base/share/classes/java/util/Objects.java
@@ -203,6 +203,7 @@ public final class Objects {
      * @return {@code obj} if not {@code null}
      * @throws NullPointerException if {@code obj} is {@code null}
      */
+    @ForceInline
     public static <T> T requireNonNull(T obj) {
         if (obj == null)
             throw new NullPointerException();
@@ -228,6 +229,7 @@ public final class Objects {
      * @return {@code obj} if not {@code null}
      * @throws NullPointerException if {@code obj} is {@code null}
      */
+    @ForceInline
     public static <T> T requireNonNull(T obj, String message) {
         if (obj == null)
             throw new NullPointerException(message);


### PR DESCRIPTION
Clean backport to improve corner-case performance.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282143](https://bugs.openjdk.org/browse/JDK-8282143): Objects.requireNonNull should be ForceInline


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1080/head:pull/1080` \
`$ git checkout pull/1080`

Update a local copy of the PR: \
`$ git checkout pull/1080` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1080`

View PR using the GUI difftool: \
`$ git pr show -t 1080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1080.diff">https://git.openjdk.org/jdk17u-dev/pull/1080.diff</a>

</details>
