### PR TITLE
Rudometov backport 98294242a94c611e2a713c2d520e59dd873ae4a0

### DIFF
--- a/test/jdk/java/awt/dnd/MouseExitGestureTriggerTest.java
+++ b/test/jdk/java/awt/dnd/MouseExitGestureTriggerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTree;
+import java.awt.EventQueue;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.event.InputEvent;
+
+/*
+  @test
+  @bug 4273712 4396746
+  @summary tests that mouse exit event doesn't trigger drag
+  @key headful
+  @run main MouseExitGestureTriggerTest
+*/
+
+public class MouseExitGestureTriggerTest {
+
+    boolean recognized = false;
+    volatile JFrame frame;
+    volatile JPanel panel;
+    volatile JTree tree;
+    volatile DragSource dragSource;
+    volatile Point srcPoint;
+    volatile Rectangle r;
+    volatile DragGestureListener dgl;
+    static final int FRAME_ACTIVATION_TIMEOUT = 2000;
+    static final int RECOGNITION_TIMEOUT = 1000;
+
+    public static void main(String[] args) throws Exception {
+        MouseExitGestureTriggerTest test = new MouseExitGestureTriggerTest();
+        EventQueue.invokeAndWait(test::init);
+        try {
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (test.frame != null) {
+                    test.frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        frame = new JFrame("MouseExitGestureTriggerTest");
+        panel = new JPanel();
+        tree = new JTree();
+
+        dragSource = DragSource.getDefaultDragSource();
+        dgl = new DragGestureListener() {
+            public void dragGestureRecognized(DragGestureEvent dge) {
+                Thread.dumpStack();
+                recognized = true;
+            }
+        };
+
+        tree.setEditable(true);
+        dragSource.createDefaultDragGestureRecognizer(tree,
+                                                      DnDConstants.ACTION_MOVE,
+                                                      dgl);
+        panel.add(tree);
+        frame.getContentPane().add(panel);
+        frame.setLocation(200, 200);
+
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public void start() throws Exception {
+        final Robot robot = new Robot();
+        Thread.sleep(FRAME_ACTIVATION_TIMEOUT);
+
+        clickRootNode(robot);
+        clickRootNode(robot);
+        clickRootNode(robot);
+
+        Thread.sleep(RECOGNITION_TIMEOUT);
+
+        EventQueue.invokeAndWait(() -> {
+            if (recognized) {
+                throw new RuntimeException("Mouse exit event triggered drag");
+            }
+        });
+    }
+
+    void clickRootNode(final Robot robot) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            srcPoint = tree.getLocationOnScreen();
+            r = tree.getRowBounds(0);
+        });
+        srcPoint.translate(r.x + 2 * r.width /3 , r.y + r.height / 2);
+        robot.mouseMove(srcPoint.x ,srcPoint.y);
+
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        Thread.sleep(10);
+        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        Thread.sleep(10);
+    }
+}

--- a/test/jdk/java/awt/dnd/MozillaDnDTest.java
+++ b/test/jdk/java/awt/dnd/MozillaDnDTest.java
@@ -64,7 +64,7 @@ import java.io.Reader;
   @test
   @bug 4746177
   @summary tests that data types exported by Netscape 6.2 are supported
-  @requires(os != "windows")
+  @requires (os.family != "windows")
   @key headful
   @run main MozillaDnDTest
 */

