### PR TITLE
8302594: use-after-free in Node::destruct

### DIFF
--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -622,33 +622,7 @@ void Node::destruct(PhaseValues* phase) {
     //assert(def->out(def->outcnt()-1) == (Node *)this,"bad def-use hacking in reclaim");
   }
   assert(outcnt() == 0, "deleting a node must not leave a dangling use");
-  // See if the input array was allocated just prior to the object
-  int edge_size = _max*sizeof(void*);
-  int out_edge_size = _outmax*sizeof(void*);
-  char *edge_end = ((char*)_in) + edge_size;
-  char *out_array = (char*)(_out == NO_OUT_ARRAY? NULL: _out);
-  int node_size = size_of();
 
-  // Free the output edge array
-  if (out_edge_size > 0) {
-    compile->node_arena()->Afree(out_array, out_edge_size);
-  }
-
-  // Free the input edge array and the node itself
-  if( edge_end == (char*)this ) {
-    // It was; free the input array and object all in one hit
-#ifndef ASSERT
-    compile->node_arena()->Afree(_in,edge_size+node_size);
-#endif
-  } else {
-    // Free just the input array
-    compile->node_arena()->Afree(_in,edge_size);
-
-    // Free just the object
-#ifndef ASSERT
-    compile->node_arena()->Afree(this,node_size);
-#endif
-  }
   if (is_macro()) {
     compile->remove_macro_node(this);
   }
@@ -667,13 +641,43 @@ void Node::destruct(PhaseValues* phase) {
   }
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
   bs->unregister_potential_barrier_node(this);
+
+  // See if the input array was allocated just prior to the object
+  int edge_size = _max*sizeof(void*);
+  int out_edge_size = _outmax*sizeof(void*);
+  char *in_array = ((char*)_in);
+  char *edge_end = in_array + edge_size;
+  char *out_array = (char*)(_out == NO_OUT_ARRAY? NULL: _out);
+  int node_size = size_of();
+
 #ifdef ASSERT
   // We will not actually delete the storage, but we'll make the node unusable.
+  compile->remove_modified_node(this);
   *(address*)this = badAddress;  // smash the C++ vtbl, probably
   _in = _out = (Node**) badAddress;
   _max = _cnt = _outmax = _outcnt = 0;
-  compile->remove_modified_node(this);
 #endif
+
+  // Free the output edge array
+  if (out_edge_size > 0) {
+    compile->node_arena()->Afree(out_array, out_edge_size);
+  }
+
+  // Free the input edge array and the node itself
+  if( edge_end == (char*)this ) {
+    // It was; free the input array and object all in one hit
+#ifndef ASSERT
+    compile->node_arena()->Afree(in_array, edge_size+node_size);
+#endif
+  } else {
+    // Free just the input array
+    compile->node_arena()->Afree(in_array, edge_size);
+
+    // Free just the object
+#ifndef ASSERT
+    compile->node_arena()->Afree(this, node_size);
+#endif
+  }
 }
 
 //------------------------------grow-------------------------------------------


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302594](https://bugs.openjdk.org/browse/JDK-8302594): use-after-free in Node::destruct


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1286/head:pull/1286` \
`$ git checkout pull/1286`

Update a local copy of the PR: \
`$ git checkout pull/1286` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1286`

View PR using the GUI difftool: \
`$ git pr show -t 1286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1286.diff">https://git.openjdk.org/jdk17u-dev/pull/1286.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1286#issuecomment-1516169613)