### PR TITLE
8289688: jfr command hangs when it processes invalid file

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -158,6 +158,8 @@ public final class ChunkHeader {
                     Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: finalChunk=" + finalChunk);
                     absoluteChunkEnd = absoluteChunkStart + chunkSize;
                     return;
+                } else if (finished) {
+                    throw new IOException("No metadata event found in finished chunk.");
                 }
             }
         }


### PR DESCRIPTION
Backport of [JDK-8289688](https://bugs.openjdk.org/browse/JDK-8289688).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289688](https://bugs.openjdk.org/browse/JDK-8289688): jfr command hangs when it processes invalid file (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1472/head:pull/1472` \
`$ git checkout pull/1472`

Update a local copy of the PR: \
`$ git checkout pull/1472` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1472`

View PR using the GUI difftool: \
`$ git pr show -t 1472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1472.diff">https://git.openjdk.org/jdk17u-dev/pull/1472.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1472#issuecomment-1597437091)