### PR TITLE
8289584: (fs) Print size values in java/nio/file/FileStore/Basic.java when they differ by > 1GiB

### DIFF
--- a/test/jdk/java/nio/file/FileStore/Basic.java
+++ b/test/jdk/java/nio/file/FileStore/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,10 +57,13 @@ public class Basic {
             throw new RuntimeException("Assertion failed");
     }
 
-    static void checkWithin1GB(long value1, long value2) {
-        long diff = Math.abs(value1 - value2);
-        if (diff > G)
-            throw new RuntimeException("values differ by more than 1GB");
+    static void checkWithin1GB(long expected, long actual) {
+        long diff = Math.abs(actual - expected);
+        if (diff > G) {
+            String msg = String.format("|actual %d - expected %d| = %d (%f G)",
+                                       actual, expected, diff, (float)diff/G);
+            throw new RuntimeException(msg);
+        }
     }
 
     static void doTests(Path dir) throws IOException {


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8289584](https://bugs.openjdk.org/browse/JDK-8289584) needs maintainer approval

### Issue
 * [JDK-8289584](https://bugs.openjdk.org/browse/JDK-8289584): (fs) Print size values in java/nio/file/FileStore/Basic.java when they differ by &gt; 1GiB (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1778/head:pull/1778` \
`$ git checkout pull/1778`

Update a local copy of the PR: \
`$ git checkout pull/1778` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1778`

View PR using the GUI difftool: \
`$ git pr show -t 1778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1778.diff">https://git.openjdk.org/jdk17u-dev/pull/1778.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1778#issuecomment-1732000474)