### PR TITLE
8301397: [11u, 17u] Bump jtreg to fix issue with build JDK 11.0.18

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -26,7 +26,7 @@
 # Versions and download locations for dependencies used by GitHub Actions (GHA)
 
 GTEST_VERSION=1.8.1
-JTREG_VERSION=6.1+2
+JTREG_VERSION=6.1+3
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
 LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.2_8.tar.gz


### PR DESCRIPTION
Bump GHA jtreg to 6.1+3 to unbreak GHA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301397](https://bugs.openjdk.org/browse/JDK-8301397): [11u, 17u] Bump jtreg to fix issue with build JDK 11.0.18


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1129/head:pull/1129` \
`$ git checkout pull/1129`

Update a local copy of the PR: \
`$ git checkout pull/1129` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1129`

View PR using the GUI difftool: \
`$ git pr show -t 1129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1129.diff">https://git.openjdk.org/jdk17u-dev/pull/1129.diff</a>

</details>
