### PR TITLE
8311862: RISC-V: small improvements to shift immediate instructions

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2677,7 +2677,13 @@ public:
       c_slli(Rd, shamt);                                                                     \
       return;                                                                                \
     }                                                                                        \
-    _slli(Rd, Rs1, shamt);                                                                   \
+    if (shamt != 0) {                                                                        \
+      _slli(Rd, Rs1, shamt);                                                                 \
+    } else {                                                                                 \
+      if (Rd != Rs1) {                                                                        \
+        addi(Rd, Rs1, 0);                                                                    \
+      }                                                                                      \
+    }                                                                                        \
   }
 
   INSN(slli);
@@ -2692,7 +2698,13 @@ public:
       C_NAME(Rd, shamt);                                                                     \
       return;                                                                                \
     }                                                                                        \
-    NORMAL_NAME(Rd, Rs1, shamt);                                                             \
+    if (shamt != 0) {                                                                        \
+      NORMAL_NAME(Rd, Rs1, shamt);                                                           \
+    } else {                                                                                 \
+      if (Rd != Rs1) {                                                                        \
+        addi(Rd, Rs1, 0);                                                                    \
+      }                                                                                      \
+    }                                                                                        \
   }
 
   INSN(srai, c_srai, _srai);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f3b96f69](https://github.com/openjdk/jdk/commit/f3b96f6937395246f09ac2ef3dfca5854217a0da) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ilya Gavrilin on 14 Jul 2023 and was reviewed by Ludovic Henry, Feilong Jiang and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311862](https://bugs.openjdk.org/browse/JDK-8311862): RISC-V: small improvements to shift immediate instructions (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1584/head:pull/1584` \
`$ git checkout pull/1584`

Update a local copy of the PR: \
`$ git checkout pull/1584` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1584`

View PR using the GUI difftool: \
`$ git pr show -t 1584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1584.diff">https://git.openjdk.org/jdk17u-dev/pull/1584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1584#issuecomment-1635979797)