### PR TITLE
8271829: mark hotspot runtime/Throwable tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/Throwable/StackTraceLogging.java
+++ b/test/hotspot/jtreg/runtime/Throwable/StackTraceLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8150778
  * @summary check stacktrace logging
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/Throwable/TestCatchThrowableOOM.java
+++ b/test/hotspot/jtreg/runtime/Throwable/TestCatchThrowableOOM.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8267118
  * @summary Test catching Throwable doesn't trigger OOME
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver TestCatchThrowableOOM
  */

--- a/test/hotspot/jtreg/runtime/Throwable/TestMaxJavaStackTraceDepth.java
+++ b/test/hotspot/jtreg/runtime/Throwable/TestMaxJavaStackTraceDepth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 7179701
  * @summary MaxJavaStackTraceDepth of zero is not handled correctly/consistently in the VM
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc:open
  * @modules java.base/java.lang:open
  * @library /test/lib


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271829](https://bugs.openjdk.org/browse/JDK-8271829) needs maintainer approval

### Issue
 * [JDK-8271829](https://bugs.openjdk.org/browse/JDK-8271829): mark hotspot runtime/Throwable tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1810/head:pull/1810` \
`$ git checkout pull/1810`

Update a local copy of the PR: \
`$ git checkout pull/1810` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1810`

View PR using the GUI difftool: \
`$ git pr show -t 1810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1810.diff">https://git.openjdk.org/jdk17u-dev/pull/1810.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1810#issuecomment-1739037483)