### PR TITLE
8307348: Parallelize heap walk for ObjectCount(AfterGC) JFR event collection

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1629,10 +1629,10 @@ void G1ConcurrentMark::report_object_count(bool mark_completed) {
   // using either the next or prev bitmap.
   if (mark_completed) {
     G1ObjectCountIsAliveClosure is_alive(_g1h);
-    _gc_tracer_cm->report_object_count_after_gc(&is_alive);
+    _gc_tracer_cm->report_object_count_after_gc(&is_alive, _g1h->workers());
   } else {
     G1CMIsAliveClosure is_alive(_g1h);
-    _gc_tracer_cm->report_object_count_after_gc(&is_alive);
+    _gc_tracer_cm->report_object_count_after_gc(&is_alive, _g1h->workers());
   }
 }
 

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -306,7 +306,7 @@ void G1FullCollector::phase1_mark_live_objects() {
 
   {
     GCTraceTime(Debug, gc, phases) debug("Report Object Count", scope()->timer());
-    scope()->tracer()->report_object_count_after_gc(&_is_alive);
+    scope()->tracer()->report_object_count_after_gc(&_is_alive, _heap->workers());
   }
 }
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2139,7 +2139,7 @@ void PSParallelCompact::marking_phase(ParCompactionManager* cm,
 
   {
     GCTraceTime(Debug, gc, phases) tm("Report Object Count", &_gc_timer);
-    _gc_tracer.report_object_count_after_gc(is_alive_closure());
+    _gc_tracer.report_object_count_after_gc(is_alive_closure(), &ParallelScavengeHeap::heap()->workers());
   }
 }
 

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -232,7 +232,7 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
 
   {
     GCTraceTime(Debug, gc, phases) tm_m("Report Object Count", gc_timer());
-    gc_tracer()->report_object_count_after_gc(&is_alive);
+    gc_tracer()->report_object_count_after_gc(&is_alive, nullptr);
   }
 }
 

--- a/src/hotspot/share/gc/shared/gcTrace.cpp
+++ b/src/hotspot/share/gc/shared/gcTrace.cpp
@@ -92,7 +92,7 @@ class ObjectCountEventSenderClosure : public KlassInfoClosure {
   }
 };
 
-void GCTracer::report_object_count_after_gc(BoolObjectClosure* is_alive_cl) {
+void GCTracer::report_object_count_after_gc(BoolObjectClosure* is_alive_cl, WorkGang* workers) {
   assert(is_alive_cl != NULL, "Must supply function to check liveness");
 
   if (ObjectCountEventSender::should_send_event()) {
@@ -101,7 +101,7 @@ void GCTracer::report_object_count_after_gc(BoolObjectClosure* is_alive_cl) {
     KlassInfoTable cit(false);
     if (!cit.allocation_failed()) {
       HeapInspection hi;
-      hi.populate_table(&cit, is_alive_cl);
+      hi.populate_table(&cit, is_alive_cl, workers);
       ObjectCountEventSenderClosure event_sender(cit.size_of_instances_in_words(), Ticks::now());
       cit.iterate(&event_sender);
     }

--- a/src/hotspot/share/gc/shared/gcTrace.hpp
+++ b/src/hotspot/share/gc/shared/gcTrace.hpp
@@ -30,6 +30,7 @@
 #include "gc/shared/gcId.hpp"
 #include "gc/shared/gcName.hpp"
 #include "gc/shared/gcWhen.hpp"
+#include "gc/shared/workgroup.hpp"
 #include "memory/metaspace.hpp"
 #include "memory/referenceType.hpp"
 #include "utilities/macros.hpp"
@@ -101,7 +102,7 @@ class GCTracer : public ResourceObj {
   void report_gc_heap_summary(GCWhen::Type when, const GCHeapSummary& heap_summary) const;
   void report_metaspace_summary(GCWhen::Type when, const MetaspaceSummary& metaspace_summary) const;
   void report_gc_reference_stats(const ReferenceProcessorStats& rp) const;
-  void report_object_count_after_gc(BoolObjectClosure* object_filter) NOT_SERVICES_RETURN;
+  void report_object_count_after_gc(BoolObjectClosure* object_filter, WorkGang* workers) NOT_SERVICES_RETURN;
 
  protected:
   GCTracer(GCName name) : _shared_gc_info(name) {}

--- a/src/hotspot/share/memory/heapInspection.hpp
+++ b/src/hotspot/share/memory/heapInspection.hpp
@@ -216,8 +216,8 @@ class KlassInfoClosure;
 
 class HeapInspection : public StackObj {
  public:
-  void heap_inspection(outputStream* st, uint parallel_thread_num = 1) NOT_SERVICES_RETURN;
-  uintx populate_table(KlassInfoTable* cit, BoolObjectClosure* filter = NULL, uint parallel_thread_num = 1) NOT_SERVICES_RETURN_(0);
+  void heap_inspection(outputStream* st, WorkGang* workers) NOT_SERVICES_RETURN;
+  uintx populate_table(KlassInfoTable* cit, BoolObjectClosure* filter, WorkGang* workers) NOT_SERVICES_RETURN_(0);
   static void find_instances_at_safepoint(Klass* k, GrowableArray<oop>* result) NOT_SERVICES_RETURN;
  private:
   void iterate_over_heap(KlassInfoTable* cit, BoolObjectClosure* filter = NULL);


### PR DESCRIPTION
Improves ObjectCount JFR events that take considerable time at GC pause. While the event is still heavy, the parallelization helps to avoid unnecessarily large stalls. 

The backport is not clean, because there are number of contextual differences: `WorkGang`, `WithUpdatedActiveWorkers` and other renames did not happen yet. I had to massage the patch to fit 17u better.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk/jfr serviceability/sa`
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307348](https://bugs.openjdk.org/browse/JDK-8307348): Parallelize heap walk for ObjectCount(AfterGC) JFR event collection (**Enhancement** - P4)


### Reviewers
 * [Oli Gillespie](https://openjdk.org/census#ogillespie) (@olivergillespie - no project role)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1441/head:pull/1441` \
`$ git checkout pull/1441`

Update a local copy of the PR: \
`$ git checkout pull/1441` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1441`

View PR using the GUI difftool: \
`$ git pr show -t 1441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1441.diff">https://git.openjdk.org/jdk17u-dev/pull/1441.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1441#issuecomment-1592735865)