### PR TITLE
8302152: Speed up tests with infinite loops, sleep less

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestCMoveWithDeadPhi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,6 @@ public class TestCMoveWithDeadPhi {
         // Give thread some time to trigger compilation
         thread.setDaemon(true);
         thread.start();
-        Thread.sleep(Utils.adjustTimeout(4000));
+        Thread.sleep(Utils.adjustTimeout(500));
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfLoopNearUsePlacement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,6 @@ public class TestInfLoopNearUsePlacement {
         thread.setDaemon(true);
         thread.start();
         // Give thread some time to trigger compilation
-        Thread.sleep(Utils.adjustTimeout(5000));
+        Thread.sleep(Utils.adjustTimeout(500));
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopCCP.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopCCP.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,6 +73,6 @@ public class TestInfiniteLoopCCP {
         // Give thread some time to trigger compilation
         thread.setDaemon(true);
         thread.start();
-        Thread.sleep(Utils.adjustTimeout(4000));
+        Thread.sleep(Utils.adjustTimeout(500));
     }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestInfiniteLoopNest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +66,7 @@ public class TestInfiniteLoopNest {
         // Give thread some time to trigger compilation
         thread.setDaemon(true);
         thread.start();
-        Thread.sleep(Utils.adjustTimeout(4000));
+        Thread.sleep(Utils.adjustTimeout(500));
     }
 
     static Boolean b;

--- a/test/hotspot/jtreg/compiler/loopopts/TestStrangeControl.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestStrangeControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,6 @@ public class TestStrangeControl {
         thread.setDaemon(true);
         thread.start();
         // Give thread executing strange control loop enough time to trigger OSR compilation
-        Thread.sleep(Utils.adjustTimeout(4000));
+        Thread.sleep(Utils.adjustTimeout(1000));
     }
 }


### PR DESCRIPTION
Backport for https://bugs.openjdk.org/browse/JDK-8302152

Clean backport, test update, low risk
Tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302152](https://bugs.openjdk.org/browse/JDK-8302152): Speed up tests with infinite loops, sleep less


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1179/head:pull/1179` \
`$ git checkout pull/1179`

Update a local copy of the PR: \
`$ git checkout pull/1179` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1179`

View PR using the GUI difftool: \
`$ git pr show -t 1179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1179.diff">https://git.openjdk.org/jdk17u-dev/pull/1179.diff</a>

</details>
