### PR TITLE
8293012: ConstantPool::print_on can crash if _cache is NULL

### DIFF
--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2244,9 +2244,10 @@ void ConstantPool::print_on(outputStream* st) const {
     st->print_cr(" - holder: " INTPTR_FORMAT, p2i(pool_holder()));
   }
   st->print_cr(" - cache: " INTPTR_FORMAT, p2i(cache()));
-  st->print_cr(" - resolved_references: " INTPTR_FORMAT, p2i(resolved_references()));
+  st->print_cr(" - resolved_references: " INTPTR_FORMAT, p2i(resolved_references_or_null()));
   st->print_cr(" - reference_map: " INTPTR_FORMAT, p2i(reference_map()));
   st->print_cr(" - resolved_klasses: " INTPTR_FORMAT, p2i(resolved_klasses()));
+  st->print_cr(" - cp length: %d", length());
 
   for (int index = 1; index < length(); index++) {      // Index 0 is unused
     ((ConstantPool*)this)->print_entry_on(index, st);


### PR DESCRIPTION
Clean backport to improve error logging path reliability.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293012](https://bugs.openjdk.org/browse/JDK-8293012): ConstantPool::print_on can crash if _cache is NULL (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1467/head:pull/1467` \
`$ git checkout pull/1467`

Update a local copy of the PR: \
`$ git checkout pull/1467` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1467`

View PR using the GUI difftool: \
`$ git pr show -t 1467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1467.diff">https://git.openjdk.org/jdk17u-dev/pull/1467.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1467#issuecomment-1596614698)