### PR TITLE
8300053: Shenandoah: Handle more GCCauses in ShenandoahControlThread::request_gc

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -479,10 +479,11 @@ void ShenandoahControlThread::request_gc(GCCause::Cause cause) {
          GCCause::is_serviceability_requested_gc(cause) ||
          cause == GCCause::_metadata_GC_clear_soft_refs ||
          cause == GCCause::_full_gc_alot ||
+         cause == GCCause::_wb_young_gc ||
          cause == GCCause::_wb_full_gc ||
          cause == GCCause::_wb_breakpoint ||
          cause == GCCause::_scavenge_alot,
-         "only requested GCs here");
+         "only requested GCs here: %s", GCCause::to_string(cause));
 
   if (is_explicit_gc(cause)) {
     if (!DisableExplicitGC) {


### PR DESCRIPTION
Clean backport to catch a corner case for Shenandoah.

Additional testing:
 - [x] macos-aarch64-server-fastdebug build
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300053](https://bugs.openjdk.org/browse/JDK-8300053): Shenandoah: Handle more GCCauses in ShenandoahControlThread::request_gc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1409/head:pull/1409` \
`$ git checkout pull/1409`

Update a local copy of the PR: \
`$ git checkout pull/1409` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1409`

View PR using the GUI difftool: \
`$ git pr show -t 1409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1409.diff">https://git.openjdk.org/jdk17u-dev/pull/1409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1409#issuecomment-1568174469)