### PR TITLE
8315214: Do not run sun/tools/jhsdb tests concurrently

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -32,7 +32,8 @@ java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/tools/jcmd \
 sun/tools/jinfo sun/tools/jmap sun/tools/jps sun/tools/jstack sun/tools/jstat \
 com/sun/tools/attach sun/security/mscapi java/util/Arrays/largeMemory \
-java/util/BitSet/stream javax/rmi java/net/httpclient/websocket
+java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
+sun/tools/jhsdb
 
 # Group definitions
 groups=TEST.groups


### PR DESCRIPTION
Backport 8315214

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315214](https://bugs.openjdk.org/browse/JDK-8315214) needs maintainer approval

### Issue
 * [JDK-8315214](https://bugs.openjdk.org/browse/JDK-8315214): Do not run sun/tools/jhsdb tests concurrently (**Sub-task** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1890/head:pull/1890` \
`$ git checkout pull/1890`

Update a local copy of the PR: \
`$ git checkout pull/1890` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1890`

View PR using the GUI difftool: \
`$ git pr show -t 1890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1890.diff">https://git.openjdk.org/jdk17u-dev/pull/1890.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1890#issuecomment-1765882185)