### PR TITLE
8285980: Several tests in compiler/c2/irTests miss @requires vm.compiler2.enabled

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestFewIterationsCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestFewIterationsCountedLoop.java
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
  * @bug 8262721
  * @summary Add Tests to verify single iteration loops are properly optimized
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestFewIterationsCountedLoop
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestSkeletonPredicates.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestSkeletonPredicates.java
@@ -32,6 +32,7 @@ import java.util.Random;
  * @bug 8278228
  * @summary C2: Improve identical back-to-back if elimination
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestSkeletonPredicates
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestStripMiningDropsSafepoint.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestStripMiningDropsSafepoint.java
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
  * @bug 8282045
  * @summary When loop strip mining fails, safepoints are removed from loop anyway
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.TestStripMiningDropsSafepoint
  */
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestSuperwordFailsUnrolling.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestSuperwordFailsUnrolling.java
@@ -32,6 +32,7 @@ import jdk.test.whitebox.WhiteBox;
  * @summary C2: loop candidate for superword not always unrolled fully if superword fails
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox
+ * @requires vm.compiler2.enabled
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -DSkipWhiteBoxInstall=true -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.c2.irTests.TestSuperwordFailsUnrolling
  */


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

These files omitted:
test/hotspot/jtreg/compiler/c2/irTests/TestCountedLoopSafepoint.java  Added in 8281322 in 19.
test/hotspot/jtreg/compiler/c2/irTests/TestDuplicateBackedge.java Added in 8279888 in 19.
test/hotspot/jtreg/compiler/c2/irTests/TestIRAddIdealNotXPlusC.java  Added in 8279607 in 19
test/hotspot/jtreg/compiler/c2/irTests/TestIRLShiftIdeal_XPlusX_LShiftC.java Added in 8278114 in 19.
test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java  Added in 8259609 in 18

test/hotspot/jtreg/compiler/c2/irTests/TestSuperwordFailsUnrolling.java
Trivial resolve

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285980](https://bugs.openjdk.org/browse/JDK-8285980): Several tests in compiler/c2/irTests miss @requires vm.compiler2.enabled (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1548/head:pull/1548` \
`$ git checkout pull/1548`

Update a local copy of the PR: \
`$ git checkout pull/1548` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1548`

View PR using the GUI difftool: \
`$ git pr show -t 1548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1548.diff">https://git.openjdk.org/jdk17u-dev/pull/1548.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1548#issuecomment-1621780307)