### PR TITLE
8306133: Open source few AWT Drag & Drop related tests

### DIFF
--- a/test/jdk/java/awt/dnd/NextDropActionTest/NextDropActionTest.java
+++ b/test/jdk/java/awt/dnd/NextDropActionTest/NextDropActionTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4887150
+  @summary tests that after performing COPY drop, MOVE drop can be performed too
+  @key headful
+  @run main NextDropActionTest
+*/
+
+import java.awt.AWTException;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.StringSelection;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+
+
+public class NextDropActionTest {
+    private final long WAIT_TIMEOUT = 30000;
+    private volatile boolean failed;
+    private volatile boolean firstEnd;
+    private volatile boolean secondEnd;
+    private final Object LOCK = new Object();
+    private Frame frame;
+    private Panel panel;
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        NextDropActionTest nextDropActionTest = new NextDropActionTest();
+        nextDropActionTest.start();
+    }
+
+    public void start() throws InterruptedException,
+            InvocationTargetException, AWTException {
+
+        EventQueue.invokeAndWait(() -> {
+            panel = new Panel();
+            frame = new Frame("NextDropActionTest");
+            frame.add(panel);
+            frame.setBounds(300, 300, 300, 300);
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+            frame.validate();
+        });
+
+        try {
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            final DragSourceListener dsl = new DragSourceAdapter() {
+                boolean firstCall = true;
+                public void dragDropEnd(DragSourceDropEvent e) {
+                    System.err.println("DragSourseListener.dragDropEnd(): " +
+                            " firstCall=" + firstCall +
+                            " drop action=" + e.getDropAction());
+                    if (firstCall) {
+                        firstCall = false;
+                        synchronized (LOCK) {
+                            firstEnd = true;
+                            LOCK.notifyAll();
+                        }
+                        return;
+                    }
+                    if (e.getDropAction() != DnDConstants.ACTION_MOVE) {
+                        System.err.println("FAILURE: wrong drop action:"
+                                + e.getDropAction());
+                        failed = true;
+                    }
+                    synchronized (LOCK) {
+                        secondEnd = true;
+                        LOCK.notifyAll();
+                    }
+                }
+            };
+
+            DragGestureListener dgl = dge ->
+                    dge.startDrag(null, new StringSelection("test"), dsl);
+
+            new DragSource().createDefaultDragGestureRecognizer(panel,
+                    DnDConstants.ACTION_COPY_OR_MOVE, dgl);
+
+            DropTargetListener dtl = new DropTargetAdapter() {
+                public void drop(DropTargetDropEvent e) {
+                    System.err.println("DropTargetListener.drop(): " +
+                            "accepting the user drop action=" + e.getDropAction());
+                    e.acceptDrop(e.getDropAction());
+                    e.dropComplete(true);
+                }
+            };
+
+            new DropTarget(frame, DnDConstants.ACTION_COPY_OR_MOVE, dtl);
+
+            Point startPoint = new Point(Util.blockTillDisplayed(panel));
+            startPoint.translate(50, 50);
+            Point endPoint = new Point(startPoint.x
+                    + DragSource.getDragThreshold() + 10,
+                    startPoint.y + DragSource.getDragThreshold() + 10);
+
+            synchronized (LOCK) {
+                robot.keyPress(KeyEvent.VK_CONTROL);
+                Util.doDragDrop(robot, startPoint, endPoint);
+                robot.keyRelease(KeyEvent.VK_CONTROL);
+                LOCK.wait(WAIT_TIMEOUT);
+            }
+            if (!firstEnd) {
+                System.err.println("DragSourseListener.dragDropEnd() " +
+                        "was not called, returning");
+                return;
+            }
+
+            synchronized (LOCK) {
+                Util.doDragDrop(robot, startPoint, endPoint);
+                LOCK.wait(WAIT_TIMEOUT);
+            }
+            if (!secondEnd) {
+                System.err.println("DragSourseListener.dragDropEnd() " +
+                        "was not called, returning");
+                return;
+            }
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+
+        if (failed) {
+            throw new RuntimeException("wrong next drop action!");
+        }
+
+        System.err.println("test passed!");
+     }
+}
+
+class Util {
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+
+    public static void doDragDrop(Robot robot, Point startPoint, Point endPoint) {
+       robot.mouseMove(startPoint.x, startPoint.y);
+       robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+       for (Point p = new Point(startPoint); !p.equals(endPoint);
+                p.translate(Util.sign(endPoint.x - p.x),
+                            Util.sign(endPoint.y - p.y))) {
+           robot.mouseMove(p.x, p.y);
+           robot.delay(100);
+       }
+       robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+    }
+
+    public static Point blockTillDisplayed(Component comp) {
+        Point p = null;
+        while (p == null) {
+            try {
+                p = comp.getLocationOnScreen();
+            } catch (IllegalStateException e) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ie) {
+                }
+            }
+        }
+        return p;
+    }
+}

