### PR TITLE
8305711: Arm: C2 always enters slowpath for monitorexit

### DIFF
--- a/src/hotspot/cpu/arm/c2_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c2_MacroAssembler_arm.cpp
@@ -160,7 +160,7 @@ void C2_MacroAssembler::fast_unlock(Register Roop, Register Rbox, Register Rscra
   // Restore the object header
   bool allow_fallthrough_on_failure = true;
   bool one_shot = true;
-  cas_for_lock_release(Rmark, Rbox, Roop, Rscratch, done, allow_fallthrough_on_failure, one_shot);
+  cas_for_lock_release(Rbox, Rmark, Roop, Rscratch, done, allow_fallthrough_on_failure, one_shot);
 
   bind(done);
 }


### PR DESCRIPTION
Backporting this to make java on Arm faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305711](https://bugs.openjdk.org/browse/JDK-8305711): Arm: C2 always enters slowpath for monitorexit


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1237/head:pull/1237` \
`$ git checkout pull/1237`

Update a local copy of the PR: \
`$ git checkout pull/1237` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1237`

View PR using the GUI difftool: \
`$ git pr show -t 1237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1237.diff">https://git.openjdk.org/jdk17u-dev/pull/1237.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1237#issuecomment-1499994752)