### PR TITLE
8295424: adjust timeout for another JLI GetObjectSizeIntrinsicsTest.java subtest

### DIFF
--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -288,7 +288,7 @@
  *                   -Xbatch -XX:TieredStopAtLevel=1
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large
  *
- * @run main/othervm -Xmx8g
+ * @run main/othervm/timeout=180 -Xmx8g
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -Xbatch -XX:-TieredCompilation
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
@@ -26,11 +26,14 @@
  * @bug 8190312
  * @summary test redirected URLs for -link
  * @library /tools/lib ../../lib
+ * @library /test/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.javadoc/jdk.javadoc.internal.api
  *          jdk.javadoc/jdk.javadoc.internal.tool
  * @build toolbox.ToolBox toolbox.JavacTask javadoc.tester.*
+ * @build jtreg.SkippedException
+ * @build jdk.test.lib.Platform
  * @run main TestRedirectLinks
  */
 
@@ -66,12 +69,18 @@ import javadoc.tester.JavadocTester;
 import toolbox.JavacTask;
 import toolbox.ToolBox;
 
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
 public class TestRedirectLinks extends JavadocTester {
     /**
      * The entry point of the test.
      * @param args the array of command line arguments.
      */
     public static void main(String... args) throws Exception {
+        if (Platform.isSlowDebugBuild()) {
+            throw new SkippedException("Test is unstable with slowdebug bits");
+        }
         TestRedirectLinks tester = new TestRedirectLinks();
         tester.runTests();
     }


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

Skipped patch for Fuzz.java. That file is not in 17.  It was introduced by [8284161: Implementation of Virtual Threads (Preview)](https://github.com/openjdk/jdk/commit/9583e3657e43cc1c6f2101a64534564db2a9bd84).
Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8295424](https://bugs.openjdk.org/browse/JDK-8295424) needs maintainer approval
- [x] [JDK-8297367](https://bugs.openjdk.org/browse/JDK-8297367) needs maintainer approval

### Issues
 * [JDK-8295424](https://bugs.openjdk.org/browse/JDK-8295424): adjust timeout for another JLI GetObjectSizeIntrinsicsTest.java subtest (**Bug** - P4 - Approved)
 * [JDK-8297367](https://bugs.openjdk.org/browse/JDK-8297367): disable TestRedirectLinks.java in slowdebug mode (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1816/head:pull/1816` \
`$ git checkout pull/1816`

Update a local copy of the PR: \
`$ git checkout pull/1816` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1816`

View PR using the GUI difftool: \
`$ git pr show -t 1816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1816.diff">https://git.openjdk.org/jdk17u-dev/pull/1816.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1816#issuecomment-1739255150)