### PR TITLE
8286481: Exception printed to stdout on Windows when storing transparent image in clipboard

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WClipboard.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WClipboard.java
@@ -83,13 +83,7 @@ final class WClipboard extends SunClipboard {
                         translateTransferable(contents, flavor, format);
                     publishClipboardData(format, bytes);
                 } catch (IOException e) {
-                    // Fix 4696186: don't print exception if data with
-                    // javaJVMLocalObjectMimeType failed to serialize.
-                    // May remove this if-check when 5078787 is fixed.
-                    if (!(flavor.isMimeTypeEqual(DataFlavor.javaJVMLocalObjectMimeType) &&
-                          e instanceof java.io.NotSerializableException)) {
-                        e.printStackTrace();
-                    }
+                    // Cannot be translated in this format, skip
                 }
             }
         } finally {


### PR DESCRIPTION
Backport of [JDK-8286481](https://bugs.openjdk.org/browse/JDK-8286481).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286481](https://bugs.openjdk.org/browse/JDK-8286481): Exception printed to stdout on Windows when storing transparent image in clipboard (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1471/head:pull/1471` \
`$ git checkout pull/1471`

Update a local copy of the PR: \
`$ git checkout pull/1471` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1471`

View PR using the GUI difftool: \
`$ git pr show -t 1471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1471.diff">https://git.openjdk.org/jdk17u-dev/pull/1471.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1471#issuecomment-1597427327)