### PR TITLE
8286474: Drop --enable-preview from Sealed Classes related tests

### DIFF
--- a/test/jdk/java/lang/reflect/sealed_classes/SealedClassesReflectionTest.java
+++ b/test/jdk/java/lang/reflect/sealed_classes/SealedClassesReflectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
  * @test
  * @bug 8227046
  * @summary reflection test for sealed classes
- * @compile --enable-preview -source ${jdk.version} SealedClassesReflectionTest.java
- * @run testng/othervm --enable-preview SealedClassesReflectionTest
+ * @compile SealedClassesReflectionTest.java
+ * @run testng/othervm SealedClassesReflectionTest
  */
 
 import java.lang.annotation.*;

--- a/test/jdk/java/lang/reflect/sealed_classes/TestSecurityManagerChecks.java
+++ b/test/jdk/java/lang/reflect/sealed_classes/TestSecurityManagerChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,8 @@
  * @library /test/lib
  * @modules java.compiler
  * @build jdk.test.lib.compiler.CompilerUtils jdk.test.lib.compiler.ModuleInfoMaker TestSecurityManagerChecks
- * @run main/othervm -Djava.security.manager=allow --enable-preview TestSecurityManagerChecks named
- * @run main/othervm -Djava.security.manager=allow --enable-preview TestSecurityManagerChecks unnamed
+ * @run main/othervm -Djava.security.manager=allow TestSecurityManagerChecks named
+ * @run main/othervm -Djava.security.manager=allow TestSecurityManagerChecks unnamed
  */
 
 import java.io.IOException;


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8286474](https://bugs.openjdk.org/browse/JDK-8286474) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286474](https://bugs.openjdk.org/browse/JDK-8286474): Drop --enable-preview from Sealed Classes related tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1774/head:pull/1774` \
`$ git checkout pull/1774`

Update a local copy of the PR: \
`$ git checkout pull/1774` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1774`

View PR using the GUI difftool: \
`$ git pr show -t 1774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1774.diff">https://git.openjdk.org/jdk17u-dev/pull/1774.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1774#issuecomment-1731982656)