### PR TITLE
8293887: AArch64 build failure with GCC 12 due to maybe-uninitialized warning in libfdlibm k_rem_pio2.c

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -49,6 +49,7 @@ $(eval $(call SetupNativeCompilation, BUILD_LIBFDLIBM, \
     CFLAGS_windows_debug := -DLOGGING, \
     CFLAGS_aix := -qfloat=nomaf, \
     DISABLED_WARNINGS_gcc := sign-compare misleading-indentation array-bounds, \
+    DISABLED_WARNINGS_gcc_k_rem_pio2.c := maybe-uninitialized, \
     DISABLED_WARNINGS_clang := sign-compare misleading-indentation, \
     DISABLED_WARNINGS_microsoft := 4146 4244 4018, \
     ARFLAGS := $(ARFLAGS), \


### PR DESCRIPTION
Trivial backport to support building GCC 12 on Aarch64.

Successfully build on Linux x64 and aarc64 with gcc 12.2.0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293887](https://bugs.openjdk.org/browse/JDK-8293887): AArch64 build failure with GCC 12 due to maybe-uninitialized warning in libfdlibm k_rem_pio2.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1231/head:pull/1231` \
`$ git checkout pull/1231`

Update a local copy of the PR: \
`$ git checkout pull/1231` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1231`

View PR using the GUI difftool: \
`$ git pr show -t 1231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1231.diff">https://git.openjdk.org/jdk17u-dev/pull/1231.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1231#issuecomment-1492463398)