### PR TITLE
8312078: [PPC] JcmdScale.java Failing on AIX

### DIFF
--- a/src/hotspot/share/services/nmtDCmd.cpp
+++ b/src/hotspot/share/services/nmtDCmd.cpp
@@ -80,7 +80,7 @@ void NMTDCmd::execute(DCmdSource source, TRAPS) {
     return;
   }
 
-  const char* scale_value = _scale.value();
+  const char* scale_value = _scale.value() != nullptr ? _scale.value() : "(null)";
   size_t scale_unit = get_scale(scale_value);
   if (scale_unit == 0) {
     output()->print_cr("Incorrect scale value: %s", scale_value);


### PR DESCRIPTION
This pull request is a backport of commit [c1a3f143](https://github.com/openjdk/jdk/commit/c1a3f143bf881dac6d6e517293c79a68129c6f5a) from the [openjdk/jdk](https://github.com/openjdk/jdk) repository, addressing the issue [JDK-8312078](https://bugs.openjdk.org/browse/JDK-8312078)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312078](https://bugs.openjdk.org/browse/JDK-8312078) needs maintainer approval

### Issue
 * [JDK-8312078](https://bugs.openjdk.org/browse/JDK-8312078): [PPC] JcmdScale.java Failing on AIX (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1891/head:pull/1891` \
`$ git checkout pull/1891`

Update a local copy of the PR: \
`$ git checkout pull/1891` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1891`

View PR using the GUI difftool: \
`$ git pr show -t 1891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1891.diff">https://git.openjdk.org/jdk17u-dev/pull/1891.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1891#issuecomment-1767815715)