### PR TITLE
8293295: Add type check asserts to java_lang_ref_Reference accessors

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -925,6 +925,8 @@ class java_lang_ref_Reference: AllStatic {
   static bool is_referent_field(oop obj, ptrdiff_t offset);
   static inline bool is_final(oop ref);
   static inline bool is_phantom(oop ref);
+  static inline bool is_weak(oop ref);
+  static inline bool is_soft(oop ref);
 
   static int referent_offset()    { CHECK_INIT(_referent_offset); }
   static int queue_offset()       { CHECK_INIT(_queue_offset); }

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -27,6 +27,7 @@
 
 #include "classfile/javaClasses.hpp"
 
+#include "memory/referenceType.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/method.hpp"
 #include "oops/oop.inline.hpp"
@@ -130,10 +131,12 @@ bool java_lang_String::is_instance_inlined(oop obj) {
 // Accessors
 
 oop java_lang_ref_Reference::weak_referent_no_keepalive(oop ref) {
+  assert(java_lang_ref_Reference::is_weak(ref) || java_lang_ref_Reference::is_soft(ref), "must be Weak or Soft Reference");
   return ref->obj_field_access<ON_WEAK_OOP_REF | AS_NO_KEEPALIVE>(_referent_offset);
 }
 
 oop java_lang_ref_Reference::phantom_referent_no_keepalive(oop ref) {
+  assert(java_lang_ref_Reference::is_phantom(ref), "must be Phantom Reference");
   return ref->obj_field_access<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>(_referent_offset);
 }
 
@@ -187,6 +190,14 @@ bool java_lang_ref_Reference::is_final(oop ref) {
 
 bool java_lang_ref_Reference::is_phantom(oop ref) {
   return InstanceKlass::cast(ref->klass())->reference_type() == REF_PHANTOM;
+}
+
+bool java_lang_ref_Reference::is_weak(oop ref) {
+  return InstanceKlass::cast(ref->klass())->reference_type() == REF_WEAK;
+}
+
+bool java_lang_ref_Reference::is_soft(oop ref) {
+  return InstanceKlass::cast(ref->klass())->reference_type() == REF_SOFT;
 }
 
 inline void java_lang_invoke_CallSite::set_target_volatile(oop site, oop target) {


### PR DESCRIPTION
Maintenance backport: check that accessors are used for proper reference types. Helps to maintain GCs.

The backport is not clean, because we miss the hunk for `java_lang_ref_Reference::weak_referent`, added by Loom integration in JDK 19.

Additional testing:
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293295](https://bugs.openjdk.org/browse/JDK-8293295): Add type check asserts to java_lang_ref_Reference accessors


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1403/head:pull/1403` \
`$ git checkout pull/1403`

Update a local copy of the PR: \
`$ git checkout pull/1403` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1403`

View PR using the GUI difftool: \
`$ git pr show -t 1403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1403.diff">https://git.openjdk.org/jdk17u-dev/pull/1403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1403#issuecomment-1564690488)