### PR TITLE
8316710: Exclude java/awt/font/Rotate/RotatedTextTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -457,6 +457,7 @@ java/awt/Modal/OnTop/OnTopTKModal6Test.java 8198666 macosx-all
 java/awt/List/SingleModeDeselect/SingleModeDeselect.java 8196367 windows-all
 java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java 8061235 macosx-all
 javax/print/PrintSEUmlauts/PrintSEUmlauts.java 8135174 generic-all
+java/awt/font/Rotate/RotatedTextTest.java 8219641 linux-all
 java/awt/font/TextLayout/LigatureCaretTest.java 8266312  generic-all
 java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-all
 java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8316710](https://bugs.openjdk.org/browse/JDK-8316710), commit [f4550497](https://github.com/openjdk/jdk21u/commit/f4550497eae71bf08cd5f591c2877ca28b7fea81) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository.

Backport is clean.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316710](https://bugs.openjdk.org/browse/JDK-8316710) needs maintainer approval

### Issue
 * [JDK-8316710](https://bugs.openjdk.org/browse/JDK-8316710): Exclude java/awt/font/Rotate/RotatedTextTest.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1832/head:pull/1832` \
`$ git checkout pull/1832`

Update a local copy of the PR: \
`$ git checkout pull/1832` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1832`

View PR using the GUI difftool: \
`$ git pr show -t 1832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1832.diff">https://git.openjdk.org/jdk17u-dev/pull/1832.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1832#issuecomment-1746822336)