### PR TITLE
8202790: DnD test DisposeFrameOnDragTest.java does not clean up

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -464,7 +464,6 @@ java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all
 java/awt/Debug/DumpOnKey/DumpOnKey.java 8202667 windows-all
 java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 8202926 linux-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
-java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java 8202790 macosx-all,linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882,8255898 linux-all,macosx-all
 java/awt/Choice/ChoicePopupLocation/ChoicePopupLocation.java 8202931 macosx-all,linux-all
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java 7124275 macosx-all

--- a/test/jdk/java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java
+++ b/test/jdk/java/awt/dnd/DisposeFrameOnDragCrash/DisposeFrameOnDragTest.java
@@ -49,6 +49,7 @@ import test.java.awt.regtesthelpers.Util;
 public class DisposeFrameOnDragTest {
 
     private static JTextArea textArea;
+    private static JFrame background;
 
     public static void main(String[] args) throws Throwable {
 
@@ -72,14 +73,20 @@ public class DisposeFrameOnDragTest {
         Util.drag(testRobot,
                 new Point((int) loc.x + 3, (int) loc.y + 3),
                 new Point((int) loc.x + 40, (int) loc.y + 40),
-                InputEvent.BUTTON1_MASK);
+                InputEvent.BUTTON1_DOWN_MASK);
 
         Util.waitForIdle(testRobot);
 
         testRobot.delay(200);
+        background.dispose();
     }
 
     private static void constructTestUI() {
+        background = new JFrame("Background");
+        background.setBounds(100, 100, 100, 100);
+        background.setUndecorated(true);
+        background.setVisible(true);
+
         final JFrame frame = new JFrame("Test frame");
         textArea = new JTextArea("Drag Me!");
         try {


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

Resolved ProblemList, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8202790](https://bugs.openjdk.org/browse/JDK-8202790) needs maintainer approval

### Issue
 * [JDK-8202790](https://bugs.openjdk.org/browse/JDK-8202790): DnD test DisposeFrameOnDragTest.java does not clean up (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1776/head:pull/1776` \
`$ git checkout pull/1776`

Update a local copy of the PR: \
`$ git checkout pull/1776` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1776`

View PR using the GUI difftool: \
`$ git pr show -t 1776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1776.diff">https://git.openjdk.org/jdk17u-dev/pull/1776.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1776#issuecomment-1731987372)