### PR TITLE
8294941: GHA: Cut down cross-compilation sysroots

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -149,7 +149,9 @@ jobs:
           # Prepare sysroot and remove unused files to minimize cache
           sudo chroot sysroot symlinks -cr .
           sudo chown ${USER} -R sysroot
-          rm -rf sysroot/{dev,proc,run,sys}
+          rm -rf sysroot/{dev,proc,run,sys,var}
+          rm -rf sysroot/usr/{sbin,bin,share}
+          rm -rf sysroot/usr/lib/{apt,udev,systemd}
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Configure'


### PR DESCRIPTION
Clean backport to improve GHA footprint overheads.

Additional testing:
 - [x] GHA (no failures during sysroot re-creation)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294941](https://bugs.openjdk.org/browse/JDK-8294941): GHA: Cut down cross-compilation sysroots (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1661/head:pull/1661` \
`$ git checkout pull/1661`

Update a local copy of the PR: \
`$ git checkout pull/1661` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1661`

View PR using the GUI difftool: \
`$ git pr show -t 1661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1661.diff">https://git.openjdk.org/jdk17u-dev/pull/1661.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1661#issuecomment-1676975997)