### PR TITLE
6381945: (cal) Japanese calendar unit test system should avoid multiple static imports

### DIFF
--- a/test/jdk/java/util/Calendar/CalendarTestScripts/Symbol.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/Symbol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static java.util.Calendar.*;
 import static java.util.GregorianCalendar.*;
 
 public class Symbol {


### PR DESCRIPTION
Backport of [JDK-6381945](https://bugs.openjdk.org/browse/JDK-6381945).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6381945](https://bugs.openjdk.org/browse/JDK-6381945): (cal) Japanese calendar unit test system should avoid multiple static imports (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1647/head:pull/1647` \
`$ git checkout pull/1647`

Update a local copy of the PR: \
`$ git checkout pull/1647` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1647`

View PR using the GUI difftool: \
`$ git pr show -t 1647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1647.diff">https://git.openjdk.org/jdk17u-dev/pull/1647.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1647#issuecomment-1669515521)