--- a/test/jdk/java/awt/dnd/MozillaDnDTest.java
+++ b/test/jdk/java/awt/dnd/MozillaDnDTest.java
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.SystemFlavorMap;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragGestureRecognizer;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.AWTEventListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+/*
+  @test
+  @bug 4746177
+  @summary tests that data types exported by Netscape 6.2 are supported
+  @requires(os != "windows")
+  @key headful
+  @run main MozillaDnDTest
+*/
+
+public class MozillaDnDTest {
+
+    public static final int CODE_NOT_RETURNED = -1;
+    public static final int CODE_OK = 0;
+    public static final int CODE_FAILURE = 1;
+    public static final String DATA = "www.sun.com";
+
+    private int returnCode = CODE_NOT_RETURNED;
+
+    volatile Frame frame;
+    volatile Robot robot;
+    volatile Panel panel;
+    volatile Point p;
+    volatile Dimension d;
+
+    public static void main(String[] args) throws Exception {
+        MozillaDnDTest test = new MozillaDnDTest();
+        if (args.length > 0) {
+            test.run(args);
+        } else {
+            EventQueue.invokeAndWait(test::init);
+            try {
+                test.start();
+            } finally {
+                EventQueue.invokeAndWait(() -> {
+                    if (test.frame != null) {
+                        test.frame.dispose();
+                    }
+                });
+            }
+        }
+    }
+
+    public void run(String[] args) {
+        try {
+            if (args.length != 4) {
+                throw new RuntimeException("Incorrect command line arguments.");
+            }
+
+            int x = Integer.parseInt(args[0]);
+            int y = Integer.parseInt(args[1]);
+            int w = Integer.parseInt(args[2]);
+            int h = Integer.parseInt(args[3]);
+
+            panel = new DragSourcePanel();
+            frame = new Frame();
+
+            frame.setTitle("DragSource frame");
+            frame.setLocation(300, 200);
+            frame.add(panel);
+            frame.pack();
+            frame.setVisible(true);
+
+            Util.waitForInit();
+
+            Point sourcePoint = panel.getLocationOnScreen();
+            Dimension d = panel.getSize();
+            sourcePoint.translate(d.width / 2, d.height / 2);
+
+            Point targetPoint = new Point(x + w / 2, y + h / 2);
+
+            robot = new Robot();
+
+            if (!Util.pointInComponent(robot, sourcePoint, panel)) {
+                System.err.println("WARNING: Couldn't locate " + panel +
+                                   " at point " + sourcePoint);
+                System.exit(MozillaDnDTest.CODE_OK);
+            }
+
+            robot.mouseMove(sourcePoint.x, sourcePoint.y);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            for (; !sourcePoint.equals(targetPoint);
+                 sourcePoint.translate(sign(targetPoint.x - sourcePoint.x),
+                                       sign(targetPoint.y - sourcePoint.y))) {
+                robot.mouseMove(sourcePoint.x, sourcePoint.y);
+                Thread.sleep(50);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+            System.exit(MozillaDnDTest.CODE_FAILURE);
+        }
+    }
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+
+    public void init() {
+        frame = new Frame();
+        panel = new DropTargetPanel();
+
+        frame.setTitle("DropTarget frame");
+        frame.setLocation(10, 200);
+        frame.add(panel);
+
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public void start() {
+        // Solaris/Linux-only test
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            return;
+        }
+        try {
+            Util.waitForInit();
+            EventQueue.invokeAndWait(() -> {
+                p = panel.getLocationOnScreen();
+                d = panel.getSize();
+            });
+
+            Robot robot = new Robot();
+            Point pp = new Point(p);
+            pp.translate(d.width / 2, d.height / 2);
+            if (!Util.pointInComponent(robot, pp, panel)) {
+                System.err.println("WARNING: Couldn't locate " + panel +
+                                   " at point " + pp);
+                return;
+            }
+
+            String javaPath = System.getProperty("java.home", "");
+            String command = javaPath + File.separator + "bin" +
+                File.separator + "java -cp " + System.getProperty("test.classes", ".") +
+                " MozillaDnDTest " +
+                p.x + " " + p.y + " " + d.width + " " + d.height;
+
+            Process process = Runtime.getRuntime().exec(command);
+            ProcessResults pres = ProcessResults.doWaitFor(process);
+            returnCode = pres.exitValue;
+
+            if (pres.stderr != null && pres.stderr.length() > 0) {
+                System.err.println("========= Child VM System.err ========");
+                System.err.print(pres.stderr);
+                System.err.println("======================================");
+            }
+
+            if (pres.stdout != null && pres.stdout.length() > 0) {
+                System.err.println("========= Child VM System.out ========");
+                System.err.print(pres.stdout);
+                System.err.println("======================================");
+            }
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+        switch (returnCode) {
+        case CODE_NOT_RETURNED:
+            System.err.println("Child VM: failed to start");
+            break;
+        case CODE_OK:
+            System.err.println("Child VM: normal termination");
+            break;
+        case CODE_FAILURE:
+            System.err.println("Child VM: abnormal termination");
+            break;
+        }
+        if (returnCode != CODE_OK) {
+            throw new RuntimeException("The test failed.");
+        }
+    }
+}
+
+class Util implements AWTEventListener {
+    private static final Toolkit tk = Toolkit.getDefaultToolkit();
+    public static final Object SYNC_LOCK = new Object();
+    private Component clickedComponent = null;
+    private static final int PAINT_TIMEOUT = 10000;
+    private static final int MOUSE_RELEASE_TIMEOUT = 10000;
+    private static final Util util = new Util();
+
+    static {
+        tk.addAWTEventListener(util, 0xFFFFFFFF);
+    }
+
+    private void reset() {
+        clickedComponent = null;
+    }
+
+    public void eventDispatched(AWTEvent e) {
+        if (e.getID() == MouseEvent.MOUSE_RELEASED) {
+            clickedComponent = (Component)e.getSource();
+            synchronized (SYNC_LOCK) {
+                SYNC_LOCK.notifyAll();
+            }
+        }
+    }
+
+    public static boolean pointInComponent(Robot robot, Point p, Component comp)
+      throws InterruptedException {
+        return util.isPointInComponent(robot, p, comp);
+    }
+
+    private boolean isPointInComponent(Robot robot, Point p, Component comp)
+      throws InterruptedException {
+        tk.sync();
+        robot.waitForIdle();
+        reset();
+        robot.mouseMove(p.x, p.y);
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        synchronized (SYNC_LOCK) {
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            SYNC_LOCK.wait(MOUSE_RELEASE_TIMEOUT);
+        }
+
+        Component c = clickedComponent;
+
+        while (c != null && c != comp) {
+            c = c.getParent();
+        }
+
+        return c == comp;
+    }
+
+    public static void waitForInit() throws InterruptedException {
+        final Frame f = new Frame() {
+                public void paint(Graphics g) {
+                    dispose();
+                    synchronized (SYNC_LOCK) {
+                        SYNC_LOCK.notifyAll();
+                    }
+                }
+            };
+        f.setBounds(600, 400, 200, 200);
+        synchronized (SYNC_LOCK) {
+            f.setVisible(true);
+            SYNC_LOCK.wait(PAINT_TIMEOUT);
+        }
+        tk.sync();
+    }
+}
+
+class ProcessResults {
+    public int exitValue;
+    public String stdout;
+    public String stderr;
+
+    public ProcessResults() {
+        exitValue = -1;
+        stdout = "";
+        stderr = "";
+    }
+
+    /**
+     * Method to perform a "wait" for a process and return its exit value.
+     * This is a workaround for <code>Process.waitFor()</code> never returning.
+     */
+    public static ProcessResults doWaitFor(Process p) {
+        ProcessResults pres = new ProcessResults();
+
+        InputStream in = null;
+        InputStream err = null;
+
+        try {
+            in = p.getInputStream();
+            err = p.getErrorStream();
+
+            boolean finished = false;
+
+            while (!finished) {
+                try {
+                    while (in.available() > 0) {
+                        pres.stdout += (char)in.read();
+                    }
+                    while (err.available() > 0) {
+                        pres.stderr += (char)err.read();
+                    }
+                    // Ask the process for its exitValue. If the process
+                    // is not finished, an IllegalThreadStateException
+                    // is thrown. If it is finished, we fall through and
+                    // the variable finished is set to true.
+                    pres.exitValue = p.exitValue();
+                    finished = true;
+                }
+                catch (IllegalThreadStateException e) {
+                    // Process is not finished yet;
+                    // Sleep a little to save on CPU cycles
+                    Thread.currentThread().sleep(500);
+                }
+            }
+            if (in != null) in.close();
+            if (err != null) err.close();
+        }
+        catch (Throwable e) {
+            System.err.println("doWaitFor(): unexpected exception");
+            e.printStackTrace();
+        }
+        return pres;
+    }
+}
+
+class DragSourcePanel extends Panel {
+    static final Dimension preferredDimension = new Dimension(200, 200);
+    static final DataFlavor df = new DataFlavor("application/mozilla-test-flavor",
+                                                null);
+    final DragSource ds = DragSource.getDefaultDragSource();
+    final Transferable t = new Transferable() {
+            final DataFlavor[] flavors = new DataFlavor[] { df };
+            public DataFlavor[] getTransferDataFlavors() {
+                return flavors;
+            }
+            public boolean isDataFlavorSupported(DataFlavor flav) {
+                return df.equals(flav);
+            }
+            public Object getTransferData(DataFlavor flav)
+              throws IOException, UnsupportedFlavorException {
+                if (!isDataFlavorSupported(flav)) {
+                    throw new UnsupportedFlavorException(flav);
+                }
+                byte[] bytes = MozillaDnDTest.DATA.getBytes("ASCII");
+                return new ByteArrayInputStream(bytes);
+            }
+        };
+    final DragSourceListener dsl = new DragSourceAdapter() {
+            public void dragDropEnd(DragSourceDropEvent dsde) {
+                System.exit(MozillaDnDTest.CODE_OK);
+            }
+        };
+    final DragGestureListener dgl = new DragGestureListener() {
+            public void dragGestureRecognized(DragGestureEvent dge) {
+                dge.startDrag(null, t, dsl);
+            }
+        };
+    final DragGestureRecognizer dgr =
+        ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY,
+                                              dgl);
+    static {
+        SystemFlavorMap sfm =
+            (SystemFlavorMap)SystemFlavorMap.getDefaultFlavorMap();
+        String[] natives = new String[] {
+            "_NETSCAPE_URL",
+            "text/plain",
+            "text/unicode",
+            "text/x-moz-url",
+            "text/html"
+        };
+        sfm.setNativesForFlavor(df, natives);
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+}
+
+class DropTargetPanel extends Panel implements DropTargetListener {
+
+    final Dimension preferredDimension = new Dimension(200, 200);
+    final DropTarget dt = new DropTarget(this, this);
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {
+        dtde.acceptDrag(DnDConstants.ACTION_COPY);
+    }
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {
+        dtde.acceptDrag(DnDConstants.ACTION_COPY);
+    }
+
+    public String getTransferString(Transferable t) {
+        String string = null;
+        DataFlavor[] dfs = t.getTransferDataFlavors();
+        for (int i = 0; i < dfs.length; i++) {
+            if ("text".equals(dfs[i].getPrimaryType()) ||
+                DataFlavor.stringFlavor.equals(dfs[i])) {
+                try {
+                    Object o = t.getTransferData(dfs[i]);
+                    if (o instanceof InputStream ||
+                        o instanceof Reader) {
+                        Reader reader = null;
+                        if (o instanceof InputStream) {
+                            InputStream is = (InputStream)o;
+                            reader = new InputStreamReader(is);
+                        } else {
+                            reader = (Reader)o;
+                        }
+                        StringBuffer buf = new StringBuffer();
+                        for (int c = reader.read(); c != -1; c = reader.read()) {
+                            buf.append((char)c);
+                        }
+                        reader.close();
+                        string = buf.toString();
+                        break;
+                    } else if (o instanceof String) {
+                        string = (String)o;
+                        break;
+                    }
+                } catch (Exception e) {
+                    // ignore.
+                }
+            }
+        }
+        return string;
+     }
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+            return;
+        }
+
+        Transferable t = dtde.getTransferable();
+        String str = getTransferString(t);
+        dtde.dropComplete(true);
+
+        if (!MozillaDnDTest.DATA.equals(str)) {
+            throw new RuntimeException("Drop data:" + str);
+        }
+    }
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+}

