### PR TITLE
8299959: C2: CmpU::Value must filter overflow computation against local sub computation

### DIFF
--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckCmpUOverflowVsSub.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8299959
+ * @summary In CmpU::Value, the sub computation may be narrower than the overflow computation.
+ *
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+StressCCP -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.rangechecks.TestRangeCheckCmpUOverflowVsSub::test
+ *                   -XX:RepeatCompilation=50
+ *                   compiler.rangechecks.TestRangeCheckCmpUOverflowVsSub
+*/
+
+package compiler.rangechecks;
+
+public class TestRangeCheckCmpUOverflowVsSub {
+    static int arr[] = new int[400];
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10; i++) {
+            test(); // repeat for multiple compilations
+        }
+    }
+
+    static void test() {
+        for(int i = 0; i < 50_000; i++) {} //empty loop - trigger OSR faster
+        int val;
+        int zero = arr[5];
+        int i = 1;
+        do {
+            for (int j = 1; j < 3; j++) {
+                for (int k = 2; k > i; k -= 3) {
+                    try {
+                        val = arr[i + 1] % k;
+                        val = arr[i - 1] % zero;
+                        val = arr[k - 1];
+                    } catch (ArithmeticException e) {} // catch div by zero
+                }
+            }
+        } while (++i < 3);
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299959](https://bugs.openjdk.org/browse/JDK-8299959): C2: CmpU::Value must filter overflow computation against local sub computation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1252/head:pull/1252` \
`$ git checkout pull/1252`

Update a local copy of the PR: \
`$ git checkout pull/1252` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1252`

View PR using the GUI difftool: \
`$ git pr show -t 1252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1252.diff">https://git.openjdk.org/jdk17u-dev/pull/1252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1252#issuecomment-1511334607)