### PR TITLE
8298735: Some tools/jpackage/windows/* tests fails with jtreg test timeout

### DIFF
--- a/test/jdk/tools/jpackage/windows/WinDirChooserTest.java
+++ b/test/jdk/tools/jpackage/windows/WinDirChooserTest.java
@@ -42,7 +42,7 @@ import jdk.jpackage.test.PackageType;
  * @build WinDirChooserTest
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=WinDirChooserTest
  */
 

--- a/test/jdk/tools/jpackage/windows/WinInstallerIconTest.java
+++ b/test/jdk/tools/jpackage/windows/WinInstallerIconTest.java
@@ -44,7 +44,7 @@ import jdk.jpackage.test.TKit;
  * @build WinInstallerIconTest
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m  jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m  jdk.jpackage.test.Main
  *  --jpt-run=WinInstallerIconTest
  */
 

--- a/test/jdk/tools/jpackage/windows/WinInstallerUiTest.java
+++ b/test/jdk/tools/jpackage/windows/WinInstallerUiTest.java
@@ -45,7 +45,7 @@ import jdk.jpackage.test.TKit;
  * @build WinInstallerUiTest
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m  jdk.jpackage.test.Main
+ * @run main/othervm/timeout=720 -Xmx512m  jdk.jpackage.test.Main
  *  --jpt-run=WinInstallerUiTest
  */
 public class WinInstallerUiTest {

--- a/test/jdk/tools/jpackage/windows/WinMenuGroupTest.java
+++ b/test/jdk/tools/jpackage/windows/WinMenuGroupTest.java
@@ -45,7 +45,7 @@ import jdk.jpackage.test.Annotations.Test;
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile WinMenuGroupTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=WinMenuGroupTest
  */
 

--- a/test/jdk/tools/jpackage/windows/WinMenuTest.java
+++ b/test/jdk/tools/jpackage/windows/WinMenuTest.java
@@ -42,7 +42,7 @@ import jdk.jpackage.test.Annotations.Test;
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile WinMenuTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=WinMenuTest
  */
 

--- a/test/jdk/tools/jpackage/windows/WinPerUserInstallTest.java
+++ b/test/jdk/tools/jpackage/windows/WinPerUserInstallTest.java
@@ -43,7 +43,7 @@ import jdk.jpackage.test.Annotations.Test;
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile WinPerUserInstallTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=WinPerUserInstallTest
  */
 

--- a/test/jdk/tools/jpackage/windows/WinScriptTest.java
+++ b/test/jdk/tools/jpackage/windows/WinScriptTest.java
@@ -42,7 +42,7 @@ import jdk.jpackage.test.JPackageCommand;
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile WinScriptTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=720 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=WinScriptTest
  */
 

--- a/test/jdk/tools/jpackage/windows/WinShortcutPromptTest.java
+++ b/test/jdk/tools/jpackage/windows/WinShortcutPromptTest.java
@@ -43,7 +43,7 @@ import jdk.jpackage.test.PackageType;
  * @build WinShortcutPromptTest
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m  jdk.jpackage.test.Main
+ * @run main/othervm/timeout=720 -Xmx512m  jdk.jpackage.test.Main
  *  --jpt-run=WinShortcutPromptTest
  */
 public class WinShortcutPromptTest {

--- a/test/jdk/tools/jpackage/windows/WinShortcutTest.java
+++ b/test/jdk/tools/jpackage/windows/WinShortcutTest.java
@@ -43,7 +43,7 @@ import jdk.jpackage.test.Annotations.Test;
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile WinShortcutTest.java
- * @run main/othervm/timeout=360 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=WinShortcutTest
  */
 

--- a/test/jdk/tools/jpackage/windows/WinUrlTest.java
+++ b/test/jdk/tools/jpackage/windows/WinUrlTest.java
@@ -46,7 +46,7 @@ import jdk.jpackage.test.PackageType;
  * @build WinUrlTest
  * @requires (os.family == "windows")
  * @modules jdk.jpackage/jdk.jpackage.internal
- * @run main/othervm/timeout=360 -Xmx512m  jdk.jpackage.test.Main
+ * @run main/othervm/timeout=720 -Xmx512m  jdk.jpackage.test.Main
  *  --jpt-run=WinUrlTest
  */
 public class WinUrlTest {


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8298735](https://bugs.openjdk.org/browse/JDK-8298735) needs maintainer approval

### Issue
 * [JDK-8298735](https://bugs.openjdk.org/browse/JDK-8298735): Some tools/jpackage/windows/* tests fails with jtreg test timeout (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1794/head:pull/1794` \
`$ git checkout pull/1794`

Update a local copy of the PR: \
`$ git checkout pull/1794` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1794`

View PR using the GUI difftool: \
`$ git pr show -t 1794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1794.diff">https://git.openjdk.org/jdk17u-dev/pull/1794.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1794#issuecomment-1735192313)