### PR TITLE
8244289: fatal error: Possible safepoint reached by thread that does not allow it

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
@@ -101,7 +101,7 @@ void JfrPostBox::deposit(int new_messages) {
 void JfrPostBox::asynchronous_post(int msg) {
   assert(!is_synchronous(msg), "invariant");
   deposit(msg);
-  JfrMonitorTryLock try_msg_lock(JfrMsg_lock);
+  JfrMutexTryLock try_msg_lock(JfrMsg_lock);
   if (try_msg_lock.acquired()) {
     JfrMsg_lock->notify_all();
   }

--- a/src/hotspot/share/jfr/utilities/jfrTryLock.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrTryLock.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,25 +50,23 @@ class JfrTryLock {
   }
 };
 
-class JfrMonitorTryLock : public StackObj {
+class JfrMutexTryLock : public StackObj {
  private:
-  Monitor* _lock;
+  Mutex* _mutex;
   bool _acquired;
 
  public:
-  JfrMonitorTryLock(Monitor* lock) : _lock(lock), _acquired(lock->try_lock()) {}
-
-  ~JfrMonitorTryLock() {
+  JfrMutexTryLock(Mutex* mutex) : _mutex(mutex), _acquired(mutex->try_lock()) {}
+  ~JfrMutexTryLock() {
     if (_acquired) {
-      assert(_lock->owned_by_self(), "invariant");
-      _lock->unlock();
+      assert(_mutex->owned_by_self(), "invariant");
+      _mutex->unlock();
     }
   }
 
   bool acquired() const {
     return _acquired;
   }
-
 };
 
 #endif // SHARE_JFR_UTILITIES_JFRTRYLOCK_HPP


### PR DESCRIPTION
Clean backport to improve JFR reliability. 

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `jdk/jfr`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8244289](https://bugs.openjdk.org/browse/JDK-8244289) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8244289](https://bugs.openjdk.org/browse/JDK-8244289): fatal error: Possible safepoint reached by thread that does not allow it (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1726/head:pull/1726` \
`$ git checkout pull/1726`

Update a local copy of the PR: \
`$ git checkout pull/1726` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1726`

View PR using the GUI difftool: \
`$ git pr show -t 1726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1726.diff">https://git.openjdk.org/jdk17u-dev/pull/1726.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1726#issuecomment-1711646279)