### PR TITLE
8297000: [jib] Add more friendly warning for proxy issues

### DIFF
--- a/bin/jib.sh
+++ b/bin/jib.sh
@@ -128,6 +128,15 @@ install_jib() {
             exit 1
         fi
     fi
+    # Want to check the filetype using file, to see if we got served a HTML error page.
+    # This is sensitive to the filename containing a specific string, but good enough.
+    file ${installed_jib_script}.gz | grep "gzip compressed data" > /dev/null
+    if [ $? -ne 0 ]; then 
+        echo "Warning: ${installed_jib_script}.gz is not a gzip file."
+        echo "If you are behind a proxy you may need to configure exceptions using no_proxy."
+        echo "The download URL was: ${jib_url}"
+        exit 1
+    fi
     echo "Extracting JIB bootstrap script"
     rm -f "${installed_jib_script}"
     gunzip "${installed_jib_script}.gz"


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297000](https://bugs.openjdk.org/browse/JDK-8297000): [jib] Add more friendly warning for proxy issues


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1249/head:pull/1249` \
`$ git checkout pull/1249`

Update a local copy of the PR: \
`$ git checkout pull/1249` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1249`

View PR using the GUI difftool: \
`$ git pr show -t 1249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1249.diff">https://git.openjdk.org/jdk17u-dev/pull/1249.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1249#issuecomment-1511254657)