### PR TITLE
8280885: Shenandoah: Some tests failed with "EA: missing allocation reference path"

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -723,7 +723,7 @@ bool ShenandoahBarrierSetC2::is_gc_pre_barrier_node(Node* node) const {
 
 // Support for GC barriers emitted during parsing
 bool ShenandoahBarrierSetC2::is_gc_barrier_node(Node* node) const {
-  if (node->Opcode() == Op_ShenandoahLoadReferenceBarrier) return true;
+  if (node->Opcode() == Op_ShenandoahLoadReferenceBarrier || node->Opcode() == Op_ShenandoahIUBarrier) return true;
   if (node->Opcode() != Op_CallLeaf && node->Opcode() != Op_CallLeafNoFP) {
     return false;
   }

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnexpectedIUBarrierEA.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnexpectedIUBarrierEA.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8280885
+ * @summary Shenandoah: Some tests failed with "EA: missing allocation reference path"
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+UseShenandoahGC -XX:+UnlockExperimentalVMOptions -XX:ShenandoahGCMode=iu
+ *                   -XX:CompileCommand=dontinline,TestUnexpectedIUBarrierEA::notInlined TestUnexpectedIUBarrierEA
+ */
+
+public class TestUnexpectedIUBarrierEA {
+
+    private static Object field;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(false);
+        }
+    }
+
+    private static void test(boolean flag) {
+        A a = new A();
+        B b = new B();
+        b.field = a;
+        notInlined();
+        Object o = b.field;
+        if (!(o instanceof A)) {
+
+        }
+        C c = new C();
+        c.field = o;
+        if (flag) {
+            field = c.field;
+        }
+    }
+
+    private static void notInlined() {
+
+    }
+
+    private static class A {
+    }
+
+    private static class B {
+        public Object field;
+    }
+
+    private static class C {
+        public Object field;
+    }
+}


### PR DESCRIPTION
Clean backport to fix Shenandoah barrier handling.

Additional testing:
 - [x] New test on Linux aarch64 fastdebug, does not fail without the fix for some reason, probably missing iterative EA, JDK-8276455)
 - [x] Linux aarch64 fastdebug `tier1` with `-XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu`
 - [x] Linux aarch64 fastdebug `tier2` with `-XX:+UseShenandoahGC -XX:ShenandoahGCMode=iu`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280885](https://bugs.openjdk.org/browse/JDK-8280885): Shenandoah: Some tests failed with "EA: missing allocation reference path" (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1537/head:pull/1537` \
`$ git checkout pull/1537`

Update a local copy of the PR: \
`$ git checkout pull/1537` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1537`

View PR using the GUI difftool: \
`$ git pr show -t 1537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1537.diff">https://git.openjdk.org/jdk17u-dev/pull/1537.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1537#issuecomment-1620138930)