--- a/test/jdk/java/awt/dnd/NoFormatsDragEnterTest/NoFormatsDragEnterTest.java
+++ b/test/jdk/java/awt/dnd/NoFormatsDragEnterTest/NoFormatsDragEnterTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4702735
+  @summary tests that a dragEnter is called even if the source doesn't
+           export data in native formats.
+  @key headful
+  @run main NoFormatsDragEnterTest
+*/
+
+import java.awt.AWTException;
+import java.awt.Canvas;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+
+public class NoFormatsDragEnterTest {
+
+    Frame frame;
+    DragSourcePanel dragSourcePanel;
+    DropTargetPanel dropTargetPanel;
+
+    static final int FRAME_ACTIVATION_TIMEOUT = 1000;
+    static final int DROP_COMPLETION_TIMEOUT = 1000;
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        NoFormatsDragEnterTest noFormatsDragEnterTest = new NoFormatsDragEnterTest();
+        EventQueue.invokeAndWait(noFormatsDragEnterTest::init);
+        noFormatsDragEnterTest.start();
+    }
+
+    public void init() {
+        frame = new Frame();
+        dragSourcePanel = new DragSourcePanel();
+        dropTargetPanel = new DropTargetPanel();
+
+        frame.setTitle("NoFormatsDragEnterTest");
+        frame.setLayout(new GridLayout(2, 1));
+        frame.add(dragSourcePanel);
+        frame.add(dropTargetPanel);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+    }
+
+    public void start() throws AWTException, InterruptedException,
+            InvocationTargetException {
+        try {
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+
+            final Point srcPoint = dragSourcePanel.getLocationOnScreen();
+            Dimension d = dragSourcePanel.getSize();
+            srcPoint.translate(d.width / 2, d.height / 2);
+
+            final Point dstPoint = dropTargetPanel.getLocationOnScreen();
+            d = dropTargetPanel.getSize();
+            dstPoint.translate(d.width / 2, d.height / 2);
+
+            robot.mouseMove(srcPoint.x, srcPoint.y);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (Point curPoint = new Point(srcPoint);
+                 !curPoint.equals(dstPoint);
+                 curPoint.translate(sign(dstPoint.x - curPoint.x),
+                                    sign(dstPoint.y - curPoint.y))) {
+                robot.mouseMove(curPoint.x, curPoint.y);
+                robot.delay(100);
+            }
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            robot.delay(DROP_COMPLETION_TIMEOUT);
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+
+        if (!dropTargetPanel.passed()) {
+            throw new RuntimeException("Drop doesn't happen.");
+        }
+    }
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n > 0 ? 1 : 0;
+    }
+}
+
+class DragSourcePanel extends Canvas implements DragGestureListener {
+
+    private final Dimension preferredDimension = new Dimension(200, 100);
+    private final DragSourceListener listener = new DragSourceAdapter() {};
+
+    public DragSourcePanel() {
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this,
+                                              DnDConstants.ACTION_COPY_OR_MOVE,
+                                              this);
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(null, new TestTransferable(), listener);
+    }
+}
+
+class TestTransferable implements Transferable {
+
+    public static DataFlavor dataFlavor = null;
+    static final Object data = new Object();
+
+    static {
+        DataFlavor df = null;
+        try {
+            df = new DataFlavor(DataFlavor.javaJVMLocalObjectMimeType +
+                                "; class=java.lang.Object");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+        dataFlavor = df;
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[] { dataFlavor };
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor df) {
+        return dataFlavor.equals(df);
+    }
+
+    public Object getTransferData(DataFlavor df)
+      throws UnsupportedFlavorException, IOException {
+        if (!isDataFlavorSupported(df)) {
+            throw new UnsupportedFlavorException(df);
+        }
+        return data;
+    }
+}
+
+class DropTargetPanel extends Canvas implements DropTargetListener {
+
+    private final Dimension preferredDimension = new Dimension(200, 100);
+    private boolean dragEnterTriggered = false;
+    private boolean dragOverTriggered = false;
+
+    public DropTargetPanel() {
+        setDropTarget(new DropTarget(this, this));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {
+        dragEnterTriggered = true;
+    }
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {
+        dragOverTriggered = true;
+    }
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+    public void drop(DropTargetDropEvent dtde) {
+        dtde.rejectDrop();
+    }
+
+    public boolean passed() {
+        // asserts that dragEnter has been called if dragOver has been called.
+        return !dragOverTriggered || dragEnterTriggered;
+    }
+}

--- a/test/jdk/java/awt/dnd/NoFormatsDropTest/NoFormatsDropTest.java
+++ b/test/jdk/java/awt/dnd/NoFormatsDropTest/NoFormatsDropTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4473062
+  @summary tests that a drop happens even if the source doesn't export
+           data in native formats.
+  @key headful
+  @run main NoFormatsDropTest
+*/
+
+import java.awt.AWTEvent;
+import java.awt.AWTException;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.AWTEventListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+public class NoFormatsDropTest implements AWTEventListener {
+
+    Frame frame;
+    DragSourcePanel dragSourcePanel;
+    DropTargetPanel dropTargetPanel;
+
+    static final int FRAME_ACTIVATION_TIMEOUT = 1000;
+    static final int DROP_COMPLETION_TIMEOUT = 1000;
+    static final int MOUSE_RELEASE_TIMEOUT = 1000;
+    static final Object SYNC_LOCK = new Object();
+
+    Component clickedComponent = null;
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        NoFormatsDropTest noFormatsDropTest = new NoFormatsDropTest();
+        EventQueue.invokeAndWait(noFormatsDropTest::init);
+        noFormatsDropTest.start();
+    }
+
+    public void init() {
+        frame = new Frame();
+        dragSourcePanel = new DragSourcePanel();
+        dropTargetPanel = new DropTargetPanel();
+
+        frame.setTitle("NoFormatsDropTest");
+        frame.setLayout(new GridLayout(2, 1));
+        frame.add(dragSourcePanel);
+        frame.add(dropTargetPanel);
+
+        frame.getToolkit().addAWTEventListener(this, AWTEvent.MOUSE_EVENT_MASK);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+    }
+
+    public void start() throws InterruptedException, AWTException,
+            InvocationTargetException {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+
+            final Point srcPoint = dragSourcePanel.getLocationOnScreen();
+            Dimension d = dragSourcePanel.getSize();
+            srcPoint.translate(d.width / 2, d.height / 2);
+
+            if (!pointInComponent(robot, srcPoint, dragSourcePanel)) {
+                System.err.println("WARNING: Couldn't locate source panel.");
+                return;
+            }
+
+            final Point dstPoint = dropTargetPanel.getLocationOnScreen();
+            d = dropTargetPanel.getSize();
+            dstPoint.translate(d.width / 2, d.height / 2);
+
+            if (!pointInComponent(robot, dstPoint, dropTargetPanel)) {
+                System.err.println("WARNING: Couldn't locate target panel.");
+                return;
+            }
+
+            robot.mouseMove(srcPoint.x, srcPoint.y);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (Point curPoint = new Point(srcPoint);
+                 !curPoint.equals(dstPoint);
+                 curPoint.translate(sign(dstPoint.x - curPoint.x),
+                                    sign(dstPoint.y - curPoint.y))) {
+                robot.mouseMove(curPoint.x, curPoint.y);
+                robot.delay(100);
+            }
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            robot.delay(DROP_COMPLETION_TIMEOUT);
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+
+        if (!dropTargetPanel.passed()) {
+            throw new RuntimeException("Drop doesn't happen.");
+        }
+    }
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n > 0 ? 1 : 0;
+    }
+
+    public void reset() {
+        clickedComponent = null;
+    }
+
+    public void eventDispatched(AWTEvent e) {
+        if (e.getID() == MouseEvent.MOUSE_RELEASED) {
+            clickedComponent = (Component)e.getSource();
+            synchronized (SYNC_LOCK) {
+                SYNC_LOCK.notifyAll();
+            }
+        }
+    }
+
+    boolean pointInComponent(Robot robot, Point p, Component comp)
+      throws InterruptedException {
+        robot.waitForIdle();
+        reset();
+        robot.mouseMove(p.x, p.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        synchronized (SYNC_LOCK) {
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            SYNC_LOCK.wait(MOUSE_RELEASE_TIMEOUT);
+        }
+
+        Component c = clickedComponent;
+
+        while (c != null && c != comp) {
+            c = c.getParent();
+        }
+
+        return c == comp;
+    }
+}
+
+class DragSourcePanel extends Panel implements DragGestureListener {
+
+    private final Dimension preferredDimension = new Dimension(200, 100);
+    private final DragSourceListener listener = new DragSourceAdapter() {};
+
+    public DragSourcePanel() {
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this,
+                                              DnDConstants.ACTION_COPY_OR_MOVE,
+                                              this);
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(null, new TestTransferable(), listener);
+    }
+}
+
+class TestTransferable implements Transferable {
+
+    public static DataFlavor dataFlavor = null;
+    static final Object data = new Object();
+
+    static {
+        DataFlavor df = null;
+        try {
+            df = new DataFlavor(DataFlavor.javaJVMLocalObjectMimeType +
+                                "; class=java.lang.Object");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+        dataFlavor = df;
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[] { dataFlavor };
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor df) {
+        return dataFlavor.equals(df);
+    }
+
+    public Object getTransferData(DataFlavor df)
+      throws UnsupportedFlavorException, IOException {
+        if (!isDataFlavorSupported(df)) {
+            throw new UnsupportedFlavorException(df);
+        }
+        return data;
+    }
+}
+
+class DropTargetPanel extends Panel implements DropTargetListener {
+
+    final Dimension preferredDimension = new Dimension(200, 100);
+    boolean passed = false;
+
+    public DropTargetPanel() {
+        setDropTarget(new DropTarget(this, this));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {}
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {}
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+        }
+
+        Transferable transfer = dtde.getTransferable();
+
+        if (transfer.isDataFlavorSupported(TestTransferable.dataFlavor)) {
+            try {
+                Object data =
+                    transfer.getTransferData(TestTransferable.dataFlavor);
+                passed = true;
+                dtc.dropComplete(true);
+            } catch (IOException e) {
+                e.printStackTrace();
+                dtc.dropComplete(false);
+            } catch (UnsupportedFlavorException e) {
+                e.printStackTrace();
+                dtc.dropComplete(false);
+            }
+        } else {
+            dtc.dropComplete(false);
+        }
+    }
+
+    boolean passed() {
+        return passed;
+    }
+}

