### PR TITLE
8271892: mark hotspot runtime/PrintStringTableStats/PrintStringTableStatsTest.java test as ignoring external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/PrintStringTableStats/PrintStringTableStatsTest.java
+++ b/test/hotspot/jtreg/runtime/PrintStringTableStats/PrintStringTableStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 /*
  * @test PrintStringTableStatsTest
  * @bug 8211821
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver PrintStringTableStatsTest
  */


### PR DESCRIPTION
I backport this for 17.0.10-oracle parity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271892](https://bugs.openjdk.org/browse/JDK-8271892) needs maintainer approval

### Issue
 * [JDK-8271892](https://bugs.openjdk.org/browse/JDK-8271892): mark hotspot runtime/PrintStringTableStats/PrintStringTableStatsTest.java test as ignoring external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1770/head:pull/1770` \
`$ git checkout pull/1770`

Update a local copy of the PR: \
`$ git checkout pull/1770` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1770`

View PR using the GUI difftool: \
`$ git pr show -t 1770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1770.diff">https://git.openjdk.org/jdk17u-dev/pull/1770.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1770#issuecomment-1731222047)