### PR TITLE
8282665: [REDO] ByteBufferTest.java: replace endless recursion with RuntimeException in void ck(double x, double y)

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/unsafe/ByteBufferTest.java
@@ -211,13 +211,22 @@ class MyByteBuffer {
 
     void ck(long x, long y) {
         if (x != y) {
-            throw new RuntimeException(" x = " + Long.toHexString(x) + ", y = " + Long.toHexString(y));
+            throw new RuntimeException("expect x == y: x = " + Long.toHexString(x) + ", y = " + Long.toHexString(y));
         }
     }
 
     void ck(double x, double y) {
-        if (x == x && y == y && x != y) {
-            ck(x, y);
+        // Check if x and y have identical values.
+        // Remember: NaN == x is false for ANY x, including if x is NaN (IEEE standard).
+        // Therefore, if x and y are NaN, x != y would return true, which is not what we want.
+        // We do not want an Exception if both are NaN.
+        // Double.compare takes care of these special cases
+        // including NaNs, and comparing -0.0 to 0.0
+        if (Double.compare(x,y) != 0) {
+            throw new RuntimeException("expect x == y:"
+                                    + "  x = " + Double.toString(x) + ", y = " + Double.toString(y)
+                                    + " (x = " + Long.toHexString(Double.doubleToRawLongBits(x))
+                                    + ", y = " + Long.toHexString(Double.doubleToRawLongBits(y)) + ")");
         }
     }
 


### PR DESCRIPTION
Backport of [JDK-8282665](https://bugs.openjdk.org/browse/JDK-8282665).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282665](https://bugs.openjdk.org/browse/JDK-8282665): [REDO] ByteBufferTest.java: replace endless recursion with RuntimeException in void ck(double x, double y) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1470/head:pull/1470` \
`$ git checkout pull/1470`

Update a local copy of the PR: \
`$ git checkout pull/1470` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1470`

View PR using the GUI difftool: \
`$ git pr show -t 1470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1470.diff">https://git.openjdk.org/jdk17u-dev/pull/1470.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1470#issuecomment-1597426979)