### PR TITLE
8272099: mark hotspot runtime/Monitor tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/Monitor/MonitorUsedDeflationThresholdTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/MonitorUsedDeflationThresholdTest.java
@@ -29,6 +29,7 @@ import jdk.test.lib.process.ProcessTools;
  * @test
  * @bug 8226416
  * @summary Test the MonitorUsedDeflationThreshold and NoAsyncDeflationProgressMax options.
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver MonitorUsedDeflationThresholdTest

--- a/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
+++ b/test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java
@@ -30,6 +30,7 @@ import java.util.stream.*;
  * @test
  * @bug 8242263
  * @summary Exercise DiagnoseSyncOnValueBasedClasses diagnostic flag
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver/timeout=180000 SyncOnValueBasedClassTest
  */


### PR DESCRIPTION
I backport this for 17.0.10-oracle parity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8272099](https://bugs.openjdk.org/browse/JDK-8272099) needs maintainer approval

### Issue
 * [JDK-8272099](https://bugs.openjdk.org/browse/JDK-8272099): mark hotspot runtime/Monitor tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1769/head:pull/1769` \
`$ git checkout pull/1769`

Update a local copy of the PR: \
`$ git checkout pull/1769` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1769`

View PR using the GUI difftool: \
`$ git pr show -t 1769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1769.diff">https://git.openjdk.org/jdk17u-dev/pull/1769.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1769#issuecomment-1731222232)