### PR TITLE
8286705: GCC 12 reports use-after-free potential bugs

### DIFF
--- a/src/java.base/share/native/libjli/parse_manifest.c
+++ b/src/java.base/share/native/libjli/parse_manifest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,8 +288,8 @@ find_positions(int fd, Byte *eb, jlong* base_offset, jlong* censtart)
     for (cp = &buffer[bytes - ENDHDR]; cp >= &buffer[0]; cp--)
         if (ENDSIG_AT(cp) && (cp + ENDHDR + ENDCOM(cp) == endpos)) {
             (void) memcpy(eb, cp, ENDHDR);
-            free(buffer);
             pos = flen - (endpos - cp);
+            free(buffer);
             return find_positions64(fd, eb, pos, base_offset, censtart);
         }
     free(buffer);

--- a/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
+++ b/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <linux/limits.h>
@@ -123,6 +124,7 @@ static int popenCommand(const char* cmdlineFormat, const char* arg,
     int callbackMode = POPEN_CALLBACK_USE;
     int exitCode = -1;
     int c;
+    ptrdiff_t char_offset;
 
     cmdline = malloc(cmdlineLenth + 1 /* \0 */);
     if (!cmdline) {
@@ -171,13 +173,14 @@ static int popenCommand(const char* cmdlineFormat, const char* arg,
         if (strBufNextChar == strBufEnd) {
             /* Double buffer size */
             strBufCapacity = strBufCapacity * 2 + 1;
+            char_offset = strBufNextChar - strBufBegin;
             strNewBufBegin = realloc(strBufBegin, strBufCapacity);
             if (!strNewBufBegin) {
                 JP_LOG_ERRNO;
                 goto cleanup;
             }
 
-            strBufNextChar = strNewBufBegin + (strBufNextChar - strBufBegin);
+            strBufNextChar = strNewBufBegin + char_offset;
             strBufEnd = strNewBufBegin + strBufCapacity;
             strBufBegin = strNewBufBegin;
         }


### PR DESCRIPTION
Backport to support building with GCC 12

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286705](https://bugs.openjdk.org/browse/JDK-8286705): GCC 12 reports use-after-free potential bugs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1088/head:pull/1088` \
`$ git checkout pull/1088`

Update a local copy of the PR: \
`$ git checkout pull/1088` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1088`

View PR using the GUI difftool: \
`$ git pr show -t 1088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1088.diff">https://git.openjdk.org/jdk17u-dev/pull/1088.diff</a>

</details>
