### PR TITLE
8282651: ZGC: vmTestbase/gc/ArrayJuggle/ tests fails intermittently with exit code 97

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle02/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle02/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp byteArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle03/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle03/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp byteArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp byteArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp byteArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle05/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle05/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp booleanArr

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle06/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle06/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp booleanArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp booleanArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle07/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle07/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp shortArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle08/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle08/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp shortArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle09/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle09/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp shortArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp shortArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle10/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle10/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp charArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle11/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle11/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,12 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log -Djava.security.manager=allow gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      -Djava.security.manager=allow
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp charArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle12/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle12/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp charArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp charArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle13/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle13/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp intArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle14/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle14/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp intArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle15/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle15/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp intArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp intArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle16/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle16/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp longArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle17/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle17/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp longArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle18/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle18/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp longArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp longArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle19/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle19/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp floatArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle20/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle20/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp floatArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle21/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle21/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp floatArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp floatArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle22/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle22/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp doubleArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle23/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle23/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp doubleArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle24/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle24/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp doubleArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp doubleArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle25/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle25/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms low
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp objectArr
+ *      -ms low
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle26/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle26/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms medium
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp objectArr
+ *      -ms medium
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle27/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle27/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm -Xlog:gc=debug:gc.log gc.ArrayJuggle.Juggle01.Juggle01 -gp objectArr -ms high
+ * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
+ *      -Xlog:gc=debug:gc.log
+ *      gc.ArrayJuggle.Juggle01.Juggle01
+ *      -gp objectArr
+ *      -ms high
  */
 

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle28/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle28/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle29/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle29/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle30/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle30/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(doubleArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle31/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle31/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle32/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle32/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle33/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle33/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp hashed(objectArr)

--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle34/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle34/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @run main/othervm
+ *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
  *      -gp random(arrays)


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282651](https://bugs.openjdk.org/browse/JDK-8282651): ZGC: vmTestbase/gc/ArrayJuggle/ tests fails intermittently with exit code 97 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1431/head:pull/1431` \
`$ git checkout pull/1431`

Update a local copy of the PR: \
`$ git checkout pull/1431` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1431`

View PR using the GUI difftool: \
`$ git pr show -t 1431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1431.diff">https://git.openjdk.org/jdk17u-dev/pull/1431.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1431#issuecomment-1589868471)