### PR TITLE
8309613: [Windows] hs_err files sometimes miss information about the code containing the error

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -503,7 +503,7 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
-bool os::platform_print_native_stack(outputStream* st, void* context, char *buf, int buf_size) {
+bool os::platform_print_native_stack(outputStream* st, void* context, char *buf, int buf_size, address& lastpc) {
   AixNativeCallstack::print_callstack_for_context(st, (const ucontext_t*)context, true, buf, (size_t) buf_size);
   return true;
 }

--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.hpp
@@ -34,7 +34,7 @@
 
   #define PLATFORM_PRINT_NATIVE_STACK 1
   static bool platform_print_native_stack(outputStream* st, void* context,
-                                          char *buf, int buf_size);
+                                          char *buf, int buf_size, address& lastpc);
 
   #define HAVE_FUNCTION_DESCRIPTORS 1
   static void* resolve_function_descriptor(void* p);

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.hpp
@@ -40,7 +40,7 @@
 #ifdef AMD64
 #define PLATFORM_PRINT_NATIVE_STACK 1
 static bool platform_print_native_stack(outputStream* st, const void* context,
-                                        char *buf, int buf_size);
+                                        char *buf, int buf_size, address& lastpc);
 #endif
 
 #endif // OS_CPU_WINDOWS_X86_OS_WINDOWS_X86_HPP

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -886,7 +886,7 @@ class os: AllStatic {
 #ifndef PLATFORM_PRINT_NATIVE_STACK
   // No platform-specific code for printing the native stack.
   static bool platform_print_native_stack(outputStream* st, const void* context,
-                                          char *buf, int buf_size) {
+                                          char *buf, int buf_size, address& lastpc) {
     return false;
   }
 #endif

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -676,7 +676,8 @@ extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native st
 extern "C" JNIEXPORT void pns2() { // print native stack
   Command c("pns2");
   static char buf[O_BUFLEN];
-  if (os::platform_print_native_stack(tty, NULL, buf, sizeof(buf))) {
+  address lastpc = nullptr;
+  if (os::platform_print_native_stack(tty, NULL, buf, sizeof(buf), lastpc)) {
     // We have printed the native stack in platform-specific code,
     // so nothing else to do in this case.
   } else {

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -313,6 +313,27 @@ static bool print_code(outputStream* st, Thread* thread, address pc, bool is_cra
   return false;
 }
 
+// Like above, but only try to figure out a short name. Return nullptr if not found.
+static const char* find_code_name(address pc) {
+  if (Interpreter::contains(pc)) {
+    InterpreterCodelet* codelet = Interpreter::codelet_containing(pc);
+    if (codelet != nullptr) {
+      return codelet->description();
+    }
+  } else {
+    StubCodeDesc* desc = StubCodeDesc::desc_for(pc);
+    if (desc != nullptr) {
+      return desc->name();
+    } else {
+      CodeBlob* cb = CodeCache::find_blob(pc);
+      if (cb != nullptr) {
+        return cb->name();
+      }
+    }
+  }
+  return nullptr;
+}
+
 /**
  * Gets the caller frame of `fr`.
  *
@@ -527,6 +548,10 @@ void VMError::report(outputStream* st, bool _verbose) {
 
   // don't allocate large buffer on stack
   static char buf[O_BUFLEN];
+
+  // Native stack trace may get stuck. We try to handle the last pc if it
+  // belongs to VM generated code.
+  address lastpc = nullptr;
 
   BEGIN
 
@@ -824,9 +849,16 @@ void VMError::report(outputStream* st, bool _verbose) {
   STEP("printing native stack")
 
    if (_verbose) {
-     if (os::platform_print_native_stack(st, _context, buf, sizeof(buf))) {
+     if (os::platform_print_native_stack(st, _context, buf, sizeof(buf), lastpc)) {
        // We have printed the native stack in platform-specific code
        // Windows/x64 needs special handling.
+       // Stack walking may get stuck. Try to find the calling code.
+       if (lastpc != nullptr) {
+         const char* name = find_code_name(lastpc);
+         if (name != nullptr) {
+           st->print_cr("The last pc belongs to %s (printed below).", name);
+         }
+       }
      } else {
        frame fr = _context ? os::fetch_frame_from_context(_context)
                            : os::current_frame();
@@ -920,6 +952,13 @@ void VMError::report(outputStream* st, bool _verbose) {
        // value outside the range.
        int limit = MIN2(ErrorLogPrintCodeLimit, printed_capacity);
        if (limit > 0) {
+         // Check if a pc was found by native stack trace above.
+         if (lastpc != nullptr) {
+           if (print_code(st, _thread, lastpc, true, printed, printed_capacity)) {
+             printed_len++;
+           }
+         }
+
          // Scan the native stack
          if (!_print_native_stack_used) {
            // Only try to print code of the crashing frame since


### PR DESCRIPTION
Backport of [JDK-8309613](https://bugs.openjdk.org/browse/JDK-8309613). Requires manual integration, but it's pretty straightforward.

Manually tested on Windows like in the upstream PR (without hsdis provided):
```
---------------  T H R E A D  ---------------

Current thread (0x000000c5550feee0):  JavaThread "main" [_thread_in_Java, id=628356, stack(0x000000c5547a0000,0x000000c5548a000
0)]

Stack: [0x000000c5547a0000,0x000000c5548a0000]
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [jvm.dll+0x64c869]  os::platform_print_native_stack+0xd9  (os_windows_x86.cpp:235)
V  [jvm.dll+0x7f6467]  VMError::report+0xc67  (vmerror.cpp:852)
V  [jvm.dll+0x7f7e1e]  VMError::report_and_die+0x79e  (vmerror.cpp:1710)
V  [jvm.dll+0x236ce7]  report_fatal+0x97  (debug.cpp:302)
V  [jvm.dll+0x586086]  MacroAssembler::debug64+0x96  (macroassembler_x86.cpp:865)
C  0x000000c564791247

The last pc belongs to nmethod (printed below).

Compiled method (c2)     498   32       4       java.lang.Object::<init> (1 bytes)
 total in heap  [0x000000c564791090,0x000000c5647912b0] = 544
 relocation     [0x000000c5647911e8,0x000000c564791200] = 24
 main code      [0x000000c564791200,0x000000c564791260] = 96
 stub code      [0x000000c564791260,0x000000c564791278] = 24
 metadata       [0x000000c564791278,0x000000c564791280] = 8
 scopes data    [0x000000c564791280,0x000000c564791288] = 8
 scopes pcs     [0x000000c564791288,0x000000c5647912a8] = 32
 dependencies   [0x000000c5647912a8,0x000000c5647912b0] = 8

[Constant Pool (empty)]

[MachCode]
[Entry Point]
  # {method} {0x0000000800443ff8} '<init>' '()V' in 'java/lang/Object'
  #           [sp+0x20]  (sp of caller)
  0x000000c564791200: 448b 5208 | 49bb 0000 | 0000 0800 | 0000 4d03 | d349 3bc2 

  0x000000c564791214: ;   {runtime_call ic_miss_stub}
  0x000000c564791214: 0f85 66fe | 8fff 6690 | 0f1f 4000 
[Verified Entry Point]
  0x000000c564791220: 4881 ec18 | 0000 0048 | 896c 2410 

  0x000000c56479122c: ;   {external_word}
  0x000000c56479122c: 48b9 1806 | b598 fa7f | 0000 4883 

  0x000000c564791238: ;   {runtime_call MacroAssembler::debug64}
  0x000000c564791238: e4f0 49ba | f05f 7598 | fa7f 0000 | 41ff d2f4 | f4f4 f4f4 | f4f4 f4f4 | f4f4 f4f4 | f4f4 f4f4 
  0x000000c564791258: f4f4 f4f4 | f4f4 f4f4 
[Exception Handler]
  0x000000c564791260: ;   {no_reloc}
  0x000000c564791260: e99b 5d91 | ffe8 0000 | 0000 4883 

  0x000000c56479126c: ;   {runtime_call DeoptimizationBlob}
  0x000000c56479126c: 2c24 05e9 | 2c5a 90ff | f4f4 f4f4 
[/MachCode]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309613](https://bugs.openjdk.org/browse/JDK-8309613): [Windows] hs_err files sometimes miss information about the code containing the error (**Bug** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1482/head:pull/1482` \
`$ git checkout pull/1482`

Update a local copy of the PR: \
`$ git checkout pull/1482` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1482`

View PR using the GUI difftool: \
`$ git pr show -t 1482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1482.diff">https://git.openjdk.org/jdk17u-dev/pull/1482.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1482#issuecomment-1600912623)