### PR TITLE
8306281: function isWsl() returns false on WSL2

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1477,7 +1477,7 @@ var getVersionNumbers = function () {
 var isWsl = function (input) {
     return ( input.build_osenv == "wsl"
              || (input.build_os == "linux"
-                 && java.lang.System.getProperty("os.version").contains("Microsoft")));
+                 && java.lang.System.getProperty("os.version").toLowerCase().contains("microsoft")));
 }
 
 var error = function (s) {


### PR DESCRIPTION
Backport of [JDK-8306281](https://bugs.openjdk.org/browse/JDK-8306281).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306281](https://bugs.openjdk.org/browse/JDK-8306281): function isWsl() returns false on WSL2 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1493/head:pull/1493` \
`$ git checkout pull/1493`

Update a local copy of the PR: \
`$ git checkout pull/1493` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1493`

View PR using the GUI difftool: \
`$ git pr show -t 1493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1493.diff">https://git.openjdk.org/jdk17u-dev/pull/1493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1493#issuecomment-1602892781)