### PR TITLE
8304954: SegmentedCodeCache fails when using large pages

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -291,9 +291,20 @@ void CodeCache::initialize_heaps() {
   FLAG_SET_ERGO(ProfiledCodeHeapSize, profiled_size);
   FLAG_SET_ERGO(NonProfiledCodeHeapSize, non_profiled_size);
 
+  const size_t ps = page_size(false, 8);
+  // Print warning if using large pages but not able to use the size given
+  if (UseLargePages) {
+    const size_t lg_ps = page_size(false, 1);
+    if (ps < lg_ps) {
+      log_warning(codecache)("Code cache size too small for " PROPERFMT " pages. "
+                             "Reverting to smaller page size (" PROPERFMT ").",
+                             PROPERFMTARGS(lg_ps), PROPERFMTARGS(ps));
+    }
+  }
+
   // If large page support is enabled, align code heaps according to large
   // page size to make sure that code cache is covered by large pages.
-  const size_t alignment = MAX2(page_size(false, 8), (size_t) os::vm_allocation_granularity());
+  const size_t alignment = MAX2(ps, (size_t) os::vm_allocation_granularity());
   non_nmethod_size = align_up(non_nmethod_size, alignment);
   profiled_size    = align_down(profiled_size, alignment);
   non_profiled_size = align_down(non_profiled_size, alignment);
@@ -305,7 +316,7 @@ void CodeCache::initialize_heaps() {
   //         Non-nmethods
   //      Profiled nmethods
   // ---------- low ------------
-  ReservedCodeSpace rs = reserve_heap_memory(cache_size);
+  ReservedCodeSpace rs = reserve_heap_memory(cache_size, ps);
   ReservedSpace profiled_space      = rs.first_part(profiled_size);
   ReservedSpace rest                = rs.last_part(profiled_size);
   ReservedSpace non_method_space    = rest.first_part(non_nmethod_size);
@@ -332,9 +343,8 @@ size_t CodeCache::page_size(bool aligned, size_t min_pages) {
   }
 }
 
-ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size) {
+ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size, size_t rs_ps) {
   // Align and reserve space for code cache
-  const size_t rs_ps = page_size();
   const size_t rs_align = MAX2(rs_ps, (size_t) os::vm_allocation_granularity());
   const size_t rs_size = align_up(size, rs_align);
   ReservedCodeSpace rs(rs_size, rs_align, rs_ps);
@@ -973,7 +983,7 @@ void CodeCache::initialize() {
     FLAG_SET_ERGO(NonNMethodCodeHeapSize, 0);
     FLAG_SET_ERGO(ProfiledCodeHeapSize, 0);
     FLAG_SET_ERGO(NonProfiledCodeHeapSize, 0);
-    ReservedCodeSpace rs = reserve_heap_memory(ReservedCodeCacheSize);
+    ReservedCodeSpace rs = reserve_heap_memory(ReservedCodeCacheSize, page_size(false, 8));
     add_heap(rs, "CodeCache", CodeBlobType::All);
   }
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -109,7 +109,7 @@ class CodeCache : AllStatic {
   static CodeHeap* get_code_heap(int code_blob_type);         // Returns the CodeHeap for the given CodeBlobType
   // Returns the name of the VM option to set the size of the corresponding CodeHeap
   static const char* get_code_heap_flag_name(int code_blob_type);
-  static ReservedCodeSpace reserve_heap_memory(size_t size);  // Reserves one continuous chunk of memory for the CodeHeaps
+  static ReservedCodeSpace reserve_heap_memory(size_t size, size_t rs_ps);  // Reserves one continuous chunk of memory for the CodeHeaps
 
   // Iteration
   static CodeBlob* first_blob(CodeHeap* heap);                // Returns the first CodeBlob on the given CodeHeap

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8304954
+ * @summary Code cache reservation should gracefully downgrade to using smaller pages if the code cache size is too small to host the requested page size.
+ * @requires os.family == "linux"
+ * @requires vm.gc != "Z"
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseLargePages -XX:LargePageSizeInBytes=1g compiler.codecache.CheckLargePages
+ */
+
+package compiler.codecache;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.whitebox.WhiteBox;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CheckLargePages {
+    private final static WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+        final boolean largePages = WHITE_BOX.getBooleanVMFlag("UseLargePages");
+        final long largePageSize = WHITE_BOX.getVMLargePageSize();
+        if (largePages && (largePageSize == 1024 * 1024 * 1024)) {
+            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                    "-XX:+UseLargePages",
+                    "-XX:+SegmentedCodeCache",
+                    "-XX:InitialCodeCacheSize=2g",
+                    "-XX:ReservedCodeCacheSize=2g",
+                    "-XX:LargePageSizeInBytes=1g",
+                    "-Xlog:pagesize=info",
+                    "-version");
+            OutputAnalyzer out = new OutputAnalyzer(pb.start());
+            out.shouldMatch("Code cache size too small for \\S* pages\\. Reverting to smaller page size \\((\\S*)\\)\\.");
+            out.shouldHaveExitValue(0);
+            // Parse page sizes to find next biggest page
+            String sizes = out.firstMatch("Usable page sizes:(.*)", 1);
+            List<Long> sizeList = Arrays.stream(sizes.trim().split("\\s*,\\s*")).map(CheckLargePages::parseMemoryString).sorted().toList();
+            final int smallerPageSizeIndex = sizeList.indexOf(largePageSize) - 1;
+            Asserts.assertGreaterThanOrEqual(smallerPageSizeIndex, 0);
+            final long smallerPageSize = sizeList.get(smallerPageSizeIndex);
+            // Retrieve reverted page size from code cache warning
+            String revertedSizeString = out.firstMatch("Code cache size too small for (\\S*) pages. Reverting to smaller page size \\((\\S*)\\)\\.", 2);
+            Asserts.assertEquals(parseMemoryString(revertedSizeString), smallerPageSize);
+        } else {
+            System.out.println("1GB large pages not supported: UseLargePages=" + largePages +
+                    (largePages ? ", largePageSize=" + largePageSize : "") + ". Skipping");
+        }
+    }
+
+    public static long parseMemoryString(String value) {
+        value = value.toUpperCase();
+        long multiplier = 1;
+        if (value.endsWith("B")) {
+            multiplier = 1;
+        } else if (value.endsWith("K")) {
+            multiplier = 1024;
+        } else if (value.endsWith("M")) {
+            multiplier = 1024 * 1024;
+        } else if (value.endsWith("G")) {
+            multiplier = 1024 * 1024 * 1024;
+        } else {
+            throw new IllegalArgumentException("Expected memory string '" + value + "'to end with either of: B, K, M, G");
+        }
+
+        long longValue = Long.parseUnsignedLong(value.substring(0, value.length() - 1));
+
+        return longValue * multiplier;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I had to resolve a row of chunks in both codeCache files, but it's all been trivial context issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8304954](https://bugs.openjdk.org/browse/JDK-8304954) needs maintainer approval

### Issue
 * [JDK-8304954](https://bugs.openjdk.org/browse/JDK-8304954): SegmentedCodeCache fails when using large pages (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1734/head:pull/1734` \
`$ git checkout pull/1734`

Update a local copy of the PR: \
`$ git checkout pull/1734` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1734`

View PR using the GUI difftool: \
`$ git pr show -t 1734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1734.diff">https://git.openjdk.org/jdk17u-dev/pull/1734.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1734#issuecomment-1717544806)