### PR TITLE
8306428: RunThese30M.java crashed with assert(early->flag() == current->flag() || early->flag() == mtNone)

### DIFF
--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -793,7 +793,8 @@ void MemDetailDiffReporter::old_virtual_memory_site(const VirtualMemoryAllocatio
 
 void MemDetailDiffReporter::diff_virtual_memory_site(const VirtualMemoryAllocationSite* early,
   const VirtualMemoryAllocationSite* current) const {
-  assert(early->flag() == current->flag(), "Should be the same");
+  assert(early->flag() == current->flag() || early->flag() == mtNone,
+    "Expect the same flag, but %s != %s", NMTUtil::flag_to_name(early->flag()),NMTUtil::flag_to_name(current->flag()));
   diff_virtual_memory_site(current->call_stack(), current->reserved(), current->committed(),
     early->reserved(), early->committed(), current->flag());
 }

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -731,6 +731,13 @@ void MemDetailDiffReporter::diff_virtual_memory_sites() const {
       } else if (compVal > 0) {
         old_virtual_memory_site(early_site);
         early_site = early_itr.next();
+      } else if (early_site->flag() != current_site->flag()) {
+        // This site was originally allocated with one flag, then released,
+        // then re-allocated at the same site (as far as we can tell) with a different flag.
+        old_virtual_memory_site(early_site);
+        early_site = early_itr.next();
+        new_virtual_memory_site(current_site);
+        current_site = current_itr.next();
       } else {
         diff_virtual_memory_site(early_site, current_site);
         early_site   = early_itr.next();
@@ -793,8 +800,6 @@ void MemDetailDiffReporter::old_virtual_memory_site(const VirtualMemoryAllocatio
 
 void MemDetailDiffReporter::diff_virtual_memory_site(const VirtualMemoryAllocationSite* early,
   const VirtualMemoryAllocationSite* current) const {
-  assert(early->flag() == current->flag() || early->flag() == mtNone,
-    "Expect the same flag, but %s != %s", NMTUtil::flag_to_name(early->flag()),NMTUtil::flag_to_name(current->flag()));
   diff_virtual_memory_site(current->call_stack(), current->reserved(), current->committed(),
     early->reserved(), early->committed(), current->flag());
 }


### PR DESCRIPTION
Backport of [JDK-8306428](https://bugs.openjdk.org/browse/JDK-8306428). Includes [JDK-8271406](https://bugs.openjdk.java.net/browse/JDK-8271406) to make the backport clean (see 1st commit, touched lines are removed by 2nd commit).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306428](https://bugs.openjdk.org/browse/JDK-8306428): RunThese30M.java crashed with assert(early-&gt;flag() == current-&gt;flag() || early-&gt;flag() == mtNone) (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1491/head:pull/1491` \
`$ git checkout pull/1491`

Update a local copy of the PR: \
`$ git checkout pull/1491` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1491`

View PR using the GUI difftool: \
`$ git pr show -t 1491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1491.diff">https://git.openjdk.org/jdk17u-dev/pull/1491.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1491#issuecomment-1602839786)