### PR TITLE
8267860: Off-by-one bug when searching arrays in AlpnGreaseTest

### DIFF
--- a/test/jdk/sun/security/ssl/ALPN/AlpnGreaseTest.java
+++ b/test/jdk/sun/security/ssl/ALPN/AlpnGreaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ public class AlpnGreaseTest implements SSLContextTemplate {
             new String(greaseBytes, StandardCharsets.ISO_8859_1);
 
     private static void findGreaseInClientHello(byte[] bytes) throws Exception {
-        for (int i = 0; i < bytes.length - greaseBytes.length; i++) {
+        for (int i = 0; i < bytes.length - greaseBytes.length + 1; i++) {
             if (Arrays.equals(bytes, i, i + greaseBytes.length,
                     greaseBytes, 0, greaseBytes.length)) {
                 System.out.println("Found greaseBytes in ClientHello at: " + i);


### PR DESCRIPTION
Backport of [JDK-8267860](https://bugs.openjdk.org/browse/JDK-8267860).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267860](https://bugs.openjdk.org/browse/JDK-8267860): Off-by-one bug when searching arrays in AlpnGreaseTest (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1644/head:pull/1644` \
`$ git checkout pull/1644`

Update a local copy of the PR: \
`$ git checkout pull/1644` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1644`

View PR using the GUI difftool: \
`$ git pr show -t 1644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1644.diff">https://git.openjdk.org/jdk17u-dev/pull/1644.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1644#issuecomment-1668522642)