### PR TITLE
8300806: Update googletest to v1.13.0

### DIFF
--- a/.github/actions/get-gtest/action.yml
+++ b/.github/actions/get-gtest/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ runs:
       uses: actions/checkout@v3
       with:
         repository: google/googletest
-        ref: 'release-${{ steps.version.outputs.value }}'
+        ref: 'v${{ steps.version.outputs.value }}'
         path: gtest
 
     - name: 'Export path to where GTest is installed'

--- a/doc/building.html
+++ b/doc/building.html
@@ -514,10 +514,10 @@
 <h2 id="running-tests">Running Tests</h2>
 <p>Most of the JDK tests are using the <a href="http://openjdk.java.net/jtreg">JTReg</a> test framework. Make sure that your configuration knows where to find your installation of JTReg. If this is not picked up automatically, use the <code>--with-jtreg=&lt;path to jtreg home&gt;</code> option to point to the JTReg framework. Note that this option should point to the JTReg home, i.e. the top directory, containing <code>lib/jtreg.jar</code> etc.</p>
 <p>The <a href="https://wiki.openjdk.java.net/display/Adoption">Adoption Group</a> provides recent builds of jtreg <a href="https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessfulBuild/artifact/jtreg/">here</a>. Download the latest <code>.tar.gz</code> file, unpack it, and point <code>--with-jtreg</code> to the <code>jtreg</code> directory that you just unpacked.</p>
-<p>Building of Hotspot Gtest suite requires the source code of Google Test framework. The top directory, which contains both <code>googletest</code> and <code>googlemock</code> directories, should be specified via <code>--with-gtest</code>. The supported version of Google Test is 1.8.1, whose source code can be obtained:</p>
+<p>Building of Hotspot Gtest suite requires the source code of Google Test framework. The top directory, which contains both <code>googletest</code> and <code>googlemock</code> directories, should be specified via <code>--with-gtest</code>. The minimum supported version of Google Test is 1.13.0, whose source code can be obtained:</p>
 <ul>
-<li>by downloading and unpacking the source bundle from <a href="https://github.com/google/googletest/releases/tag/release-1.8.1">here</a></li>
-<li>or by checking out <code>release-1.8.1</code> tag of <code>googletest</code> project: <code>git clone -b release-1.8.1 https://github.com/google/googletest</code></li>
+<li>by downloading and unpacking the source bundle from <a href="https://github.com/google/googletest/releases/tag/v1.13.0">here</a></li>
+<li>or by checking out <code>v1.13.0</code> tag of <code>googletest</code> project: <code>git clone -b v1.13.0 https://github.com/google/googletest</code></li>
 </ul>
 <p>To execute the most basic tests (tier 1), use:</p>
 <pre><code>make run-test-tier1</code></pre>

--- a/doc/building.md
+++ b/doc/building.md
@@ -852,13 +852,14 @@ https://ci.adoptium.net/view/Dependencies/job/dependency_pipeline/lastSuccessful
 Download the latest `.tar.gz` file, unpack it, and point `--with-jtreg` to the
 `jtreg` directory that you just unpacked.
 
-Building of Hotspot Gtest suite requires the source code of Google Test framework.
-The top directory, which contains both `googletest` and `googlemock`
-directories, should be specified via `--with-gtest`.
-The supported version of Google Test is 1.8.1, whose source code can be obtained:
+Building of Hotspot Gtest suite requires the source code of Google
+Test framework.  The top directory, which contains both `googletest`
+and `googlemock` directories, should be specified via `--with-gtest`.
+The minimum supported version of Google Test is 1.13.0, whose source
+code can be obtained:
 
