### PR TITLE
8286346: 3-parameter version of AllocateHeap should not ignore AllocFailType

### DIFF
--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -49,7 +49,7 @@ char* AllocateHeap(size_t size,
 char* AllocateHeap(size_t size,
                    MEMFLAGS flags,
                    AllocFailType alloc_failmode /* = AllocFailStrategy::EXIT_OOM*/) {
-  return AllocateHeap(size, flags, CALLER_PC);
+  return AllocateHeap(size, flags, CALLER_PC, alloc_failmode);
 }
 
 char* ReallocateHeap(char *old,


### PR DESCRIPTION
Clean backport to resolve the regression since JDK 11 due to [JDK-8199698](https://bugs.openjdk.org/browse/JDK-8199698). Also unblocks the backport of [JDK-8286331](https://bugs.openjdk.org/browse/JDK-8286331).

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286346](https://bugs.openjdk.org/browse/JDK-8286346): 3-parameter version of AllocateHeap should not ignore AllocFailType


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1399/head:pull/1399` \
`$ git checkout pull/1399`

Update a local copy of the PR: \
`$ git checkout pull/1399` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1399`

View PR using the GUI difftool: \
`$ git pr show -t 1399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1399.diff">https://git.openjdk.org/jdk17u-dev/pull/1399.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1399#issuecomment-1563130139)