### PR TITLE
Backport 877731d2a20249ce4724a071ba2da1faa56daca4

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -73,6 +73,9 @@ public class TestJmapCore {
     static void test(String type) throws Throwable {
         ProcessBuilder pb = ProcessTools.createTestJvm("-XX:+CreateCoredumpOnCrash",
                 "-Xmx512m", "-XX:MaxMetaspaceSize=64m", "-XX:+CrashOnOutOfMemoryError",
+                // The test loads lots of small classes to exhaust Metaspace, skip method
+                // dependency verification to improve performance in debug builds.
+                Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "--show-version",
                 TestJmapCore.class.getName(), type);
 
         // If we are going to force a core dump, apply "ulimit -c unlimited" if we can.


### PR DESCRIPTION
Backporting the fix for https://bugs.openjdk.org/browse/JDK-8315770 merged as part of openjdk/jdk#15631. https://github.com/openjdk/jdk/commit/877731d2a20249ce4724a071ba2da1faa56daca4.patch apply failed due to differences in the file and the changes have been performed selectively.

Below are the test results:
* after_release: **99.63s user 10.34s system 171% cpu 1:04.25 total**
* after_fastdebug: **433.45s user 17.35s system 401% cpu 1:52.15 total**
* before_release: **102.65s user 10.50s system 172% cpu 1:05.65 total**
* before_fastdebug: **516.82s user 16.68s system 253% cpu 3:30.51 total**