### PR TITLE
8314501: Shenandoah: sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java fails

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
@@ -85,10 +85,8 @@ public class HeapSummary extends Tool {
       printValMB("MetaspaceSize            = ", getFlagValue("MetaspaceSize", flagMap));
       printValMB("CompressedClassSpaceSize = ", getFlagValue("CompressedClassSpaceSize", flagMap));
       printValMB("MaxMetaspaceSize         = ", getFlagValue("MaxMetaspaceSize", flagMap));
-      if (heap instanceof ShenandoahHeap) {
-         printValMB("ShenandoahRegionSize     = ", ShenandoahHeapRegion.regionSizeBytes());
-      } else {
-         printValMB("G1HeapRegionSize         = ", HeapRegion.grainBytes());
+      if (heap instanceof G1CollectedHeap) {
+        printValMB("G1HeapRegionSize         = ", HeapRegion.grainBytes());
       }
 
       System.out.println();
@@ -137,6 +135,7 @@ public class HeapSummary extends Tool {
          long num_regions = sh.numOfRegions();
          System.out.println("Shenandoah Heap:");
          System.out.println("   regions   = " + num_regions);
+         printValMB("region size = ", ShenandoahHeapRegion.regionSizeBytes());
          printValMB("capacity  = ", num_regions * ShenandoahHeapRegion.regionSizeBytes());
          printValMB("used      = ", sh.used());
          printValMB("committed = ", sh.committed());

--- a/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
+++ b/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
@@ -57,8 +57,7 @@ public class JMapHeapConfigTest {
         "NewRatio",
         "SurvivorRatio",
         "MetaspaceSize",
-        "CompressedClassSpaceSize",
-        "G1HeapRegionSize"};
+        "CompressedClassSpaceSize"};
 
     // Test can't deal with negative jlongs:
     //  ignoring MaxMetaspaceSize


### PR DESCRIPTION
Clean backport to fix the test failure with Shenandoah.

Additional testing:
 - [x] Test fails with Shenandoah without the fix, passes with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314501](https://bugs.openjdk.org/browse/JDK-8314501): Shenandoah: sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java fails (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1676/head:pull/1676` \
`$ git checkout pull/1676`

Update a local copy of the PR: \
`$ git checkout pull/1676` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1676`

View PR using the GUI difftool: \
`$ git pr show -t 1676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1676.diff">https://git.openjdk.org/jdk17u-dev/pull/1676.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1676#issuecomment-1686009421)