### PR TITLE
8269091: javax/sound/sampled/Clip/SetPositionHang.java failed with ArrayIndexOutOfBoundsException: Array index out of range: -4

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
@@ -1297,8 +1297,9 @@ final class DirectAudioDevice extends AbstractMixer {
                     }
                 }
                 while (doIO && thread == curThread) {
-                    if (newFramePosition >= 0) {
-                        clipBytePosition = newFramePosition * frameSize;
+                    int npf = newFramePosition; // copy into local variable
+                    if (npf >= 0) {
+                        clipBytePosition = npf * frameSize;
                         newFramePosition = -1;
                     }
                     int endFrame = getFrameLength() - 1;

--- a/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/SetPositionHang.java
@@ -28,7 +28,7 @@ import javax.sound.sampled.LineUnavailableException;
 
 /**
  * @test
- * @bug 8266421
+ * @bug 8266421 8269091
  * @summary Tests that Clip.setFramePosition/setMicrosecondPosition do not hang.
  */
 public final class SetPositionHang implements Runnable {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269091](https://bugs.openjdk.org/browse/JDK-8269091): javax/sound/sampled/Clip/SetPositionHang.java failed with ArrayIndexOutOfBoundsException: Array index out of range: -4 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1420/head:pull/1420` \
`$ git checkout pull/1420`

Update a local copy of the PR: \
`$ git checkout pull/1420` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1420`

View PR using the GUI difftool: \
`$ git pr show -t 1420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1420.diff">https://git.openjdk.org/jdk17u-dev/pull/1420.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1420#issuecomment-1587507988)