### PR TITLE
8273559: Shenandoah: Shenandoah should support multi-threaded heap dump

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -737,7 +737,7 @@ private:
   ShenandoahVMWeakRoots<true /*concurrent*/> _vm_roots;
 
   // Roots related to concurrent class unloading
-  ShenandoahClassLoaderDataRoots<true /* concurrent */, true /* single thread*/>
+  ShenandoahClassLoaderDataRoots<true /* concurrent */>
                                              _cld_roots;
   ShenandoahConcurrentNMethodIterator        _nmethod_itr;
   ShenandoahPhaseTimings::Phase              _phase;
@@ -746,7 +746,7 @@ public:
   ShenandoahConcurrentWeakRootsEvacUpdateTask(ShenandoahPhaseTimings::Phase phase) :
     AbstractGangTask("Shenandoah Evacuate/Update Concurrent Weak Roots"),
     _vm_roots(phase),
-    _cld_roots(phase, ShenandoahHeap::heap()->workers()->active_workers()),
+    _cld_roots(phase, ShenandoahHeap::heap()->workers()->active_workers(), false /*heap iteration*/),
     _nmethod_itr(ShenandoahCodeRoots::table()),
     _phase(phase) {
     if (ShenandoahHeap::heap()->unload_classes()) {
@@ -851,7 +851,8 @@ class ShenandoahConcurrentRootsEvacUpdateTask : public AbstractGangTask {
 private:
   ShenandoahPhaseTimings::Phase                 _phase;
   ShenandoahVMRoots<true /*concurrent*/>        _vm_roots;
-  ShenandoahClassLoaderDataRoots<true /*concurrent*/, false /*single threaded*/> _cld_roots;
+  ShenandoahClassLoaderDataRoots<true /*concurrent*/>
+                                                _cld_roots;
   ShenandoahConcurrentNMethodIterator           _nmethod_itr;
 
 public:
@@ -859,7 +860,7 @@ public:
     AbstractGangTask("Shenandoah Evacuate/Update Concurrent Strong Roots"),
     _phase(phase),
     _vm_roots(phase),
-    _cld_roots(phase, ShenandoahHeap::heap()->workers()->active_workers()),
+    _cld_roots(phase, ShenandoahHeap::heap()->workers()->active_workers(), false /*heap iteration*/),
     _nmethod_itr(ShenandoahCodeRoots::table()) {
     if (!ShenandoahHeap::heap()->unload_classes()) {
       MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1326,7 +1326,8 @@ void ShenandoahHeap::scan_roots_for_iteration(ShenandoahScanObjectStack* oop_sta
   // This populates the work stack with initial objects
   // It is important to relinquish the associated locks before diving
   // into heap dumper
-  ShenandoahHeapIterationRootScanner rp;
+  uint n_workers = safepoint_workers() != NULL ? safepoint_workers()->active_workers() : 1;
+  ShenandoahHeapIterationRootScanner rp(n_workers);
   rp.roots_do(oops);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.cpp
@@ -119,7 +119,7 @@ ShenandoahSTWRootScanner::ShenandoahSTWRootScanner(ShenandoahPhaseTimings::Phase
    ShenandoahRootProcessor(phase),
    _thread_roots(phase, ShenandoahHeap::heap()->workers()->active_workers() > 1),
    _code_roots(phase),
-   _cld_roots(phase, ShenandoahHeap::heap()->workers()->active_workers()),
+   _cld_roots(phase, ShenandoahHeap::heap()->workers()->active_workers(), false /*heap iteration*/),
    _vm_roots(phase),
    _unload_classes(ShenandoahHeap::heap()->unload_classes()) {
 }
@@ -149,7 +149,7 @@ ShenandoahConcurrentRootScanner::ShenandoahConcurrentRootScanner(uint n_workers,
    ShenandoahRootProcessor(phase),
    _java_threads(phase, n_workers),
   _vm_roots(phase),
-  _cld_roots(phase, n_workers),
+  _cld_roots(phase, n_workers, false /*heap iteration*/),
   _codecache_snapshot(NULL),
   _phase(phase) {
   if (!ShenandoahHeap::heap()->unload_classes()) {
@@ -209,7 +209,7 @@ void ShenandoahConcurrentRootScanner::update_tlab_stats() {
 ShenandoahRootUpdater::ShenandoahRootUpdater(uint n_workers, ShenandoahPhaseTimings::Phase phase) :
   ShenandoahRootProcessor(phase),
   _vm_roots(phase),
-  _cld_roots(phase, n_workers),
+  _cld_roots(phase, n_workers, false /*heap iteration*/),
   _thread_roots(phase, n_workers > 1),
   _weak_roots(phase),
   _code_roots(phase) {
@@ -218,7 +218,7 @@ ShenandoahRootUpdater::ShenandoahRootUpdater(uint n_workers, ShenandoahPhaseTimi
 ShenandoahRootAdjuster::ShenandoahRootAdjuster(uint n_workers, ShenandoahPhaseTimings::Phase phase) :
   ShenandoahRootProcessor(phase),
   _vm_roots(phase),
-  _cld_roots(phase, n_workers),
+  _cld_roots(phase, n_workers, false /*heap iteration*/),
   _thread_roots(phase, n_workers > 1),
   _weak_roots(phase),
   _code_roots(phase) {
@@ -244,11 +244,11 @@ void ShenandoahRootAdjuster::roots_do(uint worker_id, OopClosure* oops) {
   _thread_roots.oops_do(oops, NULL, worker_id);
 }
 
-ShenandoahHeapIterationRootScanner::ShenandoahHeapIterationRootScanner() :
+ShenandoahHeapIterationRootScanner::ShenandoahHeapIterationRootScanner(uint n_workers) :
    ShenandoahRootProcessor(ShenandoahPhaseTimings::heap_iteration_roots),
    _thread_roots(ShenandoahPhaseTimings::heap_iteration_roots, false /*is par*/),
    _vm_roots(ShenandoahPhaseTimings::heap_iteration_roots),
-   _cld_roots(ShenandoahPhaseTimings::heap_iteration_roots, 1),
+   _cld_roots(ShenandoahPhaseTimings::heap_iteration_roots, n_workers, true /*heap iteration*/),
    _weak_roots(ShenandoahPhaseTimings::heap_iteration_roots),
    _code_roots(ShenandoahPhaseTimings::heap_iteration_roots) {
  }
@@ -279,7 +279,7 @@ public:
 
 void ShenandoahHeapIterationRootScanner::roots_do(OopClosure* oops) {
   // Must use _claim_none to avoid interfering with concurrent CLDG iteration
-  CLDToOopClosure clds(oops, ClassLoaderData::_claim_none);
+  CLDToOopClosure clds(oops, ClassLoaderData::_claim_other);
   ShenandoahMarkCodeBlobClosure code(oops);
   ShenandoahParallelOopsDoThreadClosure tc_cl(oops, &code, NULL);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.hpp
@@ -106,15 +106,13 @@ public:
   void code_blobs_do(CodeBlobClosure* blob_cl, uint worker_id);
 };
 
-template <bool CONCURRENT, bool SINGLE_THREADED>
+template <bool CONCURRENT>
 class ShenandoahClassLoaderDataRoots {
 private:
   ShenandoahSharedSemaphore     _semaphore;
   ShenandoahPhaseTimings::Phase _phase;
 
   static uint worker_count(uint n_workers) {
-    if (SINGLE_THREADED) return 1u;
-
     // Limit concurrency a bit, otherwise it wastes resources when workers are tripping
     // over each other. This also leaves free workers to process other parts of the root
     // set, while admitted workers are busy with doing the CLDG walk.
@@ -122,7 +120,7 @@ private:
   }
 
 public:
-  ShenandoahClassLoaderDataRoots(ShenandoahPhaseTimings::Phase phase, uint n_workers);
+  ShenandoahClassLoaderDataRoots(ShenandoahPhaseTimings::Phase phase, uint n_workers, bool heap_iteration);
   ~ShenandoahClassLoaderDataRoots();
 
   void always_strong_cld_do(CLDClosure* clds, uint worker_id);
@@ -163,7 +161,7 @@ class ShenandoahSTWRootScanner : public ShenandoahRootProcessor {
 private:
   ShenandoahThreadRoots           _thread_roots;
   ShenandoahCodeCacheRoots        _code_roots;
-  ShenandoahClassLoaderDataRoots<false /*concurrent*/, false /* single_thread*/>
+  ShenandoahClassLoaderDataRoots<false /*concurrent*/>
                                   _cld_roots;
   ShenandoahVMRoots<false /*concurrent*/>
                                   _vm_roots;
@@ -179,7 +177,7 @@ class ShenandoahConcurrentRootScanner : public ShenandoahRootProcessor {
 private:
   ShenandoahJavaThreadsIterator             _java_threads;
   ShenandoahVMRoots<true /*concurrent*/>    _vm_roots;
-  ShenandoahClassLoaderDataRoots<true /*concurrent*/, false /* single-threaded*/>
+  ShenandoahClassLoaderDataRoots<true /*concurrent*/>
                                            _cld_roots;
   ShenandoahNMethodTableSnapshot*          _codecache_snapshot;
   ShenandoahPhaseTimings::Phase            _phase;
@@ -200,13 +198,12 @@ class ShenandoahHeapIterationRootScanner : public ShenandoahRootProcessor {
 private:
   ShenandoahThreadRoots                                    _thread_roots;
   ShenandoahVMRoots<false /*concurrent*/>                  _vm_roots;
-  ShenandoahClassLoaderDataRoots<false /*concurrent*/, true /*single threaded*/>
-                                                           _cld_roots;
+  ShenandoahClassLoaderDataRoots<false /*concurrent*/>     _cld_roots;
   ShenandoahVMWeakRoots<false /*concurrent*/>              _weak_roots;
   ShenandoahCodeCacheRoots                                 _code_roots;
 
 public:
-  ShenandoahHeapIterationRootScanner();
+  ShenandoahHeapIterationRootScanner(uint n_workers);
 
   void roots_do(OopClosure* cl);
 };
@@ -215,8 +212,7 @@ public:
 class ShenandoahRootUpdater : public ShenandoahRootProcessor {
 private:
   ShenandoahVMRoots<false /*concurrent*/>                   _vm_roots;
-  ShenandoahClassLoaderDataRoots<false /*concurrent*/, false /*single threaded*/>
-                                                            _cld_roots;
+  ShenandoahClassLoaderDataRoots<false /*concurrent*/>      _cld_roots;
   ShenandoahThreadRoots                                     _thread_roots;
   ShenandoahVMWeakRoots<false /*concurrent*/>               _weak_roots;
   ShenandoahCodeCacheRoots                                  _code_roots;
@@ -232,8 +228,7 @@ public:
 class ShenandoahRootAdjuster : public ShenandoahRootProcessor {
 private:
   ShenandoahVMRoots<false /*concurrent*/>                   _vm_roots;
-  ShenandoahClassLoaderDataRoots<false /*concurrent*/, false /*single threaded*/>
-                                                            _cld_roots;
+  ShenandoahClassLoaderDataRoots<false /*concurrent*/>      _cld_roots;
   ShenandoahThreadRoots                                     _thread_roots;
   ShenandoahVMWeakRoots<false /*concurrent*/>               _weak_roots;
   ShenandoahCodeCacheRoots                                  _code_roots;

--- a/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahRootProcessor.inline.hpp
@@ -75,14 +75,17 @@ void ShenandoahVMRoots<CONCURRENT>::oops_do(T* cl, uint worker_id) {
   _strong_roots.oops_do(cl);
 }
 
-template <bool CONCURRENT, bool SINGLE_THREADED>
-ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::ShenandoahClassLoaderDataRoots(ShenandoahPhaseTimings::Phase phase, uint n_workers) :
+template <bool CONCURRENT>
+ShenandoahClassLoaderDataRoots<CONCURRENT>::ShenandoahClassLoaderDataRoots(ShenandoahPhaseTimings::Phase phase, uint n_workers, bool heap_iteration) :
   _semaphore(worker_count(n_workers)),
   _phase(phase) {
-  if (!SINGLE_THREADED) {
+  if (heap_iteration) {
+    ClassLoaderDataGraph::clear_claimed_marks(ClassLoaderData::_claim_other);
+  } else {
     ClassLoaderDataGraph::clear_claimed_marks();
   }
-  if (CONCURRENT && !SINGLE_THREADED) {
+
+  if (CONCURRENT) {
     ClassLoaderDataGraph_lock->lock();
   }
 
@@ -91,24 +94,19 @@ ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::ShenandoahClassLoad
   assert(CONCURRENT || Thread::current()->is_VM_thread(), "Can only be done by VM thread");
 }
 
-template <bool CONCURRENT, bool SINGLE_THREADED>
-ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::~ShenandoahClassLoaderDataRoots() {
-  if (CONCURRENT && !SINGLE_THREADED) {
+template <bool CONCURRENT>
+ShenandoahClassLoaderDataRoots<CONCURRENT>::~ShenandoahClassLoaderDataRoots() {
+  if (CONCURRENT) {
     ClassLoaderDataGraph_lock->unlock();
   }
 }
 
-template <bool CONCURRENT, bool SINGLE_THREADED>
-void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::cld_do_impl(CldDo f, CLDClosure* clds, uint worker_id) {
+template <bool CONCURRENT>
+void ShenandoahClassLoaderDataRoots<CONCURRENT>::cld_do_impl(CldDo f, CLDClosure* clds, uint worker_id) {
   if (CONCURRENT) {
     if (_semaphore.try_acquire()) {
       ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CLDGRoots, worker_id);
-      if (SINGLE_THREADED){
-        MutexLocker ml(ClassLoaderDataGraph_lock, Mutex::_no_safepoint_check_flag);
-        f(clds);
-      } else {
-        f(clds);
-      }
+      f(clds);
       _semaphore.claim_all();
     }
   } else {
@@ -117,13 +115,13 @@ void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::cld_do_impl(Cl
   }
 }
 
-template <bool CONCURRENT, bool SINGLE_THREADED>
-void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::always_strong_cld_do(CLDClosure* clds, uint worker_id) {
+template <bool CONCURRENT>
+void ShenandoahClassLoaderDataRoots<CONCURRENT>::always_strong_cld_do(CLDClosure* clds, uint worker_id) {
   cld_do_impl(&ClassLoaderDataGraph::always_strong_cld_do, clds, worker_id);
 }
 
-template <bool CONCURRENT, bool SINGLE_THREADED>
-void ShenandoahClassLoaderDataRoots<CONCURRENT, SINGLE_THREADED>::cld_do(CLDClosure* clds, uint worker_id) {
+template <bool CONCURRENT>
+void ShenandoahClassLoaderDataRoots<CONCURRENT>::cld_do(CLDClosure* clds, uint worker_id) {
   cld_do_impl(&ClassLoaderDataGraph::cld_do, clds, worker_id);
 }
 

--- a/test/hotspot/jtreg/gc/shenandoah/TestJcmdHeapDump.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestJcmdHeapDump.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=passive
+ * @library /test/lib
+ * @modules jdk.attach/com.sun.tools.attach
+
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
+ *      -XX:+ShenandoahDegeneratedGC
+ *      TestJcmdHeapDump
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=passive
+ *      -XX:-ShenandoahDegeneratedGC
+ *      TestJcmdHeapDump
+ */
+
+/*
+ * @test id=aggressive
+ * @library /test/lib
+ * @modules jdk.attach/com.sun.tools.attach
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *      -XX:+ShenandoahOOMDuringEvacALot
+ *      TestJcmdHeapDump
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *      -XX:+ShenandoahAllocFailureALot
+ *      TestJcmdHeapDump
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=aggressive
+ *      TestJcmdHeapDump
+ */
+
+/*
+ * @test id=adaptive
+ * @library /test/lib
+ * @modules jdk.attach/com.sun.tools.attach
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=adaptive
+ *      -Dtarget=10000
+ *      TestJcmdHeapDump
+ */
+
+/*
+ * @test id=static
+ * @library /test/lib
+ * @modules jdk.attach/com.sun.tools.attach
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=static
+ *      TestJcmdHeapDump
+ */
+
+/*
+ * @test id=compact
+ * @library /test/lib
+ * @modules jdk.attach/com.sun.tools.attach
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCHeuristics=compact
+ *     TestJcmdHeapDump
+ */
+
+/*
+ * @test id=iu-aggressive
+ * @library /test/lib
+ * @modules jdk.attach/com.sun.tools.attach
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
+ *      -XX:+ShenandoahOOMDuringEvacALot
+ *      TestJcmdHeapDump
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
+ *      -XX:+ShenandoahAllocFailureALot
+ *      TestJcmdHeapDump
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu -XX:ShenandoahGCHeuristics=aggressive
+ *      TestJcmdHeapDump
+ */
+
+/*
+ * @test id=iu
+ * @requires vm.gc.Shenandoah
+ * @library /test/lib
+ * @modules jdk.attach/com.sun.tools.attach
+ *
+ * @run main/othervm/timeout=480 -Xmx16m -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions
+ *      -XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu
+ *      TestJcmdHeapDump
+ */
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.File;
+
+public class TestJcmdHeapDump {
+    public static void main(String[] args) {
+        long pid = ProcessHandle.current().pid();
+        JDKToolLauncher jcmd = JDKToolLauncher.createUsingTestJDK("jcmd");
+        jcmd.addToolArg(String.valueOf(pid));
+        jcmd.addToolArg("GC.heap_dump");
+        String dumpFileName = "myheapdump" + String.valueOf(pid);
+        jcmd.addToolArg(dumpFileName);
+
+        try {
+            ProcessBuilder pb = new ProcessBuilder(jcmd.getCommand());
+            Process jcmdProc = pb.start();
+
+            OutputAnalyzer output = new OutputAnalyzer(jcmdProc);
+            jcmdProc.waitFor();
+            output.shouldHaveExitValue(0);
+        } catch (Exception e) {
+            throw new RuntimeException("Test failed: " + e);
+        }
+
+        File f = new File(dumpFileName);
+        if (f.exists()) {
+            f.delete();
+        } else {
+            throw new RuntimeException("Dump file not created");
+        }
+    }
+}


### PR DESCRIPTION
Unclean backport of JDK-8273559

Testing:

- [ ] hotspot_gc_shenandoah
- [ ] dacapo
- [ ] extremem
- [ ] specjbb2015
- [ ] hyperalloc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273559](https://bugs.openjdk.org/browse/JDK-8273559): Shenandoah: Shenandoah should support multi-threaded heap dump (**Bug** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1450/head:pull/1450` \
`$ git checkout pull/1450`

Update a local copy of the PR: \
`$ git checkout pull/1450` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1450`

View PR using the GUI difftool: \
`$ git pr show -t 1450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1450.diff">https://git.openjdk.org/jdk17u-dev/pull/1450.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1450#issuecomment-1593604960)