### PR TITLE
8277860: PPC: Remove duplicate info != NULL check

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2734,12 +2734,10 @@ void LIR_Assembler::emit_load_klass(LIR_OpLoadKlass* op) {
 
   CodeEmitInfo* info = op->info();
   if (info != NULL) {
-    if (info != NULL) {
-      if (!os::zero_page_read_protected() || !ImplicitNullChecks) {
-        explicit_null_check(obj, info);
-      } else {
-        add_debug_info_for_null_check_here(info);
-      }
+    if (!os::zero_page_read_protected() || !ImplicitNullChecks) {
+      explicit_null_check(obj, info);
+    } else {
+      add_debug_info_for_null_check_here(info);
     }
   }
 


### PR DESCRIPTION
Clean follow-up backport.

Additional testing:
 - [x] GHA builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277860](https://bugs.openjdk.org/browse/JDK-8277860): PPC: Remove duplicate info != NULL check (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1529/head:pull/1529` \
`$ git checkout pull/1529`

Update a local copy of the PR: \
`$ git checkout pull/1529` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1529`

View PR using the GUI difftool: \
`$ git pr show -t 1529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1529.diff">https://git.openjdk.org/jdk17u-dev/pull/1529.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1529#issuecomment-1618032580)