### PR TITLE
8285516: clearPassword should be called in a finally try block

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -864,14 +864,14 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
     {
         SecretKey skey = null;
 
+        PBEKeySpec keySpec = new PBEKeySpec(password);
         try {
-            PBEKeySpec keySpec = new PBEKeySpec(password);
             SecretKeyFactory skFac = SecretKeyFactory.getInstance("PBE");
             skey = skFac.generateSecret(keySpec);
-            keySpec.clearPassword();
         } catch (Exception e) {
-           throw new IOException("getSecretKey failed: " +
-                                 e.getMessage(), e);
+            throw new IOException("getSecretKey failed: " + e.getMessage(), e);
+        } finally {
+            keySpec.clearPassword();
         }
         return skey;
     }


### PR DESCRIPTION
[JDK-8285516](https://bugs.openjdk.org/browse/JDK-8285516)

Clean backport

clearPassword should be called in a finally try block

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8285516](https://bugs.openjdk.org/browse/JDK-8285516) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285516](https://bugs.openjdk.org/browse/JDK-8285516): clearPassword should be called in a finally try block (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1722/head:pull/1722` \
`$ git checkout pull/1722`

Update a local copy of the PR: \
`$ git checkout pull/1722` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1722`

View PR using the GUI difftool: \
`$ git pr show -t 1722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1722.diff">https://git.openjdk.org/jdk17u-dev/pull/1722.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1722#issuecomment-1709208086)