### PR TITLE
8231491: JDI tc02x004 failed again due to wrong # of breakpoints

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ import java.io.*;
  *
  * When the test is starting debugee, debugger creates <code>MethodEntryRequest</code>.
  * After <code>MethodEntryEvent</code> arrived, debugger checks line number of one's
- * location. It should be 73th line, that is constructor of <code>tc02x004aClass1</code>
+ * location. It should be 79th line, that is constructor of <code>tc02x004aClass1</code>
  * class. Every thread must generate <code>MethodEntryEvent</code>.
  *
  * In case, when at least one event doesn't arrive during waittime
@@ -123,7 +123,6 @@ public class tc02x004 {
 
         display("\nTEST BEGINS");
         display("===========");
-        debugee.resume();
 
         EventSet eventSet = null;
         EventIterator eventIterator = null;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc02x004/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@
  *     works as follow:
  *     When the test is starting debugee, debugger creates MethodEntryRequest.
  *     After MethodEntryEvent arrived, debugger checks line number of one's
- *     location. It should be 59th line, that is constructor of tc02x004aClass1
+ *     location. It should be 79th line, that is constructor of tc02x004aClass1
  *     class. Every thread must generate MethodEntryEvent.
  *     The test looks like tc002x001 except that synchronizing debugger and
  *     debugee is performed without IOPipe channel.


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8231491](https://bugs.openjdk.org/browse/JDK-8231491): JDI tc02x004 failed again due to wrong # of breakpoints


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1101/head:pull/1101` \
`$ git checkout pull/1101`

Update a local copy of the PR: \
`$ git checkout pull/1101` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1101`

View PR using the GUI difftool: \
`$ git pr show -t 1101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1101.diff">https://git.openjdk.org/jdk17u-dev/pull/1101.diff</a>

</details>
