### PR TITLE
8303607: SunMSCAPI provider leaks memory and keys

### DIFF
--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -523,7 +523,11 @@ JNIEXPORT void JNICALL Java_sun_security_mscapi_CKeyStore_loadKeysOrCertificateC
             else
             {
                 if (bCallerFreeProv == TRUE) {
-                    ::CryptReleaseContext(hCryptProv, NULL); // deprecated
+                    if ((dwKeySpec & CERT_NCRYPT_KEY_SPEC) == CERT_NCRYPT_KEY_SPEC) {
+                        NCryptFreeObject(hCryptProv);
+                    } else {
+                        ::CryptReleaseContext(hCryptProv, NULL); // deprecated
+                    }
                     bCallerFreeProv = FALSE;
                 }
 


### PR DESCRIPTION
Backport c51d40cfebe793b2e979db0f2d91ac3b136311bb

Backporting this to 17 as the issue is still relevant; passes tier1 tests and the fix has been verified in 17/windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8303607](https://bugs.openjdk.org/browse/JDK-8303607) needs maintainer approval

### Issue
 * [JDK-8303607](https://bugs.openjdk.org/browse/JDK-8303607): SunMSCAPI provider leaks memory and keys (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1848/head:pull/1848` \
`$ git checkout pull/1848`

Update a local copy of the PR: \
`$ git checkout pull/1848` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1848`

View PR using the GUI difftool: \
`$ git pr show -t 1848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1848.diff">https://git.openjdk.org/jdk17u-dev/pull/1848.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1848#issuecomment-1749535836)