### PR TITLE
8301190: [vectorapi] The typeChar of LaneType is incorrect when default locale is tr

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LaneType.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LaneType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ enum LaneType {
         // int:128 or int:4 or float:16, report the size in the
         // printName.  If we do unsigned or vector or bit lane types,
         // report that condition also.
-        this.typeChar = printName.toUpperCase().charAt(0);
+        this.typeChar = genericElementType.getSimpleName().charAt(0);
         assert("FDBSIL".indexOf(typeChar) == ordinal()) : this;
         // Same as in JVMS, org.objectweb.asm.Opcodes, etc.:
         this.basicType = basicType;


### PR DESCRIPTION
Clean backport to fix the incubating Vector API. This unblocks testing of those APIs in latest LTS. Yes, I understand this is awkward to backport fixes for incubating features, but this one seems to be very easy to fix, and it was already found in real test deployment.

Additional testing:
 - [x] Linux x86_64 fastdebug, `jdk/incubator/vector compiler/vectorapi`
 - [x] Linux AArch64 fastdebug, `jdk/incubator/vector compiler/vectorapi`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301190](https://bugs.openjdk.org/browse/JDK-8301190): [vectorapi] The typeChar of LaneType is incorrect when default locale is tr


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1305/head:pull/1305` \
`$ git checkout pull/1305`

Update a local copy of the PR: \
`$ git checkout pull/1305` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1305`

View PR using the GUI difftool: \
`$ git pr show -t 1305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1305.diff">https://git.openjdk.org/jdk17u-dev/pull/1305.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1305#issuecomment-1525695989)