### PR TITLE
8301637: ThreadLocalRandom.current().doubles().parallel() contention

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -422,6 +422,10 @@ public class ThreadLocalRandom extends Random {
         public long nextLong() {
             return ThreadLocalRandom.current().nextLong();
         }
+
+        public double nextDouble() {
+            return ThreadLocalRandom.current().nextDouble();
+        }
     }
 
     /**


### PR DESCRIPTION
Clean backport to resolve `ThreadLocalRandom` performance regression since JDK 17.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301637](https://bugs.openjdk.org/browse/JDK-8301637): ThreadLocalRandom.current().doubles().parallel() contention


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1404/head:pull/1404` \
`$ git checkout pull/1404`

Update a local copy of the PR: \
`$ git checkout pull/1404` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1404`

View PR using the GUI difftool: \
`$ git pr show -t 1404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1404.diff">https://git.openjdk.org/jdk17u-dev/pull/1404.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1404#issuecomment-1564718455)