### PR TITLE
8315020: The macro definition for LoongArch64 zero build is not accurate.

### DIFF
--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -573,6 +573,8 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS_HELPER],
     HOTSPOT_$1_CPU_DEFINE=S390
   elif test "x$OPENJDK_$1_CPU" = xs390x; then
     HOTSPOT_$1_CPU_DEFINE=S390
+  elif test "x$OPENJDK_$1_CPU" = xloongarch64; then
+    HOTSPOT_$1_CPU_DEFINE=LOONGARCH64
   elif test "x$OPENJDK_$1_CPU" != x; then
     HOTSPOT_$1_CPU_DEFINE=$(echo $OPENJDK_$1_CPU | tr a-z A-Z)
   fi

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1799,11 +1799,11 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   static  Elf32_Half running_arch_code=EM_SH;
 #elif  (defined RISCV)
   static  Elf32_Half running_arch_code=EM_RISCV;
-#elif  (defined LOONGARCH)
+#elif  (defined LOONGARCH64)
   static  Elf32_Half running_arch_code=EM_LOONGARCH;
 #else
     #error Method os::dll_load requires that one of following is defined:\
-        AARCH64, ALPHA, ARM, AMD64, IA32, IA64, LOONGARCH, M68K, MIPS, MIPSEL, PARISC, __powerpc__, __powerpc64__, RISCV, S390, SH, __sparc
+        AARCH64, ALPHA, ARM, AMD64, IA32, IA64, LOONGARCH64, M68K, MIPS, MIPSEL, PARISC, __powerpc__, __powerpc64__, RISCV, S390, SH, __sparc
 #endif
 
   // Identify compatibility class for VM's architecture and library's architecture


### PR DESCRIPTION
I would like to backport [JDK-8315020](https://bugs.openjdk.org/browse/JDK-8315020) to jdk17u. This backport fixes LoongArch64 Zero build. LoongArch is added to Debian Ports, and the backport will help the builds in Debian.

The patch doesn't apply clean:
- `make/autoconf/platform.m4` - Not clean. There is no support for RISCV32 in jdk17u, and this backport does not include modifications to the RISCV32 part.
- `src/hotspot/os/linux/os_linux.cpp` - Clean.

Testing:

- `linux-loongarch64-zero-release` and `linux-loongarch64-zero-fastdebug` native build

```
openjdk version "17.0.10-internal" 2024-01-16
OpenJDK Runtime Environment (fastdebug build 17.0.10-internal+0-adhoc.aoqi.jdk17u-dev)
OpenJDK 64-Bit Zero VM (fastdebug build 17.0.10-internal+0-adhoc.aoqi.jdk17u-dev, interpreted mode)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8315020](https://bugs.openjdk.org/browse/JDK-8315020) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315020](https://bugs.openjdk.org/browse/JDK-8315020): The macro definition for LoongArch64 zero build is not accurate. (**Bug** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1738/head:pull/1738` \
`$ git checkout pull/1738`

Update a local copy of the PR: \
`$ git checkout pull/1738` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1738`

View PR using the GUI difftool: \
`$ git pr show -t 1738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1738.diff">https://git.openjdk.org/jdk17u-dev/pull/1738.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1738#issuecomment-1718742315)