### PR TITLE
8312585: Rename DisableTHPStackMitigation flag to THPStackMitigation

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -98,10 +98,10 @@
           "to disable both the override and the printouts."             \
           "See prctl(PR_SET_TIMERSLACK) for more info.")                \
                                                                         \
-  product(bool, DisableTHPStackMitigation, false, DIAGNOSTIC,           \
+  product(bool, THPStackMitigation, true, DIAGNOSTIC,                   \
           "If THPs are unconditionally enabled on the system (mode "    \
           "\"always\"), the JVM will prevent THP from forming in "      \
-          "thread stacks. This switch disables that mitigation and "    \
+          "thread stacks. When disabled, the absence of this mitigation"\
           "allows THPs to form in thread stacks.")                      \
                                                                         \
   develop(bool, DelayThreadStartALot, false,                            \

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -882,7 +882,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   }
   assert(is_aligned(stack_size, os::vm_page_size()), "stack_size not aligned");
 
-  if (!DisableTHPStackMitigation) {
+  if (THPStackMitigation) {
     // In addition to the glibc guard page that prevents inter-thread-stack hugepage
     // coalescing (see comment in os::Linux::default_guard_size()), we also make
     // sure the stack size itself is not huge-page-size aligned; that makes it much
@@ -3144,7 +3144,7 @@ bool os::Linux::libnuma_init() {
 
 size_t os::Linux::default_guard_size(os::ThreadType thr_type) {
 
-  if (!DisableTHPStackMitigation) {
+  if (THPStackMitigation) {
     // If THPs are unconditionally enabled, the following scenario can lead to huge RSS
     // - parent thread spawns, in quick succession, multiple child threads
     // - child threads are slow to start
@@ -3831,15 +3831,15 @@ void os::large_page_init() {
   // coalesce small pages in thread stacks to huge pages. That costs a lot of memory and
   // is usually unwanted for thread stacks. Therefore we attempt to prevent THP formation in
   // thread stacks unless the user explicitly allowed THP formation by manually disabling
-  // -XX:+DisableTHPStackMitigation.
+  // -XX:-THPStackMitigation.
   if (HugePages::thp_mode() == THPMode::always) {
-    if (DisableTHPStackMitigation) {
-      log_info(pagesize)("JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
-    } else {
+    if (THPStackMitigation) {
       log_info(pagesize)("JVM will attempt to prevent THPs in thread stacks.");
+    } else {
+      log_info(pagesize)("JVM will *not* prevent THPs in thread stacks. This may cause high RSS.");
     }
   } else {
-    FLAG_SET_ERGO(DisableTHPStackMitigation, true); // Mitigation not needed
+    FLAG_SET_ERGO(THPStackMitigation, false); // Mitigation not needed
   }
 
   // 1) Handle the case where we do not want to use huge pages

--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -208,7 +208,7 @@ public class THPsInThreadStackPreventionTest {
 
                 // explicitly disable the no-THP-workaround:
                 finalargs.add("-XX:+UnlockDiagnosticVMOptions");
-                finalargs.add("-XX:+DisableTHPStackMitigation");
+                finalargs.add("-XX:-THPStackMitigation");
 
                 finalargs.add(TestMain.class.getName());
                 ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(finalargs);


### PR DESCRIPTION
Clean backport. 8312182 introduced a mitigation for THP-related RSS bloat; it came with a switch to switch it off. We then decided to rename the switch. Since the switch should be the same across all releases, this needs to be backported too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312585](https://bugs.openjdk.org/browse/JDK-8312585): Rename DisableTHPStackMitigation flag to THPStackMitigation (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1699/head:pull/1699` \
`$ git checkout pull/1699`

Update a local copy of the PR: \
`$ git checkout pull/1699` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1699`

View PR using the GUI difftool: \
`$ git pr show -t 1699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1699.diff">https://git.openjdk.org/jdk17u-dev/pull/1699.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1699#issuecomment-1700375286)