### PR TITLE
8285756: clean up use of bad arguments for `@clean` in langtools tests

### DIFF
--- a/test/langtools/tools/javac/6257443/T6257443.java
+++ b/test/langtools/tools/javac/6257443/T6257443.java
@@ -29,7 +29,7 @@
  * @compile package-info.java
  * @run main/othervm T6257443 -yes foo/package-info.class
  *
- * @clean foo.package-info
+ * @clean foo.*
  *
  * @compile -printsource package-info.java
  * @run main/othervm T6257443 -no foo/package-info.class

--- a/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
+++ b/test/langtools/tools/javac/jvm/ClassRefDupInConstantPoolTest.java
@@ -26,7 +26,7 @@
  * @bug 8015927
  * @summary Class reference duplicates in constant pool
  * @modules jdk.jdeps/com.sun.tools.classfile
- * @clean ClassRefDupInConstantPoolTest$Duplicates.class
+ * @clean ClassRefDupInConstantPoolTest$Duplicates
  * @run main ClassRefDupInConstantPoolTest
  */
 

--- a/test/langtools/tools/javac/warnings/suppress/PackageInfo.java
+++ b/test/langtools/tools/javac/warnings/suppress/PackageInfo.java
@@ -25,6 +25,6 @@
  * @test
  * @bug 8021112
  * @summary Verify that deprecated warnings are printed correctly for package-info.java
- * @clean pack.package-info pack.DeprecatedClass
+ * @clean pack.*
  * @compile/ref=PackageInfo.out -source 8 -XDrawDiagnostics -Xlint:deprecation,-options pack/package-info.java pack/DeprecatedClass.java
  */


### PR DESCRIPTION
I backport this to enable jtreg 7

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285756](https://bugs.openjdk.org/browse/JDK-8285756): clean up use of bad arguments for `@clean` in langtools tests (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1463/head:pull/1463` \
`$ git checkout pull/1463`

Update a local copy of the PR: \
`$ git checkout pull/1463` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1463`

View PR using the GUI difftool: \
`$ git pr show -t 1463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1463.diff">https://git.openjdk.org/jdk17u-dev/pull/1463.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1463#issuecomment-1595648016)