### PR TITLE
8306435: Juggle04/TestDescription.java should be a booleanArr test and not a byteArr one

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/ArrayJuggle/Juggle04/TestDescription.java
@@ -35,7 +35,7 @@
  *      -XX:+HeapDumpOnOutOfMemoryError
  *      -Xlog:gc=debug:gc.log
  *      gc.ArrayJuggle.Juggle01.Juggle01
- *      -gp byteArr
+ *      -gp booleanArr
  *      -ms low
  */
 


### PR DESCRIPTION
Backport of [JDK-8306435](https://bugs.openjdk.org/browse/JDK-8306435).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306435](https://bugs.openjdk.org/browse/JDK-8306435): Juggle04/TestDescription.java should be a booleanArr test and not a byteArr one (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1486/head:pull/1486` \
`$ git checkout pull/1486`

Update a local copy of the PR: \
`$ git checkout pull/1486` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1486`

View PR using the GUI difftool: \
`$ git pr show -t 1486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1486.diff">https://git.openjdk.org/jdk17u-dev/pull/1486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1486#issuecomment-1601100244)