### PR TITLE
8308152: PropertyDescriptor should work with overridden generic getter method

### DIFF
--- a/src/java.desktop/share/classes/java/beans/Introspector.java
+++ b/src/java.desktop/share/classes/java/beans/Introspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1158,6 +1158,8 @@ public class Introspector {
         // For overriden methods we need to find the most derived version.
         // So we start with the given class and walk up the superclass chain.
         for (Class<?> cl = start; cl != null; cl = cl.getSuperclass()) {
+            Class<?> type = null;
+            Method foundMethod = null;
             for (Method method : ClassInfo.get(cl).getMethods()) {
                 // make sure method signature matches.
                 if (method.getName().equals(methodName)) {
@@ -1177,9 +1179,16 @@ public class Introspector {
                                 }
                             }
                         }
-                        return method;
+                        Class<?> rt = method.getReturnType();
+                        if (foundMethod == null || type.isAssignableFrom(rt)) {
+                            foundMethod = method;
+                            type = rt;
+                        }
                     }
                 }
+            }
+            if (foundMethod != null) {
+                return foundMethod;
             }
         }
         // Now check any inherited interfaces.  This is necessary both when

--- a/test/jdk/java/beans/PropertyDescriptor/OverriddenGetter.java
+++ b/test/jdk/java/beans/PropertyDescriptor/OverriddenGetter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+
+import javax.swing.JPanel;
+
+/**
+ * @test
+ * @bug 8308152
+ * @summary PropertyDescriptor should work with overridden generic getter method
+ */
+public class OverriddenGetter {
+
+    static class Parent<T> {
+        private T value;
+        public T getValue() {return value;}
+        public final void setValue(T value) {this.value = value;}
+    }
+
+    static class ChildO extends Parent<Object> {
+        public ChildO() {}
+        @Override
+        public Object getValue() {return super.getValue();}
+    }
+
+    static class ChildA extends Parent<ArithmeticException> {
+        public ChildA() {}
+        @Override
+        public ArithmeticException getValue() {return super.getValue();}
+    }
+
+    static class ChildS extends Parent<String> {
+        public ChildS() {}
+        @Override
+        public String getValue() {return super.getValue();}
+    }
+
+    public static void main(String[] args) throws Exception {
+        test("UI", JPanel.class, "getUI", "setUI");
+        test("value", ChildO.class, "getValue", "setValue");
+        test("value", ChildA.class, "getValue", "setValue");
+        test("value", ChildS.class, "getValue", "setValue");
+    }
+
+    private static void test(String name, Class<?> beanClass,
+                             String read, String write) throws Exception
+    {
+        var gold = new PropertyDescriptor(name, beanClass, read, write);
+        BeanInfo beanInfo = Introspector.getBeanInfo(beanClass);
+        PropertyDescriptor[] pds = beanInfo.getPropertyDescriptors();
+        for (PropertyDescriptor pd : pds) {
+            if (pd.getName().equals(gold.getName())) {
+                if (pd.getReadMethod() != gold.getReadMethod()) {
+                    System.err.println("Expected: " + gold.getReadMethod());
+                    System.err.println("Actual: " + pd.getReadMethod());
+                    throw new RuntimeException("Wrong read method");
+                }
+                if (pd.getWriteMethod() != gold.getWriteMethod()) {
+                    System.err.println("Expected: " + gold.getWriteMethod());
+                    System.err.println("Actual: " + pd.getWriteMethod());
+                    throw new RuntimeException("Wrong write method");
+                }
+                if (pd.getPropertyType() != gold.getPropertyType()) {
+                    System.err.println("Expected: " + gold.getPropertyType());
+                    System.err.println("Actual: " + pd.getPropertyType());
+                    throw new RuntimeException("Wrong property type");
+                }
+                return;
+            }
+        }
+        throw new RuntimeException("The PropertyDescriptor is not found");
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [73dd03cc](https://github.com/openjdk/jdk/commit/73dd03cc5afa6d1e01a92d0027dcb82af27a48af) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 8 Jun 2023 and was reviewed by Alexander Zvegintsev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308152](https://bugs.openjdk.org/browse/JDK-8308152): PropertyDescriptor should work with overridden generic getter method (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1501/head:pull/1501` \
`$ git checkout pull/1501`

Update a local copy of the PR: \
`$ git checkout pull/1501` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1501`

View PR using the GUI difftool: \
`$ git pr show -t 1501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1501.diff">https://git.openjdk.org/jdk17u-dev/pull/1501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1501#issuecomment-1609828659)