### PR TITLE
8300205: Swing test bug8078268 make latch timeout configurable

### DIFF
--- a/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
+++ b/test/jdk/javax/swing/text/html/parser/Parser/8078268/bug8078268.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
    @run main bug8078268
 */
 public class bug8078268 {
-    private static final long TIMEOUT = 10_000;
+    private static final float tf = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
+    private static final long TIMEOUT = 10_000 * (long)tf;
 
     private static final String FILENAME = "slowparse.html";
 
@@ -61,7 +62,7 @@ public class bug8078268 {
         });
 
         if (!latch.await(TIMEOUT, MILLISECONDS)) {
-            throw new RuntimeException("Parsing takes too long.");
+            throw new RuntimeException("Parsing takes too long. Current timeout is " + TIMEOUT);
         }
         if (exception != null) {
             throw exception;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300205](https://bugs.openjdk.org/browse/JDK-8300205): Swing test bug8078268 make latch timeout configurable


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1165/head:pull/1165` \
`$ git checkout pull/1165`

Update a local copy of the PR: \
`$ git checkout pull/1165` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1165`

View PR using the GUI difftool: \
`$ git pr show -t 1165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1165.diff">https://git.openjdk.org/jdk17u-dev/pull/1165.diff</a>

</details>
