### PR TITLE
8300692: GCC 12 reports some compiler warnings in bundled freetype

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -423,7 +423,7 @@ else
           $(BUILD_LIBFREETYPE_CFLAGS), \
       EXTRA_HEADER_DIRS := $(BUILD_LIBFREETYPE_HEADER_DIRS), \
       DISABLED_WARNINGS_microsoft := 4018 4267 4244 4312 4819, \
-      DISABLED_WARNINGS_gcc := implicit-fallthrough cast-function-type bad-function-cast, \
+      DISABLED_WARNINGS_gcc := implicit-fallthrough cast-function-type bad-function-cast dangling-pointer stringop-overflow, \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
   ))


### PR DESCRIPTION
Another backport to enable building with GCC 12, local builds with other required patches to enable GCC12 and tier1/2 are passing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300692](https://bugs.openjdk.org/browse/JDK-8300692): GCC 12 reports some compiler warnings in bundled freetype


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1115/head:pull/1115` \
`$ git checkout pull/1115`

Update a local copy of the PR: \
`$ git checkout pull/1115` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1115`

View PR using the GUI difftool: \
`$ git pr show -t 1115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1115.diff">https://git.openjdk.org/jdk17u-dev/pull/1115.diff</a>

</details>
