### PR TITLE
8299617: CurrencySymbols.properties is missing the copyright notice

### DIFF
--- a/test/jdk/java/text/Format/NumberFormat/CurrencySymbols.properties
+++ b/test/jdk/java/text/Format/NumberFormat/CurrencySymbols.properties
@@ -1,3 +1,26 @@
+#
+# Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
 ar=\u00A4
 ar_AE=\u062F.\u0625.\u200F
 ar_BH=\u062F.\u0628.\u200F


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299617](https://bugs.openjdk.org/browse/JDK-8299617): CurrencySymbols.properties is missing the copyright notice (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1621/head:pull/1621` \
`$ git checkout pull/1621`

Update a local copy of the PR: \
`$ git checkout pull/1621` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1621`

View PR using the GUI difftool: \
`$ git pr show -t 1621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1621.diff">https://git.openjdk.org/jdk17u-dev/pull/1621.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1621#issuecomment-1647731802)