### PR TITLE
8308047: java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java timed out and also had jcmd pipe errors

### DIFF
--- a/test/jdk/java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java
+++ b/test/jdk/java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 6602600
- * @run main/othervm -Xmx8m BasicCancelTest
+ * @run main/othervm -Xmx64m BasicCancelTest
  * @summary Check effectiveness of RemoveOnCancelPolicy
  */
 
@@ -76,7 +76,7 @@ public class BasicCancelTest {
         // Needed to avoid OOME
         pool.setRemoveOnCancelPolicy(true);
 
-        final long moreThanYouCanChew = Runtime.getRuntime().freeMemory() / 4;
+        final long moreThanYouCanChew = Runtime.getRuntime().maxMemory() / 32;
         System.out.printf("moreThanYouCanChew=%d%n", moreThanYouCanChew);
 
         Runnable noopTask = new Runnable() { public void run() {}};


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

The chunk for ProblemList-generational-zgc.txt could not be applied because the file is not in 17.
Will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8308047](https://bugs.openjdk.org/browse/JDK-8308047) needs maintainer approval

### Issue
 * [JDK-8308047](https://bugs.openjdk.org/browse/JDK-8308047): java/util/concurrent/ScheduledThreadPoolExecutor/BasicCancelTest.java timed out and also had jcmd pipe errors (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1844/head:pull/1844` \
`$ git checkout pull/1844`

Update a local copy of the PR: \
`$ git checkout pull/1844` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1844`

View PR using the GUI difftool: \
`$ git pr show -t 1844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1844.diff">https://git.openjdk.org/jdk17u-dev/pull/1844.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1844#issuecomment-1749150227)