### PR TITLE
8296437: NMT incurs costs if disabled

### DIFF
--- a/src/hotspot/share/services/memTracker.hpp
+++ b/src/hotspot/share/services/memTracker.hpp
@@ -88,9 +88,9 @@ class MemTracker : AllStatic {
 #include "services/virtualMemoryTracker.hpp"
 
 #define CURRENT_PC ((MemTracker::tracking_level() == NMT_detail) ? \
-                    NativeCallStack(0) : NativeCallStack::empty_stack())
+                    NativeCallStack(0) : FAKE_CALLSTACK)
 #define CALLER_PC  ((MemTracker::tracking_level() == NMT_detail) ?  \
-                    NativeCallStack(1) : NativeCallStack::empty_stack())
+                    NativeCallStack(1) : FAKE_CALLSTACK)
 
 class MemBaseline;
 

--- a/src/hotspot/share/utilities/nativeCallStack.cpp
+++ b/src/hotspot/share/utilities/nativeCallStack.cpp
@@ -77,6 +77,7 @@ void NativeCallStack::print_on(outputStream* out) const {
 
 // Decode and print this call path
 void NativeCallStack::print_on(outputStream* out, int indent) const {
+  DEBUG_ONLY(assert_not_fake();)
   address pc;
   char    buf[1024];
   int     offset;

--- a/src/hotspot/share/utilities/nativeCallStack.hpp
+++ b/src/hotspot/share/utilities/nativeCallStack.hpp
@@ -57,7 +57,29 @@ class NativeCallStack : public StackObj {
 private:
   address       _stack[NMT_TrackingStackDepth];
   static const NativeCallStack _empty_stack;
+
 public:
+
+  enum class FakeMarker { its_fake };
+#ifdef ASSERT
+  static constexpr uintptr_t _fake_address = -2; // 0xFF...FE
+  inline void assert_not_fake() const {
+    assert(_stack[0] != (address)_fake_address, "Must not be a fake stack");
+  }
+#endif
+
+  // This "fake" constructor is only used in the CALLER_PC and CURRENT_PC macros
+  // when NMT is off or in summary mode. In these cases, it does not need a
+  // callstack, and we can leave the constructed object uninitialized. That will
+  // cause the constructor call to be optimized away (see JDK-8296437).
+  explicit NativeCallStack(FakeMarker dummy) {
+#ifdef ASSERT
+    for (int i = 0; i < NMT_TrackingStackDepth; i++) {
+      _stack[i] = (address)_fake_address;
+    }
+#endif
+  }
+
   // Default ctor creates an empty stack.
   // (it may make sense to remove this altogether but its used in a few places).
   NativeCallStack() {
@@ -65,12 +87,13 @@ public:
   }
 
   explicit NativeCallStack(int toSkip);
-  NativeCallStack(address* pc, int frameCount);
+  explicit NativeCallStack(address* pc, int frameCount);
 
   static inline const NativeCallStack& empty_stack() { return _empty_stack; }
 
   // if it is an empty stack
   inline bool is_empty() const {
+    DEBUG_ONLY(assert_not_fake();)
     return _stack[0] == NULL;
   }
 
@@ -92,6 +115,7 @@ public:
 
   // Helper; calculates a hash value over the stack frames in this stack
   unsigned int calculate_hash() const {
+    DEBUG_ONLY(assert_not_fake();)
     uintptr_t hash = 0;
     for (int i = 0; i < NMT_TrackingStackDepth; i++) {
       hash += (uintptr_t)_stack[i];
@@ -102,5 +126,7 @@ public:
   void print_on(outputStream* out) const;
   void print_on(outputStream* out, int indent) const;
 };
+
+#define FAKE_CALLSTACK NativeCallStack(NativeCallStack::FakeMarker::its_fake)
 
 #endif // SHARE_UTILITIES_NATIVECALLSTACK_HPP


### PR DESCRIPTION
A small improvement of memory. Nice to have.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8296437](https://bugs.openjdk.org/browse/JDK-8296437) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296437](https://bugs.openjdk.org/browse/JDK-8296437): NMT incurs costs if disabled (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1808/head:pull/1808` \
`$ git checkout pull/1808`

Update a local copy of the PR: \
`$ git checkout pull/1808` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1808`

View PR using the GUI difftool: \
`$ git pr show -t 1808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1808.diff">https://git.openjdk.org/jdk17u-dev/pull/1808.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1808#issuecomment-1738692935)