### PR TITLE
8278141: LIR_OpLoadKlass::_info shadows the field of the same name from LIR_Op

### DIFF
--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1812,15 +1812,13 @@ class LIR_OpLoadKlass: public LIR_Op {
 
  private:
   LIR_Opr _obj;
-  CodeEmitInfo* _info;
  public:
   LIR_OpLoadKlass(LIR_Opr obj, LIR_Opr result, CodeEmitInfo* info)
-    : LIR_Op(lir_load_klass, result, NULL)
+    : LIR_Op(lir_load_klass, result, info)
     , _obj(obj)
-    , _info(info) {}
+    {}
 
   LIR_Opr obj()        const { return _obj;  }
-  CodeEmitInfo* info() const { return _info; }
 
   virtual LIR_OpLoadKlass* as_OpLoadKlass() { return this; }
   virtual void emit_code(LIR_Assembler* masm);


### PR DESCRIPTION
Clean follow-up backport.

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`
 - [x] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278141](https://bugs.openjdk.org/browse/JDK-8278141): LIR_OpLoadKlass::_info shadows the field of the same name from LIR_Op (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1530/head:pull/1530` \
`$ git checkout pull/1530`

Update a local copy of the PR: \
`$ git checkout pull/1530` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1530`

View PR using the GUI difftool: \
`$ git pr show -t 1530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1530.diff">https://git.openjdk.org/jdk17u-dev/pull/1530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1530#issuecomment-1618038610)