### PR TITLE
8285965: TestScenarios.java does not check for "<!-- safepoint while printing -->" correctly

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,9 @@ import compiler.lib.ir_framework.*;
 import compiler.lib.ir_framework.shared.TestRunException;
 import jdk.test.lib.Asserts;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
 /*
  * @test
  * @requires vm.debug == true & vm.compMode != "Xint" & vm.compiler2.enabled & vm.flagless
@@ -37,6 +40,11 @@ import jdk.test.lib.Asserts;
 
 public class TestScenarios {
     public static void main(String[] args) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+        PrintStream oldOut = System.out;
+        System.setOut(ps);
+
         Scenario sDefault = new Scenario(0);
         Scenario s1 = new Scenario(1, "-XX:TLABRefillWasteFraction=51");
         Scenario s2 = new Scenario(2, "-XX:TLABRefillWasteFraction=52");
@@ -44,28 +52,23 @@ public class TestScenarios {
         Scenario s3dup = new Scenario(3, "-XX:TLABRefillWasteFraction=53");
         try {
             new TestFramework().addScenarios(sDefault, s1, s2, s3).start();
-            if (Utils.notAllBailedOut(sDefault, s1, s3)) {
-                // Not all scenarios had a bailout which means that at least one exception should have been thrown.
-                Asserts.fail("Should have thrown an exception");
-            }
+            Utils.shouldHaveThrownException(baos.toString());
         } catch (TestRunException e) {
             if (!e.getMessage().contains("The following scenarios have failed: #0, #1, #3")) {
-                // Was there a bailout in a scenario? If not fail.
-                Asserts.assertTrue(Utils.anyBailedOut(sDefault, s1, s3), e.getMessage());
+                Utils.throwIfNoSafepointPrinting(baos.toString(), e);
             }
         }
+
+        baos.reset();
         try {
             new TestFramework().addScenarios(s1, s2, s3).start();
-            if (Utils.notAllBailedOut(s1, s3)) {
-                // Not all scenarios had a bailout which means that at least one exception should have been thrown.
-                Asserts.fail("Should have thrown an exception");
-            }
+            Utils.shouldHaveThrownException(baos.toString());
         } catch (TestRunException e) {
             if (!e.getMessage().contains("The following scenarios have failed: #1, #3")) {
-                // Was there a bailout in a scenario? If not fail.
-                Asserts.assertTrue(Utils.anyBailedOut(sDefault, s1, s3), e.getMessage());
+                Utils.throwIfNoSafepointPrinting(baos.toString(), e);
             }
         }
+        System.setOut(oldOut);
         new TestFramework(ScenarioTest.class).addScenarios(s1, s2, s3).start();
         try {
             new TestFramework().addScenarios(s1, s3dup, s2, s3).start();

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/Utils.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/Utils.java
@@ -30,25 +30,17 @@ import jdk.test.lib.Asserts;
 import java.util.Arrays;
 
 public class Utils {
-    public static void shouldHaveThrownException(String s) {
+    public static void shouldHaveThrownException(String output) {
         // Do not throw an exception if we hit a safepoint while printing which could possibly let the IR matching fail.
         // This happens very rarely. If there is a problem with the test, then we will catch that on the next test invocation.
-        if (!s.contains(IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE)) {
+        if (!output.contains(IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE)) {
             Asserts.fail("Should have thrown exception");
         }
     }
 
-    /**
-     * Is there at least one scenario which hit a safepoint while printing (i.e. a bailout)?
-     */
-    public static boolean anyBailedOut(Scenario... scenarios) {
-        return Arrays.stream(scenarios).anyMatch(s -> s.getTestVMOutput().contains(IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE));
-    }
-
-    /**
-     * Is there at least one scenario which did not hit a safepoint while printing (i.e. a bailout)?
-     */
-    public static boolean notAllBailedOut(Scenario... scenarios) {
-        return Arrays.stream(scenarios).anyMatch(s -> !s.getTestVMOutput().contains(IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE));
+    public static void throwIfNoSafepointPrinting(String output, RuntimeException e) {
+        if (!output.contains(IRMatcher.SAFEPOINT_WHILE_PRINTING_MESSAGE)) {
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.


*** The "Robby Naish" PR number ***

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285965](https://bugs.openjdk.org/browse/JDK-8285965): TestScenarios.java does not check for "<!-- safepoint while printing -->" correctly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1111/head:pull/1111` \
`$ git checkout pull/1111`

Update a local copy of the PR: \
`$ git checkout pull/1111` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1111`

View PR using the GUI difftool: \
`$ git pr show -t 1111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1111.diff">https://git.openjdk.org/jdk17u-dev/pull/1111.diff</a>

</details>
