### PR TITLE
8282036: Change java/util/zip/ZipFile/DeleteTempJar.java to stop HttpServer cleanly in case of exceptions

### DIFF
--- a/test/jdk/java/util/zip/ZipFile/DeleteTempJar.java
+++ b/test/jdk/java/util/zip/ZipFile/DeleteTempJar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,16 +72,19 @@ public class DeleteTempJar
                     }
                 }
             });
-        server.start();
 
-        URL url = new URL("jar:http://localhost:"
+        server.start();
+        try {
+            URL url = new URL("jar:http://localhost:"
                           + new Integer(server.getAddress().getPort()).toString()
                           + "/deletetemp.jar!/");
-        JarURLConnection c = (JarURLConnection)url.openConnection();
-        JarFile f = c.getJarFile();
-        check(f.getEntry("entry") != null);
-        System.out.println(f.getName());
-        server.stop(0);
+            JarURLConnection c = (JarURLConnection)url.openConnection();
+            JarFile f = c.getJarFile();
+            check(f.getEntry("entry") != null);
+            System.out.println(f.getName());
+        } finally {
+            server.stop(0);
+        }
     }
 
     //--------------------- Infrastructure ---------------------------


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282036](https://bugs.openjdk.org/browse/JDK-8282036): Change java/util/zip/ZipFile/DeleteTempJar.java to stop HttpServer cleanly in case of exceptions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1127/head:pull/1127` \
`$ git checkout pull/1127`

Update a local copy of the PR: \
`$ git checkout pull/1127` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1127`

View PR using the GUI difftool: \
`$ git pr show -t 1127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1127.diff">https://git.openjdk.org/jdk17u-dev/pull/1127.diff</a>

</details>
