### PR TITLE
8303066: SOURCE_DATE_EPOCH is set by default also in older versions of JDK

### DIFF
--- a/make/Init.gmk
+++ b/make/Init.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -225,9 +225,6 @@ else # HAS_SPEC=true
 
   # Parse COMPARE_BUILD (for makefile development)
   $(eval $(call ParseCompareBuild))
-
-  # Setup reproducible build environment
-  $(eval $(call SetupReproducibleBuild))
 
   # If no LOG= was given on command line, but we have a non-standard default
   # value, use that instead and re-parse log level.

--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -305,24 +305,6 @@ else # $(HAS_SPEC)=true
   else
     topdir=$(TOPDIR)
   endif
-
-  # Setup the build environment to match the requested specification on
-  # level of reproducible builds
-  define SetupReproducibleBuild
-    ifeq ($$(SOURCE_DATE), updated)
-      SOURCE_DATE := $$(shell $$(DATE) +"%s")
-    endif
-    export SOURCE_DATE_EPOCH := $$(SOURCE_DATE)
-    ifeq ($$(IS_GNU_DATE), yes)
-      export SOURCE_DATE_ISO_8601 := $$(shell $$(DATE) --utc \
-                                                       --date="@$$(SOURCE_DATE_EPOCH)" \
-                                                       +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
-    else
-      export SOURCE_DATE_ISO_8601 := $$(shell $$(DATE) -u \
-                                                       -j -f "%s" "$$(SOURCE_DATE_EPOCH)" \
-                                                       +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
-    endif
-  endef
 
   # Parse COMPARE_BUILD into COMPARE_BUILD_*
   # Syntax: COMPARE_BUILD=CONF=<configure options>:PATCH=<patch file>:

--- a/make/modules/jdk.compiler/Gendata.gmk
+++ b/make/modules/jdk.compiler/Gendata.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,10 @@ $(eval $(call SetupJavaCompilation, COMPILE_CREATE_SYMBOLS, \
         $(INTERIM_LANGTOOLS_ARGS) \
         $(COMPILECREATESYMBOLS_ADD_EXPORTS), \
 ))
+
+ifndef SOURCE_DATE_EPOCH
+    export SOURCE_DATE_EPOCH := $(shell $(DATE) +"%s")
+endif
 
 $(SUPPORT_OUTPUTDIR)/symbols/ct.sym: \
     $(COMPILE_CREATE_SYMBOLS) \


### PR DESCRIPTION
I removed SetupReproducibleBuild. But, at building ct.sym, SOURCE_DATE_EPOCH environment variable is needed. So I added setting routine if SOURCE_DATE_EPOCH is not set.
Would you please review this fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303066](https://bugs.openjdk.org/browse/JDK-8303066): SOURCE_DATE_EPOCH is set by default also in older versions of JDK


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1186/head:pull/1186` \
`$ git checkout pull/1186`

Update a local copy of the PR: \
`$ git checkout pull/1186` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1186`

View PR using the GUI difftool: \
`$ git pr show -t 1186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1186.diff">https://git.openjdk.org/jdk17u-dev/pull/1186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1186#issuecomment-1439965079)