### PR TITLE
8283520: JFR: Memory leak in dcmd_arena

### DIFF
--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -28,6 +28,7 @@
 #include "jfr/utilities/jfrBlob.hpp"
 #include "jfr/utilities/jfrTypes.hpp"
 
+class Arena;
 class JavaThread;
 class JfrBuffer;
 class JfrStackFrame;
@@ -42,6 +43,7 @@ class JfrThreadLocal {
   JfrBuffer* _load_barrier_buffer_epoch_0;
   JfrBuffer* _load_barrier_buffer_epoch_1;
   mutable JfrStackFrame* _stackframes;
+  Arena* _dcmd_arena;
   mutable traceid _trace_id;
   JfrBlobHandle _thread;
   u8 _data_lost;
@@ -218,6 +220,8 @@ class JfrThreadLocal {
   bool is_dead() const {
     return _dead;
   }
+
+  static Arena* dcmd_arena(JavaThread* jt);
 
   bool has_thread_blob() const;
   void set_thread_blob(const JfrBlobHandle& handle);


### PR DESCRIPTION
Unclean backport to resolve a memory leak and provide parity.
The backport is unclean, because the surrounding code is significantly different due to Loom upstream.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `jdk_jfr`
 - [x] Reproducer for the leak does not leak anymore

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283520](https://bugs.openjdk.org/browse/JDK-8283520): JFR: Memory leak in dcmd_arena


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1388/head:pull/1388` \
`$ git checkout pull/1388`

Update a local copy of the PR: \
`$ git checkout pull/1388` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1388`

View PR using the GUI difftool: \
`$ git pr show -t 1388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1388.diff">https://git.openjdk.org/jdk17u-dev/pull/1388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1388#issuecomment-1559655362)