### PR TITLE
8308880: [17u] micro bench ZoneStrings missed in backport of 8278434

### DIFF
--- a/test/micro/org/openjdk/bench/java/text/ZoneStrings.java
+++ b/test/micro/org/openjdk/bench/java/text/ZoneStrings.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.text;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.text.DateFormatSymbols;
+import java.util.Locale;
+
+@BenchmarkMode(Mode.SingleShotTime)
+@State(Scope.Thread)
+public class ZoneStrings {
+
+    @Benchmark
+    public void testZoneStrings() {
+        for (Locale l : Locale.getAvailableLocales()) {
+            new DateFormatSymbols(l).getZoneStrings();
+        }
+    }
+}


### PR DESCRIPTION
I missed this test in backport of 8278434. Clean copy from the original change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308880](https://bugs.openjdk.org/browse/JDK-8308880): [17u] micro bench ZoneStrings missed in backport of 8278434


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1400/head:pull/1400` \
`$ git checkout pull/1400`

Update a local copy of the PR: \
`$ git checkout pull/1400` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1400`

View PR using the GUI difftool: \
`$ git pr show -t 1400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1400.diff">https://git.openjdk.org/jdk17u-dev/pull/1400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1400#issuecomment-1563128789)