### PR TITLE
8293579: tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java fails on Japanese Windows platform

### DIFF
--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,19 @@ public final class UnicodeArgsTest {
     @Parameter("false")
     @Test
     public void test8246042(boolean onCommandLine) {
-        final String testString = new String(Character.toChars(0x00E9));
+        final String testString;
+
+        String encoding = System.getProperty("native.encoding");
+        switch (encoding) {
+        default:
+            testString = new String(Character.toChars(0x00E9));
+            break;
+
+        case "MS932":
+        case "SJIS":
+            testString = new String(Character.toChars(0x3042));
+            break;
+        }
 
         TKit.trace(String.format("Test string code points: %s", testString
                 .codePoints()


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [121d4a51](https://github.com/openjdk/jdk/commit/121d4a5119f98adf30fa759563eec843a6e37d61) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by KIRIYAMA Takuya on 4 Oct 2022 and was reviewed by Alexey Semenyuk, Naoto Sato and Alexander Matveev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8293579](https://bugs.openjdk.org/browse/JDK-8293579) needs maintainer approval

### Issue
 * [JDK-8293579](https://bugs.openjdk.org/browse/JDK-8293579): tools/jpackage/share/jdk/jpackage/tests/UnicodeArgsTest.java fails on Japanese Windows platform (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1745/head:pull/1745` \
`$ git checkout pull/1745`

Update a local copy of the PR: \
`$ git checkout pull/1745` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1745`

View PR using the GUI difftool: \
`$ git pr show -t 1745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1745.diff">https://git.openjdk.org/jdk17u-dev/pull/1745.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1745#issuecomment-1720904813)