### PR TITLE
8292261: adjust timeouts in JLI GetObjectSizeIntrinsicsTest.java

### DIFF
--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -278,12 +278,12 @@
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  *
- * @run main/othervm -Xmx8g
+ * @run main/othervm/timeout=240 -Xmx8g
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -Xint
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
  *
- * @run main/othervm -Xmx8g
+ * @run main/othervm/timeout=240 -Xmx8g
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -Xbatch -XX:TieredStopAtLevel=1
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large


### PR DESCRIPTION
I backport this for preparation of JDK-8301377

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8292261](https://bugs.openjdk.org/browse/JDK-8292261) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292261](https://bugs.openjdk.org/browse/JDK-8292261): adjust timeouts in JLI GetObjectSizeIntrinsicsTest.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1789/head:pull/1789` \
`$ git checkout pull/1789`

Update a local copy of the PR: \
`$ git checkout pull/1789` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1789`

View PR using the GUI difftool: \
`$ git pr show -t 1789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1789.diff">https://git.openjdk.org/jdk17u-dev/pull/1789.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1789#issuecomment-1734024314)