### PR TITLE
8314121: test tools/jpackage/share/RuntimePackageTest.java#id0 fails on RHEL8

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
@@ -30,6 +30,9 @@ Requires: PACKAGE_DEFAULT_DEPENDENCIES PACKAGE_CUSTOM_DEPENDENCIES
 #build time will substantially increase and it may require unpack200/system java to install
 %define __jar_repack %{nil}
 
+# on RHEL we got unwanted improved debugging enhancements
+%define _build_id_links none
+
 %define package_filelist %{_builddir}/%{name}.files
 %define app_filelist %{_builddir}/%{name}.app.files
 %define filesystem_filelist %{_builddir}/%{name}.filesystem.files


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314121](https://bugs.openjdk.org/browse/JDK-8314121) needs maintainer approval

### Issue
 * [JDK-8314121](https://bugs.openjdk.org/browse/JDK-8314121): test tools/jpackage/share/RuntimePackageTest.java#id0 fails on RHEL8 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1799/head:pull/1799` \
`$ git checkout pull/1799`

Update a local copy of the PR: \
`$ git checkout pull/1799` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1799`

View PR using the GUI difftool: \
`$ git pr show -t 1799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1799.diff">https://git.openjdk.org/jdk17u-dev/pull/1799.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1799#issuecomment-1736836112)