### PR TITLE
8292315: Tests should not rely on specific JAR file names (hotspot)

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/CDSStreamTestDriver.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/CDSStreamTestDriver.java
@@ -37,6 +37,7 @@
 
 import org.testng.annotations.Test;
 import java.io.File;
+import java.nio.file.Path;
 import jtreg.SkippedException;
 import sun.hotspot.gc.GC;
 
@@ -49,7 +50,6 @@ public class CDSStreamTestDriver extends DynamicArchiveTestBase {
 
     private static final String classDir = System.getProperty("test.classes");
     private static final String mainClass = "TestStreamApp";
-    private static final String javaClassPath = System.getProperty("java.class.path");
     private static final String ps = System.getProperty("path.separator");
     private static final String skippedException = "jtreg.SkippedException: Unable to map shared archive: test did not complete";
 
@@ -57,14 +57,7 @@ public class CDSStreamTestDriver extends DynamicArchiveTestBase {
         String topArchiveName = getNewArchiveName();
         String appJar = JarBuilder.build("streamapp", new File(classDir), null);
 
-        String[] classPaths = javaClassPath.split(File.pathSeparator);
-        String testngJar = null;
-        for (String path : classPaths) {
-            if (path.endsWith("testng.jar")) {
-                testngJar = path;
-                break;
-            }
-        }
+        String testngJar = Path.of(Test.class.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
 
         String[] testClassNames = { "CustomFJPoolTest" };
 


### PR DESCRIPTION
I backport this to enable jtreg 7.

I needed to add an import.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292315](https://bugs.openjdk.org/browse/JDK-8292315): Tests should not rely on specific JAR file names (hotspot) (**Sub-task** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1461/head:pull/1461` \
`$ git checkout pull/1461`

Update a local copy of the PR: \
`$ git checkout pull/1461` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1461`

View PR using the GUI difftool: \
`$ git pr show -t 1461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1461.diff">https://git.openjdk.org/jdk17u-dev/pull/1461.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1461#issuecomment-1594898481)