### PR TITLE
8312525: New test runtime/os/TestTrimNative.java#trimNative is failing: did not see the expected RSS reduction

### DIFF
--- a/src/hotspot/os/linux/trimCHeapDCmd.cpp
+++ b/src/hotspot/os/linux/trimCHeapDCmd.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "precompiled.hpp"
+#include "logging/log.hpp"
 #include "runtime/os.inline.hpp"
 #include "trimCHeapDCmd.hpp"
 #include "utilities/debug.hpp"
@@ -42,6 +43,9 @@ void TrimCLibcHeapDCmd::execute(DCmdSource source, TRAPS) {
         const char sign = sc.after < sc.before ? '-' : '+';
         _output->print_cr("RSS+Swap: " PROPERFMT "->" PROPERFMT " (%c" PROPERFMT ")",
                           PROPERFMTARGS(sc.before), PROPERFMTARGS(sc.after), sign, PROPERFMTARGS(delta));
+        // Also log if native trim log is active
+        log_info(trimnative)("Manual Trim: " PROPERFMT "->" PROPERFMT " (%c" PROPERFMT ")",
+                             PROPERFMTARGS(sc.before), PROPERFMTARGS(sc.after), sign, PROPERFMTARGS(delta));
       } else {
         _output->print_cr("(no details available).");
       }


### PR DESCRIPTION
Semi-clean follow-up backport to relax the test.

There are no ProblemList additions in 17u, so this changeset does not have the relevant hunk.

Additional testing:
 - [x] Linux x86_64 fastdebug, affected test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312525](https://bugs.openjdk.org/browse/JDK-8312525): New test runtime/os/TestTrimNative.java#trimNative is failing: did not see the expected RSS reduction (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [20e67164](https://git.openjdk.org/jdk17u-dev/pull/1662/files/20e671640c324ba0fd88fcbc44197300515fd837)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1662/head:pull/1662` \
`$ git checkout pull/1662`

Update a local copy of the PR: \
`$ git checkout pull/1662` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1662`

View PR using the GUI difftool: \
`$ git pr show -t 1662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1662.diff">https://git.openjdk.org/jdk17u-dev/pull/1662.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1662#issuecomment-1677030268)