### PR TITLE
8311249: Remove unused MemAllocator::obj_memory_range

### DIFF
--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -381,15 +381,6 @@ oop ObjAllocator::initialize(HeapWord* mem) const {
   return finish(mem);
 }
 
-MemRegion ObjArrayAllocator::obj_memory_range(oop obj) const {
-  if (_do_zero) {
-    return MemAllocator::obj_memory_range(obj);
-  }
-  ArrayKlass* array_klass = ArrayKlass::cast(_klass);
-  const size_t hs = arrayOopDesc::header_size(array_klass->element_type());
-  return MemRegion(cast_from_oop<HeapWord*>(obj) + hs, _word_size - hs);
-}
-
 oop ObjArrayAllocator::initialize(HeapWord* mem) const {
   // Set array length before setting the _klass field because a
   // non-NULL klass field indicates that the object is parsable by

--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -66,10 +66,6 @@ protected:
   // back to calling CollectedHeap::mem_allocate().
   HeapWord* mem_allocate(Allocation& allocation) const;
 
-  virtual MemRegion obj_memory_range(oop obj) const {
-    return MemRegion(cast_from_oop<HeapWord*>(obj), _word_size);
-  }
-
 public:
   oop allocate() const;
   virtual oop initialize(HeapWord* mem) const = 0;
@@ -85,8 +81,6 @@ public:
 class ObjArrayAllocator: public MemAllocator {
   const int  _length;
   const bool _do_zero;
-protected:
-  virtual MemRegion obj_memory_range(oop obj) const;
 
 public:
   ObjArrayAllocator(Klass* klass, size_t word_size, int length, bool do_zero,


### PR DESCRIPTION
Semi-clean backport to eliminate unused method, and make life easier for downstreams like Lilliput JDK 17.

There was a contextual difference around this hunk, as mainline has `protected` moved by [JDK-8294900](https://bugs.openjdk.org/browse/JDK-8294900), which I don't want to backport.

```
protected:
  virtual MemRegion obj_memory_range(oop obj) const;
```

Additional testing:
 - [x] GHA builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311249](https://bugs.openjdk.org/browse/JDK-8311249): Remove unused MemAllocator::obj_memory_range (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1535/head:pull/1535` \
`$ git checkout pull/1535`

Update a local copy of the PR: \
`$ git checkout pull/1535` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1535`

View PR using the GUI difftool: \
`$ git pr show -t 1535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1535.diff">https://git.openjdk.org/jdk17u-dev/pull/1535.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1535#issuecomment-1619956764)