### PR TITLE
8313626: C2 crash due to unexpected exception control flow

### DIFF
--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -979,6 +979,8 @@ void Parse::catch_inline_exceptions(SafePointNode* ex_map) {
       if (PrintOpto && WizardMode) {
         tty->print_cr("  Catching every inline exception bci:%d -> handler_bci:%d", bci(), handler_bci);
       }
+      // If this is a backwards branch in the bytecodes, add safepoint
+      maybe_add_safepoint(handler_bci);
       merge_exception(handler_bci); // jump to handler
       return;                   // No more handling to be done here!
     }
@@ -1010,6 +1012,8 @@ void Parse::catch_inline_exceptions(SafePointNode* ex_map) {
         klass->print_name();
         tty->cr();
       }
+      // If this is a backwards branch in the bytecodes, add safepoint
+      maybe_add_safepoint(handler_bci);
       merge_exception(handler_bci);
     }
     set_control(not_subtype_ctrl);

--- a/test/hotspot/jtreg/compiler/parsing/MissingSafepointOnTryCatch.jasm
+++ b/test/hotspot/jtreg/compiler/parsing/MissingSafepointOnTryCatch.jasm
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class MissingSafepointOnTryCatch version 52:0 {
+
+    static Method m:"()V" {
+        return;
+    }
+
+    static Method test1:"()V" stack 1 {
+        try t;
+            invokestatic m:"()V";
+            return;
+
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t;
+    }
+
+    static Method test2:"()V" stack 1 {
+        try t0;
+            try t1;
+                invokestatic m:"()V";
+            endtry t1;
+            return;
+
+            catch t1 java/lang/Exception;
+            stack_map class java/lang/Exception;
+            return;
+
+            catch t0 java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t0;
+    }
+
+    public static Method th:"()V"
+      throws java/lang/Exception
+      stack 2 locals 0
+    {
+          new	class java/lang/Exception;
+          dup;
+          invokespecial	Method java/lang/Exception."<init>":"()V";
+          athrow;
+    }
+
+    static Method test3:"()V" stack 1 locals 2 {
+        try t;
+            invokestatic m:"()V";
+            iconst_1;
+            istore_0;
+    		iconst_0;
+    		istore_1;
+            return;
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            invokestatic th:"()V";
+            return;
+        endtry t;
+    }
+
+    static Method test4:"()V" stack 2 locals 2 {
+        try t;
+            invokestatic m:"()V";
+            iconst_1;
+            istore_0;
+            iconst_0;
+            istore_1;
+            return;
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            iconst_1;
+            istore_0;
+            invokestatic th:"()V";
+            return;
+        endtry t;
+    }
+
+    static Method testInfinite:"()V" stack 1 {
+        try t;
+            invokestatic th:"()V";
+            return;
+
+            catch t java/lang/Throwable;
+            stack_map class java/lang/Throwable;
+            athrow;
+        endtry t;
+    }
+
+} // end Class MissingSafepointOnTryCatch

--- a/test/hotspot/jtreg/compiler/parsing/TestMissingSafepointOnTryCatch.java
+++ b/test/hotspot/jtreg/compiler/parsing/TestMissingSafepointOnTryCatch.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8313626
+ * @summary  assert(false) failed: malformed control flow to missing safepoint on backedge of a try-catch
+ * @library /test/lib
+ * @compile MissingSafepointOnTryCatch.jasm
+ * @run main/othervm -XX:CompileCommand=quiet
+ *      -XX:CompileCommand=compileonly,MissingSafepointOnTryCatch::test*
+ *      -XX:CompileCommand=dontinline,MissingSafepointOnTryCatch::m
+ *      -XX:CompileCommand=inline,MissingSafepointOnTryCatch::th
+ *      -XX:-TieredCompilation -Xcomp TestMissingSafepointOnTryCatch
+ */
+
+import jdk.test.lib.Utils;
+
+public class TestMissingSafepointOnTryCatch {
+
+    public static void infiniteLoop() {
+        try {
+            Thread thread = new Thread() {
+                public void run() {
+                    MissingSafepointOnTryCatch.testInfinite();
+                }
+            };
+            thread.setDaemon(true);
+            thread.start();
+            Thread.sleep(Utils.adjustTimeout(500));
+        } catch (Exception e) {}
+    }
+
+    public static void main(String[] args) {
+        try {
+            // to make sure java/lang/Exception class is resolved
+            MissingSafepointOnTryCatch.th();
+        } catch (Exception e) {}
+        MissingSafepointOnTryCatch.test1();
+        MissingSafepointOnTryCatch.test2();
+        MissingSafepointOnTryCatch.test3();
+        MissingSafepointOnTryCatch.test4();
+        infiniteLoop();
+    }
+}


### PR DESCRIPTION
Clean backport to fix C2 issue.

Additional testing:
 - [x] New test fails without the patch, passes with it
 - [x] Linux AArch64 `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313626](https://bugs.openjdk.org/browse/JDK-8313626): C2 crash due to unexpected exception control flow (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1709/head:pull/1709` \
`$ git checkout pull/1709`

Update a local copy of the PR: \
`$ git checkout pull/1709` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1709`

View PR using the GUI difftool: \
`$ git pr show -t 1709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1709.diff">https://git.openjdk.org/jdk17u-dev/pull/1709.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1709#issuecomment-1698979737)