### PR TITLE
8305056: Avoid unaligned access in emit_intX methods if it's unsupported

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -31,6 +31,11 @@
 #include "utilities/debug.hpp"
 #include "utilities/macros.hpp"
 
+template <typename T>
+static inline void put_native(address p, T x) {
+    memcpy((void*)p, &x, sizeof x);
+}
+
 class CodeStrings;
 class PhaseCFG;
 class Compile;
@@ -206,7 +211,10 @@ class CodeSection {
     set_end(curr);
   }
 
-  void emit_int16(int16_t x) { *((int16_t*) end()) = x; set_end(end() + sizeof(int16_t)); }
+  template <typename T>
+  void emit_native(T x) { put_native(end(), x); set_end(end() + sizeof x); }
+
+  void emit_int16(int16_t x) { emit_native(x); }
   void emit_int16(int8_t x1, int8_t x2) {
     address curr = end();
     *((int8_t*)  curr++) = x1;
@@ -222,7 +230,7 @@ class CodeSection {
     set_end(curr);
   }
 
-  void emit_int32(int32_t x) { *((int32_t*) end()) = x; set_end(end() + sizeof(int32_t)); }
+  void emit_int32(int32_t x) { emit_native(x); }
   void emit_int32(int8_t x1, int8_t x2, int8_t x3, int8_t x4)  {
     address curr = end();
     *((int8_t*)  curr++) = x1;
@@ -232,11 +240,10 @@ class CodeSection {
     set_end(curr);
   }
 
-  void emit_int64( int64_t x)  { *((int64_t*) end()) = x; set_end(end() + sizeof(int64_t)); }
-
-  void emit_float( jfloat  x)  { *((jfloat*)  end()) = x; set_end(end() + sizeof(jfloat)); }
-  void emit_double(jdouble x)  { *((jdouble*) end()) = x; set_end(end() + sizeof(jdouble)); }
-  void emit_address(address x) { *((address*) end()) = x; set_end(end() + sizeof(address)); }
+  void emit_int64(int64_t x)  { emit_native(x); }
+  void emit_float(jfloat  x)   { emit_native(x); }
+  void emit_double(jdouble x)  { emit_native(x); }
+  void emit_address(address x) { emit_native(x); }
 
   // Share a scratch buffer for relocinfo.  (Hacky; saves a resource allocation.)
   void initialize_shared_locs(relocInfo* buf, int length);


### PR DESCRIPTION
Please review this backport to jdk17u-dev, it doesn't apply clean due to different codestyle of emit_int32 in jdk17u-dev (linebreaks)

this is important for risc-v port as there support for misaligned memory access is implementation specific option.
This commit changes logic from "always misaligned stores on all architectures" to "compiler (gcc/clang) knows better for every architecture"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8305056](https://bugs.openjdk.org/browse/JDK-8305056) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305056](https://bugs.openjdk.org/browse/JDK-8305056): Avoid unaligned access in emit_intX methods if it's unsupported (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1638/head:pull/1638` \
`$ git checkout pull/1638`

Update a local copy of the PR: \
`$ git checkout pull/1638` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1638`

View PR using the GUI difftool: \
`$ git pr show -t 1638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1638.diff">https://git.openjdk.org/jdk17u-dev/pull/1638.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1638#issuecomment-1664606697)