### PR TITLE
JDK-8300751: [17u] Remove duplicate entry in javac.properties

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -121,8 +121,6 @@ javac.opt.arg.profile=\
     <profile>
 javac.opt.arg.release=\
     <release>
-javac.opt.arg.release=\
-    <release>
 javac.opt.arg.number=\
     <number>
 javac.opt.plugin=\


### PR DESCRIPTION
Signed-off-by: Shruthi <Shruthi.Shruthi1@ibm.com>

OpenJDK bug : https://bugs.openjdk.org/browse/JDK-8300751

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300751](https://bugs.openjdk.org/browse/JDK-8300751): [17u] Remove duplicate entry in javac.properties


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1096/head:pull/1096` \
`$ git checkout pull/1096`

Update a local copy of the PR: \
`$ git checkout pull/1096` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1096`

View PR using the GUI difftool: \
`$ git pr show -t 1096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1096.diff">https://git.openjdk.org/jdk17u-dev/pull/1096.diff</a>

</details>
