### PR TITLE
8317960: [17u] Excessive CPU usage on AbstractQueuedSynchronized.isEnqueued

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -1156,7 +1156,9 @@ public abstract class AbstractQueuedLongSynchronizer
          */
         private boolean canReacquire(ConditionNode node) {
             // check links, not status to avoid enqueue race
-            return node != null && node.prev != null && isEnqueued(node);
+            Node p; // traverse unless known to be bidirectionally linked
+            return node != null && (p = node.prev) != null &&
+                (p.next == node || isEnqueued(node));
         }
 
         /**

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -1524,7 +1524,9 @@ public abstract class AbstractQueuedSynchronizer
          */
         private boolean canReacquire(ConditionNode node) {
             // check links, not status to avoid enqueue race
-            return node != null && node.prev != null && isEnqueued(node);
+            Node p; // traverse unless known to be bidirectionally linked
+            return node != null && (p = node.prev) != null &&
+                (p.next == node || isEnqueued(node));
         }
 
         /**


### PR DESCRIPTION
This patch brings the AbstractQueuedSynchronizer related changes from [JDK-8277090](https://bugs.openjdk.org/browse/JDK-8277090) to fix a performance issue that can happen in JDK17 too.

The rest of JDK-8277090 are done mostly in preparation of virtual threads and are covered under CSR [JDK-8285450](https://bugs.openjdk.org/browse/JDK-8285450). There is no plan at the moment to backport the rest of the changes to 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317960](https://bugs.openjdk.org/browse/JDK-8317960) needs maintainer approval

### Issue
 * [JDK-8317960](https://bugs.openjdk.org/browse/JDK-8317960): [17u] Excessive CPU usage on AbstractQueuedSynchronized.isEnqueued (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1875/head:pull/1875` \
`$ git checkout pull/1875`

Update a local copy of the PR: \
`$ git checkout pull/1875` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1875`

View PR using the GUI difftool: \
`$ git pr show -t 1875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1875.diff">https://git.openjdk.org/jdk17u-dev/pull/1875.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1875#issuecomment-1761436638)