### PR TITLE
8290464: Optimize ResourceArea zapping on ResourceMark release

### DIFF
--- a/src/hotspot/share/memory/resourceArea.hpp
+++ b/src/hotspot/share/memory/resourceArea.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,16 +117,34 @@ public:
              size_in_bytes(), state._size_in_bytes);
       set_size_in_bytes(state._size_in_bytes);
       state._chunk->next_chop();
+      assert(_hwm != state._hwm, "Sanity check: HWM moves when we have later chunks");
     } else {
       assert(size_in_bytes() == state._size_in_bytes, "Sanity check");
     }
-    _chunk = state._chunk;      // Roll back to saved chunk.
-    _hwm = state._hwm;
-    _max = state._max;
 
-    // Clear out this chunk (to detect allocation bugs)
-    if (ZapResourceArea) {
-      memset(state._hwm, badResourceValue, state._max - state._hwm);
+    if (_hwm != state._hwm) {
+      // HWM moved: resource area was used. Roll back!
+
+      char* replaced_hwm = _hwm;
+
+      _chunk = state._chunk;
+      _hwm = state._hwm;
+      _max = state._max;
+
+      // Clear out this chunk (to detect allocation bugs).
+      // If current chunk contains the replaced HWM, this means we are
+      // doing the rollback within the same chunk, and we only need to
+      // clear up to replaced HWM.
+      if (ZapResourceArea) {
+        char* limit = _chunk->contains(replaced_hwm) ? replaced_hwm : _max;
+        assert(limit >= _hwm, "Sanity check: non-negative memset size");
+        memset(_hwm, badResourceValue, limit - _hwm);
+      }
+    } else {
+      // No allocations. Nothing to rollback. Check it.
+      assert(_chunk == state._chunk, "Sanity check: idempotence");
+      assert(_hwm == state._hwm,     "Sanity check: idempotence");
+      assert(_max == state._max,     "Sanity check: idempotence");
     }
   }
 };


### PR DESCRIPTION
Clean backport to substantially improve testing performance.

Additional testing:
 - [x] The similar testing time improvements on original test
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290464](https://bugs.openjdk.org/browse/JDK-8290464): Optimize ResourceArea zapping on ResourceMark release (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1452/head:pull/1452` \
`$ git checkout pull/1452`

Update a local copy of the PR: \
`$ git checkout pull/1452` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1452`

View PR using the GUI difftool: \
`$ git pr show -t 1452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1452.diff">https://git.openjdk.org/jdk17u-dev/pull/1452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1452#issuecomment-1594359608)