### PR TITLE
8292698: Improve performance of DataInputStream

### DIFF
--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,8 +57,8 @@ public class DataInputStream extends FilterInputStream implements DataInput {
     /**
      * working arrays initialized on demand by readUTF
      */
-    private byte bytearr[] = new byte[80];
-    private char chararr[] = new char[80];
+    private byte[] bytearr = new byte[80];
+    private char[] chararr = new char[80];
 
     /**
      * Reads some number of bytes from the contained input stream and
@@ -245,10 +245,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final boolean readBoolean() throws IOException {
-        int ch = in.read();
-        if (ch < 0)
-            throw new EOFException();
-        return (ch != 0);
+        return readUnsignedByte() != 0;
     }
 
     /**
@@ -268,10 +265,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final byte readByte() throws IOException {
-        int ch = in.read();
-        if (ch < 0)
-            throw new EOFException();
-        return (byte)(ch);
+        return (byte) readUnsignedByte();
     }
 
     /**
@@ -315,11 +309,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final short readShort() throws IOException {
-        int ch1 = in.read();
-        int ch2 = in.read();
-        if ((ch1 | ch2) < 0)
-            throw new EOFException();
-        return (short)((ch1 << 8) + (ch2 << 0));
+        return (short) readUnsignedShort();
     }
 
     /**
@@ -340,6 +330,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final int readUnsignedShort() throws IOException {
+        InputStream in = this.in;
         int ch1 = in.read();
         int ch2 = in.read();
         if ((ch1 | ch2) < 0)
@@ -365,11 +356,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final char readChar() throws IOException {
-        int ch1 = in.read();
-        int ch2 = in.read();
-        if ((ch1 | ch2) < 0)
-            throw new EOFException();
-        return (char)((ch1 << 8) + (ch2 << 0));
+        return (char) readUnsignedShort();
     }
 
     /**
@@ -390,6 +377,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      */
     public final int readInt() throws IOException {
+        InputStream in = this.in;
         int ch1 = in.read();
         int ch2 = in.read();
         int ch3 = in.read();
@@ -399,7 +387,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
         return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
     }
 
-    private byte readBuffer[] = new byte[8];
+    private final byte[] readBuffer = new byte[8];
 
     /**
      * See the general contract of the {@code readLong}
@@ -474,7 +462,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
         return Double.longBitsToDouble(readLong());
     }
 
-    private char lineBuffer[];
+    private char[] lineBuffer;
 
     /**
      * See the general contract of the {@code readLine}
@@ -505,7 +493,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
      */
     @Deprecated
     public final String readLine() throws IOException {
-        char buf[] = lineBuffer;
+        char[] buf = lineBuffer;
 
         if (buf == null) {
             buf = lineBuffer = new char[128];
@@ -634,7 +622,7 @@ loop:   while (true) {
                     if (count > utflen)
                         throw new UTFDataFormatException(
                             "malformed input: partial character at end");
-                    char2 = (int) bytearr[count-1];
+                    char2 = bytearr[count-1];
                     if ((char2 & 0xC0) != 0x80)
                         throw new UTFDataFormatException(
                             "malformed input around byte " + count);
@@ -647,8 +635,8 @@ loop:   while (true) {
                     if (count > utflen)
                         throw new UTFDataFormatException(
                             "malformed input: partial character at end");
-                    char2 = (int) bytearr[count-2];
-                    char3 = (int) bytearr[count-1];
+                    char2 = bytearr[count-2];
+                    char3 = bytearr[count-1];
                     if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80))
                         throw new UTFDataFormatException(
                             "malformed input around byte " + (count-1));

--- a/test/micro/org/openjdk/bench/java/io/DataInputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataInputStreamTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package micro.org.openjdk.bench.java.io;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 4, warmups = 0)
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 2, time = 2)
+@State(Scope.Benchmark)
+public class DataInputStreamTest {
+    private final int size = 1024;
+
+    private ByteArrayInputStream bais;
+
+    @Setup(Level.Iteration)
+    public void setup() {
+        byte[] bytes = new byte[size];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        bais = new ByteArrayInputStream(bytes);
+    }
+
+    @Benchmark
+    public void readChar(Blackhole bh) throws Exception {
+        bais.reset();
+        DataInputStream dis = new DataInputStream(bais);
+        for (int i = 0; i < size / 2; i++) {
+            bh.consume(dis.readChar());
+        }
+    }
+
+    @Benchmark
+    public void readInt(Blackhole bh) throws Exception {
+        bais.reset();
+        DataInputStream dis = new DataInputStream(bais);
+        for (int i = 0; i < size / 4; i++) {
+            bh.consume(dis.readInt());
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to improve `DataInputStream` performance in JDK 17u.

Benchmark from the changeset:

```
Benchmark                     Mode  Cnt   Score   Error  Units

#### x86_64

# Before
DataInputStreamTest.readChar  avgt   20  19.939 ? 0.120  us/op
DataInputStreamTest.readInt   avgt   20  20.538 ? 0.052  us/op

# After
DataInputStreamTest.readChar  avgt   20  10.497 ? 0.079  us/op
DataInputStreamTest.readInt   avgt   20   5.399 ? 0.073  us/op

### AArch64

# Before
DataInputStreamTest.readChar  avgt   20  21.600 ? 0.410  us/op
DataInputStreamTest.readInt   avgt   20  21.425 ? 0.545  us/op

# After
DataInputStreamTest.readChar  avgt   20  12.186 ? 0.366  us/op
DataInputStreamTest.readInt   avgt   20   6.207 ? 0.174  us/op
```

Additional testing:
 - [x] Benchmark added by RFE
 - [x] Linux x86_64 fastdebug, `tier1 tier2 tier3`
 - [x] Linux AArch64 fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292698](https://bugs.openjdk.org/browse/JDK-8292698): Improve performance of DataInputStream


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1390/head:pull/1390` \
`$ git checkout pull/1390`

Update a local copy of the PR: \
`$ git checkout pull/1390` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1390`

View PR using the GUI difftool: \
`$ git pr show -t 1390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1390.diff">https://git.openjdk.org/jdk17u-dev/pull/1390.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1390#issuecomment-1559657559)