### PR TITLE
8314262: GHA: Cut down cross-compilation sysroots deeper

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -151,7 +151,8 @@ jobs:
           sudo chown ${USER} -R sysroot
           rm -rf sysroot/{dev,proc,run,sys,var}
           rm -rf sysroot/usr/{sbin,bin,share}
-          rm -rf sysroot/usr/lib/{apt,udev,systemd}
+          rm -rf sysroot/usr/lib/{apt,gcc,udev,systemd}
+          rm -rf sysroot/usr/libexec/gcc
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Configure'


### PR DESCRIPTION
Clean backport to improve GHA overheads.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314262](https://bugs.openjdk.org/browse/JDK-8314262): GHA: Cut down cross-compilation sysroots deeper (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1668/head:pull/1668` \
`$ git checkout pull/1668`

Update a local copy of the PR: \
`$ git checkout pull/1668` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1668`

View PR using the GUI difftool: \
`$ git pr show -t 1668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1668.diff">https://git.openjdk.org/jdk17u-dev/pull/1668.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1668#issuecomment-1680427651)