### PR TITLE
8288139: JavaThread touches oop after GC barrier is detached

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -990,11 +990,12 @@ JRT_ENTRY_NO_ASYNC(void, SharedRuntime::register_finalizer(JavaThread* current, 
 JRT_END
 
 jlong SharedRuntime::get_java_tid(Thread* thread) {
-  if (thread != NULL) {
-    if (thread->is_Java_thread()) {
-      oop obj = thread->as_Java_thread()->threadObj();
-      return (obj == NULL) ? 0 : java_lang_Thread::thread_id(obj);
-    }
+  if (thread != NULL && thread->is_Java_thread()) {
+    Thread* current = Thread::current();
+    guarantee(current != thread || thread->as_Java_thread()->is_oop_safe(),
+              "current cannot touch oops after its GC barrier is detached.");
+    oop obj = thread->as_Java_thread()->threadObj();
+    return (obj == NULL) ? 0 : java_lang_Thread::thread_id(obj);
   }
   return 0;
 }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -121,6 +121,7 @@
 #include "services/attachListener.hpp"
 #include "services/management.hpp"
 #include "services/memTracker.hpp"
+#include "services/threadIdTable.hpp"
 #include "services/threadService.hpp"
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
@@ -3577,6 +3578,13 @@ void Threads::remove(JavaThread* p, bool is_daemon) {
   // Extra scope needed for Thread_lock, so we can check
   // that we do not remove thread without safepoint code notice
   { MonitorLocker ml(Threads_lock);
+
+    if (ThreadIdTable::is_initialized()) {
+      // This cleanup must be done before the current thread's GC barrier
+      // is detached since we need to touch the threadObj oop.
+      jlong tid = SharedRuntime::get_java_tid(p);
+      ThreadIdTable::remove_thread(tid);
+    }
 
     // BarrierSet state must be destroyed after the last thread transition
     // before the thread terminates. Thread transitions result in calls to

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -695,7 +695,7 @@ JavaThread* ThreadsList::find_JavaThread_from_java_tid(jlong java_tid) const {
       if (tobj != NULL && java_tid == java_lang_Thread::thread_id(tobj)) {
         MutexLocker ml(Threads_lock);
         // Must be inside the lock to ensure that we don't add a thread to the table
-        // that has just passed the removal point in ThreadsSMRSupport::remove_thread()
+        // that has just passed the removal point in Threads::remove().
         if (!thread->is_exiting()) {
           ThreadIdTable::add_thread(java_tid, thread);
           return thread;
@@ -979,12 +979,6 @@ void ThreadsSMRSupport::release_stable_list_wake_up(bool is_nested) {
 }
 
 void ThreadsSMRSupport::remove_thread(JavaThread *thread) {
-
-  if (ThreadIdTable::is_initialized()) {
-    jlong tid = SharedRuntime::get_java_tid(thread);
-    ThreadIdTable::remove_thread(tid);
-  }
-
   ThreadsList *new_list = ThreadsList::remove_thread(ThreadsSMRSupport::get_java_thread_list(), thread);
   if (EnableThreadSMRStatistics) {
     ThreadsSMRSupport::inc_java_thread_list_alloc_cnt();

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -108,7 +108,7 @@ void ThreadIdTable::lazy_initialize(const ThreadsList *threads) {
         MutexLocker ml(Threads_lock);
         if (!thread->is_exiting()) {
           // Must be inside the lock to ensure that we don't add a thread to the table
-          // that has just passed the removal point in ThreadsSMRSupport::remove_thread()
+          // that has just passed the removal point in Threads::remove().
           add_thread(java_tid, thread);
         }
       }


### PR DESCRIPTION
Unclean backport to avoid a JVM crash. The source for uncleanliness is the absent `JavaThread::cast`, which I replaced back to `->as_Java_thread()`.

Additional testing:
 - [x] Linux AArch64 fastdebug tier1 (as part of whole batch of PRs)
 - [x] Linux AArch64 fastdebug tier2 (as part of whole batch of PRs)
 - [x] Linux AArch64 fastdebug tier3 (as part of whole batch of PRs)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #1514 must be integrated first

### Issue
 * [JDK-8288139](https://bugs.openjdk.org/browse/JDK-8288139): JavaThread touches oop after GC barrier is detached (**Bug** - P2)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1515/head:pull/1515` \
`$ git checkout pull/1515`

Update a local copy of the PR: \
`$ git checkout pull/1515` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1515`

View PR using the GUI difftool: \
`$ git pr show -t 1515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1515.diff">https://git.openjdk.org/jdk17u-dev/pull/1515.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1515#issuecomment-1613554158)