### PR TITLE
8286475: Drop --enable-preview from instanceof pattern matching related tests

### DIFF
--- a/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
+++ b/test/langtools/tools/javac/ConditionalExpressionResolvePending.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
  * @build toolbox.ToolBox toolbox.JavacTask
  * @build combo.ComboTestHelper
  * @compile ConditionalExpressionResolvePending.java
- * @run main/othervm --enable-preview ConditionalExpressionResolvePending
+ * @run main/othervm ConditionalExpressionResolvePending
  */
 
 import combo.ComboInstance;


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286475](https://bugs.openjdk.org/browse/JDK-8286475) needs maintainer approval

### Issue
 * [JDK-8286475](https://bugs.openjdk.org/browse/JDK-8286475): Drop --enable-preview from instanceof pattern matching related tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1785/head:pull/1785` \
`$ git checkout pull/1785`

Update a local copy of the PR: \
`$ git checkout pull/1785` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1785`

View PR using the GUI difftool: \
`$ git pr show -t 1785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1785.diff">https://git.openjdk.org/jdk17u-dev/pull/1785.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1785#issuecomment-1733186786)