### PR TITLE
8302320: AsyncGetCallTrace obtains too few frames in sanity test

### DIFF
--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -64,8 +64,11 @@ bool frame::safe_for_sender(JavaThread *thread) {
     return false;
   }
 
-  // unextended sp must be within the stack and above or equal sp
-  if (!thread->is_in_stack_range_incl(unextended_sp, sp)) {
+  // unextended sp must be within the stack
+  // Note: sp can be greater than unextended_sp in the case of
+  // interpreted -> interpreted calls that go through a method handle linker,
+  // since those pop the last argument (the appendix) from the stack.
+  if (!thread->is_in_stack_range_incl(unextended_sp, sp - Interpreter::stackElementSize)) {
     return false;
   }
 


### PR DESCRIPTION
Extended the AsyncGetCallTrace and fixed an issue with interpreter frames.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302320](https://bugs.openjdk.org/browse/JDK-8302320): AsyncGetCallTrace obtains too few frames in sanity test


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1197/head:pull/1197` \
`$ git checkout pull/1197`

Update a local copy of the PR: \
`$ git checkout pull/1197` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1197`

View PR using the GUI difftool: \
`$ git pr show -t 1197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1197.diff">https://git.openjdk.org/jdk17u-dev/pull/1197.diff</a>

</details>
