### PR TITLE
8244976: vmTestbase/nsk/jdi/Event/request/request001.java doesn' initialize eName

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Event/request/request001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -525,18 +525,14 @@ public class request001 extends JDIBase {
             log2(":::::::::vm.resume();");
             vm.resume();
 
-            Event  event1     = null;
-            int    flagsCopy  = flags;
-            String eName      = null;
-            int    index      = 0;
+            int flagsCopy = flags;
 
             log2("......getting and checking up on Events");
             for (int n4 = 0; n4 < namesRef.length(); n4++) {
-                int flag;
-
                 getEventSet();
-                event1 = eventIterator.nextEvent();
+                Event event1 = eventIterator.nextEvent();
 
+                int index;
                 if (event1 instanceof AccessWatchpointEvent) {
                     index = 0;
                 } else if (event1 instanceof ModificationWatchpointEvent ) {
@@ -554,11 +550,15 @@ public class request001 extends JDIBase {
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
+                    throw new JDITestRuntimeException("** unexpected event ** " + event1);
                 }
+                log2("--------> got: " + event1 + " index: " + index);
 
-                flag = 1 << index;
+                int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication: " + eName);
+                    log3("ERROR: event duplication. event " + event1
+                            + " flagsCopy = " + Integer.toBinaryString(flagsCopy)
+                            + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {
                     flagsCopy ^= flag;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventIterator/nextEvent/nextevent001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -514,18 +514,15 @@ public class nextevent001 extends JDIBase {
             log2(":::::::::vm.resume();");
             vm.resume();
 
-            Event  event1     = null;
-            int    flagsCopy  = flags;
-            String eName      = null;
-            int    index      = 0;
+            int flagsCopy = flags;
 
             log2("......getting and checking up on Events");
             for (int n4 = 0; n4 < namesRef.length(); n4++) {
-                int flag;
 
                 getEventSet();
-                event1 = eventIterator.nextEvent();
+                Event event1 = eventIterator.nextEvent();
 
+                int index;
                 if (event1 instanceof AccessWatchpointEvent) {
                     index = 0;
                 } else if (event1 instanceof ModificationWatchpointEvent ) {
@@ -543,11 +540,15 @@ public class nextevent001 extends JDIBase {
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
+                    throw new JDITestRuntimeException("** unexpected event ** " + event1);
                 }
+                log2("--------> got: " + event1 + " index: " + index);
 
-                flag = 1 << index;
+                int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication: " + eName);
+                    log3("ERROR: event duplication. event " + event1
+                            + " flagsCopy = " + Integer.toBinaryString(flagsCopy)
+                            + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {
                     flagsCopy ^= flag;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocatableEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LocatableEvent/thread/thread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -417,45 +417,35 @@ public class thread001 extends JDIBase {
             log2(":::::::::vm.resume();");
             vm.resume();
 
-            Event   event1    = null;
             String threadName = null;
             int    flagsCopy  = flags;
-            String eName      = null;
 
             log2("......getting and checking up on Events");
             for (int n4 = 0; n4 < namesRef.length(); n4++) {
-                int flag;
-                int index;
                 getEventSet();
-                event1 = eventIterator.nextEvent();
+                Event event1 = eventIterator.nextEvent();
 
+                int index;
                 if (event1 instanceof AccessWatchpointEvent) {
-                    eName = "AccessWatchpointEvent";
                     index = 0;
                 } else if (event1 instanceof ModificationWatchpointEvent ) {
-                    eName = "ModificationWatchpointEvent";
                     index = 1;
                 } else if (event1 instanceof BreakpointEvent ) {
-                    eName = "BreakpointEvent";
                     index = 2;
                 } else if (event1 instanceof ExceptionEvent ) {
-                    eName = "ExceptionEvent";
                     index = 3;
                 } else if (event1 instanceof MethodEntryEvent ) {
-                    eName = "MethodEntryEvent";
                     index = 4;
                 } else if (event1 instanceof MethodExitEvent ) {
-                    eName = "MethodExitEvent";
                     index = 5;
                 } else if (event1 instanceof StepEvent ) {
-                    eName = "StepEvent";
                     index = 6;
                 } else {
                     log3("ERROR: else clause in detecting type of event1");
                     testExitCode = FAILED;
-                    throw new JDITestRuntimeException("** unexpected event **");
+                    throw new JDITestRuntimeException("** unexpected event ** " + event1);
                 }
-                log2("--------> got: " + eName);
+                log2("--------> got: " + event1 + " index: " + index);
 
                 ThreadReference threadRef = ((LocatableEvent) event1).thread();
 
@@ -472,9 +462,11 @@ public class thread001 extends JDIBase {
                     log3("        thread's name == " + threadRef.name());
                 }
 
-                flag = 1 << index;
+                int flag = 1 << index;
                 if ((flagsCopy & flag) == 0) {
-                    log3("ERROR: event duplication: " + eName);
+                    log3("ERROR: event duplication. event " + event1
+                            + " flagsCopy = " + Integer.toBinaryString(flagsCopy)
+                            + " flag = " + Integer.toBinaryString(flag));
                     testExitCode = FAILED;
                 } else {
                     flagsCopy ^= flag;


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8244976](https://bugs.openjdk.org/browse/JDK-8244976): vmTestbase/nsk/jdi/Event/request/request001.java doesn' initialize eName


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1314/head:pull/1314` \
`$ git checkout pull/1314`

Update a local copy of the PR: \
`$ git checkout pull/1314` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1314`

View PR using the GUI difftool: \
`$ git pr show -t 1314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1314.diff">https://git.openjdk.org/jdk17u-dev/pull/1314.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1314#issuecomment-1527781334)