### PR TITLE
8209398: sun/security/pkcs11/KeyStore/SecretKeysBasic.sh failed with "PKCS11Exception: CKR_ATTRIBUTE_SENSITIVE"

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -90,6 +90,9 @@ abstract class P11Key implements Key, Length {
     // flags indicating whether the key is a token object, sensitive, extractable
     final boolean tokenObject, sensitive, extractable;
 
+    // flag indicating whether the current token is NSS
+    final transient boolean isNSS;
+
     private final NativeKeyHolder keyIDHolder;
 
     private static final boolean DISABLE_NATIVE_KEYS_EXTRACTION;
@@ -137,7 +140,7 @@ abstract class P11Key implements Key, Length {
         this.sensitive = sensitive;
         this.extractable = extractable;
         char[] tokenLabel = this.token.tokenInfo.label;
-        boolean isNSS = (tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
+        isNSS = (tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
                 && tokenLabel[2] == 'S');
         boolean extractKeyInfo = (!DISABLE_NATIVE_KEYS_EXTRACTION && isNSS &&
                 extractable && !tokenObject);
@@ -238,7 +241,8 @@ abstract class P11Key implements Key, Length {
         } else {
             // XXX short term serialization for unextractable keys
             throw new NotSerializableException
-                ("Cannot serialize sensitive and unextractable keys");
+                    ("Cannot serialize sensitive, unextractable " + (isNSS ?
+                    ", and NSS token keys" : "keys"));
         }
         return new KeyRep(type, getAlgorithm(), format, getEncodedInternal());
     }
@@ -461,7 +465,7 @@ abstract class P11Key implements Key, Length {
         }
         public String getFormat() {
             token.ensureValid();
-            if (sensitive || (extractable == false)) {
+            if (sensitive || !extractable || (isNSS && tokenObject)) {
                 return null;
             } else {
                 return "RAW";

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -644,8 +644,6 @@ javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x
 
 sun/security/provider/KeyStore/DKSTest.sh                       8180266 windows-all
 
-sun/security/pkcs11/KeyStore/SecretKeysBasic.java                 8209398 generic-all
-
 sun/security/smartcardio/TestChannel.java                       8039280 generic-all
 sun/security/smartcardio/TestConnect.java                       8039280 generic-all
 sun/security/smartcardio/TestConnectAgain.java                  8039280 generic-all


### PR DESCRIPTION
I backport this for parity with 17.0.8-oracle.

Trivial resolves due to context, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8209398](https://bugs.openjdk.org/browse/JDK-8209398): sun/security/pkcs11/KeyStore/SecretKeysBasic.sh failed with "PKCS11Exception: CKR_ATTRIBUTE_SENSITIVE" (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1454/head:pull/1454` \
`$ git checkout pull/1454`

Update a local copy of the PR: \
`$ git checkout pull/1454` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1454`

View PR using the GUI difftool: \
`$ git pr show -t 1454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1454.diff">https://git.openjdk.org/jdk17u-dev/pull/1454.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1454#issuecomment-1594446983)