### PR TITLE
8308593: Add KEEPALIVE Extended Socket Options Support for Windows

### DIFF
--- a/make/modules/jdk.net/Lib.gmk
+++ b/make/modules/jdk.net/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2023 Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/modules/jdk.net/Lib.gmk
+++ b/make/modules/jdk.net/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2020, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ include LibCommon.gmk
 
 ################################################################################
 
-ifeq ($(call isTargetOs, linux macosx), true)
+ifeq ($(call isTargetOs, linux macosx windows), true)
 
   $(eval $(call SetupJdkLibrary, BUILD_LIBEXTNET, \
       NAME := extnet, \
@@ -35,8 +35,9 @@ ifeq ($(call isTargetOs, linux macosx), true)
       CFLAGS := $(CFLAGS_JDKLIB), \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
           $(call SET_SHARED_LIBRARY_ORIGIN), \
-      LIBS := -ljava, \
+      LIBS_unix := -ljava, \
       LIBS_linux := -ljvm, \
+      LIBS_windows := jvm.lib ws2_32.lib $(WIN_JAVA_LIB), \
   ))
 
   $(BUILD_LIBEXTNET): $(call FindLib, java.base, java)

--- a/src/jdk.net/linux/classes/jdk/net/LinuxSocketOptions.java
+++ b/src/jdk.net/linux/classes/jdk/net/LinuxSocketOptions.java
@@ -63,8 +63,8 @@ class LinuxSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    void setTcpkeepAliveProbes(int fd, final int value) throws SocketException {
-        setTcpkeepAliveProbes0(fd, value);
+    void setTcpKeepAliveProbes(int fd, final int value) throws SocketException {
+        setTcpKeepAliveProbes0(fd, value);
     }
 
     @Override
@@ -78,8 +78,8 @@ class LinuxSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    int getTcpkeepAliveProbes(int fd) throws SocketException {
-        return getTcpkeepAliveProbes0(fd);
+    int getTcpKeepAliveProbes(int fd) throws SocketException {
+        return getTcpKeepAliveProbes0(fd);
     }
 
     @Override
@@ -112,10 +112,10 @@ class LinuxSocketOptions extends PlatformSocketOptions {
         return new UnixDomainPrincipal(user, group);
     }
 
-    private static native void setTcpkeepAliveProbes0(int fd, int value) throws SocketException;
+    private static native void setTcpKeepAliveProbes0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
     private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;
-    private static native int getTcpkeepAliveProbes0(int fd) throws SocketException;
+    private static native int getTcpKeepAliveProbes0(int fd) throws SocketException;
     private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
     private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
     private static native void setQuickAck0(int fd, boolean on) throws SocketException;

--- a/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
+++ b/src/jdk.net/linux/native/libextnet/LinuxSocketOptions.c
@@ -147,10 +147,10 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_LinuxSocketOptions_keepAliveOptionsSuppo
 
 /*
  * Class:     jdk_net_LinuxSocketOptions
- * Method:    setTcpkeepAliveProbes0
+ * Method:    setTcpKeepAliveProbes0
  * Signature: (II)V
  */
-JNIEXPORT void JNICALL Java_jdk_net_LinuxSocketOptions_setTcpkeepAliveProbes0
+JNIEXPORT void JNICALL Java_jdk_net_LinuxSocketOptions_setTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd, jint optval) {
     jint rv = setsockopt(fd, SOL_TCP, TCP_KEEPCNT, &optval, sizeof (optval));
     handleError(env, rv, "set option TCP_KEEPCNT failed");
@@ -180,10 +180,10 @@ JNIEXPORT void JNICALL Java_jdk_net_LinuxSocketOptions_setTcpKeepAliveIntvl0
 
 /*
  * Class:     jdk_net_LinuxSocketOptions
- * Method:    getTcpkeepAliveProbes0
+ * Method:    getTcpKeepAliveProbes0
  * Signature: (I)I;
  */
-JNIEXPORT jint JNICALL Java_jdk_net_LinuxSocketOptions_getTcpkeepAliveProbes0
+JNIEXPORT jint JNICALL Java_jdk_net_LinuxSocketOptions_getTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd) {
     jint optval, rv;
     socklen_t sz = sizeof (optval);

--- a/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
+++ b/src/jdk.net/macosx/native/libextnet/MacOSXSocketOptions.c
@@ -79,10 +79,10 @@ JNIEXPORT jboolean JNICALL Java_jdk_net_MacOSXSocketOptions_keepAliveOptionsSupp
 
 /*
  * Class:     jdk_net_MacOSXSocketOptions
- * Method:    setTcpkeepAliveProbes0
+ * Method:    setTcpKeepAliveProbes0
  * Signature: (II)V
  */
-JNIEXPORT void JNICALL Java_jdk_net_MacOSXSocketOptions_setTcpkeepAliveProbes0
+JNIEXPORT void JNICALL Java_jdk_net_MacOSXSocketOptions_setTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd, jint optval) {
     jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &optval, sizeof (optval));
     handleError(env, rv, "set option TCP_KEEPCNT failed");
@@ -112,10 +112,10 @@ JNIEXPORT void JNICALL Java_jdk_net_MacOSXSocketOptions_setTcpKeepAliveIntvl0
 
 /*
  * Class:     jdk_net_MacOSXSocketOptions
- * Method:    getTcpkeepAliveProbes0
+ * Method:    getTcpKeepAliveProbes0
  * Signature: (I)I;
  */
-JNIEXPORT jint JNICALL Java_jdk_net_MacOSXSocketOptions_getTcpkeepAliveProbes0
+JNIEXPORT jint JNICALL Java_jdk_net_MacOSXSocketOptions_getTcpKeepAliveProbes0
 (JNIEnv *env, jobject unused, jint fd) {
     jint optval, rv;
     socklen_t sz = sizeof (optval);

--- a/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
+++ b/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
+++ b/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,7 +247,7 @@ public final class ExtendedSocketOptions {
                 if (option == TCP_QUICKACK) {
                     setQuickAckOption(fd, (boolean) value);
                 } else if (option == TCP_KEEPCOUNT) {
-                    setTcpkeepAliveProbes(fd, (Integer) value);
+                    setTcpKeepAliveProbes(fd, (Integer) value);
                 } else if (option == TCP_KEEPIDLE) {
                     setTcpKeepAliveTime(fd, (Integer) value);
                 } else if (option == TCP_KEEPINTERVAL) {
@@ -276,7 +276,7 @@ public final class ExtendedSocketOptions {
                 if (option == TCP_QUICKACK) {
                     return getQuickAckOption(fd);
                 } else if (option == TCP_KEEPCOUNT) {
-                    return getTcpkeepAliveProbes(fd);
+                    return getTcpKeepAliveProbes(fd);
                 } else if (option == TCP_KEEPIDLE) {
                     return getTcpKeepAliveTime(fd);
                 } else if (option == TCP_KEEPINTERVAL) {
@@ -310,9 +310,9 @@ public final class ExtendedSocketOptions {
         return platformSocketOptions.getQuickAck(fdAccess.get(fd));
     }
 
-    private static void setTcpkeepAliveProbes(FileDescriptor fd, int value)
+    private static void setTcpKeepAliveProbes(FileDescriptor fd, int value)
             throws SocketException {
-        platformSocketOptions.setTcpkeepAliveProbes(fdAccess.get(fd), value);
+        platformSocketOptions.setTcpKeepAliveProbes(fdAccess.get(fd), value);
     }
 
     private static void setTcpKeepAliveTime(FileDescriptor fd, int value)
@@ -325,8 +325,8 @@ public final class ExtendedSocketOptions {
         platformSocketOptions.setTcpKeepAliveIntvl(fdAccess.get(fd), value);
     }
 
-    private static int getTcpkeepAliveProbes(FileDescriptor fd) throws SocketException {
-        return platformSocketOptions.getTcpkeepAliveProbes(fdAccess.get(fd));
+    private static int getTcpKeepAliveProbes(FileDescriptor fd) throws SocketException {
+        return platformSocketOptions.getTcpKeepAliveProbes(fdAccess.get(fd));
     }
 
     private static int getTcpKeepAliveTime(FileDescriptor fd) throws SocketException {
@@ -368,6 +368,8 @@ public final class ExtendedSocketOptions {
                 return newInstance("jdk.net.LinuxSocketOptions");
             } else if (osname.startsWith("Mac")) {
                 return newInstance("jdk.net.MacOSXSocketOptions");
+            } else if (osname.startsWith("Windows")) {
+                return newInstance("jdk.net.WindowsSocketOptions");
             } else {
                 return new PlatformSocketOptions();
             }
@@ -399,7 +401,7 @@ public final class ExtendedSocketOptions {
             return false;
         }
 
-        void setTcpkeepAliveProbes(int fd, final int value) throws SocketException {
+        void setTcpKeepAliveProbes(int fd, final int value) throws SocketException {
             throw new UnsupportedOperationException("unsupported TCP_KEEPCNT option");
         }
 
@@ -415,7 +417,7 @@ public final class ExtendedSocketOptions {
             throw new UnsupportedOperationException("unsupported TCP_KEEPINTVL option");
         }
 
-        int getTcpkeepAliveProbes(int fd) throws SocketException {
+        int getTcpKeepAliveProbes(int fd) throws SocketException {
             throw new UnsupportedOperationException("unsupported TCP_KEEPCNT option");
         }
 

--- a/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
+++ b/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,15 @@
 package jdk.net;
 
 import java.net.SocketException;
-import java.nio.file.attribute.UserPrincipal;
-import java.nio.file.attribute.GroupPrincipal;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import jdk.net.ExtendedSocketOptions.PlatformSocketOptions;
-import sun.nio.fs.UnixUserPrincipals;
+
 
 @SuppressWarnings("removal")
-class MacOSXSocketOptions extends PlatformSocketOptions {
+class WindowsSocketOptions extends PlatformSocketOptions {
 
-    public MacOSXSocketOptions() {
+    public WindowsSocketOptions() {
     }
 
     @Override
@@ -49,23 +47,13 @@ class MacOSXSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
-    void setTcpKeepAliveTime(int fd, final int value) throws SocketException {
-        setTcpKeepAliveTime0(fd, value);
-    }
-
-    @Override
-    boolean peerCredentialsSupported() {
-        return true;
-    }
-
-    @Override
-    void setTcpKeepAliveIntvl(int fd, final int value) throws SocketException {
-        setTcpKeepAliveIntvl0(fd, value);
-    }
-
-    @Override
     int getTcpKeepAliveProbes(int fd) throws SocketException {
         return getTcpKeepAliveProbes0(fd);
+    }
+
+    @Override
+    void setTcpKeepAliveTime(int fd, final int value) throws SocketException {
+        setTcpKeepAliveTime0(fd, value);
     }
 
     @Override
@@ -74,28 +62,23 @@ class MacOSXSocketOptions extends PlatformSocketOptions {
     }
 
     @Override
+    void setTcpKeepAliveIntvl(int fd, final int value) throws SocketException {
+        setTcpKeepAliveIntvl0(fd, value);
+    }
+
+    @Override
     int getTcpKeepAliveIntvl(int fd) throws SocketException {
         return getTcpKeepAliveIntvl0(fd);
     }
 
-    @Override
-    UnixDomainPrincipal getSoPeerCred(int fd) throws SocketException {
-        long l = getSoPeerCred0(fd);
-        int uid = (int)(l >> 32);
-        int gid = (int)l;
-        UserPrincipal user = UnixUserPrincipals.fromUid(uid);
-        GroupPrincipal group = UnixUserPrincipals.fromGid(gid);
-        return new UnixDomainPrincipal(user, group);
-    }
-
-    private static native void setTcpKeepAliveProbes0(int fd, int value) throws SocketException;
-    private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
-    private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;
-    private static native int getTcpKeepAliveProbes0(int fd) throws SocketException;
-    private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
-    private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
-    private static native long getSoPeerCred0(int fd) throws SocketException;
     private static native boolean keepAliveOptionsSupported0();
+    private static native void setTcpKeepAliveProbes0(int fd, int value) throws SocketException;
+    private static native int getTcpKeepAliveProbes0(int fd) throws SocketException;
+    private static native void setTcpKeepAliveTime0(int fd, int value) throws SocketException;
+    private static native int getTcpKeepAliveTime0(int fd) throws SocketException;
+    private static native void setTcpKeepAliveIntvl0(int fd, int value) throws SocketException;
+    private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
+
     static {
         if (System.getSecurityManager() == null) {
             System.loadLibrary("extnet");

--- a/src/jdk.net/windows/native/libextnet/WindowsSocketOptions.c
+++ b/src/jdk.net/windows/native/libextnet/WindowsSocketOptions.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <windows.h>
+#include <winsock2.h>
+
+#include <WS2tcpip.h>
+
+#include "jni.h"
+#include "jni_util.h"
+#include "jvm.h"
+
+static void handleError(JNIEnv *env, jint rv, const char *errmsg) {
+    if (rv < 0) {
+        int error = WSAGetLastError();
+        if (error == WSAENOPROTOOPT) {
+            JNU_ThrowByName(env, "java/lang/UnsupportedOperationException",
+                    "unsupported socket option");
+        } else {
+            JNU_ThrowByNameWithLastError(env, "java/net/SocketException", errmsg);
+        }
+    }
+}
+
+static jint socketOptionSupported(jint level, jint optname) {
+    WSADATA wsaData;
+    jint error = WSAStartup(MAKEWORD(2, 2), &wsaData);
+
+    if (error != 0) {
+        return 0;
+    }
+
+    SOCKET sock;
+    jint one = 1;
+    jint rv;
+    socklen_t sz = sizeof(one);
+
+    /* First try IPv6; fall back to IPv4. */
+    sock = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP);
+    if (sock == INVALID_SOCKET) {
+        error = WSAGetLastError();
+        if (error == WSAEPFNOSUPPORT || error == WSAEAFNOSUPPORT) {
+            sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+        }
+        if (sock == INVALID_SOCKET) {
+            return 0;
+        }
+    }
+
+    rv = getsockopt(sock, level, optname, (char*) &one, &sz);
+    error = WSAGetLastError();
+
+    if (rv != 0 && error == WSAENOPROTOOPT) {
+        rv = 0;
+    } else {
+        rv = 1;
+    }
+
+    closesocket(sock);
+    WSACleanup();
+
+    return rv;
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    keepAliveOptionsSupported0
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL Java_jdk_net_WindowsSocketOptions_keepAliveOptionsSupported0
+(JNIEnv *env, jobject unused) {
+    return socketOptionSupported(IPPROTO_TCP, TCP_KEEPIDLE) && socketOptionSupported(IPPROTO_TCP, TCP_KEEPCNT)
+            && socketOptionSupported(IPPROTO_TCP, TCP_KEEPINTVL);
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    setTcpKeepAliveProbes0
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpKeepAliveProbes0
+(JNIEnv *env, jobject unused, jint fd, jint optval) {
+    jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (char*) &optval, sizeof(optval));
+    handleError(env, rv, "set option TCP_KEEPCNT failed");
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    getTcpKeepAliveProbes0
+ * Signature: (I)I;
+ */
+JNIEXPORT jint JNICALL Java_jdk_net_WindowsSocketOptions_getTcpKeepAliveProbes0
+(JNIEnv *env, jobject unused, jint fd) {
+    jint optval, rv;
+    socklen_t sz = sizeof(optval);
+    rv = getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (char*) &optval, &sz);
+    handleError(env, rv, "get option TCP_KEEPCNT failed");
+    return optval;
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    setTcpKeepAliveTime0
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpKeepAliveTime0
+(JNIEnv *env, jobject unused, jint fd, jint optval) {
+    jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (char*) &optval, sizeof(optval));
+    handleError(env, rv, "set option TCP_KEEPIDLE failed");
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    getTcpKeepAliveTime0
+ * Signature: (I)I;
+ */
+JNIEXPORT jint JNICALL Java_jdk_net_WindowsSocketOptions_getTcpKeepAliveTime0
+(JNIEnv *env, jobject unused, jint fd) {
+    jint optval, rv;
+    socklen_t sz = sizeof(optval);
+    rv = getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (char*) &optval, &sz);
+    handleError(env, rv, "get option TCP_KEEPIDLE failed");
+    return optval;
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    setTcpKeepAliveIntvl0
+ * Signature: (II)V
+ */
+JNIEXPORT void JNICALL Java_jdk_net_WindowsSocketOptions_setTcpKeepAliveIntvl0
+(JNIEnv *env, jobject unused, jint fd, jint optval) {
+    jint rv = setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (char*) &optval, sizeof(optval));
+    handleError(env, rv, "set option TCP_KEEPINTVL failed");
+}
+
+/*
+ * Class:     jdk_net_WindowsSocketOptions
+ * Method:    getTcpKeepAliveIntvl0
+ * Signature: (I)I;
+ */
+JNIEXPORT jint JNICALL Java_jdk_net_WindowsSocketOptions_getTcpKeepAliveIntvl0
+(JNIEnv *env, jobject unused, jint fd) {
+    jint optval, rv;
+    socklen_t sz = sizeof(optval);
+    rv = getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (char*) &optval, &sz);
+    handleError(env, rv, "get option TCP_KEEPINTVL failed");
+    return optval;
+}


### PR DESCRIPTION
This is an unclean backport of [JDK-8308593](https://bugs.openjdk.org/browse/JDK-8308593), which provides support for the keepalive extended socket options on Windows.

The following changes were made in these files to resolve conflicts and issues:
1. make/modules/jdk.net/Lib.gmk -- I updated this script to support building extnet for Windows.

2. jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java -- I added a case to support returning an instance of WindowsSocketOptions in PlatformSocketOptions.

Tier 1 tests were ran and they're passing along with the existing keepalive tests. I also manually tested and confirmed the patch to be working on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8308593](https://bugs.openjdk.org/browse/JDK-8308593) needs maintainer approval

### Issue
 * [JDK-8308593](https://bugs.openjdk.org/browse/JDK-8308593): Add KEEPALIVE Extended Socket Options Support for Windows (**Enhancement** - P4 - Approved)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - no project role) ⚠️ Review applies to [7c75b9dd](https://git.openjdk.org/jdk17u-dev/pull/1751/files/7c75b9ddbffaf2670efefdb28ec29a9890afc5b7)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1751/head:pull/1751` \
`$ git checkout pull/1751`

Update a local copy of the PR: \
`$ git checkout pull/1751` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1751`

View PR using the GUI difftool: \
`$ git pr show -t 1751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1751.diff">https://git.openjdk.org/jdk17u-dev/pull/1751.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1751#issuecomment-1724173627)