### PR TITLE
8306658: GHA: MSVC installation could be optional since it might already be pre-installed

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -92,12 +92,26 @@ jobs:
         id: gtest
         uses: ./.github/actions/get-gtest
 
+      - name: 'Check toolchain installed'
+        id: toolchain-check
+        run: |
+          set +e
+          '/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/vc/auxiliary/build/vcvars64.bat' -vcvars_ver=${{ inputs.msvc-toolset-version }}
+          if [ $? -eq 0 ]; then
+            echo "Toolchain is already installed"
+            echo "toolchain-installed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Toolchain is not yet installed"
+            echo "toolchain-installed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: 'Install toolchain and dependencies'
         run: |
           # Run Visual Studio Installer
           '/c/Program Files (x86)/Microsoft Visual Studio/Installer/vs_installer.exe' \
             modify --quiet --installPath 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise' \
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
+        if: steps.toolchain-check.outputs.toolchain-installed != 'true'
 
       - name: 'Configure'
         run: >


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8306658](https://bugs.openjdk.org/browse/JDK-8306658), commit [d980cb48](https://github.com/openjdk/jdk/commit/d980cb48793f2bb662aece545fb00724c12a5613) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 24 Apr 2023 and was reviewed by Aleksey Shipilev and Goetz Lindenmaier.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306658](https://bugs.openjdk.org/browse/JDK-8306658): GHA: MSVC installation could be optional since it might already be pre-installed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1294/head:pull/1294` \
`$ git checkout pull/1294`

Update a local copy of the PR: \
`$ git checkout pull/1294` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1294`

View PR using the GUI difftool: \
`$ git pr show -t 1294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1294.diff">https://git.openjdk.org/jdk17u-dev/pull/1294.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1294#issuecomment-1520486691)