### PR TITLE
8300119: CgroupMetrics.getTotalMemorySize0() can report invalid results on 32 bit systems

### DIFF
--- a/src/java.base/linux/native/libjava/CgroupMetrics.c
+++ b/src/java.base/linux/native/libjava/CgroupMetrics.c
@@ -39,5 +39,7 @@ JNIEXPORT jlong JNICALL
 Java_jdk_internal_platform_CgroupMetrics_getTotalMemorySize0
   (JNIEnv *env, jclass ignored)
 {
-    return sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
+    jlong pages = sysconf(_SC_PHYS_PAGES);
+    jlong page_size = sysconf(_SC_PAGESIZE);
+    return pages * page_size;
 }


### PR DESCRIPTION
Trivial backport to keep code in sync. Clean. Fixes an issue on some 32 bit builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300119](https://bugs.openjdk.org/browse/JDK-8300119): CgroupMetrics.getTotalMemorySize0() can report invalid results on 32 bit systems


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1086/head:pull/1086` \
`$ git checkout pull/1086`

Update a local copy of the PR: \
`$ git checkout pull/1086` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1086`

View PR using the GUI difftool: \
`$ git pr show -t 1086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1086.diff">https://git.openjdk.org/jdk17u-dev/pull/1086.diff</a>

</details>
