### PR TITLE
8286287: Reading file as UTF-16 causes Error which "shouldn't happen"

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -651,8 +651,6 @@ public final class String
 
             // decode using CharsetDecoder
             int en = scale(length, cd.maxCharsPerByte());
-            cd.onMalformedInput(CodingErrorAction.REPLACE)
-                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
             char[] ca = new char[en];
             if (charset.getClass().getClassLoader0() != null &&
                     System.getSecurityManager() != null) {
@@ -1197,6 +1195,8 @@ public final class String
     private static int decodeWithDecoder(CharsetDecoder cd, char[] dst, byte[] src, int offset, int length) {
         ByteBuffer bb = ByteBuffer.wrap(src, offset, length);
         CharBuffer cb = CharBuffer.wrap(dst, 0, dst.length);
+        cd.onMalformedInput(CodingErrorAction.REPLACE)
+            .onUnmappableCharacter(CodingErrorAction.REPLACE);
         try {
             CoderResult cr = cd.decode(bb, cb, true);
             if (!cr.isUnderflow())

--- a/test/jdk/java/lang/String/NewStringNoRepl.java
+++ b/test/jdk/java/lang/String/NewStringNoRepl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8286287
+ * @summary Verifies newStringNoRepl() does not throw an Error.
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HexFormat;
+import static java.nio.charset.StandardCharsets.UTF_16;
+
+public class NewStringNoRepl {
+    private final static byte[] MALFORMED_UTF16 = {(byte)0x00, (byte)0x20, (byte)0x00};
+
+    public static void main(String... args) throws IOException {
+        var f = Files.createTempFile(null, null);
+        try (var fos = Files.newOutputStream(f)) {
+            fos.write(MALFORMED_UTF16);
+        }
+        System.out.println("Returned bytes: " +
+            HexFormat.of()
+                .withPrefix("x")
+                .withUpperCase()
+                .formatHex(Files.readString(f, UTF_16).getBytes(UTF_16)));
+        Files.delete(f);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286287](https://bugs.openjdk.org/browse/JDK-8286287): Reading file as UTF-16 causes Error which "shouldn't happen"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1221/head:pull/1221` \
`$ git checkout pull/1221`

Update a local copy of the PR: \
`$ git checkout pull/1221` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1221`

View PR using the GUI difftool: \
`$ git pr show -t 1221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1221.diff">https://git.openjdk.org/jdk17u-dev/pull/1221.diff</a>

</details>
