### PR TITLE
8303476: Add the runtime version in the release file of a JDK image

### DIFF
--- a/make/ReleaseFile.gmk
+++ b/make/ReleaseFile.gmk
@@ -51,6 +51,7 @@ define create-info-file
   $(if $(VENDOR_VERSION_STRING), \
     $(call info-file-item, "IMPLEMENTOR_VERSION", "$(VENDOR_VERSION_STRING)"))
   $(call info-file-item, "JAVA_VERSION_DATE", "$(VERSION_DATE)")
+  $(call info-file-item, "JAVA_RUNTIME_VERSION", "$(VERSION_STRING)")
   $(call info-file-item, "OS_NAME", "$(RELEASE_FILE_OS_NAME)")
   $(call info-file-item, "OS_ARCH", "$(RELEASE_FILE_OS_ARCH)")
   $(call info-file-item, "LIBC", "$(RELEASE_FILE_LIBC)")


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303476](https://bugs.openjdk.org/browse/JDK-8303476): Add the runtime version in the release file of a JDK image


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1302/head:pull/1302` \
`$ git checkout pull/1302`

Update a local copy of the PR: \
`$ git checkout pull/1302` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1302`

View PR using the GUI difftool: \
`$ git pr show -t 1302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1302.diff">https://git.openjdk.org/jdk17u-dev/pull/1302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1302#issuecomment-1523881418)