### PR TITLE
8302017: Allocate BadPaddingException only if it will be thrown

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/RSACipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/RSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -355,21 +355,38 @@ public final class RSACipher extends CipherSpi {
             switch (mode) {
             case MODE_SIGN:
                 paddingCopy = padding.pad(buffer, 0, bufOfs);
-                result = RSACore.rsa(paddingCopy, privateKey, true);
+                if (paddingCopy != null) {
+                    result = RSACore.rsa(paddingCopy, privateKey, true);
+                } else {
+                    throw new BadPaddingException("Padding error in signing");
+                }
                 break;
             case MODE_VERIFY:
                 byte[] verifyBuffer = RSACore.convert(buffer, 0, bufOfs);
                 paddingCopy = RSACore.rsa(verifyBuffer, publicKey);
                 result = padding.unpad(paddingCopy);
+                if (result == null) {
+                    throw new BadPaddingException
+                            ("Padding error in verification");
+                }
                 break;
             case MODE_ENCRYPT:
                 paddingCopy = padding.pad(buffer, 0, bufOfs);
-                result = RSACore.rsa(paddingCopy, publicKey);
+                if (paddingCopy != null) {
+                    result = RSACore.rsa(paddingCopy, publicKey);
+                } else {
+                    throw new BadPaddingException
+                            ("Padding error in encryption");
+                }
                 break;
             case MODE_DECRYPT:
                 byte[] decryptBuffer = RSACore.convert(buffer, 0, bufOfs);
                 paddingCopy = RSACore.rsa(decryptBuffer, privateKey, false);
                 result = padding.unpad(paddingCopy);
+                if (result == null) {
+                    throw new BadPaddingException
+                            ("Padding error in decryption");
+                }
                 break;
             default:
                 throw new AssertionError("Internal error");
@@ -378,9 +395,9 @@ public final class RSACipher extends CipherSpi {
         } finally {
             Arrays.fill(buffer, 0, bufOfs, (byte)0);
             bufOfs = 0;
-            if (paddingCopy != null             // will not happen
+            if (paddingCopy != null
                     && paddingCopy != buffer    // already cleaned
-                    && paddingCopy != result) { // DO NOT CLEAN, THIS IS RESULT!
+                    && paddingCopy != result) { // DO NOT CLEAN, THIS IS RESULT
                 Arrays.fill(paddingCopy, (byte)0);
             }
         }

--- a/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPadding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ import sun.security.jca.JCAUtil;
  *   0x00 | BT | PS...PS | 0x00 | data...data
  *
  * where BT is the blocktype (1 or 2). The length of the entire string
- * must be the same as the size of the modulus (i.e. 128 byte for a 1024-bit
+ * must be the same as the size of the modulus (i.e. 128 byte for a 1024 bit
  * key). Per spec, the padding string must be at least 8 bytes long. That
  * leaves up to (length of key in bytes) - 11 bytes for the data.
  *
@@ -67,7 +67,7 @@ import sun.security.jca.JCAUtil;
  * The algorithms (representations) are forwards-compatible: that is,
  * the algorithm described in previous releases are in later releases.
  * However, additional comments/checks/clarifications were added to the
- * latter versions based on real-world experience (e.g. stricter v1.5
+ * later versions based on real-world experience (e.g. stricter v1.5
  * format checking.)
  *
  * Note: RSA keys should be at least 512 bits long
@@ -100,6 +100,9 @@ public final class RSAPadding {
 
     // maximum size of the data
     private final int maxDataSize;
+
+    // OAEP: main message digest
+    private MessageDigest md;
 
     // OAEP: MGF1
     private MGF1 mgf;
@@ -147,8 +150,6 @@ public final class RSAPadding {
             // sanity check, already verified in RSASignature/RSACipher
             throw new InvalidKeyException("Padded size must be at least 64");
         }
-        // OAEP: main message digest
-        MessageDigest md;
         switch (type) {
         case PAD_BLOCKTYPE_1:
         case PAD_BLOCKTYPE_2:
@@ -200,7 +201,7 @@ public final class RSAPadding {
 
     // cache of hashes of zero length data
     private static final Map<String,byte[]> emptyHashes =
-        Collections.synchronizedMap(new HashMap<>());
+        Collections.synchronizedMap(new HashMap<String,byte[]>());
 
     /**
      * Return the value of the digest using the specified message digest

--- a/src/java.base/share/classes/sun/security/rsa/RSASignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,7 +144,7 @@ public abstract class RSASignature extends SignatureSpi {
      * Reset the message digest if it is not already reset.
      */
     private void resetDigest() {
-        if (digestReset == false) {
+        if (!digestReset) {
             md.reset();
             digestReset = true;
         }
@@ -190,13 +190,15 @@ public abstract class RSASignature extends SignatureSpi {
         try {
             byte[] encoded = encodeSignature(digestOID, digest);
             byte[] padded = padding.pad(encoded);
-            byte[] encrypted = RSACore.rsa(padded, privateKey, true);
-            return encrypted;
+            if (padded != null) {
+                return RSACore.rsa(padded, privateKey, true);
+            }
         } catch (GeneralSecurityException e) {
             throw new SignatureException("Could not sign data", e);
         } catch (IOException e) {
             throw new SignatureException("Could not encode data", e);
         }
+        throw new SignatureException("Could not sign data");
     }
 
     // verify the data and return the result. See JCA doc
@@ -208,20 +210,20 @@ public abstract class RSASignature extends SignatureSpi {
         }
         try {
             if (sigBytes.length != RSACore.getByteLength(publicKey)) {
-                throw new SignatureException("Signature length not correct: got " +
+                throw new SignatureException("Bad signature length: got " +
                     sigBytes.length + " but was expecting " +
                     RSACore.getByteLength(publicKey));
             }
-            byte[] digest = getDigestValue();
+
+            // https://www.rfc-editor.org/rfc/rfc8017.html#section-8.2.2
+            // Step 4 suggests comparing the encoded message
             byte[] decrypted = RSACore.rsa(sigBytes, publicKey);
-            byte[] unpadded = padding.unpad(decrypted);
-            byte[] decodedDigest = decodeSignature(digestOID, unpadded);
-            return MessageDigest.isEqual(digest, decodedDigest);
+
+            byte[] digest = getDigestValue();
+            byte[] encoded = encodeSignature(digestOID, digest);
+            byte[] padded = padding.pad(encoded);
+            return MessageDigest.isEqual(padded, decrypted);
         } catch (javax.crypto.BadPaddingException e) {
-            // occurs if the app has used the wrong RSA public key
-            // or if sigBytes is invalid
-            // return false rather than propagating the exception for
-            // compatibility/ease of use
             return false;
         } catch (IOException e) {
             throw new SignatureException("Signature encoding error", e);
@@ -257,15 +259,17 @@ public abstract class RSASignature extends SignatureSpi {
             throw new IOException("SEQUENCE length error");
         }
         AlgorithmId algId = AlgorithmId.parse(values[0]);
-        if (algId.getOID().equals(oid) == false) {
+        if (!algId.getOID().equals(oid)) {
             throw new IOException("ObjectIdentifier mismatch: "
                 + algId.getOID());
         }
         if (algId.getEncodedParams() != null) {
             throw new IOException("Unexpected AlgorithmId parameters");
         }
-        byte[] digest = values[1].getOctetString();
-        return digest;
+        if (values[1].isConstructed()) {
+            throw new IOException("Unexpected constructed digest value");
+        }
+        return values[1].getOctetString();
     }
 
     // set parameter, not supported. See JCA doc

--- a/src/java.base/share/classes/sun/security/rsa/RSASignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSASignature.java
@@ -144,7 +144,7 @@ public abstract class RSASignature extends SignatureSpi {
      * Reset the message digest if it is not already reset.
      */
     private void resetDigest() {
-        if (!digestReset) {
+        if (digestReset == false) {
             md.reset();
             digestReset = true;
         }
@@ -259,17 +259,15 @@ public abstract class RSASignature extends SignatureSpi {
             throw new IOException("SEQUENCE length error");
         }
         AlgorithmId algId = AlgorithmId.parse(values[0]);
-        if (!algId.getOID().equals(oid)) {
+        if (algId.getOID().equals(oid) == false) {
             throw new IOException("ObjectIdentifier mismatch: "
                 + algId.getOID());
         }
         if (algId.getEncodedParams() != null) {
             throw new IOException("Unexpected AlgorithmId parameters");
         }
-        if (values[1].isConstructed()) {
-            throw new IOException("Unexpected constructed digest value");
-        }
-        return values[1].getOctetString();
+        byte[] digest = values[1].getOctetString();
+        return digest;
     }
 
     // set parameter, not supported. See JCA doc

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -752,9 +752,12 @@ final class P11Signature extends SignatureSpi {
             int len = (p11Key.length() + 7) >> 3;
             RSAPadding padding = RSAPadding.getInstance
                                         (RSAPadding.PAD_BLOCKTYPE_1, len);
-            byte[] padded = padding.pad(data);
-            return padded;
-        } catch (GeneralSecurityException e) {
+            byte[] result = padding.pad(data);
+            if (result == null) {
+                throw new ProviderException("Error padding data");
+            }
+            return result;
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
             throw new ProviderException(e);
         }
     }

--- a/test/jdk/sun/security/rsa/RSAPaddingCheck.java
+++ b/test/jdk/sun/security/rsa/RSAPaddingCheck.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8302017
+ * @summary Ensure that RSAPadding class works as expected after refactoring
+ * @modules java.base/sun.security.rsa
+ */
+import java.util.Arrays;
+import sun.security.rsa.RSAPadding;
+
+public class RSAPaddingCheck {
+
+    private static int[] PADDING_TYPES =  {
+        RSAPadding.PAD_BLOCKTYPE_1,
+        RSAPadding.PAD_BLOCKTYPE_2,
+        RSAPadding.PAD_NONE,
+        RSAPadding.PAD_OAEP_MGF1,
+    };
+
+    public static void main(String[] args) throws Exception {
+        int size = 2048 >> 3;
+        byte[] testData = "This is some random to-be-padded Data".getBytes();
+        for (int type : PADDING_TYPES) {
+            byte[] data = (type == RSAPadding.PAD_NONE?
+                    Arrays.copyOf(testData, size) : testData);
+            System.out.println("Testing PaddingType: " + type);
+            RSAPadding padding = RSAPadding.getInstance(type, size);
+            byte[] paddedData = padding.pad(data);
+            if (paddedData == null) {
+                throw new RuntimeException("Unexpected padding op failure!");
+            }
+
+            byte[] data2 = padding.unpad(paddedData);
+            if (data2 == null) {
+                throw new RuntimeException("Unexpected unpadding op failure!");
+            }
+            if (!Arrays.equals(data, data2)) {
+                throw new RuntimeException("diff check failure!");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backport [334b977259930368160db705c1f2feda0b0e8707](https://github.com/openjdk/jdk17u-dev/commit/300ed9156581adb09e8258bc2da21f3bff4ecbde) from https://github.com/openjdk/jdk21u/pull/79

Passes tier1 tests - tested on Linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8302017](https://bugs.openjdk.org/browse/JDK-8302017) needs maintainer approval

### Issue
 * [JDK-8302017](https://bugs.openjdk.org/browse/JDK-8302017): Allocate BadPaddingException only if it will be thrown (**Enhancement** - P3 - Approved)


### Reviewers
 * [Brian Stafford](https://openjdk.org/census#bstafford) (@brianjstafford - no project role) ⚠️ Review applies to [0dfde364](https://git.openjdk.org/jdk17u-dev/pull/1864/files/0dfde364cf6f08a7649b10e0c6350b6ee81d8855)
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**) ⚠️ Review applies to [aa9d466a](https://git.openjdk.org/jdk17u-dev/pull/1864/files/aa9d466afbd67ae089f42bc549d0635ff7205fd2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1864/head:pull/1864` \
`$ git checkout pull/1864`

Update a local copy of the PR: \
`$ git checkout pull/1864` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1864`

View PR using the GUI difftool: \
`$ git pr show -t 1864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1864.diff">https://git.openjdk.org/jdk17u-dev/pull/1864.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1864#issuecomment-1754239712)