### PR TITLE
8288325: [windows] Actual and Preferred Size of AWT Non-resizable frame are different

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Window.cpp
@@ -1393,7 +1393,6 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
      */
     RECT outside;
     RECT inside;
-    int extraBottomInsets = 0;
 
     // extra padded border for captioned windows
     int extraPaddedBorderInsets = ::GetSystemMetrics(SM_CXPADDEDBORDER);
@@ -1405,12 +1404,13 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
     if (outside.right - outside.left > 0 && outside.bottom - outside.top > 0) {
         ::MapWindowPoints(GetHWnd(), 0, (LPPOINT)&inside, 2);
         m_insets.top = inside.top - outside.top;
-        m_insets.bottom = outside.bottom - inside.bottom + extraBottomInsets;
+        m_insets.bottom = outside.bottom - inside.bottom;
         m_insets.left = inside.left - outside.left;
         m_insets.right = outside.right - inside.right;
     } else {
         m_insets.top = -1;
     }
+
     if (m_insets.left < 0 || m_insets.top < 0 ||
         m_insets.right < 0 || m_insets.bottom < 0)
     {
@@ -1418,18 +1418,11 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
         jobject target = GetTarget(env);
         if (IsUndecorated() == FALSE) {
             /* Get outer frame sizes. */
-            LONG style = GetStyle();
-            if (style & WS_THICKFRAME) {
-                m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXSIZEFRAME) + extraPaddedBorderInsets;
-                m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYSIZEFRAME) + extraPaddedBorderInsets;
-            } else {
-                m_insets.left = m_insets.right =
-                    ::GetSystemMetrics(SM_CXDLGFRAME) + extraPaddedBorderInsets;
-                m_insets.top = m_insets.bottom =
-                    ::GetSystemMetrics(SM_CYDLGFRAME) + extraPaddedBorderInsets;
-            }
+            // System metrics are same for resizable & non-resizable frame.
+            m_insets.left = m_insets.right =
+                ::GetSystemMetrics(SM_CXFRAME) + extraPaddedBorderInsets;
+            m_insets.top = m_insets.bottom =
+                ::GetSystemMetrics(SM_CYFRAME) + extraPaddedBorderInsets;
             /* Add in title. */
             m_insets.top += ::GetSystemMetrics(SM_CYCAPTION);
         }
@@ -1437,7 +1430,7 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
             /* fix for 4418125: Undecorated frames are off by one */
             /* undo the -1 set above */
             /* Additional fix for 5059656 */
-                /* Also, 5089312: Window insets should be 0. */
+            /* Also, 5089312: Window insets should be 0. */
             ::memset(&m_insets, 0, sizeof(m_insets));
         }
 
@@ -1450,7 +1443,6 @@ BOOL AwtWindow::UpdateInsets(jobject insets)
             env->DeleteLocalRef(target);
             return FALSE;
         }
-        m_insets.bottom += extraBottomInsets;
         env->DeleteLocalRef(target);
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8288325](https://bugs.openjdk.org/browse/JDK-8288325) needs maintainer approval

### Issue
 * [JDK-8288325](https://bugs.openjdk.org/browse/JDK-8288325): [windows] Actual and Preferred Size of AWT Non-resizable frame are different (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1754/head:pull/1754` \
`$ git checkout pull/1754`

Update a local copy of the PR: \
`$ git checkout pull/1754` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1754`

View PR using the GUI difftool: \
`$ git pr show -t 1754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1754.diff">https://git.openjdk.org/jdk17u-dev/pull/1754.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1754#issuecomment-1727225809)