### PR TITLE
8297350: Update JMH devkit to 1.36

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -26,7 +26,7 @@
 # Create a bundle in the build directory, containing what's needed to
 # build and run JMH microbenchmarks from the OpenJDK build.
 
-JMH_VERSION=1.35
+JMH_VERSION=1.36
 COMMONS_MATH3_VERSION=3.2
 JOPT_SIMPLE_VERSION=4.6
 


### PR DESCRIPTION
Clean backport to bump to intermediate JMH version. There is a mainline PR pending to bring 1.37 in, it would be backported later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297350](https://bugs.openjdk.org/browse/JDK-8297350): Update JMH devkit to 1.36 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1656/head:pull/1656` \
`$ git checkout pull/1656`

Update a local copy of the PR: \
`$ git checkout pull/1656` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1656`

View PR using the GUI difftool: \
`$ git pr show -t 1656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1656.diff">https://git.openjdk.org/jdk17u-dev/pull/1656.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1656#issuecomment-1673354209)