### PR TITLE
8312511: GHA: Bump cross-compile runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -35,7 +35,7 @@ on:
       apt-gcc-version:
         required: false
         type: string
-        default: '10.3.0-1ubuntu1~20.04'
+        default: '10.4.0-4ubuntu1~22.04'
       apt-gcc-cross-suffix:
         required: false
         type: string
@@ -44,7 +44,7 @@ on:
 jobs:
   build-cross-compile:
     name: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Hi, recently RISC-V cross-compile GHA always failed with sysroot creation. Turns out that there are some issues with Ubuntu 20.04 runner when setting up systemd package:

```
Setting up systemd (254~rc2-3) ...
Created symlink /etc/systemd/system/getty.target.wants/getty@tty1.service -> /lib/systemd/system/getty@.service.
Created symlink /etc/systemd/system/multi-user.target.wants/remote-fs.target -> /lib/systemd/system/remote-fs.target.
Created symlink /etc/systemd/system/sysinit.target.wants/systemd-pstore.service -> /lib/systemd/system/systemd-pstore.service.
Initializing machine ID from random generator.
Failed to take /etc/passwd lock: Invalid argument
dpkg: error processing package systemd (--install):
installed systemd package post-installation script subprocess returned error exit status 1
Processing triggers for libc-bin (2.37-6) ...
Errors were encountered while processing:
systemd
```

While jdk mainline RISC-V cross-compiling was not affected, so I tried to bump the cross-compiling GHA runner to Ubuntu 22.04 and the error was gone. So maybe we could upgrade the cross-compiling runner to make RISC-V cross-builds work again.
And sorry for the annoying RISC-V cross-build failure warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312511](https://bugs.openjdk.org/browse/JDK-8312511): GHA: Bump cross-compile runner to Ubuntu 22.04 (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1613/head:pull/1613` \
`$ git checkout pull/1613`

Update a local copy of the PR: \
`$ git checkout pull/1613` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1613`

View PR using the GUI difftool: \
`$ git pr show -t 1613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1613.diff">https://git.openjdk.org/jdk17u-dev/pull/1613.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1613#issuecomment-1645635499)