### PR TITLE
8309974: some JVMCI tests fail when VM options include -XX:+EnableJVMCI

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/events/JvmciShutdownEventTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/events/JvmciShutdownEventTest.java
@@ -35,9 +35,9 @@
  *
  * @build compiler.jvmci.common.JVMCIHelpers
  *        compiler.jvmci.events.JvmciShutdownEventListener
- * @run driver jdk.test.lib.FileInstaller ./JvmciShutdownEventTest.config
+ * @run main/othervm jdk.test.lib.FileInstaller ./JvmciShutdownEventTest.config
  *     ./META-INF/services/jdk.vm.ci.services.JVMCIServiceLocator
- * @run driver jdk.test.lib.helpers.ClassFileInstaller
+ * @run main/othervm jdk.test.lib.helpers.ClassFileInstaller
  *      compiler.jvmci.common.JVMCIHelpers$EmptyHotspotCompiler
  *      compiler.jvmci.common.JVMCIHelpers$EmptyCompilerFactory
  *      compiler.jvmci.common.JVMCIHelpers$EmptyCompilationRequestResult

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/HotSpotConstantReflectionProviderTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/HotSpotConstantReflectionProviderTest.java
@@ -31,7 +31,7 @@
  *          java.base/jdk.internal.misc
  * @library /test/lib /compiler/jvmci/jdk.vm.ci.hotspot.test/src
  * @build jdk.vm.ci.hotspot.test.DummyClass
- * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.vm.ci.hotspot.test.DummyClass
+ * @run main/othervm jdk.test.lib.helpers.ClassFileInstaller jdk.vm.ci.hotspot.test.DummyClass
  * @run testng/othervm/timeout=300 -Xbootclasspath/a:.
  *      -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI
  *      -XX:-UseJVMCICompiler jdk.vm.ci.hotspot.test.HotSpotConstantReflectionProviderTest

--- a/test/hotspot/jtreg/compiler/jvmci/meta/StableFieldTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/meta/StableFieldTest.java
@@ -33,7 +33,7 @@
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *
  * @compile StableFieldTest.java
- * @run driver jdk.test.lib.helpers.ClassFileInstaller compiler.jvmci.meta.StableFieldTest
+ * @run main/othervm jdk.test.lib.helpers.ClassFileInstaller compiler.jvmci.meta.StableFieldTest
  * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseJVMCICompiler -Xbootclasspath/a:. compiler.jvmci.meta.StableFieldTest
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309974](https://bugs.openjdk.org/browse/JDK-8309974) needs maintainer approval

### Issue
 * [JDK-8309974](https://bugs.openjdk.org/browse/JDK-8309974): some JVMCI tests fail when VM options include -XX:+EnableJVMCI (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1855/head:pull/1855` \
`$ git checkout pull/1855`

Update a local copy of the PR: \
`$ git checkout pull/1855` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1855`

View PR using the GUI difftool: \
`$ git pr show -t 1855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1855.diff">https://git.openjdk.org/jdk17u-dev/pull/1855.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1855#issuecomment-1751133755)