### PR TITLE
8208077: File.listRoots performance degradation

### DIFF
--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -653,7 +653,7 @@ class WinNTFileSystem extends FileSystem {
             .valueOf(new long[] {listRoots0()})
             .stream()
             .mapToObj(i -> new File((char)('A' + i) + ":" + slash))
-            .filter(f -> access(f.getPath()) && f.exists())
+            .filter(f -> access(f.getPath()))
             .toArray(File[]::new);
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8208077](https://bugs.openjdk.org/browse/JDK-8208077): File.listRoots performance degradation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1098/head:pull/1098` \
`$ git checkout pull/1098`

Update a local copy of the PR: \
`$ git checkout pull/1098` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1098`

View PR using the GUI difftool: \
`$ git pr show -t 1098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1098.diff">https://git.openjdk.org/jdk17u-dev/pull/1098.diff</a>

</details>
