### PR TITLE
8313701: GHA: RISC-V should use the official repository for bootstrap

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -86,7 +86,7 @@ jobs:
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
-            debian-repository: https://deb.debian.org/debian-ports
+            debian-repository: https://httpredir.debian.org/debian/
             debian-version: sid
 
     steps:


### PR DESCRIPTION
Unclean backport to improve GHA stability. The conflict is due to RISC-V GHA changes of the slightly different form in 17u: does not have explicit `keyring` handling blocks. That block is going away with another clean up upstream, so I just resolved the conflict to only update the `debian-repository` itself.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313701](https://bugs.openjdk.org/browse/JDK-8313701): GHA: RISC-V should use the official repository for bootstrap (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1680/head:pull/1680` \
`$ git checkout pull/1680`

Update a local copy of the PR: \
`$ git checkout pull/1680` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1680`

View PR using the GUI difftool: \
`$ git pr show -t 1680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1680.diff">https://git.openjdk.org/jdk17u-dev/pull/1680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1680#issuecomment-1686455328)