### PR TITLE
8301377: adjust timeout for JLI GetObjectSizeIntrinsicsTest.java subtest again

### DIFF
--- a/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
+++ b/test/hotspot/jtreg/compiler/jsr292/ContinuousCallSiteTargetChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  *
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run driver compiler.jsr292.ContinuousCallSiteTargetChange
+ * @run driver/timeout=180 compiler.jsr292.ContinuousCallSiteTargetChange
  */
 
 package compiler.jsr292;

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load007/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@
  *          /test/lib
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.load001
  *      classes

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load011/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load011/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@
  *          /test/lib
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.load001
  *      classes

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load012/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/classload/load012/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@
  *          /test/lib
  * @comment generate and compile LoadableClassXXX classes
  * @run driver nsk.monitoring.stress.classload.GenClassesBuilder
- * @run main/othervm
+ * @run main/othervm/timeout=180
  *      -XX:-UseGCOverheadLimit
  *      nsk.monitoring.stress.classload.load001
  *      classes

--- a/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
+++ b/test/jdk/java/lang/instrument/GetObjectSizeIntrinsicsTest.java
@@ -278,7 +278,7 @@
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  *
- * @run main/othervm/timeout=240 -Xmx8g
+ * @run main/othervm/timeout=300 -Xmx8g
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+AbortVMOnCompilationFailure -XX:+WhiteBoxAPI -Xbootclasspath/a:.
  *                   -Xint
  *                   -javaagent:basicAgent.jar GetObjectSizeIntrinsicsTest GetObjectSizeIntrinsicsTest large


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8301377](https://bugs.openjdk.org/browse/JDK-8301377) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305502](https://bugs.openjdk.org/browse/JDK-8305502) needs maintainer approval
- [x] [JDK-8302607](https://bugs.openjdk.org/browse/JDK-8302607) needs maintainer approval

### Issues
 * [JDK-8301377](https://bugs.openjdk.org/browse/JDK-8301377): adjust timeout for JLI GetObjectSizeIntrinsicsTest.java subtest again (**Bug** - P4 - Approved)
 * [JDK-8302607](https://bugs.openjdk.org/browse/JDK-8302607): increase timeout for ContinuousCallSiteTargetChange.java (**Bug** - P5 - Approved)
 * [JDK-8305502](https://bugs.openjdk.org/browse/JDK-8305502): adjust timeouts in three more M&amp;M tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1833/head:pull/1833` \
`$ git checkout pull/1833`

Update a local copy of the PR: \
`$ git checkout pull/1833` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1833`

View PR using the GUI difftool: \
`$ git pr show -t 1833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1833.diff">https://git.openjdk.org/jdk17u-dev/pull/1833.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1833#issuecomment-1746838083)