### PR TITLE
8308554: [17u] Fix commit of 8286191. vm.musl was not removed from ExternalEditorTest

### DIFF
--- a/test/langtools/jdk/jshell/ExternalEditorTest.java
+++ b/test/langtools/jdk/jshell/ExternalEditorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
  * @test
  * @summary Testing external editor.
  * @bug 8143955 8080843 8163816 8143006 8169828 8171130 8162989 8210808
- * @comment musl/Alpine has problems executing some shell scripts, see 8285987
- * @requires !vm.musl
  * @modules jdk.jshell/jdk.internal.jshell.tool
  * @build ReplToolTesting CustomEditor EditorTestBase
  * @run testng ExternalEditorTest


### PR DESCRIPTION
…ternalEditorTest

This edit should have been included in 8286191. 
It was dropped when merging in the jdk repo with the push of JDK-8285987.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308554](https://bugs.openjdk.org/browse/JDK-8308554): [17u] Fix commit of 8286191. vm.musl was not removed from ExternalEditorTest


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1385/head:pull/1385` \
`$ git checkout pull/1385`

Update a local copy of the PR: \
`$ git checkout pull/1385` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1385`

View PR using the GUI difftool: \
`$ git pr show -t 1385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1385.diff">https://git.openjdk.org/jdk17u-dev/pull/1385.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1385#issuecomment-1557360555)