### PR TITLE
8309591: Socket.setOption(TCP_QUICKACK) uses wrong level

### DIFF
--- a/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
+++ b/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ JNIEXPORT void JNICALL Java_jdk_net_LinuxSocketOptions_setQuickAck0
     int optval;
     int rv;
     optval = (on ? 1 : 0);
-    rv = setsockopt(fd, SOL_SOCKET, TCP_QUICKACK, &optval, sizeof (optval));
+    rv = setsockopt(fd, IPPROTO_TCP, TCP_QUICKACK, &optval, sizeof (optval));
     handleError(env, rv, "set option TCP_QUICKACK failed");
 }
 
@@ -96,7 +96,7 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_getQuickAck0
 (JNIEnv *env, jobject unused, jint fd) {
     int on;
     socklen_t sz = sizeof (on);
-    int rv = getsockopt(fd, SOL_SOCKET, TCP_QUICKACK, &on, &sz);
+    int rv = getsockopt(fd, IPPROTO_TCP, TCP_QUICKACK, &on, &sz);
     handleError(env, rv, "get option TCP_QUICKACK failed");
     return on != 0;
 }
@@ -108,7 +108,7 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_getQuickAck0
  */
 JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_quickAckSupported0
 (JNIEnv *env, jobject unused) {
-    return socketOptionSupported(SOL_SOCKET, TCP_QUICKACK);
+    return socketOptionSupported(IPPROTO_TCP, TCP_QUICKACK);
 }
 
 /*


### PR DESCRIPTION
Unclean backport to fix TCP_QUICKACK bug.

The backport is unclean, because AIX hunks could not be applied. The implementation of extended socket options on AIX went into JDK 21 with [JDK-8305089](https://bugs.openjdk.org/browse/JDK-8305089).

Additional testing:
 - [x] Linux AArch64 fastdebug, `jdk_net`
 - [x] Linux AArch64 fastdebug, `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309591](https://bugs.openjdk.org/browse/JDK-8309591): Socket.setOption(TCP_QUICKACK) uses wrong level (**Bug** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1664/head:pull/1664` \
`$ git checkout pull/1664`

Update a local copy of the PR: \
`$ git checkout pull/1664` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1664`

View PR using the GUI difftool: \
`$ git pr show -t 1664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1664.diff">https://git.openjdk.org/jdk17u-dev/pull/1664.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1664#issuecomment-1677127553)