### PR TITLE
8266974: duplicate property key in java.sql.rowset resource bundle

### DIFF
--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow : no meta data
 cachedrowsetimpl.movetoins2 = moveToInsertRow : invalid number of columns
 cachedrowsetimpl.tablename = Table name cannot be null
 cachedrowsetimpl.keycols = Invalid key columns
-cachedrowsetimpl.invalidcol = Invalid column index
 cachedrowsetimpl.opnotsupp = Operation not supported by Database
 cachedrowsetimpl.matchcols = Match columns are not the same as those set
 cachedrowsetimpl.setmatchcols = Set Match columns before getting them

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_de.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_de.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow: keine Metadaten
 cachedrowsetimpl.movetoins2 = moveToInsertRow: ung\u00FCltige Spaltenanzahl
 cachedrowsetimpl.tablename = Tabellenname darf nicht null sein
 cachedrowsetimpl.keycols = Ung\u00FCltige Schl\u00FCsselspalten
-cachedrowsetimpl.invalidcol = Ung\u00FCltiger Spaltenindex
 cachedrowsetimpl.opnotsupp = Vorgang nicht von Datenbank unterst\u00FCtzt
 cachedrowsetimpl.matchcols = \u00DCbereinstimmungsspalten entsprechen nicht den festgelegten Spalten
 cachedrowsetimpl.setmatchcols = \u00DCbereinstimmungsspalten m\u00FCssen vor dem Abrufen festgelegt werden

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_es.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_es.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow: no hay metadatos
 cachedrowsetimpl.movetoins2 = moveToInsertRow: n\u00FAmero de columnas no v\u00E1lido
 cachedrowsetimpl.tablename = El nombre de la tabla no puede ser nulo
 cachedrowsetimpl.keycols = Columnas clave no v\u00E1lidas
-cachedrowsetimpl.invalidcol = \u00CDndice de columnas no v\u00E1lido
 cachedrowsetimpl.opnotsupp = La base de datos no admite esta operaci\u00F3n
 cachedrowsetimpl.matchcols = Las columnas coincidentes no concuerdan con las definidas
 cachedrowsetimpl.setmatchcols = Defina las columnas coincidentes antes de obtenerlas

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_fr.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_fr.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow : aucune m\u00E9tadonn\u00E9e
 cachedrowsetimpl.movetoins2 = moveToInsertRow : nombre de colonnes non valide
 cachedrowsetimpl.tablename = Le nom de la table ne peut pas \u00EAtre NULL
 cachedrowsetimpl.keycols = Colonnes de cl\u00E9 non valides
-cachedrowsetimpl.invalidcol = Index de colonne non valide
 cachedrowsetimpl.opnotsupp = Op\u00E9ration non prise en charge par la base de donn\u00E9es
 cachedrowsetimpl.matchcols = Les colonnes correspondantes ne sont pas les m\u00EAmes que les colonnes d\u00E9finies
 cachedrowsetimpl.setmatchcols = D\u00E9finir les colonnes correspondantes avant de les prendre

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_it.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_it.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow: nessun metadato
 cachedrowsetimpl.movetoins2 = moveToInsertRow: numero di colonne non valido
 cachedrowsetimpl.tablename = Il nome di tabella non pu\u00F2 essere nullo
 cachedrowsetimpl.keycols = Colonne chiave non valide
-cachedrowsetimpl.invalidcol = Indice di colonna non valido
 cachedrowsetimpl.opnotsupp = Operazione non supportata dal database
 cachedrowsetimpl.matchcols = Le colonne di corrispondenza non coincidono con le colonne impostate
 cachedrowsetimpl.setmatchcols = Impostare le colonne di corrispondenza prima di recuperarle

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_ja.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_ja.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow: \u30E1\u30BF\u30C7\u30FC\u30BF\u3
 cachedrowsetimpl.movetoins2 = moveToInsertRow: \u7121\u52B9\u306A\u5217\u6570
 cachedrowsetimpl.tablename = \u8868\u540D\u306Bnull\u306F\u4F7F\u7528\u3067\u304D\u307E\u305B\u3093
 cachedrowsetimpl.keycols = \u7121\u52B9\u306A\u30AD\u30FC\u5217
-cachedrowsetimpl.invalidcol = \u7121\u52B9\u306A\u5217\u7D22\u5F15
 cachedrowsetimpl.opnotsupp = \u30C7\u30FC\u30BF\u30D9\u30FC\u30B9\u3067\u30B5\u30DD\u30FC\u30C8\u3055\u308C\u306A\u3044\u64CD\u4F5C
 cachedrowsetimpl.matchcols = \u4E00\u81F4\u5217\u304C\u5217\u306E\u30BB\u30C3\u30C8\u3068\u540C\u3058\u3067\u306F\u3042\u308A\u307E\u305B\u3093
 cachedrowsetimpl.setmatchcols = \u4E00\u81F4\u5217\u3092\u53D6\u5F97\u3059\u308B\u524D\u306B\u8A2D\u5B9A\u3057\u3066\u304F\u3060\u3055\u3044

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_ko.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_ko.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow: \uBA54\uD0C0\uB370\uC774\uD130\uA
 cachedrowsetimpl.movetoins2 = moveToInsertRow: \uC5F4 \uC218\uAC00 \uBD80\uC801\uD569\uD569\uB2C8\uB2E4.
 cachedrowsetimpl.tablename = \uD14C\uC774\uBE14 \uC774\uB984\uC740 \uB110\uC77C \uC218 \uC5C6\uC2B5\uB2C8\uB2E4.
 cachedrowsetimpl.keycols = \uD0A4 \uC5F4\uC774 \uBD80\uC801\uD569\uD569\uB2C8\uB2E4.
