### PR TITLE
8291154: Create a non static nested class without enclosing class throws VerifyError

### DIFF
--- a/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.java
+++ b/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.java
@@ -1,0 +1,13 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8291154
+ * @summary Disallow static nested subclasses of non-static nested classes
+ * @compile/fail/ref=StaticNestedNonStaticSuper.out -XDrawDiagnostics StaticNestedNonStaticSuper.java
+ */
+
+class StaticNestedNonStaticSuper{
+    public abstract class NonStaticNested {
+        public static class StaticNested extends NonStaticNested {
+        }
+    }
+}

--- a/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.out
+++ b/test/langtools/tools/javac/nested/StaticNestedNonStaticSuper.out
@@ -1,0 +1,2 @@
+StaticNestedNonStaticSuper.java:10:23: compiler.err.no.encl.instance.of.type.in.scope: StaticNestedNonStaticSuper
+1 error


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8291154](https://bugs.openjdk.org/browse/JDK-8291154) needs maintainer approval

### Issue
 * [JDK-8291154](https://bugs.openjdk.org/browse/JDK-8291154): Create a non static nested class without enclosing class throws VerifyError (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1894/head:pull/1894` \
`$ git checkout pull/1894`

Update a local copy of the PR: \
`$ git checkout pull/1894` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1894`

View PR using the GUI difftool: \
`$ git pr show -t 1894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1894.diff">https://git.openjdk.org/jdk17u-dev/pull/1894.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1894#issuecomment-1770909368)