### PR TITLE
8289512: Fix GCC 12 warnings for adlc output_c.cpp

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -397,7 +397,7 @@ static int pipeline_res_mask_initializer(
   const uint cyclemasksize = (maxcycleused + 31) >> 5;
 
   int i, j;
-  int element_count = 0;
+  uint element_count = 0;
   uint *res_mask = new uint [cyclemasksize];
   uint resources_used             = 0;
   uint resources_used_exclusively = 0;
@@ -524,12 +524,12 @@ static int pipeline_res_mask_initializer(
       fprintf(fp_cpp, "static const Pipeline_Use_Element pipeline_res_mask_%03d[%d] = {\n%s};\n\n",
         ndx+1, element_count, resource_mask);
 
-    char* args = new char [9 + 2*masklen + maskdigit];
+    // "0x012345678, 0x012345678, 4294967295"
+    char* args = new char [36 + 1];
 
-    sprintf(args, "0x%0*x, 0x%0*x, %*d",
-      masklen, resources_used,
-      masklen, resources_used_exclusively,
-      maskdigit, element_count);
+    int printed = sprintf(args, "0x%x, 0x%x, %u",
+      resources_used, resources_used_exclusively, element_count);
+    assert(printed <= 36, "overflow");
 
     pipeline_res_args.addName(args);
   }
@@ -1159,11 +1159,10 @@ static void check_peepconstraints(FILE *fp, FormDict &globals, PeepMatch *pmatch
       case Form::register_interface: {
         // Check that they are allocated to the same register
         // Need parameter for index position if not result operand
-        char left_reg_index[] = ",instXXXX_idxXXXX";
+        char left_reg_index[] = ",inst4294967295_idx4294967295";
         if( left_op_index != 0 ) {
-          assert( (left_index <= 9999) && (left_op_index <= 9999), "exceed string size");
           // Must have index into operands
-          sprintf(left_reg_index,",inst%d_idx%d", (int)left_index, left_op_index);
+          sprintf(left_reg_index,",inst%u_idx%u", (unsigned)left_index, (unsigned)left_op_index);
         } else {
           strcpy(left_reg_index, "");
         }
@@ -1172,11 +1171,10 @@ static void check_peepconstraints(FILE *fp, FormDict &globals, PeepMatch *pmatch
         fprintf(fp, " == ");
 
         if( right_index != -1 ) {
-          char right_reg_index[18] = ",instXXXX_idxXXXX";
+          char right_reg_index[] = ",inst4294967295_idx4294967295";
           if( right_op_index != 0 ) {
-            assert( (right_index <= 9999) && (right_op_index <= 9999), "exceed string size");
             // Must have index into operands
-            sprintf(right_reg_index,",inst%d_idx%d", (int)right_index, right_op_index);
+            sprintf(right_reg_index,",inst%u_idx%u", (unsigned)right_index, (unsigned)right_op_index);
           } else {
             strcpy(right_reg_index, "");
           }


### PR DESCRIPTION
Backport is clean, required to build with GCC 13

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289512](https://bugs.openjdk.org/browse/JDK-8289512): Fix GCC 12 warnings for adlc output_c.cpp (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1574/head:pull/1574` \
`$ git checkout pull/1574`

Update a local copy of the PR: \
`$ git checkout pull/1574` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1574`

View PR using the GUI difftool: \
`$ git pr show -t 1574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1574.diff">https://git.openjdk.org/jdk17u-dev/pull/1574.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1574#issuecomment-1632926596)