### PR TITLE
8286331: jni_GetStringUTFChars() uses wrong heap allocator

### DIFF
--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -49,7 +49,7 @@ char* AllocateHeap(size_t size,
 char* AllocateHeap(size_t size,
                    MEMFLAGS flags,
                    AllocFailType alloc_failmode /* = AllocFailStrategy::EXIT_OOM*/) {
-  return AllocateHeap(size, flags, CALLER_PC);
+  return AllocateHeap(size, flags, CALLER_PC, alloc_failmode);
 }
 
 char* ReallocateHeap(char *old,

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2234,7 +2234,7 @@ JNI_ENTRY(const char*, jni_GetStringUTFChars(JNIEnv *env, jstring string, jboole
   if (s_value != NULL) {
     size_t length = java_lang_String::utf8_length(java_string, s_value);
     /* JNI Specification states return NULL on OOM */
-    result = AllocateHeap(length + 1, mtInternal, 0, AllocFailStrategy::RETURN_NULL);
+    result = AllocateHeap(length + 1, mtInternal, AllocFailStrategy::RETURN_NULL);
     if (result != NULL) {
       java_lang_String::as_utf8_string(java_string, s_value, result, (int) length + 1);
       if (isCopy != NULL) {

--- a/src/hotspot/share/utilities/nativeCallStack.hpp
+++ b/src/hotspot/share/utilities/nativeCallStack.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public:
     memset(_stack, 0, sizeof(_stack));
   }
 
-  NativeCallStack(int toSkip);
+  explicit NativeCallStack(int toSkip);
   NativeCallStack(address* pc, int frameCount);
 
   static inline const NativeCallStack& empty_stack() { return _empty_stack; }


### PR DESCRIPTION
Clean backport to avoid accidental stack walk during `GetStringUTFChars`. Requires #1399 to be correct.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286331](https://bugs.openjdk.org/browse/JDK-8286331): jni_GetStringUTFChars() uses wrong heap allocator


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1401/head:pull/1401` \
`$ git checkout pull/1401`

Update a local copy of the PR: \
`$ git checkout pull/1401` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1401`

View PR using the GUI difftool: \
`$ git pr show -t 1401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1401.diff">https://git.openjdk.org/jdk17u-dev/pull/1401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1401#issuecomment-1563144299)