### PR TITLE
8315683: Parallelize java/util/concurrent/tck/JSR166TestCase.java

### DIFF
--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -35,33 +35,54 @@
  */
 
 /*
- * @test
- * @summary JSR-166 tck tests, in a number of variations.
- *          The first is the conformance testing variant,
- *          while others also test implementation details.
+ * @test id=default
+ * @summary Conformance testing variant of JSR-166 tck tests.
+ * @build *
+ * @modules java.management
+ * @run junit/othervm/timeout=1000 JSR166TestCase
+ */
+
+/*
+ * @test id=security-manager
+ * @summary Conformance testing variant of JSR-166 tck tests
+ *          with java security manager set to allow.
  * @build *
  * @modules java.management
  * @run junit/othervm/timeout=1000 -Djava.security.manager=allow JSR166TestCase
+ */
+
+/*
+ * @test id=forkjoinpool-common-parallelism
+ * @summary Test implementation details variant of JSR-166
+ *          tck tests with ForkJoinPool common parallelism.
+ * @build *
+ * @modules java.management
  * @run junit/othervm/timeout=1000
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
- *      -Djava.security.manager=allow
- *      -Djsr166.testImplementationDetails=true
- *      JSR166TestCase
- * @run junit/othervm/timeout=1000
- *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
- *      --add-opens java.base/java.lang=ALL-UNNAMED
- *      -Djava.security.manager=allow
  *      -Djsr166.testImplementationDetails=true
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=0
  *      JSR166TestCase
  * @run junit/othervm/timeout=1000
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
- *      -Djava.security.manager=allow
  *      -Djsr166.testImplementationDetails=true
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -Djava.util.secureRandomSeed=true
+ *      JSR166TestCase
+ */
+
+/*
+ * @test id=others
+ * @summary Remaining test implementation details variant of
+ *          JSR-166 tck tests apart from ForkJoinPool common
+ *          parallelism.
+ * @build *
+ * @modules java.management
+ * @run junit/othervm/timeout=1000
+ *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+ *      --add-opens java.base/java.lang=ALL-UNNAMED
+ *      -Djsr166.testImplementationDetails=true
  *      JSR166TestCase
  * @run junit/othervm/timeout=1000/policy=tck.policy
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED


### PR DESCRIPTION
Backport 4415261688dc258b6d254668bcf8818c61cc65ea to JDK17u.

Backporting the fix for https://bugs.openjdk.org/browse/JDK-8315683 merged as part of https://github.com/openjdk/jdk/pull/15619. https://github.com/openjdk/jdk/commit/4415261688dc258b6d254668bcf8818c61cc65ea.patch could be cleanly applied after making the changes as per https://github.com/openjdk/jdk/commit/9583e3657e43cc1c6f2101a64534564db2a9bd84#diff-e597aff33f4a53789898d772df8ab27daa1b5361635cbbae4f1e582b5654eb21R44. Also added the missing test case `@run junit/othervm/timeout=1000 JSR166TestCase` as it was added in large Loom integration.

The test passed in release mode in linux_x86_64 with time: **611.98s user 25.42s system 1440% cpu 44.259 total**
Before it was: **333.50s user 19.46s system 564% cpu 1:02.55 total**
```
Passed: java/util/concurrent/tck/JSR166TestCase.java#default
Passed: java/util/concurrent/tck/JSR166TestCase.java#security-manager
Passed: java/util/concurrent/tck/JSR166TestCase.java#others
Passed: java/util/concurrent/tck/JSR166TestCase.java#forkjoinpool-common-parallelism
Test results: passed: 4
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315683](https://bugs.openjdk.org/browse/JDK-8315683) needs maintainer approval

### Issue
 * [JDK-8315683](https://bugs.openjdk.org/browse/JDK-8315683): Parallelize java/util/concurrent/tck/JSR166TestCase.java (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1752/head:pull/1752` \
`$ git checkout pull/1752`

Update a local copy of the PR: \
`$ git checkout pull/1752` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1752`

View PR using the GUI difftool: \
`$ git pr show -t 1752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1752.diff">https://git.openjdk.org/jdk17u-dev/pull/1752.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1752#issuecomment-1726029199)