### PR TITLE
8283724: Incorrect description for jtreg-failure-handler option

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -508,7 +508,7 @@ AC_DEFUN_ONCE([JDKOPT_ENABLE_DISABLE_FAILURE_HANDLER],
 [
   UTIL_ARG_ENABLE(NAME: jtreg-failure-handler, DEFAULT: auto,
       RESULT: BUILD_FAILURE_HANDLER,
-      DESC: [enable keeping of packaged modules in jdk image],
+      DESC: [enable building of the jtreg failure handler],
       DEFAULT_DESC: [enabled if jtreg is present],
       CHECKING_MSG: [if the jtreg failure handler should be built],
       CHECK_AVAILABLE: [


### PR DESCRIPTION
Trivial clean backport to improve context for other backports in this area.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283724](https://bugs.openjdk.org/browse/JDK-8283724): Incorrect description for jtreg-failure-handler option (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1692/head:pull/1692` \
`$ git checkout pull/1692`

Update a local copy of the PR: \
`$ git checkout pull/1692` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1692`

View PR using the GUI difftool: \
`$ git pr show -t 1692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1692.diff">https://git.openjdk.org/jdk17u-dev/pull/1692.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1692#issuecomment-1691799118)