### PR TITLE
8305721: add `make compile-commands` artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ NashornProfile.txt
 /src/utils/LogCompilation/target/
 /.project/
 /.settings/
+/compile_commands.json
+/.cache


### PR DESCRIPTION
Not a clean backport due since JDK17 does not have .gitignore changes from [8295884](https://bugs.openjdk.org/browse/JDK-8295884)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305721](https://bugs.openjdk.org/browse/JDK-8305721): add `make compile-commands` artifacts to .gitignore


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1239/head:pull/1239` \
`$ git checkout pull/1239`

Update a local copy of the PR: \
`$ git checkout pull/1239` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1239`

View PR using the GUI difftool: \
`$ git pr show -t 1239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1239.diff">https://git.openjdk.org/jdk17u-dev/pull/1239.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1239#issuecomment-1502331746)