### PR TITLE
8316743: RISC-V: Change UseVectorizedMismatchIntrinsic option result to warning

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
@@ -804,7 +804,7 @@ void LIRGenerator::do_FmaIntrinsic(Intrinsic* x) {
 }
 
 void LIRGenerator::do_vectorizedMismatch(Intrinsic* x) {
-  fatal("vectorizedMismatch intrinsic is not implemented on this platform");
+  ShouldNotReachHere();
 }
 
 // _i2l, _i2f, _i2d, _l2i, _l2f, _l2d, _f2i, _f2l, _f2d, _d2i, _d2l, _d2f

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -111,6 +111,11 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseCRC32CIntrinsics, false);
   }
 
+  if (UseVectorizedMismatchIntrinsic) {
+    warning("VectorizedMismatch intrinsic is not available on this CPU.");
+    FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
+  }
+
   if (FLAG_IS_DEFAULT(UseMD5Intrinsics)) {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, true);
   }


### PR DESCRIPTION
VectorizedMismatch intrinsic is not implemented on linux-riscv platform. Backport this fix to avoid JVM crash when user specified JVM options -XX:+UnlockDiagnosticVMOptions -XX:+UseVectorizedMismatchIntrinsic on the command line. RISC-V only change, risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316743](https://bugs.openjdk.org/browse/JDK-8316743) needs maintainer approval

### Issue
 * [JDK-8316743](https://bugs.openjdk.org/browse/JDK-8316743): RISC-V: Change UseVectorizedMismatchIntrinsic option result to warning (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1823/head:pull/1823` \
`$ git checkout pull/1823`

Update a local copy of the PR: \
`$ git checkout pull/1823` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1823`

View PR using the GUI difftool: \
`$ git pr show -t 1823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1823.diff">https://git.openjdk.org/jdk17u-dev/pull/1823.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1823#issuecomment-1744399003)