### PR TITLE
8305858: Resolve multiple definition of 'handleSocketError' when statically linking with JDK native libraries

### DIFF
--- a/src/jdk.sctp/unix/native/libsctp/Sctp.h
+++ b/src/jdk.sctp/unix/native/libsctp/Sctp.h
@@ -285,6 +285,6 @@ extern sctp_freepaddrs_func* nio_sctp_freepaddrs;
 extern sctp_bindx_func* nio_sctp_bindx;
 extern sctp_peeloff_func* nio_sctp_peeloff;
 
-jboolean loadSocketExtensionFuncs(JNIEnv* env);
+extern jint sctpHandleSocketError(JNIEnv *env, jint errorValue);
 
 #endif /* !SUN_NIO_CH_SCTP_H */

--- a/src/jdk.sctp/unix/native/libsctp/SctpChannelImpl.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpChannelImpl.c
@@ -28,7 +28,6 @@
 #include "Sctp.h"
 
 #include "jni.h"
-#include "nio_util.h"
 #include "nio.h"
 #include "net_util.h"
 #include "net_util_md.h"
@@ -69,8 +68,6 @@ static jmethodID ss_ctrID;     /* sun.nio.ch.sctp.Shutdown.<init>            */
 
 /* defined in SctpNet.c */
 jobject SockAddrToInetSocketAddress(JNIEnv* env, struct sockaddr* addr);
-
-jint handleSocketError(JNIEnv *env, jint errorValue);
 
 /*
  * Class:     sun_nio_ch_sctp_SctpChannelImpl
@@ -247,7 +244,7 @@ void handleSendFailed
         if (remaining > 0) {
             if ((rv = recvmsg(fd, msg, 0)) < 0) {
                 free(addressP);
-                handleSocketError(env, errno);
+                sctpHandleSocketError(env, errno);
                 return;
             }
 
@@ -458,7 +455,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpChannelImpl_receive0
 #endif /* __linux__ */
 
             } else {
-                handleSocketError(env, errno);
+                sctpHandleSocketError(env, errno);
                 return 0;
             }
         }
@@ -482,7 +479,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpChannelImpl_receive0
                 iov->iov_base = newBuf + rv;
                 iov->iov_len = SCTP_NOTIFICATION_SIZE - rv;
                 if ((rv = recvmsg(fd, msg, flags)) < 0) {
-                    handleSocketError(env, errno);
+                    sctpHandleSocketError(env, errno);
                     free(newBuf);
                     return 0;
                 }
@@ -582,7 +579,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpChannelImpl_send0
             JNU_ThrowByName(env, JNU_JAVANETPKG "SocketException",
                             "Socket is shutdown for writing");
         } else {
-            handleSocketError(env, errno);
+            sctpHandleSocketError(env, errno);
             return 0;
         }
     }

--- a/src/jdk.sctp/unix/native/libsctp/SctpNet.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpNet.c
@@ -30,7 +30,6 @@
 #include "Sctp.h"
 #include "jni.h"
 #include "jni_util.h"
-#include "nio_util.h"
 #include "nio.h"
 #include "net_util.h"
 #include "net_util_md.h"
@@ -63,7 +62,7 @@ static int preCloseFD = -1;     /* File descriptor to which we dup other fd's
  * functions, as well as locating the individual functions.
  * There will be a pending exception if this method returns false.
  */
-jboolean loadSocketExtensionFuncs
+static jboolean loadSocketExtensionFuncs
   (JNIEnv* env) {
     if (dlopen(nativeSctpLib, RTLD_GLOBAL | RTLD_LAZY) == NULL) {
         JNU_ThrowByName(env, "java/lang/UnsupportedOperationException",
@@ -118,7 +117,7 @@ jboolean loadSocketExtensionFuncs
 }
 
 jint
-handleSocketError(JNIEnv *env, jint errorValue)
+sctpHandleSocketError(JNIEnv *env, jint errorValue)
 {
     char *xn;
     switch (errorValue) {
@@ -195,7 +194,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpNet_socket0
                                          "Protocol not supported");
             return IOS_THROWN;
         } else {
-            return handleSocketError(env, errno);
+            return sctpHandleSocketError(env, errno);
         }
     }
 
@@ -210,7 +209,7 @@ JNIEXPORT jint JNICALL Java_sun_nio_ch_sctp_SctpNet_socket0
     //event.sctp_partial_delivery_event = 1;
     //event.sctp_adaptation_layer_event = 1;
     if (setsockopt(fd, IPPROTO_SCTP, SCTP_EVENTS, &event, sizeof(event)) != 0) {
-       handleSocketError(env, errno);
+       sctpHandleSocketError(env, errno);
     }
     return fd;
 }
@@ -248,7 +247,7 @@ JNIEXPORT void JNICALL Java_sun_nio_ch_sctp_SctpNet_bindx
 
     if (nio_sctp_bindx(fd, (void *)sap, addrsLength, add ? SCTP_BINDX_ADD_ADDR :
                        SCTP_BINDX_REM_ADDR) != 0) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
     }
 
     free(sap);
@@ -263,7 +262,7 @@ JNIEXPORT void JNICALL
 Java_sun_nio_ch_sctp_SctpNet_listen0
   (JNIEnv *env, jclass cl, jint fd, jint backlog) {
     if (listen(fd, backlog) < 0)
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
 }
 
 /*
@@ -290,7 +289,7 @@ Java_sun_nio_ch_sctp_SctpNet_connect0
         } else if (errno == EINTR) {
             return IOS_INTERRUPTED;
         }
-        return handleSocketError(env, errno);
+        return sctpHandleSocketError(env, errno);
     }
     return 1;
 }
@@ -365,7 +364,7 @@ JNIEXPORT jobjectArray JNICALL Java_sun_nio_ch_sctp_SctpNet_getLocalAddresses0
     jobjectArray isaa;
 
     if ((addrCount = nio_sctp_getladdrs(fd, 0, (struct sockaddr **)&addr_buf)) == -1) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
         return NULL;
     }
 
@@ -410,7 +409,7 @@ jobjectArray getRemoteAddresses(JNIEnv *env, jint fd, sctp_assoc_t id) {
     jobjectArray isaa;
 
     if ((addrCount = nio_sctp_getpaddrs(fd, id, (struct sockaddr **)&addr_buf)) == -1) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
         return NULL;
     }
 
@@ -733,7 +732,7 @@ JNIEXPORT void JNICALL Java_sun_nio_ch_sctp_SctpNet_shutdown0
     msg->msg_controllen = cmsg->cmsg_len;
 
     if ((rv = sendmsg(fd, msg, 0)) < 0) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
     }
 }
 
@@ -746,7 +745,7 @@ JNIEXPORT int JNICALL Java_sun_nio_ch_sctp_SctpNet_branch0
   (JNIEnv *env, jclass klass, jint fd, jint assocId) {
     int newfd = 0;
     if ((newfd = nio_sctp_peeloff(fd, assocId)) < 0) {
-        handleSocketError(env, errno);
+        sctpHandleSocketError(env, errno);
     }
 
     return newfd;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305858](https://bugs.openjdk.org/browse/JDK-8305858): Resolve multiple definition of 'handleSocketError' when statically linking with JDK native libraries (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1437/head:pull/1437` \
`$ git checkout pull/1437`

Update a local copy of the PR: \
`$ git checkout pull/1437` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1437`

View PR using the GUI difftool: \
`$ git pr show -t 1437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1437.diff">https://git.openjdk.org/jdk17u-dev/pull/1437.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1437#issuecomment-1590937614)