### PR TITLE
8307683: Loop Predication should not hoist range checks with trap on success projection by negating their condition

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2672,7 +2672,7 @@ Node* PhaseIdealLoop::add_range_check_predicate(IdealLoopTree* loop, CountedLoop
                                                 Node* predicate_proj, int scale_con, Node* offset,
                                                 Node* limit, jint stride_con, Node* value) {
   bool overflow = false;
-  BoolNode* bol = rc_predicate(loop, predicate_proj, scale_con, offset, value, nullptr, stride_con, limit, (stride_con > 0) != (scale_con > 0), overflow, false);
+  BoolNode* bol = rc_predicate(loop, predicate_proj, scale_con, offset, value, nullptr, stride_con, limit, (stride_con > 0) != (scale_con > 0), overflow);
   Node* opaque_bol = new Opaque4Node(C, bol, _igvn.intcon(1));
   register_new_node(opaque_bol, predicate_proj);
   IfNode* new_iff = nullptr;

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -737,7 +737,9 @@ public:
   bool policy_range_check( PhaseIdealLoop *phase ) const;
 
   // Return TRUE if "iff" is a range check.
-  bool is_range_check_if(IfNode *iff, PhaseIdealLoop *phase, Invariance& invar DEBUG_ONLY(COMMA ProjNode *predicate_proj)) const;
+  bool is_range_check_if(IfProjNode* if_success_proj, PhaseIdealLoop *phase, Invariance& invar DEBUG_ONLY(COMMA ProjNode *predicate_proj)) const;
+  // GLGL bool is_range_check_if(IfProjNode* if_success_proj, PhaseIdealLoop* phase, BasicType bt, Node* iv, Node*& range, Node*& offset,
+  // GLGL                        jlong& scale) const;
 
   // Estimate the number of nodes required when cloning a loop (body).
   uint est_loop_clone_sz(uint factor) const;
@@ -1306,15 +1308,12 @@ public:
   // Find a predicate
   static Node* find_predicate(Node* entry);
   // Construct a range check for a predicate if
-  BoolNode* rc_predicate(IdealLoopTree *loop, Node* ctrl,
-                         int scale, Node* offset,
-                         Node* init, Node* limit, jint stride,
-                         Node* range, bool upper, bool &overflow,
-                         bool negate);
+  BoolNode* rc_predicate(IdealLoopTree *loop, Node* ctrl, int scale, Node* offset,Node* init, Node* limit,
+                         jint stride, Node* range, bool upper, bool &overflow/* GLGL, bool negate*/);
 
   // Implementation of the loop predication to promote checks outside the loop
   bool loop_predication_impl(IdealLoopTree *loop);
-  bool loop_predication_impl_helper(IdealLoopTree *loop, ProjNode* proj, ProjNode *predicate_proj,
+  bool loop_predication_impl_helper(IdealLoopTree *loop, ProjNode* if_success_proj, ProjNode *predicate_proj,
                                     CountedLoopNode *cl, ConNode* zero, Invariance& invar,
                                     Deoptimization::DeoptReason reason);
   bool loop_predication_should_follow_branches(IdealLoopTree *loop, ProjNode *predicate_proj, float& loop_trip_cnt);

--- a/test/hotspot/jtreg/compiler/predicates/TestHoistedPredicateForNonRangeCheck.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestHoistedPredicateForNonRangeCheck.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8307683
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @summary Tests that IfNode is not wrongly chosen as range check by Loop Predication leading to crashes and wrong executions.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.predicates.TestHoistedPredicateForNonRangeCheck::test*
+ *                   compiler.predicates.TestHoistedPredicateForNonRangeCheck
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.predicates.TestHoistedPredicateForNonRangeCheck::test*
+ *                   -XX:LoopMaxUnroll=0 compiler.predicates.TestHoistedPredicateForNonRangeCheck
+ */
+
+/*
+ * @test
+ * @bug 8307683
+ * @library /test/lib /
+ * @summary Tests that IfNode is not wrongly chosen as range check by Loop Predication leading to crashes and wrong executions.
+ * @run main/othervm -Xbatch compiler.predicates.TestHoistedPredicateForNonRangeCheck calendar
+ */
+
+package compiler.predicates;
+
+import jdk.test.lib.Asserts;
+
+import java.util.Calendar;
+import java.util.Date;
+
+
+public class TestHoistedPredicateForNonRangeCheck {
+    static int iFld, iFld2;
+    static int[] iArr = new int[100];
+
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            Integer.compareUnsigned(34, 34); // Ensure Integer class is loaded and we do not emit a trap inside test() for it.
+
+            for (int i = 0; i < 2; i++) {
+                iFld = 0;
+                iFld2 = 0;
+                test();
+                Asserts.assertEQ(iFld, 3604, "wrong value");
+                Asserts.assertEQ(iFld2, 400, "wrong value");
+            }
+
+            for (int i = 0; i < 2000; i++) {
+                iFld = -100;
+                testRangeCheckNode();
+            }
+            iFld = -1;
+            iFld2 = 0;
+            testRangeCheckNode();
+            Asserts.assertEQ(iFld2, 36, "wrong value");
+        } else {
+            boolean flag = false;
+            for (int i = 0; i < 10000; i++) {
+                testCalendar1();
+                testCalendar2(flag);
+            }
+        }
+    }
+
+    public static void test() {
+        for (int i = -1; i < 1000; i++) {
+            // We hoist this check and insert a Hoisted Predicate for the lower and upper bound:
+            // -1 >=u 100 && 1000 >= u 100 -> always true and the predicates are removed.
+            // Template Assertion Predicates, however, are kept. When splitting this loop further, we insert an Assertion
+            // Predicate which fails for i = 0 and we halt.
+            // When not splitting this loop (with LoopMaxUnroll=0), we have a wrong execution due to never executing
+            // iFld2++ (we remove the check and the branch with the trap when creating the Hoisted Predicates).
+            if (Integer.compareUnsigned(i, 100) < 0) {
+                iFld2++;
+                Float.isNaN(34); // Float class is unloaded with -Xcomp -> inserts trap
+            } else {
+                iFld++;
+            }
+
+            // Same but flipped condition and moved trap to other branch - result is the same.
+            if (Integer.compareUnsigned(i, 100) >= 0) { // Loop Predication creates a Hoisted Range Check Predicate due to trap with Float.isNan().
+                iFld++;
+            } else {
+                iFld2++;
+                Float.isNaN(34); // Float class is unloaded with -Xcomp -> inserts trap
+            }
+
+            // Same but with LoadRangeNode.
+            if (Integer.compareUnsigned(i, iArr.length) >= 0) { // Loop Predication creates a Hoisted Range Check Predicate due to trap with Float.isNan().
+                iFld++;
+            } else {
+                iFld2++;
+                Float.isNaN(34); // Float class is unloaded with -Xcomp -> inserts trap
+            }
+
+            // Same but with LoadRangeNode and flipped condition and moved trap to other branch - result is the same.
+            if (Integer.compareUnsigned(i, iArr.length) >= 0) { // Loop Predication creates a Hoisted Range Check Predicate due to trap with Float.isNan().
+                iFld++;
+            } else {
+                iFld2++;
+                Float.isNaN(34); // Float class is unloaded with -Xcomp -> inserts trap
+            }
+        }
+    }
+
+    static void testRangeCheckNode() {
+        int array[] = new int[34];
+        // Hoisted Range Check Predicate with flipped bool because trap is on success proj and no trap on false proj due
+        // to catching exception:
+        // iFld >=u 34 && iFld+36 >=u 34
+        // This is always false for first 2000 iterations where, initially, iFld = -100
+        // It is still true in the last iteration where, initially, iFld = -1. But suddenly, in the second iteration,
+        // where iFld = 0, we would take the true projection for the first time - but we removed that branch when
+        // creating the Hoisted Range Check Predicate. We therefore run into the same problem as with test(): We either
+        // halt due to Assertion Predicates catching this case or we have a wrong execution (iFld2 never updated).
+        for (int i = 0; i < 37; i++) {
+            try {
+                array[iFld] = 34; // Normal RangeCheckNode
+                iFld2++;
+                Math.ceil(34); // Never taken and unloaded -> trap
+            } catch (Exception e) {
+                // False Proj of RangeCheckNode
+                iFld++;
+            }
+        }
+    }
+
+    // Reported in JDK-8307683
+    static void testCalendar1() {
+        Calendar c = Calendar.getInstance();
+        c.setLenient(false);
+        c.set(Calendar.HOUR_OF_DAY, 0);
+        c.set(Calendar.MINUTE, 0);
+        c.getTime();
+    }
+
+    // Reported in JDK-8307978
+    static void testCalendar2(boolean flag) {
+        flag = !flag;
+        Calendar timespan = removeTime(new Date(), flag);
+        timespan.getTime();
+    }
+
+    static Calendar removeTime(Date date, boolean flag) {
+        Calendar calendar = Calendar.getInstance();
+        if (flag) {
+            calendar.setLenient(false);
+        }
+        calendar.setTime(date);
+        calendar = removeTime(calendar);
+        return calendar;
+    }
+
+    static Calendar removeTime(Calendar calendar) {
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        return calendar;
+    }
+}


