### PR TITLE
8314552: Fix javadoc tests to work with jtreg 7

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testSerialVersionUID/TestSerialVersionUID.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerialVersionUID/TestSerialVersionUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,8 @@ public class TestSerialVersionUID extends JavadocTester {
 
     @Test
     public void test() {
-        javadoc("-d", "out",
+        javadoc("-encoding", "UTF-8",
+                "-d", "out",
                 testSrc("C.java"));
         checkExit(Exit.OK);
 

--- a/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ public class TestTagMisuse extends JavadocTester {
 
     @Test
     public void test() {
-        javadoc("-Xdoclint:none",
+        javadoc("-encoding", "UTF-8",
+                "-Xdoclint:none",
                 "-d", "out",
                 testSrc("TestTagMisuse.java"));
         checkExit(Exit.OK);

--- a/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@
                      }
                      """);
 
-         javadoc("-d", base.resolve("out").toString(),
+         javadoc("-encoding", "UTF-8", "-d", base.resolve("out").toString(),
                  "--no-platform-links",
                  src.resolve("C.java").toString());
          checkExit(Exit.OK);

--- a/test/langtools/jdk/javadoc/doclet/testThrowsHead/TestThrowsHead.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsHead/TestThrowsHead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,8 @@ public class TestThrowsHead extends JavadocTester {
 
     @Test
     public void test() {
-        javadoc("-d", "out",
+        javadoc("-encoding", "UTF-8",
+                "-d", "out",
                 testSrc("C.java"));
         checkExit(Exit.OK);
 

--- a/test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,8 @@ public class TestUnnamedPackage extends JavadocTester {
 
     @Test
     public void test() {
-        javadoc("-d", "out",
+        javadoc("-encoding", "UTF-8",
+                "-d", "out",
                 "-sourcepath", testSrc("src1"),
                 testSrc("src1/C.java"));
         checkExit(Exit.OK);
@@ -130,7 +131,8 @@ public class TestUnnamedPackage extends JavadocTester {
 
     @Test
     public void testUse() {
-        javadoc("-d", "out-use",
+        javadoc("-encoding", "UTF-8",
+                "-d", "out-use",
                 "-use",
                 testSrc("src2/A.java"),
                 testSrc("src2/B.java"));

--- a/test/langtools/jdk/javadoc/tool/nonConstExprs/Test.java
+++ b/test/langtools/jdk/javadoc/tool/nonConstExprs/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ public class Test {
     public static void main(String... args) throws Exception {
         File testSrc = new File(System.getProperty("test.src"));
         String[] jdoc_args = {
+            "-encoding", "UTF-8",
             "-d", "out",
             new File(testSrc, Test.class.getSimpleName() + ".java").getPath()
         };


### PR DESCRIPTION
Updating the tests to specify a UTF-8 encoding so that they work with jtreg-7 and the embedded testng jar.

```
bash ./configure --with-jtreg=jtreg-7.3+1
make images
make run-test TEST="jtreg:test/langtools/jdk/javadoc/doclet"
```

All tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314552](https://bugs.openjdk.org/browse/JDK-8314552): Fix javadoc tests to work with jtreg 7 (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1672/head:pull/1672` \
`$ git checkout pull/1672`

Update a local copy of the PR: \
`$ git checkout pull/1672` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1672`

View PR using the GUI difftool: \
`$ git pr show -t 1672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1672.diff">https://git.openjdk.org/jdk17u-dev/pull/1672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1672#issuecomment-1683122485)