### PR TITLE
8277775: Fixup bugids in RemoveDropTargetCrashTest.java - add 4357905

### DIFF
--- a/test/jdk/java/awt/dnd/RemoveDropTargetCrashTest/RemoveDropTargetCrashTest.java
+++ b/test/jdk/java/awt/dnd/RemoveDropTargetCrashTest/RemoveDropTargetCrashTest.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * @test
  * @key headful
- * @bug 4393148 8136999 8186263 8224632
+ * @bug 4393148 4357905 8136999 8186263 8224632
  * @summary tests that removal of the drop target or disposal of frame during
  *          drop processing doesn't cause crash
  * @run main/timeout=300 RemoveDropTargetCrashTest RUN_PROCESS


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277775](https://bugs.openjdk.org/browse/JDK-8277775): Fixup bugids in RemoveDropTargetCrashTest.java - add 4357905


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1279/head:pull/1279` \
`$ git checkout pull/1279`

Update a local copy of the PR: \
`$ git checkout pull/1279` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1279`

View PR using the GUI difftool: \
`$ git pr show -t 1279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1279.diff">https://git.openjdk.org/jdk17u-dev/pull/1279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1279#issuecomment-1514812556)