### PR TITLE
8295000: java/util/Formatter/Basic test cleanup

### DIFF
--- a/test/jdk/java/util/Formatter/Basic-X.java.template
+++ b/test/jdk/java/util/Formatter/Basic-X.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,22 +229,22 @@ public class Basic$Type$ extends Basic {
 #end[dec]
 #if[Byte]
     private static $type$ negate($type$ v) {
-        return new $type$((byte) -v.byteValue());
+        return (byte) -v.byteValue();
     }
 #end[Byte]
 #if[Short]
     private static $type$ negate($type$ v) {
-        return new $type$((short) -v.shortValue());
+        return (short) -v.shortValue();
     }
 #end[Short]
 #if[Integer]
     private static $type$ negate($type$ v) {
-        return new $type$(-v.intValue());
+        return -v.intValue();
     }
 #end[Integer]
 #if[Long]
     private static $type$ negate($type$ v) {
-        return new $type$(-v.longValue());
+        return -v.longValue();
     }
 #end[Long]
 
@@ -284,19 +284,19 @@ public class Basic$Type$ extends Basic {
 #end[float]
 #if[Float]
     private static $type$ create(double v) {
-        return new $type$(v);
+        return (float) v;
     }
 
     private static $type$ negate($type$ v) {
-        return new $type$(-v.floatValue());
+        return -v.floatValue();
     }
 
     private static $type$ mult($type$ v, double mul) {
-        return new $type$(v.floatValue() * (float) mul);
+        return v.floatValue() * (float) mul;
     }
 
     private static $type$ recip($type$ v) {
-        return new $type$(1.0f / v.floatValue());
+        return 1.0f / v.floatValue();
     }
 #end[Float]
 #if[double]
@@ -319,19 +319,19 @@ public class Basic$Type$ extends Basic {
 #end[double]
 #if[Double]
     private static $type$ create(double v) {
-        return new $type$(v);
+        return v;
     }
 
     private static $type$ negate($type$ v) {
-        return new $type$(-v.doubleValue());
+        return -v.doubleValue();
     }
 
     private static $type$ mult($type$ v, double mul) {
-        return new $type$(v.doubleValue() * mul);
+        return v.doubleValue() * mul;
     }
 
     private static $type$ recip($type$ v) {
-        return new $type$(1.0 / v.doubleValue());
+        return 1.0 / v.doubleValue();
     }
 #end[Double]
 
@@ -435,7 +435,7 @@ public class Basic$Type$ extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class Basic$Type$ extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -521,11 +521,21 @@ public class Basic$Type$ extends Basic {
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
 
 #if[dec]
-
 #if[prim]
         $type$ minByte = Byte.MIN_VALUE;   // -128
 #else[prim]
-        $type$ minByte = new $type$(Byte.MIN_VALUE);
+#if[Short]
+        $type$ minByte = (short) Byte.MIN_VALUE;
+#end[Short]
+#if[Byte]
+        $type$ minByte = Byte.MIN_VALUE;
+#end[Byte]
+#if[Integer]
+        $type$ minByte = (int) Byte.MIN_VALUE;
+#end[Integer]
+#if[Long]
+        $type$ minByte = (long) Byte.MIN_VALUE;
+#end[Long]
 #end[prim]
 
         //---------------------------------------------------------------------
@@ -886,9 +896,9 @@ public class Basic$Type$ extends Basic {
         //---------------------------------------------------------------------
         // %s - Float
         //---------------------------------------------------------------------
-        $type$ one = new $type$(1.0f);
-        $type$ ten = new $type$(10.0f);
-        $type$ pi  = new $type$(Math.PI);
+        $type$ one = 1.0f;
+        $type$ ten = 10.0f;
+        $type$ pi  = (float) Math.PI;
 
         test("%s", "3.1415927", pi);
 #end[Float]
@@ -906,9 +916,9 @@ public class Basic$Type$ extends Basic {
         //---------------------------------------------------------------------
         // %s - Double
         //---------------------------------------------------------------------
-        $type$ one = new $type$(1.0);
-        $type$ ten = new $type$(10.0);
-        $type$ pi  = new $type$(Math.PI);
+        $type$ one = 1.0d;
+        $type$ ten = 10.0d;
+        $type$ pi  = (double) Math.PI;
 
         test("%s", "3.141592653589793", pi);
 #end[Double]

--- a/test/jdk/java/util/Formatter/BasicBigDecimal.java
+++ b/test/jdk/java/util/Formatter/BasicBigDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicBigDecimal extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicBigDecimal extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicBigDecimal extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicBigInteger.java
+++ b/test/jdk/java/util/Formatter/BasicBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicBigInteger extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicBigInteger extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicBigInteger extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicBoolean.java
+++ b/test/jdk/java/util/Formatter/BasicBoolean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicBoolean extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicBoolean extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicBoolean extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicBooleanObject.java
+++ b/test/jdk/java/util/Formatter/BasicBooleanObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicBooleanObject extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicBooleanObject extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicBooleanObject extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicByte.java
+++ b/test/jdk/java/util/Formatter/BasicByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicByte extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicByte extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -522,8 +522,18 @@ public class BasicByte extends Basic {
 
 
 
-
         byte minByte = Byte.MIN_VALUE;   // -128
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicByteObject.java
+++ b/test/jdk/java/util/Formatter/BasicByteObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,7 +229,7 @@ public class BasicByteObject extends Basic {
 
 
     private static Byte negate(Byte v) {
-        return new Byte((byte) -v.byteValue());
+        return (byte) -v.byteValue();
     }
 
 
@@ -435,7 +435,7 @@ public class BasicByteObject extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicByteObject extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -525,7 +525,17 @@ public class BasicByteObject extends Basic {
 
 
 
-        Byte minByte = new Byte(Byte.MIN_VALUE);
+
+
+
+        Byte minByte = Byte.MIN_VALUE;
+
+
+
+
+
+
+
 
 
         //---------------------------------------------------------------------

--- a/test/jdk/java/util/Formatter/BasicChar.java
+++ b/test/jdk/java/util/Formatter/BasicChar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicChar extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicChar extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicChar extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicCharObject.java
+++ b/test/jdk/java/util/Formatter/BasicCharObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicCharObject extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicCharObject extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicCharObject extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicDateTime extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicDateTime extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicDateTime extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1697,7 +1707,6 @@ public class BasicDateTime extends Basic {
         list.remove("America/WhiteHorse");
         list.remove("Canada/Yukon");
         ids = list.toArray(new String[list.size()]);
-
         // Create a Pacific Standard Time time zone
         SimpleTimeZone tz = new SimpleTimeZone(-8 * 60 * 60 * 1000, ids[0]);
         // public GregorianCalendar(TimeZone zone, Locale aLocale);

--- a/test/jdk/java/util/Formatter/BasicDouble.java
+++ b/test/jdk/java/util/Formatter/BasicDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicDouble extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicDouble extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicDouble extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicDoubleObject.java
+++ b/test/jdk/java/util/Formatter/BasicDoubleObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -319,19 +319,19 @@ public class BasicDoubleObject extends Basic {
 
 
     private static Double create(double v) {
-        return new Double(v);
+        return v;
     }
 
     private static Double negate(Double v) {
-        return new Double(-v.doubleValue());
+        return -v.doubleValue();
     }
 
     private static Double mult(Double v, double mul) {
-        return new Double(v.doubleValue() * mul);
+        return v.doubleValue() * mul;
     }
 
     private static Double recip(Double v) {
-        return new Double(1.0 / v.doubleValue());
+        return 1.0 / v.doubleValue();
     }
 
 
@@ -435,7 +435,7 @@ public class BasicDoubleObject extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicDoubleObject extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -903,12 +903,22 @@ public class BasicDoubleObject extends Basic {
 
 
 
+
+
+
+
+
+
+
+
+
+
         //---------------------------------------------------------------------
         // %s - Double
         //---------------------------------------------------------------------
-        Double one = new Double(1.0);
-        Double ten = new Double(10.0);
-        Double pi  = new Double(Math.PI);
+        Double one = 1.0d;
+        Double ten = 10.0d;
+        Double pi  = (double) Math.PI;
 
         test("%s", "3.141592653589793", pi);
 

--- a/test/jdk/java/util/Formatter/BasicFloat.java
+++ b/test/jdk/java/util/Formatter/BasicFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicFloat extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicFloat extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -519,6 +519,16 @@ public class BasicFloat extends Basic {
         tryCatch("%F", UnknownFormatConversionException.class);
 
         tryCatch("%#g", FormatFlagsConversionMismatchException.class);
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicFloatObject.java
+++ b/test/jdk/java/util/Formatter/BasicFloatObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -284,19 +284,19 @@ public class BasicFloatObject extends Basic {
 
 
     private static Float create(double v) {
-        return new Float(v);
+        return (float) v;
     }
 
     private static Float negate(Float v) {
-        return new Float(-v.floatValue());
+        return -v.floatValue();
     }
 
     private static Float mult(Float v, double mul) {
-        return new Float(v.floatValue() * (float) mul);
+        return v.floatValue() * (float) mul;
     }
 
     private static Float recip(Float v) {
-        return new Float(1.0f / v.floatValue());
+        return 1.0f / v.floatValue();
     }
 
 
@@ -435,7 +435,7 @@ public class BasicFloatObject extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicFloatObject extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -883,12 +883,22 @@ public class BasicFloatObject extends Basic {
 
 
 
+
+
+
+
+
+
+
+
+
+
         //---------------------------------------------------------------------
         // %s - Float
         //---------------------------------------------------------------------
-        Float one = new Float(1.0f);
-        Float ten = new Float(10.0f);
-        Float pi  = new Float(Math.PI);
+        Float one = 1.0f;
+        Float ten = 10.0f;
+        Float pi  = (float) Math.PI;
 
         test("%s", "3.1415927", pi);
 

--- a/test/jdk/java/util/Formatter/BasicInt.java
+++ b/test/jdk/java/util/Formatter/BasicInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicInt extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicInt extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -522,8 +522,18 @@ public class BasicInt extends Basic {
 
 
 
-
         int minByte = Byte.MIN_VALUE;   // -128
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicIntObject.java
+++ b/test/jdk/java/util/Formatter/BasicIntObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,7 +239,7 @@ public class BasicIntObject extends Basic {
 
 
     private static Integer negate(Integer v) {
-        return new Integer(-v.intValue());
+        return -v.intValue();
     }
 
 
@@ -435,7 +435,7 @@ public class BasicIntObject extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicIntObject extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -525,7 +525,17 @@ public class BasicIntObject extends Basic {
 
 
 
-        Integer minByte = new Integer(Byte.MIN_VALUE);
+
+
+
+
+
+
+        Integer minByte = (int) Byte.MIN_VALUE;
+
+
+
+
 
 
         //---------------------------------------------------------------------

--- a/test/jdk/java/util/Formatter/BasicLong.java
+++ b/test/jdk/java/util/Formatter/BasicLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicLong extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicLong extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -522,8 +522,18 @@ public class BasicLong extends Basic {
 
 
 
-
         long minByte = Byte.MIN_VALUE;   // -128
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicLongObject.java
+++ b/test/jdk/java/util/Formatter/BasicLongObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -244,7 +244,7 @@ public class BasicLongObject extends Basic {
 
 
     private static Long negate(Long v) {
-        return new Long(-v.longValue());
+        return -v.longValue();
     }
 
 
@@ -435,7 +435,7 @@ public class BasicLongObject extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicLongObject extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -525,7 +525,17 @@ public class BasicLongObject extends Basic {
 
 
 
-        Long minByte = new Long(Byte.MIN_VALUE);
+
+
+
+
+
+
+
+
+
+        Long minByte = (long) Byte.MIN_VALUE;
+
 
 
         //---------------------------------------------------------------------

--- a/test/jdk/java/util/Formatter/BasicShort.java
+++ b/test/jdk/java/util/Formatter/BasicShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -435,7 +435,7 @@ public class BasicShort extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicShort extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -522,8 +522,18 @@ public class BasicShort extends Basic {
 
 
 
-
         short minByte = Byte.MIN_VALUE;   // -128
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/test/jdk/java/util/Formatter/BasicShortObject.java
+++ b/test/jdk/java/util/Formatter/BasicShortObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -234,7 +234,7 @@ public class BasicShortObject extends Basic {
 
 
     private static Short negate(Short v) {
-        return new Short((short) -v.shortValue());
+        return (short) -v.shortValue();
     }
 
 
@@ -435,7 +435,7 @@ public class BasicShortObject extends Basic {
         test("%-4c", "i   ", 'i');
         test("%4C",  "   I", 'i');
         test("%-4C", "I   ", 'i');
-        test("%c", "i", new Character('i'));
+        test("%c", "i", Character.valueOf('i'));
         test("%c", "H", (byte) 72);
         test("%c", "i", (short) 105);
         test("%c", "!", (int) 33);
@@ -493,7 +493,7 @@ public class BasicShortObject extends Basic {
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, 0.5f);
         tryCatch("%#s", FormatFlagsConversionMismatchException.class, "hello");
-        tryCatch("%#s", FormatFlagsConversionMismatchException.class, null);
+        tryCatch("%#s", FormatFlagsConversionMismatchException.class, (Object)null);
 
         //---------------------------------------------------------------------
         // %h
@@ -525,7 +525,17 @@ public class BasicShortObject extends Basic {
 
 
 
-        Short minByte = new Short(Byte.MIN_VALUE);
+        Short minByte = (short) Byte.MIN_VALUE;
+
+
+
+
+
+
+
+
+
+
 
 
         //---------------------------------------------------------------------


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295000](https://bugs.openjdk.org/browse/JDK-8295000): java/util/Formatter/Basic test cleanup


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1157/head:pull/1157` \
`$ git checkout pull/1157`

Update a local copy of the PR: \
`$ git checkout pull/1157` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1157`

View PR using the GUI difftool: \
`$ git pr show -t 1157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1157.diff">https://git.openjdk.org/jdk17u-dev/pull/1157.diff</a>

</details>
