### PR TITLE
Backport 89711f376751d4cfa05758705867afedfafeb602

### DIFF
--- a/test/jdk/java/awt/Choice/DragOffNoSelectTest.java
+++ b/test/jdk/java/awt/Choice/DragOffNoSelectTest.java
@@ -71,7 +71,7 @@ public class DragOffNoSelectTest implements WindowListener, Runnable {
         }
         frame.add(theChoice);
         frame.addWindowListener(testInstance);
-        frame.setSize(400, 400);
+        frame.pack();
         frame.setLocationRelativeTo(null);
 
         frame.setVisible(true);


### PR DESCRIPTION
Backport of [JDK-8307079](https://bugs.openjdk.org/browse/JDK-8307079). Tested manually on Mac M1.