### PR TITLE
8270199: Most SA tests are skipped on macosx-aarch64 because all executables are signed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -120,10 +120,10 @@ serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 serviceability/sa/ClhsdbCDSCore.java  8294316,8269982,8267433 macosx-aarch64,macosx-x64
 serviceability/sa/ClhsdbFindPC.java#id1  8294316,8269982,8267433 macosx-aarch64,macosx-x64
 serviceability/sa/ClhsdbFindPC.java#id3  8294316,8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbPmap.java#id1  8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbPmap.java#id1  8294316,8269982,8267433 macosx-aarch64,macosx-x64
 serviceability/sa/ClhsdbPstack.java#id1  8294316,8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/TestJmapCore.java  8294316,8267433 macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java  8294316,8267433 macosx-x64
+serviceability/sa/TestJmapCore.java  8294316,8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java  8294316,8269982,8267433 macosx-aarch64,macosx-x64
 
 #############################################################################
 

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class TestMutuallyExclusivePlatformPredicates {
         IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isMusl",
                 "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
                 "areCustomLoadersSupportedForCDS", "isDefaultCDSArchiveSupported",
-                "isSignedOSX");
+                "isHardenedOSX");
 
         public final List<String> methodNames;
 

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,13 +261,13 @@ public class Platform {
     }
 
     /**
-     * Return true if the test JDK is signed, otherwise false. Only valid on OSX.
+     * Return true if the test JDK is hardened, otherwise false. Only valid on OSX.
      */
-    public static boolean isSignedOSX() throws IOException {
-        // We only care about signed binaries for 10.14 and later (actually 10.14.5, but
+    public static boolean isHardenedOSX() throws IOException {
+        // We only care about hardened binaries for 10.14 and later (actually 10.14.5, but
         // for simplicity we'll also include earlier 10.14 versions).
         if (getOsVersionMajor() == 10 && getOsVersionMinor() < 14) {
-            return false; // assume not signed
+            return false; // assume not hardened
         }
 
         // Find the path to the java binary.
@@ -279,38 +279,45 @@ public class Platform {
         }
 
         // Run codesign on the java binary.
-        ProcessBuilder pb = new ProcessBuilder("codesign", "-d", "-v", javaFileName);
-        pb.redirectError(ProcessBuilder.Redirect.DISCARD);
-        pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+        ProcessBuilder pb = new ProcessBuilder("codesign", "--display", "--verbose", javaFileName);
+        pb.redirectErrorStream(true); // redirect stderr to stdout
         Process codesignProcess = pb.start();
+        BufferedReader is = new BufferedReader(new InputStreamReader(codesignProcess.getInputStream()));
+        String line;
+        boolean isHardened = false;
+        boolean hardenedStatusConfirmed = false; // set true when we confirm whether or not hardened
+        while ((line = is.readLine()) != null) {
+            System.out.println("STDOUT: " + line);
+            if (line.indexOf("flags=0x10000(runtime)") != -1 ) {
+                hardenedStatusConfirmed = true;
+                isHardened = true;
+                System.out.println("Target JDK is hardened. Some tests may be skipped.");
+            } else if (line.indexOf("flags=0x20002(adhoc,linker-signed)") != -1 ) {
+                hardenedStatusConfirmed = true;
+                isHardened = false;
+                System.out.println("Target JDK is adhoc signed, but not hardened.");
+            } else if (line.indexOf("code object is not signed at all") != -1) {
+                hardenedStatusConfirmed = true;
+                isHardened = false;
+                System.out.println("Target JDK is not signed, therefore not hardened.");
+            }
+        }
+        if (!hardenedStatusConfirmed) {
+            System.out.println("Could not confirm if TargetJDK is hardened. Assuming not hardened.");
+            isHardened = false;
+        }
+
         try {
             if (codesignProcess.waitFor(10, TimeUnit.SECONDS) == false) {
-                System.err.println("Timed out waiting for the codesign process to complete. Assuming not signed.");
+                System.err.println("Timed out waiting for the codesign process to complete. Assuming not hardened.");
                 codesignProcess.destroyForcibly();
-                return false; // assume not signed
+                return false; // assume not hardened
             }
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
 
-        // Check codesign result to see if java binary is signed. Here are the
-        // exit code meanings:
-        //    0: signed
-        //    1: not signed
-        //    2: invalid arguments
-        //    3: only has meaning with the -R argument.
-        // So we should always get 0 or 1 as an exit value.
-        if (codesignProcess.exitValue() == 0) {
-            System.out.println("Target JDK is signed. Some tests may be skipped.");
-            return true; // signed
-        } else if (codesignProcess.exitValue() == 1) {
-            System.out.println("Target JDK is not signed.");
-            return false; // not signed
-        } else {
-            System.err.println("Executing codesign failed. Assuming unsigned: " +
-                               codesignProcess.exitValue());
-            return false; // not signed
-        }
+        return isHardened;
     }
 
     private static boolean isArch(String archnameRE) {

--- a/test/lib/jdk/test/lib/SA/SATestUtils.java
+++ b/test/lib/jdk/test/lib/SA/SATestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,8 +63,8 @@ public class SATestUtils {
                     throw new SkippedException("SA Attach not expected to work. Ptrace attach not supported.");
                 }
             } else if (Platform.isOSX()) {
-                if (Platform.isSignedOSX()) {
-                    throw new SkippedException("SA Attach not expected to work. JDK is signed.");
+                if (Platform.isHardenedOSX()) {
+                    throw new SkippedException("SA Attach not expected to work. JDK is hardened.");
                 }
                 if (!Platform.isRoot() && !canAddPrivileges()) {
                     throw new SkippedException("SA Attach not expected to work. Insufficient privileges (not root and can't use sudo).");

--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,12 +136,12 @@ public class CoreUtils {
             if (!coresDir.canWrite()) {
                 throw new SkippedException("Directory \"" + coresDir + "\" is not writable");
             }
-            if (Platform.isSignedOSX()) {
+            if (Platform.isHardenedOSX()) {
                 if (Platform.getOsVersionMajor() > 10 ||
                     (Platform.getOsVersionMajor() == 10 && Platform.getOsVersionMinor() >= 15))
                 {
-                    // We can't generate cores files with signed binaries on OSX 10.15 and later.
-                    throw new SkippedException("Cannot produce core file with signed binary on OSX 10.15 and later");
+                    // We can't generate cores files with hardened binaries on OSX 10.15 and later.
+                    throw new SkippedException("Cannot produce core file with hardened binary on OSX 10.15 and later");
                 }
             }
         } else if (Platform.isLinux()) {


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

Several smaller resolves, especially in the ProblemList.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8270199](https://bugs.openjdk.org/browse/JDK-8270199) needs maintainer approval

### Issue
 * [JDK-8270199](https://bugs.openjdk.org/browse/JDK-8270199): Most SA tests are skipped on macosx-aarch64 because all executables are signed (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1866/head:pull/1866` \
`$ git checkout pull/1866`

Update a local copy of the PR: \
`$ git checkout pull/1866` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1866`

View PR using the GUI difftool: \
`$ git pr show -t 1866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1866.diff">https://git.openjdk.org/jdk17u-dev/pull/1866.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1866#issuecomment-1755129585)