### PR TITLE
8262186: Call X509KeyManager.chooseClientAlias once for all key types

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
@@ -45,7 +45,6 @@ import javax.security.auth.x500.X500Principal;
 import sun.security.ssl.CipherSuite.KeyExchange;
 import sun.security.ssl.SSLHandshake.HandshakeMessage;
 import sun.security.ssl.X509Authentication.X509Possession;
-import sun.security.ssl.X509Authentication.X509PossessionGenerator;
 
 /**
  * Pack of the CertificateRequest handshake message.
@@ -726,10 +725,11 @@ final class CertificateRequest {
             chc.handshakeSession.setPeerSupportedSignatureAlgorithms(sss);
             chc.peerSupportedAuthorities = crm.getAuthorities();
 
-            // For TLS 1.2, we need to use a combination of the CR message's
-            // allowed key types and the signature algorithms in order to
-            // find a certificate chain that has the right key and all certs
-            // using one or more of the allowed cert signature schemes.
+            // For TLS 1.2, we no longer use the certificate_types field
+            // from the CertificateRequest message to directly determine
+            // the SSLPossession.  Instead, the choosePossession method
+            // will use the accepted signature schemes in the message to
+            // determine the set of acceptable certificate types to select from.
             SSLPossession pos = choosePossession(chc, crm);
             if (pos == null) {
                 return;
@@ -784,7 +784,6 @@ final class CertificateRequest {
                             "Unable to produce CertificateVerify for " +
                             "signature scheme: " + ss.name);
                     }
-                    checkedKeyTypes.add(ss.keyAlgorithm);
                     continue;
                 }
 
@@ -794,45 +793,32 @@ final class CertificateRequest {
                         SSLLogger.warning(
                             "Unsupported authentication scheme: " + ss.name);
                     }
-                    checkedKeyTypes.add(ss.keyAlgorithm);
                     continue;
                 } else {
-                    // Any auth object will have a possession generator and
-                    // we need to make sure the key types for that generator
-                    // share at least one common algorithm with the CR's
-                    // allowed key types.
-                    if (ka.possessionGenerator instanceof
-                            X509PossessionGenerator xpg) {
-                        if (Collections.disjoint(crKeyTypes,
-                                Arrays.asList(xpg.keyTypes))) {
-                            if (SSLLogger.isOn &&
-                                    SSLLogger.isOn("ssl,handshake")) {
-                                SSLLogger.warning(
-                                        "Unsupported authentication scheme: " +
-                                                ss.name);
-                            }
-                            checkedKeyTypes.add(ss.keyAlgorithm);
-                            continue;
+                    // Any auth object will have a set of allowed key types.
+                    // This set should share at least one common algorithm with
+                    // the CR's allowed key types.
+                    if (Collections.disjoint(crKeyTypes,
+                            Arrays.asList(ka.keyTypes))) {
+                        if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                            SSLLogger.warning(
+                                    "Unsupported authentication scheme: " +
+                                            ss.name);
                         }
+                        continue;
                     }
                 }
+                supportedKeyTypes.add(ss.keyAlgorithm);
+            }
 
-                SSLPossession pos = ka.createPossession(hc);
-                if (pos == null) {
-                    if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                        SSLLogger.warning(
-                            "Unavailable authentication scheme: " + ss.name);
-                    }
-                    continue;
+            SSLPossession pos = X509Authentication
+                    .createPossession(hc, supportedKeyTypes.toArray(String[]::new));
+            if (pos == null) {
+                if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                    SSLLogger.warning("No available authentication scheme");
                 }
-
-                return pos;
             }
-
-            if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                SSLLogger.warning("No available authentication scheme");
-            }
-            return null;
+            return pos;
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
@@ -761,6 +761,7 @@ final class CertificateRequest {
             }
 
             Collection<String> checkedKeyTypes = new HashSet<>();
+            List<String> supportedKeyTypes = new ArrayList<>();
             for (SignatureScheme ss : hc.peerRequestedCertSignSchemes) {
                 if (checkedKeyTypes.contains(ss.keyAlgorithm)) {
                     if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
@@ -769,6 +770,7 @@ final class CertificateRequest {
                     }
                     continue;
                 }
+                checkedKeyTypes.add(ss.keyAlgorithm);
 
                 // Don't select a signature scheme unless we will be able to
                 // produce a CertificateVerify message later

--- a/test/jdk/sun/security/ssl/SSLContextImpl/MultipleChooseAlias.java
+++ b/test/jdk/sun/security/ssl/SSLContextImpl/MultipleChooseAlias.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+//
+// SunJSSE does not support dynamic system properties, no way to re-use
+// system properties in samevm/agentvm mode.
+//
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.KeyManagerFactorySpi;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.X509KeyManager;
+import java.net.Socket;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.Security;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+/*
+ * @test
+ * @bug 8262186
+ * @summary Callback semantics of the method X509KeyManager.chooseClientAlias(...)
+ * @library /javax/net/ssl/templates
+ * @modules java.base/sun.security.ssl:+open
+ *          java.base/javax.net.ssl:+open
+ * @run main/othervm MultipleChooseAlias PKIX
+ * @run main/othervm MultipleChooseAlias SunX509
+ */
+public class MultipleChooseAlias extends SSLSocketTemplate {
+
+    static volatile int numOfCalls = 0;
+    static String kmfAlgorithm = null;
+
+    @Override
+    protected void configureServerSocket(SSLServerSocket socket) {
+        socket.setNeedClientAuth(true);
+    }
+
+    @Override
+    protected ContextParameters getClientContextParameters() {
+        return new ContextParameters("TLS", "PKIX", "Mine");
+    }
+
+    public static void main(String[] args) throws Exception {
+        kmfAlgorithm = args[0];
+        Security.addProvider(new MyProvider());
+        try {
+            new MultipleChooseAlias().run();
+        } catch (Exception e) {
+            // expected
+        }
+        if (numOfCalls != 1) {
+            throw new RuntimeException("Too many times " + numOfCalls);
+        }
+    }
+
+    static class MyProvider extends Provider {
+        public MyProvider() {
+            super("Mine", "1", "many many things");
+            put("KeyManagerFactory.Mine", "MultipleChooseAlias$MyKMF");
+        }
+    }
+
+    // This KeyManagerFactory impl returns key managers
+    // wrapped in MyKM
+    public static class MyKMF extends KeyManagerFactorySpi {
+        KeyManagerFactory fac;
+
+        public MyKMF() {
+            try {
+                fac = KeyManagerFactory.getInstance(kmfAlgorithm);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        @Override
+        protected void engineInit(KeyStore ks, char[] password)
+                throws KeyStoreException, NoSuchAlgorithmException,
+                UnrecoverableKeyException {
+            fac.init(ks, password);
+        }
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters spec)
+                throws InvalidAlgorithmParameterException {
+            fac.init(spec);
+        }
+
+        @Override
+        protected KeyManager[] engineGetKeyManagers() {
+            KeyManager[] result = fac.getKeyManagers();
+            for (int i = 0; i < result.length; i++) {
+                result[i] = new MyKM((X509KeyManager)result[i]);
+            }
+            return result;
+        }
+    }
+
+    // This KeyManager remembers how many times  chooseClientAlias is called.
+    static class MyKM implements X509KeyManager {
+
+        X509KeyManager km;
+
+        MyKM(X509KeyManager km) {
+            this.km = km;
+        }
+
+        public String[] getClientAliases(String keyType, Principal[] issuers) {
+            return km.getClientAliases(keyType, issuers);
+        }
+
+        public String chooseClientAlias(String[] keyType, Principal[] issuers,
+                Socket socket) {
+            System.out.println("chooseClientAlias called on "
+                    + Arrays.toString(keyType));
+            numOfCalls++;
+            return null; // so it will try all key types and finally fails
+        }
+
+        public String[] getServerAliases(String keyType, Principal[] issuers) {
+            return getServerAliases(keyType, issuers);
+        }
+
+        public String chooseServerAlias(String keyType, Principal[] issuers,
+                Socket socket) {
+            return km.chooseServerAlias(keyType, issuers, socket);
+        }
+
+        public X509Certificate[] getCertificateChain(String alias) {
+            return km.getCertificateChain(alias);
+        }
+
+        public PrivateKey getPrivateKey(String alias) {
+            return km.getPrivateKey(alias);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

The first commit contains the parts applied clean. 
The second one contains two chunks I had to resolve, and some additional adaptions.

I had to resolve CertificateRequest.java because "8268199: Correct certificate requests" was already backported to 17, but was applied in head after this change.
This block was in the way of a clean patch:

17u: 
```java
              } else {
                    // Any auth object will have a possession generator and
                    // we need to make sure the key types for that generator
                    // share at least one common algorithm with the CR's
                    // allowed key types.
                    if (ka.possessionGenerator instanceof
                            X509PossessionGenerator xpg) {
                        if (Collections.disjoint(crKeyTypes,
                                Arrays.asList(xpg.keyTypes))) {
                            if (SSLLogger.isOn &&
                                    SSLLogger.isOn("ssl,handshake")) {
                                SSLLogger.warning(
                                        "Unsupported authentication scheme: " +
                                                ss.name);
                            }
                            checkedKeyTypes.add(ss.keyAlgorithm);
                            continue;
                        }
                    }
                }
```

Actually, this block was adapted in the backport of 8268199 because this change, 8262186, was not in 17 at that time.
Also, the adapted code does not compile any more because X509PossessionGenerator is removed by this change.
Thus I changed it to the original code of "8268199: Correct certificate requests":

```java
} else {
                    // Any auth object will have a set of allowed key types.
                    // This set should share at least one common algorithm with
                    // the CR's allowed key types.
                    if (Collections.disjoint(crKeyTypes,
                            Arrays.asList(ka.keyTypes))) {
                        if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                            SSLLogger.warning(
                                    "Unsupported authentication scheme: " +
                                            ss.name);
                        }
                        continue;
                    }
               }

```

After some further related adaptions the code looks the same in 17 as in head if going back to "8268199: Correct certificate requests".
This is expected as both repos contain the same changes for both resolved files at that point:
17: https://github.com/openjdk/jdk17u-dev/commits/master/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
head:      https://github.com/openjdk/jdk/commits/master/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java

("8271730: Client authentication using RSASSA-PSS ..." brings a chunk to 17 that was lost in the backport of "8268199: Correct certificate requests").

In X509Authentication.java a larger chunk did not apply because the backport of "8268199: Correct certificate requests" removed private statements from the decl of X509PossessionGenerator.  The chunk applies clean after undoing this change.

The original issue has a CSR, the backport to 17.0.10-oracle does not. I am investigating why.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8262186](https://bugs.openjdk.org/browse/JDK-8262186) needs maintainer approval

### Issue
 * [JDK-8262186](https://bugs.openjdk.org/browse/JDK-8262186): Call X509KeyManager.chooseClientAlias once for all key types (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1885/head:pull/1885` \
`$ git checkout pull/1885`

Update a local copy of the PR: \
`$ git checkout pull/1885` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1885`

View PR using the GUI difftool: \
`$ git pr show -t 1885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1885.diff">https://git.openjdk.org/jdk17u-dev/pull/1885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1885#issuecomment-1764511219)