### PR TITLE
8275333: Print count in "Too many recored phases?" assert

### DIFF
--- a/src/hotspot/share/gc/shared/gcTimer.cpp
+++ b/src/hotspot/share/gc/shared/gcTimer.cpp
@@ -130,7 +130,7 @@ void TimePartitions::clear() {
 }
 
 void TimePartitions::report_gc_phase_start(const char* name, const Ticks& time, GCPhase::PhaseType type) {
-  assert(_phases->length() <= 1000, "Too many recored phases?");
+  assert(_phases->length() <= 1000, "Too many recorded phases? (count: %d)", _phases->length());
 
   int level = _active_phases.count();
 


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8275333](https://bugs.openjdk.org/browse/JDK-8275333) needs maintainer approval

### Issue
 * [JDK-8275333](https://bugs.openjdk.org/browse/JDK-8275333): Print count in "Too many recored phases?" assert (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1898/head:pull/1898` \
`$ git checkout pull/1898`

Update a local copy of the PR: \
`$ git checkout pull/1898` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1898`

View PR using the GUI difftool: \
`$ git pr show -t 1898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1898.diff">https://git.openjdk.org/jdk17u-dev/pull/1898.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1898#issuecomment-1772166865)