### PR TITLE
8300926: Several startup regressions  ~6-70% in 21-b6 all platforms

### DIFF
--- a/src/hotspot/share/cds/lambdaFormInvokers.cpp
+++ b/src/hotspot/share/cds/lambdaFormInvokers.cpp
@@ -180,10 +180,8 @@ void LambdaFormInvokers::reload_class(char* name, ClassFileStream& st, TRAPS) {
                                                    cl_info,
                                                    CHECK);
 
-  {
-    MutexLocker mu_r(THREAD, Compile_lock); // add_to_hierarchy asserts this.
-    SystemDictionary::add_to_hierarchy(result);
-  }
+  SystemDictionary::add_to_hierarchy(THREAD, result);
+
   // new class not linked yet.
   MetaspaceShared::try_link_class(THREAD, result);
   assert(!HAS_PENDING_EXCEPTION, "Invariant");

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -68,6 +68,7 @@
 #include "prims/jvmtiExport.hpp"
 #include "prims/methodHandles.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/deoptimization.hpp"
 #include "runtime/biasedLocking.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/java.hpp"
@@ -853,12 +854,9 @@ InstanceKlass* SystemDictionary::resolve_hidden_class_from_stream(
     k->class_loader_data()->initialize_holder(Handle(THREAD, k->java_mirror()));
   }
 
-  {
-    MutexLocker mu_r(THREAD, Compile_lock);
-    // Add to class hierarchy, and do possible deoptimizations.
-    add_to_hierarchy(k);
-    // But, do not add to dictionary.
-  }
+  // Add to class hierarchy, and do possible deoptimizations.
+  add_to_hierarchy(THREAD, k);
+  // But, do not add to dictionary.
 
   k->link_class(CHECK_NULL);
 
@@ -1435,13 +1433,10 @@ void SystemDictionary::define_instance_class(InstanceKlass* k, Handle class_load
     JavaCalls::call(&result, m, &args, CHECK);
   }
 
