### PR TITLE
8293326: jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java slow on Windows

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -67,6 +67,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
@@ -1034,13 +1035,19 @@ public class Compatibility {
             throws Throwable {
         long start = System.currentTimeMillis();
         try {
+            String[] cmd;
+            if (Platform.isWindows()) {
+                cmd = new String[args.length + 3];
+                System.arraycopy(args, 0, cmd, 3, args.length);
+            } else {
+                cmd = new String[args.length + 4];
+                cmd[3] = "-J-Djava.security.egd=file:/dev/./urandom";
+                System.arraycopy(args, 0, cmd, 4, args.length);
+            }
 
-            String[] cmd = new String[args.length + 4];
             cmd[0] = toolPath;
             cmd[1] = "-J-Duser.language=en";
             cmd[2] = "-J-Duser.country=US";
-            cmd[3] = "-J-Djava.security.egd=file:/dev/./urandom";
-            System.arraycopy(args, 0, cmd, 4, args.length);
             return ProcessTools.executeCommand(cmd);
 
         } finally {


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293326](https://bugs.openjdk.org/browse/JDK-8293326): jdk/sun/security/tools/jarsigner/compatibility/SignTwice.java slow on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1139/head:pull/1139` \
`$ git checkout pull/1139`

Update a local copy of the PR: \
`$ git checkout pull/1139` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1139`

View PR using the GUI difftool: \
`$ git pr show -t 1139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1139.diff">https://git.openjdk.org/jdk17u-dev/pull/1139.diff</a>

</details>
