### PR TITLE
8289400: Improve com/sun/jdi/TestScaffold error reporting

### DIFF
--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -451,6 +451,10 @@ abstract public class TestScaffold extends TargetAdapter {
 
     protected void failure(String str) {
         println(str);
+        StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+        for (StackTraceElement traceElement : trace) {
+            System.err.println("\tat " + traceElement);
+        }
         testFailed = true;
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289400](https://bugs.openjdk.org/browse/JDK-8289400): Improve com/sun/jdi/TestScaffold error reporting


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1138/head:pull/1138` \
`$ git checkout pull/1138`

Update a local copy of the PR: \
`$ git checkout pull/1138` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1138`

View PR using the GUI difftool: \
`$ git pr show -t 1138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1138.diff">https://git.openjdk.org/jdk17u-dev/pull/1138.diff</a>

</details>
