### PR TITLE
8306409: Open source AWT KeyBoardFocusManger, LightWeightComponent related tests

### DIFF
--- a/test/jdk/java/awt/KeyboardFocusmanager/ChangeKFMTest.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/ChangeKFMTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4467840
+  @summary Generate a PropertyChange when KeyboardFocusManager changes
+  @key headful
+  @run main ChangeKFMTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.DefaultKeyboardFocusManager;
+import java.awt.EventQueue;
+import java.awt.KeyboardFocusManager;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+public class ChangeKFMTest implements PropertyChangeListener {
+    static final String CURRENT_PROP_NAME = "managingFocus";
+    boolean current_fired;
+    boolean not_current_fired;
+    KeyboardFocusManager kfm;
+    public static void main(String[] args) throws Exception {
+        ChangeKFMTest test = new ChangeKFMTest();
+        test.start();
+    }
+
+    public void start () throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            kfm = new DefaultKeyboardFocusManager();
+            kfm.addPropertyChangeListener(CURRENT_PROP_NAME, this);
+            current_fired = false;
+            not_current_fired = false;
+            KeyboardFocusManager.setCurrentKeyboardFocusManager(kfm);
+            if (!current_fired) {
+                throw new RuntimeException("Change to current was not fired on KFM instalation");
+            }
+            if (not_current_fired) {
+                throw new RuntimeException("Change to non-current was fired on KFM instalation");
+            } else {
+                System.out.println("Installation was complete correctly");
+            }
+
+            current_fired = false;
+            not_current_fired = false;
+            KeyboardFocusManager.setCurrentKeyboardFocusManager(null);
+            if (!not_current_fired) {
+                throw new RuntimeException("Change to non-current was not fired on KFM uninstalation");
+            }
+            if (current_fired) {
+                throw new RuntimeException("Change to current was fired on KFM uninstalation");
+            } else {
+                System.out.println("Uninstallation was complete correctly");
+            }
+        });
+    }
+
+    public void propertyChange(PropertyChangeEvent e) {
+        System.out.println(e.toString());
+        if (!CURRENT_PROP_NAME.equals(e.getPropertyName())) {
+            throw new RuntimeException("Unexpected property name - " + e.getPropertyName());
+        }
+        if (((Boolean)e.getNewValue()).booleanValue()) {
+            current_fired = true;
+        } else {
+            not_current_fired = true;
+        }
+        System.out.println("current_fired = " + current_fired);
+        System.out.println("not_current_fired = " + not_current_fired);
+    }
+}

--- a/test/jdk/java/awt/KeyboardFocusmanager/PropertySupportNPETest.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/PropertySupportNPETest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4458016
+  @summary KeyboardFocusManager.get[Property|Vetoable]ChangeListeners throw NPE
+  @key headful
+  @run main PropertySupportNPETest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.KeyboardFocusManager;
+
+public class PropertySupportNPETest {
+     public static void main(String[] args) throws Exception {
+         EventQueue.invokeAndWait(() -> {
+             KeyboardFocusManager kfm =
+                     KeyboardFocusManager.getCurrentKeyboardFocusManager();
+             kfm.getVetoableChangeListeners();
+             kfm.getVetoableChangeListeners("");
+             kfm.getPropertyChangeListeners();
+             kfm.getPropertyChangeListeners("");
+         });
+     }
+ }

--- a/test/jdk/java/awt/Label/NullLabelTest.java
+++ b/test/jdk/java/awt/Label/NullLabelTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6215905
+  @summary Tests that passing null value to Label.setText(String) doesn't
+            lead to VM crash.
+  @key headful
+  @run main NullLabelTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Label;
+import java.awt.Frame;
+
+public class NullLabelTest {
+
+    static Frame frame;
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            try {
+                frame = new Frame();
+                Label l = new Label("A");
+                frame.add(l);
+                frame.setLayout(new BorderLayout());
+                frame.setSize(200, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+                l.setText(null);
+            } finally {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            }
+        });
+    }
+}

