### PR TITLE
8309032: jpackage does not work for module projects unless --module-path is specified

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/LauncherData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ final class LauncherData {
     }
 
     private void verifyIsModular(boolean isModular) {
-        if ((moduleInfo != null) != isModular) {
+        if ((moduleInfo == null) == isModular) {
             throw new IllegalStateException();
         }
     }
@@ -259,14 +259,10 @@ final class LauncherData {
     private static String getStringParam(Map<String, ? super Object> params,
             String paramName) {
         Optional<Object> value = Optional.ofNullable(params.get(paramName));
-        if (value.isPresent()) {
-            return value.get().toString();
-        }
-        return null;
+        return value.map(Object::toString).orElse(null);
     }
 
-    private static <T> T getPathParam(Map<String, ? super Object> params,
-            String paramName, Supplier<T> func) throws ConfigException {
+    private static <T> T getPathParam(String paramName, Supplier<T> func) throws ConfigException {
         try {
             return func.get();
         } catch (InvalidPathException ex) {
@@ -278,7 +274,7 @@ final class LauncherData {
 
     private static Path getPathParam(Map<String, ? super Object> params,
             String paramName) throws ConfigException {
-        return getPathParam(params, paramName, () -> {
+        return getPathParam(paramName, () -> {
             String value = getStringParam(params, paramName);
             Path result = null;
             if (value != null) {
@@ -297,7 +293,7 @@ final class LauncherData {
             runtimePath = runtimePath.resolve("lib");
             modulePath = Stream.of(modulePath, List.of(runtimePath))
                     .flatMap(List::stream)
-                    .collect(Collectors.toUnmodifiableList());
+                    .toList();
         }
 
         return modulePath;
@@ -305,13 +301,9 @@ final class LauncherData {
 
     private static List<Path> getPathListParameter(String paramName,
             Map<String, ? super Object> params) throws ConfigException {
-        return getPathParam(params, paramName, () -> {
-            String value = (String) params.get(paramName);
-            return (value == null) ? List.of() :
-                    List.of(value.split(File.pathSeparator)).stream()
-                    .map(Path::of)
-                    .collect(Collectors.toUnmodifiableList());
-        });
+        return getPathParam(paramName, () ->
+                params.get(paramName) instanceof String value ?
+                        Stream.of(value.split(File.pathSeparator)).map(Path::of).toList() : List.of());
     }
 
     private String qualifiedClassName;


### PR DESCRIPTION
Fixes an error when trying to add additional launchers in jpackage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309032](https://bugs.openjdk.org/browse/JDK-8309032) needs maintainer approval

### Issue
 * [JDK-8309032](https://bugs.openjdk.org/browse/JDK-8309032): jpackage does not work for module projects unless --module-path is specified (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1717/head:pull/1717` \
`$ git checkout pull/1717`

Update a local copy of the PR: \
`$ git checkout pull/1717` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1717`

View PR using the GUI difftool: \
`$ git pr show -t 1717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1717.diff">https://git.openjdk.org/jdk17u-dev/pull/1717.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1717#issuecomment-1702090697)