### PR TITLE
8307080: Open source some more JComboBox jtreg tests

### DIFF
--- a/test/jdk/javax/swing/JComboBox/bug4171464.java
+++ b/test/jdk/javax/swing/JComboBox/bug4171464.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4171464
+   @summary JComboBox should not throw InternalError
+*/
+
+import javax.swing.ComboBoxModel;
+import javax.swing.JComboBox;
+import javax.swing.event.ListDataListener;
+
+public class bug4171464 {
+
+    public static void main(String args[]) {
+        ComboBoxModel model = new ComboBoxModel() {
+            public void setSelectedItem(Object anItem) {}
+            public Object getSelectedItem() {return null;}
+            public int getSize() {return 0;}
+            public Object getElementAt(int index) {return null;}
+            public void addListDataListener(ListDataListener l) {}
+            public void removeListDataListener(ListDataListener l) {}
+        };
+        JComboBox comboBox = new JComboBox();
+        comboBox.setModel(model);
+        try {
+            comboBox.addItem(new Object() {});
+        } catch (InternalError e) {
+            // InternalError not suitable if app supplies non-mutable model.
+            throw new RuntimeException("4171464 TEST FAILED");
+        } catch (Exception e) {
+            // Expected exception due to non-mutable model.
+        }
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4244614.java
+++ b/test/jdk/javax/swing/JComboBox/bug4244614.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+   @test
+   @bug 4244614
+   @summary Tests that JComboBox has setAction(Action) constructor
+*/
+
+import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeListener;
+import javax.swing.Action;
+import javax.swing.JComboBox;
+
+public class bug4244614 {
+
+/** Auxiliary class implementing Action
+ */
+    static class NullAction implements Action {
+        public void addPropertyChangeListener(
+                       PropertyChangeListener listener) {}
+        public void removePropertyChangeListener(
+                       PropertyChangeListener listener) {}
+        public void putValue(String key, Object value) {}
+        public void setEnabled(boolean b) {}
+        public void actionPerformed(ActionEvent e) {}
+
+        public Object getValue(String key) { return null; }
+        public boolean isEnabled() { return false; }
+    }
+
+    public static void main(String[] argv) {
+        Object[] comboData = {"First", "Second", "Third"};
+        JComboBox combo = new JComboBox(comboData);
+        Action action = new NullAction();
+        combo.setAction(action);
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4276920.java
+++ b/test/jdk/javax/swing/JComboBox/bug4276920.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4276920
+   @summary Tests that BasicComboPopup.hide() doesn't cause unnecessary repaints
+   @key headful
+*/
+
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4276920 {
+
+    static volatile TestComboBox combo;
+    static volatile JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(bug4276920::createUI);
+            Thread.sleep(2000);
+            int before = combo.getRepaintCount();
+            SwingUtilities.invokeAndWait(combo::hidePopup);
+            int after = combo.getRepaintCount();
+            if (after > before) {
+                throw new Error("Failed 4276920: BasicComboPopup.hide() caused unnecessary repaint()");
+            }
+         } finally {
+            if (frame != null) {
+            SwingUtilities.invokeAndWait(frame::dispose);
+            }
+         }
+     }
+
+     static void createUI() {
+        combo = new TestComboBox(new String[] {"Why am I so slow?"});
+        frame = new JFrame("bug4276920");
+        frame.getContentPane().add(combo);
+        frame.pack();
+        frame.validate();
+        frame.setVisible(true);
+    }
+
+    static class TestComboBox extends JComboBox {
+        int count = 0;
+
+        TestComboBox(Object[] content) {
+            super(content);
+        }
+
+        public void repaint() {
+            super.repaint();
+            count++;
+        }
+
+        int getRepaintCount() {
+            return count;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug4924758.java
+++ b/test/jdk/javax/swing/JComboBox/bug4924758.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 4924758
+   @summary 1.4 REGRESSION: In Motif L&F JComboBox doesn't react when spacebar is pressed
+   @key headful
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.event.PopupMenuEvent;
+import java.awt.event.KeyEvent;
+
+public class bug4924758 {
+
+    static volatile boolean passed = false;
+    volatile boolean isLafOk = true;
+
+    volatile JFrame mainFrame;
+    volatile JComboBox comboBox;
+
+    public static void main(String[] args) throws Exception {
+        bug4924758 test = new bug4924758();
+        try {
+            SwingUtilities.invokeAndWait(test::createUI);
+            if (!test.isLafOk) {
+                throw new RuntimeException("Could not create Win L&F");
+            }
+            test.test();
+            if (!passed) {
+                throw new RuntimeException(
+                    "Popup was not closed after VK_SPACE press. Test failed.");
+            }
+        } finally {
+            JFrame f = test.mainFrame;
+            if (f != null) {
+                SwingUtilities.invokeAndWait(() -> f.dispose());
+            }
+        }
+    }
+
+    void createUI() {
+        try {
+            UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        } catch (Exception ex) {
+            System.err.println("Can not initialize Motif L&F. Testing skipped.");
+            isLafOk = false;
+            return;
+        }
+
+        mainFrame = new JFrame("Bug4924758");
+        String[] items = {"One", "Two", "Three"};
+        comboBox = new JComboBox(items);
+        comboBox.addPopupMenuListener(new PopupMenuListener() {
+            public void popupMenuWillBecomeVisible(PopupMenuEvent e) {}
+
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+                passed = true;
+            }
+
+            public void popupMenuCanceled(PopupMenuEvent e) {}
+        });
+        mainFrame.setLayout(new BorderLayout());
+        mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        mainFrame.add(comboBox, BorderLayout.CENTER);
+        mainFrame.pack();
+        mainFrame.setLocationRelativeTo(null);
+        mainFrame.setVisible(true);
+    }
+
+    void test() throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.delay(2000);
+        Point p = comboBox.getLocationOnScreen();
+        Dimension size = comboBox.getSize();
+        p.x += size.width / 2;
+        p.y += size.height / 2;
+        robot.mouseMove(p.x, p.y);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_SPACE);
+        robot.keyRelease(KeyEvent.VK_SPACE);
+        robot.delay(2000);
+    }
+}

--- a/test/jdk/javax/swing/JComboBox/bug5029504.java
+++ b/test/jdk/javax/swing/JComboBox/bug5029504.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5029504
+  @summary Empty JComboBox drop-down list is unexpectedly high
+  @key headful
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.plaf.basic.BasicComboBoxUI;
+import javax.swing.plaf.basic.BasicComboPopup;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.event.PopupMenuEvent;
+
+public class bug5029504 {
+
+    static volatile boolean passed = true;
+    static volatile JFrame mainFrame;
+    static volatile JComboBox comboBox;
+    static volatile BasicComboPopup ourPopup = null;
+
+    public static void main(String[] args) throws Exception {
+        try {
+             SwingUtilities.invokeAndWait(bug5029504::createUI);
+             runTest();
+             if (!passed) {
+                 throw new RuntimeException(
+                    "Popup of empty JComboBox is too high. Test failed.");
+             }
+        } finally {
+            if (mainFrame != null) {
+                SwingUtilities.invokeAndWait(mainFrame::dispose);
+            }
+        }
+    }
+
+    static void createUI() {
+        mainFrame = new JFrame("Bug4924758");
+        comboBox = new JComboBox();
+        comboBox.setUI(new MyComboBoxUI());
+        comboBox.addPopupMenuListener(new PopupMenuListener() {
+            public void popupMenuWillBecomeVisible(PopupMenuEvent e) {}
+
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+                if (ourPopup != null) {
+                    int comboHeight = comboBox.getHeight();
+                    int popupHeight = ourPopup.getHeight();
+                    if (popupHeight > comboHeight*2) {
+                        passed = false;
+                    }
+                }
+            }
+
+            public void popupMenuCanceled(PopupMenuEvent e) {}
+        });
+        mainFrame.setLayout(new BorderLayout());
+        mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        mainFrame.add(comboBox, BorderLayout.CENTER);
+        mainFrame.pack();
+        mainFrame.setLocationRelativeTo(null);
+        mainFrame.validate();
+        mainFrame.setVisible(true);
+    }
+
+    static void runTest() throws Exception {
+        Robot robot = new Robot();
+        robot.delay(2000);
+        Point p = comboBox.getLocationOnScreen();
+        Dimension size = comboBox.getSize();
+        p.x += size.width / 2;
+        p.y += size.height / 2;
+        robot.mouseMove(p.x, p.y);
+        robot.keyPress(KeyEvent.VK_ENTER);
+        robot.delay(50);
+        robot.keyRelease(KeyEvent.VK_ENTER);
+        robot.delay(2000);
+    }
+
+    static class MyComboBoxUI extends BasicComboBoxUI {
+        public void setPopupVisible(JComboBox c, boolean v) {
+            if (popup instanceof BasicComboPopup) {
+                ourPopup = (BasicComboPopup) popup;
+            }
+            super.setPopupVisible(c, v);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport, new tests, low risk
Checked on macOS x64, linux x64, windows x64: tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307080](https://bugs.openjdk.org/browse/JDK-8307080): Open source some more JComboBox jtreg tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1364/head:pull/1364` \
`$ git checkout pull/1364`

Update a local copy of the PR: \
`$ git checkout pull/1364` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1364`

View PR using the GUI difftool: \
`$ git pr show -t 1364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1364.diff">https://git.openjdk.org/jdk17u-dev/pull/1364.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1364#issuecomment-1553536946)