### PR TITLE
8270447: [IR Framework] Add missing compilation level restriction when using FlipC1C2 stress option

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/TestVM.java
@@ -281,7 +281,7 @@ public class TestVM {
                     BaseTest baseTest = new BaseTest(test, shouldExcludeTest(m.getName()));
                     allTests.add(baseTest);
                     if (PRINT_VALID_IR_RULES) {
-                       irMatchRulePrinter.emitRuleEncoding(m, baseTest.isSkipped());
+                        irMatchRulePrinter.emitRuleEncoding(m, baseTest.isSkipped());
                     }
                 } catch (TestFormatException e) {
                     // Failure logged. Continue and report later.
@@ -462,19 +462,20 @@ public class TestVM {
     private void applyForceCompileCommand(Executable ex) {
         ForceCompile forceCompileAnno = getAnnotation(ex, ForceCompile.class);
         if (forceCompileAnno != null) {
-            CompLevel complevel = forceCompileAnno.value();
-            TestFormat.check(complevel != CompLevel.SKIP && complevel != CompLevel.WAIT_FOR_COMPILATION,
+            CompLevel compLevel = forceCompileAnno.value();
+            TestFormat.check(compLevel != CompLevel.SKIP && compLevel != CompLevel.WAIT_FOR_COMPILATION,
                              "Cannot define compilation level SKIP or WAIT_FOR_COMPILATION in @ForceCompile at " + ex);
-            complevel = restrictCompLevel(forceCompileAnno.value());
+            compLevel = restrictCompLevel(forceCompileAnno.value());
             if (FLIP_C1_C2) {
-                complevel = complevel.flipCompLevel();
+                compLevel = compLevel.flipCompLevel();
+                compLevel = restrictCompLevel(compLevel.flipCompLevel());
             }
             if (EXCLUDE_RANDOM) {
-                complevel = complevel.excludeCompilationRandomly(ex);
+                compLevel = compLevel.excludeCompilationRandomly(ex);
             }
-            if (complevel != CompLevel.SKIP) {
-                enqueueForCompilation(ex, complevel);
-                forceCompileMap.put(ex, complevel);
+            if (compLevel != CompLevel.SKIP) {
+                enqueueForCompilation(ex, compLevel);
+                forceCompileMap.put(ex, compLevel);
             }
         }
     }
@@ -504,7 +505,7 @@ public class TestVM {
                 } else {
                     TestFormat.checkNoThrow(!m.isAnnotationPresent(IR.class), "Found @IR annotation on non-@Test method " + m);
                     TestFormat.checkNoThrow(!m.isAnnotationPresent(Warmup.class) || getAnnotation(m, Run.class) != null,
-                                     "Found @Warmup annotation on non-@Test or non-@Run method " + m);
+                                            "Found @Warmup annotation on non-@Test or non-@Run method " + m);
                 }
             } catch (TestFormatException e) {
                 // Failure logged. Continue and report later.
@@ -530,6 +531,7 @@ public class TestVM {
         CompLevel compLevel = restrictCompLevel(testAnno.compLevel());
         if (FLIP_C1_C2) {
             compLevel = compLevel.flipCompLevel();
+            compLevel = restrictCompLevel(compLevel.flipCompLevel());
         }
         if (EXCLUDE_RANDOM) {
             compLevel = compLevel.excludeCompilationRandomly(m);
@@ -727,8 +729,8 @@ public class TestVM {
                          "Cannot use @Arguments at test method " + testMethod + " in combination with @Run method " + m);
         Warmup warmupAnno = getAnnotation(testMethod, Warmup.class);
         TestFormat.checkNoThrow(warmupAnno == null,
-                         "Cannot set @Warmup at @Test method " + testMethod + " when used with its @Run method "
-                         + m + ". Use @Warmup at @Run method instead.");
+                                "Cannot set @Warmup at @Test method " + testMethod + " when used with its @Run method "
+                                + m + ". Use @Warmup at @Run method instead.");
         Test testAnno = getAnnotation(testMethod, Test.class);
         TestFormat.checkNoThrow(runMode != RunMode.STANDALONE || testAnno.compLevel() == CompLevel.ANY,
                                 "Setting explicit compilation level for @Test method " + testMethod + " has no effect "
@@ -864,7 +866,7 @@ public class TestVM {
 
     public static void compile(Method m, CompLevel compLevel) {
         TestRun.check(compLevel != CompLevel.SKIP && compLevel != CompLevel.WAIT_FOR_COMPILATION,
-                         "Invalid compilation request with level " + compLevel);
+                      "Invalid compilation request with level " + compLevel);
         enqueueForCompilation(m, compLevel);
     }
 
@@ -907,7 +909,7 @@ public class TestVM {
      */
     private static boolean notUnstableDeoptAssertion(Method m, CompLevel level) {
         return (USE_COMPILER && !XCOMP && !IGNORE_COMPILER_CONTROLS && !TEST_C1 &&
-               (!EXCLUDE_RANDOM || WHITE_BOX.isMethodCompilable(m, level.getValue(), false)));
+                (!EXCLUDE_RANDOM || WHITE_BOX.isMethodCompilable(m, level.getValue(), false)));
     }
 
     public static void assertCompiledByC1(Method m) {
@@ -962,7 +964,7 @@ public class TestVM {
                 default -> throw new TestRunException("compiledAtLevel() should not be called with " + level);
             }
         }
-        if (!USE_COMPILER || XCOMP || TEST_C1 || IGNORE_COMPILER_CONTROLS ||
+        if (!USE_COMPILER || XCOMP || TEST_C1 || IGNORE_COMPILER_CONTROLS || FLIP_C1_C2 ||
             (EXCLUDE_RANDOM && !WHITE_BOX.isMethodCompilable(m, level.getValue(), false))) {
             return TriState.Maybe;
         }


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8270447](https://bugs.openjdk.org/browse/JDK-8270447) needs maintainer approval

### Issue
 * [JDK-8270447](https://bugs.openjdk.org/browse/JDK-8270447): [IR Framework] Add missing compilation level restriction when using FlipC1C2 stress option (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1747/head:pull/1747` \
`$ git checkout pull/1747`

Update a local copy of the PR: \
`$ git checkout pull/1747` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1747`

View PR using the GUI difftool: \
`$ git pr show -t 1747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1747.diff">https://git.openjdk.org/jdk17u-dev/pull/1747.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1747#issuecomment-1721099398)