### PR TITLE
8268298: jdk/jfr/api/consumer/log/TestVerbosity.java fails: unexpected log message

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/log/TestVerbosity.java
+++ b/test/jdk/jdk/jfr/api/consumer/log/TestVerbosity.java
@@ -42,7 +42,7 @@ import jdk.jfr.Name;
  *      jdk.jfr.api.consumer.log.TestVerbosity trace
  * @run main/othervm
  *      -Xlog:jfr+event*=debug:file=debug.log
- *      -XX:StartFlightRecording
+ *      -XX:StartFlightRecording:jdk.ExecutionSample#enabled=false
  *      jdk.jfr.api.consumer.log.TestVerbosity debug
  * @run main/othervm
  *      -Xlog:jfr+event*=info:file=info.log


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268298](https://bugs.openjdk.org/browse/JDK-8268298): jdk/jfr/api/consumer/log/TestVerbosity.java fails: unexpected log message


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1275/head:pull/1275` \
`$ git checkout pull/1275`

Update a local copy of the PR: \
`$ git checkout pull/1275` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1275`

View PR using the GUI difftool: \
`$ git pr show -t 1275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1275.diff">https://git.openjdk.org/jdk17u-dev/pull/1275.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1275#issuecomment-1514780480)