### PR TITLE
8299962: Speed up compiler/intrinsics/unsafe/DirectByteBufferTest.java and HeapByteBufferTest.java

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/DirectByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/DirectByteBufferTest.java
@@ -41,7 +41,7 @@ public class DirectByteBufferTest extends ByteBufferTest {
     public static void main(String[] args) {
         // The number of iterations is high to ensure that tiered
         // compilation kicks in all the way up to C2.
-        long iterations = 100000;
+        long iterations = 5000;
         if (args.length > 0)
             iterations = Long.parseLong(args[0]);
 

--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/HeapByteBufferTest.java
@@ -59,7 +59,7 @@ public class HeapByteBufferTest extends ByteBufferTest {
     public static void main(String[] args) {
         // The number of iterations is high to ensure that tiered
         // compilation kicks in all the way up to C2.
-        long iterations = 100000;
+        long iterations = 5000;
         if (args.length > 0)
             iterations = Long.parseLong(args[0]);
 


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299962](https://bugs.openjdk.org/browse/JDK-8299962): Speed up compiler/intrinsics/unsafe/DirectByteBufferTest.java and HeapByteBufferTest.java (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1430/head:pull/1430` \
`$ git checkout pull/1430`

Update a local copy of the PR: \
`$ git checkout pull/1430` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1430`

View PR using the GUI difftool: \
`$ git pr show -t 1430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1430.diff">https://git.openjdk.org/jdk17u-dev/pull/1430.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1430#issuecomment-1589841778)