### PR TITLE
8040793: vmTestbase/nsk/monitoring/stress/lowmem fails on calling isCollectionUsageThresholdExceeded()

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -198,6 +198,10 @@ void DefNewGeneration::compute_space_boundaries(uintx minimum_eden_size,
   uintx size = _virtual_space.committed_size();
   uintx survivor_size = compute_survivor_size(size, SpaceAlignment);
   uintx eden_size = size - (2*survivor_size);
+  if (eden_size > max_eden_size()) {
+    eden_size = max_eden_size();
+    survivor_size = (size - eden_size)/2;
+  }
   assert(eden_size > 0 && survivor_size <= eden_size, "just checking");
 
   if (eden_size < minimum_eden_size) {


### PR DESCRIPTION
Backport of [JDK-8040793](https://bugs.openjdk.org/browse/JDK-8040793).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8040793](https://bugs.openjdk.org/browse/JDK-8040793): vmTestbase/nsk/monitoring/stress/lowmem fails on calling isCollectionUsageThresholdExceeded() (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1485/head:pull/1485` \
`$ git checkout pull/1485`

Update a local copy of the PR: \
`$ git checkout pull/1485` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1485`

View PR using the GUI difftool: \
`$ git pr show -t 1485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1485.diff">https://git.openjdk.org/jdk17u-dev/pull/1485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1485#issuecomment-1601078855)