### PR TITLE
8210927: JDB tests do not update source path after doing a redefine class

### DIFF
--- a/test/jdk/com/sun/jdi/RedefineTTYLineNumber.java
+++ b/test/jdk/com/sun/jdi/RedefineTTYLineNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ class RedefineTTYLineNumberTarg {
 
 public class RedefineTTYLineNumber extends JdbTest {
 
-    public static void main(String argv[]) {
+    public static void main(String[] argv) {
         new RedefineTTYLineNumber().run();
     }
 
@@ -104,7 +104,7 @@ public class RedefineTTYLineNumber extends JdbTest {
         // so bp2Line should be equals bp1Line-1
         Asserts.assertEquals(bp2Line, bp1Line - 1, "BP line numbers");
         verifyBPSource(1, bp1Reply);
-        // uncomment the following line to reproduce JDK-8210927
-        //verifyBPSource(2, bp2Reply);
+        // verify source code is printed correctly
+        verifyBPSource(2, bp2Reply);
     }
 }

--- a/test/jdk/com/sun/jdi/lib/jdb/JdbCommand.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/JdbCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 package lib.jdb;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -274,5 +275,9 @@ public class JdbCommand {
 
     public static JdbCommand redefine(String classId, String classFileName) {
         return new JdbCommand("redefine " + classId + " " + classFileName);
+    }
+
+    public static JdbCommand use(String... sourcePath) {
+        return new JdbCommand("use " + String.join(File.pathSeparator, sourcePath));
     }
 }

--- a/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/JdbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,14 +198,17 @@ public abstract class JdbTest {
         return setBreakpointsFromTestSource(launchOptions.sourceFilename, id);
     }
 
-    // transforms class with the specified id (see {@code ClassTransformer})
-    // and executes "redefine" jdb command for {@code launchOptions.debuggeeClass}.
-    // returns reply for the command.
+    // transforms class with the specified id (see {@code ClassTransformer}),
+    // executes "redefine" jdb command for {@code launchOptions.debuggeeClass}
+    // and updates source path by using "use" jdb command.
+    // returns reply for the commands.
     protected List<String> redefineClass(int id, String... compilerOptions) {
         verifySourceFilename();
         String transformedClassFile = ClassTransformer.fromTestSource(launchOptions.sourceFilename)
                 .transform(id, launchOptions.debuggeeClass, compilerOptions);
-        return jdb.command(JdbCommand.redefine(launchOptions.debuggeeClass, transformedClassFile));
+        List<String> reply = jdb.command(JdbCommand.redefine(launchOptions.debuggeeClass, transformedClassFile));
+        reply.addAll(jdb.command(JdbCommand.use(Paths.get(transformedClassFile).getParent().toString())));
+        return reply;
     }
 
     // gets full test source path for the given test filename


### PR DESCRIPTION
I backport this test fix for parity with 17.0.8-oracle to 17.0.7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210927](https://bugs.openjdk.org/browse/JDK-8210927): JDB tests do not update source path after doing a redefine class


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1190/head:pull/1190` \
`$ git checkout pull/1190`

Update a local copy of the PR: \
`$ git checkout pull/1190` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1190`

View PR using the GUI difftool: \
`$ git pr show -t 1190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1190.diff">https://git.openjdk.org/jdk17u-dev/pull/1190.diff</a>

</details>
