### PR TITLE
8317706: Exclude java/awt/Graphics2D/DrawString/RotTransText.java on linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -507,6 +507,7 @@ java/awt/Robot/Delay/InterruptOfDelay.java 8265986 macosx-all
 java/awt/MenuBar/TestNoScreenMenuBar.java 8265987 macosx-all
 
 java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 generic-all
+java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all
 java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java 8257529 windows-x64
 
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8317706](https://bugs.openjdk.org/browse/JDK-8317706), commit [064a21d6](https://github.com/openjdk/jdk21u/commit/064a21d6d7a82ed4f43a099757698ed872c9cf7d) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository.

A simple test exclusion, applies cleanly.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317706](https://bugs.openjdk.org/browse/JDK-8317706) needs maintainer approval

### Issue
 * [JDK-8317706](https://bugs.openjdk.org/browse/JDK-8317706): Exclude java/awt/Graphics2D/DrawString/RotTransText.java on linux (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1869/head:pull/1869` \
`$ git checkout pull/1869`

Update a local copy of the PR: \
`$ git checkout pull/1869` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1869`

View PR using the GUI difftool: \
`$ git pr show -t 1869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1869.diff">https://git.openjdk.org/jdk17u-dev/pull/1869.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1869#issuecomment-1756860530)