### PR TITLE
8315377: C2: assert(u->find_out_with(Op_AddP) == nullptr) failed: more than 2 chained AddP nodes?

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1644,6 +1644,8 @@ public:
   void try_sink_out_of_loop(Node* n);
 
   bool safe_for_if_replacement(const Node* dom) const;
+
+  void update_addp_chain_base(Node* x, Node* old_base, Node* new_base);
 };
 
 

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1581,9 +1581,10 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
           assert(!n_loop->is_member(get_loop(x_ctrl)), "should have moved out of loop");
           register_new_node(x, x_ctrl);
 
-          // Chain of AddP: (AddP base (AddP base )) must keep the same base after sinking so:
-          // 1- We don't add a CastPP here when the first one is sunk so if the second one is not, their bases remain
-          // the same.
+          // Chain of AddP nodes: (AddP base (AddP base (AddP base )))
+          // All AddP nodes must keep the same base after sinking so:
+          // 1- We don't add a CastPP here until the last one of the chain is sunk: if part of the chain is not sunk,
+          // their bases remain the same.
           // (see 2- below)
           assert(!x->is_AddP() || !x->in(AddPNode::Address)->is_AddP() ||
                  x->in(AddPNode::Address)->in(AddPNode::Base) == x->in(AddPNode::Base) ||
@@ -1602,16 +1603,10 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
               if (cast != nullptr) {
                 register_new_node(cast, x_ctrl);
                 x->replace_edge(in, cast);
-                // Chain of AddP:
-                // 2- A CastPP of the base is only added now that both AddP nodes are sunk
+                // Chain of AddP nodes:
+                // 2- A CastPP of the base is only added now that all AddP nodes are sunk
                 if (x->is_AddP() && k == AddPNode::Base) {
-                  for (DUIterator_Fast imax, i = x->fast_outs(imax); i < imax; i++) {
-                    Node* u = x->fast_out(i);
-                    if (u->is_AddP() && u->in(AddPNode::Base) == n->in(AddPNode::Base)) {
-                      _igvn.replace_input_of(u, AddPNode::Base, cast);
-                      assert(u->find_out_with(Op_AddP) == nullptr, "more than 2 chained AddP nodes?");
-                    }
-                  }
+                  update_addp_chain_base(x, n->in(AddPNode::Base), cast);
                 }
                 break;
               }
@@ -1622,6 +1617,22 @@ void PhaseIdealLoop::try_sink_out_of_loop(Node* n) {
         _igvn.remove_dead_node(n);
       }
       _dom_lca_tags_round = 0;
+    }
+  }
+}
+
+void PhaseIdealLoop::update_addp_chain_base(Node* x, Node* old_base, Node* new_base) {
+  ResourceMark rm;
+  Node_List wq;
+  wq.push(x);
+  while (wq.size() != 0) {
+    Node* n = wq.pop();
+    for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
+      Node* u = n->fast_out(i);
+      if (u->is_AddP() && u->in(AddPNode::Base) == old_base) {
+        _igvn.replace_input_of(u, AddPNode::Base, new_base);
+        wq.push(u);
+      }
     }
   }
 }

--- a/test/hotspot/jtreg/compiler/loopopts/TestSinkingMoreThan2AddPNodes.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSinkingMoreThan2AddPNodes.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8315377
+ * @requires vm.compiler2.enabled
+ * @summary C2: assert(u->find_out_with(Op_AddP) == nullptr) failed: more than 2 chained AddP nodes?
+ * @library /test/lib
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestSinkingMoreThan2AddPNodes::test TestSinkingMoreThan2AddPNodes
+ *
+ */
+
+import jdk.test.lib.Utils;
+
+public class TestSinkingMoreThan2AddPNodes {
+    public static void main(String[] strArr) throws Exception {
+        Thread t = new Thread(new Runnable() {
+                public void run() {
+                    test();
+                }
+            });
+        t.setDaemon(true);
+        t.start();
+        Thread.sleep(Utils.adjustTimeout(500));
+    }
+
+    static void test() {
+        double dArr[] = new double[10];
+        int i4 = 5, i11, i12 = 2, iArr[] = new int[400];
+        long l1;
+        byte by1 = 0;
+        short s1 = 8;
+
+        for (int i = 0; i < iArr.length; i++) {
+            iArr[i] = (i % 2 == 0) ? 23 : 34;
+        }
+
+        for (i11 = 10; i11 > 9; ) {
+            l1 = 1;
+            do {
+                try {
+                    i4 = 6 % i4;
+                    i12 = iArr[(int) l1];
+                } catch (ArithmeticException a_e) {
+                }
+                by1 += 8;
+                iArr = iArr;
+            } while (++l1 < 11);
+        }
+
+        long meth_res = i12;
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I had to resolve loopnode.hpp. Trivial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315377](https://bugs.openjdk.org/browse/JDK-8315377) needs maintainer approval

### Issue
 * [JDK-8315377](https://bugs.openjdk.org/browse/JDK-8315377): C2: assert(u-&gt;find_out_with(Op_AddP) == nullptr) failed: more than 2 chained AddP nodes? (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1829/head:pull/1829` \
`$ git checkout pull/1829`

Update a local copy of the PR: \
`$ git checkout pull/1829` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1829`

View PR using the GUI difftool: \
`$ git pr show -t 1829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1829.diff">https://git.openjdk.org/jdk17u-dev/pull/1829.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1829#issuecomment-1746391284)