### PR TITLE
8307068: store a JavaThread* in the java.lang.Thread object after the JavaThread* is added to the main ThreadsList

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1793,9 +1793,16 @@ JavaThread* java_lang_Thread::thread(oop java_thread) {
   return (JavaThread*)java_thread->address_field(_eetop_offset);
 }
 
+JavaThread* java_lang_Thread::thread_acquire(oop java_thread) {
+  return reinterpret_cast<JavaThread*>(java_thread->address_field_acquire(_eetop_offset));
+}
 
 void java_lang_Thread::set_thread(oop java_thread, JavaThread* thread) {
   java_thread->address_field_put(_eetop_offset, (address)thread);
+}
+
+void java_lang_Thread::release_set_thread(oop java_thread, JavaThread* thread) {
+  java_thread->release_address_field_put(_eetop_offset, (address)thread);
 }
 
 bool java_lang_Thread::interrupted(oop java_thread) {

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -420,8 +420,10 @@ class java_lang_Thread : AllStatic {
 
   // Returns the JavaThread associated with the thread obj
   static JavaThread* thread(oop java_thread);
+  static JavaThread* thread_acquire(oop java_thread);
   // Set JavaThread for instance
   static void set_thread(oop java_thread, JavaThread* thread);
+  static void release_set_thread(oop java_thread, JavaThread* thread);
   // Interrupted status
   static bool interrupted(oop java_thread);
   static void set_interrupted(oop java_thread, bool val);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1341,8 +1341,7 @@ static void ensure_join(JavaThread* thread) {
   // Clear the native thread instance - this makes isAlive return false and allows the join()
   // to complete once we've done the notify_all below. Needs a release() to obey Java Memory Model
   // requirements.
-  OrderAccess::release();
-  java_lang_Thread::set_thread(threadObj(), NULL);
+  java_lang_Thread::release_set_thread(threadObj(), NULL);
   lock.notify_all(thread);
   // Ignore pending exception (ThreadDeath), since we are exiting anyway
   thread->clear_pending_exception();
@@ -2261,7 +2260,6 @@ void JavaThread::prepare(jobject jni_thread, ThreadPriority prio) {
   assert(InstanceKlass::cast(thread_oop->klass())->is_linked(),
          "must be initialized");
   set_threadObj(thread_oop());
-  java_lang_Thread::set_thread(thread_oop(), this);
 
   if (prio == NoPriority) {
     prio = java_lang_Thread::priority(thread_oop());
@@ -2277,6 +2275,11 @@ void JavaThread::prepare(jobject jni_thread, ThreadPriority prio) {
   // added to the Threads list for if a GC happens, then the java_thread oop
   // will not be visited by GC.
   Threads::add(this);
+  // Publish the JavaThread* in java.lang.Thread after the JavaThread* is
+  // on a ThreadsList. We don't want to wait for the release when the
+  // Theads_lock is dropped somewhere in the caller since the JavaThread*
+  // is already visible to JVM/TI via the ThreadsList.
+  java_lang_Thread::release_set_thread(thread_oop(), this);
 }
 
 oop JavaThread::current_park_blocker() {
@@ -4007,9 +4010,6 @@ void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
   MutexLocker mu(current, Threads_lock);
 
   // Initialize the fields of the thread_oop first.
-
-  java_lang_Thread::set_thread(thread_oop(), target); // isAlive == true now
-
   if (prio != NoPriority) {
     java_lang_Thread::set_priority(thread_oop(), prio);
     // Note: we don't call os::set_priority here. Possibly we should,
@@ -4022,6 +4022,11 @@ void JavaThread::start_internal_daemon(JavaThread* current, JavaThread* target,
   target->set_threadObj(thread_oop());
 
   Threads::add(target); // target is now visible for safepoint/handshake
+  // Publish the JavaThread* in java.lang.Thread after the JavaThread* is
+  // on a ThreadsList. We don't want to wait for the release when the
+  // Theads_lock is dropped when the 'mu' destructor is run since the
+  // JavaThread* is already visible to JVM/TI via the ThreadsList.
+  java_lang_Thread::release_set_thread(thread_oop(), target); // isAlive == true now
   Thread::start(target);
 }
 

--- a/src/hotspot/share/runtime/threadSMR.cpp
+++ b/src/hotspot/share/runtime/threadSMR.cpp
@@ -792,10 +792,11 @@ bool ThreadsListHandle::cv_internal_thread_to_JavaThread(jobject jthread,
     *thread_oop_p = thread_oop;
   }
 
-  JavaThread *java_thread = java_lang_Thread::thread(thread_oop);
+  JavaThread *java_thread = java_lang_Thread::thread_acquire(thread_oop);
   if (java_thread == NULL) {
-    // The java.lang.Thread does not contain a JavaThread * so it has
-    // not yet run or it has died.
+    // The java.lang.Thread does not contain a JavaThread* so it has not
+    // run enough to be put on a ThreadsList or it has exited enough to
+    // make it past ensure_join() where the JavaThread* is cleared.
     return false;
   }
   // Looks like a live JavaThread at this point.


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

I had to resolve almost all of this change.
One of the reason is that JavaThread is in thread.cpp in 17, 
but in a file of it's own in head.
All differences should be in the context, though. 
The code could be applied unchanged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307068](https://bugs.openjdk.org/browse/JDK-8307068): store a JavaThread* in the java.lang.Thread object after the JavaThread* is added to the main ThreadsList (**Sub-task** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1587/head:pull/1587` \
`$ git checkout pull/1587`

Update a local copy of the PR: \
`$ git checkout pull/1587` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1587`

View PR using the GUI difftool: \
`$ git pr show -t 1587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1587.diff">https://git.openjdk.org/jdk17u-dev/pull/1587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1587#issuecomment-1637671981)