### PR TITLE
8278456: Define jtreg jdk_desktop test group time-based sub-tasks for use by headful testing.

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -385,16 +385,33 @@ jdk_editpad = \
      jdk/editpad
 
 jdk_desktop = \
-    :jdk_awt \
-    :jdk_2d \
-    :jdk_beans \
+    :jdk_desktop_part1 \
+    :jdk_desktop_part2 \
+    :jdk_desktop_part3
+
+jdk_desktop_part1 = \
+    :jdk_client_sanity \
     :jdk_swing \
+    :jdk_2d \
     :jdk_sound \
     :jdk_imageio \
-    :jdk_accessibility \
+    :jdk_editpad \
     :jfc_demo \
-    :jdk_client_sanity \
-    :jdk_editpad
+    :jdk_accessibility \
+    :jdk_beans
+
+jdk_desktop_part2 = \
+    :jdk_awt \
+    -java/awt/Component \
+    -java/awt/Modal \
+    -java/awt/datatransfer \
+    -java/awt/Window
+
+jdk_desktop_part3 = \
+    java/awt/Component \
+    java/awt/Modal \
+    java/awt/datatransfer \
+    java/awt/Window
 
 # SwingSet3 tests.
 jdk_client_sanity = \


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278456](https://bugs.openjdk.org/browse/JDK-8278456): Define jtreg jdk_desktop test group time-based sub-tasks for use by headful testing. (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1453/head:pull/1453` \
`$ git checkout pull/1453`

Update a local copy of the PR: \
`$ git checkout pull/1453` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1453`

View PR using the GUI difftool: \
`$ git pr show -t 1453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1453.diff">https://git.openjdk.org/jdk17u-dev/pull/1453.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1453#issuecomment-1594429896)