### PR TITLE
8306652: Open source AWT MenuItem related tests

### DIFF
--- a/test/jdk/java/awt/MenuItem/EnableTest.java
+++ b/test/jdk/java/awt/MenuItem/EnableTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4257944
+  @summary PopupMenu.setEnabled fails on Win32
+  @key headful
+  @run main EnableTest
+*/
+
+import java.awt.AWTEvent;
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+
+public class EnableTest {
+    PopupMenu popup = null;
+    Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        EnableTest test = new EnableTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("EnableTest");
+                popup = new PopupMenu("Popup Menu Title");
+                MenuItem mi1 = new MenuItem("Menu Item");
+                MenuItem mi2 = new MenuItem("Menu Item");
+                popup.add(mi1);
+                popup.addSeparator();
+                popup.add(mi2);
+                popup.setEnabled(false);
+                popup.setLabel("New Label");
+                mi2.setEnabled(false);
+                frame.add(popup);
+                frame.pack();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/MenuItem/MenuSetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/MenuSetLabelTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4261935
+  @summary Menu display problem when changing the text of the menu(window 98)
+  @key headful
+  @run main MenuSetLabelTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Robot;
+
+public class MenuSetLabelTest {
+    Menu1 f;
+
+    public static void main(String[] args) throws Exception {
+        MenuSetLabelTest test = new MenuSetLabelTest();
+        test.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                f = new Menu1();
+                f.setTitle("MenuSetLabelTest");
+                f.setSize(300, 200);
+                f.setLocationRelativeTo(null);
+                f.setVisible(true);
+            });
+            Robot robot = new Robot();
+            robot.delay(1000);
+            robot.waitForIdle();
+            EventQueue.invokeAndWait(() -> {
+                f.changeMenuLabel();
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+}
+
+class Menu1 extends Frame {
+
+    String s1 = new String("short");
+    String s2 = new String("This is a long string");
+    String s3 = new String("Menu Item string");
+
+    MenuBar mb1 = new MenuBar();
+    Menu f = new Menu(s1);
+    Menu m = new Menu(s1);
+    boolean flag = true;
+
+    public Menu1()
+    {
+        for (int i = 0; i < 5; i++) {
+            m.add(new MenuItem(s3));
+        }
+        for (int i = 0; i < 10; i++) {
+            f.add(new MenuItem(s3));
+        }
+        mb1.add(f);
+        mb1.add(m);
+        setMenuBar(mb1);
+    }
+
+    public void changeMenuLabel() {
+        MenuBar mb = getMenuBar();
+        Menu m0 = mb.getMenu(0);
+        Menu m1 = mb.getMenu(1);
+
+        if (flag) {
+            m0.setLabel(s2);
+            m1.setLabel(s2);
+        } else {
+            m0.setLabel(s1);
+            m1.setLabel(s1);
+        }
+        flag = !flag;
+    }
+}

--- a/test/jdk/java/awt/MenuItem/SetLabelWithPeerCreatedTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelWithPeerCreatedTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4234266
+  @summary MenuItem throws NullPointer exception when setting the label with created peer.
+  @key headful
+  @run main SetLabelWithPeerCreatedTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+public class SetLabelWithPeerCreatedTest {
+     Frame frame;
+     public static void main(String[] args) throws Exception {
+         SetLabelWithPeerCreatedTest test = new SetLabelWithPeerCreatedTest();
+         test.start();
+     }
+
+    public void start() throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("SetLabel with Peer Created Test");
+                Menu menu = new Menu("Menu");
+                MenuItem mi = new MenuItem("Item");
+                MenuBar mb = new MenuBar();
+                menu.add(mi);
+                mb.add(menu);
+                frame.setMenuBar(mb);
+                frame.setSize(300, 200);
+                frame.setLocationRelativeTo(null);
+                mi.setLabel("new label");
+                frame.setVisible(true);
+                System.out.println("Test PASSED!");
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+ }

--- a/test/jdk/java/awt/MenuItem/SetStateTest.java
+++ b/test/jdk/java/awt/MenuItem/SetStateTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 5106833
+  @summary NullPointerException in XMenuPeer.repaintMenuItem
+  @key headful
+  @run main SetStateTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.CheckboxMenuItem;
+
+public class SetStateTest {
+    Frame frame;
+    public static void main(String[] args) throws Exception {
+        SetStateTest test = new SetStateTest();
+        test.start();
+    }
+
+    public void start () throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("SetStateTest");
+                MenuBar bar = new MenuBar();
+                Menu menu = new Menu("Menu");
+                CheckboxMenuItem checkboxMenuItem = new CheckboxMenuItem("Item");
+                bar.add(menu);
+                frame.setMenuBar(bar);
+                menu.add(checkboxMenuItem);
+                checkboxMenuItem.setState(true);
+                frame.setSize(300, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+                System.out.println("Test PASSED!");
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Clean backport, new tests, low risk
Checked on macOS x64, linux x64, windows x64: tests pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306652](https://bugs.openjdk.org/browse/JDK-8306652): Open source AWT MenuItem related tests


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1373/head:pull/1373` \
`$ git checkout pull/1373`

Update a local copy of the PR: \
`$ git checkout pull/1373` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1373`

View PR using the GUI difftool: \
`$ git pr show -t 1373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1373.diff">https://git.openjdk.org/jdk17u-dev/pull/1373.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1373#issuecomment-1553930722)