### PR TITLE
8288332: Tier1 validate-source fails after 8279614

### DIFF
--- a/test/jdk/javax/swing/border/EtchedBorder/ScaledEtchedBorderTest.java
+++ b/test/jdk/javax/swing/border/EtchedBorder/ScaledEtchedBorderTest.java
@@ -2,6 +2,10 @@
  * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288332](https://bugs.openjdk.org/browse/JDK-8288332): Tier1 validate-source fails after 8279614


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1175/head:pull/1175` \
`$ git checkout pull/1175`

Update a local copy of the PR: \
`$ git checkout pull/1175` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1175`

View PR using the GUI difftool: \
`$ git pr show -t 1175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1175.diff">https://git.openjdk.org/jdk17u-dev/pull/1175.diff</a>

</details>
