### PR TITLE
8273522: Rename test property vm.cds.archived.java.heap to vm.cds.write.archived.java.heap

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1962,7 +1962,7 @@ WB_ENTRY(jboolean, WB_IsJVMCISupportedByGC(JNIEnv* env))
 #endif
 WB_END
 
-WB_ENTRY(jboolean, WB_IsJavaHeapArchiveSupported(JNIEnv* env))
+WB_ENTRY(jboolean, WB_CanWriteJavaHeapArchive(JNIEnv* env))
   return HeapShared::is_heap_object_archiving_allowed();
 WB_END
 
@@ -2585,7 +2585,7 @@ static JNINativeMethod methods[] = {
   {CC"isDTraceIncluded",                  CC"()Z",    (void*)&WB_IsDTraceIncluded },
   {CC"isC2OrJVMCIIncluded",               CC"()Z",    (void*)&WB_isC2OrJVMCIIncluded },
   {CC"isJVMCISupportedByGC",              CC"()Z",    (void*)&WB_IsJVMCISupportedByGC},
-  {CC"isJavaHeapArchiveSupported",        CC"()Z",    (void*)&WB_IsJavaHeapArchiveSupported },
+  {CC"canWriteJavaHeapArchive",           CC"()Z",    (void*)&WB_CanWriteJavaHeapArchive },
   {CC"cdsMemoryMappingFailed",            CC"()Z",    (void*)&WB_CDSMemoryMappingFailed },
 
   {CC"clearInlineCaches0",  CC"(Z)V",                 (void*)&WB_ClearInlineCaches },

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -68,7 +68,7 @@ requires.properties= \
     vm.rtm.compiler \
     vm.cds \
     vm.cds.custom.loaders \
-    vm.cds.archived.java.heap \
+    vm.cds.write.archived.java.heap \
     vm.jvmti \
     vm.graal.enabled \
     vm.compiler1.enabled \

--- a/test/hotspot/jtreg/runtime/cds/SharedStrings.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedStrings.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Check to make sure that shared strings in the bootstrap CDS archive
  *          are actually shared
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib
  * @build SharedStringsWb jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/SharedStringsDedup.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedStringsDedup.java
@@ -24,7 +24,7 @@
 /**
  * @test SharedStringsDedup
  * @summary Test -Xshare:auto with shared strings and -XX:+UseStringDeduplication
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib
  * @run driver SharedStringsDedup
  */

--- a/test/hotspot/jtreg/runtime/cds/SharedStringsRunAuto.java
+++ b/test/hotspot/jtreg/runtime/cds/SharedStringsRunAuto.java
@@ -24,7 +24,7 @@
 /**
  * @test SharedStringsAuto
  * @summary Test -Xshare:auto with shared strings.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib
  * @run driver SharedStringsRunAuto
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagCombo.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/CommandLineFlagCombo.java
@@ -24,7 +24,7 @@
 
 /*
  * @test CommandLineFlagCombo
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @comment This test explicitly chooses the type of GC to be used by sub-processes. It may conflict with the GC type set
  * via the -vmoptions command line option of JTREG. vm.gc==null will help the test case to discard the explicitly passed
  * vm options.

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test primitive box caches integrity in various scenarios (IntegerCache etc)
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox
  * @compile CheckIntegerCacheApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleComboTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleComboTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test archived system module sub-graph and verify objects are archived.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox
  * @compile CheckArchivedModuleApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Compare archived system modules with non-archived.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile PrintSystemModulesApp.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar app.jar PrintSystemModulesApp

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Test archived module graph with custom runtime image
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/jdk/lib/testlibrary /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox
  * @compile CheckArchivedModuleApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckCachedMirrorTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/CheckCachedMirrorTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test archived mirror
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.cds.custom.loaders
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/DifferentHeapSizes.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/DifferentHeapSizes.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test automatic relocation of archive heap regions dur to heap size changes.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile ../test-classes/Hello.java
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/DumpTimeVerifyFailure.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/DumpTimeVerifyFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @test
  * @summary Dump time should not crash if any class with shared strings fails verification due to missing dependencies.
  * @bug 8186789
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile MyOuter.java MyException.java
  * @run driver DumpTimeVerifyFailure

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/GCStressTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/GCStressTest.java
@@ -26,7 +26,7 @@
  * @test
  * @key randomness
  * @summary
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox jdk.test.lib.Utils
  * @compile GCStressApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/HeapFragmentationTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/HeapFragmentationTest.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Relocate CDS archived regions to the top of the G1 heap
  * @bug 8214455
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires (sun.arch.data.model == "64" & os.maxMemory > 4g)
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HeapFragmentationApp

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/MirrorWithReferenceFieldsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/MirrorWithReferenceFieldsTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test archived mirror with reference fields
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox
  * @compile MirrorWithReferenceFieldsApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/OpenArchiveRegion.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/OpenArchiveRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test open archive heap regions
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @comment This test explicitly chooses the type of GC to be used by sub-processes. It may conflict with the GC type set
  * via the -vmoptions command line option of JTREG. vm.gc==null will help the test case to discard the explicitly passed
  * vm options.

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/PrimitiveTypesTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/PrimitiveTypesTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test archived primitive type mirrors
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox
  * @compile PrimitiveTypesApp.java

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/RedefineClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/RedefineClassTest.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Redefine shared class. GC should not cause crash with cached resolved_references.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes /test/hotspot/jtreg/runtime/cds/appcds/jvmti
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.jvmti
  * @build jdk.test.whitebox.WhiteBox
  *        RedefineClassApp

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Out of memory When dumping the CDS archive
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.jvmti
  * @run driver ExceptionDuringDumpAtObjectsInitPhase
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCSharedStringsDuringDump.java
@@ -27,7 +27,7 @@
  * @summary Similar to GCDuringDumping.java, this test adds the -XX:SharedArchiveConfigFile
  *          option for testing the interaction with GC and shared strings.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.jvmti
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/HumongousDuringDump.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/HumongousDuringDump.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Test how CDS dumping handles the existence of humongous G1 regions.
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires vm.jvmti
  * @run driver/timeout=240 HumongousDuringDump
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ExerciseGC.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ExerciseGC.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Exercise GC with shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloStringGC jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
@@ -25,7 +25,7 @@
 /**
  * @test
  * @summary Test relevant combinations of command line flags with shared strings
- * @requires vm.cds.archived.java.heap & vm.hasJFR
+ * @requires vm.cds.write.archived.java.heap & vm.hasJFR
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
  * @run driver FlagCombo
@@ -35,7 +35,7 @@
  * @test
  * @summary Test relevant combinations of command line flags with shared strings
  * @comment A special test excluding the case that requires JFR
- * @requires vm.cds.archived.java.heap & !vm.hasJFR
+ * @requires vm.cds.write.archived.java.heap & !vm.hasJFR
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
  * @run driver FlagCombo noJfr

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
@@ -31,7 +31,7 @@
  * @test
  * @summary Test options that are incompatible with use of shared strings
  *          Also test mismatch in oops encoding between dump time and run time
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @comment This test explicitly chooses the type of GC to be used by sub-processes. It may conflict with the GC type set
  * via the -vmoptions command line option of JTREG. vm.gc==null will help the test case to discard the explicitly passed
  * vm options.
@@ -46,7 +46,7 @@
 
 /*
  * @test
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires (vm.gc=="null")
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox
@@ -57,7 +57,7 @@
 
 /*
  * @test
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @requires (vm.gc=="null")
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test shared strings together with string intern operation
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @compile InternStringTest.java
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InvalidFileFormat.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InvalidFileFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Check most common errors in file format
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
  * @run driver InvalidFileFormat

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LargePages.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LargePages.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Basic shared string test with large pages
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build HelloString
  * @run driver LargePages

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockSharedStrings.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockSharedStrings.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test locking on shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @compile LockStringTest.java LockStringValueTest.java
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasic.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasic.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Basic test for shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloString
  * @run driver SharedStringsBasic

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasicPlus.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasicPlus.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Basic plus test for shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloStringPlus jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsHumongous.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsHumongous.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Use a shared string allocated in a humongous G1 region.
  * @comment -- the following implies that G1 is used (by command-line or by default)
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  *
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloString

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsStress.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsStress.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Write a lots of shared strings.
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @build HelloString
  * @run driver/timeout=500 SharedStringsStress

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWbTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWbTest.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary White box test for shared strings
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @build jdk.test.whitebox.WhiteBox SharedStringsWb
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Regression test for JDK-8098821
  * @bug 8098821
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver SysDictCrash
  */

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
@@ -26,7 +26,7 @@
  * @test
  * @summary Tests how CDS works when critical library classes are replaced with JVMTI ClassFileLoadHook
  * @library /test/lib
- * @requires vm.cds.archived.java.heap
+ * @requires vm.cds.write.archived.java.heap
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
  * @run main/othervm/native ReplaceCriticalClassesForSubgraphs

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -111,7 +111,7 @@ public class VMProps implements Callable<Map<String, String>> {
         // vm.cds is true if the VM is compiled with cds support.
         map.put("vm.cds", this::vmCDS);
         map.put("vm.cds.custom.loaders", this::vmCDSForCustomLoaders);
-        map.put("vm.cds.archived.java.heap", this::vmCDSForArchivedJavaHeap);
+        map.put("vm.cds.write.archived.java.heap", this::vmCDSCanWriteArchivedJavaHeap);
         // vm.graal.enabled is true if Graal is used as JIT
         map.put("vm.graal.enabled", this::isGraalEnabled);
         map.put("vm.compiler1.enabled", this::isCompiler1Enabled);
@@ -386,12 +386,10 @@ public class VMProps implements Callable<Map<String, String>> {
     }
 
     /**
-     * Check for CDS support for archived Java heap regions.
-     *
-     * @return true if CDS provides support for archive Java heap regions in the VM to be tested.
+     * @return true if this VM can write Java heap objects into the CDS archive
      */
-    protected String vmCDSForArchivedJavaHeap() {
-        return "" + ("true".equals(vmCDS()) && WB.isJavaHeapArchiveSupported());
+    protected String vmCDSCanWriteArchivedJavaHeap() {
+        return "" + ("true".equals(vmCDS()) && WB.canWriteJavaHeapArchive());
     }
 
     /**

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -600,7 +600,7 @@ public class WhiteBox {
   public native boolean isCDSIncluded();
   public native boolean isJFRIncluded();
   public native boolean isDTraceIncluded();
-  public native boolean isJavaHeapArchiveSupported();
+  public native boolean canWriteJavaHeapArchive();
   public native Object  getResolvedReferences(Class<?> c);
   public native void    linkClass(Class<?> c);
   public native boolean areOpenArchiveHeapObjectsMapped();


### PR DESCRIPTION
I backport this to simplify backport of tests that use the new property name.

Resolves were simple, only the method checking the flags set does not match good:

src/hotspot/share/cds/heapShared.hpp
Skipped. is_heap_object_archiving_allowed(), the predecessor of can_write(), does not have this assertion.

src/hotspot/share/prims/whitebox.cpp
I had to adapt this.
In 17, method is_heap_object_archiving_allowed() is called in WB_IsJavaHeapArchiveSupported()
Between 17 and 18, this has been renamed to can_write().
Also, WB_IsJavaHeapArchiveSupported() has been changed to call can_use(),
where this change reverts this to call can_write().
So I leave the call as-is, this shows the desired behaviour.

test/hotspot/jtreg/runtime/cds/SharedStrings.java
test/hotspot/jtreg/runtime/cds/appcds/cacheObject/ArchivedModuleWithCustomImageTest.java
test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/FlagCombo.java
test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LargePages.java
test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/LockSharedStrings.java
test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsBasicPlus.java
test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SharedStringsWbTest.java
test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/SysDictCrash.java
test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
test/lib/jdk/test/whitebox/WhiteBox.java
Trivial resolves of the property.

test/lib/sun/hotspot/WhiteBox.java: No such file or directory
Skipped, was merged with the other WhiteBox.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8273522](https://bugs.openjdk.org/browse/JDK-8273522) needs maintainer approval

### Issue
 * [JDK-8273522](https://bugs.openjdk.org/browse/JDK-8273522): Rename test property vm.cds.archived.java.heap to vm.cds.write.archived.java.heap (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1748/head:pull/1748` \
`$ git checkout pull/1748`

Update a local copy of the PR: \
`$ git checkout pull/1748` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1748`

View PR using the GUI difftool: \
`$ git pr show -t 1748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1748.diff">https://git.openjdk.org/jdk17u-dev/pull/1748.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1748#issuecomment-1722914435)