### PR TITLE
8287671: Adjust ForceGC to invoke System::gc fewer times for negative case

### DIFF
--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -76,7 +76,7 @@ public class ForceGC {
                 return true;
             }
 
-            doIt(i);
+            doit(i);
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {

--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -32,21 +32,24 @@ import java.util.function.BooleanSupplier;
  * Utility class to invoke System.gc()
  */
 public class ForceGC {
-    private final CountDownLatch cleanerInvoked = new CountDownLatch(1);
-    private final Cleaner cleaner = Cleaner.create();
+    private final static Cleaner cleaner = Cleaner.create();
+
+    private final CountDownLatch cleanerInvoked;
     private Object o;
+    private int gcCount = 0;
 
     public ForceGC() {
         this.o = new Object();
-        cleaner.register(o, () -> cleanerInvoked.countDown());
+        this.cleanerInvoked = new CountDownLatch(1);
+        cleaner.register(o, cleanerInvoked::countDown);
     }
 
     private void doit(int iter) {
         try {
             for (int i = 0; i < 10; i++) {
                 System.gc();
-                System.out.println("doit() iter: " + iter + ", gc " + i);
-                if (cleanerInvoked.await(1L, TimeUnit.SECONDS)) {
+                gcCount++;
+                if (cleanerInvoked.await(100L, TimeUnit.MILLISECONDS)) {
                     return;
                 }
             }
@@ -68,12 +71,20 @@ public class ForceGC {
         o = null; // Keep reference to Object until now, to ensure the Cleaner
                   // doesn't count down the latch before await() is called.
         for (int i = 0; i < 10; i++) {
-            if (s.getAsBoolean()) return true;
-            doit(i);
-            try { Thread.sleep(1000); } catch (InterruptedException e) {
+            if (s.getAsBoolean()) {
+                System.out.println("ForceGC condition met after System.gc() " + gcCount + " times");
+                return true;
+            }
+
+            doIt(i);
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
                 throw new AssertionError("unexpected interrupted sleep", e);
             }
         }
+
+        System.out.println("ForceGC condition not met after System.gc() " + gcCount + " times");
         return false;
     }
 }


### PR DESCRIPTION
A useful test infra improvement. Simplifies backporting changes using ForceGC.

I include build fix 8287867.

Both clean, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8287671](https://bugs.openjdk.org/browse/JDK-8287671) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8287867](https://bugs.openjdk.org/browse/JDK-8287867) needs maintainer approval
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8287671](https://bugs.openjdk.org/browse/JDK-8287671): Adjust ForceGC to invoke System::gc fewer times for negative case (**Bug** - P3 - Approved)
 * [JDK-8287867](https://bugs.openjdk.org/browse/JDK-8287867): Bad merge of jdk/test/lib/util/ForceGC.java causing test compilation error (**Bug** - P1 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1860/head:pull/1860` \
`$ git checkout pull/1860`

Update a local copy of the PR: \
`$ git checkout pull/1860` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1860`

View PR using the GUI difftool: \
`$ git pr show -t 1860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1860.diff">https://git.openjdk.org/jdk17u-dev/pull/1860.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1860#issuecomment-1752741464)