### PR TITLE
8298129: Let checkpoint event sizes grow beyond u4 limit

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -227,64 +227,72 @@ BufferPtr JfrCheckpointManager::flush(BufferPtr old, size_t used, size_t request
 }
 
 // offsets into the JfrCheckpointEntry
-static const juint starttime_offset = sizeof(jlong);
-static const juint duration_offset = starttime_offset + sizeof(jlong);
-static const juint checkpoint_type_offset = duration_offset + sizeof(jlong);
-static const juint types_offset = checkpoint_type_offset + sizeof(juint);
-static const juint payload_offset = types_offset + sizeof(juint);
+static const size_t starttime_offset = sizeof(int64_t);
+static const size_t duration_offset = starttime_offset + sizeof(int64_t);
+static const size_t checkpoint_type_offset = duration_offset + sizeof(int64_t);
+static const size_t types_offset = checkpoint_type_offset + sizeof(uint32_t);
+static const size_t payload_offset = types_offset + sizeof(uint32_t);
 
 template <typename Return>
 static Return read_data(const u1* data) {
   return JfrBigEndian::read<Return>(data);
 }
 
-static jlong total_size(const u1* data) {
-  return read_data<jlong>(data);
+static size_t total_size(const u1* data) {
+  const int64_t size = read_data<int64_t>(data);
+  assert(size > 0, "invariant");
+  return static_cast<size_t>(size);
 }
 
-static jlong starttime(const u1* data) {
-  return read_data<jlong>(data + starttime_offset);
+static int64_t starttime(const u1* data) {
+  return read_data<int64_t>(data + starttime_offset);
 }
 
-static jlong duration(const u1* data) {
-  return read_data<jlong>(data + duration_offset);
+static int64_t duration(const u1* data) {
+  return read_data<int64_t>(data + duration_offset);
 }
 
-static u1 checkpoint_type(const u1* data) {
-  return read_data<u1>(data + checkpoint_type_offset);
+static uint8_t checkpoint_type(const u1* data) {
+  return read_data<uint8_t>(data + checkpoint_type_offset);
 }
 
-static juint number_of_types(const u1* data) {
-  return read_data<juint>(data + types_offset);
+static uint32_t number_of_types(const u1* data) {
+  return read_data<uint32_t>(data + types_offset);
 }
 
-static void write_checkpoint_header(JfrChunkWriter& cw, int64_t delta_to_last_checkpoint, const u1* data) {
-  cw.reserve(sizeof(u4));
-  cw.write<u8>(EVENT_CHECKPOINT);
-  cw.write(starttime(data));
-  cw.write(duration(data));
-  cw.write(delta_to_last_checkpoint);
-  cw.write(checkpoint_type(data));
-  cw.write(number_of_types(data));
+static size_t payload_size(const u1* data) {
+  return total_size(data) - sizeof(JfrCheckpointEntry);
 }
 
-static void write_checkpoint_content(JfrChunkWriter& cw, const u1* data, size_t size) {
-  assert(data != NULL, "invariant");
-  cw.write_unbuffered(data + payload_offset, size - sizeof(JfrCheckpointEntry));
+static uint64_t calculate_event_size_bytes(JfrChunkWriter& cw, const u1* data, int64_t event_begin, int64_t delta_to_last_checkpoint) {
+  assert(data != nullptr, "invariant");
+  size_t bytes = cw.size_in_bytes(EVENT_CHECKPOINT);
+  bytes += cw.size_in_bytes(starttime(data));
+  bytes += cw.size_in_bytes(duration(data));
+  bytes += cw.size_in_bytes(delta_to_last_checkpoint);
+  bytes += cw.size_in_bytes(checkpoint_type(data));
+  bytes += cw.size_in_bytes(number_of_types(data));
+  bytes += payload_size(data); // in bytes already.
+  return bytes + cw.size_in_bytes(bytes + cw.size_in_bytes(bytes));
 }
 
 static size_t write_checkpoint_event(JfrChunkWriter& cw, const u1* data) {
   assert(data != NULL, "invariant");
   const int64_t event_begin = cw.current_offset();
   const int64_t last_checkpoint_event = cw.last_checkpoint_offset();
-  const int64_t delta_to_last_checkpoint = last_checkpoint_event == 0 ? 0 : last_checkpoint_event - event_begin;
-  const int64_t checkpoint_size = total_size(data);
-  write_checkpoint_header(cw, delta_to_last_checkpoint, data);
-  write_checkpoint_content(cw, data, checkpoint_size);
-  const int64_t event_size = cw.current_offset() - event_begin;
-  cw.write_padded_at_offset<u4>(event_size, event_begin);
   cw.set_last_checkpoint_offset(event_begin);
-  return (size_t)checkpoint_size;
+  const int64_t delta_to_last_checkpoint = last_checkpoint_event == 0 ? 0 : last_checkpoint_event - event_begin;
+  const uint64_t event_size = calculate_event_size_bytes(cw, data, event_begin, delta_to_last_checkpoint);
+  cw.write(event_size);
+  cw.write(EVENT_CHECKPOINT);
+  cw.write(starttime(data));
+  cw.write(duration(data));
+  cw.write(delta_to_last_checkpoint);
+  cw.write(checkpoint_type(data));
+  cw.write(number_of_types(data));
+  cw.write_unbuffered(data + payload_offset, payload_size(data));
+  assert(static_cast<uint64_t>(cw.current_offset() - event_begin) == event_size, "invariant");
+  return total_size(data);
 }
 
 static size_t write_checkpoints(JfrChunkWriter& cw, const u1* data, size_t size) {

--- a/src/hotspot/share/jfr/writers/jfrEncoding.hpp
+++ b/src/hotspot/share/jfr/writers/jfrEncoding.hpp
@@ -70,6 +70,11 @@ class EncoderHost : public AllStatic {
   }
 
   template <typename T>
+  static size_t size_in_bytes(T value) {
+    return IntegerEncoder::size_in_bytes(value);
+  }
+
+  template <typename T>
   static u1* write(T value, u1* pos) {
     return write(&value, 1, pos);
   }

--- a/src/hotspot/share/jfr/writers/jfrWriterHost.hpp
+++ b/src/hotspot/share/jfr/writers/jfrWriterHost.hpp
@@ -97,6 +97,8 @@ class WriterHost : public WriterPolicyImpl {
   template <typename T>
   void write_be_at_offset(T value, int64_t offset);
   int64_t reserve(size_t size);
+  template <typename T>
+  size_t size_in_bytes(T value);
 };
 
 #endif // SHARE_JFR_WRITERS_JFRWRITERHOST_HPP

--- a/src/hotspot/share/jfr/writers/jfrWriterHost.inline.hpp
+++ b/src/hotspot/share/jfr/writers/jfrWriterHost.inline.hpp
@@ -358,4 +358,10 @@ inline void WriterHost<BE, IE, WriterPolicyImpl>::write_be_at_offset(T value, in
   }
 }
 
+template <typename BE, typename IE, typename WriterPolicyImpl>
+template <typename T>
+inline size_t WriterHost<BE, IE, WriterPolicyImpl>::size_in_bytes(T value) {
+  return IE::size_in_bytes(value);
+}
+
 #endif // SHARE_JFR_WRITERS_JFRWRITERHOST_INLINE_HPP

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkParser.java
@@ -237,7 +237,7 @@ public final class ChunkParser {
         long absoluteChunkEnd = chunkHeader.getEnd();
         while (input.position() < absoluteChunkEnd) {
             long pos = input.position();
-            int size = input.readInt();
+            long size = input.readLong();
             if (size == 0) {
                 throw new IOException("Event can't have zero size");
             }
@@ -305,7 +305,7 @@ public final class ChunkParser {
         while (thisCP != abortCP && delta != 0) {
             input.position(thisCP);
             lastCP = thisCP;
-            int size = input.readInt(); // size
+            long size = input.readLong(); // size
             long typeId = input.readLong();
             if (typeId != CONSTANT_POOL_TYPE_ID) {
                 throw new IOException("Expected check point event (id = 1) at position " + lastCP + ", but found type id = " + typeId);


### PR DESCRIPTION
I'd like to backport JDK-8298129 to 17u. 
It fixes corrupted jfr dumps that can be generated for applications with a large stack trace pool or string pool. Such dumps can not be read by jfr tool or JMC.
I also plan to backport small follow-up fix JDK-8298649.

The patch doesn't apply cleanly, minor modifications required:
- jfrCheckpointManager.cpp: types in checkpoint_type() are adapted (u1 -> uint8_t insted of juint -> int32_t in jdk20). The type was modified by JDK-8284161 that is not backported to 17u
- jfrCheckpointManager.cpp: changes in write_thread_checkpoint_content() and VirtualThreadLocalCheckpointWriteOp are skipped as this code is absent in 17u. It was added by JDK-8284161 and its follow-up JDK-8293864 that are not backported to 17u
- ChunkParser.java: the second hunk in readEvent() is skipped as this code is absent in 17u. It was added by JDK-8271232 that is not backported to 17u

Tested with tier1 and jdk/jfr tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298129](https://bugs.openjdk.org/browse/JDK-8298129): Let checkpoint event sizes grow beyond u4 limit


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1102/head:pull/1102` \
`$ git checkout pull/1102`

Update a local copy of the PR: \
`$ git checkout pull/1102` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1102`

View PR using the GUI difftool: \
`$ git pr show -t 1102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1102.diff">https://git.openjdk.org/jdk17u-dev/pull/1102.diff</a>

</details>
