### PR TITLE
8304314: StackWalkTest.java fails after CODETOOLS-7903373

### DIFF
--- a/test/jdk/java/lang/StackWalker/StackWalkTest.java
+++ b/test/jdk/java/lang/StackWalker/StackWalkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public class StackWalkTest {
             "java.lang.reflect.Method",
             "com.sun.javatest.regtest.MainWrapper$MainThread",
             "com.sun.javatest.regtest.agent.MainWrapper$MainThread",
+            "com.sun.javatest.regtest.agent.MainWrapper$MainTask",
             "java.lang.Thread"
     ));
     static final List<Class<?>> streamPipelines = Arrays.asList(


### PR DESCRIPTION
I backport this to enable jtreg 7.2 in 17

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304314](https://bugs.openjdk.org/browse/JDK-8304314): StackWalkTest.java fails after CODETOOLS-7903373 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1542/head:pull/1542` \
`$ git checkout pull/1542`

Update a local copy of the PR: \
`$ git checkout pull/1542` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1542`

View PR using the GUI difftool: \
`$ git pr show -t 1542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1542.diff">https://git.openjdk.org/jdk17u-dev/pull/1542.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1542#issuecomment-1621224451)