### PR TITLE
8302172: [JVMCI] HotSpotResolvedJavaMethodImpl.canBeInlined must respect ForceInline

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -578,6 +578,9 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
 
     @Override
     public boolean canBeInlined() {
+        if (isForceInline()) {
+            return true;
+        }
         if (hasNeverInlineDirective()) {
             return false;
         }


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302172](https://bugs.openjdk.org/browse/JDK-8302172): [JVMCI] HotSpotResolvedJavaMethodImpl.canBeInlined must respect ForceInline


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1285/head:pull/1285` \
`$ git checkout pull/1285`

Update a local copy of the PR: \
`$ git checkout pull/1285` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1285`

View PR using the GUI difftool: \
`$ git pr show -t 1285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1285.diff">https://git.openjdk.org/jdk17u-dev/pull/1285.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1285#issuecomment-1516157115)