### PR TITLE
8314118: Update JMH devkit to 1.37

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -26,8 +26,8 @@
 # Create a bundle in the build directory, containing what's needed to
 # build and run JMH microbenchmarks from the OpenJDK build.
 
-JMH_VERSION=1.36
-COMMONS_MATH3_VERSION=3.2
+JMH_VERSION=1.37
+COMMONS_MATH3_VERSION=3.6.1
 JOPT_SIMPLE_VERSION=5.0.4
 
 BUNDLE_NAME=jmh-$JMH_VERSION.tar.gz


### PR DESCRIPTION
Clean backport to improve performance testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314118](https://bugs.openjdk.org/browse/JDK-8314118): Update JMH devkit to 1.37 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1666/head:pull/1666` \
`$ git checkout pull/1666`

Update a local copy of the PR: \
`$ git checkout pull/1666` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1666`

View PR using the GUI difftool: \
`$ git pr show -t 1666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1666.diff">https://git.openjdk.org/jdk17u-dev/pull/1666.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1666#issuecomment-1680215728)