### PR TITLE
8266593: vmTestbase/nsk/jvmti/PopFrame/popframe011 fails with "assert(java_thread == _state->get_thread()) failed: Must be"

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1397,6 +1397,9 @@ SetForceEarlyReturn::doit(Thread *target, bool self) {
   Thread* current_thread = Thread::current();
   HandleMark   hm(current_thread);
 
+  if (java_thread->is_exiting()) {
+    return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
+  }
   if (!self) {
     if (!java_thread->is_suspended()) {
       _result = JVMTI_ERROR_THREAD_NOT_SUSPENDED;
@@ -1527,6 +1530,10 @@ UpdateForPopTopFrameClosure::doit(Thread *target, bool self) {
   Thread* current_thread  = Thread::current();
   HandleMark hm(current_thread);
   JavaThread* java_thread = target->as_Java_thread();
+
+  if (java_thread->is_exiting()) {
+    return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
+  }
   assert(java_thread == _state->get_thread(), "Must be");
 
   if (!self && !java_thread->is_suspended()) {
@@ -1603,14 +1610,12 @@ UpdateForPopTopFrameClosure::doit(Thread *target, bool self) {
   // It's fine to update the thread state here because no JVMTI events
   // shall be posted for this PopFrame.
 
-  if (!java_thread->is_exiting() && java_thread->threadObj() != NULL) {
-    _state->update_for_pop_top_frame();
-    java_thread->set_popframe_condition(JavaThread::popframe_pending_bit);
-    // Set pending step flag for this popframe and it is cleared when next
-    // step event is posted.
-    _state->set_pending_step_for_popframe();
-    _result = JVMTI_ERROR_NONE;
-  }
+  _state->update_for_pop_top_frame();
+  java_thread->set_popframe_condition(JavaThread::popframe_pending_bit);
+  // Set pending step flag for this popframe and it is cleared when next
+  // step event is posted.
+  _state->set_pending_step_for_popframe();
+  _result = JVMTI_ERROR_NONE;
 }
 
 void
@@ -1618,6 +1623,9 @@ SetFramePopClosure::doit(Thread *target, bool self) {
   ResourceMark rm;
   JavaThread* java_thread = target->as_Java_thread();
 
+  if (java_thread->is_exiting()) {
+    return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
+  }
   assert(_state->get_thread() == java_thread, "Must be");
 
   if (!self && !java_thread->is_suspended()) {
@@ -1637,9 +1645,6 @@ SetFramePopClosure::doit(Thread *target, bool self) {
   }
 
   assert(vf->frame_pointer() != NULL, "frame pointer mustn't be NULL");
-  if (java_thread->is_exiting() || java_thread->threadObj() == NULL) {
-    return; /* JVMTI_ERROR_THREAD_NOT_ALIVE (default) */
-  }
   int frame_number = _state->count_frames() - _depth;
   _state->env_thread_state((JvmtiEnvBase*)_env)->set_frame_pop(frame_number);
   _result = JVMTI_ERROR_NONE;

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -152,7 +152,6 @@ vmTestbase/nsk/jvmti/AttachOnDemand/attach045/TestDescription.java 8202971 gener
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/TestDescription.java 8219652 aix-ppc64
 vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/TestDescription.java 8219652 aix-ppc64
-vmTestbase/nsk/jvmti/PopFrame/popframe011/TestDescription.java 8266593 generic-all
 
 vmTestbase/gc/lock/jni/jnilock002/TestDescription.java 8192647 generic-all
 


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I had to resolve due to context, trivial, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8266593](https://bugs.openjdk.org/browse/JDK-8266593) needs maintainer approval

### Issue
 * [JDK-8266593](https://bugs.openjdk.org/browse/JDK-8266593): vmTestbase/nsk/jvmti/PopFrame/popframe011 fails with "assert(java_thread == _state-&gt;get_thread()) failed: Must be" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1862/head:pull/1862` \
`$ git checkout pull/1862`

Update a local copy of the PR: \
`$ git checkout pull/1862` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1862`

View PR using the GUI difftool: \
`$ git pr show -t 1862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1862.diff">https://git.openjdk.org/jdk17u-dev/pull/1862.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1862#issuecomment-1753423120)