### PR TITLE
8305670: Performance regression in LockSupport.unpark with lots of idle threads

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -845,7 +845,6 @@ UNSAFE_ENTRY(void, Unsafe_Unpark(JNIEnv *env, jobject unsafe, jobject jthread)) 
       p->unpark();
     }
   } // FastThreadsListHandle is destroyed here.
-
 } UNSAFE_END
 
 UNSAFE_ENTRY(jint, Unsafe_GetLoadAverage0(JNIEnv *env, jobject unsafe, jdoubleArray loadavg, jint nelem)) {

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -829,20 +829,22 @@ UNSAFE_ENTRY(void, Unsafe_Park(JNIEnv *env, jobject unsafe, jboolean isAbsolute,
 
 UNSAFE_ENTRY(void, Unsafe_Unpark(JNIEnv *env, jobject unsafe, jobject jthread)) {
   if (jthread != NULL) {
-    ThreadsListHandle tlh;
-    JavaThread* thr = NULL;
-    oop java_thread = NULL;
-    (void) tlh.cv_internal_thread_to_JavaThread(jthread, &thr, &java_thread);
-    if (java_thread != NULL) {
-      // This is a valid oop.
-      if (thr != NULL) {
-        // The JavaThread is alive.
-        Parker* p = thr->parker();
-        HOTSPOT_THREAD_UNPARK((uintptr_t) p);
-        p->unpark();
-      }
+    oop thread_oop = JNIHandles::resolve_non_null(jthread);
+    // Get the JavaThread* stored in the java.lang.Thread object _before_
+    // the embedded ThreadsListHandle is constructed so we know if the
+    // early life stage of the JavaThread* is protected. We use acquire
+    // here to ensure that if we see a non-nullptr value, then we also
+    // see the main ThreadsList updates from the JavaThread* being added.
+    FastThreadsListHandle ftlh(thread_oop, java_lang_Thread::thread_acquire(thread_oop));
+    JavaThread* thr = ftlh.protected_java_thread();
+    if (thr != nullptr) {
+      // The still live JavaThread* is protected by the FastThreadsListHandle
+      // so it is safe to access.
+      Parker* p = thr->parker();
+      HOTSPOT_THREAD_UNPARK((uintptr_t) p);
+      p->unpark();
     }
-  } // ThreadsListHandle is destroyed here.
+  } // FastThreadsListHandle is destroyed here.
 
 } UNSAFE_END
 

--- a/src/hotspot/share/runtime/threadSMR.hpp
+++ b/src/hotspot/share/runtime/threadSMR.hpp
@@ -320,6 +320,29 @@ public:
   }
 };
 
+// This stack allocated FastThreadsListHandle implements the special case
+// where we want to quickly determine if a JavaThread* is protected by the
+// embedded ThreadsListHandle.
+//
+class FastThreadsListHandle : public StackObj {
+  JavaThread* _protected_java_thread;
+  ThreadsListHandle _tlh;
+
+public:
+  // The 'java_thread' parameter to the constructor must be provided
+  // by a java_lang_Thread::thread_acquire(thread_oop) call which gets
+  // us the JavaThread* stored in the java.lang.Thread object _before_
+  // the embedded ThreadsListHandle is constructed. We use acquire there
+  // to ensure that if we see a non-nullptr value, then we also see the
+  // main ThreadsList updates from the JavaThread* being added.
+  //
+  FastThreadsListHandle(oop thread_oop, JavaThread* java_thread);
+
+  JavaThread* protected_java_thread() {
+    return _protected_java_thread;
+  }
+};
+
 // This stack allocated JavaThreadIterator is used to walk the
 // specified ThreadsList using the following style:
 //


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

I had to resolve one chunk due to NULL/nullptr differences.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305670](https://bugs.openjdk.org/browse/JDK-8305670): Performance regression in LockSupport.unpark with lots of idle threads (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [7a11918c](https://git.openjdk.org/jdk17u-dev/pull/1604/files/7a11918c14262d5fdbc3791bf7e9abbd172c3058)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1604/head:pull/1604` \
`$ git checkout pull/1604`

Update a local copy of the PR: \
`$ git checkout pull/1604` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1604`

View PR using the GUI difftool: \
`$ git pr show -t 1604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1604.diff">https://git.openjdk.org/jdk17u-dev/pull/1604.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1604#issuecomment-1643836555)