### PR TITLE
8303069: Memory leak in CompilerOracle::parse_from_line

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -308,6 +308,8 @@ static void register_command(TypedMethodOptionMatcher* matcher,
 
   if (option == CompileCommand::Blackhole && !UnlockExperimentalVMOptions) {
     warning("Blackhole compile option is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions");
+    // Delete matcher as we don't keep it
+    delete matcher;
     return;
   }
 


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303069](https://bugs.openjdk.org/browse/JDK-8303069): Memory leak in CompilerOracle::parse_from_line


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1310/head:pull/1310` \
`$ git checkout pull/1310`

Update a local copy of the PR: \
`$ git checkout pull/1310` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1310`

View PR using the GUI difftool: \
`$ git pr show -t 1310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1310.diff">https://git.openjdk.org/jdk17u-dev/pull/1310.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1310#issuecomment-1527451072)