### PR TITLE
8275287: Relax memory ordering constraints on updating instance class and array class counters

### DIFF
--- a/src/hotspot/share/classfile/classLoaderDataGraph.inline.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 #include "classfile/javaClasses.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/orderAccess.hpp"
 
 inline ClassLoaderData *ClassLoaderDataGraph::find_or_create(Handle loader) {
   guarantee(loader() != NULL && oopDesc::is_oop(loader()), "Loader must be oop");
@@ -43,29 +44,29 @@ inline ClassLoaderData *ClassLoaderDataGraph::find_or_create(Handle loader) {
 }
 
 size_t ClassLoaderDataGraph::num_instance_classes() {
-  return _num_instance_classes;
+  return Atomic::load(&_num_instance_classes);
 }
 
 size_t ClassLoaderDataGraph::num_array_classes() {
-  return _num_array_classes;
+  return Atomic::load(&_num_array_classes);
 }
 
 void ClassLoaderDataGraph::inc_instance_classes(size_t count) {
-  Atomic::add(&_num_instance_classes, count);
+  Atomic::add(&_num_instance_classes, count, memory_order_relaxed);
 }
 
 void ClassLoaderDataGraph::dec_instance_classes(size_t count) {
-  assert(count <= _num_instance_classes, "Sanity");
-  Atomic::sub(&_num_instance_classes, count);
+  size_t old_count = Atomic::fetch_and_add(&_num_instance_classes, -count, memory_order_relaxed);
+  assert(old_count >= count, "Sanity");
 }
 
 void ClassLoaderDataGraph::inc_array_classes(size_t count) {
-  Atomic::add(&_num_array_classes, count);
+  Atomic::add(&_num_array_classes, count, memory_order_relaxed);
 }
 
 void ClassLoaderDataGraph::dec_array_classes(size_t count) {
-  assert(count <= _num_array_classes, "Sanity");
-  Atomic::sub(&_num_array_classes, count);
+  size_t old_count = Atomic::fetch_and_add(&_num_array_classes, -count, memory_order_relaxed);
+  assert(old_count >= count, "Sanity");
 }
 
 bool ClassLoaderDataGraph::should_clean_metaspaces_and_reset() {


### PR DESCRIPTION
Clean backport to improve CLD statistics gathering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275287](https://bugs.openjdk.org/browse/JDK-8275287): Relax memory ordering constraints on updating instance class and array class counters


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1382/head:pull/1382` \
`$ git checkout pull/1382`

Update a local copy of the PR: \
`$ git checkout pull/1382` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1382`

View PR using the GUI difftool: \
`$ git pr show -t 1382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1382.diff">https://git.openjdk.org/jdk17u-dev/pull/1382.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1382#issuecomment-1556887996)