### PR TITLE
8271890: mark hotspot runtime/Dictionary tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/Dictionary/CleanProtectionDomain.java
+++ b/test/hotspot/jtreg/runtime/Dictionary/CleanProtectionDomain.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Verifies the creation and cleaup of entries in the Protection Domain Table
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainCacheTest.java
+++ b/test/hotspot/jtreg/runtime/Dictionary/ProtectionDomainCacheTest.java
@@ -26,6 +26,7 @@
  * @bug 8151486 8218266
  * @summary Call Class.forName() on the system classloader from a class loaded
  *          from a custom classloader, using the current class's protection domain.
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @build jdk.test.lib.Utils


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271890](https://bugs.openjdk.org/browse/JDK-8271890) needs maintainer approval

### Issue
 * [JDK-8271890](https://bugs.openjdk.org/browse/JDK-8271890): mark hotspot runtime/Dictionary tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1763/head:pull/1763` \
`$ git checkout pull/1763`

Update a local copy of the PR: \
`$ git checkout pull/1763` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1763`

View PR using the GUI difftool: \
`$ git pr show -t 1763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1763.diff">https://git.openjdk.org/jdk17u-dev/pull/1763.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1763#issuecomment-1729515696)