### PR TITLE
8301187: Memory leaks in OopMapCache

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -536,6 +536,7 @@ void OopMapCache::lookup(const methodHandle& method,
     // at this time. We give the caller of lookup() a copy of the
     // interesting info via parameter entry_for, but we don't add it to
     // the cache. See the gory details in Method*.cpp.
+    tmp->flush();
     FREE_C_HEAP_OBJ(tmp);
     return;
   }
@@ -606,5 +607,6 @@ void OopMapCache::compute_one_oop_map(const methodHandle& method, int bci, Inter
   tmp->initialize();
   tmp->fill(method, bci);
   entry->resource_copy(tmp);
+  tmp->flush();
   FREE_C_HEAP_OBJ(tmp);
 }


### PR DESCRIPTION
Clean backport to eliminate a minor memory leak.

Additional testing:
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301187](https://bugs.openjdk.org/browse/JDK-8301187): Memory leaks in OopMapCache


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1412/head:pull/1412` \
`$ git checkout pull/1412`

Update a local copy of the PR: \
`$ git checkout pull/1412` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1412`

View PR using the GUI difftool: \
`$ git pr show -t 1412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1412.diff">https://git.openjdk.org/jdk17u-dev/pull/1412.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1412#issuecomment-1568669998)