### PR TITLE
8292381: java/net/httpclient/SpecialHeadersTest.java fails with "ERROR: Shutting down connection: HTTP/2 client stopped"

### DIFF
--- a/test/jdk/java/net/httpclient/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/HttpServerAdapters.java
@@ -45,6 +45,7 @@ import java.net.http.HttpHeaders;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -105,6 +106,16 @@ public interface HttpServerAdapters {
         public abstract Set<Map.Entry<String, List<String>>> entrySet();
         public abstract List<String> get(String name);
         public abstract boolean containsKey(String name);
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof HttpTestRequestHeaders other)) return false;
+            return Objects.equals(entrySet(), other.entrySet());
+        }
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(entrySet());
+        }
 
         public static HttpTestRequestHeaders of(Headers headers) {
             return new Http1TestRequestHeaders(headers);
@@ -138,6 +149,10 @@ public interface HttpServerAdapters {
             public boolean containsKey(String name) {
                 return headers.containsKey(name);
             }
+            @Override
+            public String toString() {
+                return String.valueOf(headers);
+            }
         }
         private static final class Http2TestRequestHeaders extends HttpTestRequestHeaders {
             private final HttpHeaders headers;
@@ -159,6 +174,10 @@ public interface HttpServerAdapters {
             @Override
             public boolean containsKey(String name) {
                 return headers.firstValue(name).isPresent();
+            }
+            @Override
+            public String toString() {
+                return String.valueOf(headers);
             }
         }
     }


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8292381](https://bugs.openjdk.org/browse/JDK-8292381) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292381](https://bugs.openjdk.org/browse/JDK-8292381): java/net/httpclient/SpecialHeadersTest.java fails with "ERROR: Shutting down connection: HTTP/2 client stopped" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1779/head:pull/1779` \
`$ git checkout pull/1779`

Update a local copy of the PR: \
`$ git checkout pull/1779` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1779`

View PR using the GUI difftool: \
`$ git pr show -t 1779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1779.diff">https://git.openjdk.org/jdk17u-dev/pull/1779.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1779#issuecomment-1732002237)