### PR TITLE
8291638: Keep-Alive timeout of 0 should close connection immediately

### DIFF
--- a/src/java.base/share/classes/sun/net/www/HeaderParser.java
+++ b/src/java.base/share/classes/sun/net/www/HeaderParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package sun.net.www;
 
 import java.util.Iterator;
+import java.util.OptionalInt;
 
 /* This is useful for the nightmare of parsing multi-part HTTP/RFC822 headers
  * sensibly:
@@ -246,6 +247,19 @@ public class HeaderParser {
             return Default;
         }
     }
+
+    public OptionalInt findInt(String k) {
+        try {
+            String s = findValue(k);
+            if (s == null) {
+                return OptionalInt.empty();
+            }
+            return OptionalInt.of(Integer.parseInt(s));
+        } catch (Throwable t) {
+            return OptionalInt.empty();
+        }
+    }
+
     /*
     public static void main(String[] a) throws Exception {
         System.out.print("enter line to parse> ");

--- a/src/java.base/share/classes/sun/net/www/http/HttpClient.java
+++ b/src/java.base/share/classes/sun/net/www/http/HttpClient.java
@@ -29,6 +29,7 @@ import java.io.*;
 import java.net.*;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -127,6 +128,7 @@ public class HttpClient extends NetworkClient {
      *  0: the server specified no keep alive headers
      * -1: the server provided "Connection: keep-alive" but did not specify a
      *     a particular time in a "Keep-Alive:" headers
+     * -2: the server provided "Connection: keep-alive" and timeout=0
      * Positive values are the number of seconds specified by the server
      * in a "Keep-Alive" header
      */
@@ -900,11 +902,19 @@ public class HttpClient extends NetworkClient {
                         if (keepAliveConnections < 0) {
                             keepAliveConnections = usingProxy?50:5;
                         }
-                        keepAliveTimeout = p.findInt("timeout", -1);
-                        if (keepAliveTimeout < -1) {
-                            // if the server specified a negative (invalid) value
-                            // then we set to -1, which is equivalent to no value
+                        OptionalInt timeout = p.findInt("timeout");
+                        if (timeout.isEmpty()) {
                             keepAliveTimeout = -1;
+                        } else {
+                            keepAliveTimeout = timeout.getAsInt();
+                            if (keepAliveTimeout < 0) {
+                                // if the server specified a negative (invalid) value
+                                // then we set to -1, which is equivalent to no value
+                                keepAliveTimeout = -1;
+                            } else if (keepAliveTimeout == 0) {
+                                // handled specially to mean close connection immediately
+                                keepAliveTimeout = -2;
+                            }
                         }
                     }
                 } else if (b[7] != '0') {

--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
@@ -172,6 +172,8 @@ public class KeepAliveCache
                         // different default for server and proxy
                         keepAliveTimeout = http.getUsingProxy() ? 60 : 5;
                     }
+                } else if (keepAliveTimeout == -2) {
+                    keepAliveTimeout = 0;
                 }
                 // at this point keepAliveTimeout is the number of seconds to keep
                 // alive, which could be 0, if the user specified 0 for the property

--- a/test/jdk/sun/net/www/http/HttpClient/KeepAliveTest.java
+++ b/test/jdk/sun/net/www/http/HttpClient/KeepAliveTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @library /test/lib
+ * @bug 8291226 8291638
  * @modules java.base/sun.net:+open
  *          java.base/sun.net.www.http:+open
  *          java.base/sun.net.www:+open
@@ -1015,12 +1016,6 @@ public class KeepAliveTest {
     }
 
     private void startScenario(int scenarioNumber) throws Exception {
-        //test scenarios are skipped because of JDK-8291638
-        if((scenarioNumber >= 112 && scenarioNumber <= 127) || (scenarioNumber >= 144 && scenarioNumber <= 159)) {
-            System.out.println("Scenario Skipped:"+scenarioNumber);
-            this.countDownLatch.countDown();
-            return;
-        }
         System.out.println("serverScenarios[" + scenarioNumber + "]=" + getServerScenario(scenarioNumber));
         System.out.println("clientScenarios[" + scenarioNumber + "]=" + clientScenarios[getClientScenarioNumber(scenarioNumber)]);
         if(expectedValues[scenarioNumber] == 0) {


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291638](https://bugs.openjdk.org/browse/JDK-8291638): Keep-Alive timeout of 0 should close connection immediately


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1229/head:pull/1229` \
`$ git checkout pull/1229`

Update a local copy of the PR: \
`$ git checkout pull/1229` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1229`

View PR using the GUI difftool: \
`$ git pr show -t 1229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1229.diff">https://git.openjdk.org/jdk17u-dev/pull/1229.diff</a>

</details>
