### PR TITLE
8296329: jar validator doesn't account for minor class file version

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
@@ -105,7 +105,7 @@ final class FingerPrint {
     }
 
     public boolean isCompatibleVersion(FingerPrint that) {
-        return attrs.version >= that.attrs.version;
+        return attrs.majorVersion >= that.attrs.majorVersion;
     }
 
     public boolean isSameAPI(FingerPrint that) {
@@ -236,7 +236,7 @@ final class FingerPrint {
         private String name;
         private String outerClassName;
         private String superName;
-        private int version;
+        private int majorVersion;
         private int access;
         private boolean publicClass;
         private boolean nestedClass;
@@ -255,7 +255,7 @@ final class FingerPrint {
         @Override
         public void visit(int version, int access, String name, String signature,
                           String superName, String[] interfaces) {
-            this.version = version;
+            this.majorVersion = version & 0xFFFF; // JDK-8296329: extract major version only
             this.access = access;
             this.name = name;
             this.nestedClass = name.contains("$");

--- a/test/jdk/tools/jar/multiRelease/MRTestBase.java
+++ b/test/jdk/tools/jar/multiRelease/MRTestBase.java
@@ -102,6 +102,10 @@ public class MRTestBase {
     }
 
     void javac(Path dest, Path... sourceFiles) throws Throwable {
+        javac(dest, List.of(), sourceFiles);
+    }
+
+    void javac(Path dest, List<String> extraParameters, Path... sourceFiles) throws Throwable {
 
         List<String> commands = new ArrayList<>();
         String opts = System.getProperty("test.compiler.opts");
@@ -114,6 +118,7 @@ public class MRTestBase {
         Stream.of(sourceFiles)
                 .map(Object::toString)
                 .forEach(x -> commands.add(x));
+        commands.addAll(extraParameters);
 
         StringWriter sw = new StringWriter();
         try (PrintWriter pw = new PrintWriter(sw)) {
@@ -122,7 +127,6 @@ public class MRTestBase {
                 throw new RuntimeException(sw.toString());
             }
         }
-
     }
 
     OutputAnalyzer jarWithStdin(File stdinSource,

--- a/test/jdk/tools/jar/multiRelease/VersionValidatorTest.java
+++ b/test/jdk/tools/jar/multiRelease/VersionValidatorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+* @test
+# @bug 8296329
+* @summary Tests for version validator.
+* @library /test/lib
+* @modules java.base/jdk.internal.misc
+*          jdk.compiler
+*          jdk.jartool
+* @build jdk.test.lib.Utils
+*        jdk.test.lib.Asserts
+*        jdk.test.lib.JDKToolFinder
+*        jdk.test.lib.JDKToolLauncher
+*        jdk.test.lib.Platform
+*        jdk.test.lib.process.*
+*        MRTestBase
+* @run testng/timeout=1200 VersionValidatorTest
+*/
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class VersionValidatorTest extends MRTestBase {
+    private Path root;
+
+    @BeforeMethod
+    void testInit(Method method) {
+        root = Paths.get(method.getName());
+    }
+
+    @Test(dataProvider = "differentMajorVersions")
+    public void onlyCompatibleVersionIsAllowedInMultiReleaseJar(String baseMajorVersion, String otherMajorVersion,
+            boolean enablePreviewForBaseVersion, boolean enablePreviewForOtherVersion, boolean isAcceptable)
+            throws Throwable {
+        Path baseVersionClassesDir = compileLibClass(baseMajorVersion, enablePreviewForBaseVersion);
+        Path otherVersionClassesDir = compileLibClass(otherMajorVersion, enablePreviewForOtherVersion);
+
+        var result = jar("--create", "--file", "lib.jar", "-C", baseVersionClassesDir.toString(), "Lib.class",
+                "--release", otherMajorVersion, "-C", otherVersionClassesDir.toString(), "Lib.class");
+
+        if (isAcceptable) {
+            result.shouldHaveExitValue(SUCCESS)
+                    .shouldBeEmptyIgnoreVMWarnings();
+        } else {
+            result.shouldNotHaveExitValue(SUCCESS)
+                    .shouldContain("has a class version incompatible with an earlier version");
+        }
+    }
+
+    private Path compileLibClass(String majorVersion, boolean enablePreview) throws Throwable {
+        String classTemplate = """
+                public class Lib {
+                    public static int version = $VERSION;
+                }
+                    """;
+
+        Path sourceFile = Files.createDirectories(root.resolve("src").resolve(majorVersion)).resolve("Lib.java");
+        Files.write(sourceFile, classTemplate.replace("$VERSION", majorVersion).getBytes());
+
+        Path classesDir = root.resolve("classes").resolve(majorVersion);
+
+        javac(classesDir, List.of("--release", majorVersion), sourceFile);
+        if (enablePreview) {
+            rewriteMinorVersionForEnablePreviewClass(classesDir.resolve("Lib.class"));
+        }
+        return classesDir;
+    }
+
+    private void rewriteMinorVersionForEnablePreviewClass(Path classFile) throws Throwable {
+        byte[] classBytes = Files.readAllBytes(classFile);
+        classBytes[4] = -1;
+        classBytes[5] = -1;
+        Files.write(classFile, classBytes);
+    }
+
+    @DataProvider
+    Object[][] differentMajorVersions() {
+        return new Object[][] {
+                { "19", "20", false, true, true },
+                { "19", "20", false, false, true },
+                { "19", "20", true, true, true },
+                { "19", "20", true, false, true },
+                { "20", "19", false, true, false },
+                { "20", "19", false, false, false },
+                { "20", "19", true, true, false },
+                { "20", "19", true, false, false },
+        };
+    }
+}

--- a/test/jdk/tools/jar/multiRelease/VersionValidatorTest.java
+++ b/test/jdk/tools/jar/multiRelease/VersionValidatorTest.java
@@ -105,14 +105,14 @@ public class VersionValidatorTest extends MRTestBase {
     @DataProvider
     Object[][] differentMajorVersions() {
         return new Object[][] {
-                { "19", "20", false, true, true },
-                { "19", "20", false, false, true },
-                { "19", "20", true, true, true },
-                { "19", "20", true, false, true },
-                { "20", "19", false, true, false },
-                { "20", "19", false, false, false },
-                { "20", "19", true, true, false },
-                { "20", "19", true, false, false },
+                { "16", "17", false, true, true },
+                { "16", "17", false, false, true },
+                { "16", "17", true, true, true },
+                { "16", "17", true, false, true },
+                { "17", "16", false, true, false },
+                { "17", "16", false, false, false },
+                { "17", "16", true, true, false },
+                { "17", "16", true, false, false },
         };
     }
 }


### PR DESCRIPTION
Technically not clean, changed Java versions in test (separate commit)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296329](https://bugs.openjdk.org/browse/JDK-8296329): jar validator doesn't account for minor class file version


### Reviewers
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1132/head:pull/1132` \
`$ git checkout pull/1132`

Update a local copy of the PR: \
`$ git checkout pull/1132` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1132`

View PR using the GUI difftool: \
`$ git pr show -t 1132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1132.diff">https://git.openjdk.org/jdk17u-dev/pull/1132.diff</a>

</details>
