### PR TITLE
8282011: test/jdk/tools/jpackage/windows/WinL10nTest.java test fails if light.exe is not in %PATH%

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinL10nTest.java
+++ b/test/jdk/tools/jpackage/windows/WinL10nTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,8 +94,11 @@ public class WinL10nTest {
 
     private final static Stream<String> getLightCommandLine(
             Executor.Result result) {
-        return result.getOutput().stream()
-                .filter(s -> s.trim().startsWith("light.exe"));
+        return result.getOutput().stream().filter(s -> {
+            s = s.trim();
+            return s.startsWith("light.exe") || ((s.contains("\\light.exe ")
+                    && s.contains(" -out ")));
+        });
     }
 
     @Test


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8282011](https://bugs.openjdk.org/browse/JDK-8282011) needs maintainer approval

### Issue
 * [JDK-8282011](https://bugs.openjdk.org/browse/JDK-8282011): test/jdk/tools/jpackage/windows/WinL10nTest.java test fails if light.exe is not in %PATH% (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1792/head:pull/1792` \
`$ git checkout pull/1792`

Update a local copy of the PR: \
`$ git checkout pull/1792` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1792/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1792`

View PR using the GUI difftool: \
`$ git pr show -t 1792`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1792.diff">https://git.openjdk.org/jdk17u-dev/pull/1792.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1792#issuecomment-1735088271)