### PR TITLE
8307555: Reduce memory reads in x86 MD5 intrinsic

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86_md5.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_md5.cpp
@@ -52,18 +52,15 @@
 // int com.sun.security.provider.MD5.implCompress0(byte[] b, int ofs)
 void MacroAssembler::fast_md5(Register buf, Address state, Address ofs, Address limit, bool multi_block) {
 
-  Label start, done_hash, loop0;
+  Label done_hash, loop0;
 
-  bind(start);
-
-  bind(loop0);
-
-  // Save hash values for addition after rounds
   movptr(rdi, state);
   movl(rax, Address(rdi,  0));
   movl(rbx, Address(rdi,  4));
   movl(rcx, Address(rdi,  8));
   movl(rdx, Address(rdi, 12));
+
+  bind(loop0);
 
 #define FF(r1, r2, r3, r4, k, s, t)              \
   addl(r1, t);                                   \
@@ -189,10 +186,14 @@ void MacroAssembler::fast_md5(Register buf, Address state, Address ofs, Address 
 
   // write hash values back in the correct order
   movptr(rdi, state);
-  addl(Address(rdi,  0), rax);
-  addl(Address(rdi,  4), rbx);
-  addl(Address(rdi,  8), rcx);
-  addl(Address(rdi, 12), rdx);
+  addl(rax, Address(rdi,  0));
+  movl(Address(rdi,  0), rax);
+  addl(rbx, Address(rdi,  4));
+  movl(Address(rdi,  4), rbx);
+  addl(rcx, Address(rdi,  8));
+  movl(Address(rdi,  8), rcx);
+  addl(rdx, Address(rdi, 12));
+  movl(Address(rdi, 12), rdx);
 
   if (multi_block) {
     // increment data pointer and loop if more to process


### PR DESCRIPTION
Backport [JDK-8307555](https://bugs.openjdk.org/browse/JDK-8307555)

Reduce memory reads in x86 MD5 intrinsic

Additional testing:
- [x] Linux x86_64 fastdebug `tier2`
- [x] Linux x86_64 release `tier2`
- [x] Linux x86_64 fastdebug `gtest:all`
- [x] Linux x86_64 release `gtest:all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307555](https://bugs.openjdk.org/browse/JDK-8307555): Reduce memory reads in x86 MD5 intrinsic (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1571/head:pull/1571` \
`$ git checkout pull/1571`

Update a local copy of the PR: \
`$ git checkout pull/1571` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1571`

View PR using the GUI difftool: \
`$ git pr show -t 1571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1571.diff">https://git.openjdk.org/jdk17u-dev/pull/1571.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1571#issuecomment-1631677055)