### PR TITLE
8293861: G1: Disable preventive GCs by default

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -309,7 +309,7 @@
           "disables this check.")                                           \
           range(0.0, (double)max_uintx)                                     \
                                                                             \
-  product(bool, G1UsePreventiveGC, true, DIAGNOSTIC,                        \
+  product(bool, G1UsePreventiveGC, false, DIAGNOSTIC,                       \
           "Allows collections to be triggered proactively based on the      \
            number of free regions and the expected survival rates in each   \
            section of the heap.")


### PR DESCRIPTION
Not a clean backport due to neighboring changes in the same file. Patch is simple and manual fixes are trivial.

As mentioned in the JBS issue, preventive GCs has had issues on JDK 17. TrinoDB is impacted and recommends disabling preventive GCs in https://github.com/trinodb/trino/pull/15380. We have seen internal applications that are affected by this issue as well.

GHA are full green. Locally run tier1 tests are all green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8293861](https://bugs.openjdk.org/browse/JDK-8293861) needs maintainer approval

### Issue
 * [JDK-8293861](https://bugs.openjdk.org/browse/JDK-8293861): G1: Disable preventive GCs by default (**Enhancement** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1758/head:pull/1758` \
`$ git checkout pull/1758`

Update a local copy of the PR: \
`$ git checkout pull/1758` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1758`

View PR using the GUI difftool: \
`$ git pr show -t 1758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1758.diff">https://git.openjdk.org/jdk17u-dev/pull/1758.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1758#issuecomment-1728549898)