### PR TITLE
8299075: TestStringDeduplicationInterned.java fails because extra deduplication

### DIFF
--- a/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
+++ b/test/hotspot/jtreg/gc/stringdedup/TestStringDeduplicationTools.java
@@ -333,9 +333,8 @@ class TestStringDeduplicationTools {
             // Create duplicate of baseString
             StringBuilder sb1 = new StringBuilder(baseString);
             String dupString1 = sb1.toString();
-            if (getValue(dupString1) == getValue(baseString)) {
-                throw new RuntimeException("Values should not match");
-            }
+
+            checkNotDeduplicated(getValue(dupString1), getValue(baseString));
 
             // Force baseString to be inspected for deduplication
             // and be inserted into the deduplication hashtable.
@@ -348,9 +347,8 @@ class TestStringDeduplicationTools {
             // Create a new duplicate of baseString
             StringBuilder sb2 = new StringBuilder(baseString);
             String dupString2 = sb2.toString();
-            if (getValue(dupString2) == getValue(baseString)) {
-                throw new RuntimeException("Values should not match");
-            }
+
+            checkNotDeduplicated(getValue(dupString2), getValue(baseString));
 
             // Intern the new duplicate
             Object beforeInternedValue = getValue(dupString2);
@@ -369,16 +367,13 @@ class TestStringDeduplicationTools {
             // Check original value of interned string, to make sure
             // deduplication happened on the interned string and not
             // on the base string
-            if (beforeInternedValue == getValue(baseString)) {
-                throw new RuntimeException("Values should not match");
-            }
+            checkNotDeduplicated(beforeInternedValue, getValue(baseString));
 
             // Create duplicate of baseString
             StringBuilder sb3 = new StringBuilder(baseString);
             String dupString3 = sb3.toString();
-            if (getValue(dupString3) == getValue(baseString)) {
-                throw new RuntimeException("Values should not match");
-            }
+
+            checkNotDeduplicated(dupString3, getValue(baseString));
 
             forceDeduplication(ageThreshold, FullGC);
 
@@ -393,6 +388,15 @@ class TestStringDeduplicationTools {
             }
 
             System.out.println("End: InternedTest");
+        }
+
+        private static void checkNotDeduplicated(Object value1, Object value2) {
+            // Note that the following check is invalid since a GC
+            // can run and actually deduplicate the strings.
+            //
+            // if (value1 == value2) {
+            //     throw new RuntimeException("Values should not match");
+            // }
         }
 
         public static OutputAnalyzer run() throws Exception {


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8299075](https://bugs.openjdk.org/browse/JDK-8299075) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299075](https://bugs.openjdk.org/browse/JDK-8299075): TestStringDeduplicationInterned.java fails because extra deduplication (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1836/head:pull/1836` \
`$ git checkout pull/1836`

Update a local copy of the PR: \
`$ git checkout pull/1836` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1836`

View PR using the GUI difftool: \
`$ git pr show -t 1836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1836.diff">https://git.openjdk.org/jdk17u-dev/pull/1836.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1836#issuecomment-1746903997)