### PR TITLE
8278434: timeouts in test  java/time/test/java/time/format/TestZoneTextPrinterParser.java

### DIFF
--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,8 +151,8 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
 
         // Check parent locales first
         if (!exists(names, index)) {
-            CLDRLocaleProviderAdapter clpa = (CLDRLocaleProviderAdapter)LocaleProviderAdapter.forType(Type.CLDR);
-            var cands = clpa.getCandidateLocales("", locale);
+            var cands = ((CLDRLocaleProviderAdapter)LocaleProviderAdapter.forType(Type.CLDR))
+                    .getCandidateLocales("", locale);
             for (int i = 1; i < cands.size() ; i++) {
                 String[] parentNames = super.getDisplayNameArray(id, cands.get(i));
                 if (parentNames != null && !parentNames[index].isEmpty()) {
@@ -160,11 +160,6 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
                     return;
                 }
             }
-        }
-
-        // Region Fallback
-        if (regionFormatFallback(names, index, locale)) {
-            return;
         }
 
         // Type Fallback
@@ -183,6 +178,11 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
                 names[index] = compatNames[index];
                 return;
             }
+        }
+
+        // Region Fallback
+        if (regionFormatFallback(names, index, locale)) {
+            return;
         }
 
         // last resort
@@ -230,6 +230,11 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
     }
 
     private boolean regionFormatFallback(String[] names, int index, Locale l) {
+        if (index % 2 == 0) {
+            // ignore short names
+            return false;
+        }
+
         String id = names[INDEX_TZID];
         LocaleResources lr = LocaleProviderAdapter.forType(Type.CLDR).getLocaleResources(l);
         ResourceBundle fd = lr.getJavaTimeFormatData();

--- a/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
+++ b/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
- * @bug 8081022 8151876 8166875 8189784 8206980
+ * @bug 8081022 8151876 8166875 8189784 8206980 8278434
  * @key randomness
  */
 
@@ -58,6 +58,11 @@ import org.testng.annotations.Test;
  */
 @Test
 public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
+
+    private static final Locale[] SAMPLE_LOCALES = {
+        Locale.US, Locale.UK, Locale.FRANCE, Locale.GERMANY, Locale.ITALY, Locale.forLanguageTag("es"),
+        Locale.forLanguageTag("pt-BR"), Locale.forLanguageTag("ru"),
+        Locale.CHINA, Locale.TAIWAN, Locale.JAPAN, Locale.KOREA, Locale.ROOT};
 
     protected static DateTimeFormatter getFormatter(Locale locale, TextStyle style) {
         return new DateTimeFormatterBuilder().appendZoneText(style)
@@ -68,7 +73,6 @@ public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
     public void test_printText() {
         Random r = RandomFactory.getRandom();
         int N = 8;
-        Locale[] locales = Locale.getAvailableLocales();
         Set<String> zids = ZoneRulesProvider.getAvailableZoneIds();
         ZonedDateTime zdt = ZonedDateTime.now();
 
@@ -83,7 +87,7 @@ public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
                 zdt = zdt.withZoneSameLocal(ZoneId.of(zid));
                 TimeZone tz = TimeZone.getTimeZone(zid);
                 boolean isDST = tz.inDaylightTime(new Date(zdt.toInstant().toEpochMilli()));
-                for (Locale locale : locales) {
+                for (Locale locale : SAMPLE_LOCALES) {
                     String longDisplayName = tz.getDisplayName(isDST, TimeZone.LONG, locale);
                     String shortDisplayName = tz.getDisplayName(isDST, TimeZone.SHORT, locale);
                     if ((longDisplayName.startsWith("GMT+") && shortDisplayName.startsWith("GMT+"))
@@ -116,9 +120,8 @@ public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
     }
 
     public void test_ParseText() {
-        Locale[] locales = new Locale[] { Locale.ENGLISH, Locale.JAPANESE, Locale.FRENCH };
         Set<String> zids = ZoneRulesProvider.getAvailableZoneIds();
-        for (Locale locale : locales) {
+        for (Locale locale : SAMPLE_LOCALES) {
             parseText(zids, locale, TextStyle.FULL, false);
             parseText(zids, locale, TextStyle.FULL, true);
             parseText(zids, locale, TextStyle.SHORT, false);

--- a/test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java
+++ b/test/jdk/sun/util/resources/TimeZone/ChineseTimeZoneNameTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+ * @test
+ * @bug 8275721
+ * @modules jdk.localedata
+ * @summary Checks Chinese time zone names for `UTC` using CLDR are consistent
+ * @run testng/othervm -Djava.locale.providers=CLDR,COMPAT ChineseTimeZoneNameTest
+ * @run testng/othervm -Djava.locale.providers=CLDR ChineseTimeZoneNameTest
+ */
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test
+public class ChineseTimeZoneNameTest {
+
+    private static final Locale SIMPLIFIED_CHINESE = Locale.forLanguageTag("zh-Hans");
+    private static final Locale TRADITIONAL_CHINESE = Locale.forLanguageTag("zh-Hant");
+    private static final ZonedDateTime EPOCH_UTC =
+        ZonedDateTime.ofInstant(Instant.ofEpochSecond (0), ZoneId.of ("UTC"));
+
+    @DataProvider(name="locales")
+    Object[][] data() {
+        return new Object[][] {
+            {Locale.CHINESE,                        SIMPLIFIED_CHINESE},
+            {Locale.SIMPLIFIED_CHINESE,             SIMPLIFIED_CHINESE},
+            {Locale.forLanguageTag("zh-SG"),        SIMPLIFIED_CHINESE},
+            {Locale.forLanguageTag("zh-Hans-TW"),   SIMPLIFIED_CHINESE},
+            {Locale.forLanguageTag("zh-HK"),        TRADITIONAL_CHINESE},
+            {Locale.forLanguageTag("zh-MO"),        TRADITIONAL_CHINESE},
+            {Locale.TRADITIONAL_CHINESE,            TRADITIONAL_CHINESE},
+            {Locale.forLanguageTag("zh-Hant-CN"),   TRADITIONAL_CHINESE},
+        };
+    }
+
+    @Test(dataProvider="locales")
+    public void test_ChineseTimeZoneNames(Locale testLoc, Locale resourceLoc) {
+        assertEquals(DateTimeFormatter.ofPattern("z", testLoc).format(EPOCH_UTC),
+                DateTimeFormatter.ofPattern("z", resourceLoc).format(EPOCH_UTC));
+        assertEquals(DateTimeFormatter.ofPattern("zzzz", testLoc).format(EPOCH_UTC),
+                DateTimeFormatter.ofPattern("zzzz", resourceLoc).format(EPOCH_UTC));
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

I resolved copyright and @bugs in the test, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278434](https://bugs.openjdk.org/browse/JDK-8278434): timeouts in test  java/time/test/java/time/format/TestZoneTextPrinterParser.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1228/head:pull/1228` \
`$ git checkout pull/1228`

Update a local copy of the PR: \
`$ git checkout pull/1228` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1228`

View PR using the GUI difftool: \
`$ git pr show -t 1228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1228.diff">https://git.openjdk.org/jdk17u-dev/pull/1228.diff</a>

</details>
