### PR TITLE
8312592: New parentheses warnings after HarfBuzz 7.2.0 update

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -461,7 +461,7 @@ else
    LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
    HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing \
-        array-bounds
+        array-bounds parentheses
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \


### PR DESCRIPTION
Unclean backport to unbreak JDK build on older platforms. The conflict is due to absent build warnings rework in later JDKs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312592](https://bugs.openjdk.org/browse/JDK-8312592) needs maintainer approval

### Issue
 * [JDK-8312592](https://bugs.openjdk.org/browse/JDK-8312592): New parentheses warnings after HarfBuzz 7.2.0 update (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1893/head:pull/1893` \
`$ git checkout pull/1893`

Update a local copy of the PR: \
`$ git checkout pull/1893` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1893`

View PR using the GUI difftool: \
`$ git pr show -t 1893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1893.diff">https://git.openjdk.org/jdk17u-dev/pull/1893.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1893#issuecomment-1768193272)