### PR TITLE
8284115: [IR Framework] Compilation is not found due to rare safepoint while dumping PrintIdeal/PrintOptoAssembly

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/AbstractLine.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/AbstractLine.java
@@ -25,6 +25,8 @@ package compiler.lib.ir_framework.driver.irmatching.parser;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Base class of a read line from the hotspot_pid* file.
@@ -32,9 +34,11 @@ import java.io.IOException;
 abstract class AbstractLine {
     private final BufferedReader reader;
     protected String line;
+    private final Pattern compileIdPatternForTestClass;
 
-    public AbstractLine(BufferedReader reader) {
+    public AbstractLine(BufferedReader reader, Pattern compileIdPatternForTestClass) {
         this.reader = reader;
+        this.compileIdPatternForTestClass = compileIdPatternForTestClass;
     }
 
     public String getLine() {
@@ -47,5 +51,38 @@ abstract class AbstractLine {
     public boolean readLine() throws IOException {
         line = reader.readLine();
         return line != null;
+    }
+
+    /**
+     * Is this line a start of a method in the test class? We only care about test class entries. There might be non-class
+     * entries as well if the user specified additional compile commands. Ignore these.
+     */
+    public boolean isTestClassCompilation() {
+        if (isCompilation()) {
+            Matcher matcher = compileIdPatternForTestClass.matcher(line);
+            return matcher.find();
+        }
+        return false;
+    }
+
+    /**
+     * Is this header a C2 non-OSR compilation header entry?
+     */
+    public boolean isCompilation() {
+        return line.startsWith("<task_queued") && notOSRCompilation() && notC2Compilation();
+    }
+
+    /**
+     * OSR compilations have compile_kind set.
+     */
+    protected boolean notOSRCompilation() {
+        return !line.contains("compile_kind='");
+    }
+
+    /**
+     * Non-C2 compilations have level set.
+     */
+    private boolean notC2Compilation() {
+        return !line.contains("level='");
     }
 }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/Block.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/Block.java
@@ -23,39 +23,21 @@
 
 package compiler.lib.ir_framework.driver.irmatching.parser;
 
-import java.io.BufferedReader;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.List;
 
 /**
- * Class representing a normal line read from the hotspot_pid* file.
+ * Class representing a PrintIdeal or PrintOptoAssembly output block read from the hotspot_pid* file.
  */
-class Line extends AbstractLine {
-    public Line(BufferedReader reader, Pattern compileIdPatternForTestClass) {
-        super(reader, compileIdPatternForTestClass);
+record Block(String output, List<String> testClassCompilations) {
+    public String getOutput() {
+        return output;
     }
 
-    /**
-     * Is this line a start of a PrintIdeal or PrintOptoAssembly output block?
-     */
-    public boolean isBlockStart() {
-        return isPrintIdealStart() || isPrintOptoAssemblyStart();
+    public boolean containsTestClassCompilations() {
+        return !testClassCompilations.isEmpty();
     }
 
-    /**
-     * Is this line a start of a PrintIdeal output block?
-     */
-    public boolean isPrintIdealStart() {
-        // Ignore OSR compilations which have compile_kind set.
-        return line.startsWith("<ideal") && notOSRCompilation();
-    }
-
-    /**
-     * Is this line a start of a PrintOptoAssembly output block?
-     */
-    private boolean isPrintOptoAssemblyStart() {
-        // Ignore OSR compilations which have compile_kind set.
-        return line.startsWith("<opto_assembly") && notOSRCompilation();
+    public List<String> getTestClassCompilations() {
+        return testClassCompilations;
     }
 }
-

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/BlockLine.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/BlockLine.java
@@ -24,14 +24,15 @@
 package compiler.lib.ir_framework.driver.irmatching.parser;
 
 import java.io.BufferedReader;
+import java.util.regex.Pattern;
 
 /**
  * Class representing a block line inside a PrintIdeal or PrintOptoAssembly output block read from the hotspot_pid* file.
  */
 class BlockLine extends AbstractLine {
 
-    public BlockLine(BufferedReader reader) {
-        super(reader);
+    public BlockLine(BufferedReader reader, Pattern compileIdPatternForTestClass) {
+        super(reader, compileIdPatternForTestClass);
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/BlockOutputReader.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/BlockOutputReader.java
@@ -25,27 +25,36 @@ package compiler.lib.ir_framework.driver.irmatching.parser;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Class to read all lines of a PrintIdeal or PrintOptoAssembly block.
  */
 class BlockOutputReader {
-    private final BufferedReader reader;
+    private final BlockLine line;
 
-    public BlockOutputReader(BufferedReader reader) {
-        this.reader = reader;
+    public BlockOutputReader(BufferedReader reader, Pattern compileIdPatternForTestClass) {
+        this.line = new BlockLine(reader, compileIdPatternForTestClass);
     }
 
     /**
      * Read all lines belonging to a PrintIdeal or PrintOptoAssembly output block.
      */
-    public String readBlock() throws IOException {
-        BlockLine line = new BlockLine(reader);
+    public Block readBlock() throws IOException {
         StringBuilder builder = new StringBuilder();
+        List<String> testClassCompilations = new ArrayList<>();
         while (line.readLine() && !line.isBlockEnd()) {
+            if (line.isTestClassCompilation()) {
+                // Could have safepointed while writing the block (see IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE)
+                // and enqueuing the next test class method for compilation during the interruption. Record this
+                // method to ensure that we read the PrintIdeal/PrintOptoAssembly blocks for that method later.
+                testClassCompilations.add(line.getLine());
+            }
             builder.append(escapeXML(line.getLine())).append(System.lineSeparator());
         }
-        return builder.toString();
+        return new Block(builder.toString(), testClassCompilations);
     }
 
     /**

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/HotSpotPidFileParser.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/parser/HotSpotPidFileParser.java
@@ -56,6 +56,7 @@ class HotSpotPidFileParser {
     public void setCompilationsMap(Map<String, IRMethod> compilationsMap) {
         this.compilationsMap = compilationsMap;
     }
+
     /**
      * Parse the hotspot_pid*.log file from the test VM. Read the PrintIdeal and PrintOptoAssembly outputs for all
      * methods of the test class that need to be IR matched (found in compilations map).
@@ -75,16 +76,26 @@ class HotSpotPidFileParser {
         Map<Integer, IRMethod> compileIdMap = new HashMap<>();
         try (var reader = Files.newBufferedReader(Paths.get(hotspotPidFileName))) {
             Line line = new Line(reader, compileIdPatternForTestClass);
-            BlockOutputReader blockOutputReader = new BlockOutputReader(reader);
+            BlockOutputReader blockOutputReader = new BlockOutputReader(reader, compileIdPatternForTestClass);
             while (line.readLine()) {
                 if (line.isTestClassCompilation()) {
                     parseTestMethodCompileId(compileIdMap, line.getLine());
                 } else if (isTestMethodBlockStart(line, compileIdMap)) {
-                    String blockOutput = blockOutputReader.readBlock();
-                    setIRMethodOutput(blockOutput, line, compileIdMap);
+                    processMethodBlock(compileIdMap, line, blockOutputReader);
                 }
             }
         }
+    }
+
+    private void processMethodBlock(Map<Integer, IRMethod> compileIdMap, Line line, BlockOutputReader blockOutputReader)
+            throws IOException {
+        Block block = blockOutputReader.readBlock();
+        if (block.containsTestClassCompilations()) {
+            // Register all test method compilations that could have been emitted during a rare safepoint while
+            // dumping the PrintIdeal/PrintOptoAssembly output.
+            block.getTestClassCompilations().forEach(l -> parseTestMethodCompileId(compileIdMap, l));
+        }
+        setIRMethodOutput(block.getOutput(), line, compileIdMap);
     }
 
     private void parseTestMethodCompileId(Map<Integer, IRMethod> compileIdMap, String line) {
@@ -101,6 +112,9 @@ class HotSpotPidFileParser {
         return matcher.group(2);
     }
 
+    /**
+     * Is this a @Test method?
+     */
     private boolean isTestAnnotatedMethod(String testMethodName) {
         return compilationsMap.containsKey(testMethodName);
     }
@@ -108,8 +122,6 @@ class HotSpotPidFileParser {
     private IRMethod getIrMethod(String testMethodName) {
         return compilationsMap.get(testMethodName);
     }
-
-
 
     private int getCompileId(String line) {
         Matcher matcher = COMPILE_ID_PATTERN.matcher(line);
@@ -119,6 +131,9 @@ class HotSpotPidFileParser {
         return Integer.parseInt(matcher.group(1));
     }
 
+    /**
+     * Is this line the start of a PrintIdeal/PrintOptoAssembly output block of a @Test method?
+     */
     private boolean isTestMethodBlockStart(Line line, Map<Integer, IRMethod> compileIdMap) {
       return line.isBlockStart() && isTestClassMethodBlock(line, compileIdMap);
     }


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284115](https://bugs.openjdk.org/browse/JDK-8284115): [IR Framework] Compilation is not found due to rare safepoint while dumping PrintIdeal/PrintOptoAssembly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1109/head:pull/1109` \
`$ git checkout pull/1109`

Update a local copy of the PR: \
`$ git checkout pull/1109` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1109`

View PR using the GUI difftool: \
`$ git pr show -t 1109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1109.diff">https://git.openjdk.org/jdk17u-dev/pull/1109.diff</a>

</details>
