### PR TITLE
8263044: jdk/jfr/jvm/TestDumpOnCrash.java timed out

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ChunkHeader.java
@@ -158,8 +158,18 @@ public final class ChunkHeader {
                     Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Chunk: finalChunk=" + finalChunk);
                     absoluteChunkEnd = absoluteChunkStart + chunkSize;
                     return;
-                } else if (finished) {
-                    throw new IOException("No metadata event found in finished chunk.");
+                } else {
+                    if (finished) {
+                        throw new IOException("No metadata event found in finished chunk.");
+                    }
+                    if (chunkSize == HEADER_SIZE) {
+                        // This ensures that a non-streaming parser is able
+                        // to break out of the loop in case the file is
+                        // ended before the first metadata event has
+                        // been written. This can happen during a failed crash
+                        // dump.
+                        input.pollWait();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Backport of [JDK-8263044](https://bugs.openjdk.org/browse/JDK-8263044).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263044](https://bugs.openjdk.org/browse/JDK-8263044): jdk/jfr/jvm/TestDumpOnCrash.java timed out (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1476/head:pull/1476` \
`$ git checkout pull/1476`

Update a local copy of the PR: \
`$ git checkout pull/1476` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1476`

View PR using the GUI difftool: \
`$ git pr show -t 1476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1476.diff">https://git.openjdk.org/jdk17u-dev/pull/1476.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1476#issuecomment-1598915518)