--- a/test/jdk/java/awt/dnd/NoTargetNoDragExitTest/NoTargetNoDragExitTest.java
+++ b/test/jdk/java/awt/dnd/NoTargetNoDragExitTest/NoTargetNoDragExitTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4874092
+  @summary tests that DragSourceListener.dragExit() is not called if the mouse
+           is not dragged over any drop site
+  @key headful
+  @run main NoTargetNoDragExitTest
+*/
+
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.event.AWTEventListener;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+
+
+public class NoTargetNoDragExitTest {
+    private volatile boolean failed;
+    private volatile boolean end;
+    private final Object LOCK = new Object();
+    private Frame frame;
+    private Panel panel;
+
+    public static void main(String[] args) throws Exception {
+        NoTargetNoDragExitTest noTargetNoDragExitTest = new NoTargetNoDragExitTest();
+        EventQueue.invokeAndWait(noTargetNoDragExitTest::init);
+        noTargetNoDragExitTest.start();
+    }
+
+    public void init() {
+        frame = new Frame("NoTargetNoDragExitTest");
+        panel = new Panel();
+        frame.add(panel);
+        frame.setSize(300, 300);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+    }
+
+    public void start() throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            final DragSourceListener dsl = new DragSourceAdapter() {
+                public void dragExit(DragSourceEvent e) {
+                    failed = true;
+                    System.err.println("FAILURE: DragSourceListener.dragExit() called!");
+                }
+                public void dragDropEnd(DragSourceDropEvent e) {
+                    System.err.println("DragSourceListener.dragDropEnd()");
+                    synchronized (LOCK) {
+                        end = true;
+                        LOCK.notifyAll();
+                    }
+                }
+            };
+
+            DragGestureListener dgl = dge ->
+                    dge.startDrag(null, new StringSelection("NoTargetNoDragExitTest"), dsl);
+
+            new DragSource().createDefaultDragGestureRecognizer(panel,
+                    DnDConstants.ACTION_COPY_OR_MOVE, dgl);
+
+            Point startPoint = frame.getLocationOnScreen();
+            startPoint.translate(50, 50);
+            Point endPoint = new Point(startPoint.x + 100, startPoint.y + 100);
+
+            Util.waitForInit();
+
+            if (!Util.pointInComponent(robot, startPoint, frame)) {
+                System.err.println("WARNING: Could not locate " + frame +
+                        " at point " + startPoint);
+                return;
+            }
+
+            robot.mouseMove(startPoint.x, startPoint.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (Point p = new Point(startPoint); !p.equals(endPoint);
+                 p.translate(Util.sign(endPoint.x - p.x),
+                         Util.sign(endPoint.y - p.y))) {
+                robot.mouseMove(p.x, p.y);
+                robot.delay(100);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            synchronized (LOCK) {
+                while (!end) {
+                    LOCK.wait();
+                }
+            }
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+
+        if (failed) {
+            throw new RuntimeException("DragSourceListener.dragExit() called!");
+        }
+
+        System.err.println("test passed!");
+     }
+}
+
+
+class Util implements AWTEventListener {
+    private static final Toolkit tk = Toolkit.getDefaultToolkit();
+    private static final Object SYNC_LOCK = new Object();
+    private Component clickedComponent = null;
+    private static final int PAINT_TIMEOUT = 10000;
+    private static final int MOUSE_RELEASE_TIMEOUT = 10000;
+    private static final Util util = new Util();
+
+    static {
+        tk.addAWTEventListener(util, 0xFFFFFFFF);
+    }
+
+    private void reset() {
+        clickedComponent = null;
+    }
+
+    public void eventDispatched(AWTEvent e) {
+        if (e.getID() == MouseEvent.MOUSE_RELEASED) {
+            clickedComponent = (Component)e.getSource();
+            synchronized (SYNC_LOCK) {
+                SYNC_LOCK.notifyAll();
+            }
+        }
+    }
+
+    public static boolean pointInComponent(Robot robot, Point p, Component comp)
+      throws InterruptedException {
+        return util.isPointInComponent(robot, p, comp);
+    }
+
+    private boolean isPointInComponent(Robot robot, Point p, Component comp)
+      throws InterruptedException {
+        tk.sync();
+        robot.waitForIdle();
+        reset();
+        robot.mouseMove(p.x, p.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        synchronized (SYNC_LOCK) {
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            SYNC_LOCK.wait(MOUSE_RELEASE_TIMEOUT);
+        }
+
+        Component c = clickedComponent;
+
+        while (c != null && c != comp) {
+            c = c.getParent();
+        }
+
+        return c == comp;
+    }
+
+    public static void waitForInit() throws InterruptedException {
+        final Frame f = new Frame() {
+                public void paint(Graphics g) {
+                    dispose();
+                    synchronized (SYNC_LOCK) {
+                        SYNC_LOCK.notifyAll();
+                    }
+                }
+            };
+        f.setBounds(600, 400, 200, 200);
+        synchronized (SYNC_LOCK) {
+            f.setVisible(true);
+            SYNC_LOCK.wait(PAINT_TIMEOUT);
+        }
+        tk.sync();
+    }
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+}

--- a/test/jdk/java/awt/dnd/NotReallySerializableTest/NotReallySerializableTest.java
+++ b/test/jdk/java/awt/dnd/NotReallySerializableTest/NotReallySerializableTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4187912
+  @summary Test that some incorrectly written DnD code cannot hang the app
+  @run main NotReallySerializableTest
+*/
+
+import java.awt.Button;
+import java.awt.Cursor;
+import java.awt.Point;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragGestureRecognizer;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceContext;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+
+
+public class NotReallySerializableTest {
+    public static void main(String[] args) throws IOException {
+        Toolkit tk = Toolkit.getDefaultToolkit();
+
+        DragGestureRecognizer dgr = tk.createDragGestureRecognizer
+                (java.awt.dnd.MouseDragGestureRecognizer.class,
+                        DragSource.getDefaultDragSource(), new Button(),
+                        DnDConstants.ACTION_LINK, new TrickDragGestureListener());
+        DragGestureEvent dge = new DragGestureEvent
+                (dgr, DnDConstants.ACTION_LINK, new Point(0, 0),
+                        new TrickList());
+        DragSourceContext dsc = new DragSourceContext(dge,
+                Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR),
+                null, null, new TrickTransferable(),
+                new TrickDragSourceListener());
+        DropTarget dt = new DropTarget(new Button(),
+                new TrickDropTargetListener());
+
+        ObjectOutputStream stream = new ObjectOutputStream
+                (new OutputStream() {
+                    public void write(int b) {}
+                });
+
+        stream.writeObject(dgr);
+        stream.writeObject(dge);
+        stream.writeObject(dsc);
+        stream.writeObject(dt);
+
+        System.out.println("test passed");
+    }
+}
+
+class TrickList extends ArrayList implements Serializable {
+    Object trick = new Object();
+
+    TrickList() {
+        add(trick);
+    }
+}
+
+class TrickDragGestureListener implements DragGestureListener, Serializable {
+    Object trick = new Object();
+
+    public void dragGestureRecognized(DragGestureEvent dge) {}
+}
+
+class TrickTransferable extends StringSelection implements Serializable {
+    Object trick = new Object();
+
+    TrickTransferable() {
+        super("");
+    }
+}
+
+class TrickDragSourceListener extends DragSourceAdapter
+    implements Serializable
+{
+    Object trick = new Object();
+}
+
+class TrickDropTargetListener extends DropTargetAdapter
+    implements Serializable
+{
+    Object trick = new Object();
+
+    public void drop(DropTargetDropEvent dtde) {}
+}


### PR DESCRIPTION
Clean backport, new tests, low risk
Checked on macOS x64, linux x64, windows x64: tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306133](https://bugs.openjdk.org/browse/JDK-8306133): Open source few AWT Drag &amp; Drop related tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1366/head:pull/1366` \
`$ git checkout pull/1366`

Update a local copy of the PR: \
`$ git checkout pull/1366` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1366`

View PR using the GUI difftool: \
`$ git pr show -t 1366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1366.diff">https://git.openjdk.org/jdk17u-dev/pull/1366.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1366#issuecomment-1553561654)