### PR TITLE
8307346: Add missing gc+phases logging for ObjectCount(AfterGC) JFR event collection code

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -304,7 +304,10 @@ void G1FullCollector::phase1_mark_live_objects() {
     _heap->complete_cleaning(&_is_alive, purged_class);
   }
 
-  scope()->tracer()->report_object_count_after_gc(&_is_alive);
+  {
+    GCTraceTime(Debug, gc, phases) debug("Report Object Count", scope()->timer());
+    scope()->tracer()->report_object_count_after_gc(&_is_alive);
+  }
 }
 
 void G1FullCollector::phase2_prepare_compaction() {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2137,7 +2137,10 @@ void PSParallelCompact::marking_phase(ParCompactionManager* cm,
     JVMCI_ONLY(JVMCI::do_unloading(purged_class));
   }
 
-  _gc_tracer.report_object_count_after_gc(is_alive_closure());
+  {
+    GCTraceTime(Debug, gc, phases) tm("Report Object Count", &_gc_timer);
+    _gc_tracer.report_object_count_after_gc(is_alive_closure());
+  }
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -230,7 +230,10 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
     JVMCI_ONLY(JVMCI::do_unloading(purged_class));
   }
 
-  gc_tracer()->report_object_count_after_gc(&is_alive);
+  {
+    GCTraceTime(Debug, gc, phases) tm_m("Report Object Count", gc_timer());
+    gc_tracer()->report_object_count_after_gc(&is_alive);
+  }
 }
 
 


### PR DESCRIPTION
Backport for 8307346

This would be clean, except 8280450 adds some inconsequential code immediately after the hunks in g1 and parallel for reporting task queue stats, which causes a trivial conflict.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307346](https://bugs.openjdk.org/browse/JDK-8307346): Add missing gc+phases logging for ObjectCount(AfterGC) JFR event collection code


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1344/head:pull/1344` \
`$ git checkout pull/1344`

Update a local copy of the PR: \
`$ git checkout pull/1344` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1344`

View PR using the GUI difftool: \
`$ git pr show -t 1344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1344.diff">https://git.openjdk.org/jdk17u-dev/pull/1344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1344#issuecomment-1548069762)