### PR TITLE
8308192: Error in parsing replay file when staticfield is an array of single dimension

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -850,6 +850,7 @@ class CompileReplay : public StackObj {
           value = oopFactory::new_longArray(length, CHECK);
         } else if (field_signature[0] == JVM_SIGNATURE_ARRAY &&
                    field_signature[1] == JVM_SIGNATURE_CLASS) {
+          parse_klass(CHECK); // eat up the array class name
           Klass* kelem = resolve_klass(field_signature + 1, CHECK);
           value = oopFactory::new_objArray(kelem, length, CHECK);
         } else {


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308192](https://bugs.openjdk.org/browse/JDK-8308192): Error in parsing replay file when staticfield is an array of single dimension (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1569/head:pull/1569` \
`$ git checkout pull/1569`

Update a local copy of the PR: \
`$ git checkout pull/1569` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1569`

View PR using the GUI difftool: \
`$ git pr show -t 1569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1569.diff">https://git.openjdk.org/jdk17u-dev/pull/1569.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1569#issuecomment-1630866171)