### PR TITLE
8304063: tools/jpackage/share/AppLauncherEnvTest.java fails when checking LD_LIBRARY_PATH

### DIFF
--- a/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
+++ b/test/jdk/tools/jpackage/share/AppLauncherEnvTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
 import jdk.jpackage.test.Executor;
@@ -83,8 +84,10 @@ public class AppLauncherEnvTest {
         final String expectedEnvVarValue = Optional.ofNullable(System.getenv(
                 envVarName)).orElse("") + File.pathSeparator + appDir;
 
-        TKit.assertEquals(expectedEnvVarValue, actualEnvVarValue, String.format(
-                "Check value of %s env variable", envVarName));
+        TKit.assertTextStream(expectedEnvVarValue)
+            .predicate(TKit.isLinux() ? String::endsWith : String::equals)
+            .label(String.format("value of %s env variable", envVarName))
+            .apply(Stream.of(actualEnvVarValue));
 
         final String javaLibraryPath = getValue.apply(2, "java.library.path");
         TKit.assertTrue(


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304063](https://bugs.openjdk.org/browse/JDK-8304063): tools/jpackage/share/AppLauncherEnvTest.java fails when checking LD_LIBRARY_PATH


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev pull/1210/head:pull/1210` \
`$ git checkout pull/1210`

Update a local copy of the PR: \
`$ git checkout pull/1210` \
`$ git pull https://git.openjdk.org/jdk17u-dev pull/1210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1210`

View PR using the GUI difftool: \
`$ git pr show -t 1210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1210.diff">https://git.openjdk.org/jdk17u-dev/pull/1210.diff</a>

</details>