- * by downloading and unpacking the source bundle from [here](https://github.com/google/googletest/releases/tag/release-1.8.1)
- * or by checking out `release-1.8.1` tag of `googletest` project: `git clone -b release-1.8.1 https://github.com/google/googletest`
+ * by downloading and unpacking the source bundle from [here](https://github.com/google/googletest/releases/tag/v1.13.0)
+ * or by checking out `v1.13.0` tag of `googletest` project: `git clone -b v1.13.0 https://github.com/google/googletest`
 
 To execute the most basic tests (tier 1), use:
 ```

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -29,6 +29,7 @@
 
 # Minimum supported version
 JTREG_MINIMUM_VERSION=6.1
+GTEST_MINIMUM_VERSION=1.13.0
 
 ###############################################################################
 #
@@ -58,20 +59,13 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_GTEST],
         AC_MSG_RESULT([$GTEST_FRAMEWORK_SRC])
         UTIL_FIXUP_PATH([GTEST_FRAMEWORK_SRC])
 
-        # Try to verify version. We require 1.8.1, but this can not be directly
-        # determined. :-( Instead, there are different, incorrect version
-        # numbers we can look for.
-        GTEST_VERSION_1="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -E -e 's/set\(GOOGLETEST_VERSION (.*)\)/\1/'`"
-        if test "x$GTEST_VERSION_1" != "x1.9.0"; then
-          AC_MSG_ERROR([gtest at $GTEST_FRAMEWORK_SRC does not seem to be version 1.8.1])
-        fi
-
-        # We cannot grep for "AC_IN*T" as a literal since then m4 will treat it as a macro
-        # and expand it.
-        # Additional [] needed to keep m4 from mangling shell constructs.
-        [ GTEST_VERSION_2="`$GREP -A1 ^.C_INIT $GTEST_FRAMEWORK_SRC/configure.ac | $TAIL -n 1 | $SED -E -e 's/ +\[(.*)],/\1/'`" ]
-        if test "x$GTEST_VERSION_2" != "x1.8.0"; then
-          AC_MSG_ERROR([gtest at $GTEST_FRAMEWORK_SRC does not seem to be version 1.8.1 B])
+        # Verify that the version is the required one.
+        # This is a simplified version of TOOLCHAIN_CHECK_COMPILER_VERSION
+        gtest_version="`$GREP GOOGLETEST_VERSION $GTEST_FRAMEWORK_SRC/CMakeLists.txt | $SED -E -e 's/set\(GOOGLETEST_VERSION (.*)\)/\1/'`"
+        comparable_actual_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$gtest_version"`
+        comparable_minimum_version=`$AWK -F. '{ printf("%05d%05d%05d%05d\n", [$]1, [$]2, [$]3, [$]4) }' <<< "$GTEST_MINIMUM_VERSION"`
+        if test $comparable_actual_version -lt $comparable_minimum_version ; then
+          AC_MSG_ERROR([gtest version is too old, at least version $GTEST_MINIMUM_VERSION is required])
         fi
       fi
     fi

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 
 # Versions and download locations for dependencies used by GitHub Actions (GHA)
 
-GTEST_VERSION=1.8.1
+GTEST_VERSION=1.13.0
 JTREG_VERSION=6.1+3
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1245,7 +1245,7 @@ var getJibProfilesDependencies = function (input, common) {
         gtest: {
             organization: common.organization,
             ext: "tar.gz",
-            revision: "1.8.1"
+            revision: "1.13.0+1.0"
         },
     };
 

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,7 +230,7 @@ static void runUnitTestsInner(int argc, char** argv) {
   bool is_vmassert_test = false;
   bool is_othervm_test = false;
   // death tests facility is used for both regular death tests, other vm and vmassert tests
-  if (::testing::internal::GTEST_FLAG(internal_run_death_test).length() > 0) {
+  if (::testing::GTEST_FLAG(internal_run_death_test).length() > 0) {
     // when we execute death test, filter value equals to test name
     const char* test_name = ::testing::GTEST_FLAG(filter).c_str();
     const char* const othervm_suffix = "_other_vm"; // TEST_OTHER_VM


### PR DESCRIPTION
Unclean backport to bring in gtest 1.13.0 to JDK 17u. Maintaining the version closer to mainline allows us to get cleaner backports that would not need rewrites for older 1.8.1 in 17u now.

The uncleanliness is mostly due to contextual differences, which I resolved by hand.

Additional testing:
 - [ ] Linux AArch64 fastdebug, `gtest:all` (tests that configure accepts new gtest, and that all tests work)
 - [ ] Linux x86_64 fastdebug, `gtest:all` (tests that configure accepts new gtest, and that all tests work)
 - [ ] GHA (implicitly verifies gtest works)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8300806](https://bugs.openjdk.org/browse/JDK-8300806) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JDK-8300806](https://bugs.openjdk.org/browse/JDK-8300806): Update googletest to v1.13.0 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1710/head:pull/1710` \
`$ git checkout pull/1710`

Update a local copy of the PR: \
`$ git checkout pull/1710` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1710`

View PR using the GUI difftool: \
`$ git pr show -t 1710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1710.diff">https://git.openjdk.org/jdk17u-dev/pull/1710.diff</a>

</details>
