### PR TITLE
8294902: Undefined Behavior in C2 regalloc with null references

### DIFF
--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -419,10 +419,10 @@ void *Arena::Arealloc(void* old_ptr, size_t old_size, size_t new_size, AllocFail
 
 // Determine if pointer belongs to this Arena or not.
 bool Arena::contains( const void *ptr ) const {
+  if (_chunk == NULL) return false;
 #ifdef ASSERT
   if (UseMallocOnly) {
     // really slow, but not easy to make fast
-    if (_chunk == NULL) return false;
     char** bottom = (char**)_chunk->bottom();
     for (char** p = (char**)_hwm - 1; p >= bottom; p--) {
       if (*p == ptr) return true;

--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -43,7 +43,7 @@ InlineTree::InlineTree(Compile* c,
                        JVMState* caller_jvms, int caller_bci,
                        int max_inline_level) :
   C(c),
-  _caller_jvms(caller_jvms),
+  _caller_jvms(NULL),
   _method(callee),
   _caller_tree((InlineTree*) caller_tree),
   _count_inline_bcs(method()->code_size_for_inlining()),
@@ -55,13 +55,13 @@ InlineTree::InlineTree(Compile* c,
   _count_inlines = 0;
   _forced_inline = false;
 #endif
-  if (_caller_jvms != NULL) {
+  if (caller_jvms != NULL) {
     // Keep a private copy of the caller_jvms:
     _caller_jvms = new (C) JVMState(caller_jvms->method(), caller_tree->caller_jvms());
     _caller_jvms->set_bci(caller_jvms->bci());
     assert(!caller_jvms->should_reexecute(), "there should be no reexecute bytecode with inlining");
+    assert(_caller_jvms->same_calls_as(caller_jvms), "consistent JVMS");
   }
-  assert(_caller_jvms->same_calls_as(caller_jvms), "consistent JVMS");
   assert((caller_tree == NULL ? 0 : caller_tree->stack_depth() + 1) == stack_depth(), "correct (redundant) depth parameter");
   assert(caller_bci == this->caller_bci(), "correct (redundant) bci parameter");
   // Update hierarchical counts, count_inline_bcs() and count_inlines()

--- a/src/hotspot/share/opto/chaitin.hpp
+++ b/src/hotspot/share/opto/chaitin.hpp
@@ -730,8 +730,8 @@ private:
   int yank_if_dead_recurse(Node *old, Node *orig_old, Block *current_block,
       Node_List *value, Node_List *regnd);
   int yank( Node *old, Block *current_block, Node_List *value, Node_List *regnd );
-  int elide_copy( Node *n, int k, Block *current_block, Node_List &value, Node_List &regnd, bool can_change_regs );
-  int use_prior_register( Node *copy, uint idx, Node *def, Block *current_block, Node_List &value, Node_List &regnd );
+  int elide_copy( Node *n, int k, Block *current_block, Node_List *value, Node_List *regnd, bool can_change_regs );
+  int use_prior_register( Node *copy, uint idx, Node *def, Block *current_block, Node_List *value, Node_List *regnd );
   bool may_be_copy_of_callee( Node *def ) const;
 
   // If nreg already contains the same constant as val then eliminate it

--- a/src/hotspot/share/runtime/vmStructs.hpp
+++ b/src/hotspot/share/runtime/vmStructs.hpp
@@ -188,13 +188,18 @@ private:
 #ifdef ASSERT
 
 // This macro checks the type of a VMStructEntry by comparing pointer types
-#define CHECK_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)                 \
- {typeName *dummyObj = NULL; type* dummy = &dummyObj->fieldName;                   \
-  assert(offset_of(typeName, fieldName) < sizeof(typeName), "Illegal nonstatic struct entry, field offset too large"); }
+#define CHECK_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, type) { \
+  static_assert( \
+    std::is_convertible< \
+      std::add_pointer_t<decltype(declval<typeName>().fieldName)>, \
+      std::add_pointer_t<type>>::value, \
+    "type mismatch for " XSTR(fieldName) " member of " XSTR(typeName)); \
+  assert(offset_of(typeName, fieldName) < sizeof(typeName), "..."); \
+}
 
 // This macro checks the type of a volatile VMStructEntry by comparing pointer types
-#define CHECK_VOLATILE_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)        \
- {typedef type dummyvtype; typeName *dummyObj = NULL; volatile dummyvtype* dummy = &dummyObj->fieldName; }
+#define CHECK_VOLATILE_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, type) \
+  CHECK_NONSTATIC_VM_STRUCT_ENTRY(typeName, fieldName, std::add_volatile_t<type>)
 
 // This macro checks the type of a static VMStructEntry by comparing pointer types
 #define CHECK_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)                    \

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -35,6 +35,7 @@
 #include COMPILER_HEADER(utilities/globalDefinitions)
 
 #include <cstddef>
+#include <type_traits>
 
 class oopDesc;
 
@@ -1209,5 +1210,9 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
   return k0 == k1;
 }
 
+
+// Converts any type T to a reference type.
+template<typename T>
+std::add_rvalue_reference_t<T> declval() noexcept;
 
 #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_HPP

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -144,10 +144,21 @@ inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
 #endif // _LP64
 
 // gcc warns about applying offsetof() to non-POD object or calculating
-// offset directly when base address is NULL. Use 16 to get around the
-// warning. The -Wno-invalid-offsetof option could be used to suppress
-// this warning, but we instead just avoid the use of offsetof().
-#define offset_of(klass,field) (size_t)((intx)&(((klass*)16)->field) - 16)
+// offset directly when base address is NULL. The -Wno-invalid-offsetof
+// option could be used to suppress this warning, but we instead just
+// avoid the use of offsetof().
+//
+// FIXME: This macro is complex and rather arcane. Perhaps we should
+// use offsetof() instead, with the invalid-offsetof warning
+// temporarily disabled.
+#define offset_of(klass,field)                          \
+[]() {                                                  \
+  char space[sizeof (klass)] ATTRIBUTE_ALIGNED(16);     \
+  klass* dummyObj = (klass*)space;                      \
+  char* c = (char*)(void*)&dummyObj->field;             \
+  return (size_t)(c - space);                           \
+}()
+
 
 #if defined(_LP64) && defined(__APPLE__)
 #define JLONG_FORMAT          "%ld"


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

I had to resolve arena.cpp because there is ASSERT coding in
the context, which already contains the new code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294902](https://bugs.openjdk.org/browse/JDK-8294902): Undefined Behavior in C2 regalloc with null references


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1106/head:pull/1106` \
`$ git checkout pull/1106`

Update a local copy of the PR: \
`$ git checkout pull/1106` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1106`

View PR using the GUI difftool: \
`$ git pr show -t 1106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1106.diff">https://git.openjdk.org/jdk17u-dev/pull/1106.diff</a>

</details>
