### PR TITLE
8283929: GHA: Add RISC-V build config

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -60,23 +60,23 @@ jobs:
             gnu-arch: aarch64
             debian-arch: arm64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: buster
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: buster
             gnu-abi: eabihf
           - target-cpu: s390x
             gnu-arch: s390x
             debian-arch: s390x
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: buster
           - target-cpu: ppc64le
             gnu-arch: powerpc64le
             debian-arch: ppc64el
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: buster
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -54,20 +54,34 @@ jobs:
           - arm
           - s390x
           - ppc64le
+          - riscv64
         include:
           - target-cpu: aarch64
-            debian-arch: arm64
             gnu-arch: aarch64
+            debian-arch: arm64
+            debian-repository: https://httpredir.debian.org/debian/
+            debian-version: bullseye
           - target-cpu: arm
-            debian-arch: armhf
             gnu-arch: arm
+            debian-arch: armhf
+            debian-repository: https://httpredir.debian.org/debian/
+            debian-version: bullseye
             gnu-abi: eabihf
           - target-cpu: s390x
-            debian-arch: s390x
             gnu-arch: s390x
+            debian-arch: s390x
+            debian-repository: https://httpredir.debian.org/debian/
+            debian-version: bullseye
           - target-cpu: ppc64le
-            debian-arch: ppc64el
             gnu-arch: powerpc64le
+            debian-arch: ppc64el
+            debian-repository: https://httpredir.debian.org/debian/
+            debian-version: bullseye
+          - target-cpu: riscv64
+            gnu-arch: riscv64
+            debian-arch: riscv64
+            debian-repository: https://deb.debian.org/debian-ports
+            debian-version: sid
 
     steps:
       - name: 'Checkout the JDK source'
@@ -118,9 +132,9 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
-          buster
+          ${{ matrix.debian-version }}
           sysroot
-          https://httpredir.debian.org/debian/
+          ${{ matrix.debian-repository }}
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Prepare sysroot'


### PR DESCRIPTION
Hi,
I would like to backport [JDK-8283929](https://bugs.openjdk.org/browse/JDK-8283929) to enable cross-compiling for linux-riscv64 on jdk17u-dev, as #1427 has integrated.

The backport is not clean:
1. jdk17u-dev CI uses Ubuntu focal (20.04) which doesn't have up-to-date debian-ports-archive keyring [1], so I removed the `debian-ports-archive-keyring` installing and settings.
2. The `debian-version` still uses buster instead of bullseye for other ports.


Changes tested with GHA on my personal branch and passed the cross-compiling for linux-riscv64 [2].



[1]. https://bugs.launchpad.net/ubuntu/+source/debian-ports-archive-keyring/+bug/1969202
[2]. https://github.com/feilongjiang/jdk17u-dev/actions/runs/5508731228/jobs/10041643179

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283929](https://bugs.openjdk.org/browse/JDK-8283929): GHA: Add RISC-V build config (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1562/head:pull/1562` \
`$ git checkout pull/1562`

Update a local copy of the PR: \
`$ git checkout pull/1562` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1562`

View PR using the GUI difftool: \
`$ git pr show -t 1562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1562.diff">https://git.openjdk.org/jdk17u-dev/pull/1562.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1562#issuecomment-1629208711)