### PR TITLE
8316906: Clarify TLABWasteTargetPercent flag

### DIFF
--- a/src/hotspot/share/gc/shared/tlab_globals.hpp
+++ b/src/hotspot/share/gc/shared/tlab_globals.hpp
@@ -70,10 +70,13 @@
           "Allocation averaging weight")                                    \
           range(0, 100)                                                     \
                                                                             \
+  /* At GC all TLABs are retired, and each thread's active  */              \
+  /* TLAB is assumed to be half full on average. The        */              \
+  /* remaining space is waste, proportional to TLAB size.   */              \
+  product(uintx, TLABWasteTargetPercent, 1,                                 \
+          "Percentage of Eden that can be wasted (half-full TLABs at GC)")  \
   /* Limit the lower bound of this flag to 1 as it is used  */              \
   /* in a division expression.                              */              \
-  product(uintx, TLABWasteTargetPercent, 1,                                 \
-          "Percentage of Eden that can be wasted")                          \
           range(1, 100)                                                     \
                                                                             \
   product(uintx, TLABRefillWasteFraction,    64,                            \


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316906](https://bugs.openjdk.org/browse/JDK-8316906) needs maintainer approval

### Issue
 * [JDK-8316906](https://bugs.openjdk.org/browse/JDK-8316906): Clarify TLABWasteTargetPercent flag (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1839/head:pull/1839` \
`$ git checkout pull/1839`

Update a local copy of the PR: \
`$ git checkout pull/1839` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1839`

View PR using the GUI difftool: \
`$ git pr show -t 1839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1839.diff">https://git.openjdk.org/jdk17u-dev/pull/1839.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1839#issuecomment-1749124690)