-  // Add the new class. We need recompile lock during update of CHA.
+  // Add to class hierarchy, and do possible deoptimizations.
+  add_to_hierarchy(THREAD, k);
   {
     MutexLocker mu_r(THREAD, Compile_lock);
-
-    // Add to class hierarchy, and do possible deoptimizations.
-    add_to_hierarchy(k);
-
     // Add to systemDictionary - so other classes can see it.
     // Grabs and releases SystemDictionary_lock
     update_dictionary(name_hash, k, class_loader);
@@ -1562,29 +1557,33 @@ InstanceKlass* SystemDictionary::find_or_define_instance_class(Symbol* class_nam
 
 // ----------------------------------------------------------------------------
 // Update hierachy. This is done before the new klass has been added to the SystemDictionary. The Compile_lock
-// is held, to ensure that the compiler is not using the class hierachy, and that deoptimization will kick in
-// before a new class is used.
+// is grabbed, to ensure that the compiler is not using the class hierarchy.
 
-void SystemDictionary::add_to_hierarchy(InstanceKlass* k) {
+void SystemDictionary::add_to_hierarchy(Thread* current, InstanceKlass* k) {
   assert(k != NULL, "just checking");
-  if (Universe::is_fully_initialized()) {
-    assert_locked_or_safepoint(Compile_lock);
+  assert(!SafepointSynchronize::is_at_safepoint(), "must NOT be at safepoint");
+
+  DeoptimizationScope deopt_scope;
+  {
+    MutexLocker ml(current, Compile_lock);
+
+    k->set_init_state(InstanceKlass::loaded);
+    // make sure init_state store is already done.
+    // The compiler reads the hierarchy outside of the Compile_lock.
+    // Access ordering is used to add to hierarchy.
+
+    // Link into hierarchy.
+    k->append_to_sibling_list();                    // add to superklass/sibling list
+    k->process_interfaces();                        // handle all "implements" declarations
+
+    // Now mark all code that depended on old class hierarchy.
+    // Note: must be done *after* linking k into the hierarchy (was bug 12/9/97)
+    if (Universe::is_fully_initialized()) {
+      CodeCache::mark_dependents_on(&deopt_scope, k);
+    }
   }
-
-  k->set_init_state(InstanceKlass::loaded);
-  // make sure init_state store is already done.
-  // The compiler reads the hierarchy outside of the Compile_lock.
-  // Access ordering is used to add to hierarchy.
-
-  // Link into hierachy.
-  k->append_to_sibling_list();                    // add to superklass/sibling list
-  k->process_interfaces();                        // handle all "implements" declarations
-
-  // Now flush all code that depended on old class hierarchy.
-  // Note: must be done *after* linking k into the hierarchy (was bug 12/9/97)
-  if (Universe::is_fully_initialized()) {
-    CodeCache::flush_dependents_on(k);
-  }
+  // Perform the deopt handshake outside Compile_lock.
+  deopt_scope.deoptimize_marked();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -395,8 +395,8 @@ public:
   // Return Symbol or throw exception if name given is can not be a valid Symbol.
   static Symbol* class_name_symbol(const char* name, Symbol* exception, TRAPS);
 
-  // Setup link to hierarchy
-  static void add_to_hierarchy(InstanceKlass* k);
+  // Setup link to hierarchy and deoptimize
+  static void add_to_hierarchy(Thread* current, InstanceKlass* k);
 protected:
 
   // Basic find on loaded classes

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1184,8 +1184,7 @@ bool SystemDictionaryShared::add_unregistered_class(Thread* current, InstanceKla
   bool created = false;
   _loaded_unregistered_classes->put_if_absent(name, true, &created);
   if (created) {
-    MutexLocker mu_r(current, Compile_lock); // add_to_hierarchy asserts this.
-    SystemDictionary::add_to_hierarchy(k);
+    SystemDictionary::add_to_hierarchy(current, k);
   }
   return created;
 }
@@ -1742,13 +1741,10 @@ InstanceKlass* SystemDictionaryShared::prepare_shared_lambda_proxy_class(Instanc
   assert(nest_host == shared_nest_host, "mismatched nest host");
 
   EventClassLoad class_load_start_event;
-  {
-    MutexLocker mu_r(THREAD, Compile_lock);
+  // Add to class hierarchy, and do possible deoptimizations.
+  SystemDictionary::add_to_hierarchy(THREAD, loaded_lambda);
+  // But, do not add to dictionary.
 
-    // Add to class hierarchy, and do possible deoptimizations.
-    SystemDictionary::add_to_hierarchy(loaded_lambda);
-    // But, do not add to dictionary.
-  }
   loaded_lambda->link_class(CHECK_NULL);
   // notify jvmti
   if (JvmtiExport::should_post_class_load()) {

--- a/src/hotspot/share/classfile/vmClasses.cpp
+++ b/src/hotspot/share/classfile/vmClasses.cpp
@@ -243,7 +243,7 @@ void vmClasses::resolve_shared_class(InstanceKlass* klass, ClassLoaderData* load
   Dictionary* dictionary = loader_data->dictionary();
   unsigned int hash = dictionary->compute_hash(klass->name());
   dictionary->add_klass(hash, klass->name(), klass);
-  SystemDictionary::add_to_hierarchy(klass);
+  SystemDictionary::add_to_hierarchy(THREAD, klass);
   assert(klass->is_loaded(), "Must be in at least loaded state");
 }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1019,9 +1019,8 @@ void CodeCache::cleanup_inline_caches() {
 // Keeps track of time spent for checking dependencies
 NOT_PRODUCT(static elapsedTimer dependentCheckTime;)
 
-int CodeCache::mark_for_deoptimization(KlassDepChange& changes) {
+void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, KlassDepChange& changes) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-  int number_of_marked_CodeBlobs = 0;
 
   // search the hierarchy looking for nmethods which are affected by the loading of this class
 
@@ -1033,7 +1032,7 @@ int CodeCache::mark_for_deoptimization(KlassDepChange& changes) {
   NoSafepointVerifier nsv;
   for (DepChange::ContextStream str(changes, nsv); str.next(); ) {
     Klass* d = str.klass();
-    number_of_marked_CodeBlobs += InstanceKlass::cast(d)->mark_dependent_nmethods(changes);
+    InstanceKlass::cast(d)->mark_dependent_nmethods(deopt_scope, changes);
   }
 
 #ifndef PRODUCT
@@ -1045,8 +1044,6 @@ int CodeCache::mark_for_deoptimization(KlassDepChange& changes) {
     dependentCheckTime.stop();
   }
 #endif
-
-  return number_of_marked_CodeBlobs;
 }
 
 CompiledMethod* CodeCache::find_compiled(void* start) {
@@ -1108,13 +1105,12 @@ void CodeCache::mark_for_evol_deoptimization(InstanceKlass* dependee) {
 
 
 // Walk compiled methods and mark dependent methods for deoptimization.
-int CodeCache::mark_dependents_for_evol_deoptimization() {
+void CodeCache::mark_dependents_for_evol_deoptimization(DeoptimizationScope* deopt_scope) {
   assert(SafepointSynchronize::is_at_safepoint(), "Can only do this at a safepoint!");
   // Each redefinition creates a new set of nmethods that have references to "old" Methods
   // So delete old method table and create a new one.
   reset_old_method_table();
 
-  int number_of_marked_CodeBlobs = 0;
   CompiledMethodIterator iter(CompiledMethodIterator::only_alive);
   while(iter.next()) {
     CompiledMethod* nm = iter.method();
@@ -1122,24 +1118,19 @@ int CodeCache::mark_dependents_for_evol_deoptimization() {
     // This includes methods whose inline caches point to old methods, so
     // inline cache clearing is unnecessary.
     if (nm->has_evol_metadata()) {
-      nm->mark_for_deoptimization();
+      deopt_scope->mark(nm);
       add_to_old_table(nm);
-      number_of_marked_CodeBlobs++;
     }
   }
-
-  // return total count of nmethods marked for deoptimization, if zero the caller
-  // can skip deoptimization
-  return number_of_marked_CodeBlobs;
 }
 
-void CodeCache::mark_all_nmethods_for_evol_deoptimization() {
+void CodeCache::mark_all_nmethods_for_evol_deoptimization(DeoptimizationScope* deopt_scope) {
   assert(SafepointSynchronize::is_at_safepoint(), "Can only do this at a safepoint!");
   CompiledMethodIterator iter(CompiledMethodIterator::only_alive);
   while(iter.next()) {
     CompiledMethod* nm = iter.method();
     if (!nm->method()->is_method_handle_intrinsic()) {
-      nm->mark_for_deoptimization();
+      deopt_scope->mark(nm);
       if (nm->has_evol_metadata()) {
         add_to_old_table(nm);
       }
@@ -1147,48 +1138,31 @@ void CodeCache::mark_all_nmethods_for_evol_deoptimization() {
   }
 }
 
-// Flushes compiled methods dependent on redefined classes, that have already been
-// marked for deoptimization.
-void CodeCache::flush_evol_dependents() {
-  assert(SafepointSynchronize::is_at_safepoint(), "Can only do this at a safepoint!");
-
-  // CodeCache can only be updated by a thread_in_VM and they will all be
-  // stopped during the safepoint so CodeCache will be safe to update without
-  // holding the CodeCache_lock.
-
-  // At least one nmethod has been marked for deoptimization
-
-  Deoptimization::deoptimize_all_marked();
-}
 #endif // INCLUDE_JVMTI
 
 // Mark methods for deopt (if safe or possible).
-void CodeCache::mark_all_nmethods_for_deoptimization() {
+void CodeCache::mark_all_nmethods_for_deoptimization(DeoptimizationScope* deopt_scope) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
   CompiledMethodIterator iter(CompiledMethodIterator::only_alive_and_not_unloading);
   while(iter.next()) {
     CompiledMethod* nm = iter.method();
     if (!nm->is_native_method()) {
-      nm->mark_for_deoptimization();
+      deopt_scope->mark(nm);
     }
   }
 }
 
-int CodeCache::mark_for_deoptimization(Method* dependee) {
+void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, Method* dependee) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-  int number_of_marked_CodeBlobs = 0;
 
   CompiledMethodIterator iter(CompiledMethodIterator::only_alive_and_not_unloading);
   while(iter.next()) {
     CompiledMethod* nm = iter.method();
     if (nm->is_dependent_on_method(dependee)) {
       ResourceMark rm;
-      nm->mark_for_deoptimization();
-      number_of_marked_CodeBlobs++;
+      deopt_scope->mark(nm);
     }
   }
-
-  return number_of_marked_CodeBlobs;
 }
 
 void CodeCache::make_marked_nmethods_not_entrant() {
@@ -1202,38 +1176,31 @@ void CodeCache::make_marked_nmethods_not_entrant() {
   }
 }
 
-// Flushes compiled methods dependent on dependee.
-void CodeCache::flush_dependents_on(InstanceKlass* dependee) {
+// Marks compiled methods dependent on dependee.
+void CodeCache::mark_dependents_on(DeoptimizationScope* deopt_scope, InstanceKlass* dependee) {
   assert_lock_strong(Compile_lock);
 
   if (number_of_nmethods_with_dependencies() == 0) return;
 
-  int marked = 0;
   if (dependee->is_linked()) {
     // Class initialization state change.
     KlassInitDepChange changes(dependee);
-    marked = mark_for_deoptimization(changes);
+    mark_for_deoptimization(deopt_scope, changes);
   } else {
     // New class is loaded.
     NewKlassDepChange changes(dependee);
-    marked = mark_for_deoptimization(changes);
-  }
-
-  if (marked > 0) {
-    // At least one nmethod has been marked for deoptimization
-    Deoptimization::deoptimize_all_marked();
+    mark_for_deoptimization(deopt_scope, changes);
   }
 }
 
-// Flushes compiled methods dependent on dependee
-void CodeCache::flush_dependents_on_method(const methodHandle& m_h) {
-  // --- Compile_lock is not held. However we are at a safepoint.
-  assert_locked_or_safepoint(Compile_lock);
+// Marks compiled methods dependent on dependee
+void CodeCache::mark_dependents_on_method_for_breakpoint(const methodHandle& m_h) {
+  assert(SafepointSynchronize::is_at_safepoint(), "invariant");
 
+  DeoptimizationScope deopt_scope;
   // Compute the dependent nmethods
-  if (mark_for_deoptimization(m_h()) > 0) {
-    Deoptimization::deoptimize_all_marked();
-  }
+  mark_for_deoptimization(&deopt_scope, m_h());
+  deopt_scope.deoptimize_marked();
 }
 
 void CodeCache::verify() {

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -76,6 +76,7 @@ class ExceptionCache;
 class KlassDepChange;
 class OopClosure;
 class ShenandoahParallelCodeHeapIterator;
+class DeoptimizationScope;
 
 class CodeCache : AllStatic {
   friend class VMStructs;
@@ -262,27 +263,26 @@ class CodeCache : AllStatic {
 
   // Deoptimization
  private:
-  static int  mark_for_deoptimization(KlassDepChange& changes);
+  static void mark_for_deoptimization(DeoptimizationScope* deopt_scope, KlassDepChange& changes);
 
  public:
-  static void mark_all_nmethods_for_deoptimization();
-  static int  mark_for_deoptimization(Method* dependee);
+  static void mark_all_nmethods_for_deoptimization(DeoptimizationScope* deopt_scope);
+  static void mark_for_deoptimization(DeoptimizationScope* deopt_scope, Method* dependee);
   static void make_marked_nmethods_not_entrant();
 
-  // Flushing and deoptimization
-  static void flush_dependents_on(InstanceKlass* dependee);
+  // Marks dependents during classloading
+  static void mark_dependents_on(DeoptimizationScope* deopt_scope, InstanceKlass* dependee);
 
   // RedefineClasses support
   // Flushing and deoptimization in case of evolution
   static void mark_for_evol_deoptimization(InstanceKlass* dependee);
-  static int  mark_dependents_for_evol_deoptimization();
-  static void mark_all_nmethods_for_evol_deoptimization();
-  static void flush_evol_dependents();
+  static void mark_dependents_for_evol_deoptimization(DeoptimizationScope* deopt_scope);
+  static void mark_all_nmethods_for_evol_deoptimization(DeoptimizationScope* deopt_scope);
   static void old_nmethods_do(MetadataClosure* f) NOT_JVMTI_RETURN;
   static void unregister_old_nmethod(CompiledMethod* c) NOT_JVMTI_RETURN;
 
   // Support for fullspeed debugging
-  static void flush_dependents_on_method(const methodHandle& dependee);
+  static void mark_dependents_on_method_for_breakpoint(const methodHandle& dependee);
 
   // tells how many nmethods have dependencies
   static int number_of_nmethods_with_dependencies();

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -51,7 +51,7 @@ CompiledMethod::CompiledMethod(Method* method, const char* name, CompilerType ty
                                int frame_complete_offset, int frame_size, ImmutableOopMapSet* oop_maps,
                                bool caller_must_gc_arguments)
   : CodeBlob(name, type, layout, frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments),
-    _deoptimization_status(not_marked),
+    _mark_for_deoptimization_status(not_marked),
     _deoptimization_generation(0),
     _method(method),
     _gc_data(NULL)
@@ -64,7 +64,7 @@ CompiledMethod::CompiledMethod(Method* method, const char* name, CompilerType ty
                                OopMapSet* oop_maps, bool caller_must_gc_arguments)
   : CodeBlob(name, type, CodeBlobLayout((address) this, size, header_size, cb), cb,
              frame_complete_offset, frame_size, oop_maps, caller_must_gc_arguments),
-    _deoptimization_status(not_marked),
+    _mark_for_deoptimization_status(not_marked),
     _deoptimization_generation(0),
     _method(method),
     _gc_data(NULL)
@@ -119,7 +119,7 @@ const char* CompiledMethod::state() const {
 void CompiledMethod::mark_for_deoptimization(bool inc_recompile_counts) {
   MutexLocker ml(CompiledMethod_lock->owned_by_self() ? NULL : CompiledMethod_lock,
                  Mutex::_no_safepoint_check_flag);
-  Atomic::store (&_deoptimization_status, inc_recompile_counts ? deoptimize : deoptimize_noupdate);
+  _mark_for_deoptimization_status = inc_recompile_counts ? deoptimize : deoptimize_noupdate;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -145,14 +145,13 @@ class CompiledMethod : public CodeBlob {
 
   void init_defaults();
 protected:
-  enum DeoptimizationStatus : u1 {
+  enum MarkForDeoptimizationStatus : u1 {
     not_marked,
     deoptimize,
-    deoptimize_noupdate,
-    deoptimize_done
+    deoptimize_noupdate
   };
 
-  volatile DeoptimizationStatus _deoptimization_status; // Used for stack deoptimization
+  MarkForDeoptimizationStatus _mark_for_deoptimization_status; // Used for stack deoptimization
   // Used to track in which deoptimize handshake this method will be deoptimized.
   uint64_t                      _deoptimization_generation;
 
@@ -176,11 +175,6 @@ protected:
   void* _gc_data;
 
   virtual void flush() = 0;
-
-private:
-  DeoptimizationStatus deoptimization_status() const {
-    return Atomic::load(&_deoptimization_status);
-  }
 
 protected:
   CompiledMethod(Method* method, const char* name, CompilerType type, const CodeBlobLayout& layout, int frame_complete_offset, int frame_size, ImmutableOopMapSet* oop_maps, bool caller_must_gc_arguments);
@@ -248,17 +242,14 @@ public:
   bool is_at_poll_return(address pc);
   bool is_at_poll_or_poll_return(address pc);
 
-  bool  is_marked_for_deoptimization() const { return deoptimization_status() != not_marked; }
-  void  mark_for_deoptimization(bool inc_recompile_counts = true); // TODO: must be removed
-  bool  has_been_deoptimized() const { return deoptimization_status() == deoptimize_done; }
-  void  set_deoptimized_done();
+  bool  is_marked_for_deoptimization() const { return _mark_for_deoptimization_status != not_marked; }
+  void  mark_for_deoptimization(bool inc_recompile_counts = true);
 
   bool update_recompile_counts() const {
     // Update recompile counts when either the update is explicitly requested (deoptimize)
     // or the nmethod is not marked for deoptimization at all (not_marked).
     // The latter happens during uncommon traps when deoptimized nmethod is made not entrant.
-    DeoptimizationStatus status = deoptimization_status();
-    return status != deoptimize_noupdate && status != deoptimize_done;
+    return _mark_for_deoptimization_status != deoptimize_noupdate;
   }
 
   // tells whether frames described by this nmethod can be deoptimized

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -683,8 +683,6 @@ class DepChange : public StackObj {
   virtual bool is_klass_init_change() const { return false; }
   virtual bool is_call_site_change()  const { return false; }
 
-  virtual void mark_for_deoptimization(nmethod* nm) = 0;
-
   // Subclass casting with assertions.
   KlassDepChange*    as_klass_change() {
     assert(is_klass_change(), "bad cast");
@@ -781,10 +779,6 @@ class KlassDepChange : public DepChange {
   // What kind of DepChange is this?
   virtual bool is_klass_change() const { return true; }
 
-  virtual void mark_for_deoptimization(nmethod* nm) {
-    nm->mark_for_deoptimization(/*inc_recompile_counts=*/true);
-  }
-
   InstanceKlass* type() { return _type; }
 
   // involves_context(k) is true if k == _type or any of its super types
@@ -822,10 +816,6 @@ class CallSiteDepChange : public DepChange {
 
   // What kind of DepChange is this?
   virtual bool is_call_site_change() const { return true; }
-
-  virtual void mark_for_deoptimization(nmethod* nm) {
-    nm->mark_for_deoptimization(/*inc_recompile_counts=*/false);
-  }
 
   oop call_site()     const { return _call_site();     }
   oop method_handle() const { return _method_handle(); }

--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -62,7 +62,7 @@ void DependencyContext::init() {
 //
 // Walk the list of dependent nmethods searching for nmethods which
 // are dependent on the changes that were passed in and mark them for
-// deoptimization.  Returns the number of nmethods found.
+// deoptimization.
 //
 void DependencyContext::mark_dependent_nmethods(DeoptimizationScope* deopt_scope, DepChange& changes) {
   for (nmethodBucket* b = dependencies_not_unloading(); b != NULL; b = b->next_not_unloading()) {

--- a/src/hotspot/share/code/dependencyContext.hpp
+++ b/src/hotspot/share/code/dependencyContext.hpp
@@ -32,6 +32,7 @@
 #include "runtime/safepoint.hpp"
 
 class nmethod;
+class DeoptimizationScope;
 class DepChange;
 
 //
@@ -117,10 +118,11 @@ class DependencyContext : public StackObj {
 
   static void init();
 
-  int  mark_dependent_nmethods(DepChange& changes);
+  void mark_dependent_nmethods(DeoptimizationScope* deopt_scope, DepChange& changes);
   void add_dependent_nmethod(nmethod* nm);
   void remove_dependent_nmethod(nmethod* nm);
   int  remove_all_dependents();
+  void remove_and_mark_for_deoptimization_all_dependents(DeoptimizationScope* deopt_scope);
   void clean_unloading_dependents();
   static void purge_dependency_contexts();
   static void release(nmethodBucket* b);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1550,7 +1550,10 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, JVMCI_TRAPS) {
   nmethodLocker nml(nm);
   if (nm->is_alive()) {
     // Invalidating the HotSpotNmethod means we want the nmethod to be deoptimized.
-    Deoptimization::deoptimize_all_marked(nm);
+    DeoptimizationScope deopt_scope;
+    deopt_scope.mark(nm);
+    nm->make_not_entrant();
+    deopt_scope.deoptimize_marked();    
   }
 
   // A HotSpotNmethod instance can only reference a single nmethod

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1553,7 +1553,7 @@ void JVMCIEnv::invalidate_nmethod_mirror(JVMCIObject mirror, JVMCI_TRAPS) {
     DeoptimizationScope deopt_scope;
     deopt_scope.mark(nm);
     nm->make_not_entrant();
-    deopt_scope.deoptimize_marked();    
+    deopt_scope.deoptimize_marked();
   }
 
   // A HotSpotNmethod instance can only reference a single nmethod

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -38,6 +38,7 @@
 #include "jfr/support/jfrKlassExtension.hpp"
 #endif
 
+class DeoptimizationScope;
 class klassItable;
 class RecordComponent;
 
@@ -952,7 +953,7 @@ public:
 
   // maintenance of deoptimization dependencies
   inline DependencyContext dependencies();
-  int  mark_dependent_nmethods(KlassDepChange& changes);
+  void mark_dependent_nmethods(DeoptimizationScope* deopt_scope, KlassDepChange& changes);
   void add_dependent_nmethod(nmethod* nm);
   void remove_dependent_nmethod(nmethod* nm);
   void clean_dependency_context();
@@ -962,7 +963,7 @@ public:
   void set_osr_nmethods_head(nmethod* h)     { _osr_nmethods_head = h; };
   void add_osr_nmethod(nmethod* n);
   bool remove_osr_nmethod(nmethod* n);
-  int mark_osr_nmethods(const Method* m);
+  int mark_osr_nmethods(DeoptimizationScope* deopt_scope, const Method* m);
   nmethod* lookup_osr_nmethod(const Method* m, int bci, int level, bool match_level) const;
 
 #if INCLUDE_JVMTI

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -2003,7 +2003,7 @@ void BreakpointInfo::set(Method* method) {
     // Deoptimize all dependents on this method
     HandleMark hm(thread);
     methodHandle mh(thread, method);
-    CodeCache::flush_dependents_on_method(mh);
+    CodeCache::mark_dependents_on_method_for_breakpoint(mh);
   }
 }
 

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -879,9 +879,9 @@ public:
    return method_holder()->lookup_osr_nmethod(this, InvocationEntryBci, level, match_level) != NULL;
   }
 
-  int mark_osr_nmethods() {
-    return method_holder()->mark_osr_nmethods(this);
-  }
+  // int mark_osr_nmethods() {
+  //   return method_holder()->mark_osr_nmethods(this);
+  // }
 
   nmethod* lookup_osr_nmethod_for(int bci, int level, bool match_level) {
     return method_holder()->lookup_osr_nmethod(this, bci, level, match_level);

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -879,10 +879,6 @@ public:
    return method_holder()->lookup_osr_nmethod(this, InvocationEntryBci, level, match_level) != NULL;
   }
 
-  // int mark_osr_nmethods() {
-  //   return method_holder()->mark_osr_nmethods(this);
-  // }
-
   nmethod* lookup_osr_nmethod_for(int bci, int level, bool match_level) {
     return method_holder()->lookup_osr_nmethod(this, bci, level, match_level);
   }

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4102,22 +4102,18 @@ void VM_RedefineClasses::mark_dependent_code(InstanceKlass* ik) {
 void VM_RedefineClasses::flush_dependent_code() {
   assert(SafepointSynchronize::is_at_safepoint(), "sanity check");
 
-  bool deopt_needed;
+  DeoptimizationScope deopt_scope;
 
   // This is the first redefinition, mark all the nmethods for deoptimization
   if (!JvmtiExport::all_dependencies_are_recorded()) {
+    CodeCache::mark_all_nmethods_for_evol_deoptimization(&deopt_scope);
     log_debug(redefine, class, nmethod)("Marked all nmethods for deopt");
-    CodeCache::mark_all_nmethods_for_evol_deoptimization();
-    deopt_needed = true;
   } else {
-    int deopt = CodeCache::mark_dependents_for_evol_deoptimization();
-    log_debug(redefine, class, nmethod)("Marked %d dependent nmethods for deopt", deopt);
-    deopt_needed = (deopt != 0);
+    CodeCache::mark_dependents_for_evol_deoptimization(&deopt_scope);
+    log_debug(redefine, class, nmethod)("Marked dependent nmethods for deopt");
   }
 
-  if (deopt_needed) {
-    CodeCache::flush_evol_dependents();
-  }
+  deopt_scope.deoptimize_marked();
 
   // From now on we know that the dependency information is complete
   JvmtiExport::set_all_dependencies_are_recorded(true);

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -1069,22 +1069,17 @@ void MethodHandles::clean_dependency_context(oop call_site) {
   deps.clean_unloading_dependents();
 }
 
-void MethodHandles::flush_dependent_nmethods(Handle call_site, Handle target) {
+void MethodHandles::mark_dependent_nmethods(DeoptimizationScope* deopt_scope, Handle call_site, Handle target) {
   assert_lock_strong(Compile_lock);
 
-  int marked = 0;
   CallSiteDepChange changes(call_site, target);
   {
     NoSafepointVerifier nsv;
-    MutexLocker mu2(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
     oop context = java_lang_invoke_CallSite::context_no_keepalive(call_site());
     DependencyContext deps = java_lang_invoke_MethodHandleNatives_CallSiteContext::vmdependencies(context);
-    marked = deps.mark_dependent_nmethods(changes);
-  }
-  if (marked > 0) {
-    // At least one nmethod has been marked for deoptimization.
-    Deoptimization::deoptimize_all_marked();
+    deps.mark_dependent_nmethods(deopt_scope, changes);
   }
 }
 
@@ -1380,11 +1375,15 @@ JVM_END
 JVM_ENTRY(void, MHN_setCallSiteTargetNormal(JNIEnv* env, jobject igcls, jobject call_site_jh, jobject target_jh)) {
   Handle call_site(THREAD, JNIHandles::resolve_non_null(call_site_jh));
   Handle target   (THREAD, JNIHandles::resolve_non_null(target_jh));
+  DeoptimizationScope deopt_scope;
   {
     // Walk all nmethods depending on this call site.
     MutexLocker mu(thread, Compile_lock);
-    MethodHandles::flush_dependent_nmethods(call_site, target);
+    MethodHandles::mark_dependent_nmethods(&deopt_scope, call_site, target);
     java_lang_invoke_CallSite::set_target(call_site(), target());
+    // This is assumed to be an 'atomic' operation by verification.
+    // So keep it under lock for now.
+    deopt_scope.deoptimize_marked();
   }
 }
 JVM_END
@@ -1392,11 +1391,15 @@ JVM_END
 JVM_ENTRY(void, MHN_setCallSiteTargetVolatile(JNIEnv* env, jobject igcls, jobject call_site_jh, jobject target_jh)) {
   Handle call_site(THREAD, JNIHandles::resolve_non_null(call_site_jh));
   Handle target   (THREAD, JNIHandles::resolve_non_null(target_jh));
+  DeoptimizationScope deopt_scope;
   {
     // Walk all nmethods depending on this call site.
     MutexLocker mu(thread, Compile_lock);
-    MethodHandles::flush_dependent_nmethods(call_site, target);
+    MethodHandles::mark_dependent_nmethods(&deopt_scope, call_site, target);
     java_lang_invoke_CallSite::set_target_volatile(call_site(), target());
+    // This is assumed to be an 'atomic' operation by verification.
+    // So keep it under lock for now.
+    deopt_scope.deoptimize_marked();
   }
 }
 JVM_END
@@ -1486,21 +1489,15 @@ JVM_END
 // deallocate their dependency information.
 JVM_ENTRY(void, MHN_clearCallSiteContext(JNIEnv* env, jobject igcls, jobject context_jh)) {
   Handle context(THREAD, JNIHandles::resolve_non_null(context_jh));
+  DeoptimizationScope deopt_scope;
   {
-    // Walk all nmethods depending on this call site.
-    MutexLocker mu1(thread, Compile_lock);
-
-    int marked = 0;
-    {
-      NoSafepointVerifier nsv;
-      MutexLocker mu2(THREAD, CodeCache_lock, Mutex::_no_safepoint_check_flag);
-      DependencyContext deps = java_lang_invoke_MethodHandleNatives_CallSiteContext::vmdependencies(context());
-      marked = deps.remove_all_dependents();
-    }
-    if (marked > 0) {
-      // At least one nmethod has been marked for deoptimization
-      Deoptimization::deoptimize_all_marked();
-    }
+    NoSafepointVerifier nsv;
+    MutexLocker ml(THREAD, CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    DependencyContext deps = java_lang_invoke_MethodHandleNatives_CallSiteContext::vmdependencies(context());
+    deps.remove_and_mark_for_deoptimization_all_dependents(&deopt_scope);
+    // This is assumed to be an 'atomic' operation by verification.
+    // So keep it under lock for now.
+    deopt_scope.deoptimize_marked();
   }
 }
 JVM_END

--- a/src/hotspot/share/prims/methodHandles.hpp
+++ b/src/hotspot/share/prims/methodHandles.hpp
@@ -83,7 +83,7 @@ class MethodHandles: AllStatic {
   static void remove_dependent_nmethod(oop call_site, nmethod* nm);
   static void clean_dependency_context(oop call_site);
 
-  static void flush_dependent_nmethods(Handle call_site, Handle target);
+  static void mark_dependent_nmethods(DeoptimizationScope* deopt_scope, Handle call_site, Handle target);
 
   // Generate MethodHandles adapters.
   static void generate_adapters();

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -781,26 +781,34 @@ WB_ENTRY(jboolean, WB_IsFrameDeoptimized(JNIEnv* env, jobject o, jint depth))
 WB_END
 
 WB_ENTRY(void, WB_DeoptimizeAll(JNIEnv* env, jobject o))
-  CodeCache::mark_all_nmethods_for_deoptimization();
-  Deoptimization::deoptimize_all_marked();
+  DeoptimizationScope deopt_scope;
+  CodeCache::mark_all_nmethods_for_deoptimization(&deopt_scope);
+  deopt_scope.deoptimize_marked();
 WB_END
 
 WB_ENTRY(jint, WB_DeoptimizeMethod(JNIEnv* env, jobject o, jobject method, jboolean is_osr))
   jmethodID jmid = reflected_method_to_jmid(thread, env, method);
   int result = 0;
   CHECK_JNI_EXCEPTION_(env, result);
-  MutexLocker mu(Compile_lock);
-  methodHandle mh(THREAD, Method::checked_resolve_jmethod_id(jmid));
-  if (is_osr) {
-    result += mh->mark_osr_nmethods();
-  } else if (mh->code() != NULL) {
-    mh->code()->mark_for_deoptimization();
-    ++result;
+
+  DeoptimizationScope deopt_scope;
+  {
+    MutexLocker mu(Compile_lock);
+    methodHandle mh(THREAD, Method::checked_resolve_jmethod_id(jmid));
+    if (is_osr) {
+      result += mh->method_holder()->mark_osr_nmethods(&deopt_scope, mh());
+    } else {
+      MutexLocker ml(CompiledMethod_lock, Mutex::_no_safepoint_check_flag);
+      if (mh->code() != nullptr) {
+        deopt_scope.mark(mh->code());
+        ++result;
+      }
+    }
+    CodeCache::mark_for_deoptimization(&deopt_scope, mh());
   }
-  result += CodeCache::mark_for_deoptimization(mh());
-  if (result > 0) {
-    Deoptimization::deoptimize_all_marked();
-  }
+
+  deopt_scope.deoptimize_marked();
+
   return result;
 WB_END
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -118,9 +118,7 @@ void DeoptimizationScope::mark(CompiledMethod* cm, bool inc_recompile_counts) {
     return;
   }
 
-  CompiledMethod::DeoptimizationStatus status =
-    inc_recompile_counts ? CompiledMethod::deoptimize : CompiledMethod::deoptimize_noupdate;
-  Atomic::store(&cm->_deoptimization_status, status);
+  cm->_mark_for_deoptimization_status = inc_recompile_counts ? CompiledMethod::deoptimize : CompiledMethod::deoptimize_noupdate;
 
   // Make sure active is not committed
   assert(DeoptimizationScope::_committed_deopt_gen < DeoptimizationScope::_active_deopt_gen, "Must be");

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -92,6 +92,121 @@
 
 bool DeoptimizationMarker::_is_active = false;
 
+uint64_t DeoptimizationScope::_committed_deopt_gen = 0;
+uint64_t DeoptimizationScope::_active_deopt_gen    = 1;
+bool     DeoptimizationScope::_committing_in_progress = false;
+
+DeoptimizationScope::DeoptimizationScope() : _required_gen(0) {
+  DEBUG_ONLY(_deopted = false;)
+
+  MutexLocker ml(CompiledMethod_lock, Mutex::_no_safepoint_check_flag);
+  // If there is nothing to deopt _required_gen is the same as comitted.
+  _required_gen = DeoptimizationScope::_committed_deopt_gen;
+}
+
+DeoptimizationScope::~DeoptimizationScope() {
+  assert(_deopted, "Deopt not executed");
+}
+
+void DeoptimizationScope::mark(CompiledMethod* cm, bool inc_recompile_counts) {
+  MutexLocker ml(CompiledMethod_lock->owned_by_self() ? nullptr : CompiledMethod_lock,
+                 Mutex::_no_safepoint_check_flag);
+
+  // If it's already marked but we still need it to be deopted.
+  if (cm->is_marked_for_deoptimization()) {
+    dependent(cm);
+    return;
+  }
+
+  CompiledMethod::DeoptimizationStatus status =
+    inc_recompile_counts ? CompiledMethod::deoptimize : CompiledMethod::deoptimize_noupdate;
+  Atomic::store(&cm->_deoptimization_status, status);
+
+  // Make sure active is not committed
+  assert(DeoptimizationScope::_committed_deopt_gen < DeoptimizationScope::_active_deopt_gen, "Must be");
+  assert(cm->_deoptimization_generation == 0, "Is already marked");
+
+  cm->_deoptimization_generation = DeoptimizationScope::_active_deopt_gen;
+  _required_gen                  = DeoptimizationScope::_active_deopt_gen;
+}
+
+void DeoptimizationScope::dependent(CompiledMethod* cm) {
+  MutexLocker ml(CompiledMethod_lock->owned_by_self() ? nullptr : CompiledMethod_lock,
+                 Mutex::_no_safepoint_check_flag);
+  // A method marked by someone else may have a _required_gen lower than what we marked with.
+  // Therefore only store it if it's higher than _required_gen.
+  if (_required_gen < cm->_deoptimization_generation) {
+    _required_gen = cm->_deoptimization_generation;
+  }
+}
+
+void DeoptimizationScope::deoptimize_marked() {
+  assert(!_deopted, "Already deopted");
+
+  // We are not alive yet.
+  if (!Universe::is_fully_initialized()) {
+    DEBUG_ONLY(_deopted = true;)
+    return;
+  }
+
+  // Safepoints are a special case, handled here.
+  if (SafepointSynchronize::is_at_safepoint()) {
+    DeoptimizationScope::_committed_deopt_gen = DeoptimizationScope::_active_deopt_gen;
+    DeoptimizationScope::_active_deopt_gen++;
+    Deoptimization::deoptimize_all_marked();
+    DEBUG_ONLY(_deopted = true;)
+    return;
+  }
+
+  uint64_t comitting = 0;
+  bool wait = false;
+  while (true) {
+    {
+      MutexLocker ml(CompiledMethod_lock->owned_by_self() ? nullptr : CompiledMethod_lock,
+                 Mutex::_no_safepoint_check_flag);
+      // First we check if we or someone else already deopted the gen we want.
+      if (DeoptimizationScope::_committed_deopt_gen >= _required_gen) {
+        DEBUG_ONLY(_deopted = true;)
+        return;
+      }
+      if (!_committing_in_progress) {
+        // The version we are about to commit.
+        comitting = DeoptimizationScope::_active_deopt_gen;
+        // Make sure new marks use a higher gen.
+        DeoptimizationScope::_active_deopt_gen++;
+        _committing_in_progress = true;
+        wait = false;
+      } else {
+        // Another thread is handshaking and committing a gen.
+        wait = true;
+      }
+    }
+    if (wait) {
+      // Wait and let the concurrent handshake be performed.
+      ThreadBlockInVM tbivm(JavaThread::current());
+      os::naked_yield();
+    } else {
+      // Performs the handshake.
+      Deoptimization::deoptimize_all_marked(); // May safepoint and an additional deopt may have occurred.
+      DEBUG_ONLY(_deopted = true;)
+      {
+        MutexLocker ml(CompiledMethod_lock->owned_by_self() ? nullptr : CompiledMethod_lock,
+                       Mutex::_no_safepoint_check_flag);
+        // Make sure that committed doesn't go backwards.
+        // Should only happen if we did a deopt during a safepoint above.
+        if (DeoptimizationScope::_committed_deopt_gen < comitting) {
+          DeoptimizationScope::_committed_deopt_gen = comitting;
+        }
+        _committing_in_progress = false;
+
+        assert(DeoptimizationScope::_committed_deopt_gen >= _required_gen, "Must be");
+
+        return;
+      }
+    }
+  }
+}
+
 Deoptimization::UnrollBlock::UnrollBlock(int  size_of_deoptimized_frame,
                                          int  caller_adjustment,
                                          int  caller_actual_parameters,

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -40,6 +40,32 @@ class compiledVFrame;
 
 template<class E> class GrowableArray;
 
+class DeoptimizationScope {
+ private:
+  // What gen we have done the deopt handshake for.
+  static uint64_t _committed_deopt_gen;
+  // What gen to mark a method with, hence larger than _committed_deopt_gen.
+  static uint64_t _active_deopt_gen;
+  // Indicate an in-progress deopt handshake.
+  static bool     _committing_in_progress;
+
+  // The required gen we need to execute/wait for
+  uint64_t _required_gen;
+  DEBUG_ONLY(bool _deopted;)
+
+ public:
+  DeoptimizationScope();
+  ~DeoptimizationScope();
+  // Mark a method, if already marked as dependent.
+  void mark(CompiledMethod* cm, bool inc_recompile_counts = true);
+  // Record this as a dependent method.
+  void dependent(CompiledMethod* cm);
+
+  // Execute the deoptimization.
+  // Make the nmethods not entrant, stackwalks and patch return pcs and sets post call nops.
+  void deoptimize_marked();
+};
+
 class Deoptimization : AllStatic {
   friend class VMStructs;
   friend class EscapeBarrier;


### PR DESCRIPTION
Hi, here is backport of [JDK-8300926](https://bugs.openjdk.org/browse/JDK-8300926). The patch splits deoptimization routine into two separate phases: the first implies only marking methods to be deoptimized, and the second is proper deoptimization. Only the first one is run under taken Compile_lock. Without the patch the lock stays taken during whole deoptimization routine and that prevents compilations from other threads.

Original patch is applied with the following changes:

- changes to `void LambdaFormInvokers::regenerate_class(char* class_name, ClassFileStream& st, TRAPS)` applied to `void LambdaFormInvokers::reload_class(char* name, ClassFileStream& st, TRAPS)`
- `SystemDictionary::add_to_hierarchy(JavaThread* current, InstanceKlass* k)`
changed to `SystemDictionary::add_to_hierarchy(Thread* current, InstanceKlass* k)`,
cuz in 17 it's also called from
`SystemDictionaryShared::add_unregistered_class(Thread* current, InstanceKlass* k)`
- `SystemDictionary::add_to_hierarchy(JavaThread* current, InstanceKlass* k)` does not lock/unlock k->init_monitor()
- changes to `void CodeCache::make_marked_nmethods_deoptimized()` skipped
- removal of absent `void CodeCache::make_nmethod_deoptimized(CompiledMethod* nm)` ignored
- substitution of `CompiledMethod::MarkForDeoptimizationStatus` with `DeoptimizationStatus` and related changes are skipped because in 17 `_mark_for_deoptimization_status` always accessed under CompiledMethod_lock;
- changes to `void DependencyContext::mark_dependent_nmethods(DeoptimizationScope* deopt_scope, DepChange& changes)` applied with respect to the difference in baselines
- `void DependencyContext::remove_and_mark_for_deoptimization_all_dependents(DeoptimizationScope* deopt_scope)` completely ported with respect to baseline
- changes to nmethod related to Virtual Threads were skipped
- changes to `void InstanceKlass::initialize_impl(TRAPS)` applied to `bool InstanceKlass::link_class_impl(TRAPS)`

Regression: hotspot_all (amd64/20.04LTS) - no new failures +  `runtime/cds/appcds/dynamicArchive/LambdaProxyDuringShutdown.java` previously failing now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300926](https://bugs.openjdk.org/browse/JDK-8300926): Several startup regressions  ~6-70% in 21-b6 all platforms (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1243/head:pull/1243` \
`$ git checkout pull/1243`

Update a local copy of the PR: \
`$ git checkout pull/1243` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1243`

View PR using the GUI difftool: \
`$ git pr show -t 1243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1243.diff">https://git.openjdk.org/jdk17u-dev/pull/1243.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1243#issuecomment-1510146653)