### PR TITLE
8294705: Disable an assertion in test/jdk/java/util/DoubleStreamSums/CompensatedSums.java

### DIFF
--- a/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
+++ b/test/jdk/java/util/DoubleStreamSums/CompensatedSums.java
@@ -91,7 +91,13 @@ public class CompensatedSums {
         }
 
         Assert.assertTrue(jdkParallelStreamError <= goodParallelStreamError);
-        Assert.assertTrue(badParallelStreamError >= jdkParallelStreamError);
+        /*
+         * Due to floating-point addition being inherently non-associative,
+         * and due to the unpredictable scheduling of the threads used
+         * in parallel streams, this assertion can fail intermittently,
+         * hence is suppressed for now.
+         */
+        // Assert.assertTrue(badParallelStreamError >= jdkParallelStreamError);
 
         Assert.assertTrue(goodSequentialStreamError >= jdkSequentialStreamError);
         Assert.assertTrue(naive > jdkSequentialStreamError);


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [c08ff2c7](https://github.com/openjdk/jdk/commit/c08ff2c7b88e94885f6b4701654a9e47e49567b0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Raffaello Giulietti on 20 Oct 2022 and was reviewed by Brian Burkhalter.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294705](https://bugs.openjdk.org/browse/JDK-8294705): Disable an assertion in test/jdk/java/util/DoubleStreamSums/CompensatedSums.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1103/head:pull/1103` \
`$ git checkout pull/1103`

Update a local copy of the PR: \
`$ git checkout pull/1103` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1103`

View PR using the GUI difftool: \
`$ git pr show -t 1103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1103.diff">https://git.openjdk.org/jdk17u-dev/pull/1103.diff</a>

</details>
