### PR TITLE
8307603: [AIX] Broken build after JDK-8307301

### DIFF
--- a/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
+++ b/src/java.desktop/share/native/libharfbuzz/hb-subset.cc
@@ -43,7 +43,11 @@
 #include "OT/Color/sbix/sbix.hh"
 #include "hb-ot-os2-table.hh"
 #include "hb-ot-post-table.hh"
+
+#if !defined(AIX)
 #include "hb-ot-post-table-v2subset.hh"
+#endif
+
 #include "hb-ot-cff1-table.hh"
 #include "hb-ot-cff2-table.hh"
 #include "hb-ot-vorg-table.hh"


### PR DESCRIPTION
Fixes this build error--associated with Harfbuzz--in jdk17. T1 Testing looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307603](https://bugs.openjdk.org/browse/JDK-8307603): [AIX] Broken build after JDK-8307301 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1624/head:pull/1624` \
`$ git checkout pull/1624`

Update a local copy of the PR: \
`$ git checkout pull/1624` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1624`

View PR using the GUI difftool: \
`$ git pr show -t 1624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1624.diff">https://git.openjdk.org/jdk17u-dev/pull/1624.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1624#issuecomment-1650241095)