### PR TITLE
8309104: [JVMCI] compiler/unsafe/UnsafeGetStableArrayElement test asserts wrong values with Graal

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,12 +224,12 @@ public class UnsafeGetStableArrayElement {
     }
 
     static void testMismatched(Callable<?> c, Runnable setDefaultAction) throws Exception {
-        testMismatched(c, setDefaultAction, false);
+        testMismatched(c, setDefaultAction, false, true);
     }
 
-    static void testMismatched(Callable<?> c, Runnable setDefaultAction, boolean objectArray) throws Exception {
-        if (Compiler.isGraalEnabled() && !objectArray) {
-            // Graal will constant fold mismatched reads from primitive stable arrays
+    static void testMismatched(Callable<?> c, Runnable setDefaultAction, boolean objectArray, boolean aligned) throws Exception {
+        if (Compiler.isGraalEnabled() && !objectArray && aligned) {
+            // Graal will constant fold mismatched reads from primitive stable arrays, except unaligned ones
             run(c, setDefaultAction, null);
         } else {
             run(c, null, setDefaultAction);
@@ -319,15 +319,15 @@ public class UnsafeGetStableArrayElement {
         testMatched(   Test::testD_D, Test::changeD);
 
         // Object[], aligned accesses
-        testMismatched(Test::testL_J, Test::changeL, true); // long & double are always as large as an OOP
-        testMismatched(Test::testL_D, Test::changeL, true);
+        testMismatched(Test::testL_J, Test::changeL, true, true); // long & double are always as large as an OOP
+        testMismatched(Test::testL_D, Test::changeL, true, true);
         testMatched(   Test::testL_L, Test::changeL);
 
         // Unaligned accesses
-        testMismatched(Test::testS_U, Test::changeS);
-        testMismatched(Test::testC_U, Test::changeC);
-        testMismatched(Test::testI_U, Test::changeI);
-        testMismatched(Test::testJ_U, Test::changeJ);
+        testMismatched(Test::testS_U, Test::changeS, false, false);
+        testMismatched(Test::testC_U, Test::changeC, false, false);
+        testMismatched(Test::testI_U, Test::changeI, false, false);
+        testMismatched(Test::testJ_U, Test::changeJ, true, false);
 
         // No way to reliably check the expected behavior:
         //   (1) OOPs change during GC;


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309104](https://bugs.openjdk.org/browse/JDK-8309104) needs maintainer approval

### Issue
 * [JDK-8309104](https://bugs.openjdk.org/browse/JDK-8309104): [JVMCI] compiler/unsafe/UnsafeGetStableArrayElement test asserts wrong values with Graal (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1842/head:pull/1842` \
`$ git checkout pull/1842`

Update a local copy of the PR: \
`$ git checkout pull/1842` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1842`

View PR using the GUI difftool: \
`$ git pr show -t 1842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1842.diff">https://git.openjdk.org/jdk17u-dev/pull/1842.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1842#issuecomment-1749139699)