--- a/test/jdk/java/awt/Layout/InsetsTest.java
+++ b/test/jdk/java/awt/Layout/InsetsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4087971
+  @summary Insets does not layout a component correctly
+  @key headful
+  @run main InsetsTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Insets;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+
+public class InsetsTest {
+    private int leftInsetValue;
+    private InsetsClass IC;
+
+    public static void main(String[] args) throws Exception {
+        InsetsTest test = new InsetsTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            try {
+                IC = new InsetsClass();
+                IC.setLayout(new BorderLayout());
+                IC.setSize(200, 200);
+                IC.setVisible(true);
+
+                leftInsetValue = IC.returnLeftInset();
+                if (leftInsetValue != 30) {
+                    throw new RuntimeException("Test Failed - Left inset" +
+                            "is not taken correctly");
+                }
+            } finally {
+                if (IC != null) {
+                    IC.dispose();
+                }
+            }
+        });
+    }
+}
+
+class InsetsClass extends JFrame {
+    private int value;
+    private JPanel panel;
+
+    public InsetsClass() {
+        super("TestFrame");
+        setBackground(Color.lightGray);
+
+        panel = new JPanel();
+        panel.setBorder(new EmptyBorder(new Insets(30, 30, 30, 30)));
+        panel.add(new JButton("Test Button"));
+
+        getContentPane().add(panel);
+        pack();
+        setVisible(true);
+    }
+
+    public int returnLeftInset() {
+        // Getting the left inset value
+        Insets insets = panel.getInsets();
+        value = insets.left;
+        return value;
+    }
+}

--- a/test/jdk/java/awt/LightweightComponent/LWClobberDragEvent.java
+++ b/test/jdk/java/awt/LightweightComponent/LWClobberDragEvent.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4092418
+  @summary Test for drag events been taking by Lightweight Component
+  @key headful
+  @run main LWClobberDragEvent
+*/
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+
+public class LWClobberDragEvent implements MouseListener, MouseMotionListener {
+    boolean isDragging;
+
+    static Frame frame;
+    LightweightComp lc;
+    final static int LWWidth = 200;
+    final static int LWHeight = 100;
+    final static int MAX_COUNT = 100;
+    Point locationOfLW;
+
+    public static void main(String[] args) throws Exception {
+        LWClobberDragEvent test = new LWClobberDragEvent();
+        try {
+            test.init();
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            frame = new Frame();
+            frame.setLayout(new BorderLayout());
+            isDragging = false;
+            frame.addMouseMotionListener(this);
+            frame.addMouseListener(this);
+
+            frame.setBackground(Color.white);
+
+            lc = new LightweightComp();
+            lc.setSize(LWWidth, LWHeight);
+            lc.setLocation(50, 50);
+            lc.addMouseListener(this);
+            lc.addMouseMotionListener(this);
+            frame.add(lc);
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+        });
+    }
+
+    public void start() throws Exception {
+        Robot robot = new Robot();
+        robot.delay(1000);
+        robot.waitForIdle();
+
+        EventQueue.invokeAndWait(() -> {
+            locationOfLW = getLocation(lc);
+            robot.mouseMove(locationOfLW.x + lc.getWidth() / 2,
+                    locationOfLW.y - lc.getHeight() / 2);
+        });
+
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.delay(1000);
+        //move mouse till the bottom of LWComponent
+        for (int i = 1; i < LWHeight + lc.getHeight() / 2; i++) {
+            robot.mouseMove(locationOfLW.x + lc.getWidth() / 2,
+                    locationOfLW.y - lc.getHeight() / 2 + i);
+        }
+        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.delay(1000);
+        System.out.println("Test Passed.");
+    }
+
+    public void mouseClicked(MouseEvent evt) { }
+
+    public void mouseReleased(MouseEvent evt) {
+        if (evt.getSource() == this) {
+            if (isDragging) {
+                isDragging = false;
+            }
+        } else {
+        }
+    }
+    public Point getLocation( Component co ) throws RuntimeException {
+       Point pt = null;
+       boolean bFound = false;
+       int count = 0;
+       while ( !bFound ) {
+          try {
+             pt = co.getLocationOnScreen();
+             bFound = true;
+          } catch ( Exception ex ) {
+             bFound = false;
+             count++;
+          }
+          if ( !bFound && count > MAX_COUNT ) {
+             throw new RuntimeException("don't see a component to get location");
+          }
+       }
+       return pt;
+    }
+
+    public void mousePressed(MouseEvent evt) {    }
+    public void mouseEntered(MouseEvent evt) {    }
+    public void mouseExited(MouseEvent evt) {    }
+    public void mouseMoved(MouseEvent evt) {    }
+
+    public void mouseDragged(MouseEvent evt) {
+        if (evt.getSource() == this) {
+            if (!isDragging) {
+                isDragging = true;
+            }
+        } else {
+            if (isDragging) {
+                throw new RuntimeException("Test failed: Lightweight got dragging event.");
+            }
+        }
+    }
+}
+
+class LightweightComp extends Component {
+    public void paint(Graphics g) {
+        Dimension d = getSize();
+        g.setColor(Color.red);
+        g.fillRect(0, 0, d.width, d.height);
+    }
+}

