### PR TITLE
8276651: java/lang/ProcessHandle tests fail with "RuntimeException: Input/output error" in java.lang.ProcessHandleImpl$Info.info0

### DIFF
--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -272,7 +272,8 @@ void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
         mib[2] = pid;
         size = (size_t) maxargs;
         if (sysctl(mib, 3, args, &size, NULL, 0) == -1) {
-            if (errno != EINVAL) {
+            if (errno != EINVAL && errno != EIO) {
+                // If the pid is invalid, the information returned is empty and no exception
                 JNU_ThrowByNameWithLastError(env,
                     "java/lang/RuntimeException", "sysctl failed");
             }
@@ -300,4 +301,3 @@ void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
     // Free the arg buffer
     free(args);
 }
-


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276651](https://bugs.openjdk.org/browse/JDK-8276651): java/lang/ProcessHandle tests fail with "RuntimeException: Input/output error" in java.lang.ProcessHandleImpl$Info.info0 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1685/head:pull/1685` \
`$ git checkout pull/1685`

Update a local copy of the PR: \
`$ git checkout pull/1685` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1685`

View PR using the GUI difftool: \
`$ git pr show -t 1685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1685.diff">https://git.openjdk.org/jdk17u-dev/pull/1685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1685#issuecomment-1688324662)