### PR TITLE
8313874: JNI NewWeakGlobalRef throws exception for null arg

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2918,7 +2918,7 @@ JNI_ENTRY(jweak, jni_NewWeakGlobalRef(JNIEnv *env, jobject ref))
   HOTSPOT_JNI_NEWWEAKGLOBALREF_ENTRY(env, ref);
   Handle ref_handle(thread, JNIHandles::resolve(ref));
   jweak ret = JNIHandles::make_weak_global(ref_handle, AllocFailStrategy::RETURN_NULL);
-  if (ret == NULL) {
+  if (ret == NULL && ref_handle.not_null()) {
     THROW_OOP_(Universe::out_of_memory_error_c_heap(), NULL);
   }
   HOTSPOT_JNI_NEWWEAKGLOBALREF_RETURN(ret);

--- a/test/hotspot/jtreg/runtime/jni/ReturnJNIWeak/ReturnJNIWeak.java
+++ b/test/hotspot/jtreg/runtime/jni/ReturnJNIWeak/ReturnJNIWeak.java
@@ -123,9 +123,19 @@ public final class ReturnJNIWeak {
         }
     }
 
+    // Verify passing a null value returns null and doesn't throw.
+    private static void testNullValue() {
+        System.out.println("running testNullValue");
+        registerObject(null);
+        if (getObject() != null) {
+            throw new RuntimeException("expected null");
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         testSanity();
         testSurvival();
         testClear();
+        testNullValue();
     }
 }


### PR DESCRIPTION
Nearly clean backport for https://bugs.openjdk.org/browse/JDK-8313874, the only difference is 17 using `NULL` compared to `nullptr` in tip required a manual (but trivial) merge.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313874](https://bugs.openjdk.org/browse/JDK-8313874): JNI NewWeakGlobalRef throws exception for null arg (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1688/head:pull/1688` \
`$ git checkout pull/1688`

Update a local copy of the PR: \
`$ git checkout pull/1688` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1688`

View PR using the GUI difftool: \
`$ git pr show -t 1688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1688.diff">https://git.openjdk.org/jdk17u-dev/pull/1688.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1688#issuecomment-1689703810)