### PR DESCRIPTION
This fixes a regression in 17.0.7.  To work around the regression, JDK-8297951 was backed out in 17.0.8.

Big parts of this change is passing a Proj node instead of the If that is the predecessor of the Proj through method calls. As methods differ in their arguments in 17, all these had to be resolved.
The real fix is in loop_predication_impl_helper().

Resolves in detail:

src/hotspot/share/opto/loopPredicate.cpp
In head, there are two variants of is_range_check_if(), 17 has only one. Omitted the changes to the second one.
loop_predication_impl_helper()
Renamed the variable. In head, it is if_proj->if_success_proj, here it is proj->success_proj.
I introduce a new vairalbe IfProjNode if_success_proj. Calls to loop_predication_impl_helper
pass Projs and not IfProjs, so this seems cleaner.  Added assertion.
Passing proj instead of if to is_range_check_if().
Computation of the deleted "bool negate" differs.  Deleted anyways.
Removed all the uses of negate.

src/hotspot/share/opto/loopTransform.cpp
Trivial resolve.

src/hotspot/share/opto/loopnode.cpp
extract_long_range_checks() was introduced in "8259609: C2: optimize long range checks in long counted loops".
The change is only needed as the input to is_range_check_if() was
changed from the IfNode to the IfProjNode below. The change here has no effect on the fix. Skipped.

patching file src/hotspot/share/opto/loopnode.hpp
Resolved, simple differences.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307683](https://bugs.openjdk.org/browse/JDK-8307683): Loop Predication should not hoist range checks with trap on success projection by negating their condition (**Bug** - P3)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1553/head:pull/1553` \
`$ git checkout pull/1553`

Update a local copy of the PR: \
`$ git checkout pull/1553` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1553`

View PR using the GUI difftool: \
`$ git pr show -t 1553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1553.diff">https://git.openjdk.org/jdk17u-dev/pull/1553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1553#issuecomment-1623120229)