### PR TITLE
8293107: GHA: Bump to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -138,6 +138,7 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
+          --variant=minbase
           ${{ matrix.debian-version }}
           sysroot
           ${{ matrix.debian-repository }}

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -29,17 +29,14 @@ on:
   workflow_call:
     inputs:
       gcc-major-version:
-        required: false
+        required: true
         type: string
-        default: '10'
       apt-gcc-version:
-        required: false
+        required: true
         type: string
-        default: '10.4.0-4ubuntu1~22.04'
-      apt-gcc-cross-suffix:
-        required: false
+      apt-gcc-cross-version:
+        required: true
         type: string
-        default: 'cross1'
 
 jobs:
   build-cross-compile:
@@ -109,8 +106,8 @@ jobs:
           sudo apt-get install \
               gcc-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} \
               g++-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} \
-              gcc-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-version }}${{ inputs.apt-gcc-cross-suffix }} \
-              g++-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-version }}${{ inputs.apt-gcc-cross-suffix }} \
+              gcc-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-cross-version }} \
+              g++-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-cross-version }} \
               libxrandr-dev libxtst-dev libcups2-dev libasound2-dev
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 
@@ -157,8 +154,8 @@ jobs:
           --openjdk-target=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}
           --with-sysroot=sysroot
           --with-build-jdk=${{ steps.buildjdk.outputs.jdk-path }}
-          CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-10
-          CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-10
+          CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-${{ inputs.gcc-major-version }}
+          CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-${{ inputs.gcc-major-version }}
 
       - name: 'Build'
         id: build

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -37,6 +37,9 @@ on:
       apt-gcc-cross-version:
         required: true
         type: string
+      extra-conf-options:
+        required: false
+        type: string
 
 jobs:
   build-cross-compile:
@@ -156,6 +159,10 @@ jobs:
           --with-build-jdk=${{ steps.buildjdk.outputs.jdk-path }}
           CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-${{ inputs.gcc-major-version }}
           CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-${{ inputs.gcc-major-version }}
