### PR TITLE
8291550: RISC-V: jdk uses misaligned memory access when AvoidUnalignedAccess enabled

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -308,6 +308,22 @@ public:
     rdy = 0b111,     // in instruction's rm field, selects dynamic rounding mode.In Rounding Mode register, Invalid.
   };
 
+  // handle unaligned access
+  static inline uint16_t ld_c_instr(address addr) {
+    return Bytes::get_native_u2(addr);
+  }
+  static inline void sd_c_instr(address addr, uint16_t c_instr) {
+    Bytes::put_native_u2(addr, c_instr);
+  }
+
+  // handle unaligned access
+  static inline uint32_t ld_instr(address addr) {
+    return Bytes::get_native_u4(addr);
+  }
+  static inline void sd_instr(address addr, uint32_t instr) {
+    Bytes::put_native_u4(addr, instr);
+  }
+
   static inline uint32_t extract(uint32_t val, unsigned msb, unsigned lsb) {
     assert_cond(msb >= lsb && msb <= 31);
     unsigned nbits = msb - lsb + 1;
@@ -332,10 +348,10 @@ public:
     unsigned mask = (1U << nbits) - 1;
     val <<= lsb;
     mask <<= lsb;
-    unsigned target = *(unsigned *)a;
+    unsigned target = ld_instr(a);
     target &= ~mask;
     target |= val;
-    *(unsigned *)a = target;
+    sd_instr(a, target);
   }
 
   static void patch(address a, unsigned bit, unsigned val) {
@@ -1877,10 +1893,10 @@ public:
     uint16_t mask = (1U << nbits) - 1;
     val <<= lsb;
     mask <<= lsb;
-    uint16_t target = *(uint16_t *)a;
+    uint16_t target = ld_c_instr(a);
     target &= ~mask;
     target |= val;
-    *(uint16_t *)a = target;
+    sd_c_instr(a, target);
   }
 
   static void c_patch(address a, unsigned bit, uint16_t val) {

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1099,8 +1099,10 @@ void C2_MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
 // and a2 and the length in cnt1.
 // elem_size is the element size in bytes: either 1 or 2.
 // There are two implementations.  For arrays >= 8 bytes, all
-// comparisons (including the final one, which may overlap) are
-// performed 8 bytes at a time.  For strings < 8 bytes, we compare a
+// comparisons (for hw supporting unaligned access: including the final one,
+// which may overlap) are performed 8 bytes at a time.
+// For strings < 8 bytes (and for tails of long strings when
+// AvoidUnalignedAccesses is true), we compare a
 // halfword, then a short, and then a byte.
 
 void C2_MacroAssembler::string_equals(Register a1, Register a2,
@@ -1111,10 +1113,11 @@ void C2_MacroAssembler::string_equals(Register a1, Register a2,
   Register tmp2 = t1;
 
   assert(elem_size == 1 || elem_size == 2, "must be 2 or 1 byte");
-  assert_different_registers(a1, a2, result, cnt1, t0, t1);
+  assert_different_registers(a1, a2, result, cnt1, tmp1, tmp2);
 
   BLOCK_COMMENT("string_equals {");
 
+  beqz(cnt1, SAME);
   mv(result, false);
 
   // Check for short strings, i.e. smaller than wordSize.
@@ -1129,26 +1132,31 @@ void C2_MacroAssembler::string_equals(Register a1, Register a2,
     add(a2, a2, wordSize);
     sub(cnt1, cnt1, wordSize);
     bne(tmp1, tmp2, DONE);
-  } bgtz(cnt1, NEXT_WORD);
+  } bgez(cnt1, NEXT_WORD);
 
-  // Last longword.  In the case where length == 4 we compare the
-  // same longword twice, but that's still faster than another
-  // conditional branch.
-  // cnt1 could be 0, -1, -2, -3, -4 for chars; -4 only happens when
-  // length == 4.
-  add(tmp1, a1, cnt1);
-  ld(tmp1, Address(tmp1, 0));
-  add(tmp2, a2, cnt1);
-  ld(tmp2, Address(tmp2, 0));
-  bne(tmp1, tmp2, DONE);
-  j(SAME);
+  if (!AvoidUnalignedAccesses) {
+    // Last longword.  In the case where length == 4 we compare the
+    // same longword twice, but that's still faster than another
+    // conditional branch.
+    // cnt1 could be 0, -1, -2, -3, -4 for chars; -4 only happens when
+    // length == 4.
+    add(tmp1, a1, cnt1);
+    ld(tmp1, Address(tmp1, 0));
+    add(tmp2, a2, cnt1);
+    ld(tmp2, Address(tmp2, 0));
+    bne(tmp1, tmp2, DONE);
+    j(SAME);
+  } else {
+    add(tmp1, cnt1, wordSize);
+    beqz(tmp1, SAME);
+  }
 
   bind(SHORT);
   Label TAIL03, TAIL01;
 
   // 0-7 bytes left.
-  test_bit(t0, cnt1, 2);
-  beqz(t0, TAIL03);
+  test_bit(tmp1, cnt1, 2);
+  beqz(tmp1, TAIL03);
   {
     lwu(tmp1, Address(a1, 0));
     add(a1, a1, 4);
@@ -1159,8 +1167,8 @@ void C2_MacroAssembler::string_equals(Register a1, Register a2,
 
   bind(TAIL03);
   // 0-3 bytes left.
-  test_bit(t0, cnt1, 1);
-  beqz(t0, TAIL01);
+  test_bit(tmp1, cnt1, 1);
+  beqz(tmp1, TAIL01);
   {
     lhu(tmp1, Address(a1, 0));
     add(a1, a1, 2);
@@ -1172,8 +1180,8 @@ void C2_MacroAssembler::string_equals(Register a1, Register a2,
   bind(TAIL01);
   if (elem_size == 1) { // Only needed when comparing 1-byte elements
     // 0-1 bytes left.
-    test_bit(t0, cnt1, 0);
-    beqz(t0, SAME);
+    test_bit(tmp1, cnt1, 0);
+    beqz(tmp1, SAME);
     {
       lbu(tmp1, Address(a1, 0));
       lbu(tmp2, Address(a2, 0));

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp
@@ -84,11 +84,11 @@ static const struct CheckInsn barrierInsn[] = {
 // BarrierSetAssembler::nmethod_entry_barrier. The matching ignores the specific
 // register numbers and immediate values in the encoding.
 void NativeNMethodBarrier::verify() const {
-  intptr_t addr = (intptr_t) instruction_address();
+  address addr = instruction_address();
   for(unsigned int i = 0; i < sizeof(barrierInsn)/sizeof(struct CheckInsn); i++ ) {
-    uint32_t inst = *((uint32_t*) addr);
+    uint32_t inst = Assembler::ld_instr(addr);
     if ((inst & barrierInsn[i].mask) != barrierInsn[i].bits) {
-      tty->print_cr("Addr: " INTPTR_FORMAT " Code: 0x%x", addr, inst);
+      tty->print_cr("Addr: " INTPTR_FORMAT " Code: 0x%x", p2i(addr), inst);
       fatal("not an %s instruction.", barrierInsn[i].name);
     }
     addr += 4;

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -176,8 +176,15 @@ void InterpreterMacroAssembler::check_and_handle_earlyret(Register java_thread) 
 
 void InterpreterMacroAssembler::get_unsigned_2_byte_index_at_bcp(Register reg, int bcp_offset) {
   assert(bcp_offset >= 0, "bcp is still pointing to start of bytecode");
-  lhu(reg, Address(xbcp, bcp_offset));
-  revb_h(reg, reg);
+  if (AvoidUnalignedAccesses && (bcp_offset % 2)) {
+    lbu(t1, Address(xbcp, bcp_offset));
+    lbu(reg, Address(xbcp, bcp_offset + 1));
+    slli(t1, t1, 8);
+    add(reg, reg, t1);
+  } else {
+    lhu(reg, Address(xbcp, bcp_offset));
+    revb_h_h_u(reg, reg);
+  }
 }
 
 void InterpreterMacroAssembler::get_dispatch() {
@@ -190,13 +197,23 @@ void InterpreterMacroAssembler::get_dispatch() {
 }
 
 void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,
+                                                       Register tmp,
                                                        int bcp_offset,
                                                        size_t index_size) {
   assert(bcp_offset > 0, "bcp is still pointing to start of bytecode");
   if (index_size == sizeof(u2)) {
-    load_unsigned_short(index, Address(xbcp, bcp_offset));
+    if (AvoidUnalignedAccesses) {
+      assert_different_registers(index, tmp);
+      load_unsigned_byte(index, Address(xbcp, bcp_offset));
+      load_unsigned_byte(tmp, Address(xbcp, bcp_offset + 1));
+      slli(tmp, tmp, 8);
+      add(index, index, tmp);
+    } else {
+      load_unsigned_short(index, Address(xbcp, bcp_offset));
+    }
   } else if (index_size == sizeof(u4)) {
-    lwu(index, Address(xbcp, bcp_offset));
+    load_int_misaligned(index, Address(xbcp, bcp_offset), tmp, false);
+
     // Check if the secondary index definition is still ~x, otherwise
     // we have to change the following assembler code to calculate the
     // plain index.
@@ -223,7 +240,8 @@ void InterpreterMacroAssembler::get_cache_and_index_at_bcp(Register cache,
                                                            size_t index_size) {
   assert_different_registers(cache, index);
   assert_different_registers(cache, xcpool);
-  get_cache_index_at_bcp(index, bcp_offset, index_size);
+  // register "cache" is trashed in next shadd, so lets use it as a temporary register
+  get_cache_index_at_bcp(index, cache, bcp_offset, index_size);
   assert(sizeof(ConstantPoolCacheEntry) == 4 * wordSize, "adjust code below");
   // Convert from field index to ConstantPoolCacheEntry
   // riscv already has the cache in xcpool so there is no need to
@@ -260,7 +278,8 @@ void InterpreterMacroAssembler::get_cache_entry_pointer_at_bcp(Register cache,
                                                                int bcp_offset,
                                                                size_t index_size) {
   assert_different_registers(cache, tmp);
-  get_cache_index_at_bcp(tmp, bcp_offset, index_size);
+  // register "cache" is trashed in next ld, so lets use it as a temporary register
+  get_cache_index_at_bcp(tmp, cache, bcp_offset, index_size);
   assert(sizeof(ConstantPoolCacheEntry) == 4 * wordSize, "adjust code below");
   // Convert from field index to ConstantPoolCacheEntry index
   // and from word offset to byte offset

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.hpp
@@ -113,7 +113,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void get_cache_and_index_at_bcp(Register cache, Register index, int bcp_offset, size_t index_size = sizeof(u2));
   void get_cache_and_index_and_bytecode_at_bcp(Register cache, Register index, Register bytecode, int byte_no, int bcp_offset, size_t index_size = sizeof(u2));
   void get_cache_entry_pointer_at_bcp(Register cache, Register tmp, int bcp_offset, size_t index_size = sizeof(u2));
-  void get_cache_index_at_bcp(Register index, int bcp_offset, size_t index_size = sizeof(u2));
+  void get_cache_index_at_bcp(Register index, Register tmp, int bcp_offset, size_t index_size = sizeof(u2));
   void get_method_counters(Register method, Register mcs, Label& skip);
 
   // Load cpool->resolved_references(index).

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4185,8 +4185,7 @@ address MacroAssembler::zero_words(Register ptr, Register cnt) {
 
 // base:  Address of a buffer to be zeroed, 8 bytes aligned.
 // cnt:   Immediate count in HeapWords.
-void MacroAssembler::zero_words(Register base, u_int64_t cnt)
-{
+void MacroAssembler::zero_words(Register base, u_int64_t cnt) {
   assert_different_registers(base, t0, t1);
 
   BLOCK_COMMENT("zero_words {");

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1350,7 +1350,7 @@ static int patch_imm_in_li32(address branch, int32_t target) {
 static long get_offset_of_jal(address insn_addr) {
   assert_cond(insn_addr != NULL);
   long offset = 0;
-  unsigned insn = *(unsigned*)insn_addr;
+  unsigned insn = Assembler::ld_instr(insn_addr);
   long val = (long)Assembler::sextract(insn, 31, 12);
   offset |= ((val >> 19) & 0x1) << 20;
   offset |= (val & 0xff) << 12;
@@ -1363,7 +1363,7 @@ static long get_offset_of_jal(address insn_addr) {
 static long get_offset_of_conditional_branch(address insn_addr) {
   long offset = 0;
   assert_cond(insn_addr != NULL);
-  unsigned insn = *(unsigned*)insn_addr;
+  unsigned insn = Assembler::ld_instr(insn_addr);
   offset = (long)Assembler::sextract(insn, 31, 31);
   offset = (offset << 12) | (((long)(Assembler::sextract(insn, 7, 7) & 0x1)) << 11);
   offset = offset | (((long)(Assembler::sextract(insn, 30, 25) & 0x3f)) << 5);
@@ -1375,35 +1375,35 @@ static long get_offset_of_conditional_branch(address insn_addr) {
 static long get_offset_of_pc_relative(address insn_addr) {
   long offset = 0;
   assert_cond(insn_addr != NULL);
-  offset = ((long)(Assembler::sextract(((unsigned*)insn_addr)[0], 31, 12))) << 12;                                  // Auipc.
-  offset += ((long)Assembler::sextract(((unsigned*)insn_addr)[1], 31, 20));                                         // Addi/Jalr/Load.
+  offset = ((long)(Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12))) << 12;                               // Auipc.
+  offset += ((long)Assembler::sextract(Assembler::ld_instr(insn_addr + 4), 31, 20));                                  // Addi/Jalr/Load.
   offset = (offset << 32) >> 32;
   return offset;
 }
 
 static address get_target_of_movptr(address insn_addr) {
   assert_cond(insn_addr != NULL);
-  intptr_t target_address = (((int64_t)Assembler::sextract(((unsigned*)insn_addr)[0], 31, 12)) & 0xfffff) << 29;    // Lui.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[1], 31, 20)) << 17;                        // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[3], 31, 20)) << 6;                         // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[5], 31, 20));                              // Addi/Jalr/Load.
+  intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 29; // Lui.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 4), 31, 20)) << 17;                 // Addi.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 12), 31, 20)) << 6;                 // Addi.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 20), 31, 20));                      // Addi/Jalr/Load.
   return (address) target_address;
 }
 
 static address get_target_of_li64(address insn_addr) {
   assert_cond(insn_addr != NULL);
-  intptr_t target_address = (((int64_t)Assembler::sextract(((unsigned*)insn_addr)[0], 31, 12)) & 0xfffff) << 44;    // Lui.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[1], 31, 20)) << 32;                        // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[3], 31, 20)) << 20;                        // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[5], 31, 20)) << 8;                         // Addi.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[7], 31, 20));                              // Addi.
+  intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 44; // Lui.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 4), 31, 20)) << 32;                 // Addi.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 12), 31, 20)) << 20;                // Addi.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 20), 31, 20)) << 8;                 // Addi.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 28), 31, 20));                      // Addi.
   return (address)target_address;
 }
 
 static address get_target_of_li32(address insn_addr) {
   assert_cond(insn_addr != NULL);
-  intptr_t target_address = (((int64_t)Assembler::sextract(((unsigned*)insn_addr)[0], 31, 12)) & 0xfffff) << 12;    // Lui.
-  target_address += ((int64_t)Assembler::sextract(((unsigned*)insn_addr)[1], 31, 20));                              // Addiw.
+  intptr_t target_address = (((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr), 31, 12)) & 0xfffff) << 12; // Lui.
+  target_address += ((int64_t)Assembler::sextract(Assembler::ld_instr(insn_addr + 4), 31, 20));                       // Addiw.
   return (address)target_address;
 }
 
@@ -1428,7 +1428,7 @@ int MacroAssembler::pd_patch_instruction_size(address branch, address target) {
   } else {
 #ifdef ASSERT
     tty->print_cr("pd_patch_instruction_size: instruction 0x%x at " INTPTR_FORMAT " could not be patched!\n",
-                  *(unsigned*)branch, p2i(branch));
+                  Assembler::ld_instr(branch), p2i(branch));
     Disassembler::decode(branch - 16, branch + 16);
 #endif
     ShouldNotReachHere();
@@ -1613,6 +1613,92 @@ void MacroAssembler::store_sized_value(Address dst, Register src, size_t size_in
     case  2:  sh(src, dst); break;
     case  1:  sb(src, dst); break;
     default:  ShouldNotReachHere();
+  }
+}
+
+// granularity is 1, 2 bytes per load
+void MacroAssembler::load_int_misaligned(Register dst, Address src, Register tmp, bool is_signed, int granularity) {
+  if (AvoidUnalignedAccesses && (granularity != 4)) {
+    assert_different_registers(dst, tmp, src.base());
+    switch(granularity) {
+      case 1:
+        lbu(dst, src);
+        lbu(tmp, Address(src.base(), src.offset() + 1));
+        slli(tmp, tmp, 8);
+        add(dst, dst, tmp);
+        lbu(tmp, Address(src.base(), src.offset() + 2));
+        slli(tmp, tmp, 16);
+        add(dst, dst, tmp);
+        is_signed ? lb(tmp, Address(src.base(), src.offset() + 3)) : lbu(tmp, Address(src.base(), src.offset() + 3));
+        slli(tmp, tmp, 24);
+        add(dst, dst, tmp);
+        break;
+      case 2:
+        lhu(dst, src);
+        is_signed ? lh(tmp, Address(src.base(), src.offset() + 2)) : lhu(tmp, Address(src.base(), src.offset() + 2));
+        slli(tmp, tmp, 16);
+        add(dst, dst, tmp);
+        break;
+      default:
+        ShouldNotReachHere();
+    }
+  } else {
+    is_signed ? lw(dst, src) : lwu(dst, src);
+  }
+}
+
+// granularity is 1, 2 or 4 bytes per load
+void MacroAssembler::load_long_misaligned(Register dst, Address src, Register tmp, int granularity) {
+  if (AvoidUnalignedAccesses && (granularity != 8)) {
+    assert_different_registers(dst, tmp, src.base());
+    switch(granularity){
+      case 1:
+        lbu(dst, src);
+        lbu(tmp, Address(src.base(), src.offset() + 1));
+        slli(tmp, tmp, 8);
+        add(dst, dst, tmp);
+        lbu(tmp, Address(src.base(), src.offset() + 2));
+        slli(tmp, tmp, 16);
+        add(dst, dst, tmp);
+        lbu(tmp, Address(src.base(), src.offset() + 3));
+        slli(tmp, tmp, 24);
+        add(dst, dst, tmp);
+        lbu(tmp, Address(src.base(), src.offset() + 4));
+        slli(tmp, tmp, 32);
+        add(dst, dst, tmp);
+        lbu(tmp, Address(src.base(), src.offset() + 5));
+        slli(tmp, tmp, 40);
+        add(dst, dst, tmp);
+        lbu(tmp, Address(src.base(), src.offset() + 6));
+        slli(tmp, tmp, 48);
+        add(dst, dst, tmp);
+        lbu(tmp, Address(src.base(), src.offset() + 7));
+        slli(tmp, tmp, 56);
+        add(dst, dst, tmp);
+        break;
+      case 2:
+        lhu(dst, src);
+        lhu(tmp, Address(src.base(), src.offset() + 2));
+        slli(tmp, tmp, 16);
+        add(dst, dst, tmp);
+        lhu(tmp, Address(src.base(), src.offset() + 4));
+        slli(tmp, tmp, 32);
+        add(dst, dst, tmp);
+        lhu(tmp, Address(src.base(), src.offset() + 6));
+        slli(tmp, tmp, 48);
+        add(dst, dst, tmp);
+        break;
+      case 4:
+        lwu(dst, src);
+        lwu(tmp, Address(src.base(), src.offset() + 4));
+        slli(tmp, tmp, 32);
+        add(dst, dst, tmp);
+        break;
+      default:
+        ShouldNotReachHere();
+    }
+  } else {
+    ld(dst, src);
   }
 }
 
@@ -4099,7 +4185,8 @@ address MacroAssembler::zero_words(Register ptr, Register cnt) {
 
 // base:  Address of a buffer to be zeroed, 8 bytes aligned.
 // cnt:   Immediate count in HeapWords.
-void MacroAssembler::zero_words(Register base, u_int64_t cnt) {
+void MacroAssembler::zero_words(Register base, u_int64_t cnt)
+{
   assert_different_registers(base, t0, t1);
 
   BLOCK_COMMENT("zero_words {");

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -407,6 +407,10 @@ class MacroAssembler: public Assembler {
   void load_sized_value(Register dst, Address src, size_t size_in_bytes, bool is_signed, Register dst2 = noreg);
   void store_sized_value(Address dst, Register src, size_t size_in_bytes, Register src2 = noreg);
 
+  // Misaligned loads, will use the best way, according to the AvoidUnalignedAccess flag
+  void load_int_misaligned(Register dst, Address src, Register tmp, bool is_signed, int granularity = 1);
+  void load_long_misaligned(Register dst, Address src, Register tmp, int granularity = 1);
+
  public:
   // Standard pseudo instructions
   inline void nop() {

--- a/src/hotspot/cpu/riscv/relocInfo_riscv.cpp
+++ b/src/hotspot/cpu/riscv/relocInfo_riscv.cpp
@@ -45,7 +45,7 @@ void Relocation::pd_set_data_value(address x, intptr_t o, bool verify_only) {
       if (NativeInstruction::is_load_pc_relative_at(addr())) {
         address constptr = (address)code()->oop_addr_at(reloc->oop_index());
         bytes = MacroAssembler::pd_patch_instruction_size(addr(), constptr);
-        assert(*(address*)constptr == x, "error in oop relocation");
+        assert((address)Bytes::get_native_u8(constptr) == x, "error in oop relocation");
       } else {
         bytes = MacroAssembler::patch_oop(addr(), x);
       }

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1060,8 +1060,9 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     Label L;
     __ ld(x28, Address(xmethod, Method::native_function_offset()));
     address unsatisfied = (SharedRuntime::native_method_throw_unsatisfied_link_error_entry());
-    __ mv(t1, unsatisfied);
-    __ ld(t1, Address(t1, 0));
+    __ mv(t, unsatisfied);
+    __ load_long_misaligned(t1, Address(t, 0), t0, 2); // 2 bytes aligned, but not 4 or 8
+
     __ bne(x28, t1, L);
     __ call_VM(noreg,
                CAST_FROM_FN_PTR(address,


### PR DESCRIPTION
I'd like to backport JDK-8291550 to jdk17u. This fix is related only to RISC-V.

The patch applies not cleanly. It differs from the original one in the following:

**1.** **src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp**

`#undef VFCVT_SAFE` was removed because there is no `#define VFCVT_SAFE(VFLOATCVT)` (JDK-8306966)

**2.** **src/hotspot/cpu/riscv/gc/shared/barrierSetNMethod_riscv.cpp**

The difference is in context due to method signature change by JDK-8299229
`void NativeNMethodBarrier::verify() const {..`
`bool NativeNMethodBarrier::check_barrier(err_msg& msg) const {..`

`msg.print(..)` was replaced with `tty->print_cr(..)`

**3.** **src/hotspot/cpu/riscv/interp_masm_riscv.cpp**

The changes were not applied to 
`void InterpreterMacroAssembler::load_resolved_indy_entry(Register cache, Register index) {`
This method doesn't exist, it was added by JDK-8301995.

**4.** **src/hotspot/cpu/riscv/macroAssembler_riscv.cpp**

The difference is in context due to the method signature change by JDK-8298075
`address MacroAssembler::get_target_of_li32(address insn_addr) {`
`static address get_target_of_li32(address insn_addr) `{

`NULL` was replaced with `nullptr` by JDK-8301496.

**5.** **src/hotspot/cpu/riscv/nativeInst_riscv.cpp**
         **src/hotspot/cpu/riscv/nativeInst_riscv.hpp**
 
`NULL` was replaced with `nullptr` by JDK-8301496

**Testing:** tier1 tests successfully passed on a RISC-V HiFive board with Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8291550](https://bugs.openjdk.org/browse/JDK-8291550) needs maintainer approval

### Issue
 * [JDK-8291550](https://bugs.openjdk.org/browse/JDK-8291550): RISC-V: jdk uses misaligned memory access when AvoidUnalignedAccess enabled (**Bug** - P3 - Approved)


### Reviewers
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1852/head:pull/1852` \
`$ git checkout pull/1852`

Update a local copy of the PR: \
`$ git checkout pull/1852` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1852`

View PR using the GUI difftool: \
`$ git pr show -t 1852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1852.diff">https://git.openjdk.org/jdk17u-dev/pull/1852.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1852#issuecomment-1750803354)