### PR TITLE
8306955: Open source several JComboBox jtreg tests

### DIFF
--- a/test/jdk/javax/swing/JComboBox/bug4167850.java
+++ b/test/jdk/javax/swing/JComboBox/bug4167850.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+   @test
+   @bug 4167850
+   @summary Verify no exception removing items from an empty list.
+*/
+
+import javax.swing.JComboBox;
+
+public class bug4167850 {
+
+    public static void main(String[] args) {
+        JComboBox comboBox = new JComboBox(
+            new Object[] {
+                "Coma Berenices",
+                "Triangulum",
+                "Camelopardis",
+                "Cassiopea"});
+
+        comboBox.removeAllItems();
+        comboBox.removeAllItems();
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4209474.java
+++ b/test/jdk/javax/swing/JComboBox/bug4209474.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4209474
+   @summary setSelectedItem(int) should only fire events if selection changed - avoid recursive calls
+*/
+
+import javax.swing.JComboBox;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class bug4209474 {
+
+    public static void main(String[] args) {
+
+        JComboBox comboBox = new JComboBox(
+            new Object[] {
+                        "Coma Berenices",
+                        "Triangulum",
+                        "Camelopardis",
+                        "Cassiopea"});
+
+        ActionListener listener = new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                comboBox.setSelectedIndex(0);
+            }
+        };
+
+        comboBox.addActionListener(listener);
+        comboBox.setSelectedIndex(0);
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4234119.java
+++ b/test/jdk/javax/swing/JComboBox/bug4234119.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+   @test
+   @bug 4234119
+   @summary Tests if adding items to ComboBox is slow
+*/
+
+import javax.swing.JComboBox;
+
+public class bug4234119 {
+
+    public static void main(String args[]) {
+        JComboBox jComboBox1 = new JComboBox();
+        long startTime = System.currentTimeMillis();
+        for (int i = 0 ; i < 500; i++) {
+            jComboBox1.addItem(Integer.valueOf(i));
+        }
+        long deltaTime = System.currentTimeMillis() - startTime;
+        if (deltaTime > 20000) {
+            throw new Error("Test failed: adding items to ComboBox is SLOW! (it took " + deltaTime + " ms");
+        }
+        System.out.println("Elapsed time: " + deltaTime);
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4890345.java
+++ b/test/jdk/javax/swing/JComboBox/bug4890345.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+   @test
+   @bug 4890345
+   @requires (os.family == "windows")
+   @summary 1.4.2 REGRESSION: JComboBox has problem in JTable in Windows L&F
+   @key headful
+*/
+
+import java.util.Vector;
+import java.awt.BorderLayout;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.DefaultCellEditor;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableModel;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+
+public class bug4890345 {
+
+    volatile boolean passed = false;
+    volatile boolean isLafOk = true;
+
+    volatile JFrame mainFrame;
+    volatile JTable tbl;
+
+    public static void main(String[] args) throws Exception {
+        bug4890345 test = new bug4890345();
+        try {
+            SwingUtilities.invokeAndWait(test::createUI);
+            if (!test.isLafOk) {
+                throw new RuntimeException("Could not create Win L&F");
+            }
+            test.test();
+        } finally {
+            JFrame f = test.mainFrame;
+            if (f != null) {
+                SwingUtilities.invokeAndWait(() -> f.dispose());
+            }
+        }
+    }
+
+    void createUI() {
+        try {
+            UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        } catch (Exception ex) {
+            System.err.println("Can not initialize Windows L&F. Testing skipped.");
+            isLafOk = false;
+        }
+
+        if (isLafOk) {
+            mainFrame = new JFrame("Bug4890345");
+            String[] items = {"tt", "aa", "gg", "zz", "dd", "ll" };
+            JComboBox<String> comboBox = new JComboBox<String>(items);
+
+            tbl = new JTable();
+            JScrollPane panel = new JScrollPane(tbl);
+            TableModel tm = createTableModel();
+            tbl.setModel(tm);
+            tbl.setRowHeight(20);
+            tbl.getColumnModel().getColumn(1).setCellEditor(
+                new DefaultCellEditor(comboBox));
+
+            comboBox.addPopupMenuListener(new PopupMenuListener() {
+                public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+                    passed = true;
+                }
+
+                public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {}
+                public void popupMenuCanceled(PopupMenuEvent e) {}
+            });
+
+            mainFrame.setLayout(new BorderLayout());
+            mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            mainFrame.add(panel, BorderLayout.CENTER);
+            mainFrame.pack();
+            mainFrame.setLocationRelativeTo(null);
+            mainFrame.setVisible(true);
+        }
+    }
+
+    public void test() throws Exception {
+        Robot robo = new Robot();
+        robo.setAutoDelay(50);
+        robo.delay(1000);
+        tbl.editCellAt(0,0);
+
+        robo.keyPress(KeyEvent.VK_TAB);
+        robo.keyRelease(KeyEvent.VK_TAB);
+
+        robo.keyPress(KeyEvent.VK_TAB);
+        robo.keyRelease(KeyEvent.VK_TAB);
+
+        robo.keyPress(KeyEvent.VK_F2);
+        robo.keyRelease(KeyEvent.VK_F2);
+
+        robo.keyPress(KeyEvent.VK_DOWN);
+        robo.keyRelease(KeyEvent.VK_DOWN);
+
+        robo.keyPress(KeyEvent.VK_ENTER);
+        robo.keyRelease(KeyEvent.VK_ENTER);
+
+        robo.delay(1000);
+
+        if (!passed) {
+            throw new RuntimeException("Popup was not shown after VK_DOWN press. Test failed.");
+        }
+    }
+
+    private TableModel createTableModel() {
+        Vector<String> hdr = new Vector<String>();
+        hdr.add("One");
+        hdr.add("Two");
+        Vector<Vector> data = new Vector<Vector>();
+        Vector<String> row = new Vector<String>();
+        row.add("tt");
+        row.add("dd");
+        data.add(row);
+        row = new Vector<String>();
+        row.add("ll");
+        row.add("jj");
+        data.add(row);
+        return new DefaultTableModel(data, hdr);
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4996503.java
+++ b/test/jdk/javax/swing/JComboBox/bug4996503.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+   @test
+   @bug 4996503
+   @summary REGRESSION: NotSerializableException: javax.swing.plaf.basic.BasicComboPopup+1
+   @key headful
+*/
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.IOException;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.InputEvent;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4996503 {
+
+    static volatile JFrame frame = null;
+    static volatile JComboBox<String> comboBox = null;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4996503");
+                String[] items = { "item0", "item1", "item2" };
+                comboBox = new JComboBox<String>(items);
+                frame.add(comboBox);
+                frame.pack();
+                frame.validate();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+            robot.delay(1000);
+            Point p = comboBox.getLocationOnScreen();
+            Dimension size = comboBox.getSize();
+            p.x += size.width / 2;
+            p.y += size.height / 2;
+            robot.mouseMove(p.x, p.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+
+            ObjectOutputStream out = null;
+
+            ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+            try {
+                out = new ObjectOutputStream(byteStream);
+            } catch (IOException e) {}
+            if (out != null) {
+                try {
+                    out.writeObject(comboBox);
+                } catch (Exception e) {
+                    System.out.println(e);
+                    throw new Error("Serialization exception. Test failed.");
+                }
+            }
+        } finally {
+            if (frame != null) {
+                 SwingUtilities.invokeAndWait(frame::dispose);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Clean backport, new tests, low risk
Checked on macOS x64, linux x64, windows x64, tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306955](https://bugs.openjdk.org/browse/JDK-8306955): Open source several JComboBox jtreg tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1363/head:pull/1363` \
`$ git checkout pull/1363`

Update a local copy of the PR: \
`$ git checkout pull/1363` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1363`

View PR using the GUI difftool: \
`$ git pr show -t 1363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1363.diff">https://git.openjdk.org/jdk17u-dev/pull/1363.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1363#issuecomment-1553529783)