### PR TITLE
8285755: JDK-8285093 changed the default for --with-output-sync

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -161,7 +161,7 @@ AC_DEFUN([BASIC_CHECK_MAKE_OUTPUT_SYNC],
 [
   # Check if make supports the output sync option and if so, setup using it.
   UTIL_ARG_WITH(NAME: output-sync, TYPE: literal,
-      VALID_VALUES: [none recurse line target], DEFAULT: recurse,
+      VALID_VALUES: [none recurse line target], DEFAULT: none,
       OPTIONAL: true, ENABLED_DEFAULT: true,
       ENABLED_RESULT: OUTPUT_SYNC_SUPPORTED,
       CHECKING_MSG: [for make --output-sync value],


### PR DESCRIPTION
This solves the regression from [JDK-8285093](https://bugs.openjdk.org/browse/JDK-8285093) backport. 

It manifests right now in `make test`, when the output from the tests would not show up until *all* tests complete.

Additional testing:
  - [x] Ad-hoc `make test` runs, observing the output is again live

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285755](https://bugs.openjdk.org/browse/JDK-8285755): JDK-8285093 changed the default for --with-output-sync


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1081/head:pull/1081` \
`$ git checkout pull/1081`

Update a local copy of the PR: \
`$ git checkout pull/1081` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1081`

View PR using the GUI difftool: \
`$ git pr show -t 1081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1081.diff">https://git.openjdk.org/jdk17u-dev/pull/1081.diff</a>

</details>
