### PR TITLE
8293811: Provide a reason for PassFailJFrame.forceFail

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -56,6 +56,11 @@ public class PassFailJFrame {
     private static final int ROWS = 10;
     private static final int COLUMNS = 40;
 
+    /**
+     * Prefix for the user-provided failure reason.
+     */
+    private static final String FAILURE_REASON = "Failure Reason:\n";
+
     private static final List<Window> windowList = new ArrayList<>();
     private static final Timer timer = new Timer(0, null);
     private static final CountDownLatch latch = new CountDownLatch(1);
@@ -135,8 +140,8 @@ public class PassFailJFrame {
             long leftTime = tTimeout - (System.currentTimeMillis() - startTime);
             if ((leftTime < 0) || failed) {
                 timer.stop();
-                testFailedReason = "Failure Reason:\n"
-                        + "Timeout User did not perform testing.";
+                testFailedReason = FAILURE_REASON
+                                   + "Timeout User did not perform testing.";
                 timeout = true;
                 latch.countDown();
             }
@@ -166,8 +171,8 @@ public class PassFailJFrame {
             @Override
             public void windowClosing(WindowEvent e) {
                 super.windowClosing(e);
-                testFailedReason = "Failure Reason:\n"
-                        + "User closed the instruction Frame";
+                testFailedReason = FAILURE_REASON
+                                   + "User closed the instruction Frame";
                 failed = true;
                 latch.countDown();
             }
@@ -240,7 +245,7 @@ public class PassFailJFrame {
 
         JButton okButton = new JButton("OK");
         okButton.addActionListener((ae) -> {
-            testFailedReason = "Failure Reason:\n" + jTextArea.getText();
+            testFailedReason = FAILURE_REASON + jTextArea.getText();
             dialog.setVisible(false);
         });
 
@@ -403,9 +408,17 @@ public class PassFailJFrame {
      *  Forcibly fail the test.
      */
     public static void forceFail() {
+        forceFail("forceFail called");
+    }
+
+    /**
+     *  Forcibly fail the test and provide a reason.
+     *
+     * @param reason the reason why the test is failed
+     */
+    public static void forceFail(String reason) {
         failed = true;
-        testFailedReason = "Failure Reason:\n" +
-                           "forceFail called";
+        testFailedReason = FAILURE_REASON + reason;
         latch.countDown();
     }
 }


### PR DESCRIPTION
Backport of [JDK-8293811](https://bugs.openjdk.org/browse/JDK-8293811). PrintAllPagesTest.java is not in 17u. Rest applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293811](https://bugs.openjdk.org/browse/JDK-8293811): Provide a reason for PassFailJFrame.forceFail (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1522/head:pull/1522` \
`$ git checkout pull/1522`

Update a local copy of the PR: \
`$ git checkout pull/1522` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1522`

View PR using the GUI difftool: \
`$ git pr show -t 1522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1522.diff">https://git.openjdk.org/jdk17u-dev/pull/1522.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1522#issuecomment-1614489726)