### PR TITLE
8305088: SIGSEGV in Method::is_method_handle_intrinsic

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1831,7 +1831,8 @@ bool nmethod::is_unloading() {
   // oops in the CompiledMethod, by calling oops_do on it.
   state_unloading_cycle = current_cycle;
 
-  if (is_zombie() || method()->can_be_allocated_in_NonNMethod_space()) {
+  Method* m = method();
+  if (is_zombie() || (m != nullptr && m->can_be_allocated_in_NonNMethod_space())) {
     // When the nmethod is in NonNMethod space, we may reach here without IsUnloadingBehaviour.
     // However, we only allow this for special methods which never get unloaded.
 


### PR DESCRIPTION
I had forgotten a null check when backporting [JDK-8295724](https://bugs.openjdk.org/browse/JDK-8295724). Unlike head, JDK17u uses `set_method(NULL)` in `nmethod::make_unloaded()` (and `nmethod::make_not_entrant_or_zombie`). We shouldn't ask `can_be_allocated_in_NonNMethod_space()` in these cases. The nmethod can't be a method handle intrinsic.