### PR TITLE
8283062: Uninitialized warnings in libgtest with GCC 11.2

### DIFF
--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
         $(GTEST_FRAMEWORK_SRC)/googletest/src \
         $(GTEST_FRAMEWORK_SRC)/googlemock/src, \
     INCLUDE_FILES := gtest-all.cc gmock-all.cc, \
-    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral, \
+    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral maybe-uninitialized, \
     DISABLED_WARNINGS_clang := undef unused-result format-nonliteral, \
     CFLAGS := $(JVM_CFLAGS) \
         -I$(GTEST_FRAMEWORK_SRC)/googletest \


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283062](https://bugs.openjdk.org/browse/JDK-8283062): Uninitialized warnings in libgtest with GCC 11.2


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1219/head:pull/1219` \
`$ git checkout pull/1219`

Update a local copy of the PR: \
`$ git checkout pull/1219` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1219`

View PR using the GUI difftool: \
`$ git pr show -t 1219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1219.diff">https://git.openjdk.org/jdk17u-dev/pull/1219.diff</a>

</details>
