### PR TITLE
8257856: Make ClassFileVersionsTest.java robust to JDK version updates

### DIFF
--- a/test/jdk/java/lang/module/ClassFileVersionsTest.java
+++ b/test/jdk/java/lang/module/ClassFileVersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,69 +43,65 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 public class ClassFileVersionsTest {
+    private static final int FEATURE;
+    static {
+        FEATURE = Runtime.version().feature();
+        assert FEATURE >= 10;
+    }
 
     // major, minor, modifiers for requires java.base
     @DataProvider(name = "supported")
     public Object[][] supported() {
-        return new Object[][]{
-                { 53,   0,  Set.of() },                      // JDK 9
-                { 53,   0,  Set.of(STATIC) },
-                { 53,   0,  Set.of(TRANSITIVE) },
-                { 53,   0,  Set.of(STATIC, TRANSITIVE) },
+        /*
+         * There are four test cases for JDK 9 and then one test case
+         * for each subsequent JDK version from JDK 10 to the current
+         * feature release for a total of (4 + (FEATURE - 9) ) =>
+         * (feature - 5) rows.
+         */
+        Object[][] result = new Object[(FEATURE - 5)][];
 
-                { 54,   0,  Set.of() },                      // JDK 10
-                { 55,   0,  Set.of() },                      // JDK 11
-                { 56,   0,  Set.of() },                      // JDK 12
-                { 57,   0,  Set.of() },                      // JDK 13
-                { 58,   0,  Set.of() },                      // JDK 14
-                { 59,   0,  Set.of() },                      // JDK 15
-                { 60,   0,  Set.of() },                      // JDK 16
-                { 61,   0,  Set.of() },                      // JDK 17
-        };
+        // Class file version of JDK 9 is 53.0
+        result[0] = new Object[]{ 53, 0, Set.of()};
+        result[1] = new Object[]{ 53, 0, Set.of(STATIC) };
+        result[2] = new Object[]{ 53, 0, Set.of(TRANSITIVE) };
+        result[3] = new Object[]{ 53, 0, Set.of(STATIC, TRANSITIVE) };
+
+        // Major class file version of JDK N is 44 + n. Create rows
+        // for JDK 10 through FEATURE.
+        for (int i = 4; i < (FEATURE - 5) ; i++) {
+            result[i] = new Object[]{i + 50, 0, Set.of()};
+        }
+
+        return result;
     }
 
     // major, minor, modifiers for requires java.base
     @DataProvider(name = "unsupported")
     public Object[][] unsupported() {
-        return new Object[][]{
-                { 50,   0,  Set.of()},                       // JDK 6
-                { 51,   0,  Set.of()},                       // JDK 7
-                { 52,   0,  Set.of()},                       // JDK 8
+        /*
+         * There are three test cases for releases prior to JDK 9,
+         * three test cases for each JDK version from JDK 10 to the
+         * current feature release, plus one addition test case for
+         * the next release for a total of (3 + (FEATURE - 9) * 3 + 1)
+         * rows.
+         */
+        int unsupportedCount = 3 + (FEATURE - 9)*3 + 1;
+        Object[][] result = new Object[unsupportedCount][];
 
-                { 54,   0,  Set.of(STATIC) },                // JDK 10
-                { 54,   0,  Set.of(TRANSITIVE) },
-                { 54,   0,  Set.of(STATIC, TRANSITIVE) },
+        result[0] = new Object[]{50, 0, Set.of()}; // JDK 6
+        result[1] = new Object[]{51, 0, Set.of()}; // JDK 7
+        result[2] = new Object[]{52, 0, Set.of()}; // JDK 8
 
-                { 55,   0,  Set.of(STATIC) },                // JDK 11
-                { 55,   0,  Set.of(TRANSITIVE) },
-                { 55,   0,  Set.of(STATIC, TRANSITIVE) },
+        for (int i = 10; i <= FEATURE ; i++) {
+            int base = 3 + (i-10)*3;
+            // Major class file version of JDK N is 44+n
+            result[base]     = new Object[]{i + 44, 0, Set.of(STATIC)};
+            result[base + 1] = new Object[]{i + 44, 0, Set.of(TRANSITIVE)};
+            result[base + 2] = new Object[]{i + 44, 0, Set.of(STATIC, TRANSITIVE)};
+        }
 
-                { 56,   0,  Set.of(STATIC) },                // JDK 12
-                { 56,   0,  Set.of(TRANSITIVE) },
-                { 56,   0,  Set.of(STATIC, TRANSITIVE) },
-
-                { 57,   0,  Set.of(STATIC) },                // JDK 13
-                { 57,   0,  Set.of(TRANSITIVE) },
-                { 57,   0,  Set.of(STATIC, TRANSITIVE) },
-
-                { 58,   0,  Set.of(STATIC) },                // JDK 14
-                { 58,   0,  Set.of(TRANSITIVE) },
-                { 58,   0,  Set.of(STATIC, TRANSITIVE) },
-
-                { 59,   0,  Set.of(STATIC) },                // JDK 15
-                { 59,   0,  Set.of(TRANSITIVE) },
-                { 59,   0,  Set.of(STATIC, TRANSITIVE) },
-
-                { 60,   0,  Set.of(STATIC) },                // JDK 16
-                { 60,   0,  Set.of(TRANSITIVE) },
-                { 60,   0,  Set.of(STATIC, TRANSITIVE) },
-
-                { 61,   0,  Set.of(STATIC) },                // JDK 17
-                { 61,   0,  Set.of(TRANSITIVE) },
-                { 61,   0,  Set.of(STATIC, TRANSITIVE) },
-
-                { 62,   0,  Set.of()},                       // JDK 18
-        };
+        result[unsupportedCount - 1] = new Object[]{FEATURE+1+44, 0, Set.of()};
+        return result;
     }
 
     @Test(dataProvider = "supported")


### PR DESCRIPTION
Backport JDK-8257856 for Oracle parity. Test update is not exactly needed in a backport release because no Java version update will occur there. However, it's good to have the same test code base in all releases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257856](https://bugs.openjdk.org/browse/JDK-8257856): Make ClassFileVersionsTest.java robust to JDK version updates


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1208/head:pull/1208` \
`$ git checkout pull/1208`

Update a local copy of the PR: \
`$ git checkout pull/1208` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1208`

View PR using the GUI difftool: \
`$ git pr show -t 1208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1208.diff">https://git.openjdk.org/jdk17u-dev/pull/1208.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1208#issuecomment-1474402931)