### PR TITLE
8300823: UB: Compile::_phase_optimize_finished is initialized too late

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -953,6 +953,12 @@ void Compile::Init(int aliaslevel) {
 
   _immutable_memory = NULL; // filled in at first inquiry
 
+#ifdef ASSERT
+  _type_verify_symmetry = true;
+  _phase_optimize_finished = false;
+  _exception_backedge = false;
+#endif
+
   // Globally visible Nodes
   // First set TOP to NULL to give safe behavior during creation of RootNode
   set_cached_top_node(NULL);
@@ -1055,12 +1061,6 @@ void Compile::Init(int aliaslevel) {
   Copy::zero_to_bytes(_alias_cache, sizeof(_alias_cache));
   // A NULL adr_type hits in the cache right away.  Preload the right answer.
   probe_alias_cache(NULL)->_index = AliasIdxTop;
-
-#ifdef ASSERT
-  _type_verify_symmetry = true;
-  _phase_optimize_finished = false;
-  _exception_backedge = false;
-#endif
 }
 
 //---------------------------init_start----------------------------------------


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

I resolved the Copyright. Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300823](https://bugs.openjdk.org/browse/JDK-8300823): UB: Compile::_phase_optimize_finished is initialized too late


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1271/head:pull/1271` \
`$ git checkout pull/1271`

Update a local copy of the PR: \
`$ git checkout pull/1271` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1271`

View PR using the GUI difftool: \
`$ git pr show -t 1271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1271.diff">https://git.openjdk.org/jdk17u-dev/pull/1271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1271#issuecomment-1514454227)