### PR TITLE
8307395: Add missing STS to Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -766,6 +766,7 @@ public:
 
   void work(uint worker_id) {
     ShenandoahConcurrentWorkerSession worker_session(worker_id);
+    ShenandoahSuspendibleThreadSetJoiner sts_join;
     {
       ShenandoahEvacOOMScope oom;
       // jni_roots and weak_roots are OopStorage backed roots, concurrent iteration


### PR DESCRIPTION
Clean backport to improve Shenandoah reliability.

Additional testing:
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307395](https://bugs.openjdk.org/browse/JDK-8307395): Add missing STS to Shenandoah (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1410/head:pull/1410` \
`$ git checkout pull/1410`

Update a local copy of the PR: \
`$ git checkout pull/1410` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1410`

View PR using the GUI difftool: \
`$ git pr show -t 1410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1410.diff">https://git.openjdk.org/jdk17u-dev/pull/1410.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1410#issuecomment-1568182484)