### PR TITLE
8262901: [macos_aarch64] NativeCallTest expected:<-3.8194101E18> but was:<3.02668882E10>

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/TargetDescription.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/TargetDescription.java
@@ -25,12 +25,16 @@ package jdk.vm.ci.code;
 import static jdk.vm.ci.meta.MetaUtil.identityHashCodeString;
 
 import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.services.Services;
 
 /**
  * Represents the target machine for a compiler, including the CPU architecture, the size of
  * pointers and references, alignment of stacks, caches, etc.
  */
 public class TargetDescription {
+
+    public final boolean linuxOs = Services.getSavedProperty("os.name", "").startsWith("Linux");
+    public final boolean macOs = Services.getSavedProperty("os.name", "").startsWith("Mac");
 
     public final Architecture arch;
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
@@ -93,7 +93,7 @@ public class AArch64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFac
         // ARMv8 defines r18 as being available to the platform ABI. Windows
         // and Darwin use it for such. Linux doesn't assign it and thus r18 can
         // be used as an additional register.
-        boolean canUsePlatformRegister = config.linuxOs;
+        boolean canUsePlatformRegister = target.linuxOs;
         return new AArch64HotSpotRegisterConfig(target, config.useCompressedOops, canUsePlatformRegister);
     }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotRegisterConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotRegisterConfig.java
@@ -228,6 +228,27 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
         }
     }
 
+    private int parseStackArg(ValueKind<?> valueKind, AllocatableValue[] locations, int index, int currentStackOffset, HotSpotCallingConventionType type) {
+        int kindSize = valueKind.getPlatformKind().getSizeInBytes();
+        locations[index] = StackSlot.get(valueKind, currentStackOffset, !type.out);
+        currentStackOffset += Math.max(kindSize, target.wordSize);
+        return currentStackOffset;
+    }
+
+    private int parseDarwinNativeStackArg(ValueKind<?> valueKind, AllocatableValue[] locations, int index, int currentStackOffset, HotSpotCallingConventionType type) {
+        int kindSize = valueKind.getPlatformKind().getSizeInBytes();
+        if (currentStackOffset % kindSize != 0) {
+            // In MacOS natural alignment is used
+            // See https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+            currentStackOffset += kindSize - currentStackOffset % kindSize;
+        }
+        locations[index] = StackSlot.get(valueKind, currentStackOffset, !type.out);
+        // In MacOS "Function arguments may consume slots on the stack that are not multiples of 8 bytes"
+        // See https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+        currentStackOffset += kindSize;
+        return currentStackOffset;
+    }
+
     private CallingConvention callingConvention(RegisterArray generalParameterRegisters, JavaType returnType, JavaType[] parameterTypes, HotSpotCallingConventionType type,
                     ValueKindFactory<?> valueKindFactory) {
         AllocatableValue[] locations = new AllocatableValue[parameterTypes.length];
@@ -264,9 +285,11 @@ public class AArch64HotSpotRegisterConfig implements RegisterConfig {
             }
 
             if (locations[i] == null) {
-                ValueKind<?> valueKind = valueKindFactory.getValueKind(kind);
-                locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.out);
-                currentStackOffset += Math.max(valueKind.getPlatformKind().getSizeInBytes(), target.wordSize);
+                if (target.macOs && type == HotSpotCallingConventionType.NativeCall) {
+                    currentStackOffset = parseDarwinNativeStackArg(valueKindFactory.getValueKind(kind), locations, i, currentStackOffset, type);
+                } else {
+                    currentStackOffset = parseStackArg(valueKindFactory.getValueKind(kind), locations, i, currentStackOffset, type);
+                }
             }
         }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
@@ -24,7 +24,6 @@ package jdk.vm.ci.hotspot.aarch64;
 
 import jdk.vm.ci.hotspot.HotSpotVMConfigAccess;
 import jdk.vm.ci.hotspot.HotSpotVMConfigStore;
