### PR TITLE
8312182: THPs cause huge RSS due to thread start timing issue

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -85,6 +85,15 @@
   product(bool, UseCpuAllocPath, false, DIAGNOSTIC,                     \
           "Use CPU_ALLOC code path in os::active_processor_count ")     \
                                                                         \
+  product(bool, THPStackMitigation, true, DIAGNOSTIC,                   \
+          "If THPs are unconditionally enabled on the system (mode "    \
+          "\"always\"), the JVM will prevent THP from forming in "      \
+          "thread stacks. When disabled, the absence of this mitigation"\
+          "allows THPs to form in thread stacks.")                      \
+                                                                        \
+  develop(bool, DelayThreadStartALot, false,                            \
+          "Artificially delay thread starts randomly for testing.")     \
+                                                                        \
   product(bool, DumpPerfMapAtExit, false, DIAGNOSTIC,                   \
           "Write map file for Linux perf tool at exit")                 \
                                                                         \

--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "hugepages.hpp"
+
+#include "logging/log.hpp"
+#include "logging/logStream.hpp"
+#include "runtime/os.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+
+// Given a file that contains a single (integral) number, return that number in (*out) and true;
+// in case of an error, return false.
+static bool read_number_file(const char* file, size_t* out) {
+  FILE* f = ::fopen(file, "r");
+  bool rc = false;
+  if (f != NULL) {
+    uint64_t i = 0;
+    if (::fscanf(f, SIZE_FORMAT, out) == 1) {
+      rc = true;
+    }
+    ::fclose(f);
+  }
+  return rc;
+}
+
+THPSupport::THPSupport() :
+    _initialized(false), _mode(thp_never), _pagesize(SIZE_MAX) {}
+
+
+THPMode THPSupport::mode() const {
+  assert(_initialized, "Not initialized");
+  return _mode;
+}
+
+size_t THPSupport::pagesize() const {
+  assert(_initialized, "Not initialized");
+  return _pagesize;
+}
+
+void THPSupport::scan_os() {
+  // Scan /sys/kernel/mm/transparent_hugepage/enabled
+  // see mm/huge_memory.c
+  _mode = thp_never;
+  const char* filename = "/sys/kernel/mm/transparent_hugepage/enabled";
+  FILE* f = ::fopen(filename, "r");
+  if (f != NULL) {
+    char buf[64];
+    char* s = fgets(buf, sizeof(buf), f);
+    assert(s == buf, "Should have worked");
+    if (::strstr(buf, "[madvise]") != NULL) {
+      _mode = thp_madvise;
+    } else if (::strstr(buf, "[always]") != NULL) {
+      _mode = thp_always;
+    } else {
+      assert(::strstr(buf, "[never]") != NULL, "Weird content of %s: %s", filename, buf);
+    }
+    fclose(f);
+  }
+
+  // Scan large page size for THP from hpage_pmd_size
+  _pagesize = 0;
+  if (read_number_file("/sys/kernel/mm/transparent_hugepage/hpage_pmd_size", &_pagesize)) {
+    assert(_pagesize > 0, "Expected");
+  }
+  _initialized = true;
+
+  LogTarget(Info, pagesize) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    print_on(&ls);
+  }
+}
+
+void THPSupport::print_on(outputStream* os) {
+  if (_initialized) {
+    os->print_cr("Transparent hugepage (THP) support:");
+    os->print_cr("  THP mode: %s",
+        (_mode == thp_always ? "always" : (_mode == thp_never ? "never" : "madvise")));
+    os->print_cr("  THP pagesize: " SIZE_FORMAT, _pagesize);
+  } else {
+    os->print_cr("  unknown.");
+  }
+}
+
+THPSupport HugePages::_thp_support;
+
+void HugePages::initialize() {
+  _thp_support.scan_os();
+}
+
+void HugePages::print_on(outputStream* os) {
+  _thp_support.print_on(os);
+}

