### PR TITLE
8301123: Enable Symbol refcounting underflow checks in PRODUCT

### DIFF
--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -310,10 +310,8 @@ bool Symbol::try_increment_refcount() {
 // this caller.
 void Symbol::increment_refcount() {
   if (!try_increment_refcount()) {
-#ifdef ASSERT
     print();
     fatal("refcount has gone to zero");
-#endif
   }
 #ifndef PRODUCT
   if (refcount() != PERM_REFCOUNT) { // not a permanent symbol
@@ -333,10 +331,8 @@ void Symbol::decrement_refcount() {
     if (refc == PERM_REFCOUNT) {
       return;  // refcount is permanent, permanent is sticky
     } else if (refc == 0) {
-#ifdef ASSERT
       print();
       fatal("refcount underflow");
-#endif
       return;
     } else {
       found = Atomic::cmpxchg(&_hash_and_refcount, old_value, old_value - 1);
@@ -356,10 +352,8 @@ void Symbol::make_permanent() {
     if (refc == PERM_REFCOUNT) {
       return;  // refcount is permanent, permanent is sticky
     } else if (refc == 0) {
-#ifdef ASSERT
       print();
       fatal("refcount underflow");
-#endif
       return;
     } else {
       int hash = extract_hash(old_value);

--- a/test/hotspot/gtest/classfile/test_symbolTable.cpp
+++ b/test/hotspot/gtest/classfile/test_symbolTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,4 +144,11 @@ public:
 
 TEST_VM(SymbolTable, test_symbol_refcount_parallel) {
   mt_test_doer<DriverSymbolThread>();
+}
+
+TEST_VM_FATAL_ERROR_MSG(SymbolTable, test_symbol_underflow, ".*refcount has gone to zero.*") {
+  Symbol* my_symbol = SymbolTable::new_symbol("my_symbol2023");
+  EXPECT_TRUE(my_symbol->refcount() == 1) << "Symbol refcount just created is 1";
+  my_symbol->decrement_refcount();
+  my_symbol->increment_refcount();  // Should crash even in PRODUCT mode
 }


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

I had to resolve the copyright in the test file, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301123](https://bugs.openjdk.org/browse/JDK-8301123): Enable Symbol refcounting underflow checks in PRODUCT


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1274/head:pull/1274` \
`$ git checkout pull/1274`

Update a local copy of the PR: \
`$ git checkout pull/1274` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1274`

View PR using the GUI difftool: \
`$ git pr show -t 1274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1274.diff">https://git.openjdk.org/jdk17u-dev/pull/1274.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1274#issuecomment-1514764010)