### PR TITLE
8176567: nsk/jdi/ReferenceType/instances/instances002: TestFailure: Unexpected size of referenceType.instances(nsk.share.jdi.TestInterfaceImplementer1): 11, expected: 10

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/invoker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -753,7 +753,9 @@ invoker_completeInvokeRequest(jthread thread)
         }
         id = request->id;
         exc = request->exception;
+        request->exception = NULL;
         returnValue = request->returnValue;
+        request->returnValue.l = NULL;
 
         /* Release return value and exception references, but delay the release
          * until after the return packet was sent. */
@@ -796,23 +798,20 @@ invoker_completeInvokeRequest(jthread thread)
         (void)outStream_writeObjectTag(env, &out, exc);
         (void)outStream_writeObjectRef(env, &out, exc);
         outStream_sendReply(&out);
+        /*
+         * Delete potentially saved global references for return value
+         * and exception. This must be done before sending the reply or
+         * these objects will briefly be viewable by the debugger as live
+         * when they shouldn't be.
+         */
+        if (mustReleaseReturnValue && returnValue.l != NULL) {
+            tossGlobalRef(env, &returnValue.l);
+        }
+        if (exc != NULL) {
+            tossGlobalRef(env, &exc);
+        }
         outStream_destroy(&out);
     }
-
-    /*
-     * Delete potentially saved global references of return value
-     * and exception
-     */
-    eventHandler_lock(); // for proper lock order
-    debugMonitorEnter(invokerLock);
-    if (mustReleaseReturnValue && returnValue.l != NULL) {
-        tossGlobalRef(env, &returnValue.l);
-    }
-    if (exc != NULL) {
-        tossGlobalRef(env, &exc);
-    }
-    debugMonitorExit(invokerLock);
-    eventHandler_unlock();
 }
 
 jboolean


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

A trivial resolve, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8176567](https://bugs.openjdk.org/browse/JDK-8176567) needs maintainer approval

### Issue
 * [JDK-8176567](https://bugs.openjdk.org/browse/JDK-8176567): nsk/jdi/ReferenceType/instances/instances002: TestFailure: Unexpected size of referenceType.instances(nsk.share.jdi.TestInterfaceImplementer1): 11, expected: 10 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1901/head:pull/1901` \
`$ git checkout pull/1901`

Update a local copy of the PR: \
`$ git checkout pull/1901` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1901`

View PR using the GUI difftool: \
`$ git pr show -t 1901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1901.diff">https://git.openjdk.org/jdk17u-dev/pull/1901.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1901#issuecomment-1775295852)