### PR TITLE
8272702: Resolving URI relative path with no / may lead to incorrect toString

### DIFF
--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -2135,10 +2135,12 @@ public final class URI
                 path = base.substring(0, i + 1);
         } else {
             StringBuilder sb = new StringBuilder(base.length() + cn);
-            // 5.2 (6a)
-            if (i >= 0)
+            // 5.2 (6a-b)
+            if (i >= 0 || !absolute) {
                 sb.append(base, 0, i + 1);
-            // 5.2 (6b)
+            } else {
+                sb.append('/');
+            }
             sb.append(child);
             path = sb.toString();
         }

--- a/test/jdk/java/net/URI/Test.java
+++ b/test/jdk/java/net/URI/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /* @test
  * @summary Unit test for java.net.URI
  * @bug 4464135 4505046 4503239 4438319 4991359 4866303 7023363 7041800
- *      7171415 6933879
+ *      7171415 6339649 6933879 8037396 8272072
  * @author Mark Reinhold
  */
 
@@ -1364,6 +1364,7 @@ public class Test {
     }
 
     static void eq(String expected, String actual) {
+        testCount++;
         if (expected == null && actual == null) {
             return;
         }
@@ -1612,9 +1613,11 @@ public class Test {
     // miscellaneous bugs/rfes that don't fit in with the test framework
 
     static void bugs() {
+        header("Bugs");
         b6339649();
         b6933879();
         b8037396();
+        b8272072();
     }
 
     // 6339649 - include detail message from nested exception
@@ -1626,6 +1629,7 @@ public class Test {
                 throw new RuntimeException ("No detail message");
             }
         }
+        testCount++;
     }
 
     // 6933879 - check that "." and "_" characters are allowed in IPv6 scope_id.
@@ -1671,6 +1675,24 @@ public class Test {
         eq("/a%20b%5Bc%20d%5D", u.getRawPath());
         eq("a%20b[c%20d]", u.getRawQuery());
         eq("a%20b[c%20d]", u.getRawFragment());
+    }
+
+    // 8272072 - Resolving URI relative path with no "/" may lead to incorrect toString
+    private static void b8272072() {
+        try {
+            URI baseURI = new URI("http://example.com");
+            URI relativeURI = new URI("test");
+            URI resolvedURI = baseURI.resolve(relativeURI);
+
+            eq(new URI("http://example.com/test"), resolvedURI);
+
+            baseURI = new URI("relativeBase");
+            resolvedURI = baseURI.resolve(relativeURI);
+
+            eq(new URI("test"), resolvedURI);
+        } catch (URISyntaxException e) {
+            throw new AssertionError("shouldn't ever happen", e);
+        }
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
I backport this as it affects to JDK 17.
Does not apply clean due to a conflict with https://bugs.openjdk.org/browse/JDK-8285521 but it's the same logic.

---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Issue
 * [JDK-8272702](https://bugs.openjdk.org/browse/JDK-8272702): Resolving URI relative path with no / may lead to incorrect toString


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1176/head:pull/1176` \
`$ git checkout pull/1176`

Update a local copy of the PR: \
`$ git checkout pull/1176` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1176`

View PR using the GUI difftool: \
`$ git pr show -t 1176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1176.diff">https://git.openjdk.org/jdk17u-dev/pull/1176.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272702](https://bugs.openjdk.org/browse/JDK-8272702): Resolving URI relative path with no / may lead to incorrect toString


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1176/head:pull/1176` \
`$ git checkout pull/1176`

Update a local copy of the PR: \
`$ git checkout pull/1176` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1176`

View PR using the GUI difftool: \
`$ git pr show -t 1176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1176.diff">https://git.openjdk.org/jdk17u-dev/pull/1176.diff</a>

</details>
