### PR TITLE
8312535: MidiSystem.getSoundbank() throws unexpected SecurityException

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/JARSoundbankReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/JARSoundbankReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -40,6 +41,7 @@ import javax.sound.midi.Soundbank;
 import javax.sound.midi.spi.SoundbankReader;
 
 import sun.reflect.misc.ReflectUtil;
+import sun.security.action.GetBooleanAction;
 
 /**
  * JarSoundbankReader is used to read soundbank object from jar files.
@@ -48,12 +50,15 @@ import sun.reflect.misc.ReflectUtil;
  */
 public final class JARSoundbankReader extends SoundbankReader {
 
-    /*
-     * Name of the system property that enables the Jar soundbank loading
-     * true if jar sound bank is allowed to be loaded
-     * default is false
+    /**
+     * Value of the system property that enables the Jar soundbank loading
+     * {@code true} if jar sound bank is allowed to be loaded default is
+     * {@code false}.
      */
-    private final static String JAR_SOUNDBANK_ENABLED = "jdk.sound.jarsoundbank";
+    @SuppressWarnings("removal")
+    private static final boolean JAR_SOUNDBANK_ENABLED =
+            AccessController.doPrivileged(
+                    new GetBooleanAction("jdk.sound.jarsoundbank"));
 
     private static boolean isZIP(URL url) {
         boolean ok = false;
@@ -81,7 +86,7 @@ public final class JARSoundbankReader extends SoundbankReader {
     public Soundbank getSoundbank(URL url)
             throws InvalidMidiDataException, IOException {
         Objects.requireNonNull(url);
-        if (!Boolean.getBoolean(JAR_SOUNDBANK_ENABLED) || !isZIP(url))
+        if (!JAR_SOUNDBANK_ENABLED || !isZIP(url))
             return null;
 
         ArrayList<Soundbank> soundbanks = new ArrayList<>();

--- a/test/jdk/javax/sound/midi/Soundbanks/GetSoundBankSecurityException/GetSoundBankSecurityException.java
+++ b/test/jdk/javax/sound/midi/Soundbanks/GetSoundBankSecurityException/GetSoundBankSecurityException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import javax.sound.midi.InvalidMidiDataException;
+import javax.sound.midi.MidiSystem;
+
+/**
+ * @test
+ * @bug 8312535
+ * @summary MidiSystem.getSoundbank() throws unexpected SecurityException
+ * @run main/othervm/policy=security.policy GetSoundBankSecurityException
+ */
+public final class GetSoundBankSecurityException {
+
+    public static void main(String[] args) throws Exception {
+        File tempFile = new File("sound.bank");
+        tempFile.createNewFile();
+        try {
+            MidiSystem.getSoundbank(tempFile);
+            throw new RuntimeException("InvalidMidiDataException is expected");
+        } catch (InvalidMidiDataException ignore) {
+        } finally {
+            Files.delete(Paths.get(tempFile.getAbsolutePath()));
+        }
+    }
+}

--- a/test/jdk/javax/sound/midi/Soundbanks/GetSoundBankSecurityException/security.policy
+++ b/test/jdk/javax/sound/midi/Soundbanks/GetSoundBankSecurityException/security.policy
@@ -1,0 +1,4 @@
+grant {
+    permission java.io.FilePermission "*", "read,write,delete";
+    permission java.util.PropertyPermission  "user.dir",  "read";
+};


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [87298d2a](https://github.com/openjdk/jdk/commit/87298d2ade41c689d3140981a123b0e9130fc651) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 22 Aug 2023 and was reviewed by Phil Race.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312535](https://bugs.openjdk.org/browse/JDK-8312535): MidiSystem.getSoundbank() throws unexpected SecurityException (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1689/head:pull/1689` \
`$ git checkout pull/1689`

Update a local copy of the PR: \
`$ git checkout pull/1689` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1689`

View PR using the GUI difftool: \
`$ git pr show -t 1689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1689.diff">https://git.openjdk.org/jdk17u-dev/pull/1689.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1689#issuecomment-1692199991)