--- a/test/jdk/java/awt/dnd/MultiDataFlavorDropTest.java
+++ b/test/jdk/java/awt/dnd/MultiDataFlavorDropTest.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.io.InputStream;
+import java.io.Serializable;
+
+/*
+  @test
+  @bug 4399700
+  @summary tests that drop transfer data can be requested in several data flavors.
+  @key headful
+  @run main MultiDataFlavorDropTest
+*/
+
+public class MultiDataFlavorDropTest {
+
+    public static final int CODE_NOT_RETURNED = -1;
+    public static final int CODE_OK = 0;
+    public static final int CODE_FAILURE = 1;
+    public static final int FRAME_ACTIVATION_TIMEOUT = 2000;
+    public static final int DROP_TIMEOUT = 10000;
+    public static final int DROP_COMPLETION_TIMEOUT = 1000;
+
+    private int returnCode = CODE_NOT_RETURNED;
+
+    volatile Frame frame;
+    volatile Robot robot;
+    volatile Panel panel;
+    volatile Point p;
+    volatile Dimension d;
+
+    public static void main(String[] args) throws Exception {
+        MultiDataFlavorDropTest test = new MultiDataFlavorDropTest();
+        if (args.length > 0) {
+            test.run(args);
+        } else {
+            EventQueue.invokeAndWait(test::init);
+            try {
+                test.start();
+            } finally {
+                EventQueue.invokeAndWait(() -> {
+                    if (test.frame != null) {
+                        test.frame.dispose();
+                    }
+                });
+            }
+        }
+    }
+
+    public void run(String[] args) {
+        try {
+            if (args.length != 4) {
+                throw new RuntimeException("Incorrect command line arguments.");
+            }
+
+            int x = Integer.parseInt(args[0]);
+            int y = Integer.parseInt(args[1]);
+            int w = Integer.parseInt(args[2]);
+            int h = Integer.parseInt(args[3]);
+
+            Transferable t = new TransferableNumber();
+            panel = new DragSourcePanel(t);
+
+            frame = new Frame();
+            frame.setTitle("DragSource frame");
+            frame.setLocation(300, 200);
+            frame.add(panel);
+            frame.pack();
+            frame.setVisible(true);
+
+            Thread.sleep(FRAME_ACTIVATION_TIMEOUT);
+
+            Point sourcePoint = panel.getLocationOnScreen();
+            Dimension d = panel.getSize();
+            sourcePoint.translate(d.width / 2, d.height / 2);
+
+            Point targetPoint = new Point(x + w / 2, y + h / 2);
+
+            robot = new Robot();
+            robot.mouseMove(sourcePoint.x, sourcePoint.y);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            for (; !sourcePoint.equals(targetPoint);
+                 sourcePoint.translate(sign(targetPoint.x - sourcePoint.x),
+                         sign(targetPoint.y - sourcePoint.y))) {
+                robot.mouseMove(sourcePoint.x, sourcePoint.y);
+                Thread.sleep(10);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+
+            synchronized (t) {
+                t.wait(DROP_TIMEOUT);
+            }
+
+            Thread.sleep(DROP_COMPLETION_TIMEOUT);
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+            System.exit(MultiDataFlavorDropTest.CODE_FAILURE);
+        }
+        System.exit(MultiDataFlavorDropTest.CODE_OK);
+    }
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+
+    public void init() {
+        frame = new Frame();
+        panel = new DropTargetPanel();
+
+        frame.setTitle("MultiDataFlavorDropTest");
+        frame.setLocation(10, 200);
+        frame.add(panel);
+
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public void start() throws Exception {
+        Thread.sleep(FRAME_ACTIVATION_TIMEOUT);
+
+        EventQueue.invokeAndWait(() -> {
+            p = panel.getLocationOnScreen();
+            d = panel.getSize();
+        });
+
+        String javaPath = System.getProperty("java.home", "");
+        String command = javaPath + File.separator + "bin" +
+                File.separator + "java -cp " + System.getProperty("test.classes", ".") +
+                " MultiDataFlavorDropTest " +
+                p.x + " " + p.y + " " + d.width + " " + d.height;
+
+        Process process = Runtime.getRuntime().exec(command);
+        returnCode = process.waitFor();
+
+        InputStream errorStream = process.getErrorStream();
+        int count = errorStream.available();
+        if (count > 0) {
+            byte[] b = new byte[count];
+            errorStream.read(b);
+            System.err.println("========= Child VM System.err ========");
+            System.err.print(new String(b));
+            System.err.println("======================================");
+        }
+
+        switch (returnCode) {
+            case CODE_NOT_RETURNED:
+                System.err.println("Child VM: failed to start");
+                break;
+            case CODE_OK:
+                System.err.println("Child VM: normal termination");
+                break;
+            case CODE_FAILURE:
+                System.err.println("Child VM: abnormal termination");
+                break;
+        }
+        if (returnCode != CODE_OK) {
+            throw new RuntimeException("The test failed.");
+        }
+    }
+}
+
+class DragSourceButton extends Button implements Serializable,
+                                                 DragGestureListener,
+                                                 DragSourceListener {
+
+    final Transferable transferable;
+
+    public DragSourceButton(Transferable t) {
+        super("DragSourceButton");
+
+        this.transferable = t;
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY,
+                                              this);
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(null, transferable, this);
+    }
+
+    public void dragEnter(DragSourceDragEvent dsde) {}
+
+    public void dragExit(DragSourceEvent dse) {}
+
+    public void dragOver(DragSourceDragEvent dsde) {}
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {}
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {}
+}
+
+class IntegerDataFlavor extends DataFlavor {
+
+    private final int number;
+
+    public IntegerDataFlavor(int n) throws ClassNotFoundException {
+        super("application/integer-" + n +
+              "; class=java.lang.Integer");
+        this.number = n;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+}
+
+class TransferableNumber implements Transferable {
+
+    private int transferDataRequestCount = 0;
+    public static final int NUM_DATA_FLAVORS = 5;
+    static final DataFlavor[] supportedFlavors =
+        new DataFlavor[NUM_DATA_FLAVORS];
+
+    static {
+        try {
+            for (int i = 0; i < NUM_DATA_FLAVORS; i++) {
+                supportedFlavors[i] =
+                    new IntegerDataFlavor(i);
+            }
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return supportedFlavors;
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor flavor) {
+        if (flavor instanceof IntegerDataFlavor) {
+            IntegerDataFlavor integerFlavor = (IntegerDataFlavor)flavor;
+            int flavorNumber = integerFlavor.getNumber();
+            if (flavorNumber >= 0 && flavorNumber < NUM_DATA_FLAVORS) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Object getTransferData(DataFlavor flavor)
+      throws UnsupportedFlavorException {
+
+        if (!isDataFlavorSupported(flavor)) {
+            throw new UnsupportedFlavorException(flavor);
+        }
+
+        transferDataRequestCount++;
+
+        if (transferDataRequestCount >= NUM_DATA_FLAVORS) {
+            synchronized (this) {
+                this.notifyAll();
+            }
+        }
+
+        IntegerDataFlavor integerFlavor = (IntegerDataFlavor)flavor;
+        return new Integer(integerFlavor.getNumber());
+    }
+}
+
+class DragSourcePanel extends Panel {
+
+    final Dimension preferredDimension = new Dimension(200, 200);
+
+    public DragSourcePanel(Transferable t) {
+        setLayout(new GridLayout(1, 1));
+        add(new DragSourceButton(t));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+}
+
+class DropTargetPanel extends Panel implements DropTargetListener {
+
+    final Dimension preferredDimension = new Dimension(200, 200);
+
+    public DropTargetPanel() {
+        setBackground(Color.green);
+        setDropTarget(new DropTarget(this, this));
+        setLayout(new GridLayout(1, 1));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {
+        dtde.acceptDrag(DnDConstants.ACTION_COPY);
+    }
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {
+        dtde.acceptDrag(DnDConstants.ACTION_COPY);
+    }
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+            return;
+        }
+
+        removeAll();
+        final List list = new List();
+        add(list);
+
+        Transferable t = dtde.getTransferable();
+        DataFlavor[] dfs = t.getTransferDataFlavors();
+
+        if (dfs.length != TransferableNumber.NUM_DATA_FLAVORS) {
+            throw new RuntimeException("FAILED: Incorrect number of data flavors.");
+        }
+
+        for (int i = 0; i < dfs.length; i++) {
+
+            DataFlavor flavor = dfs[i];
+            Integer transferNumber = null;
+
+            if (flavor.getRepresentationClass().equals(Integer.class)) {
+                try {
+                    transferNumber = (Integer)t.getTransferData(flavor);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    throw new RuntimeException("FAILED: Cannot get data: " +
+                                               flavor.getMimeType());
+                }
+            }
+
+            boolean supportedFlavor = false;
+            for (int j = 0; j < TransferableNumber.NUM_DATA_FLAVORS; j++) {
+                int number = (i + j) % TransferableNumber.NUM_DATA_FLAVORS;
+                try {
+                    if (flavor.equals(new IntegerDataFlavor(number))) {
+                        if (!(new Integer(number).equals(transferNumber))) {
+                            throw new RuntimeException("FAILED: Invalid data \n" +
+                                                       "\tflavor : " + flavor +
+                                                       "\tdata   : " + transferNumber);
+                        }
+                        supportedFlavor = true;
+                        break;
+                    }
+                } catch (ClassNotFoundException cannotHappen) {
+                }
+            }
+            if (!supportedFlavor) {
+                throw new RuntimeException("FAILED: Invalid flavor: " + flavor);
+            }
+
+            list.add(transferNumber + ":" + flavor.getMimeType());
+        }
+
+        dtc.dropComplete(true);
+        validate();
+    }
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+}

--- a/test/jdk/java/awt/dnd/NativeDragJavaDropTest.java
+++ b/test/jdk/java/awt/dnd/NativeDragJavaDropTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+
+/*
+  @test
+  @bug 4399700
+  @summary tests that Motif drag support for label widget doesn't cause
+           crash when used for drag and drop from label to Java drop target
+  @key headful
+  @run main NativeDragJavaDropTest
+*/
+
+public class NativeDragJavaDropTest {
+
+    volatile Frame frame;
+    volatile DropTargetLabel label;
+    volatile Point p;
+    volatile Dimension d;
+    public static final int FRAME_ACTIVATION_TIMEOUT = 1000;
+    public static final int DRAG_START_TIMEOUT = 500;
+    public static final int DROP_COMPLETION_TIMEOUT = 2000;
+
+    public static void main(String[] args) throws Exception {
+        NativeDragJavaDropTest test = new NativeDragJavaDropTest();
+        EventQueue.invokeAndWait(test::init);
+        try {
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (test.frame != null) {
+                    test.frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        frame = new Frame();
+        label = new DropTargetLabel();
+        frame.setTitle("NativeDragJavaDropTest");
+        frame.setLocation(200, 200);
+        frame.add(label);
+
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public void start() throws Exception {
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        Thread.sleep(FRAME_ACTIVATION_TIMEOUT);
+
+        EventQueue.invokeAndWait(() -> {
+            p = label.getLocationOnScreen();
+            d = label.getSize();
+        });
+
+        p.translate(d.width / 2, d.height / 2);
+
+        robot.mouseMove(p.x, p.y);
+        robot.mousePress(InputEvent.BUTTON2_MASK);
+
+        Thread.sleep(DRAG_START_TIMEOUT);
+
+        robot.mouseRelease(InputEvent.BUTTON2_MASK);
+
+        Thread.sleep(DROP_COMPLETION_TIMEOUT);
+    }
+}
+
+class DropTargetLabel extends Label implements DropTargetListener {
+
+    final Dimension preferredDimension = new Dimension(200, 100);
+
+    public DropTargetLabel() {
+        super("Label");
+        setDropTarget(new DropTarget(this, this));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {}
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {}
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+        }
+
+        DataFlavor[] dfs = dtde.getCurrentDataFlavors();
+
+        if (dfs != null && dfs.length >= 1) {
+            Transferable transfer = dtde.getTransferable();
+
+            try {
+                Object obj = (Object)transfer.getTransferData(dfs[0]);
+            } catch (Throwable e) {
+                e.printStackTrace();
+                dtc.dropComplete(false);
+            }
+        }
+        dtc.dropComplete(true);
+    }
+}

--- a/test/jdk/java/awt/dnd/NestedHeavyweightDropTargetTest.java
+++ b/test/jdk/java/awt/dnd/NestedHeavyweightDropTargetTest.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTEvent;
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.AWTEventListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/*
+  @test
+  @bug 4389284
+  @summary tests that drop targets registered on nested heavyweight
+           components work properly
+  @key headful
+  @run main NestedHeavyweightDropTargetTest
+*/
+
+public class NestedHeavyweightDropTargetTest {
+
+    volatile Frame frame;
+    volatile DragSourceButton dragSourceButton;
+    volatile DropTargetPanel dropTargetPanel;
+    volatile InnerDropTargetPanel innerDropTargetPanel;
+    volatile Button button;
+    volatile Dimension d;
+    volatile Point srcPoint;
+    volatile Point dstPoint;
+
+    static final int DROP_COMPLETION_TIMEOUT = 1000;
+
+    public static void main(String[] args) throws Exception {
+        NestedHeavyweightDropTargetTest test = new NestedHeavyweightDropTargetTest();
+        EventQueue.invokeAndWait(test::init);
+        try {
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (test.frame != null) {
+                    test.frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        frame = new Frame();
+        dragSourceButton = new DragSourceButton();
+        dropTargetPanel = new DropTargetPanel();
+        innerDropTargetPanel = new InnerDropTargetPanel();
+        button = new Button("button");
+        button.setBackground(Color.red);
+
+        innerDropTargetPanel.setLayout(new GridLayout(3, 1));
+        innerDropTargetPanel.add(button);
+        innerDropTargetPanel.setBackground(Color.yellow);
+
+        dropTargetPanel.setLayout(new GridLayout(2, 1));
+        dropTargetPanel.add(innerDropTargetPanel);
+        dropTargetPanel.setBackground(Color.green);
+
+        frame.setTitle("NestedHeavyweightDropTargetTest");
+        frame.setLocation(200, 200);
+        frame.setLayout(new BorderLayout());
+        frame.add(dropTargetPanel, BorderLayout.CENTER);
+        frame.add(dragSourceButton, BorderLayout.SOUTH);
+
+        frame.pack();
+
+        innerDropTargetPanel.setDropTarget(new DropTarget(innerDropTargetPanel, innerDropTargetPanel));
+        dropTargetPanel.setDropTarget(new DropTarget(dropTargetPanel, dropTargetPanel));
+
+        frame.setVisible(true);
+    }
+
+    public void start() throws Exception {
+        Robot robot = new Robot();
+        Util.waitForInit();
+
+        test1(robot);
+        test2(robot);
+    }
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+
+    public void test1(Robot robot) throws Exception {
+        innerDropTargetPanel.setDragEnterTriggered(false);
+        innerDropTargetPanel.setDragOverTriggered(false);
+        innerDropTargetPanel.setDragExitTriggered(false);
+        innerDropTargetPanel.setDropTriggered(false);
+
+        EventQueue.invokeAndWait(() -> {
+            srcPoint = dragSourceButton.getLocationOnScreen();
+            d = dragSourceButton.getSize();
+        });
+
+        srcPoint.translate(d.width / 2, d.height / 2);
+
+        if (!Util.pointInComponent(robot, srcPoint, dragSourceButton)) {
+            System.err.println("WARNING: Couldn't locate " + dragSourceButton +
+                               " at point " + srcPoint);
+            return;
+        }
+
+        EventQueue.invokeAndWait(() -> {
+            dstPoint = innerDropTargetPanel.getLocationOnScreen();
+            d = innerDropTargetPanel.getSize();
+        });
+
+        dstPoint.translate(d.width / 2, d.height / 2);
+
+        if (!Util.pointInComponent(robot, dstPoint, innerDropTargetPanel)) {
+            System.err.println("WARNING: Couldn't locate " + innerDropTargetPanel +
+                               " at point " + dstPoint);
+            return;
+        }
+
+        robot.mouseMove(srcPoint.x, srcPoint.y);
+        robot.keyPress(KeyEvent.VK_CONTROL);
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        for (;!srcPoint.equals(dstPoint);
+             srcPoint.translate(sign(dstPoint.x - srcPoint.x),
+                                sign(dstPoint.y - srcPoint.y))) {
+            robot.mouseMove(srcPoint.x, srcPoint.y);
+            Thread.sleep(10);
+        }
+        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.keyRelease(KeyEvent.VK_CONTROL);
+
+        Thread.sleep(DROP_COMPLETION_TIMEOUT);
+
+        if (!innerDropTargetPanel.isDragEnterTriggered()) {
+            throw new RuntimeException("child dragEnter() not triggered");
+        }
+
+        if (!innerDropTargetPanel.isDragOverTriggered()) {
+            throw new RuntimeException("child dragOver() not triggered");
+        }
+
+        if (!innerDropTargetPanel.isDropTriggered()) {
+            throw new RuntimeException("child drop() not triggered");
+        }
+    }
+
+    public void test2(Robot robot) throws Exception {
+        innerDropTargetPanel.setDragEnterTriggered(false);
+        innerDropTargetPanel.setDragOverTriggered(false);
+        innerDropTargetPanel.setDragExitTriggered(false);
+        innerDropTargetPanel.setDropTriggered(false);
+
+        EventQueue.invokeAndWait(() -> {
+            srcPoint = dragSourceButton.getLocationOnScreen();
+            d = dragSourceButton.getSize();
+        });
+        srcPoint.translate(d.width / 2, d.height / 2);
+
+        if (!Util.pointInComponent(robot, srcPoint, dragSourceButton)) {
+            System.err.println("WARNING: Couldn't locate " + dragSourceButton +
+                               " at point " + srcPoint);
+            return;
+        }
+
+        EventQueue.invokeAndWait(() -> {
+            dstPoint = button.getLocationOnScreen();
+            d = button.getSize();
+        });
+
+        dstPoint.translate(d.width / 2, d.height / 2);
+
+        if (!Util.pointInComponent(robot, dstPoint, button)) {
+            System.err.println("WARNING: Couldn't locate " + button +
+                               " at point " + dstPoint);
+            return;
+        }
+
+        robot.mouseMove(srcPoint.x, srcPoint.y);
+        robot.keyPress(KeyEvent.VK_CONTROL);
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        for (;!srcPoint.equals(dstPoint);
+             srcPoint.translate(sign(dstPoint.x - srcPoint.x),
+                                sign(dstPoint.y - srcPoint.y))) {
+            robot.mouseMove(srcPoint.x, srcPoint.y);
+            Thread.sleep(10);
+        }
+        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.keyRelease(KeyEvent.VK_CONTROL);
+
+        Thread.sleep(DROP_COMPLETION_TIMEOUT);
+
+        if (!innerDropTargetPanel.isDragEnterTriggered()) {
+            throw new RuntimeException("child dragEnter() not triggered");
+        }
+
+        if (!innerDropTargetPanel.isDragOverTriggered()) {
+            throw new RuntimeException("child dragOver() not triggered");
+        }
+
+        if (!innerDropTargetPanel.isDropTriggered()) {
+            throw new RuntimeException("child drop() not triggered");
+        }
+    }
+}
+
+class Util implements AWTEventListener {
+    private static final Toolkit tk = Toolkit.getDefaultToolkit();
+    public static final Object SYNC_LOCK = new Object();
+    private Component clickedComponent = null;
+    private static final int PAINT_TIMEOUT = 10000;
+    private static final int MOUSE_RELEASE_TIMEOUT = 10000;
+    private static final Util util = new Util();
+
+    static {
+        tk.addAWTEventListener(util, 0xFFFFFFFF);
+    }
+
+    private void reset() {
+        clickedComponent = null;
+    }
+
+    public void eventDispatched(AWTEvent e) {
+        if (e.getID() == MouseEvent.MOUSE_RELEASED) {
+            clickedComponent = (Component)e.getSource();
+            synchronized (SYNC_LOCK) {
+                SYNC_LOCK.notifyAll();
+            }
+        }
+    }
+
+    public static boolean pointInComponent(Robot robot, Point p, Component comp)
+      throws InterruptedException {
+        return util.isPointInComponent(robot, p, comp);
+    }
+
+    private boolean isPointInComponent(Robot robot, Point p, Component comp)
+      throws InterruptedException {
+        tk.sync();
+        robot.waitForIdle();
+        reset();
+        robot.mouseMove(p.x, p.y);
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        synchronized (SYNC_LOCK) {
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            SYNC_LOCK.wait(MOUSE_RELEASE_TIMEOUT);
+        }
+
+        Component c = clickedComponent;
+
+        while (c != null && c != comp) {
+            c = c.getParent();
+        }
+
+        return c == comp;
+    }
+
+    public static void waitForInit() throws InterruptedException {
+        final Frame f = new Frame() {
+                public void paint(Graphics g) {
+                    dispose();
+                    synchronized (SYNC_LOCK) {
+                        SYNC_LOCK.notifyAll();
+                    }
+                }
+            };
+        f.setBounds(600, 400, 200, 200);
+        synchronized (SYNC_LOCK) {
+            f.setVisible(true);
+            SYNC_LOCK.wait(PAINT_TIMEOUT);
+        }
+        tk.sync();
+    }
+}
+
+class DragSourceButton extends Button implements Serializable,
+                                                 Transferable,
+                                                 DragGestureListener,
+                                                 DragSourceListener {
+    private final DataFlavor dataflavor =
+        new DataFlavor(Button.class, "DragSourceButton");
+
+    public DragSourceButton() {
+        this("DragSourceButton");
+    }
+
+    public DragSourceButton(String str) {
+        super(str);
+
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY,
+                                              this);
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(null, this, this);
+    }
+
+    public void dragEnter(DragSourceDragEvent dsde) {}
+
+    public void dragExit(DragSourceEvent dse) {}
+
+    public void dragOver(DragSourceDragEvent dsde) {}
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {}
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {}
+
+    public Object getTransferData(DataFlavor flavor)
+      throws UnsupportedFlavorException, IOException {
+
+        if (!isDataFlavorSupported(flavor)) {
+            throw new UnsupportedFlavorException(flavor);
+        }
+
+        Object retObj = null;
+
+        ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
+        ObjectOutputStream ooStream = new ObjectOutputStream(baoStream);
+        ooStream.writeObject(this);
+
+        ByteArrayInputStream baiStream = new ByteArrayInputStream(baoStream.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(baiStream);
+        try {
+            retObj = ois.readObject();
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.toString());
+        }
+
+        return retObj;
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[] { dataflavor };
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor dflavor) {
+        return dataflavor.equals(dflavor);
+    }
+}
+
+class InnerDropTargetPanel extends DropTargetPanel {
+    private boolean dragEnterTriggered = false;
+    private boolean dragOverTriggered = false;
+    private boolean dragExitTriggered = false;
+    private boolean dropTriggered = false;
+
+    public void dragEnter(DropTargetDragEvent dtde) {
+        setDragEnterTriggered(true);
+    }
+
+    public void dragExit(DropTargetEvent dte) {
+        setDragExitTriggered(true);
+    }
+
+    public void dragOver(DropTargetDragEvent dtde) {
+        setDragOverTriggered(true);
+    }
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+    public void drop(DropTargetDropEvent dtde) {
+        setDropTriggered(true);
+        dtde.rejectDrop();
+    }
+
+    public boolean isDragEnterTriggered() {
+        return dragEnterTriggered;
+    }
+
+    public boolean isDragOverTriggered() {
+        return dragOverTriggered;
+    }
+
+    public boolean isDragExitTriggered() {
+        return dragExitTriggered;
+    }
+
+    public boolean isDropTriggered() {
+        return dropTriggered;
+    }
+
+    public void setDragEnterTriggered(boolean b) {
+        dragEnterTriggered = b;
+    }
+
+    public void setDragOverTriggered(boolean b) {
+        dragOverTriggered = b;
+    }
+
+    public void setDragExitTriggered(boolean b) {
+        dragExitTriggered = b;
+    }
+
+    public void setDropTriggered(boolean b) {
+        dropTriggered = b;
+    }
+}
+
+class DropTargetPanel extends Panel implements DropTargetListener {
+
+    public void dragEnter(DropTargetDragEvent dtde) {}
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {}
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+        }
+
+        DataFlavor[] dfs = dtde.getCurrentDataFlavors();
+        Component comp = null;
+
+        if (dfs != null && dfs.length >= 1) {
+            Transferable transfer = dtde.getTransferable();
+
+            try {
+                comp = (Component)transfer.getTransferData(dfs[0]);
+            } catch (Throwable e) {
+                e.printStackTrace();
+                dtc.dropComplete(false);
+            }
+        }
+        dtc.dropComplete(true);
+
+        add(comp);
+    }
+}


### PR DESCRIPTION
Backport https://github.com/openjdk/jdk/commit/98294242a94c611e2a713c2d520e59dd873ae4a0
https://bugs.openjdk.org/browse/JDK-8307128 Open source some drag and drop tests 4

Not clean as required quick fix for @requires
mac reported error _Error. Parse Exception: Invalid tag: requires(os_

Clean backport + fix for requires in MozillaDnDTest, new tests, low risk
Checked on macOS x64, linux x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1359/head:pull/1359` \
`$ git checkout pull/1359`

Update a local copy of the PR: \
`$ git checkout pull/1359` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1359`

View PR using the GUI difftool: \
`$ git pr show -t 1359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1359.diff">https://git.openjdk.org/jdk17u-dev/pull/1359.diff</a>

</details>
