### PR TITLE
8310551: vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java timed out due to missing prompt

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class interrupt001 extends JdbTest {
     static final String LAST_BREAK      = DEBUGGEE_CLASS + ".breakHere";
     static final String MYTHREAD        = "MyThread";
     static final String DEBUGGEE_THREAD = DEBUGGEE_CLASS + "$" + MYTHREAD;
-    static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notInterrupted.get()";
+    static final String DEBUGGEE_RESULT = DEBUGGEE_CLASS + ".notInterrupted";
 
     static int numThreads = nsk.jdb.interrupt.interrupt001.interrupt001a.numThreads;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,8 +56,8 @@ public class interrupt001a {
                         lock.wait();
                     }
                 } catch (InterruptedException e) {
-                    notInterrupted.decrementAndGet();
                     synchronized (waitnotify) {
+                        notInterrupted--;
                         waitnotify.notify();
                     }
                 }
@@ -83,7 +83,7 @@ public class interrupt001a {
     private JdbArgumentHandler argumentHandler;
     private Log log;
 
-    public static final AtomicInteger notInterrupted = new AtomicInteger(numThreads);
+    public static volatile int notInterrupted = numThreads;
 
     public int runIt(String args[], PrintStream out) {
 
@@ -122,8 +122,8 @@ public class interrupt001a {
 
         long waitTime = argumentHandler.getWaitTime() * 60 * 1000;
         long startTime = System.currentTimeMillis();
-        while (notInterrupted.get() > 0 && System.currentTimeMillis() - startTime <= waitTime) {
-            synchronized (waitnotify) {
+        synchronized (waitnotify) {
+            while (notInterrupted > 0 && System.currentTimeMillis() - startTime <= waitTime) {
                 try {
                     waitnotify.wait(waitTime);
                 } catch (InterruptedException e) {


### PR DESCRIPTION
Backport of [JDK-8310551](https://bugs.openjdk.org/browse/JDK-8310551). Applies cleanly except removal from ProblemList. (Not problem listed in 17u). Test has passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310551](https://bugs.openjdk.org/browse/JDK-8310551): vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java timed out due to missing prompt (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1654/head:pull/1654` \
`$ git checkout pull/1654`

Update a local copy of the PR: \
`$ git checkout pull/1654` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1654`

View PR using the GUI difftool: \
`$ git pr show -t 1654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1654.diff">https://git.openjdk.org/jdk17u-dev/pull/1654.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1654#issuecomment-1671683715)