### PR TITLE
8297640: Increase buffer size for buf (insert_features_names) in Abstract_VM_Version::insert_features_names

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -787,7 +787,7 @@ void VM_Version::get_processor_features() {
     _has_intel_jcc_erratum = IntelJccErratumMitigation;
   }
 
-  char buf[512];
+  char buf[1024];
   int res = jio_snprintf(
               buf, sizeof(buf),
               "(%u cores per cpu, %u threads per core) family %d model %d stepping %d microcode 0x%x",


### PR DESCRIPTION
I backport this for parity with 11.0.22-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297640](https://bugs.openjdk.org/browse/JDK-8297640) needs maintainer approval

### Issue
 * [JDK-8297640](https://bugs.openjdk.org/browse/JDK-8297640): Increase buffer size for buf (insert_features_names) in Abstract_VM_Version::insert_features_names (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1874/head:pull/1874` \
`$ git checkout pull/1874`

Update a local copy of the PR: \
`$ git checkout pull/1874` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1874`

View PR using the GUI difftool: \
`$ git pr show -t 1874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1874.diff">https://git.openjdk.org/jdk17u-dev/pull/1874.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1874#issuecomment-1761189719)