### PR TITLE
8303564: C2: "Bad graph detected in build_loop_late" after a CMove is wrongly split thru phi

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1334,8 +1334,8 @@ void PhaseIdealLoop::split_if_with_blocks_post(Node *n) {
         return; // Compare must be in same blk as if
       }
     } else if (iff->is_CMove()) { // Trying to split-up a CMOVE
-      // Can't split CMove with different control edge.
-      if (iff->in(0) != NULL && iff->in(0) != n_ctrl ) {
+      // Can't split CMove with different control.
+      if (get_ctrl(iff) != n_ctrl) {
         return;
       }
       if (get_ctrl(iff->in(2)) == n_ctrl ||

--- a/test/hotspot/jtreg/compiler/loopopts/TestWrongCMovSplitIf.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestWrongCMovSplitIf.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8303564
+ * @summary C2: "Bad graph detected in build_loop_late" after a CMove is wrongly split thru phi
+ * @run main/othervm -XX:-BackgroundCompilation TestWrongCMovSplitIf
+ */
+
+public class TestWrongCMovSplitIf {
+    private static int[] field1 = new int[1];
+    private static int field3;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(true);
+            test(false);
+            testHelper(1000, false);
+        }
+    }
+
+    private static void test(boolean flag) {
+        int i;
+        for (i = 0; i < 2; i++) {
+            for (int j = 0; j < 10; j++) {
+                for (int k = 0; k < 10; k++) {
+
+                }
+            }
+        }
+        field3 = testHelper(i, flag);
+        for (int j = 0; j < 10; j++) {
+            for (int k = 0; k < 10; k++) {
+                for (int l = 0; l < 10; l++) {
+                    for (int m = 0; m < 10; m++) {
+
+                    }
+
+                }
+            }
+        }
+    }
+
+    private static int testHelper(int i, boolean flag) {
+        int stop = 1000;
+        if (i == 2) {
+            if (flag) {
+                stop = 2;
+            } else {
+                stop = 1;
+            }
+        }
+        int f = 0;
+        for (int j = 0; j < stop; j++) {
+            f += field1[0];
+        }
+        return f;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303564](https://bugs.openjdk.org/browse/JDK-8303564): C2: "Bad graph detected in build_loop_late" after a CMove is wrongly split thru phi


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1309/head:pull/1309` \
`$ git checkout pull/1309`

Update a local copy of the PR: \
`$ git checkout pull/1309` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1309`

View PR using the GUI difftool: \
`$ git pr show -t 1309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1309.diff">https://git.openjdk.org/jdk17u-dev/pull/1309.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1309#issuecomment-1527431017)