### PR TITLE
8307653: Adjust delay time and gc log argument in TestAbortOnVMOperationTimeout

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -26,7 +26,7 @@ import jdk.test.lib.process.*;
 
 /*
  * @test TestAbortOnVMOperationTimeout
- * @bug 8181143 8269523
+ * @bug 8181143 8269523 8307653
  * @summary Check abort on VM timeout is working
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
@@ -50,11 +50,9 @@ public class TestAbortOnVMOperationTimeout {
             return;
         }
 
-        // These should definitely pass: more than a minute is enough for Serial to act.
-        // The values are deliberately non-round to trip off periodic task granularity.
-        for (int delay : new int[]{63423, 12388131}) {
-            testWith(delay, true);
-        }
+        // This should definitely pass: more than 3 minutes is enough for Serial to act.
+        // The value is deliberately non-round to trip off periodic task granularity.
+        testWith(183423, true);
 
         // These should fail: Serial is not very fast but we have seen the test
         // execute as quickly as 2ms!
@@ -71,7 +69,7 @@ public class TestAbortOnVMOperationTimeout {
                 "-Xmx256m",
                 "-XX:+UseSerialGC",
                 "-XX:-CreateCoredumpOnCrash",
-                "-Xlog:gc",
+                "-Xlog:gc*=info",
                 "TestAbortOnVMOperationTimeout",
                 "foo"
         );


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307653](https://bugs.openjdk.org/browse/JDK-8307653): Adjust delay time and gc log argument in TestAbortOnVMOperationTimeout (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1597/head:pull/1597` \
`$ git checkout pull/1597`

Update a local copy of the PR: \
`$ git checkout pull/1597` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1597`

View PR using the GUI difftool: \
`$ git pr show -t 1597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1597.diff">https://git.openjdk.org/jdk17u-dev/pull/1597.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1597#issuecomment-1640395893)