### PR TITLE
8290083: ResponseBodyBeforeError: AssertionError or SSLException: Unsupported or unrecognized SSL message

### DIFF
--- a/test/jdk/java/net/httpclient/ResponseBodyBeforeError.java
+++ b/test/jdk/java/net/httpclient/ResponseBodyBeforeError.java
@@ -322,7 +322,10 @@ public class ResponseBodyBeforeError {
 
         @Override
         public void run() {
+            int maxUnexpected = 10; // if we get there too often we may
+                                    // want to reassess the diagnosis
             while (!closed) {
+                boolean accepted = false;
                 try (Socket s = ss.accept()) {
                     out.print(name + ": got connection ");
                     InputStream is = s.getInputStream();
@@ -333,26 +336,39 @@ public class ResponseBodyBeforeError {
                     readRequestHeaders(is);
 
                     String query = uriPath.getRawQuery();
-                    assert query != null;
+                    if (query == null) {
+                        throw new IOException("expected query not found in: " + uriPath);
+                    }
                     String qv = query.split("=")[1];
                     int len;
                     if (qv.equals("all")) {
                         len = responseBody().getBytes(US_ASCII).length;
                     } else {
-                        len = Integer.parseInt(query.split("=")[1]);
+                        len = Integer.parseInt(qv);
                     }
+
+                    // if we get an exception past this point
+                    // we will rethrow it
+                    accepted = true;
 
                     OutputStream os = s.getOutputStream();
                     os.write(responseHeaders().getBytes(US_ASCII));
-                    out.println(name  + ": headers written, writing " + len  + " body bytes");
+                    out.println(name + ": headers written, writing " + len + " body bytes");
                     byte[] responseBytes = responseBody().getBytes(US_ASCII);
-                    for (int i = 0; i< len; i++) {
+                    for (int i = 0; i < len; i++) {
                         os.write(responseBytes[i]);
                         os.flush();
                     }
-                } catch (IOException e) {
-                    if (!closed)
-                        throw new UncheckedIOException("Unexpected", e);
+                } catch (IOException | RuntimeException e) {
+                    if (!closed) {
+                        if (--maxUnexpected <= 0 || accepted) {
+                            if (e instanceof IOException io)
+                                throw new UncheckedIOException(io);
+                            else throw (RuntimeException) e;
+                        }
+                        out.println("ignoring unexpected exception: " + e);
+                        continue;
+                    }
                 }
             }
         }


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290083](https://bugs.openjdk.org/browse/JDK-8290083): ResponseBodyBeforeError: AssertionError or SSLException: Unsupported or unrecognized SSL message


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1153/head:pull/1153` \
`$ git checkout pull/1153`

Update a local copy of the PR: \
`$ git checkout pull/1153` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1153`

View PR using the GUI difftool: \
`$ git pr show -t 1153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1153.diff">https://git.openjdk.org/jdk17u-dev/pull/1153.diff</a>

</details>
