### PR TITLE
8305690: [X86] Do not emit two REX prefixes in Assembler::prefix

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -9683,7 +9683,7 @@ void Assembler::prefix(Register dst, Address adr, Prefix p) {
     if (adr.index_needs_rex()) {
       assert(false, "prefix(Register dst, Address adr, Prefix p) does not support handling of an X");
     } else {
-      prefix(REX_B);
+      p = (Prefix)(p | REX_B);
     }
   } else {
     if (adr.index_needs_rex()) {


### PR DESCRIPTION
Hi all,

This patch prevents `Assembler::prefix` from emitting two `REX` prefixes.

Low risk:
It is a corner case which is not triggered by the current code.
In order to avoid bugs in the future, it is good to backport it.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305690](https://bugs.openjdk.org/browse/JDK-8305690): [X86] Do not emit two REX prefixes in Assembler::prefix


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1334/head:pull/1334` \
`$ git checkout pull/1334`

Update a local copy of the PR: \
`$ git checkout pull/1334` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1334`

View PR using the GUI difftool: \
`$ git pr show -t 1334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1334.diff">https://git.openjdk.org/jdk17u-dev/pull/1334.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1334#issuecomment-1538547834)