### PR TITLE
8271904: mark hotspot runtime/ClassFile tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassFile/FormatCheckingTest.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/FormatCheckingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8148854
  * @summary Ensure class name loaded by app class loader is format checked by default
+ * @requires vm.flagless
  * @library /test/lib
  * @compile BadHelloWorld.jcod
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/ClassFile/JsrRewriting.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/JsrRewriting.java
@@ -32,6 +32,7 @@
  * @bug 7053586
  * @bug 7185550
  * @bug 7149464
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.desktop

--- a/test/hotspot/jtreg/runtime/ClassFile/OomWhileParsingRepeatedJsr.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/OomWhileParsingRepeatedJsr.java
@@ -33,6 +33,7 @@
  * @bug 7037122
  * @bug 7123945
  * @bug 8016029
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.desktop

--- a/test/hotspot/jtreg/runtime/ClassFile/TestCheckedExceptions.java
+++ b/test/hotspot/jtreg/runtime/ClassFile/TestCheckedExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
  *          clause does not cause the JVM to assert nor throw an exception.
  *          Also, test that logging can be used to print a message about bogus
  *          classes in method throws clauses.
+ * @requires vm.flagless
  * @library /test/lib
  * @compile CheckedExceptions.jcod
  * @run driver TestCheckedExceptions


### PR DESCRIPTION
I backport this for 17.0.10-oracle parity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8271904](https://bugs.openjdk.org/browse/JDK-8271904) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271904](https://bugs.openjdk.org/browse/JDK-8271904): mark hotspot runtime/ClassFile tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1768/head:pull/1768` \
`$ git checkout pull/1768`

Update a local copy of the PR: \
`$ git checkout pull/1768` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1768`

View PR using the GUI difftool: \
`$ git pr show -t 1768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1768.diff">https://git.openjdk.org/jdk17u-dev/pull/1768.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1768#issuecomment-1731217593)