### PR TITLE
8275440: Remove VirtualSpaceList::is_full()

### DIFF
--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
@@ -200,15 +200,6 @@ bool VirtualSpaceList::contains(const MetaWord* p) const {
   return false;
 }
 
-// Returns true if the vslist is not expandable and no more root chunks
-// can be allocated.
-bool VirtualSpaceList::is_full() const {
-  if (!_can_expand && _first_node != NULL && _first_node->free_words() == 0) {
-    return true;
-  }
-  return false;
-}
-
 // Convenience methods to return the global class-space chunkmanager
 //  and non-class chunkmanager, respectively.
 VirtualSpaceList* VirtualSpaceList::vslist_class() {

--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.hpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.hpp
@@ -128,10 +128,6 @@ public:
   // Returns true if this pointer is contained in one of our nodes.
   bool contains(const MetaWord* p) const;
 
-  // Returns true if the list is not expandable and no more root chunks
-  // can be allocated.
-  bool is_full() const;
-
   // Convenience methods to return the global class-space vslist
   //  and non-class vslist, respectively.
   static VirtualSpaceList* vslist_class();

--- a/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
@@ -61,9 +61,9 @@ class ChunkManagerRandomChunkAllocTest {
     return max_chunks;
   }
 
-  // Return true if, after an allocation error happened, a reserve error seems likely.
+  // Return true if, after an allocation error happened, a reserve error seems possible.
   bool could_be_reserve_error() {
-    return _context.vslist().is_full();
+    return _context.reserve_limit() < max_uintx;
   }
 
   // Return true if, after an allocation error happened, a commit error seems likely.


### PR DESCRIPTION
A small test stabilization fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8275440](https://bugs.openjdk.org/browse/JDK-8275440) needs maintainer approval

### Issue
 * [JDK-8275440](https://bugs.openjdk.org/browse/JDK-8275440): Remove VirtualSpaceList::is_full() (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1795/head:pull/1795` \
`$ git checkout pull/1795`

Update a local copy of the PR: \
`$ git checkout pull/1795` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1795`

View PR using the GUI difftool: \
`$ git pr show -t 1795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1795.diff">https://git.openjdk.org/jdk17u-dev/pull/1795.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1795#issuecomment-1735202284)