### PR TITLE
8300079: SIGSEGV in LibraryCallKit::inline_string_copy due to constant NULL src argument

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1288,10 +1288,13 @@ bool LibraryCallKit::inline_string_copy(bool compress) {
   AllocateArrayNode* alloc = tightly_coupled_allocation(dst);
 
   // Figure out the size and type of the elements we will be copying.
-  const Type* src_type = src->Value(&_gvn);
-  const Type* dst_type = dst->Value(&_gvn);
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType dst_elem = dst_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  const TypeAryPtr* src_type = src->Value(&_gvn)->isa_aryptr();
+  const TypeAryPtr* dst_type = dst->Value(&_gvn)->isa_aryptr();
+  if (src_type == nullptr || dst_type == nullptr) {
+    return false;
+  }
+  BasicType src_elem = src_type->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType dst_elem = dst_type->klass()->as_array_klass()->element_type()->basic_type();
   assert((compress && dst_elem == T_BYTE && (src_elem == T_BYTE || src_elem == T_CHAR)) ||
          (!compress && src_elem == T_BYTE && (dst_elem == T_BYTE || dst_elem == T_CHAR)),
          "Unsupported array types for inline_string_copy");
@@ -4943,8 +4946,8 @@ bool LibraryCallKit::inline_encodeISOArray(bool ascii) {
   }
 
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType dst_elem = dst_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType dst_elem = top_dest->klass()->as_array_klass()->element_type()->basic_type();
   if (!((src_elem == T_CHAR) || (src_elem== T_BYTE)) || dst_elem != T_BYTE) {
     return false;
   }
@@ -4997,8 +5000,8 @@ bool LibraryCallKit::inline_multiplyToLen() {
     return false;
   }
 
-  BasicType x_elem = x_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType y_elem = y_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType x_elem = top_x->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType y_elem = top_y->klass()->as_array_klass()->element_type()->basic_type();
   if (x_elem != T_INT || y_elem != T_INT) {
     return false;
   }
@@ -5105,8 +5108,8 @@ bool LibraryCallKit::inline_squareToLen() {
     return false;
   }
 
-  BasicType x_elem = x_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType z_elem = z_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType x_elem = top_x->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType z_elem = top_z->klass()->as_array_klass()->element_type()->basic_type();
   if (x_elem != T_INT || z_elem != T_INT) {
     return false;
   }
@@ -5154,8 +5157,8 @@ bool LibraryCallKit::inline_mulAdd() {
     return false;
   }
 
-  BasicType out_elem = out_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType in_elem = in_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType out_elem = top_out->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType in_elem = top_in->klass()->as_array_klass()->element_type()->basic_type();
   if (out_elem != T_INT || in_elem != T_INT) {
     return false;
   }
@@ -5209,10 +5212,10 @@ bool LibraryCallKit::inline_montgomeryMultiply() {
     return false;
   }
 
-  BasicType a_elem = a_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType b_elem = b_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType n_elem = n_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType m_elem = m_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType a_elem = top_a->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType b_elem = top_b->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType n_elem = top_n->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType m_elem = top_m->klass()->as_array_klass()->element_type()->basic_type();
   if (a_elem != T_INT || b_elem != T_INT || n_elem != T_INT || m_elem != T_INT) {
     return false;
   }
@@ -5265,9 +5268,9 @@ bool LibraryCallKit::inline_montgomerySquare() {
     return false;
   }
 
-  BasicType a_elem = a_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType n_elem = n_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType m_elem = m_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType a_elem = top_a->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType n_elem = top_n->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType m_elem = top_m->klass()->as_array_klass()->element_type()->basic_type();
   if (a_elem != T_INT || n_elem != T_INT || m_elem != T_INT) {
     return false;
   }
@@ -5317,8 +5320,8 @@ bool LibraryCallKit::inline_bigIntegerShift(bool isRightShift) {
     return false;
   }
 
-  BasicType newArr_elem = newArr_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
-  BasicType oldArr_elem = oldArr_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType newArr_elem = top_newArr->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType oldArr_elem = top_oldArr->klass()->as_array_klass()->element_type()->basic_type();
   if (newArr_elem != T_INT || oldArr_elem != T_INT) {
     return false;
   }
@@ -5531,7 +5534,7 @@ bool LibraryCallKit::inline_updateBytesCRC32() {
   }
 
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }
@@ -5620,7 +5623,7 @@ bool LibraryCallKit::inline_updateBytesCRC32C() {
   }
 
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }
@@ -5713,7 +5716,7 @@ bool LibraryCallKit::inline_updateBytesAdler32() {
   }
 
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }
@@ -6550,7 +6553,7 @@ bool LibraryCallKit::inline_digestBase_implCompress(vmIntrinsics::ID id) {
     return false;
   }
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }
@@ -6642,7 +6645,7 @@ bool LibraryCallKit::inline_digestBase_implCompressMB(int predicate) {
     return false;
   }
   // Figure out the size and type of the elements we will be copying.
-  BasicType src_elem = src_type->isa_aryptr()->klass()->as_array_klass()->element_type()->basic_type();
+  BasicType src_elem = top_src->klass()->as_array_klass()->element_type()->basic_type();
   if (src_elem != T_BYTE) {
     return false;
   }

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestCopyValueOf.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestCopyValueOf.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8300079
+ * @summary Verify that String.copyValueOf properly handles null input with intrinsified helper methods.
+ * @run main/othervm -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileCommand=compileonly,compiler.intrinsics.string.TestCopyValueOf::test
+ *                   -XX:CompileCommand=dontinline,java.lang.String::rangeCheck
+ *                   compiler.intrinsics.string.TestCopyValueOf
+ */
+
+package compiler.intrinsics.string;
+
+public class TestCopyValueOf {
+
+    public static boolean test() {
+        try {
+            String.copyValueOf(null, 42, 43);
+        } catch (NullPointerException e) {
+            return true;
+        }
+        return false;
+    }
+
+    public static void main(String[] args) {
+        // Warmup
+        char data[] = {42};
+        String.copyValueOf(data, 0, 1);
+
+        if (!test()) {
+            throw new RuntimeException("Unexpected result");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

Does not apply because
"8275201: C2: hide klass() accessor from TypeOopPtr and typeKlassPtr subclasses" is not in 17.

The problem fixed by this change is that isa_aryptr() can return NULL.
I checked all occurances of this call. Many of them are checked for NULL which 
was missing in head before this fix. For inline_string_copy() the check was missing
in 17.
For many of the other checks, the result is assigned to a variable and then checked, 
but then isa_aryptr() is called again. I changed the code to use the checked variable.
I hope this makes clear that the check may not be removed :)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300079](https://bugs.openjdk.org/browse/JDK-8300079): SIGSEGV in LibraryCallKit::inline_string_copy due to constant NULL src argument


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1297/head:pull/1297` \
`$ git checkout pull/1297`

Update a local copy of the PR: \
`$ git checkout pull/1297` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1297`

View PR using the GUI difftool: \
`$ git pr show -t 1297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1297.diff">https://git.openjdk.org/jdk17u-dev/pull/1297.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1297#issuecomment-1522967401)