### PR TITLE
8299658: C1 compilation crashes in LinearScan::resolve_exception_edge

### DIFF
--- a/src/hotspot/share/c1/c1_LinearScan.cpp
+++ b/src/hotspot/share/c1/c1_LinearScan.cpp
@@ -1953,6 +1953,14 @@ void LinearScan::resolve_exception_edge(XHandler* handler, int throwing_op_id, i
     // interval at the throwing instruction must be searched using the operands
     // of the phi function
     Value from_value = phi->operand_at(handler->phi_operand());
+    if (from_value == nullptr) {
+      // We have reached here in a kotlin application running with JVMTI
+      // capability "can_access_local_variables".
+      // The illegal state is not yet propagated to this phi. Do it here.
+      phi->make_illegal();
+      // We can skip the illegal phi edge.
+      return;
+    }
 
     // with phi functions it can happen that the same from_value is used in
     // multiple mappings, so notify move-resolver that this is allowed


### PR DESCRIPTION
Clean backport of [JDK-8299658](https://bugs.openjdk.org/browse/JDK-8299658).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299658](https://bugs.openjdk.org/browse/JDK-8299658): C1 compilation crashes in LinearScan::resolve_exception_edge (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1716/head:pull/1716` \
`$ git checkout pull/1716`

Update a local copy of the PR: \
`$ git checkout pull/1716` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1716`

View PR using the GUI difftool: \
`$ git pr show -t 1716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1716.diff">https://git.openjdk.org/jdk17u-dev/pull/1716.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1716#issuecomment-1701665761)