### PR TITLE
8271887: mark hotspot runtime/CDSCompressedKPtrs tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java
+++ b/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/CDSCompressedKPtrs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @requires vm.cds
  * @requires vm.bits == 64
+ * @requires vm.flagless
  * @bug 8003424
  * @summary Testing UseCompressedClassPointers with CDS
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/XShareAuto.java
+++ b/test/hotspot/jtreg/runtime/CDSCompressedKPtrs/XShareAuto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /**
  * @test
  * @requires vm.cds
+ * @requires vm.flagless
  * @bug 8005933
  * @summary -Xshare:auto is the default when -Xshare is not specified
  * @library /test/lib


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271887](https://bugs.openjdk.org/browse/JDK-8271887) needs maintainer approval

### Issue
 * [JDK-8271887](https://bugs.openjdk.org/browse/JDK-8271887): mark hotspot runtime/CDSCompressedKPtrs tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1811/head:pull/1811` \
`$ git checkout pull/1811`

Update a local copy of the PR: \
`$ git checkout pull/1811` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1811`

View PR using the GUI difftool: \
`$ git pr show -t 1811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1811.diff">https://git.openjdk.org/jdk17u-dev/pull/1811.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1811#issuecomment-1739034988)