### PR TITLE
8295812: Skip the "half float" support in LittleCMS during the build

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -265,7 +265,7 @@ endif
 ################################################################################
 
 # The fast floor code loses precision.
-LCMS_CFLAGS=-DCMS_DONT_USE_FAST_FLOOR
+LCMS_CFLAGS=-DCMS_DONT_USE_FAST_FLOOR -DCMS_NO_HALF_SUPPORT
 
 ifeq ($(USE_EXTERNAL_LCMS), true)
   # If we're using an external library, we'll just need the wrapper part.


### PR DESCRIPTION
Hi all,

  This pull request contains a backport of commit [f0a6e71e](https://github.com/openjdk/jdk/commit/f0a6e71e4d63c9820659f6ff29f94d0476d48b09) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

  The commit being backported was authored by Sergey Bylokhov on 10 Nov 2022 and was reviewed by Erik Joelsson, Phil Race and Magnus Ihse Bursie.

  Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295812](https://bugs.openjdk.org/browse/JDK-8295812): Skip the "half float" support in LittleCMS during the build (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1393/head:pull/1393` \
`$ git checkout pull/1393`

Update a local copy of the PR: \
`$ git checkout pull/1393` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1393`

View PR using the GUI difftool: \
`$ git pr show -t 1393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1393.diff">https://git.openjdk.org/jdk17u-dev/pull/1393.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1393#issuecomment-1561945616)