### PR TITLE
Backport 63ef2143289f4aac52c8b2a6b555ed2b33dc1c07

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/image/SurfaceManager.java
+++ b/src/java.desktop/share/classes/sun/awt/image/SurfaceManager.java
@@ -89,7 +89,7 @@ public abstract class SurfaceManager {
         imgaccessor.setSurfaceManager(img, mgr);
     }
 
-    private ConcurrentHashMap<Object,Object> cacheMap;
+    private volatile ConcurrentHashMap<Object,Object> cacheMap;
 
     /**
      * Return an arbitrary cached object for an arbitrary cache key.


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [63ef2143](https://github.com/openjdk/jdk/commit/63ef2143289f4aac52c8b2a6b555ed2b33dc1c07) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Per Minborg on 22 Feb 2023 and was reviewed by Sergey Bylokhov.
Thanks!