### PR TITLE
8303440: The "ZonedDateTime.parse" may not accept the "UTC+XX" zone id

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -4321,8 +4321,10 @@ public final class DateTimeFormatterBuilder {
                     if (length >= position + 3 && context.charEquals(text.charAt(position + 2), 'C')) {
                         // There are localized zone texts that start with "UTC", e.g.
                         // "UTC\u221210:00" (MINUS SIGN instead of HYPHEN-MINUS) in French.
-                        // Exclude those ZoneText cases.
-                        if (!(this instanceof ZoneTextPrinterParser)) {
+                        // Exclude those cases.
+                        if (length == position + 3 ||
+                                context.charEquals(text.charAt(position + 3), '+') ||
+                                context.charEquals(text.charAt(position + 3), '-')) {
                             return parseOffsetBased(context, text, position, position + 3, OffsetIdPrinterParser.INSTANCE_ID_ZERO);
                         }
                     } else {

--- a/test/jdk/java/time/test/java/time/format/TestUTCParse.java
+++ b/test/jdk/java/time/test/java/time/format/TestUTCParse.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @modules jdk.localedata
+ * @bug 8303440
+ * @summary Test parsing "UTC-XX:XX" text works correctly
+ */
+package test.java.time.format;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.TextStyle;
+import java.time.temporal.TemporalQueries;
+import java.util.Locale;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+public class TestUTCParse {
+
+    static {
+        // Assuming CLDR's SHORT name for "America/Los_Angeles"
+        // produces "UTC\u212208:00"
+        System.setProperty("java.locale.providers", "CLDR");
+    }
+
+    @DataProvider
+    public Object[][] utcZoneIdStrings() {
+        return new Object[][] {
+            {"UTC"},
+            {"UTC+01:30"},
+            {"UTC-01:30"},
+        };
+    }
+
+    @Test
+    public void testUTCShortNameRoundTrip() {
+        var fmt = DateTimeFormatter.ofPattern("z", Locale.FRANCE);
+        var zdt = ZonedDateTime.of(2023, 3, 3, 0, 0, 0, 0, ZoneId.of("America/Los_Angeles"));
+        var formatted = fmt.format(zdt);
+        assertEquals(formatted, "UTC\u221208:00");
+        assertEquals(fmt.parse(formatted).query(TemporalQueries.zoneId()), zdt.getZone());
+    }
+
+    @Test(dataProvider = "utcZoneIdStrings")
+    public void testUTCOffsetRoundTrip(String zidString) {
+        var fmt = new DateTimeFormatterBuilder()
+                .appendZoneText(TextStyle.NARROW)
+                .toFormatter();
+        var zid = ZoneId.of(zidString);
+        assertEquals(fmt.parse(zidString).query(TemporalQueries.zoneId()), zid);
+    }
+}


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [cfb0a25a](https://github.com/openjdk/jdk/commit/cfb0a25a4ee1a9cebd88c84fa622c46fe1c89bae) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Naoto Sato on 6 Mar 2023 and was reviewed by Iris Clark, Jaikiran Pai, Roger Riggs and Lance Andersen.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303440](https://bugs.openjdk.org/browse/JDK-8303440): The "ZonedDateTime.parse" may not accept the "UTC+XX" zone id


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1198/head:pull/1198` \
`$ git checkout pull/1198`

Update a local copy of the PR: \
`$ git checkout pull/1198` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1198`

View PR using the GUI difftool: \
`$ git pr show -t 1198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1198.diff">https://git.openjdk.org/jdk17u-dev/pull/1198.diff</a>

</details>
