### PR TITLE
8301338: Identical branch conditions in CompileBroker::print_heapinfo

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2905,13 +2905,13 @@ void CompileBroker::print_heapinfo(outputStream* out, const char* function, size
     ts.update(); // record starting point
     MutexLocker mu11(function_lock_1, Mutex::_safepoint_check_flag);
     MutexLocker mu22(function_lock_2, Mutex::_no_safepoint_check_flag);
-    if ((function_lock_1 != NULL) || (function_lock_1 != NULL)) {
+    if ((function_lock_1 != NULL) || (function_lock_2 != NULL)) {
       out->print_cr("\n__ Compile & CodeCache (function) lock wait took %10.3f seconds _________\n", ts.seconds());
     }
 
     ts.update(); // record starting point
     CodeCache::aggregate(out, granularity);
-    if ((function_lock_1 != NULL) || (function_lock_1 != NULL)) {
+    if ((function_lock_1 != NULL) || (function_lock_2 != NULL)) {
       out->print_cr("\n__ Compile & CodeCache (function) lock hold took %10.3f seconds _________\n", ts.seconds());
     }
   }


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

I had to resolve because 8300243: Replace NULL with nullptr in share/compiler
is not in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301338](https://bugs.openjdk.org/browse/JDK-8301338): Identical branch conditions in CompileBroker::print_heapinfo


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1272/head:pull/1272` \
`$ git checkout pull/1272`

Update a local copy of the PR: \
`$ git checkout pull/1272` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1272`

View PR using the GUI difftool: \
`$ git pr show -t 1272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1272.diff">https://git.openjdk.org/jdk17u-dev/pull/1272.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1272#issuecomment-1514469604)