### PR TITLE
8292683: Remove BadKeyUsageTest.java from Problem List

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -637,8 +637,6 @@ sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8161536 generic-
 
 sun/security/tools/keytool/ListKeychainStore.sh                 8156889 macosx-all
 
-sun/security/tools/jarsigner/warnings/BadKeyUsageTest.java      8026393 generic-all
-
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64
 
 sun/security/smartcardio/TestChannel.java                       8039280 generic-all


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292683](https://bugs.openjdk.org/browse/JDK-8292683): Remove BadKeyUsageTest.java from Problem List (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1607/head:pull/1607` \
`$ git checkout pull/1607`

Update a local copy of the PR: \
`$ git checkout pull/1607` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1607`

View PR using the GUI difftool: \
`$ git pr show -t 1607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1607.diff">https://git.openjdk.org/jdk17u-dev/pull/1607.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1607#issuecomment-1643862039)