### PR TITLE
Backport c67149be4bd4922f9e6a55eb17deca684941d535

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -92,7 +92,7 @@ public class WindowsHelper {
         BiConsumer<JPackageCommand, Boolean> installMsi = (cmd, install) -> {
             cmd.verifyIsOfType(PackageType.WIN_MSI);
             runMsiexecWithRetries(Executor.of("msiexec", "/qn", "/norestart",
-                    install ? "/i" : "/x").addArgument(cmd.outputBundle()));
+                    install ? "/i" : "/x").addArgument(cmd.outputBundle().normalize()));
         };
 
         PackageHandlers msi = new PackageHandlers();


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.