### PR TITLE
8294548: Problem list SA core file tests on macosx-x64 due to JDK-8294316

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -115,13 +115,13 @@ serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 w
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 serviceability/jvmti/CompiledMethodLoad/Zombie.java 8245877 linux-aarch64
 
-serviceability/sa/ClhsdbCDSCore.java 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbFindPC.java#id1 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbFindPC.java#id3 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbPmap.java#id1 8267433 macosx-x64
-serviceability/sa/ClhsdbPstack.java#id1 8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/TestJmapCore.java 8267433 macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
+serviceability/sa/ClhsdbCDSCore.java  8294316,8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id1  8294316,8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id3  8294316,8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbPmap.java#id1  8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbPstack.java#id1  8294316,8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/TestJmapCore.java  8294316,8267433 macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java  8294316,8267433 macosx-x64
 
 #############################################################################
 


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

I had to resolve because subtests are named #1, #3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294548](https://bugs.openjdk.org/browse/JDK-8294548): Problem list SA core file tests on macosx-x64 due to JDK-8294316


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1188/head:pull/1188` \
`$ git checkout pull/1188`

Update a local copy of the PR: \
`$ git checkout pull/1188` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1188`

View PR using the GUI difftool: \
`$ git pr show -t 1188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1188.diff">https://git.openjdk.org/jdk17u-dev/pull/1188.diff</a>

</details>
