### PR TITLE
8285690: CloneableReference subtest should not throw CloneNotSupportedException

### DIFF
--- a/test/jdk/java/lang/ref/ReferenceClone.java
+++ b/test/jdk/java/lang/ref/ReferenceClone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8201793
+ * @bug 8201793 8285690
  * @summary Test Reference::clone to throw CloneNotSupportedException
  */
 
@@ -47,7 +47,9 @@ public class ReferenceClone {
         CloneableReference ref = new CloneableReference(o);
         try {
             ref.clone();
-        } catch (CloneNotSupportedException e) {}
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException("CloneableReference::clone should not throw CloneNotSupportedException");
+        }
     }
 
     private void assertCloneNotSupported(CloneableRef ref) {


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285690](https://bugs.openjdk.org/browse/JDK-8285690): CloneableReference subtest should not throw CloneNotSupportedException


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1099/head:pull/1099` \
`$ git checkout pull/1099`

Update a local copy of the PR: \
`$ git checkout pull/1099` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1099`

View PR using the GUI difftool: \
`$ git pr show -t 1099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1099.diff">https://git.openjdk.org/jdk17u-dev/pull/1099.diff</a>

</details>
