### PR TITLE
8308232: nsk/jdb tests don't pass -verbose flag to the debuggee

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
@@ -217,6 +217,10 @@ public class Launcher extends DebugeeBinder {
                     }
                 }
                 String cmdline = classToExecute + " " + ArgumentHandler.joinArguments(argumentHandler.getArguments(), " ");
+                cmdline += " -waittime " + argumentHandler.getWaitTime();
+                if (argumentHandler.verbose()) {
+                    cmdline += " -verbose";
+                }
                 connect.append(",main=" + cmdline.trim());
 
             }


### PR DESCRIPTION
Backport of [JDK-8308232](https://bugs.openjdk.org/browse/JDK-8308232). Recognized as clean (context differs because Loom is not it 17u). nsk/jdb tests have passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308232](https://bugs.openjdk.org/browse/JDK-8308232): nsk/jdb tests don't pass -verbose flag to the debuggee (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1655/head:pull/1655` \
`$ git checkout pull/1655`

Update a local copy of the PR: \
`$ git checkout pull/1655` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1655`

View PR using the GUI difftool: \
`$ git pr show -t 1655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1655.diff">https://git.openjdk.org/jdk17u-dev/pull/1655.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1655#issuecomment-1673001681)