### PR TITLE
8270859: Post JEP 411 refactoring: client libs with maximum covering > 10K

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/eio/FileManager.java
+++ b/src/java.desktop/macosx/classes/com/apple/eio/FileManager.java
@@ -53,9 +53,13 @@ import java.io.*;
  *
  * @since 1.4
  */
-@SuppressWarnings("removal")
 public class FileManager {
     static {
+        loadOSXLibrary();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadOSXLibrary() {
         java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Void>() {
                 public Void run() {
@@ -132,6 +136,7 @@ public class FileManager {
          * @since 1.4
          */
     public static void setFileTypeAndCreator(String filename, int type, int creator) throws IOException {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkWrite(filename);
@@ -146,6 +151,7 @@ public class FileManager {
          * @since 1.4
          */
     public static void setFileType(String filename, int type) throws IOException {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkWrite(filename);
@@ -160,6 +166,7 @@ public class FileManager {
          * @since 1.4
          */
     public static void setFileCreator(String filename, int creator) throws IOException {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkWrite(filename);
@@ -174,6 +181,7 @@ public class FileManager {
          * @since 1.4
          */
     public static int getFileType(String filename) throws IOException {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkRead(filename);
@@ -188,6 +196,7 @@ public class FileManager {
          * @since 1.4
          */
     public static int getFileCreator(String filename) throws IOException {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkRead(filename);
@@ -251,6 +260,7 @@ public class FileManager {
          * @since 1.4
          */
     public static String findFolder(short domain, int folderType, boolean createIfNeeded) throws FileNotFoundException {
+        @SuppressWarnings("removal")
         final SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(new RuntimePermission("canExamineFileSystem"));
@@ -278,6 +288,7 @@ public class FileManager {
          */
     @Deprecated
     public static void openURL(String url) throws IOException {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(new RuntimePermission("canOpenURLs"));
@@ -329,6 +340,7 @@ public class FileManager {
 
         private static native String getNativeResourceFromBundle(String resourceName, String subDirName, String type) throws FileNotFoundException;
         private static String getResourceFromBundle(String resourceName, String subDirName, String type) throws FileNotFoundException {
+                @SuppressWarnings("removal")
                 final SecurityManager security = System.getSecurityManager();
                 if (security != null) security.checkPermission(new RuntimePermission("canReadBundle"));
 
@@ -347,6 +359,7 @@ public class FileManager {
          * @since Java for Mac OS X 10.5 Update 2 - 1.5
          */
         public static String getPathToApplicationBundle() {
+                @SuppressWarnings("removal")
                 SecurityManager security = System.getSecurityManager();
                 if (security != null) security.checkPermission(new RuntimePermission("canReadBundle"));
                 return getNativePathToApplicationBundle();
@@ -368,6 +381,7 @@ public class FileManager {
                 if (file == null) throw new FileNotFoundException();
                 final String fileName = file.getAbsolutePath();
 
+                @SuppressWarnings("removal")
                 final SecurityManager security = System.getSecurityManager();
                 if (security != null) security.checkDelete(fileName);
 
@@ -391,6 +405,7 @@ public class FileManager {
                 if (file == null || !file.exists()) throw new FileNotFoundException();
                 final String fileName = file.getAbsolutePath();
 
+                @SuppressWarnings("removal")
                 final SecurityManager security = System.getSecurityManager();
                 if (security != null) security.checkRead(fileName);
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileView.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileView.java
@@ -34,7 +34,7 @@ import javax.swing.filechooser.FileView;
 
 import com.apple.laf.AquaUtils.RecyclableSingleton;
 
-@SuppressWarnings({"removal","serial"}) // JDK implementation class
+@SuppressWarnings("serial") // JDK implementation class
 class AquaFileView extends FileView {
     private static final boolean DEBUG = false;
 
@@ -57,6 +57,11 @@ class AquaFileView extends FileView {
     static final int kLSItemInfoExtensionIsHidden  = 0x00100000; /* Item has a hidden extension*/
 
     static {
+        loadOSXUILibrary();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadOSXUILibrary() {
         java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Void>() {
                 public Void run() {

--- a/src/java.desktop/macosx/classes/com/apple/laf/ScreenMenu.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/ScreenMenu.java
@@ -36,12 +36,17 @@ import sun.awt.SunToolkit;
 import sun.lwawt.LWToolkit;
 import sun.lwawt.macosx.*;
 
-@SuppressWarnings({"removal","serial"}) // JDK implementation class
+@SuppressWarnings("serial") // JDK implementation class
 final class ScreenMenu extends Menu
         implements ContainerListener, ComponentListener,
                    ScreenMenuPropertyHandler {
 
     static {
+        loadAWTLibrary();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadAWTLibrary() {
         java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Void>() {
                 public Void run() {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -67,12 +67,16 @@ import javax.swing.KeyStroke;
 import sun.awt.AWTAccessor;
 import sun.lwawt.LWWindowPeer;
 
-@SuppressWarnings("removal")
 class CAccessibility implements PropertyChangeListener {
     private static Set<String> ignoredRoles;
 
     static {
-        // Need to load the native library for this code.
+        loadAWTLibrary();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadAWTLibrary() {
+            // Need to load the native library for this code.
         java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Void>() {
                 public Void run() {

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -131,7 +131,6 @@ final class NamedCursor extends Cursor {
 /**
  * Mac OS X Cocoa-based AWT Toolkit.
  */
-@SuppressWarnings("removal")
 public final class LWCToolkit extends LWToolkit {
     // While it is possible to enumerate all mouse devices
     // and query them for the number of buttons, the code
@@ -147,6 +146,7 @@ public final class LWCToolkit extends LWToolkit {
     static {
         System.err.flush();
 
+        @SuppressWarnings("removal")
         ResourceBundle platformResources = java.security.AccessController.doPrivileged(
                 new java.security.PrivilegedAction<ResourceBundle>() {
             @Override
@@ -176,20 +176,23 @@ public final class LWCToolkit extends LWToolkit {
         if (!GraphicsEnvironment.isHeadless()) {
             initIDs();
         }
-        inAWT = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-            @Override
-            public Boolean run() {
-                return !Boolean.parseBoolean(System.getProperty("javafx.embed.singleThread", "false"));
-            }
-        });
     }
 
     /*
      * If true  we operate in normal mode and nested runloop is executed in JavaRunLoopMode
      * If false we operate in singleThreaded FX/AWT interop mode and nested loop uses NSDefaultRunLoopMode
      */
-    private static final boolean inAWT;
+    @SuppressWarnings("removal")
+    private static final boolean inAWT
+            = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+        @Override
+        public Boolean run() {
+            return !Boolean.parseBoolean(
+                    System.getProperty("javafx.embed.singleThread", "false"));
+        }
+    });
 
+    @SuppressWarnings("removal")
     public LWCToolkit() {
         final String extraButtons = "sun.awt.enableExtraMouseButtons";
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
@@ -248,6 +251,7 @@ public final class LWCToolkit extends LWToolkit {
     }
 
     // This is only called from native code.
+    @SuppressWarnings("removal")
     static void systemColorsChanged() {
         EventQueue.invokeLater(() -> {
             AccessController.doPrivileged( (PrivilegedAction<Object>) () -> {
@@ -586,6 +590,7 @@ public final class LWCToolkit extends LWToolkit {
     private static final String APPKIT_THREAD_NAME = "AppKit Thread";
 
     // Intended to be called from the LWCToolkit.m only.
+    @SuppressWarnings("removal")
     private static void installToolkitThreadInJava() {
         Thread.currentThread().setName(APPKIT_THREAD_NAME);
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/src/java.desktop/share/classes/java/awt/EventQueue.java
+++ b/src/java.desktop/share/classes/java/awt/EventQueue.java
@@ -94,7 +94,6 @@ import jdk.internal.access.JavaSecurityAccess;
  *
  * @since       1.1
  */
-@SuppressWarnings("removal")
 public class EventQueue {
     private static final AtomicInteger threadInitNumber = new AtomicInteger();
 
@@ -192,8 +191,6 @@ public class EventQueue {
         return eventLog;
     }
 
-    private static boolean fxAppThreadIsDispatchThread;
-
     static {
         AWTAccessor.setEventQueueAccessor(
             new AWTAccessor.EventQueueAccessor() {
@@ -230,14 +227,15 @@ public class EventQueue {
                     return eventQueue.getMostRecentEventTimeImpl();
                 }
             });
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            public Object run() {
-                fxAppThreadIsDispatchThread =
-                        "true".equals(System.getProperty("javafx.embed.singleThread"));
-                return null;
-            }
-        });
     }
+
+    @SuppressWarnings("removal")
+    private static boolean fxAppThreadIsDispatchThread =
+            AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                public Boolean run() {
+                    return "true".equals(System.getProperty("javafx.embed.singleThread"));
+                }
+            });
 
     /**
      * Initializes a new instance of {@code EventQueue}.
@@ -734,8 +732,11 @@ public class EventQueue {
             }
         };
 
+        @SuppressWarnings("removal")
         final AccessControlContext stack = AccessController.getContext();
+        @SuppressWarnings("removal")
         final AccessControlContext srcAcc = getAccessControlContextFrom(src);
+        @SuppressWarnings("removal")
         final AccessControlContext eventAcc = event.getAccessControlContext();
         if (srcAcc == null) {
             javaSecurityAccess.doIntersectionPrivilege(action, stack, eventAcc);
@@ -750,6 +751,7 @@ public class EventQueue {
         }
     }
 
+    @SuppressWarnings("removal")
     private static AccessControlContext getAccessControlContextFrom(Object src) {
         return src instanceof Component ?
             ((Component)src).getAccessControlContext() :

--- a/src/java.desktop/share/classes/javax/print/DocFlavor.java
+++ b/src/java.desktop/share/classes/javax/print/DocFlavor.java
@@ -385,7 +385,6 @@ import java.io.Serializable;
  *
  * @author Alan Kaminsky
  */
-@SuppressWarnings("removal")
 public class DocFlavor implements Serializable, Cloneable {
 
     /**
@@ -405,13 +404,10 @@ public class DocFlavor implements Serializable, Cloneable {
      * This is the charset for all the "HOST" pre-defined {@code DocFlavors} in
      * the executing VM.
      */
-    public static final String hostEncoding;
-
-    static {
-        hostEncoding =
+    @SuppressWarnings("removal")
+    public static final String hostEncoding =
             java.security.AccessController.doPrivileged(
                   new sun.security.action.GetPropertyAction("file.encoding"));
-    }
 
     /**
      * MIME type.

--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -85,7 +85,7 @@ import sun.awt.AppContext;
  * @author Lynn Monsanto
  * @since 1.2
  */
-@SuppressWarnings({"removal","serial"}) // Same-version serialization only
+@SuppressWarnings("serial") // Same-version serialization only
 public class ImageIcon implements Icon, Serializable, Accessible {
     /* Keep references to the filename and location so that
      * alternate persistence schemes have the option to archive
@@ -105,8 +105,27 @@ public class ImageIcon implements Icon, Serializable, Accessible {
      * It is left for backward compatibility only.
      * @deprecated since 1.8
      */
+    @SuppressWarnings("removal")
     @Deprecated
-    protected static final Component component;
+    protected static final Component component
+            = AccessController.doPrivileged(new PrivilegedAction<Component>() {
+        public Component run() {
+            try {
+                final Component component = createNoPermsComponent();
+
+                // 6482575 - clear the appContext field so as not to leak it
+                AWTAccessor.getComponentAccessor().
+                        setAppContext(component, null);
+
+                return component;
+            } catch (Throwable e) {
+                // We don't care about component.
+                // So don't prevent class initialisation.
+                e.printStackTrace();
+                return null;
+            }
+        }
+    });
 
     /**
      * Do not use this shared media tracker, which is used to load images.
@@ -114,30 +133,9 @@ public class ImageIcon implements Icon, Serializable, Accessible {
      * @deprecated since 1.8
      */
     @Deprecated
-    protected static final MediaTracker tracker;
+    protected static final MediaTracker tracker = new MediaTracker(component);
 
-    static {
-        component = AccessController.doPrivileged(new PrivilegedAction<Component>() {
-            public Component run() {
-                try {
-                    final Component component = createNoPermsComponent();
-
-                    // 6482575 - clear the appContext field so as not to leak it
-                    AWTAccessor.getComponentAccessor().
-                            setAppContext(component, null);
-
-                    return component;
-                } catch (Throwable e) {
-                    // We don't care about component.
-                    // So don't prevent class initialisation.
-                    e.printStackTrace();
-                    return null;
-                }
-            }
-        });
-        tracker = new MediaTracker(component);
-    }
-
+    @SuppressWarnings("removal")
     private static Component createNoPermsComponent() {
         // 7020198 - set acc field to no permissions and no subject
         // Note, will have appContext set.

--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -101,7 +101,7 @@ import sun.awt.SunToolkit;
  */
 @JavaBean(defaultProperty = "UI", description = "A small window that pops up and displays a series of choices.")
 @SwingContainer(false)
-@SuppressWarnings({"removal","serial"})
+@SuppressWarnings("serial")
 public class JPopupMenu extends JComponent implements Accessible,MenuElement {
 
     /**
@@ -117,14 +117,11 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
         new StringBuffer("JPopupMenu.defaultLWPopupEnabledKey");
 
     /** Bug#4425878-Property javax.swing.adjustPopupLocationToFit introduced */
-    static boolean popupPostionFixDisabled = false;
-
-    static {
-        popupPostionFixDisabled = java.security.AccessController.doPrivileged(
+    @SuppressWarnings("removal")
+    static boolean popupPostionFixDisabled =
+            java.security.AccessController.doPrivileged(
                 new sun.security.action.GetPropertyAction(
-                "javax.swing.adjustPopupLocationToFit","")).equals("false");
-
-    }
+                    "javax.swing.adjustPopupLocationToFit","")).equals("false");
 
     transient  Component invoker;
     transient  Popup popup;

--- a/src/java.desktop/share/classes/javax/swing/JRootPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JRootPane.java
@@ -199,7 +199,7 @@ import sun.security.action.GetBooleanAction;
  * @since 1.2
  */
 /// PENDING(klobad) Who should be opaque in this component?
-@SuppressWarnings({"removal","serial"})
+@SuppressWarnings("serial")
 public class JRootPane extends JComponent implements Accessible {
 
     private static final String uiClassID = "RootPaneUI";
@@ -208,13 +208,19 @@ public class JRootPane extends JComponent implements Accessible {
      * Whether or not we should dump the stack when true double buffering
      * is disabled. Default is false.
      */
-    private static final boolean LOG_DISABLE_TRUE_DOUBLE_BUFFERING;
+    @SuppressWarnings("removal")
+    private static final boolean LOG_DISABLE_TRUE_DOUBLE_BUFFERING
+            = AccessController.doPrivileged(new GetBooleanAction(
+                                   "swing.logDoubleBufferingDisable"));
 
     /**
      * Whether or not we should ignore requests to disable true double
      * buffering. Default is false.
      */
-    private static final boolean IGNORE_DISABLE_TRUE_DOUBLE_BUFFERING;
+    @SuppressWarnings("removal")
+    private static final boolean IGNORE_DISABLE_TRUE_DOUBLE_BUFFERING
+            = AccessController.doPrivileged(new GetBooleanAction(
+                                   "swing.ignoreDoubleBufferingDisable"));
 
     /**
      * Constant used for the windowDecorationStyle property. Indicates that
@@ -325,15 +331,6 @@ public class JRootPane extends JComponent implements Accessible {
      * heavy weight popups (backed by a window) set this to false.
      */
     boolean useTrueDoubleBuffering = true;
-
-    static {
-        LOG_DISABLE_TRUE_DOUBLE_BUFFERING =
-            AccessController.doPrivileged(new GetBooleanAction(
-                                   "swing.logDoubleBufferingDisable"));
-        IGNORE_DISABLE_TRUE_DOUBLE_BUFFERING =
-            AccessController.doPrivileged(new GetBooleanAction(
-                                   "swing.ignoreDoubleBufferingDisable"));
-    }
 
     /**
      * Creates a <code>JRootPane</code>, setting up its

--- a/src/java.desktop/share/classes/javax/swing/SortingFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/javax/swing/SortingFocusTraversalPolicy.java
@@ -59,7 +59,6 @@ import java.security.AccessController;
  * @see java.util.Comparator
  * @since 1.4
  */
-@SuppressWarnings("removal")
 public class SortingFocusTraversalPolicy
     extends InternalFrameFocusTraversalPolicy
 {
@@ -96,12 +95,10 @@ public class SortingFocusTraversalPolicy
      * When false, the default (tim-sort) algo is used, which may lead to an exception.
      * See: JDK-8048887
      */
-    private static final boolean legacySortingFTPEnabled;
-
-    static {
-        legacySortingFTPEnabled = "true".equals(AccessController.doPrivileged(
-            new GetPropertyAction("swing.legacySortingFTPEnabled", "true")));
-    }
+    @SuppressWarnings("removal")
+    private static final boolean legacySortingFTPEnabled = "true".equals(
+            AccessController.doPrivileged(
+                    new GetPropertyAction("swing.legacySortingFTPEnabled", "true")));
 
     /**
      * Constructs a SortingFocusTraversalPolicy without a Comparator.

--- a/src/java.desktop/share/classes/sun/font/FontUtilities.java
+++ b/src/java.desktop/share/classes/sun/font/FontUtilities.java
@@ -38,7 +38,6 @@ import sun.util.logging.PlatformLogger;
 /**
  * A collection of utility methods.
  */
-@SuppressWarnings("removal")
 public final class FontUtilities {
 
     public static boolean isLinux;
@@ -56,7 +55,11 @@ public final class FontUtilities {
 
     // This static initializer block figures out the OS constants.
     static {
+        initStatic();
+    }
 
+    @SuppressWarnings("removal")
+    private static void initStatic() {
         AccessController.doPrivileged(new PrivilegedAction<Object>() {
             @SuppressWarnings("deprecation") // PlatformLogger.setLevel is deprecated.
             @Override

--- a/src/java.desktop/share/classes/sun/font/StrikeCache.java
+++ b/src/java.desktop/share/classes/sun/font/StrikeCache.java
@@ -61,7 +61,6 @@ free native memory resources.
 
  */
 
-@SuppressWarnings("removal")
 public final class StrikeCache {
 
     static final Unsafe unsafe = Unsafe.getUnsafe();
@@ -135,6 +134,11 @@ public final class StrikeCache {
     static native void getGlyphCacheDescription(long[] infoArray);
 
     static {
+        initStatic();
+    }
+
+    @SuppressWarnings("removal")
+    private static void initStatic() {
 
         long[] nativeInfo = new long[13];
         getGlyphCacheDescription(nativeInfo);

--- a/src/java.desktop/share/classes/sun/java2d/SunGraphicsEnvironment.java
+++ b/src/java.desktop/share/classes/sun/java2d/SunGraphicsEnvironment.java
@@ -59,21 +59,19 @@ import sun.security.action.GetPropertyAction;
  * @see GraphicsDevice
  * @see GraphicsConfiguration
  */
-@SuppressWarnings("removal")
 public abstract class SunGraphicsEnvironment extends GraphicsEnvironment
     implements DisplayChangedListener {
 
     /** Establish the default font to be used by SG2D. */
     private final Font defaultFont = new Font(Font.DIALOG, Font.PLAIN, 12);
 
-    private static final boolean uiScaleEnabled;
-    private static final double debugScale;
+    @SuppressWarnings("removal")
+    private static final boolean uiScaleEnabled
+            = "true".equals(AccessController.doPrivileged(
+            new GetPropertyAction("sun.java2d.uiScale.enabled", "true")));
 
-    static {
-        uiScaleEnabled = "true".equals(AccessController.doPrivileged(
-                new GetPropertyAction("sun.java2d.uiScale.enabled", "true")));
-        debugScale = uiScaleEnabled ? getScaleFactor("sun.java2d.uiScale") : -1;
-    }
+    private static final double debugScale =
+            uiScaleEnabled ? getScaleFactor("sun.java2d.uiScale") : -1;
 
     protected GraphicsDevice[] screens;
 
@@ -299,6 +297,7 @@ public abstract class SunGraphicsEnvironment extends GraphicsEnvironment
 
     public static double getScaleFactor(String propertyName) {
 
+        @SuppressWarnings("removal")
         String scaleFactor = AccessController.doPrivileged(
                 new GetPropertyAction(propertyName, "-1"));
 

--- a/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java
+++ b/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java
@@ -68,7 +68,7 @@ import sun.swing.SwingUtilities2.RepaintListener;
  * @author Artem Ananiev
  * @author Anton Tarasov
  */
-@SuppressWarnings({"removal","serial"}) // JDK-implementation class
+@SuppressWarnings("serial") // JDK-implementation class
 public final class JLightweightFrame extends LightweightFrame implements RootPaneContainer {
 
     private final JRootPane rootPane = new JRootPane();
@@ -83,19 +83,6 @@ public final class JLightweightFrame extends LightweightFrame implements RootPan
     private volatile double scaleFactorX;
     private volatile double scaleFactorY;
 
-    /**
-     * {@code copyBufferEnabled}, true by default, defines the following strategy.
-     * A duplicating (copy) buffer is created for the original pixel buffer.
-     * The copy buffer is synchronized with the original buffer every time the
-     * latter changes. {@code JLightweightFrame} passes the copy buffer array
-     * to the {@link LightweightContent#imageBufferReset} method. The code spot
-     * which synchronizes two buffers becomes the only critical section guarded
-     * by the lock (managed with the {@link LightweightContent#paintLock()},
-     * {@link LightweightContent#paintUnlock()} methods).
-     */
-    private static boolean copyBufferEnabled;
-    private int[] copyBuffer;
-
     private PropertyChangeListener layoutSizeListener;
     private RepaintListener repaintListener;
 
@@ -106,14 +93,28 @@ public final class JLightweightFrame extends LightweightFrame implements RootPan
                 frame.updateClientCursor();
             }
         });
-        copyBufferEnabled = "true".equals(AccessController.
-            doPrivileged(new GetPropertyAction("swing.jlf.copyBufferEnabled", "true")));
     }
+
+    /**
+     * {@code copyBufferEnabled}, true by default, defines the following strategy.
+     * A duplicating (copy) buffer is created for the original pixel buffer.
+     * The copy buffer is synchronized with the original buffer every time the
+     * latter changes. {@code JLightweightFrame} passes the copy buffer array
+     * to the {@link LightweightContent#imageBufferReset} method. The code spot
+     * which synchronizes two buffers becomes the only critical section guarded
+     * by the lock (managed with the {@link LightweightContent#paintLock()},
+     * {@link LightweightContent#paintUnlock()} methods).
+     */
+    @SuppressWarnings("removal")
+    private static boolean copyBufferEnabled = "true".equals(AccessController.
+            doPrivileged(new GetPropertyAction("swing.jlf.copyBufferEnabled", "true")));
+    private int[] copyBuffer;
 
     /**
      * Constructs a new, initially invisible {@code JLightweightFrame}
      * instance.
      */
+    @SuppressWarnings("removal")
     public JLightweightFrame() {
         super();
         AffineTransform defaultTransform =
@@ -330,7 +331,7 @@ public final class JLightweightFrame extends LightweightFrame implements RootPan
         content.imageUpdated(x, y, width, height);
     }
 
-    @SuppressWarnings("serial") // anonymous class inside
+    @SuppressWarnings({"removal","serial"}) // anonymous class inside
     private void initInterior() {
         contentPane = new JPanel() {
             @Override

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
@@ -53,10 +53,14 @@ import sun.java2d.xr.XRSurfaceData;
  * @see GraphicsDevice
  * @see java.awt.GraphicsConfiguration
  */
-@SuppressWarnings("removal")
 public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
 
     static {
+        initStatic();
+    }
+
+    @SuppressWarnings("removal")
+    private static void initStatic() {
         java.security.AccessController.doPrivileged(
                           new java.security.PrivilegedAction<Object>() {
             public Object run() {
@@ -295,6 +299,7 @@ public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
             return true;
         }
 
+        @SuppressWarnings("removal")
         String isRemote = java.security.AccessController.doPrivileged(
             new sun.security.action.GetPropertyAction("sun.java2d.remote"));
         if (isRemote != null) {
@@ -317,6 +322,7 @@ public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
             return true;
         }
 
+        @SuppressWarnings("removal")
         Boolean result = java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Boolean>() {
             public Boolean run() {

--- a/src/java.desktop/unix/classes/sun/print/CUPSPrinter.java
+++ b/src/java.desktop/unix/classes/sun/print/CUPSPrinter.java
@@ -46,7 +46,6 @@ import javax.print.attribute.EnumSyntax;
 import javax.print.attribute.standard.PrinterName;
 
 
-@SuppressWarnings("removal")
 public class CUPSPrinter  {
     private static final String debugPrefix = "CUPSPrinter>> ";
     private static final double PRINTER_DPI = 72.0;
@@ -83,6 +82,11 @@ public class CUPSPrinter  {
     private static int cupsPort = 0;
 
     static {
+        initStatic();
+    }
+
+    @SuppressWarnings("removal")
+    private static void initStatic() {
         // load awt library to access native code
         java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Void>() {
@@ -292,6 +296,7 @@ public class CUPSPrinter  {
                 IPPPrintService.getIPPConnection(url);
 
             if (urlConnection != null) {
+                @SuppressWarnings("removal")
                 OutputStream os = java.security.AccessController.
                     doPrivileged(new java.security.PrivilegedAction<OutputStream>() {
                         public OutputStream run() {
@@ -406,6 +411,7 @@ public class CUPSPrinter  {
                 IPPPrintService.getIPPConnection(url);
 
             if (urlConnection != null) {
+                @SuppressWarnings("removal")
                 OutputStream os = java.security.AccessController.
                     doPrivileged(new java.security.PrivilegedAction<OutputStream>() {
                         public OutputStream run() {

--- a/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
@@ -58,7 +58,6 @@ import java.nio.file.Files;
  * Remind: This class uses solaris commands. We also need a linux
  * version
  */
-@SuppressWarnings("removal")
 public class PrintServiceLookupProvider extends PrintServiceLookup
     implements BackgroundServiceLookup, Runnable {
 
@@ -76,8 +75,9 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
     private static final int DEFAULT_MINREFRESH = 120;  // 2 minutes
     private static int minRefreshTime = DEFAULT_MINREFRESH;
 
-
-    static String osname;
+    @SuppressWarnings("removal")
+    static String osname = java.security.AccessController.doPrivileged(
+            new sun.security.action.GetPropertyAction("os.name"));
 
     // List of commands used to deal with the printer queues on AIX
     String[] lpNameComAix = {
@@ -97,6 +97,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
          * can be used to force the printing code to poll or not poll
          * for PrintServices.
          */
+        @SuppressWarnings("removal")
         String pollStr = java.security.AccessController.doPrivileged(
             new sun.security.action.GetPropertyAction("sun.java2d.print.polling"));
 
@@ -112,6 +113,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
          * can be used to specify minimum refresh time (in seconds)
          * for polling PrintServices.  The default is 120.
          */
+        @SuppressWarnings("removal")
         String refreshTimeStr = java.security.AccessController.doPrivileged(
             new sun.security.action.GetPropertyAction(
                 "sun.java2d.print.minRefreshTime"));
@@ -126,15 +128,13 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
             }
         }
 
-        osname = java.security.AccessController.doPrivileged(
-            new sun.security.action.GetPropertyAction("os.name"));
-
         /* The system property "sun.java2d.print.aix.lpstat"
          * can be used to force the usage of 'lpstat -p' to enumerate all
          * printer queues. By default we use 'lsallq', because 'lpstat -p' can
          * take lots of time if thousands of printers are attached to a server.
          */
         if (isAIX()) {
+            @SuppressWarnings("removal")
             String aixPrinterEnumerator = java.security.AccessController.doPrivileged(
                 new sun.security.action.GetPropertyAction("sun.java2d.print.aix.lpstat"));
 
@@ -222,6 +222,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
      * lead people to assume its guaranteed.
      */
     public synchronized PrintService[] getPrintServices() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPrintJobAccess();
@@ -560,6 +561,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
      */
     public PrintService[] getPrintServices(DocFlavor flavor,
                                            AttributeSet attributes) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
           security.checkPrintJobAccess();
@@ -623,6 +625,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
     public MultiDocPrintService[]
         getMultiDocPrintServices(DocFlavor[] flavors,
                                  AttributeSet attributes) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
           security.checkPrintJobAccess();
@@ -632,6 +635,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
 
 
     public synchronized PrintService getDefaultPrintService() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
           security.checkPrintJobAccess();
@@ -865,6 +869,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
         return printerNames.toArray(new String[printerNames.size()]);
     }
 
+    @SuppressWarnings("removal")
     static String[] execCmd(final String command) {
         ArrayList<String> results = null;
         try {

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
@@ -309,7 +309,6 @@ public class UnixPrintJob implements CancelablePrintJob {
         }
     }
 
-    @SuppressWarnings("removal")
     public void print(Doc doc, PrintRequestAttributeSet attributes)
         throws PrintException {
 
@@ -536,7 +535,8 @@ public class UnixPrintJob implements CancelablePrintJob {
 
         // now spool the print data.
         PrinterOpener po = new PrinterOpener();
-        java.security.AccessController.doPrivileged(po);
+        @SuppressWarnings("removal")
+        var dummy = java.security.AccessController.doPrivileged(po);
         if (po.pex != null) {
             throw po.pex;
         }
@@ -609,7 +609,8 @@ public class UnixPrintJob implements CancelablePrintJob {
 
         if (mDestType == UnixPrintJob.DESTPRINTER) {
             PrinterSpooler spooler = new PrinterSpooler();
-            java.security.AccessController.doPrivileged(spooler);
+            @SuppressWarnings("removal")
+            var dummy2 = java.security.AccessController.doPrivileged(spooler);
             if (spooler.pex != null) {
                 throw spooler.pex;
             }

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintService.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintService.java
@@ -74,14 +74,12 @@ import javax.print.attribute.standard.Sides;
 import javax.print.event.PrintServiceAttributeListener;
 
 
-@SuppressWarnings("removal")
 public class UnixPrintService implements PrintService, AttributeUpdater,
                                          SunPrinterJobService {
 
     /* define doc flavors for text types in the default encoding of
      * this platform since we can always read those.
      */
-    private static String encoding = "ISO8859_1";
     private static DocFlavor textByteFlavor;
 
     private static DocFlavor[] supportedDocFlavors = null;
@@ -147,10 +145,9 @@ public class UnixPrintService implements PrintService, AttributeUpdater,
       "| grep -E '^[ 0-9a-zA-Z_-]*@' | awk '{print $4}'"
     };
 
-    static {
-        encoding = java.security.AccessController.doPrivileged(
+    @SuppressWarnings("removal")
+    private static String encoding = java.security.AccessController.doPrivileged(
             new sun.security.action.GetPropertyAction("file.encoding"));
-    }
 
     /* let's try to support a few of these */
     private static final Class<?>[] serviceAttrCats = {
@@ -421,6 +418,7 @@ public class UnixPrintService implements PrintService, AttributeUpdater,
     }
 
     public DocPrintJob createPrintJob() {
+      @SuppressWarnings("removal")
       SecurityManager security = System.getSecurityManager();
       if (security != null) {
         security.checkPrintJobAccess();

--- a/src/java.desktop/windows/classes/sun/awt/Win32FontManager.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32FontManager.java
@@ -45,32 +45,26 @@ import sun.font.TrueTypeFont;
 /**
  * The X11 implementation of {@link FontManager}.
  */
-@SuppressWarnings("removal")
 public final class Win32FontManager extends SunFontManager {
 
-    private static TrueTypeFont eudcFont;
-
-    static {
-
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-
-                public Object run() {
+    @SuppressWarnings("removal")
+    private static final TrueTypeFont eudcFont =
+            AccessController.doPrivileged(new PrivilegedAction<TrueTypeFont>() {
+                public TrueTypeFont run() {
                     String eudcFile = getEUDCFontFile();
                     if (eudcFile != null) {
                         try {
                             /* Must use Java rasteriser since GDI doesn't
                              * enumerate (allow direct use) of EUDC fonts.
                              */
-                            eudcFont = new TrueTypeFont(eudcFile, null, 0,
+                            return new TrueTypeFont(eudcFile, null, 0,
                                                         true, false);
                         } catch (FontFormatException e) {
                         }
                     }
                     return null;
                 }
-
             });
-    }
 
     /* Used on Windows to obtain from the windows registry the name
      * of a file containing the system EUFC font. If running in one of
@@ -84,6 +78,7 @@ public final class Win32FontManager extends SunFontManager {
         return eudcFont;
     }
 
+    @SuppressWarnings("removal")
     public Win32FontManager() {
         super();
         AccessController.doPrivileged(new PrivilegedAction<Object>() {
@@ -218,6 +213,7 @@ public final class Win32FontManager extends SunFontManager {
         info[1] = "c:\\windows\\fonts";
         final String[] dirs = getPlatformFontDirs(true);
         if (dirs.length > 1) {
+            @SuppressWarnings("removal")
             String dir = (String)
                 AccessController.doPrivileged(new PrivilegedAction<Object>() {
                         public Object run() {
@@ -252,6 +248,7 @@ public final class Win32FontManager extends SunFontManager {
         fontsForPrinting = pathName;
     }
 
+    @SuppressWarnings("removal")
     public static void registerJREFontsForPrinting() {
         final String pathName;
         synchronized (Win32GraphicsEnvironment.class) {

--- a/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
@@ -41,13 +41,17 @@ import javax.print.attribute.PrintServiceAttribute;
 import javax.print.attribute.PrintServiceAttributeSet;
 import javax.print.attribute.standard.PrinterName;
 
-@SuppressWarnings("removal")
 public class PrintServiceLookupProvider extends PrintServiceLookup {
 
     private PrintService defaultPrintService;
     private PrintService[] printServices; /* includes the default printer */
 
     static {
+        loadAWTLibrary();
+    }
+
+    @SuppressWarnings("removal")
+    private static void loadAWTLibrary() {
         java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction<Void>() {
                 public Void run() {
@@ -102,6 +106,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
      * lead people to assume its guaranteed.
      */
     public synchronized PrintService[] getPrintServices() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPrintJobAccess();
@@ -202,6 +207,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
     public PrintService[] getPrintServices(DocFlavor flavor,
                                            AttributeSet attributes) {
 
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
           security.checkPrintJobAccess();
@@ -267,6 +273,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
     public MultiDocPrintService[]
         getMultiDocPrintServices(DocFlavor[] flavors,
                                  AttributeSet attributes) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
           security.checkPrintJobAccess();
@@ -276,6 +283,7 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
 
 
     public synchronized PrintService getDefaultPrintService() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
           security.checkPrintJobAccess();


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [90cd2fa1](https://github.com/openjdk/jdk/commit/90cd2fa16458dcc3e36171fa4bf21f26bc92b168) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Weijun Wang on 27 Jul 2021 and was reviewed by Sergey Bylokhov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270859](https://bugs.openjdk.org/browse/JDK-8270859): Post JEP 411 refactoring: client libs with maximum covering &gt; 10K


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1148/head:pull/1148` \
`$ git checkout pull/1148`

Update a local copy of the PR: \
`$ git checkout pull/1148` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1148`

View PR using the GUI difftool: \
`$ git pr show -t 1148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1148.diff">https://git.openjdk.org/jdk17u-dev/pull/1148.diff</a>

</details>
