### PR TITLE
8307403: java/util/zip/DeInflate.java timed out

### DIFF
--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -33,7 +33,6 @@ import java.nio.*;
 import java.util.*;
 import java.util.zip.*;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class DeInflate {
 
@@ -137,14 +136,14 @@ public class DeInflate {
     static void check(Deflater def, byte[] in, int len, boolean nowrap)
         throws Throwable
     {
-        byte[] tempBuffer = new byte[len];
+        byte[] tempBuffer = new byte[1024];
         byte[] out1, out2;
         int m = 0, n = 0;
         Inflater inf = new Inflater(nowrap);
         def.setInput(in, 0, len);
         def.finish();
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(len)) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             while (!def.finished()) {
                 int temp_counter = def.deflate(tempBuffer);
                 m += temp_counter;
@@ -314,6 +313,7 @@ public class DeInflate {
                     for (int i = 0; i < 5; i++) {
                         int len = (i == 0)? dataIn.length
                                           : new Random().nextInt(dataIn.length);
+                        System.out.println("iteration: " + (i + 1) + " input length: " + len);
                         // use a new deflater
                         Deflater def = newDeflater(level, strategy, dowrap, dataOut2);
                         check(def, dataIn, len, dowrap);


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8307403](https://bugs.openjdk.org/browse/JDK-8307403) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307403](https://bugs.openjdk.org/browse/JDK-8307403): java/util/zip/DeInflate.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1835/head:pull/1835` \
`$ git checkout pull/1835`

Update a local copy of the PR: \
`$ git checkout pull/1835` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1835`

View PR using the GUI difftool: \
`$ git pr show -t 1835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1835.diff">https://git.openjdk.org/jdk17u-dev/pull/1835.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1835#issuecomment-1746883683)