### PR TITLE
8307732: build-test-lib is broken

### DIFF
--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -36,9 +36,10 @@ TEST_LIB_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/lib
 
 $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
-    SRC := $(TEST_LIB_SOURCE_DIR)/sun, \
+    SRC := $(TEST_LIB_SOURCE_DIR)/sun $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
+    DISABLED_WARNINGS := deprecation removal, \
 ))
 
 TARGETS += $(BUILD_WB_JAR)
@@ -50,7 +51,7 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     BIN := $(TEST_LIB_SUPPORT)/test-lib_classes, \
     HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
-    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast, \
+    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal, \
 ))
 
 TARGETS += $(BUILD_TEST_LIB_JAR)

--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ TEST_LIB_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/lib
 
 $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
-    SRC := $(TEST_LIB_SOURCE_DIR)/sun $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
+    SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
-    DISABLED_WARNINGS := deprecation removal, \
+    DISABLED_WARNINGS := deprecation removal preview, \
+    JAVAC_FLAGS := --enable-preview, \
 ))
 
 TARGETS += $(BUILD_WB_JAR)
@@ -51,7 +52,8 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     BIN := $(TEST_LIB_SUPPORT)/test-lib_classes, \
     HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
-    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal, \
+    DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal preview, \
+    JAVAC_FLAGS := --enable-preview, \
 ))
 
 TARGETS += $(BUILD_TEST_LIB_JAR)

--- a/make/test/BuildTestLib.gmk
+++ b/make/test/BuildTestLib.gmk
@@ -36,7 +36,7 @@ TEST_LIB_SUPPORT := $(SUPPORT_OUTPUTDIR)/test/lib
 
 $(eval $(call SetupJavaCompilation, BUILD_WB_JAR, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
-    SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/parser, \
+    SRC := $(TEST_LIB_SOURCE_DIR)/jdk/test/whitebox/, \
     BIN := $(TEST_LIB_SUPPORT)/wb_classes, \
     JAR := $(TEST_LIB_SUPPORT)/wb.jar, \
     DISABLED_WARNINGS := deprecation removal preview, \
@@ -53,7 +53,13 @@ $(eval $(call SetupJavaCompilation, BUILD_TEST_LIB_JAR, \
     HEADERS := $(TEST_LIB_SUPPORT)/test-lib_headers, \
     JAR := $(TEST_LIB_SUPPORT)/test-lib.jar, \
     DISABLED_WARNINGS := try deprecation rawtypes unchecked serial cast removal preview, \
-    JAVAC_FLAGS := --enable-preview, \
+    JAVAC_FLAGS := --add-exports java.base/sun.security.util=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.classfile=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.classfile.attribute=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.classfile.constantpool=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.classfile.java.lang.constant=ALL-UNNAMED \
+        --add-exports java.base/jdk.internal.module=ALL-UNNAMED \
+        --enable-preview, \
 ))
 
 TARGETS += $(BUILD_TEST_LIB_JAR)

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -303,7 +303,7 @@ public class ASN1Formatter implements HexPrinter.Formatter {
                 case TAG_BitString:
                     out.append(String.format("%s [%d]", tagName(tag), len));
                     do {
-                        var skipped = in.skip(len);
+                        var skipped = (int) in.skip(len);
                         len -= skipped;
                         available -= skipped;
                     } while (len > 0);

--- a/test/lib/jdk/test/lib/net/HttpHeaderParser.java
+++ b/test/lib/jdk/test/lib/net/HttpHeaderParser.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-public class HttpHeaderParser {
+public final class HttpHeaderParser {
     private static final char CR = '\r';
     private static final char LF = '\n';
     private static final char HT = '\t';


### PR DESCRIPTION
- This PR backports JDK-8274345, JDK-8303922, JDK-8307732 to jdk17u-dev. The build-test-lib target is broken on jdk17 and is needed to build wb.jar and test-lib.jar.
- `make build-test-lib` works as expected after the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8274345](https://bugs.openjdk.org/browse/JDK-8274345) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8303922](https://bugs.openjdk.org/browse/JDK-8303922) needs maintainer approval
- [x] [JDK-8307732](https://bugs.openjdk.org/browse/JDK-8307732) needs maintainer approval

### Issues
 * [JDK-8307732](https://bugs.openjdk.org/browse/JDK-8307732): build-test-lib is broken (**Bug** - P4 - Approved)
 * [JDK-8274345](https://bugs.openjdk.org/browse/JDK-8274345): make build-test-lib is broken (**Bug** - P4 - Approved)
 * [JDK-8303922](https://bugs.openjdk.org/browse/JDK-8303922): build-test-lib target is broken (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1801/head:pull/1801` \
`$ git checkout pull/1801`

Update a local copy of the PR: \
`$ git checkout pull/1801` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1801`

View PR using the GUI difftool: \
`$ git pr show -t 1801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1801.diff">https://git.openjdk.org/jdk17u-dev/pull/1801.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1801#issuecomment-1737242936)