### PR TITLE
8317705: ProblemList sun/tools/jstat/jstatLineCountsX.sh on linux-ppc64le and aix due to JDK-8248691

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -784,10 +784,10 @@ sun/tools/jstatd/TestJstatdDefaults.java                        8081569,8226420 
 sun/tools/jstatd/TestJstatdRmiPort.java                         8226420,8251259 windows-all
 sun/tools/jstatd/TestJstatdServer.java                          8081569,8226420 windows-all
 
-sun/tools/jstat/jstatLineCounts1.sh                             8268211 linux-aarch64
-sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aarch64
-sun/tools/jstat/jstatLineCounts3.sh                             8268211 linux-aarch64
-sun/tools/jstat/jstatLineCounts4.sh                             8268211 linux-aarch64
+sun/tools/jstat/jstatLineCounts1.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
+sun/tools/jstat/jstatLineCounts2.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
+sun/tools/jstat/jstatLineCounts3.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
+sun/tools/jstat/jstatLineCounts4.sh                             8248691,8268211 linux-ppc64le,aix-ppc64,linux-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of[JDK-8317705](https://bugs.openjdk.org/browse/JDK-8317705), commit [7d0a9374](https://github.com/openjdk/jdk21u/commit/7d0a937446d37ef2cd88ebf91b3a429134d447a0) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository.

A test exclusion, applies clean.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317705](https://bugs.openjdk.org/browse/JDK-8317705) needs maintainer approval

### Issue
 * [JDK-8317705](https://bugs.openjdk.org/browse/JDK-8317705): ProblemList sun/tools/jstat/jstatLineCountsX.sh on linux-ppc64le and aix due to JDK-8248691 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1870/head:pull/1870` \
`$ git checkout pull/1870`

Update a local copy of the PR: \
`$ git checkout pull/1870` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1870`

View PR using the GUI difftool: \
`$ git pr show -t 1870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1870.diff">https://git.openjdk.org/jdk17u-dev/pull/1870.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1870#issuecomment-1756874049)