### PR TITLE
8298488: [macos13] tools/jpackage tests failing with "Exit code: 137" on macOS

### DIFF
--- a/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
+++ b/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java
@@ -374,7 +374,7 @@ public class MacAppImageBuilder extends AbstractAppImageBuilder {
                         ENTITLEMENTS.fetchFrom(params));
             }
             restoreKeychainList(params);
-        } else if (Platform.isArmMac()) {
+        } else if (Platform.isMac()) {
             signAppBundle(params, root, "-", null, null);
         } else {
             // Calling signAppBundle() without signingIdentity will result in

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -178,10 +178,6 @@ final public class TKit {
         return (OS.contains("mac"));
     }
 
-    public static boolean isArmMac() {
-        return (isOSX() && "aarch64".equals(System.getProperty("os.arch")));
-    }
-
     public static boolean isLinux() {
         return ((OS.contains("nix") || OS.contains("nux")));
     }


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

I dropped the change to test/jdk/tools/jpackage/share/AppContentTest.java because that file is not in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298488](https://bugs.openjdk.org/browse/JDK-8298488): [macos13] tools/jpackage tests failing with "Exit code: 137" on macOS


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1258/head:pull/1258` \
`$ git checkout pull/1258`

Update a local copy of the PR: \
`$ git checkout pull/1258` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1258`

View PR using the GUI difftool: \
`$ git pr show -t 1258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1258.diff">https://git.openjdk.org/jdk17u-dev/pull/1258.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1258#issuecomment-1512662980)