### PR TITLE
8298073: gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java causes test task timeout on macosx

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -81,7 +81,6 @@ gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
 gc/stress/gclocker/TestGCLockerWithParallel.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
-gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java 8241293 macosx-x64
 
 applications/jcstress/acqrel.java 8277434 linux-aarch64
 

--- a/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
+++ b/test/hotspot/jtreg/gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,11 @@ package gc.metaspace;
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:CompressedClassSpaceSize=48m gc.metaspace.CompressedClassSpaceSizeInJmapHeap
+ * @run main/timeout=240 gc.metaspace.CompressedClassSpaceSizeInJmapHeap
  */
 
 import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.SA.SATestUtils;
@@ -49,7 +50,9 @@ public class CompressedClassSpaceSizeInJmapHeap {
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
 
-        String pid = Long.toString(ProcessTools.getProcessId());
+        LingeredApp theApp = new LingeredApp();
+        LingeredApp.startApp(theApp, "-XX:CompressedClassSpaceSize=48m");
+        String pid = Long.toString(theApp.getPid());
 
         JDKToolLauncher jmap = JDKToolLauncher.create("jhsdb")
                                               .addToolArg("jmap")
@@ -69,6 +72,8 @@ public class CompressedClassSpaceSizeInJmapHeap {
         OutputAnalyzer output = new OutputAnalyzer(read(out));
         output.shouldContain("CompressedClassSpaceSize = 50331648 (48.0MB)");
         out.delete();
+
+        LingeredApp.stopApp(theApp);
     }
 
     private static void run(ProcessBuilder pb) throws Exception {


### PR DESCRIPTION
II backport this for parity with 17.0.7-oracle.

I had to resolve.
ProblemList: not listed for macosx-aarch64.
The @run command differed, removed IgnoreUnrecognizedOptions jin addition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8298073](https://bugs.openjdk.org/browse/JDK-8298073): gc/metaspace/CompressedClassSpaceSizeInJmapHeap.java causes test task timeout on macosx
 * [JDK-8241293](https://bugs.openjdk.org/browse/JDK-8241293): CompressedClassSpaceSizeInJmapHeap.java time out after 8 minutes


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1146/head:pull/1146` \
`$ git checkout pull/1146`

Update a local copy of the PR: \
`$ git checkout pull/1146` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1146`

View PR using the GUI difftool: \
`$ git pr show -t 1146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1146.diff">https://git.openjdk.org/jdk17u-dev/pull/1146.diff</a>

</details>
