### PR TITLE
8271893: mark hotspot runtime/PerfMemDestroy/PerfMemDestroy.java test as ignoring external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/PerfMemDestroy/PerfMemDestroy.java
+++ b/test/hotspot/jtreg/runtime/PerfMemDestroy/PerfMemDestroy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8030955
  * @summary Allow multiple calls to PerfMemory::destroy() without asserting.
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
I backport this for 17.0.10-oracle parity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8271893](https://bugs.openjdk.org/browse/JDK-8271893) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271893](https://bugs.openjdk.org/browse/JDK-8271893): mark hotspot runtime/PerfMemDestroy/PerfMemDestroy.java test as ignoring external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1766/head:pull/1766` \
`$ git checkout pull/1766`

Update a local copy of the PR: \
`$ git checkout pull/1766` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1766`

View PR using the GUI difftool: \
`$ git pr show -t 1766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1766.diff">https://git.openjdk.org/jdk17u-dev/pull/1766.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1766#issuecomment-1731197053)