### PR TITLE
8295777: java/net/httpclient/ConnectExceptionTest.java should not rely on system resolver

### DIFF
--- a/test/jdk/java/net/httpclient/ConnectExceptionTest.java
+++ b/test/jdk/java/net/httpclient/ConnectExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @summary Expect ConnectException for all non-security related connect errors
  * @bug 8204864
- * @run testng/othervm ConnectExceptionTest
+ * @run testng/othervm -Djdk.net.hosts.file=HostFileDoesNotExist ConnectExceptionTest
  * @run testng/othervm/java.security.policy=noPermissions.policy ConnectExceptionTest
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295777](https://bugs.openjdk.org/browse/JDK-8295777): java/net/httpclient/ConnectExceptionTest.java should not rely on system resolver


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1168/head:pull/1168` \
`$ git checkout pull/1168`

Update a local copy of the PR: \
`$ git checkout pull/1168` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1168`

View PR using the GUI difftool: \
`$ git pr show -t 1168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1168.diff">https://git.openjdk.org/jdk17u-dev/pull/1168.diff</a>

</details>
