### PR TITLE
8271073: Improve testing with VM option VerifyArchivedFields

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -524,8 +524,12 @@
   product(bool, VerifyDuringGC, false, DIAGNOSTIC,                          \
           "Verify memory system during GC (between phases)")                \
                                                                             \
-  product(bool, VerifyArchivedFields, trueInDebug, DIAGNOSTIC,              \
-          "Verify memory when archived oop fields are loaded from CDS)")    \
+  product(int, VerifyArchivedFields, 0, DIAGNOSTIC,                         \
+          "Verify memory when archived oop fields are loaded from CDS; "    \
+          "0: No check; "                                                   \
+          "1: Basic verification with VM_Verify (no side effects); "        \
+          "2: Detailed verification by forcing a GC (with side effects)")   \
+          range(0, 2)                                                       \
                                                                             \
   product(ccstrlist, VerifyGCType, "", DIAGNOSTIC,                          \
              "GC type(s) to verify when Verify*GC is enabled."              \

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestCommon.java
@@ -412,6 +412,8 @@ public class TestCommon extends CDSTestUtils {
             cmd.add(opts.appJar);
         }
 
+        CDSTestUtils.addVerifyArchivedFields(cmd);
+
         for (String s : opts.suffix) cmd.add(s);
 
         if (RUN_WITH_JFR) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/VerifyArchivedFields.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/cacheObject/VerifyArchivedFields.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary run with -XX:VerifyArchivedFields=2 for more expensive verification
+ *          of the archived heap objects.
+ * @requires vm.cds.write.archived.java.heap
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @build Hello
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar Hello.jar Hello
+ * @run driver VerifyArchivedFields
+ */
+
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class VerifyArchivedFields {
+    // Note: -XX:VerifyArchivedFields=2 will force a GC every time when
+    // HeapShared::initialize_from_archived_subgraph(Klass* k, ...) is called. This ensures
+    // that it's safe to do a GC even when the oop->klass() of some archived heap objects
+    // are not yet loaded into the system dictionary.
+    public static void main(String[] args) throws Exception {
+        TestCommon.test(ClassFileInstaller.getJarPath("Hello.jar"),
+                        TestCommon.list("Hello"),
+                        "-XX:+UnlockDiagnosticVMOptions",
+                        "-XX:VerifyArchivedFields=2",
+                        "-Xlog:cds=debug",
+                        "-Xlog:cds+heap=debug",
+                        "-Xlog:gc*=debug",
+                        "Hello");
+  }
+}

--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -399,6 +399,12 @@ public class CDSTestUtils {
                                .addPrefix(cliPrefix) );
     }
 
+    // Enable basic verification (VerifyArchivedFields=1, no side effects) for all CDS
+    // tests to make sure the archived heap objects are mapped/loaded properly.
+    public static void addVerifyArchivedFields(ArrayList<String> cmd) {
+        cmd.add("-XX:+UnlockDiagnosticVMOptions");
+        cmd.add("-XX:VerifyArchivedFields=1");
+    }
 
     // Execute JVM with CDS archive, specify CDSOptions
     public static OutputAnalyzer runWithArchive(CDSOptions opts)
@@ -416,6 +422,7 @@ public class CDSTestUtils {
                 opts.archiveName = getDefaultArchiveName();
             cmd.add("-XX:SharedArchiveFile=" + opts.archiveName);
         }
+        addVerifyArchivedFields(cmd);
 
         if (opts.useVersion)
             cmd.add("-version");


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I omitted the change to method HeapShared::verify_loaded_heap() in headShared.cpp.
That method is not in 17. Also, I found no further occurances of the flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271073](https://bugs.openjdk.org/browse/JDK-8271073) needs maintainer approval

### Issue
 * [JDK-8271073](https://bugs.openjdk.org/browse/JDK-8271073): Improve testing with VM option VerifyArchivedFields (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1772/head:pull/1772` \
`$ git checkout pull/1772`

Update a local copy of the PR: \
`$ git checkout pull/1772` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1772`

View PR using the GUI difftool: \
`$ git pr show -t 1772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1772.diff">https://git.openjdk.org/jdk17u-dev/pull/1772.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1772#issuecomment-1731258552)