### PR TITLE
8294956: GHA: qemu-debootstrap is deprecated, use the regular one

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: 'Create sysroot'
         run: >
-          sudo qemu-debootstrap
+          sudo debootstrap
           --arch=${{ matrix.debian-arch }}
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev


### PR DESCRIPTION
Clean backport to improve GHA reliability.

Additional testing:
 - [x] GHA (sysroots are re-created successfully)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294956](https://bugs.openjdk.org/browse/JDK-8294956): GHA: qemu-debootstrap is deprecated, use the regular one (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1660/head:pull/1660` \
`$ git checkout pull/1660`

Update a local copy of the PR: \
`$ git checkout pull/1660` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1660`

View PR using the GUI difftool: \
`$ git pr show -t 1660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1660.diff">https://git.openjdk.org/jdk17u-dev/pull/1660.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1660#issuecomment-1676944396)