### PR TITLE
8281874: Can't unpack msi installers from test/jdk/tools/jpackage/windows/test/jdk/tools/jpackage/windows/WinShortcutPromptTest.java test

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinShortcutPromptTest.java
+++ b/test/jdk/tools/jpackage/windows/WinShortcutPromptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,13 +122,13 @@ public class WinShortcutPromptTest {
         StringBuilder sb = new StringBuilder(cmd.name());
         sb.append("With");
         if (withShortcutPrompt) {
-            sb.append("ShortcutPrompt");
+            sb.append("P");
         }
         if (withStartMenuShortcut) {
-            sb.append("StartMenu");
+            sb.append("M");
         }
         if (withDesktopShortcut) {
-            sb.append("Desktop");
+            sb.append("D");
         }
         cmd.setArgumentValue("--name", sb.toString());
     }


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8281874](https://bugs.openjdk.org/browse/JDK-8281874) needs maintainer approval

### Issue
 * [JDK-8281874](https://bugs.openjdk.org/browse/JDK-8281874): Can't unpack msi installers from test/jdk/tools/jpackage/windows/test/jdk/tools/jpackage/windows/WinShortcutPromptTest.java test (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1791/head:pull/1791` \
`$ git checkout pull/1791`

Update a local copy of the PR: \
`$ git checkout pull/1791` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1791`

View PR using the GUI difftool: \
`$ git pr show -t 1791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1791.diff">https://git.openjdk.org/jdk17u-dev/pull/1791.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1791#issuecomment-1735082017)