### PR TITLE
8306682: Open source a few more AWT Choice tests

### DIFF
--- a/test/jdk/java/awt/Choice/ChoiceMouseEventOutbounds.java
+++ b/test/jdk/java/awt/Choice/ChoiceMouseEventOutbounds.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6272965
+  @summary PIT: Choice triggers MousePressed when pressing mouse outside comp while drop-down is active, XTkt
+  @key headful
+*/
+
+import java.awt.Choice;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class ChoiceMouseEventOutbounds {
+
+    static final int DELAY = 100;
+    static volatile Choice choice1;
+    static volatile Frame frame;
+    static volatile Robot robot;
+    static volatile boolean mousePressed = false;
+    static volatile boolean mouseReleased = false;
+    static volatile boolean mouseClicked = false;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+
+    static void createUI() {
+        choice1 = new Choice();
+        for (int i = 1; i<10; i++) {
+            choice1.add("item "+i);
+        }
+
+        choice1.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent me) {
+                mousePressed = true;
+                System.out.println(me);
+            }
+            public void mouseReleased(MouseEvent me) {
+                mouseReleased = true;
+                System.out.println(me);
+            }
+            public void mouseClicked(MouseEvent me) {
+                mouseClicked = true;
+                System.out.println(me);
+            }
+        });
+
+        frame = new Frame("ChoiceMouseEventOutbounds");
+        frame.add(choice1);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+    }
+
+    static void runTest() throws Exception {
+        // On Windows, Choice will not close its pop-down menu on a RIGHT
+        // MousePress outside of the Choice. So this scenario isn't
+        // tested here for that reason.
+
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(50);
+        robot.delay(DELAY*10);
+        testMouseClick(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(DELAY);
+        testMouseClick(InputEvent.BUTTON2_DOWN_MASK);
+        robot.delay(DELAY);
+        testMouseClick(InputEvent.BUTTON3_DOWN_MASK);
+
+        System.out.println("Test passed: Choice doesn't generate MOUSEPRESS/CLICK/RELEASE outside Choice.");
+    }
+
+    static void testMouseClick(int button) {
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.delay(DELAY);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(DELAY);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(DELAY*3);
+
+        //they are true because we just pressed mouse
+        mousePressed = false;
+        mouseReleased = false;
+        mouseClicked = false;
+
+        //move mouse outside Choice
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y - choice1.getHeight());
+        robot.delay(DELAY*3);
+        robot.mousePress(button);
+        robot.delay(DELAY);
+        robot.mouseRelease(button);
+
+        if (mousePressed || mouseReleased || mouseClicked) {
+            System.out.println("ERROR: "+ mousePressed+","+mouseReleased +","+mouseClicked);
+            throw new RuntimeException(
+               "Test failed. Choice shouldn't generate PRESSED, RELEASED, CLICKED events outside "+ button);
+        } else {
+            System.out.println(
+               "Test passed. Choice didn't generated MouseDragged PRESSED, RELEASED, CLICKED events outside "+ button);
+        }
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(DELAY);
+        mousePressed = false;
+        mouseReleased = false;
+        mouseClicked = false;
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceMoveTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceMoveTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4323906
+  @summary Test that Choice location is not updated erroneously
+  @key headful
+*/
+
+/**
+ * summary: The test adds a Choice to a Container with BorderLayout, and
+ *          adds the Container to a Frame with null Layout.  When
+ *          the Container is moved in the x direction, the Choice should
+ *          not move in the y direction.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.EventQueue;
+import java.awt.Frame;
+
+public class ChoiceMoveTest {
+
+    static volatile Frame frame;
+    static volatile Container c;
+    static volatile Choice ch;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+
+    static void createUI() {
+        frame = new Frame("Choice Move Test");
+        frame.setSize(500, 500);
+        frame.setLayout(null);
+
+        c = new Container();
+        c.setBackground(Color.green);
+        frame.add(c);
+        c.setSize(200, 200);
+        c.setLocation(100, 100);
+        c.setLayout(new BorderLayout());
+
+        ch = new Choice();
+        ch.setSize(100, 27);
+        c.add(ch, BorderLayout.SOUTH);
+        frame.setVisible(true);
+        frame.validate();
+    }
+
+    static void runTest () throws Exception {
+        Thread.sleep(1000);
+        // If this test ever gives us problems, try putting getLocation() in a
+        // ComponentListener.
+        int xbefore = ch.getLocation().x;
+        int ybefore = ch.getLocation().y;
+        System.out.println("Choice location before: " + xbefore + ", " + ybefore);
+
+        c.setLocation(200, 100);
+        Thread.sleep(1000);
+
+        java.awt.Toolkit.getDefaultToolkit().sync();
+        Thread.sleep(1000);
+        int xafter = ch.getLocation().x;
+        int yafter = ch.getLocation().y;
+        System.out.println("Choice location after: " + xafter + ", " + yafter);
+
+        if (ybefore != yafter) {
+            System.out.println("Test FAILED");
+            throw new RuntimeException("Test failed - Choice should not move in the y direction.");
+        }
+        else {
+            System.out.println("Test passed.");
+        }
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceStaysOpenedOnTAB.java
+++ b/test/jdk/java/awt/Choice/ChoiceStaysOpenedOnTAB.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 6239938
+  @summary Choice drop-down does not disappear when it loses focus, on XToolkit
+  @key headful
+  @requires (os.family == "linux")
+*/
+
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+public class ChoiceStaysOpenedOnTAB {
+
+    static volatile Robot robot;
+    static volatile Choice choice1;
+    static volatile Frame frame;
+
+    public static void main(String[] args) throws Exception {
+
+        if (!System.getProperty("os.name").toLowerCase().startsWith("linux")) {
+            System.out.println("This test is for Linux only");
+            return;
+        }
+
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+            if (frame != null) {
+               EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+
+    static void createUI() {
+        choice1 = new Choice();
+        for (int i = 1; i<10; i++) {
+            choice1.add("item-0"+i);
+        }
+        choice1.setForeground(Color.red);
+        choice1.setBackground(Color.red);
+        Button b1 = new Button("FirstButton");
+        Button b2 = new Button("SecondButton");
+        frame = new Frame("ChoiceStaysOpenedOnTAB");
+        Panel panel = new Panel();
+        panel.add(b1);
+        panel.add(choice1);
+        panel.add(b2);
+        frame.add(panel);
+        frame.setSize(400,400);
+        frame.setLocationRelativeTo(null);
+        frame.validate();
+        frame.setVisible(true);
+    }
+
+    static void runTest() throws Exception {
+
+        /*
+         * Choice should not lose focus while it is opened with
+         * TAB/Shitf-TAB KeyPress on XAWT.
+         * Should only pass on XAWT.
+         */
+        robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.setAutoDelay(50);
+        robot.delay(1000);
+
+        testTABKeyPress(InputEvent.BUTTON1_DOWN_MASK, KeyEvent.VK_TAB, false);
+        testTABKeyPress(InputEvent.BUTTON1_DOWN_MASK, KeyEvent.VK_TAB, true);
+        System.out.println("Passed : Choice should not lose focus on TAB key press while it is opened.");
+    }
+
+    static void testTABKeyPress(int openButton, int keyButton, boolean isShiftUsed) {
+        Point pt = choice1.getLocationOnScreen();
+        robot.mouseMove(pt.x + choice1.getWidth()/2, pt.y + choice1.getHeight()/2);
+        robot.delay(100);
+        robot.mousePress(openButton);
+        robot.mouseRelease(openButton);
+        robot.delay(200);
+
+        Color color = robot.getPixelColor(pt.x + choice1.getWidth()/2,
+                                          pt.y + 3 * choice1.getHeight());
+        if (!color.equals(Color.red)) {
+            throw new RuntimeException(
+                "Choice wasn't opened with LEFTMOUSE button" + openButton +":"+keyButton+":"+isShiftUsed);
+        }
+        robot.delay(200);
+        if (isShiftUsed) {
+            robot.keyPress(KeyEvent.VK_SHIFT);
+        }
+        robot.keyPress(keyButton);
+        robot.keyRelease(keyButton);
+
+        if (isShiftUsed) {
+            robot.keyRelease(KeyEvent.VK_SHIFT);
+        }
+
+        robot.delay(200);
+        if (!choice1.isFocusOwner()) {
+            System.out.println("Choice has focus=="+choice1.isFocusOwner());
+            throw new RuntimeException(
+                "Choice has no focus after pressing TAB/Shitf+TAB" + openButton +":"+keyButton+":"+isShiftUsed);
+        }
+        int px = pt.x + choice1.getWidth()/2;
+        int py = pt.y + 3 * choice1.getHeight();
+        color = robot.getPixelColor(px, py);
+        //we should take a color on the point on the choice's menu
+        System.out.println("color got "+color);
+        if (!color.equals(Color.red)) {
+            throw new RuntimeException(
+                "Choice closed after TAB/Shift+TAB key press" + openButton +":"+keyButton+":"+isShiftUsed);
+        }
+
+        //close opened choice
+        robot.keyPress(KeyEvent.VK_ESCAPE);
+        robot.keyRelease(KeyEvent.VK_ESCAPE);
+        robot.delay(200);
+    }
+}

--- a/test/jdk/java/awt/Choice/DragOffNoSelectTest.java
+++ b/test/jdk/java/awt/Choice/DragOffNoSelectTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4902933
+  @summary Test that dragging off an unfurled Choice prevents selecting a new item
+  @key headful
+*/
+
+import java.awt.Choice;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+
+public class DragOffNoSelectTest implements WindowListener, Runnable {
+
+    static volatile DragOffNoSelectTest testInstance;
+    static volatile Frame frame;
+    static volatile Choice theChoice;
+    static volatile Robot robot;
+    static final String firstItem = new String("First Choice Item");
+
+    static volatile Object lock = new Object();
+
+    public static void main(String[] args) throws Exception {
+        testInstance = new DragOffNoSelectTest();
+        robot = new Robot();
+        robot.setAutoDelay(500);
+        try {
+            EventQueue.invokeAndWait(() -> createUI());
+            runTest();
+        } finally {
+            if (frame != null) {
+               EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+
+    static void createUI() {
+        frame = new Frame("DragOffNoSelectTest");
+        theChoice = new Choice();
+        theChoice.add(firstItem);
+        for (int i = 0; i < 10; i++) {
+            theChoice.add(new String("Choice Item " + i));
+        }
+        frame.add(theChoice);
+        frame.addWindowListener(testInstance);
+        frame.setSize(400, 400);
+        frame.setLocationRelativeTo(null);
+
+        frame.setVisible(true);
+        frame.validate();
+    }
+
+    static void runTest() throws Exception {
+        robot.mouseMove(10, 30);
+        synchronized (lock) {
+            try {
+                lock.wait(120000);
+            }
+            catch (InterruptedException e) {}
+        }
+        robot.waitForIdle();
+
+        if (!firstItem.equals(theChoice.getSelectedItem())) {
+            throw new RuntimeException("TEST FAILED - new item was selected");
+        }
+    }
+
+    public void run() {
+        robot.delay(1000);
+        // get loc of Choice on screen
+        Point loc = theChoice.getLocationOnScreen();
+        // get bounds of Choice
+        Dimension size = theChoice.getSize();
+        robot.mouseMove(loc.x + size.width - 10, loc.y + size.height / 2);
+
+        robot.setAutoDelay(500);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+
+        robot.mouseMove(loc.x + size.width / 2, loc.y + size.height + size.height / 2);
+        robot.mouseMove(loc.x + size.width / 2, loc.y + 2*size.height + size.height / 2);
+        robot.mouseMove(loc.x + size.width / 2, loc.y + 3*size.height + size.height / 2);
+        robot.mouseMove(loc.x + size.width / 2, loc.y + 4*size.height + size.height / 2);
+        robot.mouseMove(loc.x + size.width, loc.y + 4*size.height + size.height / 2);
+        robot.mouseMove(loc.x + 2*size.width, loc.y + 4*size.height + size.height / 2);
+        robot.mouseMove(loc.x + 3*size.width, loc.y + 4*size.height + size.height / 2);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        synchronized(lock) {
+            lock.notify();
+        }
+    }
+
+    public void windowOpened(WindowEvent e) {
+        System.out.println("windowActivated()");
+        Thread testThread = new Thread(testInstance);
+        testThread.start();
+    }
+    public void windowActivated(WindowEvent e) { }
+    public void windowDeactivated(WindowEvent e) {}
+    public void windowClosed(WindowEvent e) {}
+    public void windowClosing(WindowEvent e) {}
+    public void windowIconified(WindowEvent e) {}
+    public void windowDeiconified(WindowEvent e) {}
+
+}
+


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306682](https://bugs.openjdk.org/browse/JDK-8306682): Open source a few more AWT Choice tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1518/head:pull/1518` \
`$ git checkout pull/1518`

Update a local copy of the PR: \
`$ git checkout pull/1518` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1518`

View PR using the GUI difftool: \
`$ git pr show -t 1518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1518.diff">https://git.openjdk.org/jdk17u-dev/pull/1518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1518#issuecomment-1613636047)