### PR TITLE
8312625: Test serviceability/dcmd/vm/TrimLibcHeapTest.java failed: RSS use increased

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/TrimLibcHeapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/TrimLibcHeapTest.java
@@ -46,7 +46,7 @@ public class TrimLibcHeapTest {
         if (Platform.isMusl()) {
             output.shouldContain("Not available");
         } else {
-            output.shouldMatch("Trim native heap: RSS\\+Swap: \\d+[BKMG]->\\d+[BKMG] \\(-\\d+[BKMG]\\)");
+            output.shouldMatch("Trim native heap: RSS\\+Swap: \\d+[BKMG]->\\d+[BKMG] \\([+-]\\d+[BKMG]\\)");
         }
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8312625](https://bugs.openjdk.org/browse/JDK-8312625), commit [117f42db](https://github.com/openjdk/jdk/commit/117f42dbe9a78bcf43bdf3873d5d86a19a9092d3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 26 Jul 2023 and was reviewed by Kevin Walls and David Holmes.

It hopefully fixes an issue that intermittently shows in our CI.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8312625](https://bugs.openjdk.org/browse/JDK-8312625) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312625](https://bugs.openjdk.org/browse/JDK-8312625): Test serviceability/dcmd/vm/TrimLibcHeapTest.java failed: RSS use increased (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1718/head:pull/1718` \
`$ git checkout pull/1718`

Update a local copy of the PR: \
`$ git checkout pull/1718` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1718`

View PR using the GUI difftool: \
`$ git pr show -t 1718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1718.diff">https://git.openjdk.org/jdk17u-dev/pull/1718.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1718#issuecomment-1702666280)