### PR TITLE
8276058: Some swing test fails on specific CI macos system

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -187,7 +187,7 @@ java/awt/Toolkit/RealSync/Test.java 6849383 linux-all
 java/awt/LightweightComponent/LightweightEventTest/LightweightEventTest.java 8159252 windows-all
 java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java 8203047 macosx-all
 java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java 8073636 macosx-all
-java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055,8266245 windows-all,linux-all,macosx-aarch64
+java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055,8266245 windows-all,linux-all,macosx-all
 java/awt/Focus/8013611/JDK8013611.java 8175366 windows-all,macosx-all
 java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all

--- a/test/jdk/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
+++ b/test/jdk/java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java
@@ -46,6 +46,10 @@ public class MakeWindowAlwaysOnTop
     private static Frame f;
     private static Dialog d;
 
+    // move away from cursor
+    private final static int OFFSET_X = -20;
+    private final static int OFFSET_Y = -20;
+
     public static void main(String[] args) throws Exception
     {
         Robot r = Util.createRobot();
@@ -101,7 +105,7 @@ public class MakeWindowAlwaysOnTop
         Util.waitForIdle(r);
 
 
-        Color c = r.getPixelColor(p.x + f.getWidth() / 2, p.y + f.getHeight() / 2);
+        Color c = r.getPixelColor(p.x + f.getWidth() / 2 - OFFSET_X, p.y + f.getHeight() / 2 - OFFSET_Y);
         System.out.println("Color = " + c);
 
         String exceptionMessage = null;

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -80,7 +80,7 @@ public class bug6276188 {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
-            Color color = robot.getPixelColor(p.x - OFFSET_X, p.y - OFFSET_y);
+            Color color = robot.getPixelColor(p.x - OFFSET_X, p.y - OFFSET_Y);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
             boolean red = color.getRed() > 0 && color.getGreen() == 0 && color.getBlue() == 0;

--- a/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
+++ b/test/jdk/javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java
@@ -37,46 +37,67 @@ import java.awt.event.*;
 import javax.swing.*;
 import javax.swing.plaf.synth.*;
 
-public class bug6276188 extends JFrame {
+public class bug6276188 {
 
     private static JButton button;
     private static Point p;
+    private static JFrame testFrame;
+
+     // move away from cursor
+    private final static int OFFSET_X = -20;
+    private final static int OFFSET_Y = -20;
 
     public static void main(String[] args) throws Throwable {
-        SynthLookAndFeel lookAndFeel = new SynthLookAndFeel();
-        lookAndFeel.load(bug6276188.class.getResourceAsStream("bug6276188.xml"), bug6276188.class);
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
-        UIManager.setLookAndFeel(lookAndFeel);
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                JFrame testFrame = new JFrame();
-                testFrame.setLayout(new BorderLayout());
-                testFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-                testFrame.add(BorderLayout.CENTER, button = new JButton());
+            SynthLookAndFeel lookAndFeel = new SynthLookAndFeel();
+            lookAndFeel.load(bug6276188.class.getResourceAsStream("bug6276188.xml"), bug6276188.class);
+            UIManager.setLookAndFeel(lookAndFeel);
 
-                testFrame.setSize(new Dimension(320, 200));
-                testFrame.setVisible(true);
+            SwingUtilities.invokeAndWait(new Runnable() {
+                public void run() {
+                    testFrame = new JFrame();
+                    testFrame.setLayout(new BorderLayout());
+                    testFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    testFrame.add(BorderLayout.CENTER, button = new JButton());
+
+                    testFrame.setSize(new Dimension(320, 200));
+                    testFrame.setLocationRelativeTo(null);
+                    testFrame.setVisible(true);
+                }
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            p = Util.getCenterPoint(button);
+            System.out.println("Button center point: " + p);
+
+            robot.mouseMove(p.x , p.y);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+
+            Color color = robot.getPixelColor(p.x - OFFSET_X, p.y - OFFSET_y);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            boolean red = color.getRed() > 0 && color.getGreen() == 0 && color.getBlue() == 0;
+            if (!red) {
+                System.err.println("Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
+                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                Rectangle screen = new Rectangle(0, 0, (int) screenSize.getWidth(), (int) screenSize.getHeight());
+                BufferedImage img = robot.createScreenCapture(screen);
+                javax.imageio.ImageIO.write(img, "png", new java.io.File("image.png"));
+                throw new RuntimeException("Synth ButtonUI does not handle PRESSED & MOUSE_OVER state");
             }
-        });
-
-        Robot robot = new Robot();
-        robot.setAutoDelay(50);
-        robot.waitForIdle();
-        robot.delay(200);
-
-        p = Util.getCenterPoint(button);
-
-        robot.mouseMove(p.x , p.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.waitForIdle();
-        robot.delay(1000);
-
-        Color color = robot.getPixelColor(p.x, p.y);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        boolean red = color.getRed() > 0 && color.getGreen() == 0 && color.getBlue() == 0;
-        if (!red) {
-            System.err.println("Red: " + color.getRed() + "; Green: " + color.getGreen() + "; Blue: " + color.getBlue());
-            throw new RuntimeException("Synth ButtonUI does not handle PRESSED & MOUSE_OVER state");
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (testFrame != null) {
+                    testFrame.dispose();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8276058](https://bugs.openjdk.java.net/browse/JDK-8276058), commit [91607436](https://github.com/openjdk/jdk/commit/91607436b79126ccb999deaf38a98209dbfe6ec1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 18 Nov 2021 and was reviewed by Phil Race and Alexander Zuev.

It applied clean and I added the fix for [JDK-8277407](https://bugs.openjdk.org/browse/JDK-8277407) as well, since bug6276188.java would fail to compile otherwise. Marking as clean.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8276058](https://bugs.openjdk.org/browse/JDK-8276058): Some swing test fails on specific CI macos system
 * [JDK-8277407](https://bugs.openjdk.org/browse/JDK-8277407): javax/swing/plaf/synth/SynthButtonUI/6276188/bug6276188.java fails to compile after JDK-8276058


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1337/head:pull/1337` \
`$ git checkout pull/1337`

Update a local copy of the PR: \
`$ git checkout pull/1337` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1337`

View PR using the GUI difftool: \
`$ git pr show -t 1337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1337.diff">https://git.openjdk.org/jdk17u-dev/pull/1337.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1337#issuecomment-1539789627)