### PR TITLE
8282227: Locale information for nb is not working properly

### DIFF
--- a/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -238,6 +238,8 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
         return applyParentLocales(baseName, candidates);
     }
 
+    private static final Locale NB = Locale.forLanguageTag("nb");
+    private static final Locale NO = Locale.forLanguageTag("no");
     private List<Locale> applyParentLocales(String baseName, List<Locale> candidates) {
         // check irregular parents
         for (int i = 0; i < candidates.size(); i++) {
@@ -247,11 +249,15 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
                 if (p != null &&
                     !candidates.get(i+1).equals(p)) {
                     List<Locale> applied = candidates.subList(0, i+1);
-                    if (applied.contains(p)) {
-                        // avoid circular recursion (could happen with nb/no case)
-                        continue;
+                    // Tweak for Norwegian locales, CLDR switched the canonical form of
+                    // Norwegian Bokmal language code from "nb" to "no" in CLDR 39
+                    // (https://unicode-org.atlassian.net/browse/CLDR-2698)
+                    if (p.equals(NB) || p.equals(NO)) {
+                        applied.add(NO);
+                        applied.add(Locale.ROOT);
+                    } else {
+                        applied.addAll(applyParentLocales(baseName, super.getCandidateLocales(baseName, p)));
                     }
-                    applied.addAll(applyParentLocales(baseName, super.getCandidateLocales(baseName, p)));
                     return applied;
                 }
             }

--- a/test/jdk/sun/util/resources/cldr/NorwegianFallbackTest.java
+++ b/test/jdk/sun/util/resources/cldr/NorwegianFallbackTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8282227
+ * @modules jdk.localedata
+ * @summary Checks Norwegian locale fallback retrieves resource bundles correctly.
+ * @run main/othervm -Djava.locale.providers=COMPAT NorwegianFallbackTest nb
+ * @run main/othervm -Djava.locale.providers=COMPAT NorwegianFallbackTest nn
+ * @run main/othervm -Djava.locale.providers=COMPAT NorwegianFallbackTest no
+ * @run main/othervm -Djava.locale.providers=CLDR NorwegianFallbackTest nb
+ * @run main/othervm -Djava.locale.providers=CLDR NorwegianFallbackTest nn
+ * @run main/othervm -Djava.locale.providers=CLDR NorwegianFallbackTest no
+ */
+
+import java.text.DateFormatSymbols;
+import java.util.List;
+import java.util.Locale;
+import static java.util.Calendar.SUNDAY;
+
+public class NorwegianFallbackTest {
+
+    private final static String SUN_ROOT = DateFormatSymbols.getInstance(Locale.ROOT).getShortWeekdays()[SUNDAY];
+    private final static List<Locale> TEST_LOCS = List.of(
+            Locale.forLanguageTag("nb"),
+            Locale.forLanguageTag("nn"),
+            Locale.forLanguageTag("no")
+    );
+
+    public static void main(String... args) {
+        // Dummy instance
+        var startup_loc = Locale.forLanguageTag(args[0]);
+        DateFormatSymbols.getInstance(startup_loc);
+
+        TEST_LOCS.stream()
+            .peek(l -> System.out.print("Testing locale: " + l + ", (startup locale: " + startup_loc + ")... "))
+            .map(l -> DateFormatSymbols.getInstance(l).getShortWeekdays()[SUNDAY])
+            .forEach(sun -> {
+                if (sun.equals(SUN_ROOT)) {
+                    throw new RuntimeException("Norwegian fallback failed");
+                } else {
+                    System.out.println("Got " + "\"" + sun + "\" for Sunday short name");
+                }
+            });
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282227](https://bugs.openjdk.org/browse/JDK-8282227): Locale information for nb is not working properly


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1220/head:pull/1220` \
`$ git checkout pull/1220`

Update a local copy of the PR: \
`$ git checkout pull/1220` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1220`

View PR using the GUI difftool: \
`$ git pr show -t 1220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1220.diff">https://git.openjdk.org/jdk17u-dev/pull/1220.diff</a>

</details>
