### PR TITLE
8300939: sun/security/provider/certpath/OCSP/OCSPNoContentLength.java fails due to network errors

### DIFF
--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -321,12 +321,13 @@ public class SimpleOCSPServer {
      * @return the hexdump of the byte array
      */
     private static String dumpHexBytes(byte[] data) {
-        return dumpHexBytes(data, 16, "\n", " ");
+        return dumpHexBytes(data, data.length, 16, "\n", " ");
     }
 
     /**
      *
-     * @param data the array of bytes to dump to stdout.
+     * @param data the array of bytes to dump to stdout
+     * @param dataLen the length of the data to be displayed
      * @param itemsPerLine the number of bytes to display per line
      * if the {@code lineDelim} character is blank then all bytes will be
      * printed on a single line.
@@ -335,11 +336,11 @@ public class SimpleOCSPServer {
      *
      * @return The hexdump of the byte array
      */
-    private static String dumpHexBytes(byte[] data, int itemsPerLine,
-            String lineDelim, String itemDelim) {
+    private static String dumpHexBytes(byte[] data, int dataLen,
+            int itemsPerLine, String lineDelim, String itemDelim) {
         StringBuilder sb = new StringBuilder();
         if (data != null) {
-            for (int i = 0; i < data.length; i++) {
+            for (int i = 0; i < dataLen; i++) {
                 if (i % itemsPerLine == 0 && i != 0) {
                     sb.append(lineDelim);
                 }
@@ -489,6 +490,7 @@ public class SimpleOCSPServer {
             throws NoSuchAlgorithmException {
         if (!started) {
             sigAlgId = AlgorithmId.get(algName);
+            log("Signature algorithm set to " + sigAlgId.getName());
         }
     }
 
@@ -552,6 +554,8 @@ public class SimpleOCSPServer {
     public void setDisableContentLength(boolean isDisabled) {
         if (!started) {
             omitContentLength = isDisabled;
+            log("Response Content-Length field " +
+                    (isDisabled ? "disabled" : "enabled"));
         }
     }
 
@@ -726,6 +730,10 @@ public class SimpleOCSPServer {
                     OutputStream out = ocspSocket.getOutputStream()) {
                 peerSockAddr =
                         (InetSocketAddress)ocspSocket.getRemoteSocketAddress();
+
+                // Read in the first line which will be the request line.
+                // This will be tokenized so we know if we are dealing with
+                // a GET or POST.
                 String[] headerTokens = readLine(in).split(" ");
                 LocalOcspRequest ocspReq = null;
                 LocalOcspResponse ocspResp = null;
@@ -734,12 +742,12 @@ public class SimpleOCSPServer {
                     if (headerTokens[0] != null) {
                         log("Received incoming HTTP " + headerTokens[0] +
                                 " from " + peerSockAddr);
-                        switch (headerTokens[0]) {
+                        switch (headerTokens[0].toUpperCase()) {
                             case "POST":
                                 ocspReq = parseHttpOcspPost(in);
                                 break;
                             case "GET":
-                                ocspReq = parseHttpOcspGet(headerTokens);
+                                ocspReq = parseHttpOcspGet(headerTokens, in);
                                 break;
                             default:
                                 respStat = ResponseStatus.MALFORMED_REQUEST;
@@ -773,6 +781,9 @@ public class SimpleOCSPServer {
                     ocspResp = new LocalOcspResponse(respStat);
                 }
                 sendResponse(out, ocspResp);
+                out.flush();
+
+                log("Closing " + ocspSocket);
             } catch (IOException | CertificateException exc) {
                 err(exc);
             }
@@ -870,6 +881,8 @@ public class SimpleOCSPServer {
          *
          * @param headerTokens the individual String tokens from the first
          * line of the HTTP GET.
+         * @param inStream the input stream from the socket bound to this
+         * {@code OcspHandler}.
          *
          * @return the OCSP Request as a {@code LocalOcspRequest}
          *
@@ -878,8 +891,26 @@ public class SimpleOCSPServer {
          * @throws CertificateException if one or more of the certificates in
          * the OCSP request cannot be read/parsed.
          */
-        private LocalOcspRequest parseHttpOcspGet(String[] headerTokens)
-                throws IOException, CertificateException {
+        private LocalOcspRequest parseHttpOcspGet(String[] headerTokens,
+                InputStream inStream) throws IOException, CertificateException {
+            // Before we process the remainder of the GET URL, we should drain
+            // the InputStream of any other header data.  We (for now) won't
+            // use it, but will display the contents if logging is enabled.
+            boolean endOfHeader = false;
+            while (!endOfHeader) {
+                String[] lineTokens = readLine(inStream).split(":", 2);
+                // We expect to see a type and value pair delimited by a colon.
+                if (lineTokens[0].isEmpty()) {
+                    endOfHeader = true;
+                } else if (lineTokens.length == 2) {
+                    log(String.format("ReqHdr: %s: %s", lineTokens[0].trim(),
+                            lineTokens[1].trim()));
+                } else {
+                    // A colon wasn't found and token 0 should be the whole line
+                    log("ReqHdr: " + lineTokens[0].trim());
+                }
+            }
+
             // We have already established headerTokens[0] to be "GET".
             // We should have the URL-encoded base64 representation of the
             // OCSP request in headerTokens[1].  We need to strip any leading
@@ -1200,10 +1231,14 @@ public class SimpleOCSPServer {
                 sb.append("CertId, Algorithm = ");
                 sb.append(cid.getHashAlgorithm()).append("\n");
                 sb.append("\tIssuer Name Hash: ");
-                sb.append(dumpHexBytes(cid.getIssuerNameHash(), 256, "", ""));
+                byte[] cidHashBuf = cid.getIssuerNameHash();
+                sb.append(dumpHexBytes(cidHashBuf, cidHashBuf.length,
+                        256, "", ""));
                 sb.append("\n");
                 sb.append("\tIssuer Key Hash: ");
-                sb.append(dumpHexBytes(cid.getIssuerKeyHash(), 256, "", ""));
+                cidHashBuf = cid.getIssuerKeyHash();
+                sb.append(dumpHexBytes(cidHashBuf, cidHashBuf.length,
+                        256, "", ""));
                 sb.append("\n");
                 sb.append("\tSerial Number: ").append(cid.getSerialNumber());
                 if (!extensions.isEmpty()) {
@@ -1543,10 +1578,14 @@ public class SimpleOCSPServer {
                 sb.append("CertId, Algorithm = ");
                 sb.append(certId.getHashAlgorithm()).append("\n");
                 sb.append("\tIssuer Name Hash: ");
-                sb.append(dumpHexBytes(certId.getIssuerNameHash(), 256, "", ""));
+                byte[] cidHashBuf = certId.getIssuerNameHash();
+                sb.append(dumpHexBytes(cidHashBuf, cidHashBuf.length,
+                        256, "", ""));
                 sb.append("\n");
                 sb.append("\tIssuer Key Hash: ");
-                sb.append(dumpHexBytes(certId.getIssuerKeyHash(), 256, "", ""));
+                cidHashBuf = certId.getIssuerKeyHash();
+                sb.append(dumpHexBytes(cidHashBuf, cidHashBuf.length,
+                        256, "", ""));
                 sb.append("\n");
                 sb.append("\tSerial Number: ").append(certId.getSerialNumber());
                 sb.append("\n");

--- a/test/jdk/sun/security/provider/certpath/OCSP/OCSPNoContentLength.java
+++ b/test/jdk/sun/security/provider/certpath/OCSP/OCSPNoContentLength.java
@@ -56,7 +56,7 @@ public class OCSPNoContentLength {
     static String EE_ALIAS = "endentity";
 
     // Enable debugging for additional output
-    static final boolean debug = false;
+    static final boolean debug = true;
 
     // PKI components we will need for this test
     static X509Certificate rootCert;        // The root CA certificate
@@ -66,7 +66,6 @@ public class OCSPNoContentLength {
     static KeyStore trustStore;             // SSL Client trust store
     static SimpleOCSPServer rootOcsp;       // Root CA OCSP Responder
     static int rootOcspPort;                // Port number for root OCSP
-
 
     public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
Hi!

Here is backport of [JDK-8300939](https://bugs.openjdk.org/browse/JDK-8300939) fixing `sun/security/provider/certpath/OCSP/OCSPNoContentLength.java` test. Original patch applied cleanly except removing issue record from `test/jdk/ProblemList.txt`.

Verification/regression (amd64/LTS20.04): jdk_security

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300939](https://bugs.openjdk.org/browse/JDK-8300939): sun/security/provider/certpath/OCSP/OCSPNoContentLength.java fails due to network errors


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1394/head:pull/1394` \
`$ git checkout pull/1394`

Update a local copy of the PR: \
`$ git checkout pull/1394` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1394`

View PR using the GUI difftool: \
`$ git pr show -t 1394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1394.diff">https://git.openjdk.org/jdk17u-dev/pull/1394.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1394#issuecomment-1561310088)