### PR TITLE
8315549: CITime misreports code/total nmethod sizes

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2753,8 +2753,8 @@ void CompileBroker::print_times(bool per_compiler, bool aggregate) {
   int total_bailout_count = CompileBroker::_total_bailout_count;
   int total_invalidated_count = CompileBroker::_total_invalidated_count;
 
-  int nmethods_size = CompileBroker::_sum_nmethod_code_size;
-  int nmethods_code_size = CompileBroker::_sum_nmethod_size;
+  int nmethods_code_size = CompileBroker::_sum_nmethod_code_size;
+  int nmethods_size = CompileBroker::_sum_nmethod_size;
 
   tty->cr();
   tty->print_cr("Accumulated compiler times");


### PR DESCRIPTION
Unclean backport to fix -XX:+CITime reporting. Does not apply cleanly, because the variable type has been changed in JDK 22.

Additional testing:
 - [x] Eyeballing `-XX:+CITime` output

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315549](https://bugs.openjdk.org/browse/JDK-8315549) needs maintainer approval

### Issue
 * [JDK-8315549](https://bugs.openjdk.org/browse/JDK-8315549): CITime misreports code/total nmethod sizes (**Bug** - P5 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1719/head:pull/1719` \
`$ git checkout pull/1719`

Update a local copy of the PR: \
`$ git checkout pull/1719` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1719`

View PR using the GUI difftool: \
`$ git pr show -t 1719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1719.diff">https://git.openjdk.org/jdk17u-dev/pull/1719.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1719#issuecomment-1705149183)