### PR TITLE
8286623: Bundle zlib by default with JDK on macos aarch64

### DIFF
--- a/make/autoconf/lib-bundled.m4
+++ b/make/autoconf/lib-bundled.m4
@@ -166,7 +166,9 @@ AC_DEFUN_ONCE([LIB_SETUP_ZLIB],
 
   DEFAULT_ZLIB=system
   if test "x$OPENJDK_TARGET_OS" = xwindows -o "x$OPENJDK_TARGET_OS" = xaix; then
-    # On windows and aix default is bundled, on others default is system
+    # On windows and aix default is bundled
+    DEFAULT_ZLIB=bundled
+  elif test "x$OPENJDK_TARGET_OS" = xmacosx -a "x$OPENJDK_TARGET_CPU" = xaarch64; then
     DEFAULT_ZLIB=bundled
   fi
 

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -457,7 +457,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: "macosx",
             target_cpu: "aarch64",
             dependencies: ["devkit", "gtest"],
-            configure_args: concat(common.configure_args_64bit, "--with-zlib=system",
+            configure_args: concat(common.configure_args_64bit,
                 "--with-macosx-version-max=11.00.00"),
         },
 


### PR DESCRIPTION
Applies cleanly other than a minor diff in the `jib-profiles.js` surrounding lines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286623](https://bugs.openjdk.org/browse/JDK-8286623): Bundle zlib by default with JDK on macos aarch64 (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1609/head:pull/1609` \
`$ git checkout pull/1609`

Update a local copy of the PR: \
`$ git checkout pull/1609` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1609`

View PR using the GUI difftool: \
`$ git pr show -t 1609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1609.diff">https://git.openjdk.org/jdk17u-dev/pull/1609.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1609#issuecomment-1644578996)