### PR TITLE
8294958: java/net/httpclient/ConnectTimeout tests are slow

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,19 +54,13 @@ public abstract class AbstractConnectTimeout {
 
     static List<List<Duration>> TIMEOUTS = List.of(
                     // connectTimeout   HttpRequest timeout
-            Arrays.asList( NO_DURATION,   ofSeconds(1)  ),
             Arrays.asList( NO_DURATION,   ofMillis(100) ),
-            Arrays.asList( NO_DURATION,   ofNanos(99)   ),
             Arrays.asList( NO_DURATION,   ofNanos(1)    ),
 
-            Arrays.asList( ofSeconds(1),  NO_DURATION   ),
             Arrays.asList( ofMillis(100), NO_DURATION   ),
-            Arrays.asList( ofNanos(99),   NO_DURATION   ),
             Arrays.asList( ofNanos(1),    NO_DURATION   ),
 
-            Arrays.asList( ofSeconds(1),  ofMinutes(1)  ),
             Arrays.asList( ofMillis(100), ofMinutes(1)  ),
-            Arrays.asList( ofNanos(99),   ofMinutes(1)  ),
             Arrays.asList( ofNanos(1),    ofMinutes(1)  )
     );
 

--- a/test/jdk/java/net/httpclient/AbstractConnectTimeoutHandshake.java
+++ b/test/jdk/java/net/httpclient/AbstractConnectTimeoutHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,17 +68,11 @@ public abstract class AbstractConnectTimeoutHandshake {
 
     static List<List<Duration>> TIMEOUTS = List.of(
                     // connectTimeout   HttpRequest timeout
-            Arrays.asList( NO_DURATION,   ofSeconds(1)  ),
-            Arrays.asList( NO_DURATION,   ofSeconds(2)  ),
-            Arrays.asList( NO_DURATION,   ofMillis(500) ),
+            Arrays.asList( NO_DURATION,   ofMillis(100) ),
 
-            Arrays.asList( ofSeconds(1),  NO_DURATION   ),
-            Arrays.asList( ofSeconds(2),  NO_DURATION   ),
-            Arrays.asList( ofMillis(500), NO_DURATION   ),
+            Arrays.asList( ofMillis(100), NO_DURATION   ),
 
-            Arrays.asList( ofSeconds(1),  ofMinutes(1)  ),
-            Arrays.asList( ofSeconds(2),  ofMinutes(1)  ),
-            Arrays.asList( ofMillis(500), ofMinutes(1)  )
+            Arrays.asList( ofMillis(100), ofMinutes(1)  )
     );
 
     static final List<String> METHODS = List.of("GET" , "POST");


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294958](https://bugs.openjdk.org/browse/JDK-8294958): java/net/httpclient/ConnectTimeout tests are slow


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1167/head:pull/1167` \
`$ git checkout pull/1167`

Update a local copy of the PR: \
`$ git checkout pull/1167` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1167`

View PR using the GUI difftool: \
`$ git pr show -t 1167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1167.diff">https://git.openjdk.org/jdk17u-dev/pull/1167.diff</a>

</details>
