### PR TITLE
8275704: Metaspace::contains() should be threadsafe

### DIFF
--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.hpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.hpp
@@ -40,22 +40,32 @@ namespace metaspace {
 class Metachunk;
 class FreeChunkListVector;
 
-// VirtualSpaceList manages a single (if its non-expandable) or
-//  a series of (if its expandable) virtual memory regions used
+// VirtualSpaceList manages a series of virtual memory regions used
 //  for metaspace.
 //
 // Internally it holds a list of nodes (VirtualSpaceNode) each
 //  managing a single contiguous memory region. The first node of
 //  this list is the current node and used for allocation of new
 //  root chunks.
+//
+// The list will only ever grow, never shrink. It will be immortal,
+//  never to be destroyed.
+//
+// The list will only be modified under lock protection, but may be
+//  read concurrently without lock.
+//
+// The list may be prevented from expanding beyond a single node -
+//  in that case it degenerates to a one-node-list (used for
+//  class space).
+//
 
 class VirtualSpaceList : public CHeapObj<mtClass> {
 
   // Name
   const char* const _name;
 
-  // Head of the list.
-  VirtualSpaceNode* _first_node;
+  // Head of the list (last added).
+  VirtualSpaceNode* volatile _first_node;
 
   // Number of nodes (kept for statistics only).
   IntCounter _nodes_counter;


### PR DESCRIPTION
Makes Metaspace::contains() threadsafe by adding fences to VS list node walking.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275704](https://bugs.openjdk.org/browse/JDK-8275704): Metaspace::contains() should be threadsafe


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1120/head:pull/1120` \
`$ git checkout pull/1120`

Update a local copy of the PR: \
`$ git checkout pull/1120` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1120`

View PR using the GUI difftool: \
`$ git pr show -t 1120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1120.diff">https://git.openjdk.org/jdk17u-dev/pull/1120.diff</a>

</details>
