### PR TITLE
8314679: SA fails to properly attach to JVM after having just detached from a different JVM

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
@@ -83,6 +83,8 @@ public class FileMapInfo {
   }
 
   private static void initialize(TypeDataBase db) {
+    vTableTypeMap = null; // force vTableTypeMap to get re-initialized later
+
     Type FileMapInfo_type = db.lookupType("FileMapInfo");
     Type FileMapHeader_type = db.lookupType("FileMapHeader");
     Type CDSFileMapRegion_type = db.lookupType("CDSFileMapRegion");

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbAttachDifferentJVMs.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbAttachDifferentJVMs.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
+
+/**
+ * @test
+ * @bug 8314679
+ * @summary Test clhsdb attach, detach, and then attach to different JVM
+ * @requires vm.hasSA
+ * @library /test/lib
+ * @run main/othervm ClhsdbAttachDifferentJVMs
+ */
+
+public class ClhsdbAttachDifferentJVMs {
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Starting ClhsdbAttach test");
+
+        LingeredApp theApp1 = null;
+        LingeredApp theApp2 = null;
+        try {
+            ClhsdbLauncher test = new ClhsdbLauncher();
+            theApp1 = LingeredApp.startApp();
+            System.out.println("Started LingeredApp with pid " + theApp1.getPid());
+            theApp2 = LingeredApp.startApp();
+            System.out.println("Started LingeredApp with pid " + theApp2.getPid());
+            String attach1 = "attach " + theApp1.getPid();
+            String attach2 = "attach " + theApp2.getPid();
+
+            List<String> cmds = List.of(
+                    "where",
+                    attach1,
+                    "threads",
+                    "detach",
+                    attach2,
+                    "jstack");
+
+            Map<String, List<String>> expStrMap = new HashMap<>();
+            expStrMap.put("where", List.of(
+                    "Command not valid until attached to a VM"));
+            expStrMap.put(attach1, List.of(
+                    "Attaching to process " + theApp1.getPid()));
+            expStrMap.put("threads", List.of(
+                    "Reference Handler"));
+            expStrMap.put(attach2, List.of(
+                    "Attaching to process " + theApp2.getPid()));
+            expStrMap.put("jstack", List.of(
+                    "Reference Handler"));
+
+            Map<String, List<String>> unexpStrMap = new HashMap<>();
+            unexpStrMap.put("jstack", List.of(
+                    "WARNING"));
+
+            test.run(-1, cmds, expStrMap, unexpStrMap);
+        } catch (SkippedException se) {
+            throw se;
+        } catch (Exception ex) {
+            throw new RuntimeException("Test ERROR " + ex, ex);
+        } finally {
+            LingeredApp.stopApp(theApp1);
+            LingeredApp.stopApp(theApp2);
+        }
+        System.out.println("Test PASSED");
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I dropped the patch for the generational ZGC ProbleList as the file is not in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314679](https://bugs.openjdk.org/browse/JDK-8314679) needs maintainer approval

### Issue
 * [JDK-8314679](https://bugs.openjdk.org/browse/JDK-8314679): SA fails to properly attach to JVM after having just detached from a different JVM (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1741/head:pull/1741` \
`$ git checkout pull/1741`

Update a local copy of the PR: \
`$ git checkout pull/1741` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1741`

View PR using the GUI difftool: \
`$ git pr show -t 1741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1741.diff">https://git.openjdk.org/jdk17u-dev/pull/1741.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1741#issuecomment-1719393687)