### PR TITLE
8300266: Detect Virtualization on Linux aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -60,6 +60,9 @@ protected:
 public:
   // Initialization
   static void initialize();
+  static void check_virtualizations();
+
+  static void print_platform_virtualization_info(outputStream*);
 
   // Asserts
   static void assert_is_initialized() {


### PR DESCRIPTION
Backport of 8300266

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300266](https://bugs.openjdk.org/browse/JDK-8300266): Detect Virtualization on Linux aarch64


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1152/head:pull/1152` \
`$ git checkout pull/1152`

Update a local copy of the PR: \
`$ git checkout pull/1152` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1152`

View PR using the GUI difftool: \
`$ git pr show -t 1152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1152.diff">https://git.openjdk.org/jdk17u-dev/pull/1152.diff</a>

</details>
