### PR TITLE
8290469: Add new positioning options to PassFailJFrame test framework

### DIFF
--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -81,6 +81,10 @@ public class TrayIconScalingTest {
         PassFailJFrame passFailJFrame = new PassFailJFrame("TrayIcon " +
                 "Test Instructions", INSTRUCTIONS, 8, 18, 85);
         createAndShowGUI();
+        // does not have a test window,
+        // hence only the instruction frame is positioned
+        PassFailJFrame.positionTestWindow(null,
+                PassFailJFrame.Position.HORIZONTAL);
         try {
             passFailJFrame.awaitAndCheck();
         } finally {

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/ClippedImages.java
@@ -59,6 +59,7 @@ import static java.awt.EventQueue.invokeAndWait;
 public class ClippedImages {
 
     private static ClippedImageCanvas c;
+    private static Frame frame;
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
@@ -100,7 +101,7 @@ public class ClippedImages {
     }
 
     public static void createTestUI() {
-        Frame frame = new Frame("Clipped Src Area Image Printing Test");
+        frame = new Frame("Clipped Src Area Image Printing Test");
         c = new ClippedImageCanvas();
         frame.add(c, BorderLayout.CENTER);
 
@@ -123,10 +124,10 @@ public class ClippedImages {
         frame.add(p, BorderLayout.SOUTH);
         frame.setLocationRelativeTo(null);
         frame.pack();
-        frame.setVisible(true);
 
         PassFailJFrame.addTestWindow(frame);
         PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
+        frame.setVisible(true);
     }
 
     private static void printOne() {

--- a/test/jdk/java/awt/print/PrinterJob/PrintGlyphVectorTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintGlyphVectorTest.java
@@ -34,13 +34,11 @@ import java.awt.BorderLayout;
 import java.awt.Button;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.Label;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import java.awt.geom.Point2D;
@@ -51,6 +49,7 @@ import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 
 public class PrintGlyphVectorTest extends Component implements Printable {
+    private static Frame f;
 
     private static final String INSTRUCTIONS = """
             Note: You must have a printer installed for this test.
@@ -128,7 +127,7 @@ public class PrintGlyphVectorTest extends Component implements Printable {
             PassFailJFrame.forcePass();
         }
 
-        Frame f = new Frame("Test PrintGlyphVector");
+        f = new Frame("Test PrintGlyphVector");
         PrintGlyphVectorTest pvt = new PrintGlyphVectorTest();
         f.add(pvt, BorderLayout.CENTER);
 
@@ -149,13 +148,13 @@ public class PrintGlyphVectorTest extends Component implements Printable {
 
         f.add(printButton, BorderLayout.SOUTH);
         f.pack();
-        f.setVisible(true);
 
         // add the test frame to dispose
         PassFailJFrame.addTestWindow(f);
 
         // Arrange the test instruction frame and test frame side by side
         PassFailJFrame.positionTestWindow(f, PassFailJFrame.Position.HORIZONTAL);
+        f.setVisible(true);
     }
 
     public static void main(String[] arg) throws Exception {

--- a/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
@@ -74,8 +74,6 @@ public class PrintLatinCJKTest implements Printable {
             });
             frame.getContentPane().add(b, BorderLayout.SOUTH);
             frame.pack();
-            frame.setLocationRelativeTo(null);
-            frame.setVisible(true);
 
             // add the test frame to dispose
             PassFailJFrame.addTestWindow(frame);
@@ -83,6 +81,7 @@ public class PrintLatinCJKTest implements Printable {
             // Arrange the test instruction frame and test frame side by side
             PassFailJFrame.positionTestWindow(frame,
                     PassFailJFrame.Position.HORIZONTAL);
+            frame.setVisible(true);
         });
     }
 
@@ -100,7 +99,7 @@ public class PrintLatinCJKTest implements Printable {
 
     public static void main(String[] args) throws InterruptedException, InvocationTargetException {
         PassFailJFrame passFailJFrame = new PassFailJFrame("Test Instruction" +
-                "Frame", info, 10, 40, 5);
+                "Frame", info, 10, 10, 45);
         showFrame();
         passFailJFrame.awaitAndCheck();
     }

--- a/test/jdk/javax/swing/JRadioButton/bug4380543.java
+++ b/test/jdk/javax/swing/JRadioButton/bug4380543.java
@@ -20,15 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/* @test
- * @bug 4380543
- * @key headful
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
- * @summary setMargin() does not work for AbstractButton
- * @run main/manual bug4380543
-*/
-
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
@@ -45,6 +36,14 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
+/* @test
+ * @bug 4380543
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary setMargin() does not work for AbstractButton
+ * @run main/manual bug4380543
+ */
 public class bug4380543 {
     static TestFrame testObj;
     static String instructions
@@ -62,17 +61,16 @@ public class bug4380543 {
 
     public static void main(String[] args) throws Exception {
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                try {
-                    passFailJFrame = new PassFailJFrame(instructions);
-                    testObj = new TestFrame();
-                    //Adding the Test Frame to handle dispose
-                    PassFailJFrame.addTestWindow(testObj);
-                    PassFailJFrame.positionTestWindow(testObj, PassFailJFrame.Position.HORIZONTAL);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                passFailJFrame = new PassFailJFrame(instructions);
+                testObj = new TestFrame();
+                //Adding the Test Frame to handle dispose
+                PassFailJFrame.addTestWindow(testObj);
+                PassFailJFrame.positionTestWindow(testObj, PassFailJFrame.Position.HORIZONTAL);
+                testObj.setVisible(true);
+            } catch (Exception e) {
+                e.printStackTrace();
             }
         });
         passFailJFrame.awaitAndCheck();
@@ -111,9 +109,7 @@ class TestFrame extends JFrame implements ActionListener {
         }
 
         getContentPane().add(p,BorderLayout.SOUTH);
-
         setSize(500, 300);
-        setVisible(true);
     }
 
     private static void setLookAndFeel(String laf) {

--- a/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
+++ b/test/jdk/javax/swing/JTabbedPane/4209065/bug4209065.java
@@ -21,6 +21,13 @@
  * questions.
  */
 
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
 /*
  * @test
  * @bug 4209065
@@ -29,14 +36,6 @@
  * @summary To test if the style of the text on the tab matches the description.
  * @run main/manual bug4209065
  */
-
-import java.lang.reflect.InvocationTargetException;
-
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JTabbedPane;
-import javax.swing.SwingUtilities;
-
 
 public final class bug4209065 {
 
@@ -47,37 +46,32 @@ public final class bug4209065 {
                     " text may be larger\nthan the tab height but this is OK" +
                     " and NOT a failure.";
 
-    public static void createAndShowGUI() throws InterruptedException,
-            InvocationTargetException {
-        SwingUtilities.invokeAndWait(() -> {
-            frame = new JFrame("JTabbedPane");
+    public static void createAndShowGUI() {
 
-            JTabbedPane tp = new JTabbedPane();
+        frame = new JFrame("JTabbedPane");
+        JTabbedPane tp = new JTabbedPane();
 
-            tp.addTab("<html><center><font size=+3>big</font></center></html>",
-                    new JLabel());
-            tp.addTab("<html><center><font color=red>red</font></center></html>",
-                    new JLabel());
-            tp.addTab("<html><center><em><b>Bold Italic!</b></em></center></html>",
-                    new JLabel());
+        tp.addTab("<html><center><font size=+3>big</font></center></html>",
+                new JLabel());
+        tp.addTab("<html><center><font color=red>red</font></center></html>",
+                new JLabel());
+        tp.addTab("<html><center><em><b>Bold Italic!</b></em></center></html>",
+                new JLabel());
 
-            frame.getContentPane().add(tp);
-            frame.setSize(400, 400);
-            frame.setLocationRelativeTo(null);
-            frame.setVisible(true);
+        frame.getContentPane().add(tp);
+        frame.setSize(400, 400);
 
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-        });
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(frame,
+                PassFailJFrame.Position.HORIZONTAL);
+        frame.setVisible(true);
     }
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
         PassFailJFrame passFailJFrame = new PassFailJFrame("JTabbedPane " +
                 "Test Instructions", text, 5, 19, 35);
-        createAndShowGUI();
+        SwingUtilities.invokeAndWait(bug4209065::createAndShowGUI);
         passFailJFrame.awaitAndCheck();
     }
 }


### PR DESCRIPTION
Backport of [JDK-8290469](https://bugs.openjdk.org/browse/JDK-8290469). The tests ModalDialogTest.java, PrintAllPagesTest.java and HtmlScriptTagParserTest.java are not in 17u. Skipped. The rest applies cleanly. Tested manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290469](https://bugs.openjdk.org/browse/JDK-8290469): Add new positioning options to PassFailJFrame test framework (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1506/head:pull/1506` \
`$ git checkout pull/1506`

Update a local copy of the PR: \
`$ git checkout pull/1506` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1506`

View PR using the GUI difftool: \
`$ git pr show -t 1506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1506.diff">https://git.openjdk.org/jdk17u-dev/pull/1506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1506#issuecomment-1611661779)