### PR TITLE
8306489: Open source AWT List related tests

### DIFF
--- a/test/jdk/java/awt/List/ISCAfterRemoveAllTest.java
+++ b/test/jdk/java/awt/List/ISCAfterRemoveAllTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6291736
+  @summary ITEM_STATE_CHANGED triggered after List.removeAll(), XToolkit
+  @key headful
+  @run main ISCAfterRemoveAllTest
+*/
+
+import java.awt.AWTException;
+import java.awt.FlowLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.InputEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+
+public class ISCAfterRemoveAllTest implements ItemListener {
+    List list;
+    Frame frame;
+    volatile boolean passed = true;
+
+    public static void main(String[] args) throws Exception {
+        ISCAfterRemoveAllTest test = new ISCAfterRemoveAllTest();
+        test.start();
+    }
+
+    public void start () throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                list = new List(4, false);
+                frame = new Frame("ISCAfterRemoveAllTest");
+                list.add("000");
+                list.add("111");
+                list.add("222");
+                list.add("333");
+                list.add("444");
+                list.add("555");
+                list.add("666");
+                list.add("777");
+                list.add("888");
+                list.add("999");
+
+                frame.add(list);
+                frame.setLayout(new FlowLayout());
+                frame.setSize(300, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private void test() throws Exception {
+        Robot r = new Robot();
+        r.delay(1000);
+        r.waitForIdle();
+        EventQueue.invokeAndWait(() -> {
+            Point loc = list.getLocationOnScreen();
+            r.mouseMove(loc.x + list.getWidth() / 2, loc.y + list.getHeight() / 2);
+        });
+        r.delay(100);
+        r.mousePress(InputEvent.BUTTON1_MASK);
+        r.delay(10);
+        r.mouseRelease(InputEvent.BUTTON1_MASK);
+        r.delay(100);
+
+        EventQueue.invokeAndWait(() -> {
+            list.removeAll();
+
+            // The interesting events are generated after removing
+            list.addItemListener(this);
+            r.delay(100);
+
+            list.requestFocusInWindow();
+            r.delay(100);
+            if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != list) {
+                throw new RuntimeException("Test failed - list isn't focus owner.");
+            }
+        });
+
+        r.delay(10);
+        r.keyPress(KeyEvent.VK_UP);
+        r.delay(10);
+        r.keyRelease(KeyEvent.VK_UP);
+        r.delay(100);
+
+        // This is the test case for the 6299853 issue
+        r.delay(10);
+        r.keyPress(KeyEvent.VK_SPACE);
+        r.delay(10);
+        r.keyRelease(KeyEvent.VK_SPACE);
+        r.delay(100);
+
+        r.waitForIdle();
+
+        if (!passed) {
+            throw new RuntimeException("Test failed.");
+        }
+    }
+
+    public void itemStateChanged(ItemEvent ie) {
+        System.out.println(ie);
+        // We shouldn't generate any events since the list is empty
+        passed = false;
+    }
+
+}

--- a/test/jdk/java/awt/List/InstanceOfSelectedArray.java
+++ b/test/jdk/java/awt/List/InstanceOfSelectedArray.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4322321
+  @summary tests that List.getSelectedIndexes() doesn't return reference to internal array
+  @key headful
+  @run main InstanceOfSelectedArray
+*/
+
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+
+public class InstanceOfSelectedArray {
+     List testList;
+     Frame frame;
+     int[] selected;
+
+     public static void main(String[] args) throws Exception {
+         InstanceOfSelectedArray test = new InstanceOfSelectedArray();
+         test.start();
+     }
+
+     public void start () throws Exception {
+         try {
+             EventQueue.invokeAndWait(() -> {
+                 testList = new List();
+                 frame = new Frame("InstanceOfSelectedArrayTest");
+                 testList.addItem("First");
+                 testList.addItem("Second");
+                 testList.addItem("Third");
+
+                 frame.add(testList);
+                 frame.setLayout(new FlowLayout());
+                 frame.setSize(300, 200);
+                 frame.setLocationRelativeTo(null);
+                 frame.setVisible(true);
+
+                 testList.select(2);
+
+                 selected = testList.getSelectedIndexes();
+                 selected[0] = 0;
+                 selected = testList.getSelectedIndexes();
+
+                 if (selected[0] == 0) {
+                     System.out.println("List returned the reference to internal array.");
+                     System.out.println("Test FAILED");
+                     throw new RuntimeException("Test FAILED");
+                 }
+             });
+
+             System.out.println("List returned a clone of its internal array.");
+             System.out.println("Test PASSED");
+         } finally {
+             EventQueue.invokeAndWait(() -> {
+                 if (frame != null) {
+                     frame.dispose();
+                 }
+             });
+         }
+     }
+}

