### PR TITLE
8316566: RISC-V: Zero extended narrow oop passed to Atomic::cmpxchg

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
@@ -37,7 +37,7 @@ inline void OrderAccess::storestore() { release(); }
 inline void OrderAccess::loadstore()  { acquire(); }
 inline void OrderAccess::storeload()  { fence(); }
 
-#define FULL_MEM_BARRIER  __sync_synchronize()
+#define FULL_MEM_BARRIER  __atomic_thread_fence(__ATOMIC_SEQ_CST);
 #define READ_MEM_BARRIER  __atomic_thread_fence(__ATOMIC_ACQUIRE);
 #define WRITE_MEM_BARRIER __atomic_thread_fence(__ATOMIC_RELEASE);
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9ffec67a](https://github.com/openjdk/jdk21u/commit/9ffec67a3f2dada329a9887338c570424a79e7f8) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository.

The commit being backported was authored by Robbin Ehn on 4 Oct 2023 and had no reviewers.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316566](https://bugs.openjdk.org/browse/JDK-8316566) needs maintainer approval

### Issue
 * [JDK-8316566](https://bugs.openjdk.org/browse/JDK-8316566): RISC-V: Zero extended narrow oop passed to Atomic::cmpxchg (**Bug** - P4 - Approved)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1858/head:pull/1858` \
`$ git checkout pull/1858`

Update a local copy of the PR: \
`$ git checkout pull/1858` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1858`

View PR using the GUI difftool: \
`$ git pr show -t 1858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1858.diff">https://git.openjdk.org/jdk17u-dev/pull/1858.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1858#issuecomment-1752342850)