### PR TITLE
8289745: JfrStructCopyFailed uses heap words instead of bytes for object sizes

### DIFF
--- a/src/hotspot/share/gc/g1/g1Trace.cpp
+++ b/src/hotspot/share/gc/g1/g1Trace.cpp
@@ -163,9 +163,9 @@ void G1NewTracer::send_evacuation_failed_event(const EvacuationFailedInfo& ef_in
     // Create JFR structured failure data
     JfrStructCopyFailed evac_failed;
     evac_failed.set_objectCount(ef_info.failed_count());
-    evac_failed.set_firstSize(ef_info.first_size());
-    evac_failed.set_smallestSize(ef_info.smallest_size());
-    evac_failed.set_totalSize(ef_info.total_size());
+    evac_failed.set_firstSize(ef_info.first_size() * HeapWordSize);
+    evac_failed.set_smallestSize(ef_info.smallest_size() * HeapWordSize);
+    evac_failed.set_totalSize(ef_info.total_size() * HeapWordSize);
     // Add to the event
     e.set_gcId(GCId::current());
     e.set_evacuationFailed(evac_failed);

--- a/src/hotspot/share/gc/shared/gcTraceSend.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceSend.cpp
@@ -157,9 +157,9 @@ void OldGCTracer::send_old_gc_event() const {
 static JfrStructCopyFailed to_struct(const CopyFailedInfo& cf_info) {
   JfrStructCopyFailed failed_info;
   failed_info.set_objectCount(cf_info.failed_count());
-  failed_info.set_firstSize(cf_info.first_size());
-  failed_info.set_smallestSize(cf_info.smallest_size());
-  failed_info.set_totalSize(cf_info.total_size());
+  failed_info.set_firstSize(cf_info.first_size() * HeapWordSize);
+  failed_info.set_smallestSize(cf_info.smallest_size() * HeapWordSize);
+  failed_info.set_totalSize(cf_info.total_size() * HeapWordSize);
   return failed_info;
 }
 

--- a/test/jdk/jdk/jfr/event/gc/detailed/PromotionFailedEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/PromotionFailedEvent.java
@@ -49,12 +49,16 @@ public class PromotionFailedEvent {
         // This test can not always trigger the expected event.
         // Test is ok even if no events found.
         List<RecordedEvent> events = RecordingFile.readAllEvents(Paths.get(jfr_file));
+        int minObjectAlignment = 8;
         for (RecordedEvent event : events) {
             System.out.println("Event: " + event);
             long smallestSize = Events.assertField(event, "promotionFailed.smallestSize").atLeast(1L).getValue();
+            Asserts.assertTrue((smallestSize % minObjectAlignment) == 0, "smallestSize " + smallestSize + " is not a valid size.");
             long firstSize = Events.assertField(event, "promotionFailed.firstSize").atLeast(smallestSize).getValue();
+            Asserts.assertTrue((firstSize % minObjectAlignment) == 0, "firstSize " + firstSize + " is not a valid size.");
             long totalSize = Events.assertField(event, "promotionFailed.totalSize").atLeast(firstSize).getValue();
             long objectCount = Events.assertField(event, "promotionFailed.objectCount").atLeast(1L).getValue();
+            Asserts.assertTrue((totalSize % minObjectAlignment) == 0, "totalSize " + totalSize + " is not a valid size.");
             Asserts.assertLessThanOrEqual(smallestSize * objectCount, totalSize, "smallestSize * objectCount <= totalSize");
         }
     }

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestEvacuationFailedEvent.java
@@ -76,13 +76,17 @@ public class TestEvacuationFailedEvent {
 
         // Verify recording
         List<RecordedEvent> events = Events.fromRecording(recording);
+        int minObjectAlignment = 8;
 
         Events.hasEvents(events);
         for (RecordedEvent event : events) {
             long objectCount = Events.assertField(event, "evacuationFailed.objectCount").atLeast(1L).getValue();
             long smallestSize = Events.assertField(event, "evacuationFailed.smallestSize").atLeast(1L).getValue();
+            Asserts.assertTrue((smallestSize % minObjectAlignment) == 0, "smallestSize " + smallestSize + " is not a valid size.");
             long firstSize = Events.assertField(event, "evacuationFailed.firstSize").atLeast(smallestSize).getValue();
+            Asserts.assertTrue((firstSize % minObjectAlignment) == 0, "firstSize " + firstSize + " is not a valid size.");
             long totalSize = Events.assertField(event, "evacuationFailed.totalSize").atLeast(firstSize).getValue();
+            Asserts.assertTrue((totalSize % minObjectAlignment) == 0, "totalSize " + totalSize + " is not a valid size.");
             Asserts.assertLessThanOrEqual(smallestSize * objectCount, totalSize, "smallestSize * objectCount <= totalSize");
         }
         recording.close();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7f0e9bd6](https://github.com/openjdk/jdk/commit/7f0e9bd632198c7fd34d27b85ca51ea0e2442e4d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ralf Schmelter on 12 Jul 2022 and was reviewed by Markus Grönlund and Thomas Stuefe.

It just fixes the metadata of an JFR event.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8289745](https://bugs.openjdk.org/browse/JDK-8289745) needs maintainer approval

### Issue
 * [JDK-8289745](https://bugs.openjdk.org/browse/JDK-8289745): JfrStructCopyFailed uses heap words instead of bytes for object sizes (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1592/head:pull/1592` \
`$ git checkout pull/1592`

Update a local copy of the PR: \
`$ git checkout pull/1592` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1592`

View PR using the GUI difftool: \
`$ git pr show -t 1592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1592.diff">https://git.openjdk.org/jdk17u-dev/pull/1592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1592#issuecomment-1639715223)