### PR TITLE
8312065: Socket.connect does not timeout as expected when profiling

### DIFF
--- a/src/java.base/aix/native/libnet/aix_close.c
+++ b/src/java.base/aix/native/libnet/aix_close.c
@@ -489,7 +489,17 @@ int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
 }
 
 int NET_Poll(struct pollfd *ufds, unsigned int nfds, int timeout) {
-    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout) );
+    int ret;
+    threadEntry_t self;
+    fdEntry_t *fdEntry = getFdEntry(ufds[0].fd);
+    if (fdEntry == NULL) {
+        errno = EBADF;
+        return -1;
+    }
+    startOp(fdEntry, &self);
+    ret = poll(ufds, nfds, timeout);
+    endOp(fdEntry, &self);
+    return ret;
 }
 
 /*

--- a/src/java.base/linux/native/libnet/linux_close.c
+++ b/src/java.base/linux/native/libnet/linux_close.c
@@ -396,7 +396,17 @@ int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
 }
 
 int NET_Poll(struct pollfd *ufds, unsigned int nfds, int timeout) {
-    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout) );
+    int ret;
+    threadEntry_t self;
+    fdEntry_t *fdEntry = getFdEntry(ufds[0].fd);
+    if (fdEntry == NULL) {
+        errno = EBADF;
+        return -1;
+    }
+    startOp(fdEntry, &self);
+    ret = poll(ufds, nfds, timeout);
+    endOp(fdEntry, &self);
+    return ret;
 }
 
 /*

--- a/src/java.base/macosx/native/libnet/bsd_close.c
+++ b/src/java.base/macosx/native/libnet/bsd_close.c
@@ -400,7 +400,17 @@ int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
 }
 
 int NET_Poll(struct pollfd *ufds, unsigned int nfds, int timeout) {
-    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout) );
+    int ret;
+    threadEntry_t self;
+    fdEntry_t *fdEntry = getFdEntry(ufds[0].fd);
+    if (fdEntry == NULL) {
+        errno = EBADF;
+        return -1;
+    }
+    startOp(fdEntry, &self);
+    ret = poll(ufds, nfds, timeout);
+    endOp(fdEntry, &self);
+    return ret;
 }
 
 /*

--- a/test/jdk/java/net/Socket/B8312065.java
+++ b/test/jdk/java/net/Socket/B8312065.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8312065
+ * @summary Socket.connect does not timeout as expected when profiling (i.e. keep receiving signal)
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @run main/othervm/timeout=120 -Djdk.net.usePlainSocketImpl B8312065
+ */
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+import jdk.jfr.consumer.RecordingFile;
+import sun.misc.Signal;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class B8312065 {
+    private static volatile boolean success = false;
+    private static Recording recording = null;
+    private static volatile boolean isSendSignal = true;
+    private static volatile boolean signalReceived = false;
+    private static final boolean debug = true;
+
+    public static void main(String[] args) throws Exception {
+        // If the thread executing java.net.PlainSocketImpl.socketConnect receives continuous signals,
+        // the thread will be blocked for a long time (about 2 minutes).
+        // To test in the sub-thread, the main thread can detect the execution time of the sub-thread to avoid the
+        // test duration being too long.
+        Thread t = new Thread(() -> {
+            try {
+                task();
+            } catch (Exception e) {
+                error(e.getMessage(), e);
+            }
+        });
+        t.setDaemon(true);
+        t.start();
+
+        int timeoutSeconds = 10;
+        t.join(timeoutSeconds * 1000);
+        if (t.isAlive()) {
+            throw new RuntimeException("Test Failed: " + timeoutSeconds +
+                    " seconds have passed and it has not timed out");
+        }
+
+        if (!success) {
+            throw new RuntimeException("Test Failed");
+        }
+    }
+
+    private static void task() throws IOException, ParseException, InterruptedException {
+        Thread.currentThread().setName("B8312065");
+
+        // Find OS thread ID of the current thread
+        long osThreadId = getOSThreadId();
+        if (osThreadId == 0) {
+            throw new RuntimeException("Failed to get operating system thread id");
+        }
+
+        Thread t = startSendingSignalToThread(osThreadId);
+
+        test();
+
+        isSendSignal = false;
+        t.join();
+    }
+
+    private static Thread startSendingSignalToThread(long osThreadId) throws InterruptedException {
+        // Setup SIGPROF handler
+        Signal.handle(new Signal("PROF"), (signal) -> {
+            signalReceived = true;
+        });
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Send SIGPROF to the thread every second
+        Thread t = new Thread(() -> {
+            while (isSendSignal) {
+                try {
+                    Runtime.getRuntime().exec("kill -SIGPROF " + osThreadId).waitFor();
+                    Thread.sleep(1000);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        t.setDaemon(true);
+        t.start();
+
+        latch.await();
+        if (!signalReceived) {
+            throw new RuntimeException("failed to send signal");
+        }
+        return t;
+    }
+
+    static void test() {
+        Socket socket = null;
+        long startMillis = millisTime();
+        int timeoutMillis = 2000;
+        try {
+            socket = new Socket();
+            connectWithTimeout(socket, timeoutMillis);
+            error("connected successfully!");
+        } catch (SocketTimeoutException socketTimeout) {
+            long duration = millisTime() - startMillis;
+            long min = timeoutMillis - 100;
+            long max = timeoutMillis + 2000;
+            if (duration < min) {
+                error("Duration " + duration + "ms, expected >= " + min + "ms");
+            } else if (duration > max) {
+                error("Duration " + duration + "ms, expected <= " + max + "ms");
+            } else {
+                debug("Passed: Received: " + socketTimeout + ", duration " + duration + " millis");
+                passed();
+            }
+        } catch (Exception exception) {
+            error("Connect timeout test failed", exception);
+        } finally {
+            close(socket);
+        }
+    }
+
+    static void connectWithTimeout(Socket socket, int timeout) throws IOException {
+        // There is no good way to mock SocketTimeoutException, just assume 192.168.255.255 is not in use.
+        socket.connect(new InetSocketAddress("192.168.255.255", 8080), timeout);
+    }
+
+    /**
+     * Returns the current time in milliseconds.
+     */
+    private static long millisTime() {
+        long now = System.nanoTime();
+        return TimeUnit.MILLISECONDS.convert(now, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * The JFR event records the OS thread ID, which is a reliable way.
+     * Another way is use /proc/thread-self, but unfortunately, it's not supported until linux 3.17
+     * @return Operating System Thread id
+     * @throws IOException
+     * @throws ParseException
+     */
+    private static long getOSThreadId() throws IOException, ParseException {
+        startJFR();
+
+        sleep(); // trigger jdk.ThreadSleep Event
+
+        Path jfrPath = null;
+        try {
+            jfrPath = Files.createTempFile("B8312065", ".jfr");
+            recording.dump(jfrPath);
+            RecordingFile file = new RecordingFile(jfrPath);
+            while (file.hasMoreEvents()) {
+                RecordedEvent event = file.readEvent();
+                if ("jdk.ThreadSleep".equals(event.getEventType().getName())) {
+                    RecordedThread thread = event.getThread();
+                    if (thread.getJavaName().equals("B8312065")) {
+                        return thread.getOSThreadId();
+                    }
+                }
+            }
+        } finally {
+            if (jfrPath != null) {
+                jfrPath.toFile().delete();
+            }
+            recording.stop();
+        }
+
+        return 0L;
+    }
+
+    private static void startJFR() throws IOException, ParseException {
+        Configuration recordingConfig = Configuration.getConfiguration("default");
+        recording = new Recording(recordingConfig);
+        recording.start();
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(1000);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    static void debug(String message) {
+        if (debug) {
+            System.out.println(message);
+        }
+    }
+
+    static void unexpected(Exception e ) {
+        System.out.println("Unexpected Exception: " + e);
+    }
+
+    static void close(Closeable closeable) {
+        if (closeable != null) try { closeable.close(); } catch (IOException e) {unexpected(e);}
+    }
+
+    static void error(String message) {
+        System.out.println(message);
+    }
+
+    static void error(String message, Exception e) {
+        System.out.println(message);
+        e.printStackTrace();
+    }
+
+    static void passed() {
+        success = true;
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a fix for [JDK-8312065](https://bugs.openjdk.org/browse/JDK-8312065).

The old SocketImpl is still present in JDK 17, can be enabled with -Djdk.net.usePlainSocketImpl.

I have verified that this problem exists on Linux and macOS, and I feel that it also exists on AIX, 
so I repaired these 3 platforms. Windows implementations are different, so don't have this problem.

I added a platform dependent test.

The test needs to get the OS thread ID of the Java thread. It seems that there is no good Java API to get it directly. The minimum requirement of Linux [/proc/thread-self](https://man7.org/linux/man-pages/man5/proc.5.html#:~:text=/proc/thread%2Dself%20(since%20Linux%203.17)) is Linux 3.17.
The JFR event records the OS thread ID, although this method is cumbersome, it is reliable.

The test also needs to use the kill command to send a signal to the thread. macOS's kill seems to only support process, and I don't have an AIX environment, so this test only supports Linux.

Thanks!
