### PR TITLE
8289917: Metadata for regionsRefilled of G1EvacuationStatistics event is wrong

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -349,7 +349,7 @@
     <Field type="ulong" contentType="bytes" name="used" label="Used" description="Total memory occupied by objects within PLABs" />
     <Field type="ulong" contentType="bytes" name="undoWaste" label="Undo Wasted" description="Total memory wasted due to allocation undo within PLABs" />
     <Field type="ulong" contentType="bytes" name="regionEndWaste" label="Region End Wasted" description="Total memory wasted at the end of regions due to refill" />
-    <Field type="uint" contentType="bytes" name="regionsRefilled" label="Region Refills" description="Total memory wasted at the end of regions due to refill" />
+    <Field type="uint" name="regionsRefilled" label="Region Refills" description="Number of regions refilled" />
     <Field type="ulong" contentType="bytes" name="directAllocated" label="Allocated (direct)" description="Total memory allocated using direct allocation outside of PLABs" />
     <Field type="ulong" contentType="bytes" name="failureUsed" label="Used (failure)" description="Total memory occupied by objects in regions where evacuation failed" />
     <Field type="ulong" contentType="bytes" name="failureWaste" label="Wasted (failure)" description="Total memory left unused in regions where evacuation failed" />


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [728157fa](https://github.com/openjdk/jdk/commit/728157fa03913991088f6bb257a8bc16706792a9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ralf Schmelter on 12 Jul 2022 and was reviewed by Thomas Schatzl, Markus Grönlund, Thomas Stuefe and Erik Gahlin.

It just fixes the metadata of an JFR event.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289917](https://bugs.openjdk.org/browse/JDK-8289917): Metadata for regionsRefilled of G1EvacuationStatistics event is wrong (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1520/head:pull/1520` \
`$ git checkout pull/1520`

Update a local copy of the PR: \
`$ git checkout pull/1520` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1520`

View PR using the GUI difftool: \
`$ git pr show -t 1520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1520.diff">https://git.openjdk.org/jdk17u-dev/pull/1520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1520#issuecomment-1614233861)