### PR TITLE
8283056: show abstract machine code in hs-err for all VM crashes

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -909,7 +909,7 @@ void VMError::report(outputStream* st, bool _verbose) {
 
   STEP("printing code blobs if possible")
 
-     if (_verbose && _context) {
+     if (_verbose) {
        const int printed_capacity = max_error_log_print_code;
        address printed[printed_capacity];
        printed[0] = nullptr;
@@ -928,7 +928,8 @@ void VMError::report(outputStream* st, bool _verbose) {
              printed_len++;
            }
          } else {
-           frame fr = os::fetch_frame_from_context(_context);
+           frame fr = _context ? os::fetch_frame_from_context(_context)
+                               : os::current_frame();
            while (printed_len < limit && fr.pc() != nullptr) {
              if (print_code(st, _thread, fr.pc(), fr.pc() == _pc, printed, printed_capacity)) {
                printed_len++;


### PR DESCRIPTION
Backport of [JDK-8283056](https://bugs.openjdk.java.net/browse/JDK-8283056). Greatly helps analyzing crashes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283056](https://bugs.openjdk.org/browse/JDK-8283056): show abstract machine code in hs-err for all VM crashes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1481/head:pull/1481` \
`$ git checkout pull/1481`

Update a local copy of the PR: \
`$ git checkout pull/1481` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1481`

View PR using the GUI difftool: \
`$ git pr show -t 1481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1481.diff">https://git.openjdk.org/jdk17u-dev/pull/1481.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1481#issuecomment-1600488512)