### PR TITLE
8301342: Prefer ArrayList to LinkedList in LayoutComparator

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/LayoutComparator.java
+++ b/src/java.desktop/share/classes/javax/swing/LayoutComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,8 @@
  */
 package javax.swing;
 
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.ListIterator;
 import java.awt.Component;
 import java.awt.ComponentOrientation;
@@ -63,7 +63,7 @@ final class LayoutComparator implements Comparator<Component>, java.io.Serializa
         // each Component and then search from the Window down until the
         // hierarchy branches.
         if (a.getParent() != b.getParent()) {
-            LinkedList<Component> aAncestory = new LinkedList<Component>();
+            ArrayList<Component> aAncestory = new ArrayList<>();
 
             for(; a != null; a = a.getParent()) {
                 aAncestory.add(a);
@@ -76,7 +76,7 @@ final class LayoutComparator implements Comparator<Component>, java.io.Serializa
                 throw new ClassCastException();
             }
 
-            LinkedList<Component> bAncestory = new LinkedList<Component>();
+            ArrayList<Component> bAncestory = new ArrayList<>();
 
             for(; b != null; b = b.getParent()) {
                 bAncestory.add(b);


### PR DESCRIPTION
Backport for [JDK-8301342](https://bugs.openjdk.org/browse/JDK-8301342)

Clean backport, trivial fix, low risk
Run ui tests on linux and mac

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301342](https://bugs.openjdk.org/browse/JDK-8301342): Prefer ArrayList to LinkedList in LayoutComparator


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1180/head:pull/1180` \
`$ git checkout pull/1180`

Update a local copy of the PR: \
`$ git checkout pull/1180` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1180`

View PR using the GUI difftool: \
`$ git pr show -t 1180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1180.diff">https://git.openjdk.org/jdk17u-dev/pull/1180.diff</a>

</details>
