### PR TITLE
8304725: AsyncGetCallTrace can cause SIGBUS on M1

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2263,7 +2263,11 @@ PcDesc* PcDescContainer::find_pc_desc_internal(address pc, bool approximate, con
 
   if (match_desc(upper, pc_offset, approximate)) {
     assert(upper == linear_search(search, pc_offset, approximate), "search ok");
-    _pc_desc_cache.add_pc_desc(upper);
+    if (!Thread::current_in_asgct()) {
+      // we don't want to modify the cache if we're in ASGCT
+      // which is typically called in a signal handler
+      _pc_desc_cache.add_pc_desc(upper);
+    }
     return upper;
   } else {
     assert(NULL == linear_search(search, pc_offset, approximate), "search ok");

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -598,6 +598,9 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
   // !important! make sure all to call thread->set_in_asgct(false) before every return
   thread->set_in_asgct(true);
 
+  // signify to other code in the VM that we're in ASGCT
+  ThreadInAsgct tia(thread);
+
   switch (thread->thread_state()) {
   case _thread_new:
   case _thread_uninitialized:

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -654,6 +654,31 @@ protected:
     assert(_wx_state == expected, "wrong state");
   }
 #endif // __APPLE__ && AARCH64
+
+ private:
+  bool _in_asgct = false;
+ public:
+  bool in_asgct() const { return _in_asgct; }
+  void set_in_asgct(bool value) { _in_asgct = value; }
+  static bool current_in_asgct() {
+    Thread *cur = Thread::current_or_null_safe();
+    return cur != nullptr && cur->in_asgct();
+  }
+};
+
+class ThreadInAsgct {
+ private:
+  Thread* _thread;
+ public:
+  ThreadInAsgct(Thread* thread) : _thread(thread) {
+    assert(thread != nullptr, "invariant");
+    assert(!thread->in_asgct(), "invariant");
+    thread->set_in_asgct(true);
+  }
+  ~ThreadInAsgct() {
+    assert(_thread->in_asgct(), "invariant");
+    _thread->set_in_asgct(false);
+  }
 };
 
 // Inline implementation of Thread::current()


### PR DESCRIPTION
Hi!

I'd like to backport these changes to get around the WX status uncertainty in AsyncGetCallTrace. The function doesn't use ThreadWXEnable like other VM signal handlers, and writing to the CompiledMethod field results in SIGBUS. 

Clean backport. Tested with hostpot tier1 and manually enabled jtreg/serviceability/AsyncGetCallTrace

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304725](https://bugs.openjdk.org/browse/JDK-8304725): AsyncGetCallTrace can cause SIGBUS on M1 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1554/head:pull/1554` \
`$ git checkout pull/1554`

Update a local copy of the PR: \
`$ git checkout pull/1554` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1554`

View PR using the GUI difftool: \
`$ git pr show -t 1554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1554.diff">https://git.openjdk.org/jdk17u-dev/pull/1554.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1554#issuecomment-1623445572)