### PR TITLE
8296675: Exclude linux-aarch64 in NSS tests

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -700,10 +700,12 @@ public abstract class PKCS11Test {
         osMap.put("Linux-arm-32", new String[] {
                 "/usr/lib/arm-linux-gnueabi/nss/",
                 "/usr/lib/arm-linux-gnueabihf/nss/" });
-        osMap.put("Linux-aarch64-64", new String[] {
-                "/usr/lib/aarch64-linux-gnu/",
-                "/usr/lib/aarch64-linux-gnu/nss/",
-                "/usr/lib64/" });
+        // Exclude linux-aarch64 at the moment until the following bug is fixed:
+        // 8296631: NSS tests failing on OL9 linux-aarch64 hosts
+//        osMap.put("Linux-aarch64-64", new String[] {
+//                "/usr/lib/aarch64-linux-gnu/",
+//                "/usr/lib/aarch64-linux-gnu/nss/",
+//                "/usr/lib64/" });
         return osMap;
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296675](https://bugs.openjdk.org/browse/JDK-8296675): Exclude linux-aarch64 in NSS tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1159/head:pull/1159` \
`$ git checkout pull/1159`

Update a local copy of the PR: \
`$ git checkout pull/1159` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1159`

View PR using the GUI difftool: \
`$ git pr show -t 1159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1159.diff">https://git.openjdk.org/jdk17u-dev/pull/1159.diff</a>

</details>
