### PR TITLE
8307425: Socket input stream read burns CPU cycles with back-to-back poll(0) calls

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,6 +177,11 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             millis = -1;
         } else {
             millis = NANOSECONDS.toMillis(nanos);
+            if (nanos > MILLISECONDS.toNanos(millis)) {
+                // Round up any excess nanos to the nearest millisecond to
+                // avoid parking for less than requested.
+                millis++;
+            }
         }
         Net.poll(fd, event, millis);
     }

--- a/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SelChImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.nio.channels.Channel;
 import java.io.FileDescriptor;
 import java.io.IOException;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
@@ -88,6 +89,11 @@ public interface SelChImpl extends Channel {
             millis = -1;
         } else {
             millis = NANOSECONDS.toMillis(nanos);
+            if (nanos > MILLISECONDS.toNanos(millis)) {
+                // Round up any excess nanos to the nearest millisecond to
+                // avoid parking for less than requested.
+                millis++;
+            }
         }
         Net.poll(getFD(), event, millis);
     }


### PR DESCRIPTION
Backport 73ac710533a45bf5ba17f308aa49556b877b8bf9 to JDK 17u.

Backporting the fix for https://bugs.openjdk.org/browse/JDK-8307425 merged as part of https://github.com/openjdk/jdk/pull/13798#
Almost all the hunks were rejected. DatagramChannelImpl doesn't override park in jdk17, and hence has been left unchanged. Respective hunks for NioSocketImpl and SelChImpl were not cleanly applied due to the difference in how park is implemented for the respective classes between openjdk/jdk17u and openjdk/jdk. In openjdk/jdk in park, current thread is checked to be virtual or not and if that equates to true Poller.poll is used instead of Net.poll.

NioSocketImpl.java in openjdk/jdk17u:
```
private void park(FileDescriptor fd, int event, long nanos) throws IOException {
        long millis;
        if (nanos == 0) {
            millis = -1;
        } else {
            millis = NANOSECONDS.toMillis(nanos);
        }
        Net.poll(fd, event, millis);
    }
```
NioSocketImpl.java in openjdk/jdk:
```
private void park(FileDescriptor fd, int event, long nanos) throws IOException {
        Thread t = Thread.currentThread();
        if (t.isVirtual()) {
            Poller.poll(fdVal(fd), event, nanos, this::isOpen);
            if (t.isInterrupted()) {
                throw new InterruptedIOException();
            }
        } else {
            long millis;
            if (nanos == 0) {
                millis = -1;
            } else {
                millis = NANOSECONDS.toMillis(nanos);
                if (nanos > MILLISECONDS.toNanos(millis)) {
                    // Round up any excess nanos to the nearest millisecond to
                    // avoid parking for less than requested.
                    millis++;
                }
            }
            Net.poll(fd, event, millis);
        }
    }
```

SelChImpl.java in openjdk/jdk17u:
```
default void park(int event, long nanos) throws IOException {
        long millis;
        if (nanos <= 0) {
            millis = -1;
        } else {
            millis = NANOSECONDS.toMillis(nanos);
        }
        Net.poll(getFD(), event, millis);
    }
```
SelChImpl.java in openjdk/jdk17u:
```
default void park(int event, long nanos) throws IOException {
        if (Thread.currentThread().isVirtual()) {
            Poller.poll(getFDVal(), event, nanos, this::isOpen);
        } else {
            long millis;
            if (nanos <= 0) {
                millis = -1;
            } else {
                millis = NANOSECONDS.toMillis(nanos);
                if (nanos > MILLISECONDS.toNanos(millis)) {
                    // Round up any excess nanos to the nearest millisecond to
                    // avoid parking for less than requested.
                    millis++;
                }
            }
            Net.poll(getFD(), event, millis);
        }
    }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307425](https://bugs.openjdk.org/browse/JDK-8307425): Socket input stream read burns CPU cycles with back-to-back poll(0) calls


### Reviewers
 * [Oli Gillespie](https://openjdk.org/census#ogillespie) (@olivergillespie - no project role)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1341/head:pull/1341` \
`$ git checkout pull/1341`

Update a local copy of the PR: \
`$ git checkout pull/1341` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1341`

View PR using the GUI difftool: \
`$ git pr show -t 1341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1341.diff">https://git.openjdk.org/jdk17u-dev/pull/1341.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1341#issuecomment-1542777066)