### PR TITLE
8258951: java/net/httpclient/HandshakeFailureTest.java failed with "RuntimeException: Not found expected SSLHandshakeException in java.io.IOException"

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -468,10 +468,11 @@ class Http2Connection  {
             CompletableFuture<Void> cf = new MinimalFuture<>();
             SSLEngine engine = aconn.getEngine();
             String engineAlpn = engine.getApplicationProtocol();
-            assert Objects.equals(alpn, engineAlpn)
-                    : "alpn: %s, engine: %s".formatted(alpn, engineAlpn);
-
-            DEBUG_LOGGER.log("checkSSLConfig: alpn: %s", alpn );
+            DEBUG_LOGGER.log("checkSSLConfig: alpn: '%s', engine: '%s'", alpn, engineAlpn);
+            if (alpn == null && engineAlpn != null) {
+                alpn = engineAlpn;
+            }
+            DEBUG_LOGGER.log("checkSSLConfig: alpn: '%s'", alpn );
 
             if (alpn == null || !alpn.equals("h2")) {
                 String msg;
@@ -494,6 +495,8 @@ class Http2Connection  {
                 cf.completeExceptionally(new ALPNException(msg, aconn));
                 return cf;
             }
+            assert Objects.equals(alpn, engineAlpn)
+                    : "alpn: %s, engine: %s".formatted(alpn, engineAlpn);
             cf.complete(null);
             return cf;
         };

--- a/test/jdk/java/net/httpclient/HandshakeFailureTest.java
+++ b/test/jdk/java/net/httpclient/HandshakeFailureTest.java
@@ -49,7 +49,7 @@ import javax.net.ssl.SSLSocket;
 
 /**
  * @test
- * @bug 8238990
+ * @bug 8238990 8258951
  * @run main/othervm -Djdk.internal.httpclient.debug=true HandshakeFailureTest TLSv1.2
  * @run main/othervm -Djdk.internal.httpclient.debug=true HandshakeFailureTest TLSv1.3
  * @summary Verify SSLHandshakeException is received when the handshake fails,


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8258951](https://bugs.openjdk.org/browse/JDK-8258951) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258951](https://bugs.openjdk.org/browse/JDK-8258951): java/net/httpclient/HandshakeFailureTest.java failed with "RuntimeException: Not found expected SSLHandshakeException in java.io.IOException" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1838/head:pull/1838` \
`$ git checkout pull/1838`

Update a local copy of the PR: \
`$ git checkout pull/1838` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1838`

View PR using the GUI difftool: \
`$ git pr show -t 1838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1838.diff">https://git.openjdk.org/jdk17u-dev/pull/1838.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1838#issuecomment-1749109429)