### PR TITLE
8303809: Dispose context in SPNEGO NegotiatorImpl

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
@@ -528,4 +528,13 @@ public abstract class AuthenticationInfo extends AuthCacheValue implements Clone
         s2 = new String (pw.getPassword());
         s.defaultWriteObject ();
     }
+
+    /**
+     * Releases any system or cryptographic resources.
+     * It is up to implementors to override disposeContext()
+     * to take necessary action.
+     */
+    public void disposeContext() {
+        // do nothing
+    }
 }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -2029,6 +2029,12 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             if (serverAuthKey != null) {
                 AuthenticationInfo.endAuthRequest(serverAuthKey);
             }
+            if (proxyAuthentication != null) {
+                proxyAuthentication.disposeContext();
+            }
+            if (serverAuthentication != null) {
+                serverAuthentication.disposeContext();
+            }
         }
     }
 
@@ -2273,6 +2279,9 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
         } finally  {
             if (proxyAuthKey != null) {
                 AuthenticationInfo.endAuthRequest(proxyAuthKey);
+            }
+            if (proxyAuthentication != null) {
+                proxyAuthentication.disposeContext();
             }
         }
 
@@ -2523,6 +2532,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             }
             if (ret != null) {
                 if (!ret.setHeaders(this, p, raw)) {
+                    ret.disposeContext();
                     ret = null;
                 }
             }
@@ -2695,6 +2705,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
 
             if (ret != null ) {
                 if (!ret.setHeaders(this, p, raw)) {
+                    ret.disposeContext();
                     ret = null;
                 }
             }
@@ -2721,6 +2732,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     DigestAuthentication da = (DigestAuthentication)
                         currentProxyCredentials;
                     da.checkResponse (raw, method, getRequestURI());
+                    currentProxyCredentials.disposeContext();
                     currentProxyCredentials = null;
                 }
             }
@@ -2731,6 +2743,7 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                     DigestAuthentication da = (DigestAuthentication)
                         currentServerCredentials;
                     da.checkResponse (raw, method, url);
+                    currentServerCredentials.disposeContext();
                     currentServerCredentials = null;
                 }
             }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -245,6 +245,22 @@ class NegotiateAuthentication extends AuthenticationInfo {
         return negotiator.nextToken(token);
     }
 
+    /**
+     * Releases any system resources and cryptographic information stored in
+     * the context object and invalidates the context.
+     */
+    @Override
+    public void disposeContext() {
+        if (negotiator != null) {
+            try {
+                negotiator.disposeContext();
+            } catch (IOException ioEx) {
+                //do not rethrow IOException
+            }
+            negotiator = null;
+        }
+    }
+
     // MS will send a final WWW-Authenticate even if the status is already
     // 200 OK. The token can be fed into initSecContext() again to determine
     // if the server can be trusted. This is not the same concept as Digest's

--- a/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/Negotiator.java
@@ -82,5 +82,7 @@ public abstract class Negotiator {
             logger.finest("NegotiateAuthentication: " + e);
         }
     }
+
+    public void disposeContext() throws IOException { };
 }
 

--- a/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
+++ b/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
@@ -127,6 +127,11 @@ public class NegotiatorImpl extends Negotiator {
                         "fallback to other scheme if allowed. Reason:");
                 e.printStackTrace();
             }
+            try {
+                disposeContext();
+            } catch (Exception ex) {
+                //dispose context silently
+            }
             IOException ioe = new IOException("Negotiate support not initiated");
             ioe.initCause(e);
             throw ioe;
@@ -151,6 +156,9 @@ public class NegotiatorImpl extends Negotiator {
     @Override
     public byte[] nextToken(byte[] token) throws IOException {
         try {
+            if (context == null) {
+                throw new IOException("Negotiate support cannot continue. Context is invalidated");
+            }
             return context.initSecContext(token, 0, token.length);
         } catch (GSSException e) {
             if (DEBUG) {
@@ -161,5 +169,27 @@ public class NegotiatorImpl extends Negotiator {
             ioe.initCause(e);
             throw ioe;
         }
+    }
+
+    /**
+     * Releases any system resources and cryptographic information stored in
+     * the context object and invalidates the context.
+     *
+     * @throws IOException containing a reason of failure in the cause
+     */
+    @Override
+    public void disposeContext() throws IOException {
+        try {
+            if (context != null) {
+                context.dispose();
+            }
+        } catch (GSSException e) {
+            if (DEBUG) {
+                System.out.println("Cannot release resources. Reason:");
+                e.printStackTrace();
+            }
+            throw new IOException("Cannot release resources", e);
+        };
+        context = null;
     }
 }


### PR DESCRIPTION
Almost clean backport of JDK-8303809

NegotiatorImpl is merged manually because of no JDK-8282632 in 17u - difference in IOException initialization

sun/security/jgss sun/security/krb5 sun/net/www/protocol/http tests passed successfully

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303809](https://bugs.openjdk.org/browse/JDK-8303809): Dispose context in SPNEGO NegotiatorImpl


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1203/head:pull/1203` \
`$ git checkout pull/1203`

Update a local copy of the PR: \
`$ git checkout pull/1203` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1203`

View PR using the GUI difftool: \
`$ git pr show -t 1203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1203.diff">https://git.openjdk.org/jdk17u-dev/pull/1203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1203#issuecomment-1470381664)