### PR TITLE
8276711: compiler/codecache/cli tests failing when SegmentedCodeCache used with -Xint

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -354,7 +354,7 @@ bool CodeCache::heap_available(int code_blob_type) {
   if (!SegmentedCodeCache) {
     // No segmentation: use a single code heap
     return (code_blob_type == CodeBlobType::All);
-  } else if (Arguments::is_interpreter_only()) {
+  } else if (CompilerConfig::is_interpreter_only()) {
     // Interpreter only: we don't need any method code heaps
     return (code_blob_type == CodeBlobType::NonNMethod);
   } else if (CompilerConfig::is_c1_profiling()) {

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -316,7 +316,6 @@ void CompilerConfig::set_compilation_policy_flags() {
     }
   }
 
-
   if (CompileThresholdScaling < 0) {
     vm_exit_during_initialization("Negative value specified for CompileThresholdScaling", NULL);
   }
@@ -522,6 +521,10 @@ bool CompilerConfig::check_args_consistency(bool status) {
         warning("TieredCompilation disabled due to -Xint.");
       }
       FLAG_SET_CMDLINE(TieredCompilation, false);
+    }
+    if (SegmentedCodeCache) {
+      warning("SegmentedCodeCache has no meaningful effect with -Xint");
+      FLAG_SET_DEFAULT(SegmentedCodeCache, false);
     }
 #if INCLUDE_JVMCI
     if (EnableJVMCI) {

--- a/test/hotspot/jtreg/compiler/codecache/cli/TestSegmentedCodeCacheOption.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/TestSegmentedCodeCacheOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,9 @@ public class TestSegmentedCodeCacheOption {
     private static final String[] UNEXPECTED_MESSAGES = new String[] {
             ".*" + SEGMENTED_CODE_CACHE + ".*"
     };
+    private static final String[] XINT_EXPECTED_MESSAGE = new String[] {
+            "SegmentedCodeCache has no meaningful effect with -Xint"
+    };
 
 
     private static enum TestCase {
@@ -86,10 +89,11 @@ public class TestSegmentedCodeCacheOption {
                 // ... and even w/ Xint.
                 testCaseExitCodeMessage = "It should be possible to use "
                         + USE_SEGMENTED_CODE_CACHE + " in interpreted mode "
-                        + "without any errors.";
+                        + "but it produces a warning that it is ignored.";
 
                 CommandLineOptionTest.verifyJVMStartup(
-                        /* expected messages */ null, UNEXPECTED_MESSAGES,
+                        XINT_EXPECTED_MESSAGE,
+                        /* unexpected messages */ null,
                         testCaseExitCodeMessage, testCaseWarningMessage,
                         ExitCode.OK, false, INT_MODE, USE_SEGMENTED_CODE_CACHE);
             }
@@ -117,14 +121,6 @@ public class TestSegmentedCodeCacheOption {
                         CommandLineOptionTest.prepareNumericFlag(
                                 BlobType.All.sizeOptionName,
                                 BELOW_THRESHOLD_CC_SIZE));
-                // SCC could be explicitly enabled w/ Xint
-                errorMessage = String.format("It should be possible to "
-                                + "explicitly enable %s in interpreted mode.",
-                        SEGMENTED_CODE_CACHE);
-
-                CommandLineOptionTest.verifyOptionValue(SEGMENTED_CODE_CACHE,
-                        "true", errorMessage, false, INT_MODE,
-                        USE_SEGMENTED_CODE_CACHE);
                 // SCC could be explicitly enabled w/o TieredCompilation and w/
                 // small ReservedCodeCacheSize value
                 errorMessage = String.format("It should be possible to "

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,13 +64,7 @@ public class TestCodeHeapSizeOptions extends CodeCacheCLITestBase {
     private TestCodeHeapSizeOptions() {
         super(CodeCacheCLITestBase.OPTIONS_SET,
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
-                        .CommonDescriptions.INT_MODE.description,
-                        GENERIC_RUNNER),
-                new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.NON_TIERED.description,
-                        GENERIC_RUNNER),
-                new CodeCacheCLITestCase(CodeCacheCLITestCase
-                        .CommonDescriptions.TIERED_LEVEL_0.description,
                         GENERIC_RUNNER),
                 new CodeCacheCLITestCase(CodeCacheCLITestCase
                         .CommonDescriptions.TIERED_LEVEL_1.description,

--- a/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestCase.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/common/CodeCacheCLITestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,9 +66,9 @@ public class CodeCacheCLITestCase {
     public enum CommonDescriptions {
         /**
          * Verifies that in interpreted mode PrintCodeCache output contains
-         * only NonNMethod code heap.
+         * the whole code cache. Int mode disables SegmentedCodeCache with a warning.
          */
-        INT_MODE(ONLY_SEGMENTED, EnumSet.of(BlobType.NonNMethod), USE_INT_MODE),
+        INT_MODE(ONLY_SEGMENTED, EnumSet.of(BlobType.All), USE_INT_MODE),
         /**
          * Verifies that with disabled SegmentedCodeCache PrintCodeCache output
          * contains only CodeCache's entry.
@@ -87,11 +87,11 @@ public class CodeCacheCLITestCase {
                         false)),
         /**
          * Verifies that with TieredStopAtLevel=0 PrintCodeCache output will
-         * contain information about non-nmethods and non-profiled nmethods
+         * warn about SegmentedCodeCache and contain information about all
          * heaps only.
          */
         TIERED_LEVEL_0(SEGMENTED_SERVER,
-                EnumSet.of(BlobType.NonNMethod, BlobType.MethodNonProfiled),
+                EnumSet.of(BlobType.All),
                 CommandLineOptionTest.prepareBooleanFlag(TIERED_COMPILATION,
                         true),
                 CommandLineOptionTest.prepareNumericFlag(TIERED_STOP_AT, 0)),


### PR DESCRIPTION
Clean backport to have a non-segmented CodeCache for JVM running with `-XX:TieredStopAtLevel=0 -XX:+SegmentedCodeCache`.  The fix has been in mainline for 1.5 years.
Risks are low: the fix prevents the allocation of the non-profiled code heap which is not used in the interpreter-only mode.

Additional testing:
- [x]  Linux x86_64 fastdebug: `tier1`
- [x]  Linux x86_64 fastdebug: `tier2`
- [x]  Linux x86_64 fastdebug: `tier3`
- [x]  Linux AArch64 fastdebug: `tier1`
- [x]  Linux AArch64 fastdebug: `tier2`
- [x]  Linux AArch64 fastdebug: `tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276711](https://bugs.openjdk.org/browse/JDK-8276711) needs maintainer approval

### Issue
 * [JDK-8276711](https://bugs.openjdk.org/browse/JDK-8276711): compiler/codecache/cli tests failing when SegmentedCodeCache used with -Xint (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1728/head:pull/1728` \
`$ git checkout pull/1728`

Update a local copy of the PR: \
`$ git checkout pull/1728` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1728`

View PR using the GUI difftool: \
`$ git pr show -t 1728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1728.diff">https://git.openjdk.org/jdk17u-dev/pull/1728.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1728#issuecomment-1715604660)