### PR TITLE
8301097: Update GHA XCode to 12.5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,7 +202,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
-      xcode-toolset-version: '11.7'
+      xcode-toolset-version: '12.5.1'
     if: needs.select.outputs.macos-x64 == 'true'
 
   build-macos-aarch64:
@@ -211,7 +211,7 @@ jobs:
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
-      xcode-toolset-version: '12.4'
+      xcode-toolset-version: '12.5.1'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
     if: needs.select.outputs.macos-aarch64 == 'true'
 


### PR DESCRIPTION
I think we should update the mac build environment.

I had to resolve. Trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301097](https://bugs.openjdk.org/browse/JDK-8301097): Update GHA XCode to 12.5.1 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1566/head:pull/1566` \
`$ git checkout pull/1566`

Update a local copy of the PR: \
`$ git checkout pull/1566` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1566`

View PR using the GUI difftool: \
`$ git pr show -t 1566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1566.diff">https://git.openjdk.org/jdk17u-dev/pull/1566.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1566#issuecomment-1630227010)