--- a/test/jdk/java/awt/LightweightComponent/LightweightDragTest.java
+++ b/test/jdk/java/awt/LightweightComponent/LightweightDragTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4050138
+  @summary Lightweight components: Enter/Exit mouse events
+  incorrectly reported during drag
+  @key headful
+  @run main LightweightDragTest
+*/
+
+import java.awt.AWTException;
+import java.awt.AWTEvent;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+
+public class LightweightDragTest {
+    MyComponent c,c2;
+    static Frame frame;
+    volatile int x = 0;
+    volatile int y = 0;
+    volatile int x2 = 0;
+    volatile int y2 = 0;
+
+    public static void main(String[] args) throws Exception {
+        LightweightDragTest test = new LightweightDragTest();
+        try {
+            EventQueue.invokeAndWait(() -> {
+                test.init();
+            });
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        frame = new Frame("Test LightWeight Component Drag");
+        c = new MyComponent();
+        c2 = new MyComponent();
+        frame.add(c, BorderLayout.WEST);
+        frame.add(c2, BorderLayout.EAST);
+        frame.setSize(250, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+   public void start() throws Exception {
+       Robot rb;
+       try {
+           rb = new Robot();
+       } catch (AWTException e) {
+           throw new Error("Could not create robot");
+       }
+       rb.setAutoDelay(10);
+       rb.delay(1000);
+       rb.waitForIdle();
+
+       EventQueue.invokeAndWait(() -> {
+           x = c.getLocationOnScreen().x + c.getWidth() / 2;
+           y = c.getLocationOnScreen().y + c.getHeight() / 2;
+           x2 = c2.getLocationOnScreen().x + c2.getWidth() / 2;
+           y2 = c2.getLocationOnScreen().y + c2.getHeight() / 2;
+       });
+       int xt = x;
+       int yt = y;
+       rb.mouseMove(xt, yt);
+       rb.mousePress(InputEvent.BUTTON1_MASK);
+       EventQueue.invokeAndWait(() -> {
+           c.isInside = true;
+           c2.isInside = false;
+       });
+       // drag
+       while (xt != x2 || yt != y2) {
+           if (x2 > xt) ++xt;
+           if (x2 < xt) --xt;
+           if (y2 > yt) ++yt;
+           if (y2 < yt) --yt;
+           rb.mouseMove(xt, yt);
+       }
+       rb.mouseRelease(InputEvent.BUTTON1_MASK);
+       EventQueue.invokeAndWait(() -> {
+           if (c.isInside || !c2.isInside) {
+               throw new Error("Test failed: mouse events did not arrive");
+           }
+       });
+   }
+}
+
+class MyComponent extends Component {
+    public boolean isInside;
+    public void paint(Graphics g) {
+        g.setColor(getBackground());
+        g.fillRect(0,0,getSize().width,getSize().height);
+    }
+    public MyComponent() {
+        enableEvents(AWTEvent.MOUSE_EVENT_MASK);
+        setBackground(Color.blue);
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(100, 100);
+    }
+
+    public void processEvent(AWTEvent e) {
+        int eventID = e.getID();
+        if ((eventID == MouseEvent.MOUSE_ENTERED)) {
+            setBackground(Color.red);
+            repaint();
+            isInside = true;
+        } else if (eventID == MouseEvent.MOUSE_EXITED) {
+            setBackground(Color.blue);
+            repaint();
+            isInside = false;
+        }
+        super.processEvent(e);
+    }
+}


### PR DESCRIPTION
Clean backport, new tests, low risk
Checked on macOS x64, linux x64, windows x64: tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306409](https://bugs.openjdk.org/browse/JDK-8306409): Open source AWT KeyBoardFocusManger, LightWeightComponent related tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1370/head:pull/1370` \
`$ git checkout pull/1370`

Update a local copy of the PR: \
`$ git checkout pull/1370` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1370`

View PR using the GUI difftool: \
`$ git pr show -t 1370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1370.diff">https://git.openjdk.org/jdk17u-dev/pull/1370.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1370#issuecomment-1553581219)