### PR TITLE
8307130: Open source few Swing JMenu tests

### DIFF
--- a/test/jdk/javax/swing/JMenu/bug4173633.java
+++ b/test/jdk/javax/swing/JMenu/bug4173633.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+  @test
+  @bug 4173633
+  @summary Test for infinite recursion when JMenu with separator
+  @run main bug4173633
+*/
+
+import javax.swing.JMenu;
+
+public class bug4173633 {
+    public static void main(String[] args) {
+        JMenu m = new JMenu("bug4173633");
+        m.addSeparator();
+        if (m.getItem(0) == m) {
+            throw new RuntimeException("BUG 4173633 FAILED");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4186641.java
+++ b/test/jdk/javax/swing/JMenu/bug4186641.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4186641 4242461
+  @summary JMenu.getPopupMenuOrigin() protected (not privet) now.
+  @key headful
+  @run main bug4186641
+*/
+
+import java.awt.Point;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+
+
+public class bug4186641 {
+
+    volatile static JFrame fr;
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            init();
+            if (fr != null) {
+                fr.dispose();
+            }
+        });
+    }
+
+    public static void init() {
+        class TestJMenu extends JMenu {
+            public TestJMenu() {
+                super("Test");
+            }
+
+            void test() {
+                Point testpoint = getPopupMenuOrigin();
+            }
+        }
+
+        TestJMenu mnu = new TestJMenu();
+        fr = new JFrame("bug4186641");
+        JMenuBar mb = new JMenuBar();
+        fr.setJMenuBar(mb);
+        mb.add(mnu);
+        JMenuItem mi = new JMenuItem("test");
+        mnu.add(mi);
+        fr.setSize(100,100);
+        fr.setVisible(true);
+        mnu.setVisible(true);
+
+        mnu.test();
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4219523.java
+++ b/test/jdk/javax/swing/JMenu/bug4219523.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4219523
+  @summary Tests if JMenu completely uninstalls UI
+  @run main bug4219523
+*/
+
+import java.awt.Insets;
+
+import javax.swing.JMenuItem;
+import javax.swing.plaf.basic.BasicMenuItemUI;
+
+
+public class bug4219523 {
+    public static void main(String args[]) {
+        class TestMenuItem extends JMenuItem {
+            public int SetMarginCalls;
+            TestMenuItem(){
+                super();
+                SetMarginCalls = 0;
+            }
+            public void setMargin(Insets m){
+                if (m == null) SetMarginCalls++;
+                super.setMargin(m);
+            }
+        }
+        BasicMenuItemUI bmiui = new BasicMenuItemUI();
+        TestMenuItem mi = new TestMenuItem();
+        bmiui.installUI(mi);
+        int installCall = mi.SetMarginCalls;
+        bmiui.uninstallUI(mi);
+        if (mi.SetMarginCalls <= installCall) {
+            throw new Error("Test failed: Uninstall UI does " +
+                    "not uninstall DefaultMargin properties");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug5013739.java
+++ b/test/jdk/javax/swing/JMenu/bug5013739.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5013739
+  @summary MNEMONIC CONFLICTS IN DISABLED/HIDDEN MENU ITEMS
+  @library ../regtesthelpers
+  @build JRobot
+  @key headful
+  @run main bug5013739
+*/
+
+import java.awt.Component;
+import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.AbstractAction;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+
+public class bug5013739 {
+
+    static boolean passed = true;
+    static JFrame mainFrame;
+    static JMenu file;
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            mainFrame = new JFrame("Bug5013739");
+            JMenuBar mb = new JMenuBar();
+            mainFrame.setJMenuBar(mb);
+            file = new JMenu("File");
+            JMenuItem about = new JMenuItem("About");
+            about.setMnemonic('A');
+            about.addActionListener(new AbstractAction() {
+                public void actionPerformed(ActionEvent evt) {
+                    passed = false;
+                }
+            });
+            file.add(about);
+            about.setVisible(false);
+            file.add("Open");
+            file.add("Close");
+            file.setMnemonic('F');
+            mb.add(file);
+            mainFrame.pack();
+            mainFrame.setVisible(true);
+            Util.blockTillDisplayed(mainFrame);
+        });
+
+        try {
+            JRobot robo = JRobot.getRobot();
+            robo.delay(500);
+            robo.clickMouseOn(file);
+            robo.hitKey(KeyEvent.VK_A);
+            robo.delay(1000);
+        } finally {
+            if (mainFrame != null) {
+                SwingUtilities.invokeAndWait(() -> mainFrame.dispose());
+            }
+        }
+        if (!passed) {
+            throw new RuntimeException("Hidden menu item is selectable "+
+                    "via mnemonic. Test failed.");
+        }
+    }
+}
+
+class Util {
+    public static Point blockTillDisplayed(Component comp) {
+        Point p = null;
+        while (p == null) {
+            try {
+                p = comp.getLocationOnScreen();
+            } catch (IllegalStateException e) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ie) {
+                }
+            }
+        }
+        return p;
+    }
+}


### PR DESCRIPTION
Backport https://github.com/openjdk/jdk/commit/d9052b946682d1c0f2629455d73fe4e6b95b29db
https://bugs.openjdk.org/browse/JDK-8307130 Open source few Swing JMenu tests

Clean backport, new tests, low risk
Checked on macOS x64, linux x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307130](https://bugs.openjdk.org/browse/JDK-8307130): Open source few Swing JMenu tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1356/head:pull/1356` \
`$ git checkout pull/1356`

Update a local copy of the PR: \
`$ git checkout pull/1356` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1356`

View PR using the GUI difftool: \
`$ git pr show -t 1356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1356.diff">https://git.openjdk.org/jdk17u-dev/pull/1356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1356#issuecomment-1550495547)