### PR TITLE
8288497: add support for JavaThread::is_oop_safe()

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3583,6 +3583,12 @@ void Threads::remove(JavaThread* p, bool is_daemon) {
     // StackWatermarkSet::on_safepoint(), which performs GC processing,
     // requiring the GC state to be alive.
     BarrierSet::barrier_set()->on_thread_detach(p);
+    if (p->is_exiting()) {
+      // If we got here via JavaThread::exit(), then we remember that the
+      // thread's GC barrier has been detached. We don't do this when we get
+      // here from another path, e.g., cleanup_failed_attach_current_thread().
+      p->set_terminated(JavaThread::_thread_gc_barrier_detached);
+    }
 
     assert(ThreadsSMRSupport::get_java_thread_list()->includes(p), "p must be present");
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -886,8 +886,9 @@ class JavaThread: public Thread {
   // JavaThread termination support
  public:
   enum TerminatedTypes {
-    _not_terminated = 0xDEAD - 2,
+    _not_terminated = 0xDEAD - 3,
     _thread_exiting,                             // JavaThread::exit() has been called for this thread
+    _thread_gc_barrier_detached,                 // thread's GC barrier has been detached
     _thread_terminated,                          // JavaThread is removed from thread list
     _vm_exited                                   // JavaThread is still executing native code, but VM is terminated
                                                  // only VM_Exit can set _vm_exited
@@ -896,10 +897,14 @@ class JavaThread: public Thread {
  private:
   // In general a JavaThread's _terminated field transitions as follows:
   //
-  //   _not_terminated => _thread_exiting => _thread_terminated
+  //   _not_terminated => _thread_exiting => _thread_gc_barrier_detached => _thread_terminated
   //
   // _vm_exited is a special value to cover the case of a JavaThread
   // executing native code after the VM itself is terminated.
+  //
+  // A JavaThread that fails to JNI attach has these _terminated field transitions:
+  //   _not_terminated => _thread_terminated
+  //
   volatile TerminatedTypes _terminated;
 
   jint                  _in_deopt_handler;       // count of deoptimization
@@ -1126,13 +1131,17 @@ class JavaThread: public Thread {
   bool on_thread_list() const { return _on_thread_list; }
   void set_on_thread_list() { _on_thread_list = true; }
 
-  // thread has called JavaThread::exit() or is terminated
+  // thread has called JavaThread::exit(), thread's GC barrier is detached
+  // or thread is terminated
   bool is_exiting() const;
+  // thread's GC barrier is NOT detached and thread is NOT terminated
+  bool is_oop_safe() const;
   // thread is terminated (no longer on the threads list); we compare
-  // against the two non-terminated values so that a freed JavaThread
+  // against the three non-terminated values so that a freed JavaThread
   // will also be considered terminated.
   bool check_is_terminated(TerminatedTypes l_terminated) const {
-    return l_terminated != _not_terminated && l_terminated != _thread_exiting;
+    return l_terminated != _not_terminated && l_terminated != _thread_exiting &&
+           l_terminated != _thread_gc_barrier_detached;
   }
   bool is_terminated() const;
   void set_terminated(TerminatedTypes t);

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -184,21 +184,24 @@ inline void JavaThread::set_done_attaching_via_jni() {
 }
 
 inline bool JavaThread::is_exiting() const {
-  // Use load-acquire so that setting of _terminated by
-  // JavaThread::exit() is seen more quickly.
   TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
-  return l_terminated == _thread_exiting || check_is_terminated(l_terminated);
+  return l_terminated == _thread_exiting ||
+         l_terminated == _thread_gc_barrier_detached ||
+         check_is_terminated(l_terminated);
+}
+
+inline bool JavaThread::is_oop_safe() const {
+  TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
+  return l_terminated != _thread_gc_barrier_detached &&
+         !check_is_terminated(l_terminated);
 }
 
 inline bool JavaThread::is_terminated() const {
-  // Use load-acquire so that setting of _terminated by
-  // JavaThread::exit() is seen more quickly.
   TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
   return check_is_terminated(l_terminated);
 }
 
 inline void JavaThread::set_terminated(TerminatedTypes t) {
-  // use release-store so the setting of _terminated is seen more quickly
   Atomic::release_store(&_terminated, t);
 }
 

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -162,7 +162,8 @@ void ThreadService::remove_thread(JavaThread* thread, bool daemon) {
 
   assert(!thread->is_terminated(), "must not be terminated");
   if (!thread->is_exiting()) {
-    // JavaThread::exit() skipped calling current_thread_exiting()
+    // We did not get here via JavaThread::exit() so current_thread_exiting()
+    // was not called, e.g., JavaThread::cleanup_failed_attach_current_thread().
     decrement_thread_counts(thread, daemon);
   }
 


### PR DESCRIPTION
Clean backport on the way to fix [JDK-8288139](https://bugs.openjdk.org/browse/JDK-8288139). Requires follow-ups as dependent PRs.

Additional testing:
 - [x] Linux AArch64 fastdebug tier1 (as part of whole batch of PRs)
 - [x] Linux AArch64 fastdebug tier2 (as part of whole batch of PRs)
 - [x] Linux AArch64 fastdebug tier3 (as part of whole batch of PRs)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288497](https://bugs.openjdk.org/browse/JDK-8288497): add support for JavaThread::is_oop_safe() (**Sub-task** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1514/head:pull/1514` \
`$ git checkout pull/1514`

Update a local copy of the PR: \
`$ git checkout pull/1514` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1514`

View PR using the GUI difftool: \
`$ git pr show -t 1514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1514.diff">https://git.openjdk.org/jdk17u-dev/pull/1514.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1514#issuecomment-1613544018)