### PR TITLE
8316178: Better diagnostic header for CodeBlobs

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -189,7 +189,8 @@ void RuntimeBlob::trace_new_stub(RuntimeBlob* stub, const char* name1, const cha
     if (PrintStubCode) {
       ttyLocker ttyl;
       tty->print_cr("- - - [BEGIN] - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
-      tty->print_cr("Decoding %s " INTPTR_FORMAT, stub_id, (intptr_t) stub);
+      tty->print_cr("Decoding %s " PTR_FORMAT " [" PTR_FORMAT ", " PTR_FORMAT "] (%d bytes)",
+                    stub_id, p2i(stub), p2i(stub->code_begin()), p2i(stub->code_end()), stub->code_size());
       Disassembler::decode(stub->code_begin(), stub->code_end(), tty);
       if ((stub->oop_maps() != NULL) && AbstractDisassembler::show_structs()) {
         tty->print_cr("- - - [OOP MAPS]- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");


### PR DESCRIPTION
Semi-clean backport to improve JVM diagnostics. The surrounding lines are a bit different, that is why the patch does not apply cleanly.

Additional testing:
 - [x] Eyeballing JVM output

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316178](https://bugs.openjdk.org/browse/JDK-8316178) needs maintainer approval

### Issue
 * [JDK-8316178](https://bugs.openjdk.org/browse/JDK-8316178): Better diagnostic header for CodeBlobs (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1759/head:pull/1759` \
`$ git checkout pull/1759`

Update a local copy of the PR: \
`$ git checkout pull/1759` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1759`

View PR using the GUI difftool: \
`$ git pr show -t 1759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1759.diff">https://git.openjdk.org/jdk17u-dev/pull/1759.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1759#issuecomment-1728946526)