### PR TITLE
8283057: Update GCC to version 11.2.0 for Oracle builds on Linux

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -273,7 +273,7 @@
 <tbody>
 <tr class="odd">
 <td>Linux</td>
-<td>gcc 10.2.0</td>
+<td>gcc 11.2.0</td>
 </tr>
 <tr class="even">
 <td>macOS</td>
@@ -288,7 +288,7 @@
 <p>All compilers are expected to be able to compile to the C99 language standard, as some C99 features are used in the source code. Microsoft Visual Studio doesn't fully support C99 so in practice shared code is limited to using C99 features that it does support.</p>
 <h3 id="gcc">gcc</h3>
 <p>The minimum accepted version of gcc is 5.0. Older versions will generate a warning by <code>configure</code> and are unlikely to work.</p>
-<p>The JDK is currently known to be able to compile with at least version 10.2 of gcc.</p>
+<p>The JDK is currently known to be able to compile with at least version 11.2 of gcc.</p>
 <p>In general, any version between these two should be usable.</p>
 <h3 id="clang">clang</h3>
 <p>The minimum accepted version of clang is 3.5. Older versions will not be accepted by <code>configure</code>.</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -321,7 +321,7 @@ issues.
 
 | Operating system   | Toolchain version                          |
 | ------------------ | ------------------------------------------ |
-| Linux              | gcc 10.2.0                                 |
+| Linux              | gcc 11.2.0                                 |
 | macOS              | Apple Xcode 10.1 (using clang 10.0.0)      |
 | Windows            | Microsoft Visual Studio 2022 update 17.1.0 |
 
@@ -335,7 +335,7 @@ features that it does support.
 The minimum accepted version of gcc is 5.0. Older versions will generate a warning
 by `configure` and are unlikely to work.
 
-The JDK is currently known to be able to compile with at least version 10.2 of
+The JDK is currently known to be able to compile with at least version 11.2 of
 gcc.
 
 In general, any version between these two should be usable.

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1048,10 +1048,10 @@ var getJibProfilesProfiles = function (input, common, data) {
 var getJibProfilesDependencies = function (input, common) {
 
     var devkit_platform_revisions = {
-        linux_x64: "gcc10.3.0-OL6.4+1.0",
+        linux_x64: "gcc11.2.0-OL6.4+1.0",
         macosx: "Xcode12.4+1.0",
         windows_x64: "VS2022-17.1.0+1.0",
-        linux_aarch64: "gcc10.3.0-OL7.6+1.0",
+        linux_aarch64: "gcc11.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
         linux_ppc64le: "gcc8.2.0-Fedora27+1.0",
         linux_s390x: "gcc8.2.0-Fedora27+1.0"

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -87,8 +87,17 @@ endif
 # Define external dependencies
 
 # Latest that could be made to work.
-GCC_VER := 10.3.0
-ifeq ($(GCC_VER), 10.3.0)
+GCC_VER := 11.2.0
+ifeq ($(GCC_VER), 11.2.0)
+  gcc_ver := gcc-11.2.0
+  binutils_ver := binutils-2.37
+  ccache_ver := ccache-3.7.12
+  mpfr_ver := mpfr-4.1.0
+  gmp_ver := gmp-6.2.1
+  mpc_ver := mpc-1.2.1
+  gdb_ver := gdb-11.1
+  REQUIRED_MIN_MAKE_MAJOR_VERSION := 4
+else ifeq ($(GCC_VER), 10.3.0)
   gcc_ver := gcc-10.3.0
   binutils_ver := binutils-2.36.1
   ccache_ver := ccache-3.7.11


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283057](https://bugs.openjdk.org/browse/JDK-8283057): Update GCC to version 11.2.0 for Oracle builds on Linux


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1323/head:pull/1323` \
`$ git checkout pull/1323`

Update a local copy of the PR: \
`$ git checkout pull/1323` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1323`

View PR using the GUI difftool: \
`$ git pr show -t 1323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1323.diff">https://git.openjdk.org/jdk17u-dev/pull/1323.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1323#issuecomment-1534920671)