--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_LINUX_HUGEPAGES_HPP
+#define OS_LINUX_HUGEPAGES_HPP
+
+#include "memory/allocation.hpp"
+#include "runtime/os.hpp" // for os::PageSizes
+#include "utilities/globalDefinitions.hpp"
+
+class outputStream;
+
+enum THPMode { thp_always, thp_never, thp_madvise };
+
+// 2) for transparent hugepages
+class THPSupport {
+  bool _initialized;
+
+  // See /sys/kernel/mm/transparent_hugepages/enabled
+  THPMode _mode;
+
+  // Contains the THP page size
+  size_t _pagesize;
+
+public:
+
+  THPSupport();
+
+  // Queries the OS, fills in object
+  void scan_os();
+
+  THPMode mode() const;
+  size_t pagesize() const;
+  void print_on(outputStream* os);
+};
+
+// Umbrella static interface
+class HugePages : public AllStatic {
+
+  static THPSupport _thp_support;
+
+public:
+
+  static const THPSupport& thp_info() { return _thp_support; }
+
+  static THPMode thp_mode()                     { return _thp_support.mode(); }
+  static bool supports_thp()                    { return thp_mode() == thp_madvise || thp_mode() == thp_always; }
+  static size_t thp_pagesize()                  { return _thp_support.pagesize(); }
+
+  static void initialize();
+  static void print_on(outputStream* os);
+};
+
+#endif // OS_LINUX_HUGEPAGES_HPP

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -30,6 +30,7 @@
 #include "code/vtableStubs.hpp"
 #include "compiler/compileBroker.hpp"
 #include "compiler/disassembler.hpp"
+#include "hugepages.hpp"
 #include "interpreter/interpreter.hpp"
 #include "jvmtifiles/jvmti.h"
 #include "logging/log.hpp"
@@ -721,6 +722,10 @@ static void *thread_native_entry(Thread *thread) {
 
   assert(osthread->pthread_id() != 0, "pthread_id was not set as expected");
 
+  if (DelayThreadStartALot) {
+    os::naked_short_sleep(100);
+  }
+
   // call one more level start routine
   thread->call_run();
 
@@ -877,13 +882,16 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   }
   assert(is_aligned(stack_size, os::vm_page_size()), "stack_size not aligned");
 
