### PR TITLE
Backport dfd2d83144fe4d78a7144acda6d9cb3e0045ea70

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -500,13 +500,11 @@ public class VM {
     boolType = (CIntegerType) db.lookupType("bool");
 
     minObjAlignmentInBytes = getObjectAlignmentInBytes();
-    if (minObjAlignmentInBytes == 8) {
-      logMinObjAlignmentInBytes = 3;
-    } else if (minObjAlignmentInBytes == 16) {
-      logMinObjAlignmentInBytes = 4;
-    } else {
-      throw new RuntimeException("Object alignment " + minObjAlignmentInBytes + " not yet supported");
+    if ((minObjAlignmentInBytes & (minObjAlignmentInBytes - 1)) != 0) {
+      throw new RuntimeException("Object alignment " + minObjAlignmentInBytes + " is not power of two");
     }
+
+    logMinObjAlignmentInBytes = Integer.numberOfTrailingZeros(minObjAlignmentInBytes);
 
     if (isCompressedOopsEnabled()) {
       // Size info for oops within java objects is fixed

--- a/test/hotspot/jtreg/serviceability/sa/TestObjectAlignment.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestObjectAlignment.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import sun.jvm.hotspot.HotSpotAgent;
+import sun.jvm.hotspot.runtime.VM;
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.SA.SATestUtils;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @library /test/lib
+ * @requires vm.hasSA
+ * @modules jdk.hotspot.agent/sun.jvm.hotspot
+ *          jdk.hotspot.agent/sun.jvm.hotspot.runtime
+ * @run driver TestObjectAlignment
+ */
+
+public class TestObjectAlignment {
+
+    private static LingeredApp theApp = null;
+
+    private static void checkAlignment(String pid, int expectedAlign) throws Exception {
+        HotSpotAgent agent = new HotSpotAgent();
+
+        try {
+            agent.attach(Integer.parseInt(pid));
+            int actualAlign = VM.getVM().getObjectAlignmentInBytes();
+            Asserts.assertEquals(expectedAlign, actualAlign,
+                                 "Address of HeapRegion does not match.");
+        } finally {
+            agent.detach();
+        }
+    }
+
+    private static void createAnotherToAttach(long lingeredAppPid, int expectedAlign)
+                                                         throws Exception {
+        // Start a new process to attach to the lingered app
+        ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            "--add-modules=jdk.hotspot.agent",
+            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED",
+            "--add-exports=jdk.hotspot.agent/sun.jvm.hotspot.runtime=ALL-UNNAMED",
+            "TestObjectAlignment",
+            Long.toString(lingeredAppPid),
+            Integer.toString(expectedAlign)
+        );
+        SATestUtils.addPrivilegesIfNeeded(processBuilder);
+        OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
+        SAOutput.shouldHaveExitValue(0);
+        System.out.println(SAOutput.getOutput());
+    }
+
+    public static void main (String... args) throws Exception {
+        SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
+        if (args == null || args.length == 0) {
+            for (int align = 8; align <= 256; align *= 2) {
+                try {
+                    theApp = new LingeredApp();
+                    LingeredApp.startApp(theApp, "-XX:ObjectAlignmentInBytes=" + align);
+                    createAnotherToAttach(theApp.getPid(), align);
+                } finally {
+                    LingeredApp.stopApp(theApp);
+                }
+            }
+        } else {
+            checkAlignment(args[0], Integer.parseInt(args[1]));
+        }
+    }
+}


### PR DESCRIPTION
Improves SA support for larger alignments. 

Needs a follow-up backport to fix x86_32.

Additional testing:
 - [ ] New test fails without a fix, passes with the fix
 - [x] Linux x86_64 fastdebug `serviceability/sa`