### PR TITLE
8309266: C2: assert(final_con == (jlong)final_int) failed: final value should be integer

### DIFF
--- a/src/hotspot/share/opto/connode.hpp
+++ b/src/hotspot/share/opto/connode.hpp
@@ -39,6 +39,7 @@ public:
   ConNode( const Type *t ) : TypeNode(t->remove_speculative(),1) {
     init_req(0, (Node*)Compile::current()->root());
     init_flags(Flag_is_Con);
+    init_class_id(Class_Con);
   }
   virtual int  Opcode() const;
   virtual uint hash() const;
@@ -53,7 +54,9 @@ public:
 // Simple integer constants
 class ConINode : public ConNode {
 public:
-  ConINode( const TypeInt *t ) : ConNode(t) {}
+  ConINode(const TypeInt *t) : ConNode(t) {
+    init_class_id(Class_ConI);
+  }
   virtual int Opcode() const;
 
   // Factory method:

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1891,8 +1891,14 @@ const Type* LoopLimitNode::Value(PhaseGVN* phase) const {
     int final_int = (int)final_con;
     // The final value should be in integer range since the loop
     // is counted and the limit was checked for overflow.
-    assert(final_con == (jlong)final_int, "final value should be integer");
-    return TypeInt::make(final_int);
+    // Assert checks for overflow only if all input nodes are ConINodes, as during CCP
+    // there might be a temporary overflow from PhiNodes see JDK-8309266
+    assert((in(Init)->is_ConI() && in(Limit)->is_ConI() && in(Stride)->is_ConI()) ? final_con == (jlong)final_int : true, "final value should be integer");
+    if (final_con == (jlong)final_int) {
+      return TypeInt::make(final_int);
+    } else {
+      return bottom_type();
+    }
   }
 
   return bottom_type(); // TypeInt::INT

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -574,7 +574,8 @@ public:
     // Def-Use info is unchanged
     Node* n1 = in(i1);
     Node* n2 = in(i2);
-    _in[i1] = n2;    _in[i2] = n1;
+    _in[i1] = n2;
+    _in[i2] = n1;
     // If this node is in the hash table, make sure it doesn't need a rehash.
     assert(check_hash == NO_HASH || check_hash == hash(), "edge swap must preserve hash code");
   }

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -70,6 +70,7 @@ class CmpNode;
 class CodeBuffer;
 class ConstraintCastNode;
 class ConNode;
+class ConINode;
 class CompareAndSwapNode;
 class CompareAndExchangeNode;
 class CountedLoopNode;
@@ -573,8 +574,7 @@ public:
     // Def-Use info is unchanged
     Node* n1 = in(i1);
     Node* n2 = in(i2);
-    _in[i1] = n2;
-    _in[i2] = n1;
+    _in[i1] = n2;    _in[i2] = n1;
     // If this node is in the hash table, make sure it doesn't need a rehash.
     assert(check_hash == NO_HASH || check_hash == hash(), "edge swap must preserve hash code");
   }
@@ -707,6 +707,8 @@ public:
         DEFINE_CLASS_ID(EncodePKlass, EncodeNarrowPtr, 1)
       DEFINE_CLASS_ID(Vector, Type, 7)
         DEFINE_CLASS_ID(VectorMaskCmp, Vector, 0)
+      DEFINE_CLASS_ID(Con, Type, 8)
+          DEFINE_CLASS_ID(ConI, Con, 0)
 
     DEFINE_CLASS_ID(Proj,  Node, 3)
       DEFINE_CLASS_ID(CatchProj, Proj, 0)
@@ -854,6 +856,7 @@ public:
   DEFINE_CLASS_QUERY(CheckCastPP)
   DEFINE_CLASS_QUERY(CastII)
   DEFINE_CLASS_QUERY(CastLL)
+  DEFINE_CLASS_QUERY(ConI)
   DEFINE_CLASS_QUERY(ConstraintCast)
   DEFINE_CLASS_QUERY(ClearArray)
   DEFINE_CLASS_QUERY(CMove)

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoopLimitOverflowDuringCCP.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoopLimitOverflowDuringCCP.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309266
+ * @summary Integer overflow in LoopLimit::Value during PhaseCCP::analyze, triggered by the Phi Node from "flag ? Integer.MAX_VALUE : 1000"
+ * @run main/othervm -Xbatch -XX:CompileOnly=compiler.loopopts.TestLoopLimitOverflowDuringCCP::* compiler.loopopts.TestLoopLimitOverflowDuringCCP
+ */
+
+package compiler.loopopts;
+
+public class TestLoopLimitOverflowDuringCCP {
+    static boolean flag;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            flag = !flag;
+            test();
+        }
+    }
+
+    public static void test() {
+        int limit = flag ? Integer.MAX_VALUE : 1000;
+        int i = 0;
+        while (i < limit) {
+            i += 3;
+            if (flag) {
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

Clean backport, but does not compiole because is_ConI is not supported by 17.
I include the parts to define this from "8298952: All nodes should have type(n) == Value(n) after IGVN"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309266](https://bugs.openjdk.org/browse/JDK-8309266): C2: assert(final_con == (jlong)final_int) failed: final value should be integer (**Bug** - P3)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [d1762345](https://git.openjdk.org/jdk17u-dev/pull/1570/files/d1762345590562248cb586effe97814df3a42949)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1570/head:pull/1570` \
`$ git checkout pull/1570`

Update a local copy of the PR: \
`$ git checkout pull/1570` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1570`

View PR using the GUI difftool: \
`$ git pr show -t 1570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1570.diff">https://git.openjdk.org/jdk17u-dev/pull/1570.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1570#issuecomment-1630922084)