### PR TITLE
8273909: vmTestbase/nsk/jdi/Event/request/request001 can still fail with "ERROR: new event is not ThreadStartEvent"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
@@ -335,7 +335,6 @@ public class request001 extends JDIBase {
 
             log2("......setting up ThreadStartRequest");
             ThreadStartRequest tsr = eventRManager.createThreadStartRequest();
-            tsr.addCountFilter(1);
             tsr.setSuspendPolicy(EventRequest.SUSPEND_ALL);
             tsr.putProperty("number", "ThreadStartRequest");
             tsr.enable();
@@ -344,7 +343,6 @@ public class request001 extends JDIBase {
 
             log2("......setting up ThreadDeathRequest");
             ThreadDeathRequest tdr = eventRManager.createThreadDeathRequest();
-            tdr.addCountFilter(1);
             tdr.setSuspendPolicy(EventRequest.SUSPEND_ALL);
             tsr.putProperty("number", "ThreadDeathRequest");
             tdr.enable();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
@@ -322,7 +322,6 @@ public class nextevent001 extends JDIBase {
         {
             log2("......setting up ThreadStartRequest");
             ThreadStartRequest tsr = eventRManager.createThreadStartRequest();
-            tsr.addCountFilter(1);
             tsr.setSuspendPolicy(EventRequest.SUSPEND_ALL);
             tsr.putProperty("number", "ThreadStartRequest");
             tsr.enable();
@@ -331,7 +330,6 @@ public class nextevent001 extends JDIBase {
 
             log2("......setting up ThreadDeathRequest");
             ThreadDeathRequest tdr = eventRManager.createThreadDeathRequest();
-            tdr.addCountFilter(1);
             tdr.setSuspendPolicy(EventRequest.SUSPEND_ALL);
             tsr.putProperty("number", "ThreadDeathRequest");
             tdr.enable();

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadDeathRequest/addThreadFilter/addthreadfilter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadDeathRequest/addThreadFilter/addthreadfilter001.java
@@ -279,21 +279,18 @@ public class addthreadfilter001 extends JDIBase {
         log2("......setting up ThreadDeathRequest");
         ThreadDeathRequest tdr1 = eventRManager.createThreadDeathRequest();
 //        tdr1.addThreadFilter(mainThread);
-        tdr1.addCountFilter(1);
         tdr1.setSuspendPolicy(EventRequest.SUSPEND_ALL);
         tdr1.putProperty("number", "ThreadDeathRequest1");
         tdr1.enable();
 
         ThreadDeathRequest tdr2 = eventRManager.createThreadDeathRequest();
 //        tsr2.addThreadFilter(mainThread);
-        tdr2.addCountFilter(1);
         tdr2.setSuspendPolicy(EventRequest.SUSPEND_ALL);
         tdr2.putProperty("number", "ThreadDeathRequest2");
         tdr2.enable();
 
         ThreadDeathRequest tdr3 = eventRManager.createThreadDeathRequest();
         tdr3.addThreadFilter(testThread);
-        tdr3.addCountFilter(1);
         tdr3.setSuspendPolicy(EventRequest.SUSPEND_ALL);
         tdr3.putProperty("number", "ThreadDeathRequest3");
         tdr3.enable();


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273909](https://bugs.openjdk.org/browse/JDK-8273909): vmTestbase/nsk/jdi/Event/request/request001 can still fail with "ERROR: new event is not ThreadStartEvent"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1277/head:pull/1277` \
`$ git checkout pull/1277`

Update a local copy of the PR: \
`$ git checkout pull/1277` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1277`

View PR using the GUI difftool: \
`$ git pr show -t 1277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1277.diff">https://git.openjdk.org/jdk17u-dev/pull/1277.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1277#issuecomment-1514788615)