### PR TITLE
8268916: Tests for AffirmTrust roots

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -352,6 +352,46 @@
  * @run main/othervm -Djava.security.debug=certpath CAInterop certignarootca CRL
  */
 
+/*
+ * @test id=affirmtrustcommercialca
+ * @bug 8040012
+ * @summary Interoperability tests with AffirmTrust Commercial CA
+ * @library /test/lib
+ * @build jtreg.SkippedException ValidatePathWithURL CAInterop
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustcommercialca OCSP
+ * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustcommercialca CRL
+ */
+
+/*
+ * @test id=affirmtrustnetworkingca
+ * @bug 8040012
+ * @summary Interoperability tests with AffirmTrust Networking CA
+ * @library /test/lib
+ * @build jtreg.SkippedException ValidatePathWithURL CAInterop
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustnetworkingca OCSP
+ * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustnetworkingca CRL
+ */
+
+/*
+ * @test id=affirmtrustpremiumca
+ * @bug 8040012
+ * @summary Interoperability tests with AffirmTrust Premium CA
+ * @library /test/lib
+ * @build jtreg.SkippedException ValidatePathWithURL CAInterop
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustpremiumca OCSP
+ * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustpremiumca CRL
+ */
+
+/*
+ * @test id=affirmtrustpremiumeccca
+ * @bug 8040012
+ * @summary Interoperability tests with AffirmTrust Premium ECC CA
+ * @library /test/lib
+ * @build jtreg.SkippedException ValidatePathWithURL CAInterop
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustpremiumeccca OCSP
+ * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustpremiumeccca CRL
+ */
+
 /**
  * Collection of certificate validation tests for interoperability with external CAs
  */
@@ -478,6 +518,20 @@ public class CAInterop {
             case "certignarootca" ->
                     new CATestURLs("https://valid.servicesca.dhimyotis.com",
                             "https://revoked.servicesca.dhimyotis.com");
+
+            // These are listed at https://www.affirmtrust.com/resources/
+            case "affirmtrustcommercialca" ->
+                    new CATestURLs("https://validcommercial.affirmtrust.com",
+                            "https://revokedcommercial.affirmtrust.com");
+            case "affirmtrustnetworkingca" ->
+                    new CATestURLs("https://validnetworking.affirmtrust.com",
+                            "https://revokednetworking.affirmtrust.com");
+            case "affirmtrustpremiumca" ->
+                    new CATestURLs("https://validpremium.affirmtrust.com",
+                            "https://revokedpremium.affirmtrust.com");
+            case "affirmtrustpremiumeccca" ->
+                    new CATestURLs("https://validpremiumecc.affirmtrust.com",
+                            "https://revokedpremiumecc.affirmtrust.com");
 
             default -> throw new RuntimeException("No test setup found for: " + alias);
         };


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8268916](https://bugs.openjdk.org/browse/JDK-8268916) needs maintainer approval

### Issue
 * [JDK-8268916](https://bugs.openjdk.org/browse/JDK-8268916): Tests for AffirmTrust roots (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1897/head:pull/1897` \
`$ git checkout pull/1897`

Update a local copy of the PR: \
`$ git checkout pull/1897` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1897`

View PR using the GUI difftool: \
`$ git pr show -t 1897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1897.diff">https://git.openjdk.org/jdk17u-dev/pull/1897.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1897#issuecomment-1771594383)