### PR TITLE
8271891: mark hotspot runtime/Safepoint tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortOnVMOperationTimeout.java
@@ -28,6 +28,7 @@ import jdk.test.lib.process.*;
  * @test TestAbortOnVMOperationTimeout
  * @bug 8181143 8269523 8307653
  * @summary Check abort on VM timeout is working
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -30,6 +30,7 @@ import jdk.test.whitebox.WhiteBox;
  * @test TestAbortVMOnSafepointTimeout
  * @summary Check if VM can kill thread which doesn't reach safepoint.
  * @bug 8219584 8227528
+ * @requires vm.flagless
  * @library /testlibrary /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271891](https://bugs.openjdk.org/browse/JDK-8271891) needs maintainer approval

### Issue
 * [JDK-8271891](https://bugs.openjdk.org/browse/JDK-8271891): mark hotspot runtime/Safepoint tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1764/head:pull/1764` \
`$ git checkout pull/1764`

Update a local copy of the PR: \
`$ git checkout pull/1764` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1764`

View PR using the GUI difftool: \
`$ git pr show -t 1764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1764.diff">https://git.openjdk.org/jdk17u-dev/pull/1764.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1764#issuecomment-1729515232)