-cachedrowsetimpl.invalidcol = \uC5F4 \uC778\uB371\uC2A4\uAC00 \uBD80\uC801\uD569\uD569\uB2C8\uB2E4.
 cachedrowsetimpl.opnotsupp = \uB370\uC774\uD130\uBCA0\uC774\uC2A4\uC5D0\uC11C \uC9C0\uC6D0\uD558\uC9C0 \uC54A\uB294 \uC791\uC5C5\uC785\uB2C8\uB2E4.
 cachedrowsetimpl.matchcols = \uC77C\uCE58 \uC5F4\uC774 \uC124\uC815\uB41C \uC5F4\uACFC \uB3D9\uC77C\uD558\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4.
 cachedrowsetimpl.setmatchcols = \uC77C\uCE58 \uC5F4\uC744 \uC124\uC815\uD55C \uD6C4 \uAC00\uC838\uC624\uC2ED\uC2DC\uC624.

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_pt_BR.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_pt_BR.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow : sem metadados
 cachedrowsetimpl.movetoins2 = moveToInsertRow : n\u00FAmero de colunas inv\u00E1lido
 cachedrowsetimpl.tablename = O nome da tabela n\u00E3o pode ser nulo
 cachedrowsetimpl.keycols = Colunas de chaves inv\u00E1lidas
-cachedrowsetimpl.invalidcol = \u00CDndice de coluna inv\u00E1lido
 cachedrowsetimpl.opnotsupp = Opera\u00E7\u00E3o n\u00E3o suportada pelo Banco de Dados
 cachedrowsetimpl.matchcols = As colunas correspondentes n\u00E3o s\u00E3o iguais \u00E0s colunas definidas
 cachedrowsetimpl.setmatchcols = Definir Colunas correspondentes antes de obt\u00EA-las

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_sv.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_sv.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow: inga metadata
 cachedrowsetimpl.movetoins2 = moveToInsertRow: ogiltigt antal kolumner
 cachedrowsetimpl.tablename = Tabellnamnet kan inte vara null
 cachedrowsetimpl.keycols = Ogiltiga nyckelkolumner
-cachedrowsetimpl.invalidcol = Ogiltigt kolumnindex
 cachedrowsetimpl.opnotsupp = Databasen har inte st\u00F6d f\u00F6r denna \u00E5tg\u00E4rd
 cachedrowsetimpl.matchcols = Matchningskolumnerna \u00E4r inte samma som de som st\u00E4llts in
 cachedrowsetimpl.setmatchcols = St\u00E4ll in matchningskolumnerna innan du h\u00E4mtar dem

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_zh_CN.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_zh_CN.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow: \u65E0\u5143\u6570\u636E
 cachedrowsetimpl.movetoins2 = moveToInsertRow: \u5217\u6570\u65E0\u6548
 cachedrowsetimpl.tablename = \u8868\u540D\u4E0D\u80FD\u4E3A\u7A7A\u503C
 cachedrowsetimpl.keycols = \u5173\u952E\u5B57\u5217\u65E0\u6548
-cachedrowsetimpl.invalidcol = \u5217\u7D22\u5F15\u65E0\u6548
 cachedrowsetimpl.opnotsupp = \u64CD\u4F5C\u4E0D\u53D7\u6570\u636E\u5E93\u652F\u6301
 cachedrowsetimpl.matchcols = \u5339\u914D\u5217\u4E0E\u8BBE\u7F6E\u7684\u90A3\u4E9B\u5339\u914D\u5217\u4E0D\u540C
 cachedrowsetimpl.setmatchcols = \u5728\u83B7\u53D6\u5339\u914D\u5217\u4E4B\u524D\u5148\u8BBE\u7F6E\u5339\u914D\u5217

--- a/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_zh_TW.properties
+++ b/src/java.sql.rowset/share/classes/com/sun/rowset/RowSetResourceBundle_zh_TW.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,6 @@ cachedrowsetimpl.movetoins1 = moveToInsertRow: \u6C92\u6709\u63CF\u8FF0\u8CC7\u6
 cachedrowsetimpl.movetoins2 = moveToInsertRow: \u6B04\u6578\u7121\u6548
 cachedrowsetimpl.tablename = \u8868\u683C\u540D\u7A31\u4E0D\u80FD\u70BA\u7A7A\u503C
 cachedrowsetimpl.keycols = \u95DC\u9375\u6B04\u7121\u6548
-cachedrowsetimpl.invalidcol = \u6B04\u7D22\u5F15\u7121\u6548
 cachedrowsetimpl.opnotsupp = \u8CC7\u6599\u5EAB\u4E0D\u652F\u63F4\u4F5C\u696D
 cachedrowsetimpl.matchcols = \u5339\u914D\u6B04\u548C\u8A2D\u5B9A\u7684\u6B04\u4E0D\u540C
 cachedrowsetimpl.setmatchcols = \u5728\u53D6\u5F97\u5339\u914D\u6B04\u4E4B\u524D\u8A2D\u5B9A\u5B83\u5011


### PR DESCRIPTION
Signed-off-by: Shruthi <Shruthi.Shruthi1@ibm.com>

OpenJDK PR : https://github.com/openjdk/jdk/pull/7212
OpenJDK bug : https://bugs.openjdk.org/browse/JDK-8266974

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266974](https://bugs.openjdk.org/browse/JDK-8266974): duplicate property key in java.sql.rowset resource bundle


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1091/head:pull/1091` \
`$ git checkout pull/1091`

Update a local copy of the PR: \
`$ git checkout pull/1091` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1091`

View PR using the GUI difftool: \
`$ git pr show -t 1091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1091.diff">https://git.openjdk.org/jdk17u-dev/pull/1091.diff</a>

</details>
