### PR TITLE
8313402: C1: Incorrect LoadIndexed value numbering

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -960,7 +960,7 @@ LEAF(LoadIndexed, AccessIndexed)
   ciType* declared_type() const;
 
   // generic;
-  HASHING3(LoadIndexed, true, type()->tag(), array()->subst(), index()->subst())
+  HASHING3(LoadIndexed, true, elt_type(), array()->subst(), index()->subst())
 };
 
 

--- a/test/hotspot/jtreg/compiler/c1/TestLoadIndexedMismatch.java
+++ b/test/hotspot/jtreg/compiler/c1/TestLoadIndexedMismatch.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8313402
+ * @summary C1: Incorrect LoadIndexed value numbering
+ * @requires vm.compiler1.enabled
+ * @library /compiler/patches /test/lib
+ * @build java.base/java.lang.Helper
+ * @run main/othervm -Xbatch -XX:CompileThreshold=100
+ *                   -XX:TieredStopAtLevel=1
+ *                   compiler.c1.TestLoadIndexedMismatch
+ */
+
+package compiler.c1;
+
+public class TestLoadIndexedMismatch {
+    static final byte[] ARR = {42, 42};
+    static final char EXPECTED_CHAR = (char)(42*256 + 42);
+
+    public static char work() {
+        // LoadIndexed (B)
+        byte b = ARR[0];
+        // StringUTF16.charAt intrinsic, LoadIndexed (C)
+        char c = Helper.charAt(ARR, 0);
+        return c;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            char c = work();
+            if (c != EXPECTED_CHAR) {
+                throw new IllegalStateException("Read: " + (int)c + ", expected: " + (int)EXPECTED_CHAR);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Clean backport to fix the important C1 bug.

Additional testing:
 - [x] New regression test fails without the patch, passes with it, when JDK-8313676 is applied
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313402](https://bugs.openjdk.org/browse/JDK-8313402): C1: Incorrect LoadIndexed value numbering (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1636/head:pull/1636` \
`$ git checkout pull/1636`

Update a local copy of the PR: \
`$ git checkout pull/1636` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1636`

View PR using the GUI difftool: \
`$ git pr show -t 1636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1636.diff">https://git.openjdk.org/jdk17u-dev/pull/1636.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1636#issuecomment-1663814906)