--- a/test/jdk/java/awt/List/ListEnterExitTest.java
+++ b/test/jdk/java/awt/List/ListEnterExitTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4274839 4281703
+  @summary tests that List receives mouse enter/exit events properly
+  @key headful
+  @run main ListEnterExitTest
+*/
+
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class ListEnterExitTest {
+    final List list = new List();
+    final MouseEnterExitListener mouseEnterExitListener = new MouseEnterExitListener();
+    Frame frame;
+    volatile Point p;
+
+    public static void main(String[] args) throws Exception {
+        ListEnterExitTest test = new ListEnterExitTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("ListEnterExitTest");
+                list.add("Item 1");
+                list.add("Item 2");
+                list.addMouseListener(mouseEnterExitListener);
+                frame.add(list);
+                frame.setLayout(new FlowLayout());
+                frame.setSize(300, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+            final Robot robot = new Robot();
+            robot.delay(1000);
+            robot.waitForIdle();
+
+            EventQueue.invokeAndWait(() -> {
+                p = list.getLocationOnScreen();
+            });
+            robot.mouseMove(p.x + 10, p.y + 10);
+            robot.delay(100);
+            robot.waitForIdle();
+            robot.mouseMove(p.x - 10, p.y - 10);
+            robot.delay(100);
+            robot.waitForIdle();
+            robot.mouseMove(p.x + 10, p.y + 10);
+
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+
+            synchronized (mouseEnterExitListener) {
+                mouseEnterExitListener.wait(2000);
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+        if (!mouseEnterExitListener.isPassed()) {
+            throw new RuntimeException("Haven't receive mouse enter/exit events");
+        }
+
+    }
+
+}
+
+class MouseEnterExitListener extends MouseAdapter {
+
+    volatile boolean passed_1 = false;
+    volatile boolean passed_2 = false;
+
+    public void mouseEntered(MouseEvent e) {
+        passed_1 = true;
+    }
+
+    public void mouseExited(MouseEvent e) {
+        passed_2 = true;
+    }
+
+    public void mousePressed(MouseEvent e) {
+        synchronized (this) {
+            System.out.println("mouse pressed");
+            this.notifyAll();
+        }
+    }
+
+    public boolean isPassed() {
+        return passed_1 & passed_2;
+    }
+}

--- a/test/jdk/java/awt/List/ListNullTest.java
+++ b/test/jdk/java/awt/List/ListNullTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4195583
+  @summary Tests List.add(String item) to make sure an NPE is not thrown
+                 when item == null
+  @key headful
+  @run main ListNullTest
+*/
+
+import java.awt.FlowLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Robot;
+
+public class ListNullTest {
+   List list;
+   Frame frame;
+
+   public static void main(String[] args) throws Exception {
+      ListNullTest test = new ListNullTest();
+      test.start();
+   }
+
+   public void start () throws Exception {
+      try {
+         EventQueue.invokeAndWait(() -> {
+            list = new List(15);
+            frame = new Frame("ListNullTest");
+            frame.add(list);
+            frame.setLayout(new FlowLayout());
+            frame.setSize(200, 200);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+            list.add("", 0);
+            list.add((String) null, 1);
+         });
+      } finally {
+         EventQueue.invokeAndWait(() -> {
+            if (frame != null) {
+               frame.dispose();
+            }
+         });
+      }
+   }
+}

--- a/test/jdk/java/awt/List/MaxWidthTest.java
+++ b/test/jdk/java/awt/List/MaxWidthTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6373369
+  @summary Bug in WListPeer.getMaxWidth(), checks that the preferred width
+  of the list is calculated correctly
+  @requires (os.family == "windows")
+  @key headful
+  @run main MaxWidthTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.FontMetrics;
+import java.awt.List;
+import java.awt.TextArea;
+import java.awt.Toolkit;
+
+public class MaxWidthTest {
+    static Frame frame;
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("MaxWidthTest");
+                frame.setLayout(new BorderLayout());
+                List list = new List();
+                list.add("Very very very long string - the actual width more than the minimum width !!!");
+                frame.add(BorderLayout.WEST, list);
+                frame.add(BorderLayout.CENTER, new TextArea());
+
+                frame.setBounds(200, 200, 200, 200);
+                frame.pack();
+                frame.setVisible(true);
+
+                // as WListPeer.minimumSize() - just predefined value
+                FontMetrics fm = frame.getFontMetrics(list.getFont());
+                int minimum = 20 + fm.stringWidth("0123456789abcde");
+
+                // as WListPeer.preferredSize() - equals to Max.max(minimum,getMaxWidth()+20)
+                // getMaxWidth() returns the actual size of the list
+                int preferred = list.getPreferredSize().width;
+
+                System.out.println(preferred + "," + minimum);
+                if (preferred <= minimum) {
+                    throw new RuntimeException("Test failed because the actual width more than the minimum width.");
+                }
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/List/PageUPSelectsItemsTest.java
+++ b/test/jdk/java/awt/List/PageUPSelectsItemsTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6190768
+  @summary Tests that pressing pg-up / pg-down on AWT list doesn't selects the items, on XToolkit
+  @key headful
+  @run main PageUPSelectsItemsTest
+*/
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Label;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class PageUPSelectsItemsTest implements FocusListener, KeyListener {
+
+    List list = new List(6, true);
+    Label label = new Label("for focus");
+
+    Frame frame;
+
+    final Object LOCK = new Object();
+    final int ACTION_TIMEOUT = 500;
+
+    public static void main(String[] args) throws Exception {
+        PageUPSelectsItemsTest test = new PageUPSelectsItemsTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                list.add("0");
+                list.add("1");
+                list.add("2");
+                list.add("3");
+                list.add("4");
+                list.add("5");
+                list.add("6");
+                list.add("7");
+                list.add("8");
+                list.add("9");
+                list.add("10");
+                list.add("11");
+                list.add("12");
+
+                list.select(8);
+
+                list.addFocusListener(this);
+                list.addKeyListener(this);
+                frame = new Frame("PageUPSelectsItemsTest");
+                frame.setLayout(new BorderLayout());
+                frame.add(BorderLayout.SOUTH, list);
+                frame.add(BorderLayout.CENTER, label);
+                frame.setSize(300, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private void test() throws Exception {
+        synchronized (LOCK) {
+
+            Robot r = new Robot();
+            r.delay(500);
+
+            Point loc = label.getLocationOnScreen();
+            r.mouseMove(loc.x + (int) (label.getWidth() / 2), loc.y + (int) (label.getHeight() / 2));
+            r.mousePress(InputEvent.BUTTON1_MASK);
+            r.delay(10);
+            r.mouseRelease(InputEvent.BUTTON1_MASK);
+            r.delay(500);
+
+            list.requestFocusInWindow();
+            LOCK.wait(ACTION_TIMEOUT);
+            if (KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner() != list) {
+                throw new RuntimeException("Test failed - list isn't focus owner.");
+            }
+
+            r.delay(10);
+            loc = list.getLocationOnScreen();
+
+            r.delay(50);
+            r.keyPress(KeyEvent.VK_PAGE_UP);
+            r.delay(50);
+            r.keyRelease(KeyEvent.VK_PAGE_UP);
+            r.delay(50);
+
+            r.keyPress(KeyEvent.VK_PAGE_DOWN);
+            r.delay(50);
+            r.keyRelease(KeyEvent.VK_PAGE_DOWN);
+            r.delay(50);
+
+            r.waitForIdle();
+            EventQueue.invokeAndWait(new Runnable() {
+                public void run() {
+                    System.out.println("Dummy block");
+                }
+            });
+
+            System.err.println("Selected objects: " + list.getSelectedItems().length);
+
+            if (list.getSelectedItems().length > 1) {
+                throw new RuntimeException("Test failed");
+            }
+        }
+    }
+
+    public void focusGained(FocusEvent e) {
+
+        synchronized (LOCK) {
+            LOCK.notifyAll();
+        }
+
+    }
+
+    public void focusLost(FocusEvent e) {
+    }
+
+    public void keyPressed(KeyEvent e){
+        System.out.println("keyPressed-"+e);
+    }
+
+    public void keyReleased(KeyEvent e){
+        System.out.println("keyReleased-"+e);
+    }
+
+    public void keyTyped(KeyEvent e){
+        System.out.println("keyTyped-"+e);
+    }
+}

--- a/test/jdk/java/awt/List/TriggerActionEventTest.java
+++ b/test/jdk/java/awt/List/TriggerActionEventTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6190746
+  @summary Tests that list trigger ActionEvent when double clicking a programmatically selected item, XToolkit
+  @key headful
+  @run main TriggerActionEventTest
+*/
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Robot;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class TriggerActionEventTest implements ActionListener {
+    final Object LOCK = new Object();
+    final int ACTION_TIMEOUT = 1000;
+
+    List list;
+    Frame frame;
+    volatile Point loc;
+    private volatile boolean passed = false;
+
+    public static void main(String[] args) throws Exception {
+        TriggerActionEventTest TrgrActnEvntTest = new TriggerActionEventTest();
+        TrgrActnEvntTest.test(new TestState(0));
+        TrgrActnEvntTest.test(new TestState(3));
+    }
+
+    private void test(TestState currentState) throws Exception {
+
+        synchronized (LOCK) {
+            System.out.println("begin test for: " + currentState);
+
+            EventQueue.invokeAndWait(() -> {
+                list = new List();
+
+                list.clear();
+                list.add("0");
+                list.add("1");
+                list.add("2");
+                list.add("3");
+                list.addActionListener(this);
+
+                int index = currentState.getSelectedIndex();
+
+                list.select(index);
+
+                frame = new Frame("TriggerActionEventTest");
+                frame.setLayout(new BorderLayout());
+                frame.add(BorderLayout.SOUTH, list);
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+
+            Robot r = new Robot();
+            r.delay(500);
+            EventQueue.invokeAndWait(() -> {
+                loc = list.getLocationOnScreen();
+            });
+
+            r.mouseMove(loc.x + 10, loc.y + 10);
+            r.mousePress(InputEvent.BUTTON1_MASK);
+            r.delay(10);
+            r.mouseRelease(InputEvent.BUTTON1_MASK);
+            r.mousePress(InputEvent.BUTTON1_MASK);
+            r.delay(10);
+            r.mouseRelease(InputEvent.BUTTON1_MASK);
+            r.delay(10);
+
+
+            LOCK.wait(ACTION_TIMEOUT);
+
+            System.out.println(currentState);
+            if (!passed) {
+                throw new RuntimeException("Test failed");
+            }
+            this.passed = false;
+
+            EventQueue.invokeAndWait(() -> {
+                list.removeActionListener(this);
+                frame.remove(list);
+                frame.setVisible(false);
+            });
+
+        }
+    }
+
+    public void actionPerformed (ActionEvent ae) {
+        synchronized (LOCK) {
+            System.out.println(ae);
+            passed = true;
+            LOCK.notifyAll();
+        }
+    }
+
+}
+
+class TestState {
+    private final int selectedIndex;
+
+    public TestState(int selectedIndex) {
+        this.selectedIndex = selectedIndex;
+    }
+
+    public int getSelectedIndex() {
+        return selectedIndex;
+    }
+
+    public String toString() {
+        return ""+selectedIndex;
+    }
+
+}


### PR DESCRIPTION
Backport of https://github.com/openjdk/jdk/commit/82a8e91ef7c3b397f9cce3854722cfe4bace6f2e
https://bugs.openjdk.org/browse/JDK-8306489 Open source AWT List related tests

Clean backport, new tests
Tested on macOS x64 and linux x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306489](https://bugs.openjdk.org/browse/JDK-8306489): Open source AWT List related tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1350/head:pull/1350` \
`$ git checkout pull/1350`

Update a local copy of the PR: \
`$ git checkout pull/1350` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1350`

View PR using the GUI difftool: \
`$ git pr show -t 1350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1350.diff">https://git.openjdk.org/jdk17u-dev/pull/1350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1350#issuecomment-1550477207)