### PR TITLE
8315751: RandomTestBsi1999 fails often with timeouts on Linux ppc64le

### DIFF
--- a/test/jdk/java/util/Random/RandomTestBsi1999.java
+++ b/test/jdk/java/util/Random/RandomTestBsi1999.java
@@ -43,9 +43,9 @@ import static java.util.stream.Collectors.toSet;
 
 /**
  * @test
- * @summary test bit sequences produced by clases that implement interface RandomGenerator
+ * @summary test bit sequences produced by classes that implement interface RandomGenerator
  * @bug 8248862
- * @run main RandomTestBsi1999
+ * @run main/othervm/timeout=400 RandomTestBsi1999
  * @key randomness
  */
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315751](https://bugs.openjdk.org/browse/JDK-8315751) needs maintainer approval

### Issue
 * [JDK-8315751](https://bugs.openjdk.org/browse/JDK-8315751): RandomTestBsi1999 fails often with timeouts on Linux ppc64le (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1727/head:pull/1727` \
`$ git checkout pull/1727`

Update a local copy of the PR: \
`$ git checkout pull/1727` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1727`

View PR using the GUI difftool: \
`$ git pr show -t 1727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1727.diff">https://git.openjdk.org/jdk17u-dev/pull/1727.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1727#issuecomment-1715225908)