### PR TITLE
8272654: Mark word accesses should not use Access API

### DIFF
--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -45,8 +45,7 @@
 // We need a separate file to avoid circular references
 
 markWord oopDesc::mark() const {
-  uintptr_t v = HeapAccess<MO_RELAXED>::load_at(as_oop(), mark_offset_in_bytes());
-  return markWord(v);
+  return Atomic::load(&_mark);
 }
 
 markWord* oopDesc::mark_addr() const {
@@ -54,7 +53,7 @@ markWord* oopDesc::mark_addr() const {
 }
 
 void oopDesc::set_mark(markWord m) {
-  HeapAccess<MO_RELAXED>::store_at(as_oop(), mark_offset_in_bytes(), m.value());
+  Atomic::store(&_mark, m);
 }
 
 void oopDesc::set_mark(HeapWord* mem, markWord m) {
@@ -62,12 +61,11 @@ void oopDesc::set_mark(HeapWord* mem, markWord m) {
 }
 
 void oopDesc::release_set_mark(markWord m) {
-  HeapAccess<MO_RELEASE>::store_at(as_oop(), mark_offset_in_bytes(), m.value());
+  Atomic::release_store(&_mark, m);
 }
 
 markWord oopDesc::cas_set_mark(markWord new_mark, markWord old_mark) {
-  uintptr_t v = HeapAccess<>::atomic_cmpxchg_at(as_oop(), mark_offset_in_bytes(), old_mark.value(), new_mark.value());
-  return markWord(v);
+  return Atomic::cmpxchg(&_mark, old_mark, new_mark);
 }
 
 markWord oopDesc::cas_set_mark(markWord new_mark, markWord old_mark, atomic_memory_order order) {


### PR DESCRIPTION
Clean backport to sync up 17u, 21u and tip versions of the `markWord` code. This simplifies maintenance and further backports.

Additional testing:
 - [x] Eyeballing object code for affected methods, they are exactly the same on AArch64
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272654](https://bugs.openjdk.org/browse/JDK-8272654): Mark word accesses should not use Access API (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1445/head:pull/1445` \
`$ git checkout pull/1445`

Update a local copy of the PR: \
`$ git checkout pull/1445` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1445`

View PR using the GUI difftool: \
`$ git pr show -t 1445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1445.diff">https://git.openjdk.org/jdk17u-dev/pull/1445.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1445#issuecomment-1592841521)