### PR TITLE
8308223: failure handler missed jcmd.vm.info command

### DIFF
--- a/test/failure_handler/src/share/conf/common.properties
+++ b/test/failure_handler/src/share/conf/common.properties
@@ -33,7 +33,7 @@ onTimeout=\
         jcmd.compiler.queue \
   jcmd.vm.classloader_stats jcmd.vm.stringtable \
         jcmd.vm.symboltable jcmd.vm.uptime jcmd.vm.dynlibs \
-        jcmd.vm.system_properties \
+        jcmd.vm.system_properties jcmd.vm.info \
   jcmd.gc.heap_info jcmd.gc.class_histogram jcmd.gc.finalizer_info \
   jstack
 


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

Simple resolve needed due to context. Will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8308223](https://bugs.openjdk.org/browse/JDK-8308223) needs maintainer approval

### Issue
 * [JDK-8308223](https://bugs.openjdk.org/browse/JDK-8308223): failure handler missed jcmd.vm.info command (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1854/head:pull/1854` \
`$ git checkout pull/1854`

Update a local copy of the PR: \
`$ git checkout pull/1854` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1854`

View PR using the GUI difftool: \
`$ git pr show -t 1854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1854.diff">https://git.openjdk.org/jdk17u-dev/pull/1854.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1854#issuecomment-1751114877)