+          ${{ inputs.extra-conf-options }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -40,6 +40,12 @@ on:
       extra-conf-options:
         required: false
         type: string
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
 
 jobs:
   build-cross-compile:
@@ -159,7 +165,7 @@ jobs:
           --with-build-jdk=${{ steps.buildjdk.outputs.jdk-path }}
           CC=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-gcc-${{ inputs.gcc-major-version }}
           CXX=${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}-g++-${{ inputs.gcc-major-version }}
-          ${{ inputs.extra-conf-options }} || (
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
@@ -168,5 +174,5 @@ jobs:
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: 'hotspot'
+          make-target: 'hotspot ${{ inputs.make-arguments }}'
           platform: linux-${{ matrix.target-cpu }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -42,6 +42,13 @@ on:
         required: false
         type: string
         default: '[ "debug", "release" ]'
+      gcc-major-version:
+        required: true
+        type: string
+      gcc-package-suffix:
+        required: false
+        type: string
+        default: ''
       apt-gcc-version:
         required: true
         type: string
@@ -101,8 +108,8 @@ jobs:
           fi
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
-          sudo apt-get install gcc-${{ inputs.apt-gcc-version }} g++-${{ inputs.apt-gcc-version }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+          sudo apt-get install gcc-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }}=${{ inputs.apt-gcc-version }} g++-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }}=${{ inputs.apt-gcc-version }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 
       - name: 'Configure'
         run: >

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -62,7 +62,7 @@ on:
 jobs:
   build-linux:
     name: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -122,7 +122,10 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -58,6 +58,12 @@ on:
       apt-extra-packages:
         required: false
         type: string
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
 
 jobs:
   build-linux:
@@ -122,7 +128,7 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          ${{ inputs.extra-conf-options }} || (
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
@@ -131,7 +137,7 @@ jobs:
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: '${{ inputs.make-target }}'
+          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
           platform: ${{ inputs.platform }}
           debug-suffix: '${{ matrix.suffix }}'
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -97,7 +97,10 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
 
       - name: 'Build'
         id: build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -45,6 +45,12 @@ on:
       xcode-toolset-version:
         required: true
         type: string
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
 
 jobs:
   build-macos:
@@ -97,7 +103,7 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-zlib=system
-          ${{ inputs.extra-conf-options }} || (
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
@@ -106,7 +112,7 @@ jobs:
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: '${{ inputs.make-target }}'
+          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
           platform: ${{ inputs.platform }}
           debug-suffix: '${{ matrix.suffix }}'
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -124,7 +124,10 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
-          ${{ inputs.extra-conf-options }}
+          ${{ inputs.extra-conf-options }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
         env:
           # We need a minimal PATH on Windows
           # Set PATH to "", so just GITHUB_PATH is included

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -48,6 +48,12 @@ on:
       msvc-toolset-architecture:
         required: true
         type: string
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
 
 env:
   # These are needed to make the MSYS2 bash work properly
@@ -124,7 +130,7 @@ jobs:
           --with-gtest=${{ steps.gtest.outputs.path }}
           --enable-jtreg-failure-handler
           --with-msvc-toolset-version=${{ inputs.msvc-toolset-version }}
-          ${{ inputs.extra-conf-options }} || (
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
@@ -137,7 +143,7 @@ jobs:
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: '${{ inputs.make-target }}'
+          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
           platform: ${{ inputs.platform }}
           debug-suffix: '${{ matrix.suffix }}'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,8 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
     if: needs.select.outputs.linux-x64 == 'true' || needs.select.outputs.linux-cross-compile == 'true'
 
@@ -131,7 +132,9 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x86
-      apt-gcc-version: '10-multilib'
+      gcc-major-version: '10'
+      gcc-package-suffix: '-multilib'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
@@ -147,7 +150,8 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       extra-conf-options: '--disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -159,7 +163,8 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -171,7 +176,8 @@ jobs:
       platform: linux-x64
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -184,7 +190,8 @@ jobs:
       make-target: 'hotspot'
       # Technically this is not the "debug" level, but we can't inject a new matrix state for just this job
       debug-levels: '[ "debug" ]'
-      apt-gcc-version: '10=10.3.0-1ubuntu1~20.04'
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -194,6 +201,10 @@ jobs:
       - select
       - build-linux-x64
     uses: ./.github/workflows/build-cross-compile.yml
+    with:
+      gcc-major-version: '10'
+      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
+      apt-gcc-cross-version: '10.3.0-1ubuntu1~20.04cross1'
     if: needs.select.outputs.linux-cross-compile == 'true'
 
   build-macos-x64:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
 
   select:
     name: 'Select platforms'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
       linux-x86: ${{ steps.include.outputs.linux-x86 }}
@@ -122,7 +122,7 @@ jobs:
     with:
       platform: linux-x64
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10.3.0-15ubuntu1'
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
     if: needs.select.outputs.linux-x64 == 'true' || needs.select.outputs.linux-cross-compile == 'true'
 
@@ -134,7 +134,7 @@ jobs:
       platform: linux-x86
       gcc-major-version: '10'
       gcc-package-suffix: '-multilib'
-      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10.3.0-15ubuntu1'
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
@@ -151,7 +151,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10.3.0-15ubuntu1'
       extra-conf-options: '--disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -164,7 +164,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10.3.0-15ubuntu1'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -177,7 +177,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10.3.0-15ubuntu1'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -191,7 +191,7 @@ jobs:
       # Technically this is not the "debug" level, but we can't inject a new matrix state for just this job
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
+      apt-gcc-version: '10.3.0-15ubuntu1'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
     if: needs.select.outputs.linux-x64-variants == 'true'
 
@@ -203,8 +203,8 @@ jobs:
     uses: ./.github/workflows/build-cross-compile.yml
     with:
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-1ubuntu1~20.04'
-      apt-gcc-cross-version: '10.3.0-1ubuntu1~20.04cross1'
+      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-cross-version: '10.3.0-8ubuntu1cross1'
     if: needs.select.outputs.linux-cross-compile == 'true'
 
   build-macos-x64:
@@ -260,7 +260,7 @@ jobs:
     with:
       platform: linux-x64
       bootjdk-platform: linux-x64
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
 
   test-linux-x86:
     name: linux-x86
@@ -270,7 +270,7 @@ jobs:
     with:
       platform: linux-x86
       bootjdk-platform: linux-x64
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
 
   test-macos-x64:
     name: macos-x64
@@ -295,7 +295,7 @@ jobs:
   # Remove bundles so they are not misconstrued as binary distributions from the JDK project
   remove-bundles:
     name: 'Remove bundle artifacts'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always()
     needs:
       - build-linux-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
     with:
       platform: linux-x64
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
@@ -142,7 +142,7 @@ jobs:
       platform: linux-x86
       gcc-major-version: '10'
       gcc-package-suffix: '-multilib'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
@@ -161,7 +161,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       extra-conf-options: '--disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -176,7 +176,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -191,7 +191,7 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -207,7 +207,7 @@ jobs:
       # Technically this is not the "debug" level, but we can't inject a new matrix state for just this job
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
+      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -221,8 +221,8 @@ jobs:
     uses: ./.github/workflows/build-cross-compile.yml
     with:
       gcc-major-version: '10'
-      apt-gcc-version: '10.3.0-15ubuntu1'
-      apt-gcc-cross-version: '10.3.0-8ubuntu1cross1'
+      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
+      apt-gcc-cross-version: '10.5.0-1ubuntu1~22.04cross1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-cross-compile == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,12 @@ on:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
         default: 'linux-x64, linux-x86, linux-x64-variants, linux-cross-compile, macos-x64, macos-aarch64, windows-x64, windows-aarch64'
+      configure-arguments:
+        description: 'Additional configure arguments'
+        required: false
+      make-arguments:
+        description: 'Additional make arguments'
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -123,6 +129,8 @@ jobs:
       platform: linux-x64
       gcc-major-version: '10'
       apt-gcc-version: '10.3.0-15ubuntu1'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
     if: needs.select.outputs.linux-x64 == 'true' || needs.select.outputs.linux-cross-compile == 'true'
 
@@ -140,6 +148,8 @@ jobs:
       # install their dependencies manually.
       apt-extra-packages: 'libfreetype6-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386'
       extra-conf-options: '--with-target-bits=32'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x86 == 'true'
 
   build-linux-x64-hs-nopch:
@@ -153,6 +163,8 @@ jobs:
       gcc-major-version: '10'
       apt-gcc-version: '10.3.0-15ubuntu1'
       extra-conf-options: '--disable-precompiled-headers'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-zero:
@@ -166,6 +178,8 @@ jobs:
       gcc-major-version: '10'
       apt-gcc-version: '10.3.0-15ubuntu1'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-minimal:
@@ -179,6 +193,8 @@ jobs:
       gcc-major-version: '10'
       apt-gcc-version: '10.3.0-15ubuntu1'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-optimized:
@@ -193,6 +209,8 @@ jobs:
       gcc-major-version: '10'
       apt-gcc-version: '10.3.0-15ubuntu1'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64-variants == 'true'
 
   build-linux-cross-compile:
@@ -205,6 +223,8 @@ jobs:
       gcc-major-version: '10'
       apt-gcc-version: '10.3.0-15ubuntu1'
       apt-gcc-cross-version: '10.3.0-8ubuntu1cross1'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-cross-compile == 'true'
 
   build-macos-x64:
@@ -214,6 +234,8 @@ jobs:
     with:
       platform: macos-x64
       xcode-toolset-version: '12.5.1'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-x64 == 'true'
 
   build-macos-aarch64:
@@ -224,6 +246,8 @@ jobs:
       platform: macos-aarch64
       xcode-toolset-version: '12.5.1'
       extra-conf-options: '--openjdk-target=aarch64-apple-darwin'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.macos-aarch64 == 'true'
 
   build-windows-x64:
@@ -234,6 +258,8 @@ jobs:
       platform: windows-x64
       msvc-toolset-version: '14.29'
       msvc-toolset-architecture: 'x86.x64'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.windows-x64 == 'true'
 
   build-windows-aarch64:
@@ -246,6 +272,8 @@ jobs:
       msvc-toolset-architecture: 'arm64'
       make-target: 'hotspot'
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.windows-aarch64 == 'true'
 
   ###


### PR DESCRIPTION
This is a series of commits that bring 17u GHA close to mainline. The root change is Ubuntu 22.04 bump, but that one could not be tested alone, because GHA would be broken due to missing compilers, dependencies, etc. Therefore, I opted to do a bulk PR that contains a series of inter-dependent changes. This PR should bring 17u GHA to the good state, atomically.

The included changes are in separate commits, if you want to review them separately. But it would be easier to see the changes against JDK 22 GHA. There are differences against JDK 22 GHA, but those look minor, not breaking/fixing current GHA, and we can backport separately once we get JDK 17u GHA in shape.

Additional testing:
 - [x] GHA
 - [x] Eyeballing the difference between patched JDK 17u and JDK 22 GHA: [jdk17-jdk22-gha-diff.txt](https://github.com/openjdk/jdk17u-dev/files/12261456/jdk17-jdk22-gha-diff.txt)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8293107](https://bugs.openjdk.org/browse/JDK-8293107): GHA: Bump to Ubuntu 22.04 (**Enhancement** - P4)
 * [JDK-8293098](https://bugs.openjdk.org/browse/JDK-8293098): GHA: Harmonize GCC version handling for host and cross builds (**Enhancement** - P4)
 * [JDK-8293361](https://bugs.openjdk.org/browse/JDK-8293361): GHA: dump config.log in case of configure failure (**Bug** - P4)
 * [JDK-8295213](https://bugs.openjdk.org/browse/JDK-8295213): Run GHA manually with user-specified make and configure arguments (**Enhancement** - P4)
 * [JDK-8313428](https://bugs.openjdk.org/browse/JDK-8313428): GHA: Bump GCC versions for July 2023 updates (**Enhancement** - P4)
 * [JDK-8313707](https://bugs.openjdk.org/browse/JDK-8313707): GHA: Bootstrap sysroots with --variant=minbase (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1640/head:pull/1640` \
`$ git checkout pull/1640`

Update a local copy of the PR: \
`$ git checkout pull/1640` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1640`

View PR using the GUI difftool: \
`$ git pr show -t 1640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1640.diff">https://git.openjdk.org/jdk17u-dev/pull/1640.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1640#issuecomment-1667322781)