### PR TITLE
8314263: Signed jars triggering Logger finder recursion and StackOverflowError

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -66,6 +66,7 @@ import java.util.WeakHashMap;
 import java.util.function.Supplier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+import jdk.internal.logger.LoggerFinderLoader.TemporaryLoggerFinder;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.StaticProperty;
 import jdk.internal.module.ModuleBootstrap;
@@ -1713,13 +1714,16 @@ public final class System {
             // We do not need to synchronize: LoggerFinderLoader will
             // always return the same instance, so if we don't have it,
             // just fetch it again.
-            if (service == null) {
+            LoggerFinder finder = service;
+            if (finder == null) {
                 PrivilegedAction<LoggerFinder> pa =
                         () -> LoggerFinderLoader.getLoggerFinder();
-                service = AccessController.doPrivileged(pa, null,
+                finder = AccessController.doPrivileged(pa, null,
                         LOGGERFINDER_PERMISSION);
+                if (finder instanceof TemporaryLoggerFinder) return finder;
+                service = finder;
             }
-            return service;
+            return finder;
         }
 
     }

--- a/src/java.base/share/classes/jdk/internal/logger/LazyLoggers.java
+++ b/src/java.base/share/classes/jdk/internal/logger/LazyLoggers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,9 @@ import java.lang.System.LoggerFinder;
 import java.lang.System.Logger;
 import java.lang.ref.WeakReference;
 import java.util.Objects;
+import java.util.function.BooleanSupplier;
+
+import jdk.internal.logger.LoggerFinderLoader.TemporaryLoggerFinder;
 import jdk.internal.misc.VM;
 import sun.util.logging.PlatformLogger;
 
@@ -110,6 +113,9 @@ public final class LazyLoggers {
         // We need to pass the actual caller module when creating the logger.
         private final WeakReference<Module> moduleRef;
 
+        // whether this is the loading thread, can be null
+        private final BooleanSupplier isLoadingThread;
+
         // The name of the logger that will be created lazyly
         final String name;
         // The plain logger SPI object - null until it is accessed for the
@@ -122,16 +128,24 @@ public final class LazyLoggers {
         private LazyLoggerAccessor(String name,
                                    LazyLoggerFactories<? extends Logger> factories,
                                    Module module) {
-            this(Objects.requireNonNull(name), Objects.requireNonNull(factories),
-                    Objects.requireNonNull(module), null);
+            this(name, factories, module, null);
         }
 
         private LazyLoggerAccessor(String name,
                                    LazyLoggerFactories<? extends Logger> factories,
-                                   Module module, Void unused) {
+                                   Module module, BooleanSupplier isLoading) {
+
+            this(Objects.requireNonNull(name), Objects.requireNonNull(factories),
+                    Objects.requireNonNull(module), isLoading, null);
+        }
+
+        private LazyLoggerAccessor(String name,
+                                   LazyLoggerFactories<? extends Logger> factories,
+                                   Module module, BooleanSupplier isLoading, Void unused) {
             this.name = name;
             this.factories = factories;
             this.moduleRef = new WeakReference<>(module);
+            this.isLoadingThread = isLoading;
         }
 
         /**
@@ -162,7 +176,7 @@ public final class LazyLoggers {
             // BootstrapLogger has the logic to decide whether to invoke the
             // SPI or use a temporary (BootstrapLogger or SimpleConsoleLogger)
             // logger.
-            wrapped = BootstrapLogger.getLogger(this);
+            wrapped = BootstrapLogger.getLogger(this, isLoadingThread);
             synchronized(this) {
                 // if w has already been in between, simply drop 'wrapped'.
                 setWrappedIfNotSet(wrapped);
@@ -194,7 +208,7 @@ public final class LazyLoggers {
             // BootstrapLogger has the logic to decide whether to invoke the
             // SPI or use a temporary (BootstrapLogger or SimpleConsoleLogger)
             // logger.
-            final Logger wrapped = BootstrapLogger.getLogger(this);
+            final Logger wrapped = BootstrapLogger.getLogger(this, isLoadingThread);
             synchronized(this) {
                 // if w has already been set, simply drop 'wrapped'.
                 setWrappedIfNotSet(wrapped);
@@ -282,10 +296,10 @@ public final class LazyLoggers {
          * Creates a new lazy logger accessor for the named logger. The given
          * factories will be use when it becomes necessary to actually create
          * the logger.
-         * @param <T> An interface that extends {@link Logger}.
          * @param name The logger name.
          * @param factories The factories that should be used to create the
          *                  wrapped logger.
+         * @param module The module for which the logger is being created
          * @return A new LazyLoggerAccessor.
          */
         public static LazyLoggerAccessor makeAccessor(String name,
@@ -340,6 +354,7 @@ public final class LazyLoggers {
             prov = sm == null ? LoggerFinder.getLoggerFinder() :
                 AccessController.doPrivileged(
                         (PrivilegedAction<LoggerFinder>)LoggerFinder::getLoggerFinder);
+            if (prov instanceof TemporaryLoggerFinder) return prov;
             provider = prov;
         }
         return prov;
@@ -359,7 +374,6 @@ public final class LazyLoggers {
            new LazyLoggerFactories<>(loggerSupplier);
 
 
-
     // A concrete implementation of Logger that delegates to a  System.Logger,
     // but only creates the System.Logger instance lazily when it's used for
     // the first time.
@@ -375,6 +389,11 @@ public final class LazyLoggers {
         private JdkLazyLogger(LazyLoggerAccessor holder, Void unused) {
             super(holder);
         }
+    }
+
+    static Logger makeLazyLogger(String name, Module module, BooleanSupplier isLoading) {
+        final LazyLoggerAccessor holder = new LazyLoggerAccessor(name, factories, module, isLoading);
+        return new JdkLazyLogger(holder, null);
     }
 
     /**

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/META-INF/services/java.lang.System$LoggerFinder
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/META-INF/services/java.lang.System$LoggerFinder
@@ -1,0 +1,1 @@
+loggerfinder.SimpleLoggerFinder

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
@@ -26,12 +26,11 @@
  * @bug 8314263
  * @summary Creating a logger while loading the Logger finder
  *          triggers recursion and StackOverflowError
- * @modules java.base/sun.util.logging
- * @library /test/lib
+ * @modules java.base/sun.util.logging java.base/jdk.internal.logger:+open
+ * @library ../lib
  * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
  * @run main/othervm PlatformRecursiveLoadingTest
  */
-
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -50,6 +49,8 @@ public class PlatformRecursiveLoadingTest {
      */
     public static void main(String[] args) throws Throwable {
         PlatformLogger.getLogger("main").info("in main");
+        // allow time to let bootstrap logger flush data
+        BootstrapLoggerUtils.awaitPending();
         List<Object> logs = loggerfinder.SimpleLoggerFinder.LOGS;
         logs.stream().map(SimpleLogRecord::of).forEach(System.out::println);
         logs.stream().map(SimpleLogRecord::of).forEach(SimpleLogRecord::check);

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8314263
+ * @summary Creating a logger while loading the Logger finder
+ *          triggers recursion and StackOverflowError
+ * @modules java.base/sun.util.logging
+ * @library /test/lib
+ * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
+ * @run main/othervm PlatformRecursiveLoadingTest
+ */
+
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.LogRecord;
+
+import sun.util.logging.PlatformLogger;
+
+public class PlatformRecursiveLoadingTest {
+
+    /**
+     * This test triggers recursion by calling `System.getLogger` in the class init and constructor
+     * of a custom LoggerFinder. Without the fix, this is expected to throw
+     * java.lang.NoClassDefFoundError: Could not initialize class jdk.internal.logger.LoggerFinderLoader$ErrorPolicy
+     * caused by: java.lang.StackOverflowError
+     */
+    public static void main(String[] args) throws Throwable {
+        PlatformLogger.getLogger("main").info("in main");
+        List<Object> logs = loggerfinder.SimpleLoggerFinder.LOGS;
+        logs.stream().map(SimpleLogRecord::of).forEach(System.out::println);
+        logs.stream().map(SimpleLogRecord::of).forEach(SimpleLogRecord::check);
+        assertEquals(String.valueOf(logs.size()), String.valueOf(3));
+    }
+
+    static List<Object> asList(Object[] params) {
+        return params == null ? null : Arrays.asList(params);
+    }
+
+    record SimpleLogRecord(String message, Instant instant, String loggerName,
+                           java.util.logging.Level level, List<Object> params,
+                           String resourceBundleName, long seqNumber,
+                           String sourceClassName, String methodName, Throwable thrown) {
+        SimpleLogRecord(LogRecord record) {
+            this(record.getMessage(), record.getInstant(), record.getLoggerName(), record.getLevel(),
+                    asList(record.getParameters()), record.getResourceBundleName(), record.getSequenceNumber(),
+                    record.getSourceClassName(), record.getSourceMethodName(), record.getThrown());
+        }
+        static SimpleLogRecord of(Object o) {
+            return (o instanceof LogRecord record) ? new SimpleLogRecord(record) : null;
+        }
+        static SimpleLogRecord check(SimpleLogRecord record) {
+            if (record.loggerName.equals("dummy")) {
+                assertEquals(record.sourceClassName, "jdk.internal.logger.BootstrapLogger$LogEvent");
+                assertEquals(record.methodName(), "log");
+            }
+            if (record.loggerName.equals("main")) {
+                assertEquals(record.sourceClassName, PlatformRecursiveLoadingTest.class.getName());
+                assertEquals(record.methodName, "main");
+            }
+            return record;
+        }
+    }
+
+    private static void assertEquals(String received, String expected) {
+        if (!expected.equals(received)) {
+            throw new RuntimeException("Received: " + received);
+        }
+    }
+}

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
@@ -26,6 +26,8 @@
  * @bug 8314263
  * @summary Creating a logger while loading the Logger finder
  *          triggers recursion and StackOverflowError
+ * @modules java.base/jdk.internal.logger:+open
+ * @library ../lib
  * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
  * @run main/othervm RecursiveLoadingTest
  */
@@ -45,6 +47,8 @@ public class RecursiveLoadingTest {
      */
     public static void main(String[] args) throws Throwable {
         System.getLogger("main").log(System.Logger.Level.INFO, "in main");
+        // allow time to let bootstrap logger flush data
+        BootstrapLoggerUtils.awaitPending();
         List<Object> logs = loggerfinder.SimpleLoggerFinder.LOGS;
         logs.stream().map(SimpleLogRecord::of).forEach(System.out::println);
         logs.stream().map(SimpleLogRecord::of).forEach(SimpleLogRecord::check);

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8314263
+ * @summary Creating a logger while loading the Logger finder
+ *          triggers recursion and StackOverflowError
+ * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
+ * @run main/othervm RecursiveLoadingTest
+ */
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.LogRecord;
+
+public class RecursiveLoadingTest {
+
+    /**
+     * This test triggers recursion by calling `System.getLogger` in the class init and constructor
+     * of a custom LoggerFinder. Without the fix, this is expected to throw
+     * java.lang.NoClassDefFoundError: Could not initialize class jdk.internal.logger.LoggerFinderLoader$ErrorPolicy
+     * caused by: java.lang.StackOverflowError
+     */
+    public static void main(String[] args) throws Throwable {
+        System.getLogger("main").log(System.Logger.Level.INFO, "in main");
+        List<Object> logs = loggerfinder.SimpleLoggerFinder.LOGS;
+        logs.stream().map(SimpleLogRecord::of).forEach(System.out::println);
+        logs.stream().map(SimpleLogRecord::of).forEach(SimpleLogRecord::check);
+        assertEquals(String.valueOf(logs.size()), String.valueOf(3));
+    }
+
+    static List<Object> asList(Object[] params) {
+        return params == null ? null : Arrays.asList(params);
+    }
+
+    record SimpleLogRecord(String message, Instant instant, String loggerName,
+                           java.util.logging.Level level, List<Object> params,
+                           String resourceBundleName, long seqNumber,
+                           String sourceClassName, String methodName, Throwable thrown) {
+        SimpleLogRecord(LogRecord record) {
+            this(record.getMessage(), record.getInstant(), record.getLoggerName(), record.getLevel(),
+                    asList(record.getParameters()), record.getResourceBundleName(), record.getSequenceNumber(),
+                    record.getSourceClassName(), record.getSourceMethodName(), record.getThrown());
+        }
+        static SimpleLogRecord of(Object o) {
+            return (o instanceof LogRecord record) ? new SimpleLogRecord(record) : null;
+        }
+        static SimpleLogRecord check(SimpleLogRecord record) {
+            if (record.loggerName.equals("dummy")) {
+                assertEquals(record.sourceClassName, "jdk.internal.logger.BootstrapLogger$LogEvent");
+                assertEquals(record.methodName(), "log");
+            }
+            if (record.loggerName.equals("main")) {
+                assertEquals(record.sourceClassName, RecursiveLoadingTest.class.getName());
+                assertEquals(record.methodName, "main");
+            }
+            return record;
+        }
+    }
+
+    private static void assertEquals(String received, String expected) {
+        if (!expected.equals(received)) {
+            throw new RuntimeException("Received: " + received);
+        }
+    }
+}

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/SimpleLoggerFinder.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/SimpleLoggerFinder.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package loggerfinder;
+
+import java.lang.*;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+public class SimpleLoggerFinder extends System.LoggerFinder {
+
+    public static final CopyOnWriteArrayList<Object> LOGS = new CopyOnWriteArrayList<>();
+    static {
+        try {
+            long sleep = new Random().nextLong(1000L) + 1L;
+            // simulate a slow load service
+            Thread.sleep(sleep);
+            System.getLogger("dummy")
+                    .log(System.Logger.Level.INFO,
+                            "Logger finder service load sleep value: " + sleep);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final Map<String, SimpleLogger> loggers = new ConcurrentHashMap<>();
+    public SimpleLoggerFinder() {
+        System.getLogger("dummy")
+                .log(System.Logger.Level.INFO,
+                        "Logger finder service created");
+    }
+
+    @Override
+    public System.Logger getLogger(String name, Module module) {
+        return loggers.computeIfAbsent(name, SimpleLogger::new);
+    }
+
+    private static class SimpleLogger implements System.Logger {
+        private final java.util.logging.Logger logger;
+
+        private static final class SimpleHandler extends Handler {
+            @Override
+            public void publish(LogRecord record) {
+                LOGS.add(record);
+            }
+            @Override public void flush() { }
+            @Override public void close() { }
+        }
+
+        public SimpleLogger(String name) {
+            logger = Logger.getLogger(name);
+            logger.addHandler(new SimpleHandler());
+        }
+
+        @Override
+        public String getName() {
+            return logger.getName();
+        }
+
+        java.util.logging.Level level(Level level) {
+            return switch (level) {
+                case ALL -> java.util.logging.Level.ALL;
+                case DEBUG -> java.util.logging.Level.FINE;
+                case TRACE -> java.util.logging.Level.FINER;
+                case INFO -> java.util.logging.Level.INFO;
+                case WARNING -> java.util.logging.Level.WARNING;
+                case ERROR -> java.util.logging.Level.SEVERE;
+                case OFF -> java.util.logging.Level.OFF;
+            };
+        }
+
+        @Override
+        public boolean isLoggable(Level level) {
+            return logger.isLoggable(level(level));
+        }
+
+        @Override
+        public void log(Level level, ResourceBundle bundle, String msg, Throwable thrown) {
+            var julLevel = level(level);
+            if (!logger.isLoggable(julLevel)) return;
+            if (bundle != null) {
+                logger.logrb(julLevel, bundle, msg, thrown);
+            } else {
+                logger.log(julLevel, msg, thrown);
+            }
+        }
+
+        @Override
+        public void log(Level level, ResourceBundle bundle, String format, Object... params) {
+            var julLevel = level(level);
+            if (!logger.isLoggable(julLevel)) return;
+            if (params == null) {
+                if (bundle == null) {
+                    logger.log(julLevel, format);
+                } else {
+                    logger.logrb(julLevel, bundle, format);
+                }
+            } else {
+                if (bundle == null) {
+                    logger.log(julLevel, format, params);
+                } else {
+                    logger.logrb(julLevel, bundle, format, params);
+                }
+            }
+        }
+    }
+}
+

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/META-INF/services/java.lang.System$LoggerFinder
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/META-INF/services/java.lang.System$LoggerFinder
@@ -1,0 +1,1 @@
+loggerfinder.SimpleLoggerFinder

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8314263
+ * @summary Signed jars triggering Logger finder recursion and StackOverflowError
+ * @library /test/lib
+ * @build jdk.test.lib.compiler.CompilerUtils
+ *        jdk.test.lib.process.*
+ *        jdk.test.lib.util.JarUtils
+ *        jdk.test.lib.JDKToolLauncher
+ * @compile SignedLoggerFinderTest.java SimpleLoggerFinder.java
+ * @run main SignedLoggerFinderTest init
+ * @run main SignedLoggerFinderTest init sign
+ */
+
+import java.io.File;
+import java.nio.file.*;
+import java.security.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.jar.*;
+
+import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.util.JarUtils;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.Arrays.asList;
+
+public class SignedLoggerFinderTest {
+
+    /**
+     * This test triggers recursion in the broken JDK. The error can
+     * manifest in a few different ways.
+     * One error seen is "java.lang.NoClassDefFoundError:
+     * Could not initialize class jdk.internal.logger.LoggerFinderLoader$ErrorPolicy"
+     *
+     * The original reported error was a StackOverflow (also seen in different iterations
+     * of this run). Running test in signed and unsigned jar mode for sanity coverage.
+     * The current bug only manifests when jars are signed.
+     */
+
+    private static boolean init = false;
+    private static boolean signJars = false;
+    private static boolean mutliThreadLoad = false;
+    private static volatile boolean testComplete = false;
+
+    private static final String KEYSTORE = "8314263.keystore";
+    private static final String ALIAS = "JavaTest";
+    private static final String STOREPASS = "changeit";
+    private static final String KEYPASS = "changeit";
+    private static final String DNAME = "CN=sample";
+    private static final String CUSTOM_LOGGER_FINDER_NAME =
+            "loggerfinder.SimpleLoggerFinder";
+    private static final String CUSTOM_LOGGER_NAME =
+            "loggerfinder.SimpleLoggerFinder$SimpleLogger";
+    private static final String INTERNAL_LOGGER_FINDER_NAME =
+            "sun.util.logging.internal.LoggingProviderImpl";
+    private static final String INTERNAL_LOGGER_NAME =
+            "sun.util.logging.internal.LoggingProviderImpl$JULWrapper";
+    private static final Path jarPath1 =
+        Path.of(System.getProperty("test.classes", "."), "SimpleLoggerFinder.jar");
+    private static final Path jarPath2 =
+            Path.of(System.getProperty("test.classes", "."), "SimpleLoggerFinder2.jar");
+
+    public static void main(String[] args) throws Throwable {
+        init = args.length >=1 && args[0].equals("init");
+        signJars = args.length >=2 && args[1].equals("sign");
+
+        // init only passed in by jtreg test run, initialize the environment
+        // for the subsequent test run
+        if (init) {
+            initialize();
+            launchTest(false, false);
+            launchTest(false, true);
+            launchTest(true, false);
+            launchTest(true, true);
+
+        } else {
+            // set up complete. Run the code to trigger the recursion
+            // We're in the JVM launched by ProcessTools.executeCommand
+            boolean multiThreadLoad = Boolean.getBoolean("multiThreadLoad");
+            boolean withCustomLoggerFinder = Boolean.getBoolean("withCustomLoggerFinder");
+
+            if (multiThreadLoad) {
+                long sleep = new Random().nextLong(100L) + 1L;
+                System.out.println("multi thread load sleep value: " + sleep);
+                new Thread(runnableWithSleep(
+                        () -> System.getLogger("logger" + System.currentTimeMillis()),
+                        sleep, "System.getLogger type: ")).start();
+                new Thread(runnableWithSleep(
+                        () -> System.LoggerFinder.getLoggerFinder(),
+                        sleep, "System.getLoggerFinder type: ")).start();
+            }
+
+            if (withCustomLoggerFinder) {
+                JarFile jf = new JarFile(jarPath1.toString(), true);
+                jf.getInputStream(jf.getJarEntry("loggerfinder/SimpleLoggerFinder.class"));
+                JarFile jf2 = new JarFile(jarPath2.toString(), true);
+                jf2.getInputStream(jf.getJarEntry("loggerfinder/SimpleLoggerFinder.class"));
+            } else {
+                // some other call to prod LoggerFinder loading
+                System.getLogger("random" + System.currentTimeMillis());
+                System.LoggerFinder.getLoggerFinder();
+            }
+            Security.setProperty("test_1", "test");
+
+            // some extra sanity checks
+            if (withCustomLoggerFinder) {
+                assertEquals(System.LoggerFinder.getLoggerFinder().getClass().getName(),
+                        CUSTOM_LOGGER_FINDER_NAME);
+                System.Logger testLogger = System.getLogger("jdk.event.security");
+                assertEquals(testLogger.getClass().getName(), CUSTOM_LOGGER_NAME);
+            } else {
+                assertEquals(System.LoggerFinder.getLoggerFinder().getClass().getName(),
+                        INTERNAL_LOGGER_FINDER_NAME);
+                System.Logger testLogger = System.getLogger("jdk.event.security");
+                assertEquals(testLogger.getClass().getName(), INTERNAL_LOGGER_NAME);
+            }
+            testComplete = true;
+
+            // LoggerFinder should be initialized, trigger a simple log call
+            Security.setProperty("test_2", "test");
+        }
+    }
+
+    // helper to create the inner test. Run config variations with the LoggerFinder jars
+    // on the classpath and with other threads running System.Logger calls during load
+    private static void launchTest(boolean multiThreadLoad, boolean withCustomLoggerFinder) {
+        List<String> cmds = new ArrayList<>();
+        cmds.add(JDKToolFinder.getJDKTool("java"));
+        cmds.addAll(asList(Utils.getTestJavaOpts()));
+        if (withCustomLoggerFinder) {
+            cmds.addAll(List.of("-classpath",
+                System.getProperty("test.classes") + File.pathSeparator +
+                jarPath1.toString() + File.pathSeparator + jarPath2.toString(),
+                "-Dtest.classes=" + System.getProperty("test.classes")));
+        } else {
+            cmds.addAll(List.of("-classpath",
+                System.getProperty("test.classes")));
+        }
+        cmds.addAll(List.of(
+            // following debug property seems useful to tickle the issue
+            "-Dsun.misc.URLClassPath.debug=true",
+            // console logger level to capture event output
+            "-Djdk.system.logger.level=DEBUG",
+            // useful for debug purposes
+            "-Djdk.logger.finder.error=DEBUG",
+            // enable logging to verify correct output
+            "-Djava.util.logging.config.file=" +
+                    Path.of(System.getProperty("test.src", "."), "logging.properties")));
+        if (multiThreadLoad) {
+            cmds.add("-DmultiThreadLoad=true");
+        }
+        if (withCustomLoggerFinder) {
+            cmds.add("-DwithCustomLoggerFinder=true");
+        }
+        cmds.addAll(List.of(
+            "SignedLoggerFinderTest",
+            "no-init"));
+
+        try {
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(cmds.stream()
+                    .filter(t -> !t.isEmpty())
+                    .toArray(String[]::new))
+                    .shouldHaveExitValue(0);
+            if (withCustomLoggerFinder) {
+                outputAnalyzer
+                    .shouldContain("TEST LOGGER: [test_1, test]")
+                    .shouldContain("TEST LOGGER: [test_2, test]");
+            } else {
+                outputAnalyzer
+                    .shouldContain("SecurityPropertyModification: key:test_1")
+                    .shouldContain("SecurityPropertyModification: key:test_2");
+            }
+            if (withCustomLoggerFinder && signJars) {
+                // X509 cert generated during verification of signed jar file
+                outputAnalyzer
+                    .shouldContain(DNAME);
+            }
+
+        } catch (Throwable t) {
+            throw new RuntimeException("Unexpected fail.", t);
+        }
+    }
+
+    private static Runnable runnableWithSleep(Supplier s, long sleep, String desc) {
+        return () -> {
+            while(!testComplete) {
+                System.out.println(desc + s.get().getClass().getName());
+                try {
+                    Thread.sleep(sleep);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    private static void initialize() throws Throwable {
+        if (signJars) {
+            genKey();
+        }
+
+        Path classes = Paths.get(System.getProperty("test.classes", ""));
+        JarUtils.createJarFile(jarPath1,
+            classes,
+            classes.resolve("loggerfinder/SimpleLoggerFinder.class"),
+            classes.resolve("loggerfinder/SimpleLoggerFinder$SimpleLogger.class"));
+
+        JarUtils.updateJarFile(jarPath1, Path.of(System.getProperty("test.src")),
+            Path.of("META-INF", "services", "java.lang.System$LoggerFinder"));
+        if (signJars) {
+            signJar(jarPath1.toString());
+        }
+        // multiple signed jars with services to have ServiceLoader iteration
+        Files.copy(jarPath1, jarPath2, REPLACE_EXISTING);
+    }
+
+    private static void genKey() throws Throwable {
+        String keytool = JDKToolFinder.getJDKTool("keytool");
+        Files.deleteIfExists(Paths.get(KEYSTORE));
+        ProcessTools.executeCommand(keytool,
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
+                "-genkey",
+                "-keyalg", "rsa",
+                "-alias", ALIAS,
+                "-keystore", KEYSTORE,
+                "-keypass", KEYPASS,
+                "-dname", DNAME,
+                "-storepass", STOREPASS
+        ).shouldHaveExitValue(0);
+    }
+
+
+    private static OutputAnalyzer signJar(String jarName) throws Throwable {
+        List<String> args = new ArrayList<>();
+        args.add("-verbose");
+        args.add(jarName);
+        args.add(ALIAS);
+
+        return jarsigner(args);
+    }
+
+    private static OutputAnalyzer jarsigner(List<String> extra)
+            throws Throwable {
+        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jarsigner")
+                .addVMArg("-Duser.language=en")
+                .addVMArg("-Duser.country=US")
+                .addToolArg("-keystore")
+                .addToolArg(KEYSTORE)
+                .addToolArg("-storepass")
+                .addToolArg(STOREPASS)
+                .addToolArg("-keypass")
+                .addToolArg(KEYPASS);
+        for (String s : extra) {
+            if (s.startsWith("-J")) {
+                launcher.addVMArg(s.substring(2));
+            } else {
+                launcher.addToolArg(s);
+            }
+        }
+        return ProcessTools.executeCommand(launcher.getCommand());
+    }
+
+    private static void assertEquals(String received, String expected) {
+        if (!expected.equals(received)) {
+            throw new RuntimeException("Received: " + received);
+        }
+    }
+}

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
@@ -25,7 +25,8 @@
  * @test
  * @bug 8314263
  * @summary Signed jars triggering Logger finder recursion and StackOverflowError
- * @library /test/lib
+ * @modules java.base/jdk.internal.logger:+open
+ * @library /test/lib ../lib
  * @build jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.process.*
  *        jdk.test.lib.util.JarUtils
@@ -146,6 +147,8 @@ public class SignedLoggerFinderTest {
 
             // LoggerFinder should be initialized, trigger a simple log call
             Security.setProperty("test_2", "test");
+            // allow time to let bootstrap logger flush data
+            BootstrapLoggerUtils.awaitPending();
         }
     }
 
@@ -165,6 +168,8 @@ public class SignedLoggerFinderTest {
                 System.getProperty("test.classes")));
         }
         cmds.addAll(List.of(
+            // allow test to access internal bootstrap logger functionality
+            "--add-opens=java.base/jdk.internal.logger=ALL-UNNAMED",
             // following debug property seems useful to tickle the issue
             "-Dsun.misc.URLClassPath.debug=true",
             // console logger level to capture event output

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
@@ -25,8 +25,9 @@
  * @test
  * @bug 8314263
  * @summary Signed jars triggering Logger finder recursion and StackOverflowError
- * @modules java.base/jdk.internal.logger:+open
  * @library /test/lib ../lib
+ * @compile/module=java.base share/classes/jdk/internal/event/EventHelper.java
+ * @modules java.base/jdk.internal.logger:+open
  * @build jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.process.*
  *        jdk.test.lib.util.JarUtils
@@ -167,7 +168,11 @@ public class SignedLoggerFinderTest {
             cmds.addAll(List.of("-classpath",
                 System.getProperty("test.classes")));
         }
+
+        Path patches = Paths.get(System.getProperty("test.classes"), "patches", "java.base");
         cmds.addAll(List.of(
+            // patch of EventHelper to log at INFO level (for bootstrap logger)
+            "--patch-module", "java.base=" + patches.toString(),
             // allow test to access internal bootstrap logger functionality
             "--add-opens=java.base/jdk.internal.logger=ALL-UNNAMED",
             // following debug property seems useful to tickle the issue

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SimpleLoggerFinder.java
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SimpleLoggerFinder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package loggerfinder;
+
+import java.lang.*;
+import java.util.*;
+
+public class SimpleLoggerFinder extends System.LoggerFinder {
+
+    static {
+        try {
+            long sleep = new Random().nextLong(1000L) + 1L;
+            System.out.println("Logger finder service load sleep value: " + sleep);
+            // simulate a slow load service
+            Thread.sleep(sleep);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+     @Override
+     public System.Logger getLogger(String name, Module module) {
+         return new SimpleLogger(name);
+     }
+
+    private static class SimpleLogger implements System.Logger {
+        private final String name;
+
+        public SimpleLogger(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean isLoggable(Level level) {
+            return true;
+        }
+
+        @Override
+        public void log(Level level, ResourceBundle bundle, String msg, Throwable thrown) {
+            System.out.println("TEST LOGGER: " + msg);
+        }
+
+        @Override
+        public void log(Level level, ResourceBundle bundle, String format, Object... params) {
+            System.out.println("TEST LOGGER: " + Arrays.asList(params));
+
+        }
+    }
+}

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/java.base/share/classes/jdk/internal/event/EventHelper.java
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/java.base/share/classes/jdk/internal/event/EventHelper.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.event;
+
+import jdk.internal.access.JavaUtilJarAccess;
+import jdk.internal.access.SharedSecrets;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+/**
+ * A helper class to have events logged to a JDK Event Logger.
+ */
+
+public final class EventHelper {
+
+    private static final JavaUtilJarAccess JUJA = SharedSecrets.javaUtilJarAccess();
+    private static volatile boolean loggingSecurity;
+    private static volatile System.Logger securityLogger;
+    private static final VarHandle LOGGER_HANDLE;
+    static {
+        System.err.println("Patch version of EventHelper loaded");
+        try {
+            LOGGER_HANDLE =
+                    MethodHandles.lookup().findStaticVarHandle(
+                            EventHelper.class, "securityLogger", System.Logger.class);
+        } catch (ReflectiveOperationException e) {
+            throw new Error(e);
+        }
+    }
+    // a patch module to help this test ensure events are logged when
+    // bootstrap logger is in use
+    private static final System.Logger.Level LOG_LEVEL = System.Logger.Level.INFO;
+
+    // helper class used for logging security related events for now
+    private static final String SECURITY_LOGGER_NAME = "jdk.event.security";
+
+
+    public static void logTLSHandshakeEvent(Instant start,
+                                            String peerHost,
+                                            int peerPort,
+                                            String cipherSuite,
+                                            String protocolVersion,
+                                            long peerCertId) {
+        assert securityLogger != null;
+        String prepend = getDurationString(start);
+        securityLogger.log(LOG_LEVEL, prepend +
+        " TLSHandshake: {0}:{1,number,#}, {2}, {3}, {4,number,#}",
+        peerHost, peerPort, protocolVersion, cipherSuite, peerCertId);
+    }
+
+    public static void logSecurityPropertyEvent(String key,
+                                                String value) {
+
+        assert securityLogger != null;
+        securityLogger.log(LOG_LEVEL,
+            "SecurityPropertyModification: key:{0}, value:{1}", key, value);
+    }
+
+    public static void logX509ValidationEvent(long anchorCertId,
+                                         long[] certIds) {
+        assert securityLogger != null;
+        String codes = LongStream.of(certIds)
+                .mapToObj(Long::toString)
+                .collect(Collectors.joining(", "));
+        securityLogger.log(LOG_LEVEL,
+                "ValidationChain: {0,number,#}, {1}", anchorCertId, codes);
+    }
+
+    public static void logX509CertificateEvent(String algId,
+                                               String serialNum,
+                                               String subject,
+                                               String issuer,
+                                               String keyType,
+                                               int length,
+                                               long certId,
+                                               long beginDate,
+                                               long endDate) {
+        assert securityLogger != null;
+        securityLogger.log(LOG_LEVEL, "X509Certificate: Alg:{0}, Serial:{1}" +
+            ", Subject:{2}, Issuer:{3}, Key type:{4}, Length:{5,number,#}" +
+            ", Cert Id:{6,number,#}, Valid from:{7}, Valid until:{8}",
+            algId, serialNum, subject, issuer, keyType, length,
+            certId, new Date(beginDate), new Date(endDate));
+    }
+
+    /**
+     * Method to calculate a duration timestamp for events which measure
+     * the start and end times of certain operations.
+     * @param start Instant indicating when event started recording
+     * @return A string representing duraction from start time to
+     * time of this method call. Empty string is start is null.
+     */
+    private static String getDurationString(Instant start) {
+        if (start != null) {
+            if (start.equals(Instant.MIN)) {
+                return "N/A";
+            }
+            Duration duration = Duration.between(start, Instant.now());
+            long micros = duration.toNanos() / 1_000;
+            if (micros < 1_000_000) {
+                return "duration = " + (micros / 1_000.0) + " ms:";
+            } else {
+                return "duration = " + ((micros / 1_000) / 1_000.0) + " s:";
+            }
+        } else {
+            return "";
+        }
+    }
+
+    /**
+     * Helper to determine if security events are being logged
+     * at a preconfigured logging level. The configuration value
+     * is read once at class initialization.
+     *
+     * @return boolean indicating whether an event should be logged
+     */
+    public static boolean isLoggingSecurity() {
+        // Avoid a bootstrap issue where the commitEvent attempts to
+        // trigger early loading of System Logger but where
+        // the verification process still has JarFiles locked
+        if (securityLogger == null && !JUJA.isInitializing()) {
+            LOGGER_HANDLE.compareAndSet( null, System.getLogger(SECURITY_LOGGER_NAME));
+            loggingSecurity = securityLogger.isLoggable(LOG_LEVEL);
+        }
+        return loggingSecurity;
+    }
+
+}

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/logging.properties
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/logging.properties
@@ -1,0 +1,14 @@
+############################################################
+#  	Configuration file for log testing
+#
+############################################################
+
+handlers= java.util.logging.ConsoleHandler
+
+.level= FINE
+
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+jdk.event.security.level = FINE
+

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerAPIsTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerAPIsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.ResourceBundle;
-import java.util.Set;
+
 import jdk.internal.logger.BootstrapLogger;
 import jdk.internal.logger.LazyLoggers;
 
@@ -38,9 +38,10 @@ import jdk.internal.logger.LazyLoggers;
  * @bug     8144460 8144214
  * @summary Cover the logXX and LogEvent.valueOf APIs of BootstrapLogger
  *          and logXX APIs of SimpleConsoleLogger.
+ * @library ../../lib
  * @modules java.base/jdk.internal.logger:+open
  *          java.base/sun.util.logging
- * @build BootstrapLoggerUtils LogStream
+ * @build LogStream
  * @run main/othervm BootstrapLoggerAPIsTest
  */
 

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,9 +53,10 @@ import jdk.internal.logger.LazyLoggers;
  * @summary JDK implementation specific unit test for JDK internal artifacts.
             Tests the behavior of bootstrap loggers (and SimpleConsoleLoggers
  *          too).
+ * @library ../../lib
  * @modules java.base/jdk.internal.logger:+open
  *          java.logging
- * @build BootstrapLoggerUtils LogStream
+ * @build LogStream
  * @run main/othervm BootstrapLoggerTest NO_SECURITY
  * @run main/othervm -Djava.security.manager=allow BootstrapLoggerTest SECURE
  * @run main/othervm/timeout=120 -Djava.security.manager=allow BootstrapLoggerTest SECURE_AND_WAIT

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/LogStream.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/LogStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-
-import jdk.internal.logger.BootstrapLogger;
 
 /**
  * We use an instance of this class to check what the logging system has printed

--- a/test/jdk/java/lang/System/LoggerFinder/lib/BootstrapLoggerUtils.java
+++ b/test/jdk/java/lang/System/LoggerFinder/lib/BootstrapLoggerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ import java.util.function.BooleanSupplier;
 
 import jdk.internal.logger.BootstrapLogger;
 
-class BootstrapLoggerUtils {
+public final class BootstrapLoggerUtils {
 
     private static final Field IS_BOOTED;
     private static final Method AWAIT_PENDING;
@@ -46,11 +46,11 @@ class BootstrapLoggerUtils {
         }
     }
 
-    static void setBootedHook(BooleanSupplier supplier) throws IllegalAccessException {
+    public static void setBootedHook(BooleanSupplier supplier) throws IllegalAccessException {
         IS_BOOTED.set(null, supplier);
     }
 
-    static void awaitPending() {
+    public static void awaitPending() {
         try {
             AWAIT_PENDING.invoke(null);
         } catch (IllegalAccessException | IllegalArgumentException


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I resolved a copyright and an import statement.
I include follow up test fix JDK-8315696 and [JDK-8316087](https://bugs.openjdk.org/browse/JDK-8316087).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8314263](https://bugs.openjdk.org/browse/JDK-8314263) needs maintainer approval
- [x] [JDK-8316087](https://bugs.openjdk.org/browse/JDK-8316087) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315696](https://bugs.openjdk.org/browse/JDK-8315696) needs maintainer approval

### Issues
 * [JDK-8314263](https://bugs.openjdk.org/browse/JDK-8314263): Signed jars triggering Logger finder recursion and StackOverflowError (**Bug** - P2 - Approved)
 * [JDK-8315696](https://bugs.openjdk.org/browse/JDK-8315696): SignedLoggerFinderTest.java test failed (**Bug** - P3 - Approved)
 * [JDK-8316087](https://bugs.openjdk.org/browse/JDK-8316087): Test SignedLoggerFinderTest.java is still failing (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1756/head:pull/1756` \
`$ git checkout pull/1756`

Update a local copy of the PR: \
`$ git checkout pull/1756` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1756`

View PR using the GUI difftool: \
`$ git pr show -t 1756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1756.diff">https://git.openjdk.org/jdk17u-dev/pull/1756.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1756#issuecomment-1727613330)