-  // Add an additional page to the stack size to reduce its chances of getting large page aligned
-  // so that the stack does not get backed by a transparent huge page.
-  size_t default_large_page_size = os::Linux::default_large_page_size();
-  if (default_large_page_size != 0 &&
-      stack_size >= default_large_page_size &&
-      is_aligned(stack_size, default_large_page_size)) {
-    stack_size += os::vm_page_size();
+  if (THPStackMitigation) {
+    // In addition to the glibc guard page that prevents inter-thread-stack hugepage
+    // coalescing (see comment in os::Linux::default_guard_size()), we also make
+    // sure the stack size itself is not huge-page-size aligned; that makes it much
+    // more likely for thread stack boundaries to be unaligned as well and hence
+    // protects thread stacks from being targeted by khugepaged.
+    if (HugePages::thp_pagesize() > 0 &&
+        is_aligned(stack_size, HugePages::thp_pagesize())) {
+      stack_size += os::vm_page_size();
+    }
   }
 
   int status = pthread_attr_setstacksize(&attr, stack_size);
@@ -3135,6 +3143,27 @@ bool os::Linux::libnuma_init() {
 }
 
 size_t os::Linux::default_guard_size(os::ThreadType thr_type) {
+
+  if (THPStackMitigation) {
+    // If THPs are unconditionally enabled, the following scenario can lead to huge RSS
+    // - parent thread spawns, in quick succession, multiple child threads
+    // - child threads are slow to start
+    // - thread stacks of future child threads are adjacent and get merged into one large VMA
+    //   by the kernel, and subsequently transformed into huge pages by khugepaged
+    // - child threads come up, place JVM guard pages, thus splinter the large VMA, splinter
+    //   the huge pages into many (still paged-in) small pages.
+    // The result of that sequence are thread stacks that are fully paged-in even though the
+    // threads did not even start yet.
+    // We prevent that by letting the glibc allocate a guard page, which causes a VMA with different
+    // permission bits to separate two ajacent thread stacks and therefore prevent merging stacks
+    // into one VMA.
+    //
+    // Yes, this means we have two guard sections - the glibc and the JVM one - per thread. But the
+    // cost for that one extra protected page is dwarfed from a large win in performance and memory
+    // that avoiding interference by khugepaged buys us.
+    return os::vm_page_size();
+  }
+
   // Creating guard page is very expensive. Java thread has HotSpot
   // guard pages, only enable glibc guard page for non-Java threads.
   // (Remember: compiler thread is a Java thread, too!)
@@ -3848,7 +3877,25 @@ bool os::Linux::setup_large_page_type(size_t page_size) {
 }
 
 void os::large_page_init() {
-  // Always initialize the default large page size even if large pages are not being used.
+
+  // Query OS information first.
+  HugePages::initialize();
+
+  // If THPs are unconditionally enabled (THP mode "always"), khugepaged may attempt to
+  // coalesce small pages in thread stacks to huge pages. That costs a lot of memory and
+  // is usually unwanted for thread stacks. Therefore we attempt to prevent THP formation in
+  // thread stacks unless the user explicitly allowed THP formation by manually disabling
+  // -XX:-THPStackMitigation.
+  if (HugePages::thp_mode() == thp_always) {
+    if (THPStackMitigation) {
+      log_info(pagesize)("JVM will attempt to prevent THPs in thread stacks.");
+    } else {
+      log_info(pagesize)("JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+    }
+  } else {
+    FLAG_SET_ERGO(THPStackMitigation, false); // Mitigation not needed
+  }
+
   size_t default_large_page_size = scan_default_large_page_size();
   os::Linux::_default_large_page_size = default_large_page_size;
 

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.io.*;
+import java.util.Set;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class HugePageConfiguration {
+
+    Set<Long> _staticHugePageSizes;
+    long _staticDefaultHugePageSize;
+
+    enum THPMode {always, never, madvise, unknown}
+    THPMode _thpMode;
+    long _thpPageSize;
+
+    public Set<Long> getStaticHugePageSizes() {
+        return _staticHugePageSizes;
+    }
+
+    public long getStaticDefaultHugePageSize() {
+        return _staticDefaultHugePageSize;
+    }
+
+    public THPMode getThpMode() {
+        return _thpMode;
+    }
+
+    public long getThpPageSize() {
+        return _thpPageSize;
+    }
+
+    public HugePageConfiguration(Set<Long> _staticHugePageSizes, long _staticDefaultHugePageSize, THPMode _thpMode, long _thpPageSize) {
+        this._staticHugePageSizes = _staticHugePageSizes;
+        this._staticDefaultHugePageSize = _staticDefaultHugePageSize;
+        this._thpMode = _thpMode;
+        this._thpPageSize = _thpPageSize;
+    }
+
+    @Override
+    public String toString() {
+        return "Configuration{" +
+                "_staticHugePageSizes=" + _staticHugePageSizes +
+                ", _staticDefaultHugePageSize=" + _staticDefaultHugePageSize +
+                ", _thpMode=" + _thpMode +
+                ", _thpPageSize=" + _thpPageSize +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        HugePageConfiguration that = (HugePageConfiguration) o;
+        return _staticDefaultHugePageSize == that._staticDefaultHugePageSize && _thpPageSize == that._thpPageSize && Objects.equals(_staticHugePageSizes, that._staticHugePageSizes) && _thpMode == that._thpMode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_staticHugePageSizes, _staticDefaultHugePageSize, _thpMode, _thpPageSize);
+    }
+
+    private static long readDefaultHugePageSizeFromOS() {
+        Pattern pat = Pattern.compile("Hugepagesize: *(\\d+) +kB");
+        long result = 0;
+        try (Scanner scanner = new Scanner(new File("/proc/meminfo"))) {
+            while (scanner.hasNextLine()) {
+                Matcher mat = pat.matcher(scanner.nextLine());
+                if (mat.matches()) {
+                    scanner.close();
+                    return Long.parseLong(mat.group(1)) * 1024;
+                }
+            }
+        } catch (FileNotFoundException e) {
+            System.out.println("Could not open /proc/meminfo");
+        }
+        return 0;
+    }
+
+    private static Set<Long> readSupportedHugePagesFromOS() {
+        TreeSet<Long> pagesizes = new TreeSet<>();
+        Pattern pat = Pattern.compile("hugepages-(\\d+)kB");
+        File[] subdirs = new File("/sys/kernel/mm/hugepages").listFiles();
+        if (subdirs != null) {
+            for (File f : subdirs) {
+                String name = f.getName();
+                Matcher mat = pat.matcher(name);
+                if (mat.matches()) {
+                    long pagesize = Long.parseLong(mat.group(1)) * 1024;
+                    pagesizes.add(pagesize);
+                }
+            }
+        }
+        return pagesizes;
+    }
+
+    private static THPMode readTHPModeFromOS() {
+        THPMode mode = THPMode.unknown;
+        String file = "/sys/kernel/mm/transparent_hugepage/enabled";
+        try (FileReader fr = new FileReader(file);
+             BufferedReader reader = new BufferedReader(fr)) {
+            String s = reader.readLine();
+            if (s.contains("[never]")) {
+                mode = THPMode.never;
+            } else if (s.contains("[always]")) {
+                mode = THPMode.always;
+            } else if (s.contains("[madvise]")) {
+                mode = THPMode.madvise;
+            } else {
+                throw new RuntimeException("Unexpected content of " + file + ": " + s);
+            }
+        } catch (IOException e) {
+            System.out.println("Failed to read " + file);
+            mode = THPMode.unknown;
+        }
+        return mode;
+    }
+
+    private static long readTHPPageSizeFromOS() {
+        long pagesize = 0;
+        String file = "/sys/kernel/mm/transparent_hugepage/hpage_pmd_size";
+        try (FileReader fr = new FileReader(file);
+             BufferedReader reader = new BufferedReader(fr)) {
+            String s = reader.readLine();
+            pagesize = Long.parseLong(s);
+        } catch (IOException | NumberFormatException e) { /* ignored */ }
+        return pagesize;
+    }
+
+    // Fill object with info read from proc file system
+    public static HugePageConfiguration readFromOS() {
+        return new HugePageConfiguration(readSupportedHugePagesFromOS(),
+                readDefaultHugePageSizeFromOS(),
+                readTHPModeFromOS(),
+                readTHPPageSizeFromOS());
+    }
+
+    private static long parseSIUnit(String num, String unit) {
+        long n = Long.parseLong(num);
+        if (unit.equals("K")) {
+            return n * 1024;
+        } else if (unit.equals("M")) {
+            return n * 1024 * 1024;
+        } else if (unit.equals("G")) {
+            return n * 1024 * 1024 * 1024;
+        }
+        throw new RuntimeException("Invalid unit " + unit);
+    }
+
+    public static HugePageConfiguration readFromJVMLog(OutputAnalyzer output) {
+        // Expects output from -Xlog:pagesize
+        // Example:
+        // [0.001s][info][pagesize] Static hugepage support:
+        // [0.001s][info][pagesize]   hugepage size: 2M
+        // [0.001s][info][pagesize]   hugepage size: 1G
+        // [0.001s][info][pagesize]   default hugepage size: 2M
+        // [0.001s][info][pagesize] Transparent hugepage (THP) support:
+        // [0.001s][info][pagesize]   THP mode: madvise
+        // [0.001s][info][pagesize]   THP pagesize: 2M
+        TreeSet<Long> hugepages = new TreeSet<>();
+        long defaultHugepageSize = 0;
+        THPMode thpMode = THPMode.never;
+        long thpPageSize = 0;
+        Pattern patternHugepageSize = Pattern.compile(".*\\[pagesize] *hugepage size: (\\d+)([KMG])");
+        Pattern patternDefaultHugepageSize = Pattern.compile(".*\\[pagesize] *default hugepage size: (\\d+)([KMG]) *");
+        Pattern patternTHPPageSize = Pattern.compile(".*\\[pagesize] *THP pagesize: (\\d+)([KMG])");
+        Pattern patternTHPMode = Pattern.compile(".*\\[pagesize] *THP mode: (\\S+)");
+        List<String> lines = output.asLines();
+        for (String s : lines) {
+            Matcher mat = patternHugepageSize.matcher(s);
+            if (mat.matches()) {
+                hugepages.add(parseSIUnit(mat.group(1), mat.group(2)));
+                continue;
+            }
+            if (defaultHugepageSize == 0) {
+                mat = patternDefaultHugepageSize.matcher(s);
+                if (mat.matches()) {
+                    defaultHugepageSize = parseSIUnit(mat.group(1), mat.group(2));
+                    continue;
+                }
+            }
+            if (thpPageSize == 0) {
+                mat = patternTHPPageSize.matcher(s);
+                if (mat.matches()) {
+                    thpPageSize = parseSIUnit(mat.group(1), mat.group(2));
+                    continue;
+                }
+            }
+            mat = patternTHPMode.matcher(s);
+            if (mat.matches()) {
+                thpMode = THPMode.valueOf(mat.group(1));
+            }
+        }
+
+        return new HugePageConfiguration(hugepages, defaultHugepageSize, thpMode, thpPageSize);
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=ENABLED
+ * @bug 8303215 8312182
+ * @summary On THP=always systems, we prevent THPs from forming within thread stacks
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver THPsInThreadStackPreventionTest PATCH-ENABLED
+ */
+
+/*
+ * @test id=DISABLED
+ * @bug 8303215 8312182
+ * @summary On THP=always systems, we prevent THPs from forming within thread stacks (negative test)
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires vm.debug
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main/manual THPsInThreadStackPreventionTest  PATCH-DISABLED
+ */
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+public class THPsInThreadStackPreventionTest {
+
+    // We test the mitigation for "huge rss for THP=always" introduced with JDK-8312182 and JDK-8302015:
+    //
+    // We start a program that spawns a ton of threads with a stack size close to THP page size. The threads
+    // are idle and should not build up a lot of stack. The threads are started with an artificial delay
+    // between thread start and stack guardpage creation, which exacerbates the RSS bloat (for explanation
+    // please see 8312182).
+    //
+    // We then observe RSS of that program. We expect it to stay below a reasonable maximum. The unpatched
+    // version should show an RSS of ~2 GB (paying for the fully paged in thread stacks). The fixed variant should
+    // cost only ~200-400 MB.
+
+    static final int numThreads = 1000;
+    static final long threadStackSizeMB = 2; // must be 2M
+    static final long heapSizeMB = 64;
+    static final long basicRSSOverheadMB = heapSizeMB + 150;
+    // A successful completion of this test would show not more than X KB per thread stack.
+    static final long acceptableRSSPerThreadStack = 128 * 1024;
+    static final long acceptableRSSForAllThreadStacks = numThreads * acceptableRSSPerThreadStack;
+    static final long acceptableRSSLimitMB = (acceptableRSSForAllThreadStacks / (1024 * 1024)) + basicRSSOverheadMB;
+
+    private static class TestMain {
+
+        static class Sleeper extends Thread {
+            CyclicBarrier barrier;
+            public Sleeper(CyclicBarrier barrier) {
+                this.barrier = barrier;
+            }
+            @Override
+            public void run() {
+                try {
+                    barrier.await(); // wait for all siblings
+                    barrier.await(); // wait main thread to print status
+                } catch (InterruptedException | BrokenBarrierException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public static void main(String[] args) throws BrokenBarrierException, InterruptedException {
+
+            // Fire up 1000 threads with 2M stack size each.
+            Sleeper[] threads = new Sleeper[numThreads];
+            CyclicBarrier barrier = new CyclicBarrier(numThreads + 1);
+
+            for (int i = 0; i < numThreads; i++) {
+                threads[i] = new Sleeper(barrier);
+                threads[i].start();
+            }
+
+            // Wait for all threads to come up
+            barrier.await();
+
+            // print status
+            String file = "/proc/self/status";
+            try (FileReader fr = new FileReader(file);
+                 BufferedReader reader = new BufferedReader(fr)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    System.out.println(line);
+                }
+            } catch (IOException | NumberFormatException e) { /* ignored */ }
+
+            // Signal threads to stop
+            barrier.await();
+
+        }
+    }
+
+    static class ProcSelfStatus {
+
+        public long rssMB;
+        public long swapMB;
+        public int numLifeThreads;
+
+        // Parse output from /proc/self/status
+        public static ProcSelfStatus parse(OutputAnalyzer o) {
+            ProcSelfStatus status = new ProcSelfStatus();
+            String s = o.firstMatch("Threads:\\s*(\\d+)", 1);
+            Objects.requireNonNull(s);
+            status.numLifeThreads = Integer.parseInt(s);
+            s = o.firstMatch("VmRSS:\\s*(\\d+) kB", 1);
+            Objects.requireNonNull(s);
+            status.rssMB = Long.parseLong(s) / 1024;
+            s = o.firstMatch("VmSwap:\\s*(\\d+) kB", 1);
+            Objects.requireNonNull(s);
+            status.swapMB = Long.parseLong(s) / 1024;
+            return status;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        HugePageConfiguration config = HugePageConfiguration.readFromOS();
+        // This issue is bound to THP=always
+        if (config.getThpMode() != HugePageConfiguration.THPMode.always) {
+            throw new SkippedException("Test only makes sense in THP \"always\" mode");
+        }
+
+        String[] defaultArgs = {
+            "-Xlog:pagesize",
+            "-Xmx" + heapSizeMB + "m", "-Xms" + heapSizeMB + "m", "-XX:+AlwaysPreTouch", // stabilize RSS
+            "-Xss" + threadStackSizeMB + "m",
+            "-XX:-CreateCoredumpOnCrash",
+            // Limits the number of JVM-internal threads, which depends on the available cores of the
+            // machine. RSS+Swap could exceed acceptableRSSLimitMB when JVM creates many internal threads.
+            "-XX:ActiveProcessorCount=2",
+            // This will delay the child threads before they create guard pages, thereby greatly increasing the
+            // chance of large VMA formation + hugepage coalescation; see JDK-8312182
+            "-XX:+DelayThreadStartALot"
+        };
+        ArrayList<String> finalargs = new ArrayList<>(Arrays.asList(defaultArgs));
+
+        switch (args[0]) {
+            case "PATCH-ENABLED": {
+                finalargs.add(TestMain.class.getName());
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
+
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+                output.shouldHaveExitValue(0);
+
+                // this line indicates the mitigation is active:
+                output.shouldContain("[pagesize] JVM will attempt to prevent THPs in thread stacks.");
+
+                ProcSelfStatus status = ProcSelfStatus.parse(output);
+                if (status.numLifeThreads < numThreads) {
+                    throw new RuntimeException("Number of live threads lower than expected: " + status.numLifeThreads + ", expected " + numThreads);
+                } else {
+                    System.out.println("Found " + status.numLifeThreads + " to be alive. Ok.");
+                }
+
+                long rssPlusSwapMB = status.swapMB + status.rssMB;
+
+                if (rssPlusSwapMB > acceptableRSSLimitMB) {
+                    throw new RuntimeException("RSS+Swap larger than expected: " + rssPlusSwapMB + "m, expected at most " + acceptableRSSLimitMB + "m");
+                } else {
+                    if (rssPlusSwapMB < heapSizeMB) { // we pretouch the java heap, so we expect to see at least that:
+                        throw new RuntimeException("RSS+Swap suspiciously low: " + rssPlusSwapMB + "m, expected at least " + heapSizeMB + "m");
+                    }
+                    System.out.println("Okay: RSS+Swap=" + rssPlusSwapMB + ", within acceptable limit of " + acceptableRSSLimitMB);
+                }
+            }
+            break;
+
+            case "PATCH-DISABLED": {
+
+                // Only execute manually! this will allocate ~2gb of memory!
+
+                // explicitly disable the no-THP-workaround:
+                finalargs.add("-XX:+UnlockDiagnosticVMOptions");
+                finalargs.add("-XX:-THPStackMitigation");
+
+                finalargs.add(TestMain.class.getName());
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);
+                OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+                output.shouldHaveExitValue(0);
+
+                // We deliberately switched off mitigation, VM should tell us:
+                output.shouldContain("[pagesize] JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
+
+                // Parse output from self/status
+                ProcSelfStatus status = ProcSelfStatus.parse(output);
+                if (status.numLifeThreads < numThreads) {
+                    throw new RuntimeException("Number of live threads lower than expected (" + status.numLifeThreads + ", expected " + numThreads +")");
+                } else {
+                    System.out.println("Found " + status.numLifeThreads + " to be alive. Ok.");
+                }
+
+                long rssPlusSwapMB = status.swapMB + status.rssMB;
+
+                if (rssPlusSwapMB < acceptableRSSLimitMB) {
+                    throw new RuntimeException("RSS+Swap lower than expected: " + rssPlusSwapMB + "m, expected more than " + acceptableRSSLimitMB + "m");
+                }
+                break;
+            }
+
+            default: throw new RuntimeException("Bad argument: " + args[0]);
+        }
+    }
+}


### PR DESCRIPTION
Unclean composite backport to jdk17u. Fixes JDK-8312182 - "THPs cause huge RSS due to thread start timing issue" (https://bugs.openjdk.org/browse/JDK-8312182)

Problem:

On a machine with transparent huge pages (THP) unconditionally enabled (/sys/kernel/mm/transparent_hugepage/enabled = "always"), the JVM may show a huge memory footprint (RSS) and degraded thread start performance.

The following factors make the problem more severe and more likely:
- thread stack size of 2M (on arm64 or x64) or larger
- many threads, or high thread creation churn
- a slow or overloaded machine (since part of the problem is timing-dependent)

For a detailed discussion of the underlying problem, please see https://github.com/openjdk/jdk/pull/14919.

----------------

In jdk Head, the issue got fixed with a sequence of patches:

- [JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215) "Make thread stacks not use huge pages"
- [JDK-8312182](https://bugs.openjdk.org/browse/JDK-8312182) "THPs cause huge RSS due to thread start timing"

However, JDK-8312182 itself needed one preparatory fix:
- [JDK-8310233](https://bugs.openjdk.org/browse/JDK-8310233) "Fix THP detection on Linux"

and then we had several corner-case test problems which are fixed with:
- [JDK-8312394](https://bugs.openjdk.org/browse/JDK-8312394) "[linux] SIGSEGV if kernel was built without hugepage support"
- [JDK-8312620](https://bugs.openjdk.org/browse/JDK-8312620) "WSL Linux build crashes after JDK-8310233"
- [JDK-8314139](https://bugs.openjdk.org/browse/JDK-8314139) "TEST_BUG: runtime/os/THPsInThreadStackPreventionTest.java could fail on machine with large number of cores"

and finally, we decided to rename the switch that allows to switch off the THP mitigation with a final patch:
- [JDK-8312585](https://bugs.openjdk.org/browse/JDK-8312585) "Rename DisableTHPStackMitigation flag to THPStackMitigation"


Instead of downporting these 7 patches verbatim, I prepared a composite patch containing only the necessary mitigation and mitigation tests.

This is similar to the [jdk11u downport](https://github.com/openjdk/jdk11u-dev/pull/2086), but in jdk17u, [JDK-8303215](https://bugs.openjdk.org/browse/JDK-8303215) had been already backported. Therefore there are some minor differences.

This patch does:
- make sure that all thread stacks have at least one glibc guard page to prevent clustering of adjacent thread stacks into one VMA
- change the default size of stacks to be not aligned to 2MB to prevent intra-stack THPs from forming

The patch needs some infrastructure, but I downported only the necessary parts: the helper class "HugePages", which is used in head to scan the operating system for information about THP settings. I only included the parts to do with THPs and left the rest out.

The patch also includes a regression test.

------

Testing:

I manually tested the JVM on Linux x64 with THP=always:

Without the patch (-Xmx1g -Xms1g -XX:+AlwaysPreTouch -Xss2m, 10000 threads started), I see slow thread startup and *11 GB - 14 GB* of RSS.

The patched version comes up a lot faster and only shows *1.3* GB of RSS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8312182](https://bugs.openjdk.org/browse/JDK-8312182): THPs cause huge RSS due to thread start timing issue (**Bug** - P3)
 * [JDK-8310687](https://bugs.openjdk.org/browse/JDK-8310687): JDK-8303215 is incomplete (**Bug** - P4)
 * [JDK-8310233](https://bugs.openjdk.org/browse/JDK-8310233): Fix THP detection on Linux (**Bug** - P4)
 * [JDK-8312394](https://bugs.openjdk.org/browse/JDK-8312394): [linux] SIGSEGV if kernel was built without hugepage support (**Bug** - P3)
 * [JDK-8312620](https://bugs.openjdk.org/browse/JDK-8312620): WSL Linux build crashes after JDK-8310233 (**Bug** - P3)
 * [JDK-8314139](https://bugs.openjdk.org/browse/JDK-8314139): TEST_BUG: runtime/os/THPsInThreadStackPreventionTest.java could fail on machine with large number of cores (**Bug** - P4)
 * [JDK-8312585](https://bugs.openjdk.org/browse/JDK-8312585): Rename DisableTHPStackMitigation flag to THPStackMitigation (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1679/head:pull/1679` \
`$ git checkout pull/1679`

Update a local copy of the PR: \
`$ git checkout pull/1679` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1679`

View PR using the GUI difftool: \
`$ git pr show -t 1679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1679.diff">https://git.openjdk.org/jdk17u-dev/pull/1679.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1679#issuecomment-1686620890)