### PR TITLE
8304353: Add lib-test tier1 testing in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
+          - 'lib-test/tier1'
 
         include:
           - test-name: 'jdk/tier1 part 1'
@@ -96,6 +97,10 @@ jobs:
 
           - test-name: 'hs/tier1 serviceability'
             test-suite: 'test/hotspot/jtreg/:tier1_serviceability'
+            debug-suffix: -debug
+
+          - test-name: 'lib-test/tier1'
+            test-suite: 'test/lib-test/:tier1'
             debug-suffix: -debug
 
     steps:


### PR DESCRIPTION
Clean backport to improve GHA coverage.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304353](https://bugs.openjdk.org/browse/JDK-8304353): Add lib-test tier1 testing in GHA (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1658/head:pull/1658` \
`$ git checkout pull/1658`

Update a local copy of the PR: \
`$ git checkout pull/1658` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1658`

View PR using the GUI difftool: \
`$ git pr show -t 1658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1658.diff">https://git.openjdk.org/jdk17u-dev/pull/1658.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1658#issuecomment-1676948696)