### PR TITLE
8300997: Add curl support to createJMHBundle.sh

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,22 @@ mkdir -p $BUILD_DIR $JAR_DIR
 cd $JAR_DIR
 rm -f *
 
-wget https://repo.maven.apache.org/maven2/org/apache/commons/commons-math3/$COMMONS_MATH3_VERSION/commons-math3-$COMMONS_MATH3_VERSION.jar
-wget https://repo.maven.apache.org/maven2/net/sf/jopt-simple/jopt-simple/$JOPT_SIMPLE_VERSION/jopt-simple-$JOPT_SIMPLE_VERSION.jar
-wget https://repo.maven.apache.org/maven2/org/openjdk/jmh/jmh-core/$JMH_VERSION/jmh-core-$JMH_VERSION.jar
-wget https://repo.maven.apache.org/maven2/org/openjdk/jmh/jmh-generator-annprocess/$JMH_VERSION/jmh-generator-annprocess-$JMH_VERSION.jar
+fetchJar() {
+  url="https://repo.maven.apache.org/maven2/$1/$2/$3/$2-$3.jar"
+  if command -v curl > /dev/null; then
+      curl -O --fail $url
+  elif command -v wget > /dev/null; then
+      wget $url
+  else
+      echo "Could not find either curl or wget"
+      exit 1
+  fi
+}
+
+fetchJar org/apache/commons commons-math3 $COMMONS_MATH3_VERSION
+fetchJar net/sf/jopt-simple jopt-simple $JOPT_SIMPLE_VERSION
+fetchJar org/openjdk/jmh jmh-core $JMH_VERSION
+fetchJar org/openjdk/jmh jmh-generator-annprocess $JMH_VERSION
 
 tar -cvzf ../$BUNDLE_NAME *
 


### PR DESCRIPTION
Clean backport to improve devkit creation.

Additional testing:
 - [x] devkit created successfully

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8300997](https://bugs.openjdk.org/browse/JDK-8300997) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300997](https://bugs.openjdk.org/browse/JDK-8300997): Add curl support to createJMHBundle.sh (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1803/head:pull/1803` \
`$ git checkout pull/1803`

Update a local copy of the PR: \
`$ git checkout pull/1803` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1803`

View PR using the GUI difftool: \
`$ git pr show -t 1803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1803.diff">https://git.openjdk.org/jdk17u-dev/pull/1803.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1803#issuecomment-1737363109)