### PR TITLE
8286430: make test TEST="gtest:<sometag>" exits with error when it shouldn't

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -523,7 +523,7 @@ define SetupRunGtestTestBody
 	    $$(subst $$(TOPDIR)/, , $$($1_TEST_RESULTS_DIR))))
 	$$(if $$(wildcard $$($1_RESULT_FILE)), \
 	  $$(eval $1_TOTAL := $$(shell $$(AWK) '/==========.* tests? from .* \
-	      test cases? ran/ { print $$$$2 }' $$($1_RESULT_FILE))) \
+	      test (cases?|suites?) ran/ { print $$$$2 }' $$($1_RESULT_FILE))) \
 	  $$(if $$($1_TOTAL), , $$(eval $1_TOTAL := 0)) \
 	  $$(eval $1_PASSED := $$(shell $$(AWK) '/\[  PASSED  \] .* tests?./ \
 	      { print $$$$4 }' $$($1_RESULT_FILE))) \


### PR DESCRIPTION
Clean backport to unblock update to gtest 1.13.

Additional testing:
 - [x] Linux AArch64 `gtest:all` with gtest 1.8.1 (still works)
 - [x] Linux AArch64 `gtest:all` with gtest 1.13 (with another PR enabling it, now works)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286430](https://bugs.openjdk.org/browse/JDK-8286430): make test TEST="gtest:&lt;sometag&gt;" exits with error when it shouldn't (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1711/head:pull/1711` \
`$ git checkout pull/1711`

Update a local copy of the PR: \
`$ git checkout pull/1711` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1711`

View PR using the GUI difftool: \
`$ git pr show -t 1711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1711.diff">https://git.openjdk.org/jdk17u-dev/pull/1711.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1711#issuecomment-1699599354)