### PR TITLE
8282077: PKCS11 provider C_sign() impl should handle CKR_BUFFER_TOO_SMALL error

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -144,11 +144,22 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1Sign
 
     TRACE1("DEBUG C_Sign: ret rv=0x%lX\n", rv);
 
+    if (rv == CKR_BUFFER_TOO_SMALL) {
+        bufP = (CK_BYTE_PTR) malloc(ckSignatureLength);
+        if (bufP == NULL) {
+            throwOutOfMemoryError(env, 0);
+            goto cleanup;
+        }
+        rv = (*ckpFunctions->C_Sign)(ckSessionHandle, ckpData, ckDataLength,
+            bufP, &ckSignatureLength);
+    }
+
     if (ckAssertReturnValueOK(env, rv) == CK_ASSERT_OK) {
         jSignature = ckByteArrayToJByteArray(env, bufP, ckSignatureLength);
         TRACE1("DEBUG C_Sign: signature length = %lu\n", ckSignatureLength);
     }
 
+cleanup:
     free(ckpData);
     if (bufP != BUF) { free(bufP); }
 


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282077](https://bugs.openjdk.org/browse/JDK-8282077): PKCS11 provider C_sign() impl should handle CKR_BUFFER_TOO_SMALL error


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1218/head:pull/1218` \
`$ git checkout pull/1218`

Update a local copy of the PR: \
`$ git checkout pull/1218` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1218`

View PR using the GUI difftool: \
`$ git pr show -t 1218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1218.diff">https://git.openjdk.org/jdk17u-dev/pull/1218.diff</a>

</details>
