### PR TITLE
6779701: Wrong defect ID in the code of test LocalRMIServerSocketFactoryTest.java

### DIFF
--- a/test/jdk/sun/management/jmxremote/LocalRMIServerSocketFactoryTest.java
+++ b/test/jdk/sun/management/jmxremote/LocalRMIServerSocketFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,17 +64,17 @@ public class LocalRMIServerSocketFactoryTest {
         }
 
 
-        // case of 6674166: this is very unlikely to happen, even if
-        //     both 6674166 and 6774170 aren't fixed. If it happens
+        // case of 6774166: this is very unlikely to happen, even if
+        //     both 6774166 and 6774170 aren't fixed. If it happens
         //     however, it might indicate that neither defects are fixed.
 
         if (x instanceof NullPointerException) {
             throw new Exception(message + " - " +
-                    "Congratulations! it seems you have triggered 6674166. " +
-                    "Neither 6674166 nor 6774170 seem to be fixed: " + x, x);
+                    "Congratulations! it seems you have triggered 6774166. " +
+                    "Neither 6774166 nor 6774170 seem to be fixed: " + x, x);
         } else if (x instanceof IOException) {
             throw new Exception(message + " - " +
-                    "Unexpected IOException. Maybe you triggered 6674166? " +
+                    "Unexpected IOException. Maybe you triggered 6774166? " +
                     x, x);
         } else if (x != null) {
             throw new Exception(message + " - " +


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6779701](https://bugs.openjdk.org/browse/JDK-6779701): Wrong defect ID in the code of test LocalRMIServerSocketFactoryTest.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1122/head:pull/1122` \
`$ git checkout pull/1122`

Update a local copy of the PR: \
`$ git checkout pull/1122` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1122`

View PR using the GUI difftool: \
`$ git pr show -t 1122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1122.diff">https://git.openjdk.org/jdk17u-dev/pull/1122.diff</a>

</details>
