### PR TITLE
8312620: WSL Linux build crashes after JDK-8310233

### DIFF
--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -52,6 +52,9 @@ class StaticHugePageSupport {
   // - is the size one gets when using mmap(MAP_HUGETLB) when omitting size specifiers like MAP_HUGE_SHIFT)
   size_t _default_hugepage_size;
 
+  // If true, the kernel support for hugepages is inconsistent
+  bool _inconsistent;
+
 public:
   StaticHugePageSupport();
 
@@ -60,6 +63,8 @@ public:
   os::PageSizes pagesizes() const;
   size_t default_hugepage_size() const;
   void print_on(outputStream* os);
+
+  bool inconsistent() const { return _inconsistent; }
 };
 
 enum class THPMode { always, never, madvise };
@@ -98,7 +103,7 @@ public:
   static const THPSupport& thp_info() { return _thp_support; }
 
   static size_t default_static_hugepage_size()  { return _static_hugepage_support.default_hugepage_size(); }
-  static bool supports_static_hugepages()       { return default_static_hugepage_size() > 0; }
+  static bool supports_static_hugepages()       { return default_static_hugepage_size() > 0 && !_static_hugepage_support.inconsistent(); }
   static THPMode thp_mode()                     { return _thp_support.mode(); }
   static bool supports_thp()                    { return thp_mode() == THPMode::madvise || thp_mode() == THPMode::always; }
   static size_t thp_pagesize()                  { return _thp_support.pagesize(); }

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDetection.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDetection.java
@@ -29,14 +29,14 @@
  * @requires os.family == "linux"
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver HugePageDetection
+ * @run driver TestHugePageDetection
  */
 
 import java.util.*;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
-public class HugePageDetection {
+public class TestHugePageDetection {
 
     public static void main(String[] args) throws Exception {
 


### PR DESCRIPTION
Clean backport (based on https://github.com/openjdk/jdk17u-dev/pull/1695), fixes an issue where the build on Windows WSL was failing post-8310233.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312620](https://bugs.openjdk.org/browse/JDK-8312620): WSL Linux build crashes after JDK-8310233 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1696/head:pull/1696` \
`$ git checkout pull/1696`

Update a local copy of the PR: \
`$ git checkout pull/1696` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1696`

View PR using the GUI difftool: \
`$ git pr show -t 1696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1696.diff">https://git.openjdk.org/jdk17u-dev/pull/1696.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1696#issuecomment-1698814284)