### PR TITLE
8285919: Remove debug printout from JDK-8285093

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -699,7 +699,6 @@ UTIL_DEFUN_NAMED([UTIL_ARG_WITH],
   ARG_CHECK_AVAILABLE
 
   # Check if the option should be turned on
-  echo check msg:ARG_CHECKING_MSG:
   AC_MSG_CHECKING(ARG_CHECKING_MSG)
 
   if test x$AVAILABLE = xfalse; then


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8285919](https://bugs.openjdk.java.net/browse/JDK-8285919), commit [64225e19](https://github.com/openjdk/jdk/commit/64225e19995e81d2e836ce84befea1a01bb6c860) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The sneaky output is present in jdk17u after backport of [JDK-8285093](https://bugs.openjdk.org/browse/JDK-8285093).

The commit being backported was authored by Magnus Ihse Bursie on 29 Apr 2022 and was reviewed by Erik Joelsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285919](https://bugs.openjdk.org/browse/JDK-8285919): Remove debug printout from JDK-8285093


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1082/head:pull/1082` \
`$ git checkout pull/1082`

Update a local copy of the PR: \
`$ git checkout pull/1082` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1082`

View PR using the GUI difftool: \
`$ git pr show -t 1082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1082.diff">https://git.openjdk.org/jdk17u-dev/pull/1082.diff</a>

</details>
