### PR TITLE
8249826: 5 javax/net/ssl/SSLEngine tests use @ignore w/o bug-id

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -635,6 +635,13 @@ sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8161536 generic-
 
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64
 
+javax/net/ssl/SSLEngine/TestAllSuites.java                      8298874 generic-all
+javax/net/ssl/SSLEngine/IllegalRecordVersion.java               8298873 generic-all
+javax/net/ssl/SSLEngine/EngineCloseOnAlert.java                 8298868 generic-all
+javax/net/ssl/SSLEngine/ConnectionTest.java                     8298869 generic-all
+javax/net/ssl/SSLEngine/CheckStatus.java                        8298872 generic-all
+javax/net/ssl/SSLEngine/Basics.java                             8298867 generic-all
+
 sun/security/smartcardio/TestChannel.java                       8039280 generic-all
 sun/security/smartcardio/TestConnect.java                       8039280 generic-all
 sun/security/smartcardio/TestConnectAgain.java                  8039280 generic-all

--- a/test/jdk/javax/net/ssl/SSLEngine/Basics.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/Basics.java
@@ -26,8 +26,6 @@
  * @bug 4495742
  * @summary Add non-blocking SSL/TLS functionality, usable with any
  *      I/O abstraction
- * @ignore JSSE supported cipher suites are changed with CR 6916074,
- *     need to update this test case in JDK 7 soon
  *
  * This is intended to test many of the basic API calls to the SSLEngine
  * interface.  This doesn't really exercise much of the SSL code.

--- a/test/jdk/javax/net/ssl/SSLEngine/CheckStatus.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/CheckStatus.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 4948079
  * @summary SSLEngineResult needs updating [none yet]
- * @ignore the dependent implementation details are changed
+ *
  * @run main/othervm -Djsse.enableCBCProtection=false CheckStatus
  *
  * @author Brad Wetmore

--- a/test/jdk/javax/net/ssl/SSLEngine/ConnectionTest.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/ConnectionTest.java
@@ -26,7 +26,6 @@
  * @bug 4495742
  * @summary Add non-blocking SSL/TLS functionality, usable with any
  *      I/O abstraction
- * @ignore the dependent implementation details are changed
  * @author Brad Wetmore
  *
  * @run main/othervm ConnectionTest

--- a/test/jdk/javax/net/ssl/SSLEngine/EngineCloseOnAlert.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/EngineCloseOnAlert.java
@@ -26,7 +26,7 @@
  * @bug 8133632
  * @summary javax.net.ssl.SSLEngine does not properly handle received
  *      SSL fatal alerts
- * @ignore the dependent implementation details are changed
+ *
  * @run main/othervm EngineCloseOnAlert
  */
 

--- a/test/jdk/javax/net/ssl/SSLEngine/IllegalHandshakeMessage.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/IllegalHandshakeMessage.java
@@ -30,7 +30,6 @@
  * @test
  * @bug 8180643
  * @summary Illegal handshake message
- * @ignore the dependent implementation details are changed
  * @run main/othervm IllegalHandshakeMessage
  */
 

--- a/test/jdk/javax/net/ssl/SSLEngine/IllegalRecordVersion.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/IllegalRecordVersion.java
@@ -28,7 +28,7 @@
  * @test
  * @bug 8042449
  * @summary Issue for negative byte major record version
- * @ignore the dependent implementation details are changed
+ *
  * @run main/othervm IllegalRecordVersion
  */
 

--- a/test/jdk/javax/net/ssl/SSLEngine/TestAllSuites.java
+++ b/test/jdk/javax/net/ssl/SSLEngine/TestAllSuites.java
@@ -24,8 +24,7 @@
 /*
  * @test
  * @bug 4495742
- * @ignore JSSE supported cipher suites are changed with CR 6916074,
- *     need to update this test case in JDK 7 soon
+ *
  * @run main/timeout=180 TestAllSuites
  * @summary Add non-blocking SSL/TLS functionality, usable with any
  *      I/O abstraction


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I resolved the problem list. Will mark as clean if not recognized as such.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8249826](https://bugs.openjdk.org/browse/JDK-8249826) needs maintainer approval

### Issue
 * [JDK-8249826](https://bugs.openjdk.org/browse/JDK-8249826): 5 javax/net/ssl/SSLEngine tests use @<!---->ignore w/o bug-id (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1787/head:pull/1787` \
`$ git checkout pull/1787`

Update a local copy of the PR: \
`$ git checkout pull/1787` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1787`

View PR using the GUI difftool: \
`$ git pr show -t 1787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1787.diff">https://git.openjdk.org/jdk17u-dev/pull/1787.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1787#issuecomment-1733868782)