-import jdk.vm.ci.services.Services;
 
 /**
  * Used to access native configuration details.
@@ -36,8 +35,6 @@ class AArch64HotSpotVMConfig extends HotSpotVMConfigAccess {
     AArch64HotSpotVMConfig(HotSpotVMConfigStore config) {
         super(config);
     }
-
-    final boolean linuxOs = Services.getSavedProperty("os.name", "").startsWith("Linux");
 
     final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -43,7 +43,6 @@
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 compiler/jvmci/compilerToVM/GetFlagValueTest.java 8204459 generic-all
-compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8262901 macosx-aarch64
 compiler/tiered/LevelTransitionTest.java 8067651 generic-all
 
 compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/libNativeCallTest.c
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/libNativeCallTest.c
@@ -189,6 +189,39 @@ JNIEXPORT jfloat JNICALL Java_jdk_vm_ci_code_test_NativeCallTest__1L32SDILDS(JNI
                    a,   b,   c,   d,   e,   f);
 }
 
+jint JNICALL I32I(jint i00, jint i01, jint i02, jint i03, jint i04, jint i05, jint i06, jint i07,
+                  jint i08, jint i09, jint i0a, jint i0b, jint i0c, jint i0d, jint i0e, jint i0f,
+                  jint i10, jint i11, jint i12, jint i13, jint i14, jint i15, jint i16, jint i17,
+                  jint i18, jint i19, jint i1a, jint i1b, jint i1c, jint i1d, jint i1e, jint i1f,
+                  jint a) {
+  return i00 + i01 + i02 + i03 + i04 + i05 + i06 + i07 +
+         i08 + i09 + i0a + i0b + i0c + i0d + i0e + i0f +
+         i10 + i11 + i12 + i13 + i14 + i15 + i16 + i17 +
+         i18 + i19 + i1a + i1b + i1c + i1d + i1e + i1f +
+         a;
+}
+
+JNIEXPORT jlong JNICALL Java_jdk_vm_ci_code_test_NativeCallTest_getI32I(JNIEnv *env, jclass clazz) {
+  return (jlong) (intptr_t) I32I;
+}
+
+JNIEXPORT jint JNICALL Java_jdk_vm_ci_code_test_NativeCallTest__1I32I(JNIEnv *env, jclass clazz,
+                                                                      jint i00, jint i01, jint i02, jint i03,
+                                                                      jint i04, jint i05, jint i06, jint i07,
+                                                                      jint i08, jint i09, jint i0a, jint i0b,
+                                                                      jint i0c, jint i0d, jint i0e, jint i0f,
+                                                                      jint i10, jint i11, jint i12, jint i13,
+                                                                      jint i14, jint i15, jint i16, jint i17,
+                                                                      jint i18, jint i19, jint i1a, jint i1b,
+                                                                      jint i1c, jint i1d, jint i1e, jint i1f,
+                                                                      jint a) {
+  return I32I(i00, i01, i02, i03, i04, i05, i06, i07,
+              i08, i09, i0a, i0b, i0c, i0d, i0e, i0f,
+              i10, i11, i12, i13, i14, i15, i16, i17,
+              i18, i19, i1a, i1b, i1c, i1d, i1e, i1f,
+              a);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
@@ -125,6 +125,26 @@ public class NativeCallTest extends CodeInstallationTest {
         test("I32SDILDS", getI32SDILDS(), float.class, argClazz, argValues);
     }
 
+    @Test
+    public void testI32I() {
+        int sCount = 32;
+        // Pairs of <Object>, <Class>
+        Object[] remainingArgs = new Object[]{
+                        12, int.class
+        };
+        Class<?>[] argClazz = new Class[sCount + remainingArgs.length / 2];
+        Object[] argValues = new Object[sCount + remainingArgs.length / 2];
+        for (int i = 0; i < sCount; i++) {
+            argValues[i] = i;
+            argClazz[i] = int.class;
+        }
+        for (int i = 0; i < remainingArgs.length; i += 2) {
+            argValues[sCount + i / 2] = remainingArgs[i + 0];
+            argClazz[sCount + i / 2] = (Class<?>) remainingArgs[i + 1];
+        }
+        test("I32I", getI32I(), int.class, argClazz, argValues);
+    }
+
     public void test(String name, long addr, Class<?> returnClazz, Class<?>[] types, Object[] values) {
         try {
             test(asm -> {
@@ -243,5 +263,25 @@ public class NativeCallTest extends CodeInstallationTest {
                         l10, l11, l12, l13, l14, l15, l16, l17,
                         l18, l19, l1a, l1b, l1c, l1d, l1e, l1f,
                         a, b, c, d, e, f);
+    }
+
+    public static native long getI32I();
+
+    public static native int _I32I(int i00, int i01, int i02, int i03, int i04, int i05, int i06, int i07,
+                    int i08, int i09, int i0a, int i0b, int i0c, int i0d, int i0e, int i0f,
+                    int i10, int i11, int i12, int i13, int i14, int i15, int i16, int i17,
+                    int i18, int i19, int i1a, int i1b, int i1c, int i1d, int i1e, int i1f,
+                    int a);
+
+    public static int I32I(int i00, int i01, int i02, int i03, int i04, int i05, int i06, int i07,
+                    int i08, int i09, int i0a, int i0b, int i0c, int i0d, int i0e, int i0f,
+                    int i10, int i11, int i12, int i13, int i14, int i15, int i16, int i17,
+                    int i18, int i19, int i1a, int i1b, int i1c, int i1d, int i1e, int i1f,
+                    int a) {
+        return _I32I(i00, i01, i02, i03, i04, i05, i06, i07,
+                    i08, i09, i0a, i0b, i0c, i0d, i0e, i0f,
+                    i10, i11, i12, i13, i14, i15, i16, i17,
+                    i18, i19, i1a, i1b, i1c, i1d, i1e, i1f,
+                    a);
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java
@@ -158,7 +158,13 @@ public class NativeCallTest extends CodeInstallationTest {
                 asm.emitCallPrologue(cc, values);
                 asm.emitCall(addr);
                 asm.emitCallEpilogue(cc);
-                asm.emitFloatRet(((RegisterValue) cc.getReturn()).getRegister());
+                if (returnClazz == float.class) {
+                    asm.emitFloatRet(((RegisterValue) cc.getReturn()).getRegister());
+                } else if (returnClazz == int.class) {
+                    asm.emitIntRet(((RegisterValue) cc.getReturn()).getRegister());
+                } else {
+                    assert false : "Unimplemented return type: " + returnClazz;
+                }
             }, getMethod(name, types), values);
         } catch (Throwable e) {
             e.printStackTrace();

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/aarch64/AArch64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/aarch64/AArch64TestAssembler.java
@@ -269,8 +269,7 @@ public class AArch64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallPrologue(CallingConvention cc, Object... prim) {
-        emitGrowStack(cc.getStackSize());
-        frameSize += cc.getStackSize();
+        growFrame(cc.getStackSize());
         AllocatableValue[] args = cc.getArguments();
         for (int i = 0; i < args.length; i++) {
             emitLoad(args[i], prim[i]);
@@ -279,8 +278,7 @@ public class AArch64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallEpilogue(CallingConvention cc) {
-        emitGrowStack(-cc.getStackSize());
-        frameSize -= cc.getStackSize();
+        growFrame(-cc.getStackSize());
     }
 
     @Override

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/amd64/AMD64TestAssembler.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/amd64/AMD64TestAssembler.java
@@ -403,8 +403,7 @@ public class AMD64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallPrologue(CallingConvention cc, Object... prim) {
-        emitGrowStack(cc.getStackSize());
-        frameSize += cc.getStackSize();
+        growFrame(cc.getStackSize());
         AllocatableValue[] args = cc.getArguments();
         // Do the emission in reverse, this avoids register collisons of xmm0 - which is used a
         // scratch register when putting arguments on the stack.
@@ -427,7 +426,6 @@ public class AMD64TestAssembler extends TestAssembler {
 
     @Override
     public void emitCallEpilogue(CallingConvention cc) {
-        emitGrowStack(-cc.getStackSize());
-        frameSize -= cc.getStackSize();
+        growFrame(-cc.getStackSize());
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

The files have been moved in 17 by backport "8303588: [JVMCI] make JVMCI source directories conform with standard layout". After fixing the patch file to point to the new locations, the patch applies clean.

I include follow-up bug fix JDK-8296821. This also applied clean, except for the ProblemList change. 
Problemlisting of the test was not backported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8296821](https://bugs.openjdk.org/browse/JDK-8296821) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8262901](https://bugs.openjdk.org/browse/JDK-8262901) needs maintainer approval

### Issues
 * [JDK-8262901](https://bugs.openjdk.org/browse/JDK-8262901): [macos_aarch64] NativeCallTest expected:&lt;-3.8194101E18&gt; but was:&lt;3.02668882E10&gt; (**Bug** - P4 - Approved)
 * [JDK-8296821](https://bugs.openjdk.org/browse/JDK-8296821): compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java fails after JDK-8262901 (**Bug** - P2 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1888/head:pull/1888` \
`$ git checkout pull/1888`

Update a local copy of the PR: \
`$ git checkout pull/1888` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1888`

View PR using the GUI difftool: \
`$ git pr show -t 1888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1888.diff">https://git.openjdk.org/jdk17u-dev/pull/1888.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1888#issuecomment-1764838790)