### PR TITLE
8292033: Move jdk.X509Certificate event logic to JCA layer

### DIFF
--- a/src/java.base/share/classes/java/security/cert/CertificateFactory.java
+++ b/src/java.base/share/classes/java/security/cert/CertificateFactory.java
@@ -26,14 +26,14 @@
 package java.security.cert;
 
 import java.io.InputStream;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
 import java.security.Provider;
 import java.security.Security;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
 
 import sun.security.jca.*;
 import sun.security.jca.GetInstance.Instance;
@@ -352,7 +352,9 @@ public class CertificateFactory {
     public final Certificate generateCertificate(InputStream inStream)
         throws CertificateException
     {
-        return certFacSpi.engineGenerateCertificate(inStream);
+        Certificate c = certFacSpi.engineGenerateCertificate(inStream);
+        JCAUtil.tryCommitCertEvent(c);
+        return c;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/event/X509CertificateEvent.java
+++ b/src/java.base/share/classes/jdk/internal/event/X509CertificateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,15 @@ package jdk.internal.event;
  */
 
 public final class X509CertificateEvent extends Event {
+    private static final X509CertificateEvent EVENT = new X509CertificateEvent();
+
+    /**
+     * Returns {@code true} if event is enabled, {@code false} otherwise.
+     */
+    public static boolean isTurnedOn() {
+        return EVENT.isEnabled();
+    }
+
     public String algorithm;
     public String serialNumber;
     public String subject;

--- a/src/java.base/share/classes/sun/security/jca/JCAUtil.java
+++ b/src/java.base/share/classes/sun/security/jca/JCAUtil.java
@@ -27,6 +27,13 @@ package sun.security.jca;
 
 import java.lang.ref.*;
 import java.security.*;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import jdk.internal.event.EventHelper;
+import jdk.internal.event.X509CertificateEvent;
+import sun.security.util.KeyUtil;
 
 /**
  * Collection of static utility methods used by the security framework.
@@ -91,6 +98,45 @@ public final class JCAUtil {
             }
         }
         return result;
+    }
 
+    public static void tryCommitCertEvent(Certificate cert) {
+        if ((X509CertificateEvent.isTurnedOn() || EventHelper.isLoggingSecurity()) &&
+                (cert instanceof X509Certificate x509)) {
+            PublicKey pKey = x509.getPublicKey();
+            String algId = x509.getSigAlgName();
+            String serNum = x509.getSerialNumber().toString(16);
+            String subject = x509.getSubjectX500Principal().toString();
+            String issuer = x509.getIssuerX500Principal().toString();
+            String keyType = pKey.getAlgorithm();
+            int length = KeyUtil.getKeySize(pKey);
+            int hashCode = x509.hashCode();
+            long beginDate = x509.getNotBefore().getTime();
+            long endDate = x509.getNotAfter().getTime();
+            if (X509CertificateEvent.isTurnedOn()) {
+                X509CertificateEvent xce = new X509CertificateEvent();
+                xce.algorithm = algId;
+                xce.serialNumber = serNum;
+                xce.subject = subject;
+                xce.issuer = issuer;
+                xce.keyType = keyType;
+                xce.keyLength = length;
+                xce.certificateId = hashCode;
+                xce.validFrom = beginDate;
+                xce.validUntil = endDate;
+                xce.commit();
+            }
+            if (EventHelper.isLoggingSecurity()) {
+                EventHelper.logX509CertificateEvent(algId,
+                        serNum,
+                        subject,
+                        issuer,
+                        keyType,
+                        length,
+                        hashCode,
+                        beginDate,
+                        endDate);
+            }
+        }
     }
 }

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
@@ -355,7 +355,7 @@ public final class OCSPResponse {
             try {
                 for (int i = 0; i < derCerts.length; i++) {
                     X509CertImpl cert =
-                        new X509CertImpl(derCerts[i].toByteArray());
+                        X509CertImpl.newX509CertImpl(derCerts[i].toByteArray());
                     certs.add(cert);
 
                     if (debug != null) {

--- a/src/java.base/share/classes/sun/security/provider/certpath/X509CertificatePair.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/X509CertificatePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,7 @@ public class X509CertificatePair {
                         }
                         opt = opt.data.getDerValue();
                         forward = X509Factory.intern
-                                        (new X509CertImpl(opt.toByteArray()));
+                                        (X509CertImpl.newX509CertImpl(opt.toByteArray()));
                     }
                     break;
                 case TAG_REVERSE:
@@ -251,7 +251,7 @@ public class X509CertificatePair {
                         }
                         opt = opt.data.getDerValue();
                         reverse = X509Factory.intern
-                                        (new X509CertImpl(opt.toByteArray()));
+                                        (X509CertImpl.newX509CertImpl(opt.toByteArray()));
                     }
                     break;
                 default:

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.security.auth.x500.X500Principal;
 
+import sun.security.jca.JCAUtil;
 import sun.security.util.*;
 import sun.security.provider.X509Factory;
 
@@ -302,6 +303,13 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
             signedCert = null;
             throw new CertificateException("Unable to initialize, " + e, e);
         }
+    }
+
+    // helper method to record certificate, if necessary, after construction
+    public static X509CertImpl newX509CertImpl(byte[] certData) throws CertificateException {
+        var cert = new X509CertImpl(certData);
+        JCAUtil.tryCommitCertEvent(cert);
+        return cert;
     }
 
     /**

--- a/test/jdk/jdk/jfr/event/security/TestX509ValidationEvent.java
+++ b/test/jdk/jdk/jfr/event/security/TestX509ValidationEvent.java
@@ -39,7 +39,7 @@ import jdk.test.lib.security.TestCertificate;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @modules jdk.jfr/jdk.jfr.events
+ * @modules jdk.jfr/jdk.jfr.events java.base/sun.security.x509 java.base/sun.security.tools.keytool
  * @run main/othervm jdk.jfr.event.security.TestX509ValidationEvent
  */
 public class TestX509ValidationEvent {

--- a/test/jdk/jdk/security/logging/TestX509CertificateLog.java
+++ b/test/jdk/jdk/security/logging/TestX509CertificateLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 
 package jdk.security.logging;
 
-import java.security.cert.CertificateFactory;
 import jdk.test.lib.security.TestCertificate;
 
 /*
@@ -31,6 +30,7 @@ import jdk.test.lib.security.TestCertificate;
  * @bug 8148188
  * @summary Enhance the security libraries to record events of interest
  * @library /test/lib /test/jdk
+ * @modules java.base/sun.security.x509 java.base/sun.security.tools.keytool
  * @run main/othervm jdk.security.logging.TestX509CertificateLog LOGGING_ENABLED
  * @run main/othervm jdk.security.logging.TestX509CertificateLog LOGGING_DISABLED
  */

--- a/test/jdk/jdk/security/logging/TestX509ValidationLog.java
+++ b/test/jdk/jdk/security/logging/TestX509ValidationLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import jdk.test.lib.security.TestCertificate;
  * @bug 8148188
  * @summary Enhance the security libraries to record events of interest
  * @library /test/lib /test/jdk
+ * @modules java.base/sun.security.x509 java.base/sun.security.tools.keytool
  * @run main/othervm jdk.security.logging.TestX509ValidationLog LOGGING_ENABLED
  * @run main/othervm jdk.security.logging.TestX509ValidationLog LOGGING_DISABLED
  */


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

JCAUtil.java: resolved imports.

X509Factory.java
* resolved imports
* in head, engineGenerateCertificate() is refactored. Part of it 
  is moved to cachedGetX509Cert(), and this is edited.
  I fixed the corresponding, identical code in engineGenerateCertificate() in 
  17. I did not find other places in head where the new method is called.
* The patch removes commitEvent(). This did not apply because of the 'static'
  keyword in head.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292033](https://bugs.openjdk.org/browse/JDK-8292033): Move jdk.X509Certificate event logic to JCA layer


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1092/head:pull/1092` \
`$ git checkout pull/1092`

Update a local copy of the PR: \
`$ git checkout pull/1092` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1092`

View PR using the GUI difftool: \
`$ git pr show -t 1092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1092.diff">https://git.openjdk.org/jdk17u-dev/pull/1092.diff</a>

</details>
