### PR TITLE
8271905: mark hotspot runtime/Metaspace tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/MaxMetaspaceSizeEnvVarTest.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/MaxMetaspaceSizeEnvVarTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8260349
  * @summary test that setting via the env-var and options file shows up as expected
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver MaxMetaspaceSizeEnvVarTest
  */

--- a/test/hotspot/jtreg/runtime/Metaspace/MaxMetaspaceSizeTest.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/MaxMetaspaceSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 /*
  * @test MaxMetaspaceSizeTest
  * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true
+ * @requires vm.flagless
  * @bug 8087291
  * @library /test/lib
  * @run driver MaxMetaspaceSizeTest


### PR DESCRIPTION
I backport this for 17.0.10-oracle parity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8271905](https://bugs.openjdk.org/browse/JDK-8271905) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271905](https://bugs.openjdk.org/browse/JDK-8271905): mark hotspot runtime/Metaspace tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1767/head:pull/1767` \
`$ git checkout pull/1767`

Update a local copy of the PR: \
`$ git checkout pull/1767` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1767`

View PR using the GUI difftool: \
`$ git pr show -t 1767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1767.diff">https://git.openjdk.org/jdk17u-dev/pull/1767.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1767#issuecomment-1731199564)