### PR TITLE
8286694: Incorrect argument processing in java launcher

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,8 @@
  * the CreateExecutionEnviroment will remove the -d<n> flags.
  */
 
+
+#include <assert.h>
 
 #include "java.h"
 #include "jni.h"
@@ -1626,7 +1628,8 @@ TranslateApplicationArgs(int jargc, const char **jargv, int *pargc, char ***parg
     for (i = 0; i < jargc; i++) {
         const char *arg = jargv[i];
         if (arg[0] == '-' && arg[1] == 'J') {
-            *nargv++ = ((arg + 2) == NULL) ? NULL : JLI_StringDup(arg + 2);
+            assert(arg[2] != '\0' && "Invalid JAVA_ARGS or EXTRA_JAVA_ARGS defined by build");
+            *nargv++ = JLI_StringDup(arg + 2);
         }
     }
 


### PR DESCRIPTION
Backport of another fix for GCC 12 support. Build and tier1/2 are passing locally with required patches on linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286694](https://bugs.openjdk.org/browse/JDK-8286694): Incorrect argument processing in java launcher


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1117/head:pull/1117` \
`$ git checkout pull/1117`

Update a local copy of the PR: \
`$ git checkout pull/1117` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1117`

View PR using the GUI difftool: \
`$ git pr show -t 1117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1117.diff">https://git.openjdk.org/jdk17u-dev/pull/1117.diff</a>

</details>
