### PR TITLE
8294717: (bf) DirectByteBuffer constructor will leak if allocating Deallocator or Cleaner fails with OOME

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -134,7 +134,14 @@ class Direct$Type$Buffer$RW$$BO$
         } else {
             address = base;
         }
-        cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+        try {
+            cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+        } catch (Throwable t) {
+            // Prevent leak if the Deallocator or Cleaner fail for any reason
+            UNSAFE.freeMemory(base);
+            Bits.unreserveMemory(size, cap);
+            throw t;
+        }
         att = null;
 #else[rw]
         super(cap);


### PR DESCRIPTION
Clean backport to eliminate a leak corner case.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294717](https://bugs.openjdk.org/browse/JDK-8294717): (bf) DirectByteBuffer constructor will leak if allocating Deallocator or Cleaner fails with OOME


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1396/head:pull/1396` \
`$ git checkout pull/1396`

Update a local copy of the PR: \
`$ git checkout pull/1396` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1396`

View PR using the GUI difftool: \
`$ git pr show -t 1396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1396.diff">https://git.openjdk.org/jdk17u-dev/pull/1396.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1396#issuecomment-1561842100)