### PR TITLE
8247351: [aarch64] NullPointerException during stack walking (clhsdb "where -a")

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/RegisterMap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/RegisterMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,7 @@ public abstract class RegisterMap implements Cloneable {
       Assert.that(0 <= i && i < regCount, "sanity check");
       Assert.that(0 <= index && index < locationValidSize, "sanity check");
     }
-    if ((locationValid[index] & (1 << i % locationValidTypeSize)) != 0) {
+    if ((locationValid[index] & (1L << i % locationValidTypeSize)) != 0) {
       return location[i];
     } else {
       return getLocationPD(reg);
@@ -162,7 +162,7 @@ public abstract class RegisterMap implements Cloneable {
       Assert.that(updateMap, "updating map that does not need updating");
     }
     location[i]          = loc;
-    locationValid[index] |= (1 << (i % locationValidTypeSize));
+    locationValid[index] |= (1L << (i % locationValidTypeSize));
   }
 
   public boolean getIncludeArgumentOops() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/aarch64/AARCH64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/aarch64/AARCH64Frame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2019, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -70,7 +70,7 @@ public class AARCH64Frame extends Frame {
   // Native frames
   private static final int NATIVE_FRAME_INITIAL_PARAM_OFFSET =  2;
 
-  private static VMReg fp = new VMReg(29);
+  private static VMReg fp = new VMReg(29 << 1);
 
   static {
     VM.registerVMInitializedObserver(new Observer() {


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8247351](https://bugs.openjdk.org/browse/JDK-8247351) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247351](https://bugs.openjdk.org/browse/JDK-8247351): [aarch64] NullPointerException during stack walking (clhsdb "where -a") (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1749/head:pull/1749` \
`$ git checkout pull/1749`

Update a local copy of the PR: \
`$ git checkout pull/1749` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1749`

View PR using the GUI difftool: \
`$ git pr show -t 1749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1749.diff">https://git.openjdk.org/jdk17u-dev/pull/1749.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1749#issuecomment-1722934702)