### PR TITLE
8274615: Support relaxed atomic add for linux-aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/atomic_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/atomic_aarch64.hpp
@@ -37,6 +37,8 @@ typedef uint64_t (*aarch64_atomic_stub_t)(volatile void *ptr, uint64_t arg1, uin
 // Pointers to stubs
 extern aarch64_atomic_stub_t aarch64_atomic_fetch_add_4_impl;
 extern aarch64_atomic_stub_t aarch64_atomic_fetch_add_8_impl;
+extern aarch64_atomic_stub_t aarch64_atomic_fetch_add_4_relaxed_impl;
+extern aarch64_atomic_stub_t aarch64_atomic_fetch_add_8_relaxed_impl;
 extern aarch64_atomic_stub_t aarch64_atomic_xchg_4_impl;
 extern aarch64_atomic_stub_t aarch64_atomic_xchg_8_impl;
 extern aarch64_atomic_stub_t aarch64_atomic_cmpxchg_1_impl;

--- a/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.S
+++ b/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.S
@@ -47,6 +47,28 @@ aarch64_atomic_fetch_add_4_default_impl:
         mov     w0, w2
         ret
 
+        .global aarch64_atomic_fetch_add_8_relaxed_default_impl
+        .align 5
+aarch64_atomic_fetch_add_8_relaxed_default_impl:
+        prfm    pstl1strm, [x0]
+0:      ldxr    x2, [x0]
+        add     x8, x2, x1
+        stxr    w9, x8, [x0]
+        cbnz    w9, 0b
+        mov     x0, x2
+        ret
+
+        .global aarch64_atomic_fetch_add_4_relaxed_default_impl
+        .align 5
+aarch64_atomic_fetch_add_4_relaxed_default_impl:
+        prfm    pstl1strm, [x0]
+0:      ldxr    w2, [x0]
+        add     w8, w2, w1
+        stxr    w9, w8, [x0]
+        cbnz    w9, 0b
+        mov     w0, w2
+        ret
+
         .globl aarch64_atomic_xchg_4_default_impl
         .align 5
 aarch64_atomic_xchg_4_default_impl:

--- a/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2021, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -87,9 +87,14 @@ inline D Atomic::PlatformAdd<4>::fetch_and_add(D volatile* dest, I add_value,
                                                atomic_memory_order order) const {
   STATIC_ASSERT(4 == sizeof(I));
   STATIC_ASSERT(4 == sizeof(D));
-  D old_value
-    = atomic_fastcall(aarch64_atomic_fetch_add_4_impl, dest, add_value);
-  return old_value;
+  aarch64_atomic_stub_t stub;
+  switch (order) {
+  case memory_order_relaxed:
+    stub = aarch64_atomic_fetch_add_4_relaxed_impl; break;
+  default:
+    stub = aarch64_atomic_fetch_add_4_impl; break;
+  }
+  return atomic_fastcall(stub, dest, add_value);
 }
 
 template<>
@@ -98,9 +103,14 @@ inline D Atomic::PlatformAdd<8>::fetch_and_add(D volatile* dest, I add_value,
                                                atomic_memory_order order) const {
   STATIC_ASSERT(8 == sizeof(I));
   STATIC_ASSERT(8 == sizeof(D));
-  D old_value
-    = atomic_fastcall(aarch64_atomic_fetch_add_8_impl, dest, add_value);
-  return old_value;
+  aarch64_atomic_stub_t stub;
+  switch (order) {
+  case memory_order_relaxed:
+    stub = aarch64_atomic_fetch_add_8_relaxed_impl; break;
+  default:
+    stub = aarch64_atomic_fetch_add_8_impl; break;
+  }
+  return atomic_fastcall(stub, dest, add_value);
 }
 
 template<>


### PR DESCRIPTION
Clean backport to unlock AArch64-specific performance improvements in VM code.

Additional testing:
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274615](https://bugs.openjdk.org/browse/JDK-8274615): Support relaxed atomic add for linux-aarch64


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1383/head:pull/1383` \
`$ git checkout pull/1383`

Update a local copy of the PR: \
`$ git checkout pull/1383` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1383`

View PR using the GUI difftool: \
`$ git pr show -t 1383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1383.diff">https://git.openjdk.org/jdk17u-dev/pull/1383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1383#issuecomment-1556887453)