### PR TITLE
8308766: TLAB initialization may cause div by zero

### DIFF
--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -213,9 +213,11 @@ void ThreadLocalAllocBuffer::initialize() {
   set_desired_size(initial_desired_size());
 
   size_t capacity = Universe::heap()->tlab_capacity(thread()) / HeapWordSize;
-  // Keep alloc_frac as float and not double to avoid the double to float conversion
-  float alloc_frac = desired_size() * target_refills() / (float) capacity;
-  _allocation_fraction.sample(alloc_frac);
+  if (capacity > 0) {
+    // Keep alloc_frac as float and not double to avoid the double to float conversion
+    float alloc_frac = desired_size() * target_refills() / (float)capacity;
+    _allocation_fraction.sample(alloc_frac);
+  }
 
   set_refill_waste_limit(initial_refill_waste_limit());
 


### PR DESCRIPTION
Clean backport to avoid a rare SIGFPE. Patch is trivial, so it makes sense to have it in 17u, even after rather short soak time in mainline.

Additional testing:
  - [x] GHA tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308766](https://bugs.openjdk.org/browse/JDK-8308766): TLAB initialization may cause div by zero (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1536/head:pull/1536` \
`$ git checkout pull/1536`

Update a local copy of the PR: \
`$ git checkout pull/1536` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1536`

View PR using the GUI difftool: \
`$ git pr show -t 1536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1536.diff">https://git.openjdk.org/jdk17u-dev/pull/1536.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1536#issuecomment-1620125349)