### PR TITLE
8281507: Two javac tests have bad jtreg `@clean` tags

### DIFF
--- a/test/langtools/tools/javac/8074306/TestSyntheticNullChecks.java
+++ b/test/langtools/tools/javac/8074306/TestSyntheticNullChecks.java
@@ -27,7 +27,7 @@
  * @summary NULLCHK is emitted as Object.getClass
  * @compile -source 7 -target 7 TestSyntheticNullChecks.java
  * @run main TestSyntheticNullChecks 7
- * @clean TestSyntheticNullChecks*
+ * @clean *
  * @compile TestSyntheticNullChecks.java
  * @run main TestSyntheticNullChecks 9
  */

--- a/test/langtools/tools/javac/StringConcat/TestIndyStringConcat.java
+++ b/test/langtools/tools/javac/StringConcat/TestIndyStringConcat.java
@@ -34,23 +34,23 @@ import java.io.File;
  * @summary Test that StringConcat is working for JDK >= 9
  * @modules jdk.jdeps/com.sun.tools.classfile
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -source 7 -target 7 TestIndyStringConcat.java
  * @run main TestIndyStringConcat false
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -source 8 -target 8 TestIndyStringConcat.java
  * @run main TestIndyStringConcat false
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -XDstringConcat=inline -source 9 -target 9 TestIndyStringConcat.java
  * @run main TestIndyStringConcat false
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -XDstringConcat=indy -source 9 -target 9 TestIndyStringConcat.java
  * @run main TestIndyStringConcat true
  *
- * @clean TestIndyStringConcat*
+ * @clean *
  * @compile -XDstringConcat=indyWithConstants -source 9 -target 9 TestIndyStringConcat.java
  * @run main TestIndyStringConcat true
  */


### PR DESCRIPTION
I backport this to enable jtreg 7

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281507](https://bugs.openjdk.org/browse/JDK-8281507): Two javac tests have bad jtreg `@clean` tags (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1462/head:pull/1462` \
`$ git checkout pull/1462`

Update a local copy of the PR: \
`$ git checkout pull/1462` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1462`

View PR using the GUI difftool: \
`$ git pr show -t 1462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1462.diff">https://git.openjdk.org/jdk17u-dev/pull/1462.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1462#issuecomment-1595646970)