### PR TITLE
8308103: Massive (up to ~30x) increase in C2 compilation time since JDK 17

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1600,7 +1600,13 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
                 cast = ConstraintCastNode::make_cast_for_type(x_ctrl, in, in_t, ConstraintCastNode::UnconditionalDependency);
               }
               if (cast != nullptr) {
-                register_new_node(cast, x_ctrl);
+                Node* prev = _igvn.hash_find_insert(cast);
+                if (prev != nullptr) {
+                  cast->destruct(&_igvn);
+                  cast = prev;
+                } else {
+                  register_new_node(cast, x_ctrl);
+                }
                 x->replace_edge(in, cast);
                 // Chain of AddP:
                 // 2- A CastPP of the base is only added now that both AddP nodes are sunk

--- a/test/hotspot/jtreg/compiler/loopopts/TestSinkingNodesCausesLongCompilation.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSinkingNodesCausesLongCompilation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308103
+ * @summary Massive (up to ~30x) increase in C2 compilation time since JDK 17
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestSinkingNodesCausesLongCompilation::mainTest -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:RepeatCompilation=30 TestSinkingNodesCausesLongCompilation
+ */
+
+public class TestSinkingNodesCausesLongCompilation {
+    public static final int N = 400;
+    public static int iFld=41489;
+
+    public void mainTest(String[] strArr1) {
+        int i9=-13, i10=-248, i11=-4, i13=33, i15=-171, i18=-58, iArr2[]=new int[N];
+
+        for (i9 = 7; i9 < 256; i9++) {
+            i11 = 1;
+            do {
+            } while (++i11 < 101);
+        }
+        for (int i14 : iArr2) {
+            for (i15 = 63; 0 < i15; i15 -= 2) {
+                i10 *= i13;
+                i10 >>= i14;
+            }
+            for (i18 = 2; 63 > i18; i18++) {
+                i10 = iFld;
+                iArr2[i18] |= i11;
+            }
+        }
+        System.out.println("i9 = " + i9);
+    }
+
+    public static void main(String[] strArr) {
+        TestSinkingNodesCausesLongCompilation _instance = new TestSinkingNodesCausesLongCompilation();
+        for (int i = 0; i < 10; i++) {
+            _instance.mainTest(strArr);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8308103](https://bugs.openjdk.org/browse/JDK-8308103) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308103](https://bugs.openjdk.org/browse/JDK-8308103): Massive (up to ~30x) increase in C2 compilation time since JDK 17 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1827/head:pull/1827` \
`$ git checkout pull/1827`

Update a local copy of the PR: \
`$ git checkout pull/1827` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1827`

View PR using the GUI difftool: \
`$ git pr show -t 1827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1827.diff">https://git.openjdk.org/jdk17u-dev/pull/1827.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1827#issuecomment-1746347069)