### PR TITLE
8186765: Speed up test sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java

### DIFF
--- a/test/jdk/sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java
+++ b/test/jdk/sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,17 @@ public class ProxyAuthTest extends SSLSocketTemplate {
     @Override
     protected boolean isCustomizedClientConnection() {
         return true;
+    }
+
+    @Override
+    protected void doServerSide() throws Exception {
+        if (expectSuccess) {
+            super.doServerSide();
+        } else {
+            // we don't expect anything to connect to the server
+            serverPort = 443;
+            serverCondition.countDown();
+        }
     }
 
     @Override


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8186765](https://bugs.openjdk.org/browse/JDK-8186765): Speed up test sun/net/www/protocol/https/HttpsClient/ProxyAuthTest.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1156/head:pull/1156` \
`$ git checkout pull/1156`

Update a local copy of the PR: \
`$ git checkout pull/1156` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1156`

View PR using the GUI difftool: \
`$ git pr show -t 1156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1156.diff">https://git.openjdk.org/jdk17u-dev/pull/1156.diff</a>

</details>
