### PR TITLE
Backport 438c969b7b07eeef0158b089e5a168849e04bf56

### DIFF
--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -4182,9 +4182,8 @@ public final class DateTimeFormatterBuilder {
             }
             Locale locale = context.getLocale();
             boolean isCaseSensitive = context.isCaseSensitive();
-            Set<String> regionIds = new HashSet<>(ZoneRulesProvider.getAvailableZoneIds());
-            Set<String> nonRegionIds = new HashSet<>(64);
-            int regionIdsSize = regionIds.size();
+            Set<String> availableZoneIds = ZoneRulesProvider.getAvailableZoneIds();
+            int regionIdsSize = availableZoneIds.size();
 
             Map<Locale, Entry<Integer, SoftReference<PrefixTree>>> cached =
                 isCaseSensitive ? cachedTree : cachedTreeCI;
@@ -4197,6 +4196,8 @@ public final class DateTimeFormatterBuilder {
                 (tree = entry.getValue().get()) == null)) {
                 tree = PrefixTree.newTree(context);
                 zoneStrings = TimeZoneNameUtility.getZoneStrings(locale);
+                Set<String> nonRegionIds = new HashSet<>(64);
+                Set<String> regionIds = new HashSet<>(availableZoneIds);
                 for (String[] names : zoneStrings) {
                     String zid = names[0];
                     if (!regionIds.remove(zid)) {

--- a/test/micro/org/openjdk/bench/java/time/format/ZonedDateTimeFormatterBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/time/format/ZonedDateTimeFormatterBenchmark.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.time.format;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.concurrent.TimeUnit;
+
+@Fork(4)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class ZonedDateTimeFormatterBenchmark {
+
+    private static final DateTimeFormatter df = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy:MM:dd:HH:mm:v")
+            .toFormatter();
+    private static final String TEXT = "2015:03:10:12:13:ECT";
+
+    @Setup
+    public void setUp() {
+        ZonedDateTime.parse(TEXT, df);
+    }
+
+    @Benchmark
+    public ZonedDateTime parse() {
+        return ZonedDateTime.parse(TEXT, df);
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [438c969b](https://github.com/openjdk/jdk/commit/438c969b7b07eeef0158b089e5a168849e04bf56) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Tsypanov on 29 Mar 2023 and was reviewed by Naoto Sato.

Since the original uses the new `newHashMap` and `newHashSet` methods from https://bugs.openjdk.org/browse/JDK-8284780 which are not here in 17, I've not included those changes in the backport. They are not a significant part of the original fix, the main point of the change is kept which is avoiding the creation of 2 new hash sets on the cached path. Running the included benchmark confirms the performance improvement even with the omissions:

Base:
```
Benchmark                                                  Mode  Cnt      Score     Error   Units
ZonedDateTimeFormatterBenchmark.parse                      avgt   20  18248.082 ? 166.440   ns/op
ZonedDateTimeFormatterBenchmark.parse:?gc.alloc.rate       avgt   20   1274.964 ?  11.448  MB/sec
ZonedDateTimeFormatterBenchmark.parse:?gc.alloc.rate.norm  avgt   20  24400.418 ?   1.591    B/op
ZonedDateTimeFormatterBenchmark.parse:?gc.count            avgt   20     44.000            counts
ZonedDateTimeFormatterBenchmark.parse:?gc.time             avgt   20     35.000                ms
```

Patch:
```
Benchmark                                                  Mode  Cnt    Score   Error   Units
ZonedDateTimeFormatterBenchmark.parse                      avgt   20  923.943 ? 8.737   ns/op
ZonedDateTimeFormatterBenchmark.parse:?gc.alloc.rate       avgt   20  883.450 ? 8.163  MB/sec
ZonedDateTimeFormatterBenchmark.parse:?gc.alloc.rate.norm  avgt   20  856.021 ? 0.079    B/op
ZonedDateTimeFormatterBenchmark.parse:?gc.count            avgt   20   32.000          counts
ZonedDateTimeFormatterBenchmark.parse:?gc.time             avgt   20   27.000              ms
```