### PR TITLE
8300696: [AIX] AttachReturnError fails

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -50,6 +50,12 @@
 #include "utilities/formatBuffer.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/vmError.hpp"
+#ifdef AIX
+#include "loadlib_aix.hpp"
+#endif
+#ifdef LINUX
+#include "os_linux.hpp"
+#endif
 
 #include <dirent.h>
 #include <dlfcn.h>
@@ -717,6 +723,9 @@ void os::dll_unload(void *lib) {
     log_info(os)("Attempt to unload shared library \"%s\" [" INTPTR_FORMAT "] failed, %s",
                   l_path, p2i(lib), error_report);
   }
+  // Update the dll cache
+  AIX_ONLY(LoadedLibraries::reload());
+  LINUX_ONLY(os::free(l_pathdup));
 }
 
 jlong os::lseek(int fd, jlong offset, int whence) {


### PR DESCRIPTION
This PR backports the change reported in [JDK-8300696](https://bugs.openjdk.org/browse/JDK-8300696).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8300696](https://bugs.openjdk.org/browse/JDK-8300696) needs maintainer approval

### Issue
 * [JDK-8300696](https://bugs.openjdk.org/browse/JDK-8300696): [AIX] AttachReturnError fails (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1896/head:pull/1896` \
`$ git checkout pull/1896`

Update a local copy of the PR: \
`$ git checkout pull/1896` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1896`

View PR using the GUI difftool: \
`$ git pr show -t 1896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1896.diff">https://git.openjdk.org/jdk17u-dev/pull/1896.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1896#issuecomment-1771547998)