### PR TITLE
8294183: AArch64: Wrong macro check in SharedRuntime::generate_deopt_blob

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2359,10 +2359,9 @@ void SharedRuntime::generate_deopt_blob() {
 
   Label retaddr;
   __ set_last_Java_frame(sp, noreg, retaddr, rscratch1);
-#ifdef ASSERT0
+#ifdef ASSERT
   { Label L;
-    __ ldr(rscratch1, Address(rthread,
-                              JavaThread::last_Java_fp_offset()));
+    __ ldr(rscratch1, Address(rthread, JavaThread::last_Java_fp_offset()));
     __ cbz(rscratch1, L);
     __ stop("SharedRuntime::generate_deopt_blob: last_Java_fp not cleared");
     __ bind(L);


### PR DESCRIPTION
Clean backport to improve AArch64 testing.

Additional testing:
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294183](https://bugs.openjdk.org/browse/JDK-8294183): AArch64: Wrong macro check in SharedRuntime::generate_deopt_blob


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1398/head:pull/1398` \
`$ git checkout pull/1398`

Update a local copy of the PR: \
`$ git checkout pull/1398` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1398`

View PR using the GUI difftool: \
`$ git pr show -t 1398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1398.diff">https://git.openjdk.org/jdk17u-dev/pull/1398.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1398#issuecomment-1563097652)