### PR TITLE
8314517: some tests fail in case ipv6 is disabled on the machine

### DIFF
--- a/test/jdk/java/net/InetAddress/HostsFileOrderingTest.java
+++ b/test/jdk/java/net/InetAddress/HostsFileOrderingTest.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jdk.test.lib.net.IPSupport;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.Assert;
@@ -39,6 +41,8 @@ import org.testng.Assert;
 
 /* @test
  * @bug 8244958
+ * @library /test/lib
+ * @build jdk.test.lib.Platform jdk.test.lib.net.IPSupport
  * @summary Test that "jdk.net.hosts.file" NameService implementation returns addresses
  *          with respect to "java.net.preferIPv4Stack" and "java.net.preferIPv6Addresses" system
  *          property values
@@ -104,6 +108,9 @@ public class HostsFileOrderingTest {
     static ExpectedOrder getExpectedOrderFromSystemProperties() {
         if (PREFER_IPV4_STACK_VALUE != null &&
             PREFER_IPV4_STACK_VALUE.equalsIgnoreCase("true")) {
+            return ExpectedOrder.IPV4_ONLY;
+        }
+        if (!IPSupport.hasIPv6()) {
             return ExpectedOrder.IPV4_ONLY;
         }
 

--- a/test/jdk/java/net/InetAddress/InternalNameServiceTest.java
+++ b/test/jdk/java/net/InetAddress/InternalNameServiceTest.java
@@ -27,6 +27,8 @@
  *          the system property jdk.net.hosts.file. This property specifies
  *          a file name that contains address host mappings, similar to those in
  *          /etc/hosts file.
+ * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
  * @run main/othervm -Djdk.net.hosts.file=TestHosts -Dsun.net.inetaddr.ttl=0
  *      InternalNameServiceTest
  */
@@ -37,6 +39,8 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+
+import jdk.test.lib.net.IPSupport;
 
 public class InternalNameServiceTest {
 
@@ -128,17 +132,16 @@ public class InternalNameServiceTest {
         }
 
         // IPV6 tests
-
-        // IPV6 tests
-        addMappingToHostsFile("host-ipv6.sample-domain", "::1", hostsFileName,
-                true);
-        testAddress = InetAddress.getByName("host-ipv6.sample-domain");
-        retrievedIpAddr = testAddress.getAddress();
-        if (!Arrays.equals(retrievedIpAddr, expectedIpAddrIpv6_1)) {
-            System.out.println("retrieved ipv6 addr == " + Arrays.toString(retrievedIpAddr));
-            System.out.println("expected ipv6 addr == " + Arrays.toString(expectedIpAddrIpv6_1));
-            throw new RuntimeException(
-                    "retrieved IPV6 Addr not equal to expected IPV6 Addr");
+        if (IPSupport.hasIPv6()) {
+            addMappingToHostsFile("host-ipv6.sample-domain", "::1", hostsFileName, true);
+            testAddress = InetAddress.getByName("host-ipv6.sample-domain");
+            retrievedIpAddr = testAddress.getAddress();
+            if (!Arrays.equals(retrievedIpAddr, expectedIpAddrIpv6_1)) {
+                System.out.println("retrieved ipv6 addr == " + Arrays.toString(retrievedIpAddr));
+                System.out.println("expected ipv6 addr == " + Arrays.toString(expectedIpAddrIpv6_1));
+                throw new RuntimeException(
+                        "retrieved IPV6 Addr not equal to expected IPV6 Addr");
+            }
         }
     }
 

--- a/test/jdk/java/net/InetAddress/InternalNameServiceWithHostsFileTest.java
+++ b/test/jdk/java/net/InetAddress/InternalNameServiceWithHostsFileTest.java
@@ -28,6 +28,8 @@
  *          a file name that contains address host mappings, similar to those in
  *          /etc/hosts file. TestHosts-III file  exist, with a set of ipv4 and ipv6
  *          mappings
+ * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
  * @run main/othervm -Djdk.net.hosts.file=${test.src}/TestHosts-III -Dsun.net.inetaddr.ttl=0
  *      InternalNameServiceWithHostsFileTest
  */
@@ -35,6 +37,8 @@
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+
+import jdk.test.lib.net.IPSupport;
 
 public class InternalNameServiceWithHostsFileTest {
     public static void main(String args[]) throws Exception {
@@ -52,26 +56,31 @@ public class InternalNameServiceWithHostsFileTest {
 
         // 10.2.3.4  testHost.testDomain
         testHostsMapping(expectedIpv4Address, "testHost.testDomain");
-        // ::1     ip6-localhost ip6-loopback
-        testHostsMapping(expectedIpv6LocalhostAddress, "ip6-localhost");
-        // fe00::0 ip6-localnet
-        testHostsMapping(expectedIpv6LocalAddress, "ip6-localnet");
-        // fe80::1 link-local-host
-        testHostsMapping(expectedIpv6Address, "link-local-host");
+
+        if (IPSupport.hasIPv6()) {
+            // ::1     ip6-localhost ip6-loopback
+            testHostsMapping(expectedIpv6LocalhostAddress, "ip6-localhost");
+            // fe00::0 ip6-localnet
+            testHostsMapping(expectedIpv6LocalAddress, "ip6-localnet");
+            // fe80::1 link-local-host
+            testHostsMapping(expectedIpv6Address, "link-local-host");
+        }
 
         testReverseLookup("10.2.3.4", "testHost.testDomain");
 
-        testReverseLookup("::1", "ip6-localhost");
-        testReverseLookup("0:0:0:0:0:0:0:1", "ip6-localhost");
-        testReverseLookup("0000:0000:0000:0000:0000:0000:0000:0001", "ip6-localhost");
+        if (IPSupport.hasIPv6()) {
+            testReverseLookup("::1", "ip6-localhost");
+            testReverseLookup("0:0:0:0:0:0:0:1", "ip6-localhost");
+            testReverseLookup("0000:0000:0000:0000:0000:0000:0000:0001", "ip6-localhost");
 
-        testReverseLookup("fe00::0", "ip6-localnet");
-        testReverseLookup("fe00:0:0:0:0:0:0:0", "ip6-localnet");
-        testReverseLookup("fe00:0000:0000:0000:0000:0000:0000:0000", "ip6-localnet");
+            testReverseLookup("fe00::0", "ip6-localnet");
+            testReverseLookup("fe00:0:0:0:0:0:0:0", "ip6-localnet");
+            testReverseLookup("fe00:0000:0000:0000:0000:0000:0000:0000", "ip6-localnet");
 
-        testReverseLookup("fe80::1", "link-local-host");
-        testReverseLookup("fe80:000:0:00:0:000:00:1", "link-local-host");
-        testReverseLookup("fe80:0000:0000:0000:0000:0000:0000:0001", "link-local-host");
+            testReverseLookup("fe80::1", "link-local-host");
+            testReverseLookup("fe80:000:0:00:0:000:00:1", "link-local-host");
+            testReverseLookup("fe80:0000:0000:0000:0000:0000:0000:0001", "link-local-host");
+        }
     }
 
     private static void testHostsMapping(byte[] expectedIpAddress, String hostName)


### PR DESCRIPTION
Backport 8314517

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314517](https://bugs.openjdk.org/browse/JDK-8314517): some tests fail in case ipv6 is disabled on the machine (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1702/head:pull/1702` \
`$ git checkout pull/1702`

Update a local copy of the PR: \
`$ git checkout pull/1702` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1702`

View PR using the GUI difftool: \
`$ git pr show -t 1702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1702.diff">https://git.openjdk.org/jdk17u-dev/pull/1702.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1702#issuecomment-1695563599)