### PR TITLE
8297476: Increase InlineSmallCode default from 1000 to 2500 for RISC-V

### DIFF
--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -394,13 +394,7 @@ void CompilerConfig::set_compilation_policy_flags() {
   if (CompilerConfig::is_tiered() && CompilerConfig::is_c2_enabled()) {
 #ifdef COMPILER2
     // Some inlining tuning
-#ifdef X86
-    if (FLAG_IS_DEFAULT(InlineSmallCode)) {
-      FLAG_SET_DEFAULT(InlineSmallCode, 2500);
-    }
-#endif
-
-#if defined AARCH64
+#if defined(X86) || defined(AARCH64) || defined(RISCV64)
     if (FLAG_IS_DEFAULT(InlineSmallCode)) {
       FLAG_SET_DEFAULT(InlineSmallCode, 2500);
     }


### PR DESCRIPTION
I would like to backport [JDK-8297476](https://bugs.openjdk.org/browse/JDK-8297476). Patch applies cleanly.
This improves renaissance benchmark performance obviously on linux-riscv64 platform.
And this won't affect other platforms as it doesn't change the default value of the parameter for them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297476](https://bugs.openjdk.org/browse/JDK-8297476): Increase InlineSmallCode default from 1000 to 2500 for RISC-V (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1565/head:pull/1565` \
`$ git checkout pull/1565`

Update a local copy of the PR: \
`$ git checkout pull/1565` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1565`

View PR using the GUI difftool: \
`$ git pr show -t 1565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1565.diff">https://git.openjdk.org/jdk17u-dev/pull/1565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1565#issuecomment-1630029039)