### PR TITLE
8292713: Unsafe.allocateInstance should be intrinsified without UseUnalignedAccesses

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -397,6 +397,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_compareAndExchangeReference:
   case vmIntrinsics::_compareAndExchangeReferenceAcquire:
   case vmIntrinsics::_compareAndExchangeReferenceRelease:
+  case vmIntrinsics::_allocateInstance:
     if (!InlineUnsafeOps) return true;
     break;
   case vmIntrinsics::_getShortUnaligned:
@@ -407,7 +408,6 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_putCharUnaligned:
   case vmIntrinsics::_putIntUnaligned:
   case vmIntrinsics::_putLongUnaligned:
-  case vmIntrinsics::_allocateInstance:
     if (!InlineUnsafeOps || !UseUnalignedAccesses) return true;
     break;
   case vmIntrinsics::_hashCode:


### PR DESCRIPTION
Clean backport to improve ARM32 performance in 17u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292713](https://bugs.openjdk.org/browse/JDK-8292713): Unsafe.allocateInstance should be intrinsified without UseUnalignedAccesses


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1389/head:pull/1389` \
`$ git checkout pull/1389`

Update a local copy of the PR: \
`$ git checkout pull/1389` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1389`

View PR using the GUI difftool: \
`$ git pr show -t 1389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1389.diff">https://git.openjdk.org/jdk17u-dev/pull/1389.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1389#issuecomment-1559655204)