### PR TITLE
8280007: Enable Neoverse N1 optimizations for Arm Neoverse V1 & N2

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -197,8 +197,10 @@ void VM_Version::initialize() {
     }
   }
 
-  // Neoverse N1
-  if (_cpu == CPU_ARM && (_model == 0xd0c || _model2 == 0xd0c)) {
+  // Neoverse N1, N2 and V1
+  if (_cpu == CPU_ARM && ((_model == 0xd0c || _model2 == 0xd0c)
+                          || (_model == 0xd49 || _model2 == 0xd49)
+                          || (_model == 0xd40 || _model2 == 0xd40))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }


### PR DESCRIPTION
Enable Neoverse N1 optimizations for Arm Neoverse V1 & N2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280007](https://bugs.openjdk.org/browse/JDK-8280007): Enable Neoverse N1 optimizations for Arm Neoverse V1 & N2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1089/head:pull/1089` \
`$ git checkout pull/1089`

Update a local copy of the PR: \
`$ git checkout pull/1089` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1089`

View PR using the GUI difftool: \
`$ git pr show -t 1089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1089.diff">https://git.openjdk.org/jdk17u-dev/pull/1089.diff</a>

</details>
