### PR TITLE
8307156: native_thread not protected by TLH

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -726,20 +726,21 @@ static bool check_exclusion_state_on_thread_start(JavaThread* jt) {
   return true;
 }
 
-static JavaThread* get_native(jobject thread) {
-  ThreadsListHandle tlh;
+static JavaThread* get_native(ThreadsListHandle& tlh, jobject thread) {
   JavaThread* native_thread = NULL;
   (void)tlh.cv_internal_thread_to_JavaThread(thread, &native_thread, NULL);
   return native_thread;
 }
 
 jlong JfrJavaSupport::jfr_thread_id(jobject thread) {
-  JavaThread* native_thread = get_native(thread);
+  ThreadsListHandle tlh;
+  JavaThread* native_thread = get_native(tlh, thread);
   return native_thread != NULL ? JFR_THREAD_ID(native_thread) : 0;
 }
 
 void JfrJavaSupport::exclude(jobject thread) {
-  JavaThread* native_thread = get_native(thread);
+  ThreadsListHandle tlh;
+  JavaThread* native_thread = get_native(tlh, thread);
   if (native_thread != NULL) {
     JfrThreadLocal::exclude(native_thread);
   } else {
@@ -749,7 +750,8 @@ void JfrJavaSupport::exclude(jobject thread) {
 }
 
 void JfrJavaSupport::include(jobject thread) {
-  JavaThread* native_thread = get_native(thread);
+  ThreadsListHandle tlh;
+  JavaThread* native_thread = get_native(tlh, thread);
   if (native_thread != NULL) {
     JfrThreadLocal::include(native_thread);
   } else {
@@ -759,7 +761,8 @@ void JfrJavaSupport::include(jobject thread) {
 }
 
 bool JfrJavaSupport::is_excluded(jobject thread) {
-  JavaThread* native_thread = get_native(thread);
+  ThreadsListHandle tlh;
+  JavaThread* native_thread = get_native(tlh, thread);
   return native_thread != NULL ? native_thread->jfr_thread_local()->is_excluded() : is_thread_excluded(thread);
 }
 


### PR DESCRIPTION
Unclean backport to improve JFR reliability. The original patch does not apply to JDK 17, because later refactorings during Loom integration introduced significant contextual differences. I reapplied and fixed the patch, making sure every `get_native` call is protected by `TLH`.

Additional testing:
 - [x] Linux x86_64 fastdebug `jdk/jfr`
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307156](https://bugs.openjdk.org/browse/JDK-8307156): native_thread not protected by TLH (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1442/head:pull/1442` \
`$ git checkout pull/1442`

Update a local copy of the PR: \
`$ git checkout pull/1442` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1442`

View PR using the GUI difftool: \
`$ git pr show -t 1442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1442.diff">https://git.openjdk.org/jdk17u-dev/pull/1442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1442#issuecomment-1592730827)