### PR TITLE
8314658: [17u] GHA: Sync up debian-version for cross-builds

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -66,23 +66,23 @@ jobs:
             gnu-arch: aarch64
             debian-arch: arm64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: buster
+            debian-version: bullseye
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: buster
+            debian-version: bullseye
             gnu-abi: eabihf
           - target-cpu: s390x
             gnu-arch: s390x
             debian-arch: s390x
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: buster
+            debian-version: bullseye
           - target-cpu: ppc64le
             gnu-arch: powerpc64le
             debian-arch: ppc64el
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: buster
+            debian-version: bullseye
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64


### PR DESCRIPTION
[JDK-8283929](https://bugs.openjdk.org/browse/JDK-8283929) brought the change to cross-compilation configs that bootstrapped with "buster". This was a deviation from the original change, AFAICS because the runners were still on Ubuntu 20.04.

After the upgrade to Ubuntu 22.04 runner with [JDK-8312511](https://bugs.openjdk.org/browse/JDK-8312511), it would make more sense to bootstrap with "bullseye", like current mainline that also runs with 22.04 does. This avoids accidental infra breakages that would be only detectable on 17u, not on mainline.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314658](https://bugs.openjdk.org/browse/JDK-8314658): [17u] GHA: Sync up debian-version for cross-builds (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1681/head:pull/1681` \
`$ git checkout pull/1681`

Update a local copy of the PR: \
`$ git checkout pull/1681` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1681`

View PR using the GUI difftool: \
`$ git pr show -t 1681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1681.diff">https://git.openjdk.org/jdk17u-dev/pull/1681.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1681#issuecomment-1686513658)