### PR TITLE
8304880: [PPC64] VerifyOops code in C1 doesn't work with ZGC

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -828,7 +828,6 @@ int LIR_Assembler::load(Register base, int offset, LIR_Opr to_reg, BasicType typ
           } else {
             __ ld(to_reg->as_register(), offset, base);
           }
-          __ verify_oop(to_reg->as_register(), FILE_AND_LINE);
           break;
         }
       case T_FLOAT:  __ lfs(to_reg->as_float_reg(), offset, base); break;
@@ -859,7 +858,6 @@ int LIR_Assembler::load(Register base, Register disp, LIR_Opr to_reg, BasicType 
         } else {
           __ ldx(to_reg->as_register(), base, disp);
         }
-        __ verify_oop(to_reg->as_register(), FILE_AND_LINE);
         break;
       }
     case T_FLOAT:  __ lfsx(to_reg->as_float_reg() , base, disp); break;


### PR DESCRIPTION
Backport of [JDK-8304880](https://bugs.openjdk.org/browse/JDK-8304880). Doesn't apply cleanly, but this change is trivial to backport because it only removes 2 small code pieces. (Can't verify oops between raw load and load barrier with ZGC.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304880](https://bugs.openjdk.org/browse/JDK-8304880): [PPC64] VerifyOops code in C1 doesn't work with ZGC


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1225/head:pull/1225` \
`$ git checkout pull/1225`

Update a local copy of the PR: \
`$ git checkout pull/1225` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1225`

View PR using the GUI difftool: \
`$ git pr show -t 1225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1225.diff">https://git.openjdk.org/jdk17u-dev/pull/1225.diff</a>

</details>
