### PR TITLE
8312573: Failure during CompileOnly parsing leads to ShouldNotReachHere

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -992,21 +992,10 @@ void CompilerOracle::parse_compile_only(char* line) {
       }
     }
 
-    if (*line == method_sep) {
-      if (className == NULL) {
-        className = "";
-        c_match = MethodMatcher::Any;
-      }
-    } else {
-      // got foo or foo/bar
-      if (className == NULL) {
-        ShouldNotReachHere();
-      } else {
-        // missing class name handled as "Any" class match
-        if (className[0] == '\0') {
-          c_match = MethodMatcher::Any;
-        }
-      }
+    if (className == nullptr || className[0] == '\0') {
+      // missing class name handled as "Any" class match
+      className = "";
+      c_match = MethodMatcher::Any;
     }
 
     // each directive is terminated by , or NUL or . followed by NUL

--- a/test/hotspot/jtreg/compiler/compilercontrol/parser/TestCompileOnly.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/parser/TestCompileOnly.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8312573
+ * @summary Test -XX:CompileOnly= with invalid arguments
+ * @library /test/lib /
+ * @run driver compiler.compilercontrol.parser.TestCompileOnly
+ */
+
+package compiler.compilercontrol.parser;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestCompileOnly {
+
+    public static void main(String[] args) throws Exception {
+        test(",");
+        test(" ");
+        test(", ");
+        test(" ,");
+        test(",,");
+        test("  ");
+    }
+
+    public static void test(String compileOnlyCommand) throws Exception {
+        OutputAnalyzer output = ProcessTools.executeTestJvm("-XX:CompileOnly=" + compileOnlyCommand, "-version");
+        output.shouldHaveExitValue(0);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I had to resolve because of NULL/nulptr differences.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8312573](https://bugs.openjdk.org/browse/JDK-8312573) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312573](https://bugs.openjdk.org/browse/JDK-8312573): Failure during CompileOnly parsing leads to ShouldNotReachHere (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1735/head:pull/1735` \
`$ git checkout pull/1735`

Update a local copy of the PR: \
`$ git checkout pull/1735` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1735`

View PR using the GUI difftool: \
`$ git pr show -t 1735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1735.diff">https://git.openjdk.org/jdk17u-dev/pull/1735.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1735#issuecomment-1717574716)