### PR TITLE
8307165: java/awt/dnd/NoFormatsDropTest/NoFormatsDropTest.java timed out

### DIFF
--- a/test/jdk/java/awt/dnd/NoFormatsDropTest/NoFormatsDropTest.java
+++ b/test/jdk/java/awt/dnd/NoFormatsDropTest/NoFormatsDropTest.java
@@ -65,8 +65,8 @@ import java.lang.reflect.InvocationTargetException;
 public class NoFormatsDropTest implements AWTEventListener {
 
     Frame frame;
-    DragSourcePanel dragSourcePanel;
-    DropTargetPanel dropTargetPanel;
+    volatile DragSourcePanel dragSourcePanel;
+    volatile DropTargetPanel dropTargetPanel;
 
     static final int FRAME_ACTIVATION_TIMEOUT = 1000;
     static final int DROP_COMPLETION_TIMEOUT = 1000;
@@ -103,7 +103,6 @@ public class NoFormatsDropTest implements AWTEventListener {
             InvocationTargetException {
         try {
             Robot robot = new Robot();
-            robot.setAutoWaitForIdle(true);
             robot.delay(FRAME_ACTIVATION_TIMEOUT);
 
             final Point srcPoint = dragSourcePanel.getLocationOnScreen();
@@ -134,6 +133,7 @@ public class NoFormatsDropTest implements AWTEventListener {
                 robot.mouseMove(curPoint.x, curPoint.y);
                 robot.delay(100);
             }
+            robot.waitForIdle();
             robot.keyRelease(KeyEvent.VK_CONTROL);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
@@ -244,7 +244,7 @@ class TestTransferable implements Transferable {
 class DropTargetPanel extends Panel implements DropTargetListener {
 
     final Dimension preferredDimension = new Dimension(200, 100);
-    boolean passed = false;
+    volatile boolean passed = false;
 
     public DropTargetPanel() {
         setDropTarget(new DropTarget(this, this));


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307165](https://bugs.openjdk.org/browse/JDK-8307165): java/awt/dnd/NoFormatsDropTest/NoFormatsDropTest.java timed out (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1591/head:pull/1591` \
`$ git checkout pull/1591`

Update a local copy of the PR: \
`$ git checkout pull/1591` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1591`

View PR using the GUI difftool: \
`$ git pr show -t 1591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1591.diff">https://git.openjdk.org/jdk17u-dev/pull/1591.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1591#issuecomment-1639710706)