### PR TITLE
8048190: NoClassDefFoundError omits original ExceptionInInitializerError

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2719,6 +2719,51 @@ void java_lang_Throwable::get_stack_trace_elements(Handle throwable,
   }
 }
 
+Handle java_lang_Throwable::get_cause_with_stack_trace(Handle throwable, TRAPS) {
+  // Call to JVM to fill in the stack trace and clear declaringClassObject to
+  // not keep classes alive in the stack trace.
+  // call this:  public StackTraceElement[] getStackTrace()
+  assert(throwable.not_null(), "shouldn't be");
+
+  JavaValue result(T_ARRAY);
+  JavaCalls::call_virtual(&result, throwable,
+                          vmClasses::Throwable_klass(),
+                          vmSymbols::getStackTrace_name(),
+                          vmSymbols::getStackTrace_signature(),
+                          CHECK_NH);
+  Handle stack_trace(THREAD, result.get_oop());
+  assert(stack_trace->is_objArray(), "Should be an array");
+
+  // Throw ExceptionInInitializerError as the cause with this exception in
+  // the message and stack trace.
+
+  // Now create the message with the original exception and thread name.
+  Symbol* message = java_lang_Throwable::detail_message(throwable());
+  ResourceMark rm(THREAD);
+  stringStream st;
+  st.print("Exception %s%s ", throwable()->klass()->name()->as_klass_external_name(),
+             message == nullptr ? "" : ":");
+  if (message == NULL) {
+    st.print("[in thread \"%s\"]", THREAD->name());
+  } else {
+    st.print("%s [in thread \"%s\"]", message->as_C_string(), THREAD->name());
+  }
+
+  Symbol* exception_name = vmSymbols::java_lang_ExceptionInInitializerError();
+  Handle h_cause = Exceptions::new_exception(THREAD, exception_name, st.as_string());
+
+  // If new_exception returns a different exception while creating the exception, return null.
+  if (h_cause->klass()->name() != exception_name) {
+    log_info(class, init)("Exception thrown while saving initialization exception %s",
+                          h_cause->klass()->external_name());
+    return Handle();
+  }
+  java_lang_Throwable::set_stacktrace(h_cause(), stack_trace());
+  // Clear backtrace because the stacktrace should be used instead.
+  set_backtrace(h_cause(), NULL);
+  return h_cause;
+}
+
 bool java_lang_Throwable::get_top_method_and_bci(oop throwable, Method** method, int* bci) {
   JavaThread* current = JavaThread::current();
   objArrayHandle result(current, objArrayOop(backtrace(throwable)));

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -567,6 +567,10 @@ class java_lang_Throwable: AllStatic {
   static void fill_in_stack_trace(Handle throwable, const methodHandle& method = methodHandle());
   // Programmatic access to stack trace
   static void get_stack_trace_elements(Handle throwable, objArrayHandle stack_trace, TRAPS);
+
+  // For recreating class initialization error exceptions.
+  static Handle get_cause_with_stack_trace(Handle throwable, TRAPS);
+
   // Printing
   static void print(oop throwable, outputStream* st);
   static void print_stack_trace(Handle throwable, outputStream* st);

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1626,6 +1626,8 @@ bool SystemDictionary::do_unloading(GCTimer* gc_timer) {
     } else {
       assert(_pd_cache_table->number_of_entries() == 0, "should be empty");
     }
+
+    InstanceKlass::clean_initialization_error_table();
   }
 
   return unloading_occurred;

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -368,6 +368,7 @@
   template(class_initializer_name,                    "<clinit>")                                 \
   template(println_name,                              "println")                                  \
   template(printStackTrace_name,                      "printStackTrace")                          \
+  template(getStackTrace_name,                        "getStackTrace")                            \
   template(main_name,                                 "main")                                     \
   template(name_name,                                 "name")                                     \
   template(priority_name,                             "priority")                                 \
@@ -593,7 +594,9 @@
   template(int_String_signature,                      "(I)Ljava/lang/String;")                                    \
   template(boolean_boolean_int_signature,             "(ZZ)I")                                                    \
   template(big_integer_shift_worker_signature,        "([I[IIII)V")                                               \
-  template(reflect_method_signature,                  "Ljava/lang/reflect/Method;")                                                    \
+  template(reflect_method_signature,                  "Ljava/lang/reflect/Method;")                               \
+  template(getStackTrace_signature,                    "()[Ljava/lang/StackTraceElement;")                        \
+                                                                                                                  \
   /* signature symbols needed by intrinsics */                                                                    \
   VM_INTRINSICS_DO(VM_INTRINSIC_IGNORE, VM_SYMBOL_IGNORE, VM_SYMBOL_IGNORE, template, VM_ALIAS_IGNORE)            \
                                                                                                                   \

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1196,6 +1196,7 @@ public:
   virtual Klass* array_klass(TRAPS);
   virtual Klass* array_klass_or_null();
 
+  static void clean_initialization_error_table();
 private:
   void fence_and_clear_init_lock();
 
@@ -1204,6 +1205,9 @@ private:
   void initialize_impl                           (TRAPS);
   void initialize_super_interfaces               (TRAPS);
   void eager_initialize_impl                     ();
+
+  void add_initialization_error(JavaThread* current, Handle exception);
+  oop get_initialization_error(JavaThread* current);
 
   // find a local method (returns NULL if not found)
   Method* find_method_impl(const Symbol* name,

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -43,6 +43,7 @@ Mutex*   Patching_lock                = NULL;
 Mutex*   CompiledMethod_lock          = NULL;
 Monitor* SystemDictionary_lock        = NULL;
 Mutex*   SharedDictionary_lock        = NULL;
+Monitor* ClassInitError_lock          = NULL;
 Mutex*   Module_lock                  = NULL;
 Mutex*   CompiledIC_lock              = NULL;
 Mutex*   InlineCacheBuffer_lock       = NULL;
@@ -255,6 +256,7 @@ void mutex_init() {
 
   def(SystemDictionary_lock        , PaddedMonitor, leaf,        true,  _safepoint_check_always);
   def(SharedDictionary_lock        , PaddedMutex  , leaf,        true,  _safepoint_check_always);
+  def(ClassInitError_lock          , PaddedMonitor, leaf+1,      true,  _safepoint_check_always);
   def(Module_lock                  , PaddedMutex  , leaf+2,      false, _safepoint_check_always);
   def(InlineCacheBuffer_lock       , PaddedMutex  , leaf,        true,  _safepoint_check_never);
   def(VMStatistic_lock             , PaddedMutex  , leaf,        false, _safepoint_check_always);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -35,6 +35,7 @@ extern Mutex*   Patching_lock;                   // a lock used to guard code pa
 extern Mutex*   CompiledMethod_lock;             // a lock used to guard a compiled method and OSR queues
 extern Monitor* SystemDictionary_lock;           // a lock on the system dictionary
 extern Mutex*   SharedDictionary_lock;           // a lock on the CDS shared dictionary
+extern Monitor* ClassInitError_lock;             // a lock on the class initialization error table
 extern Mutex*   Module_lock;                     // a lock on module and package related data structures
 extern Mutex*   CompiledIC_lock;                 // a lock used to guard compiled IC patching and access
 extern Mutex*   InlineCacheBuffer_lock;          // a lock used to guard the InlineCacheBuffer

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/InitExceptionUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/InitExceptionUnloadTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8048190
+ * @summary Test that the NCDFE saves the stack trace for the original exception
+ *          during class initialization with ExceptionInInitializationError,
+ *          and doesn't prevent the classes in the stacktrace to be unloaded.
+ * @requires vm.opt.final.ClassUnloading
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build sun.hotspot.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -Xmn8m -XX:+UnlockDiagnosticVMOptions -Xlog:class+unload -XX:+WhiteBoxAPI InitExceptionUnloadTest
+ */
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import sun.hotspot.WhiteBox;
+import jdk.test.lib.classloader.ClassUnloadCommon;
+
+public class InitExceptionUnloadTest {
+    static public class ThrowsRuntimeException { static int x = 1/0; }
+    static public class ThrowsError { static { if (true) throw new Error(); } }
+    static public class SpecialException extends RuntimeException {
+        SpecialException(int count, String message) {
+            super(message + count);
+        }
+    }
+    static public class ThrowsSpecialException {
+        static {
+            if (true) throw new SpecialException(3, "Very Special ");
+        }
+    }
+
+    static public class ThrowsOOM {
+        static {
+            if (true) {
+                // Actually getting an OOM might be fragile but it was tested.
+                throw new OutOfMemoryError("Java heap space");
+            }
+        }
+    }
+
+    private static void verify_stack(Throwable e, String expected, String cause) throws Exception {
+        ByteArrayOutputStream byteOS = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(byteOS);
+        e.printStackTrace(printStream);
+        printStream.close();
+        String stackTrace = byteOS.toString("ASCII");
+        if (!stackTrace.contains(expected) || (cause != null && !stackTrace.contains(cause))) {
+            throw new RuntimeException(expected + " and " + cause + " missing from stacktrace");
+        }
+    }
+
+    static String[] expected = new String[] {
+        "java.lang.ExceptionInInitializerError",
+        "Caused by: java.lang.ArithmeticException: / by zero",
+        "java.lang.NoClassDefFoundError: Could not initialize class InitExceptionUnloadTest$ThrowsRuntimeException",
+        "Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.ArithmeticException: / by zero [in thread",
+        "java.lang.Error",
+        null,
+        "java.lang.NoClassDefFoundError: Could not initialize class InitExceptionUnloadTest$ThrowsError",
+        "Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.Error [in thread",
+        "java.lang.ExceptionInInitializerError",
+        "Caused by: InitExceptionUnloadTest$SpecialException: Very Special 3",
+        "java.lang.NoClassDefFoundError: Could not initialize class InitExceptionUnloadTest$ThrowsSpecialException",
+        "Caused by: java.lang.ExceptionInInitializerError: Exception InitExceptionUnloadTest$SpecialException: Very Special 3",
+        "java.lang.OutOfMemoryError",
+        "Java heap space",
+        "java.lang.NoClassDefFoundError: Could not initialize class InitExceptionUnloadTest$ThrowsOOM",
+        "Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.OutOfMemoryError: Java heap space [in thread"
+    };
+
+    static String[] classNames = new String[] {
+        "InitExceptionUnloadTest$ThrowsRuntimeException",
+        "InitExceptionUnloadTest$ThrowsError",
+        "InitExceptionUnloadTest$ThrowsSpecialException",
+        "InitExceptionUnloadTest$ThrowsOOM" };
+
+    public static WhiteBox wb = WhiteBox.getWhiteBox();
+
+    static void test() throws Throwable {
+        ClassLoader cl = ClassUnloadCommon.newClassLoader();
+        int i = 0;
+        for (String className : classNames) {
+            for (int tries = 2; tries-- > 0; ) {
+                System.err.println("--- try to load " + className);
+                try {
+                    Class<?> c = cl.loadClass(className);
+                    Object inst = c.newInstance();
+                } catch (Throwable t) {
+                    t.printStackTrace();
+                    System.err.println();
+                    System.err.println("Check results");
+                    verify_stack(t, expected[i], expected[i+1]);
+                    i += 2;
+                    System.err.println();
+                }
+            }
+        }
+        cl = null;
+        ClassUnloadCommon.triggerUnloading();  // should unload these classes
+        for (String className : classNames) {
+          ClassUnloadCommon.failIf(wb.isClassAlive(className), "should be unloaded");
+        }
+    }
+    public static void main(java.lang.String[] unused) throws Throwable {
+        test();
+        test();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.7-oracle.

I had to adapt the declaration of _initialization_error_table because "8270061: Change parameter order of ResourceHashtable" is not in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8048190](https://bugs.openjdk.org/browse/JDK-8048190): NoClassDefFoundError omits original ExceptionInInitializerError


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [4cee8df5](https://git.openjdk.org/jdk17u-dev/pull/1195/files/4cee8df5f35976c578b7b535e2680b7f1a1b276e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1195/head:pull/1195` \
`$ git checkout pull/1195`

Update a local copy of the PR: \
`$ git checkout pull/1195` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1195`

View PR using the GUI difftool: \
`$ git pr show -t 1195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1195.diff">https://git.openjdk.org/jdk17u-dev/pull/1195.diff</a>

</details>
