### PR TITLE
8293563: [macos-aarch64] SA core file tests failing with sun.jvm.hotspot.oops.UnknownOopException

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -116,13 +116,13 @@ serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorStatArrayCorrectnessTest.j
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 
-serviceability/sa/ClhsdbCDSCore.java  8294316,8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbFindPC.java#id1  8294316,8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbFindPC.java#id3  8294316,8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbPmap.java#id1  8294316,8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/ClhsdbPstack.java#id1  8294316,8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/TestJmapCore.java  8294316,8269982,8267433 macosx-aarch64,macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java  8294316,8269982,8267433 macosx-aarch64,macosx-x64
+serviceability/sa/ClhsdbCDSCore.java  8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id1  8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id3  8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbPmap.java#id1  8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbPstack.java#id1  8294316,8267433 macosx-x64
+serviceability/sa/TestJmapCore.java  8294316,8267433 macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java  8294316,8267433 macosx-x64
 
 #############################################################################
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ public class ClhsdbCDSCore {
                 "-Xshare:auto",
                 "-XX:+ProfileInterpreter",
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+                CoreUtils.getAlwaysPretouchArg(true),
                 CrashApp.class.getName()
             };
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java
@@ -93,9 +93,9 @@ public class ClhsdbFindPC {
             theApp = new LingeredApp();
             theApp.setForceCrash(withCore);
             if (withXcomp) {
-                LingeredApp.startApp(theApp, "-Xcomp");
+                LingeredApp.startApp(theApp, "-Xcomp", CoreUtils.getAlwaysPretouchArg(withCore));
             } else {
-                LingeredApp.startApp(theApp, "-Xint");
+                LingeredApp.startApp(theApp, "-Xint", CoreUtils.getAlwaysPretouchArg(withCore));
             }
             System.out.print("Started LingeredApp ");
             if (withXcomp) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPmap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class ClhsdbPmap {
             ClhsdbLauncher test = new ClhsdbLauncher();
             theApp = new LingeredApp();
             theApp.setForceCrash(withCore);
-            LingeredApp.startApp(theApp);
+            LingeredApp.startApp(theApp, CoreUtils.getAlwaysPretouchArg(withCore));
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
             if (withCore) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbPstack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class ClhsdbPstack {
             ClhsdbLauncher test = new ClhsdbLauncher();
             theApp = new LingeredApp();
             theApp.setForceCrash(withCore);
-            LingeredApp.startApp(theApp);
+            LingeredApp.startApp(theApp, CoreUtils.getAlwaysPretouchArg(withCore));
             System.out.println("Started LingeredApp with pid " + theApp.getPid());
 
             if (withCore) {

--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,7 @@ public class TestJmapCore {
                 "-Xmx512m", "-XX:MaxMetaspaceSize=64m", "-XX:+CrashOnOutOfMemoryError",
                 // The test loads lots of small classes to exhaust Metaspace, skip method
                 // dependency verification to improve performance in debug builds.
+                CoreUtils.getAlwaysPretouchArg(true),
                 Platform.isDebugBuild() ? "-XX:-VerifyDependencies" : "--show-version",
                 TestJmapCore.class.getName(), type);
 

--- a/test/lib/jdk/test/lib/util/CoreUtils.java
+++ b/test/lib/jdk/test/lib/util/CoreUtils.java
@@ -258,4 +258,14 @@ public class CoreUtils {
         }
     }
 
+    public static String getAlwaysPretouchArg(boolean withCore) {
+        // macosx-aarch64 has an issue where sometimes the java heap will not be dumped to the
+        // core file. Using -XX:+AlwaysPreTouch fixes the problem.
+        if (withCore && Platform.isOSX() && Platform.isAArch64()) {
+            return "-XX:+AlwaysPreTouch";
+        } else {
+            return "-XX:-AlwaysPreTouch";
+        }
+    }
+
 }


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

I resolved the problemlist because there was an other bug added for mac x64.
TestJmapCore.java also needed a simple resolve.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8293563](https://bugs.openjdk.org/browse/JDK-8293563) needs maintainer approval

### Issue
 * [JDK-8293563](https://bugs.openjdk.org/browse/JDK-8293563): [macos-aarch64] SA core file tests failing with sun.jvm.hotspot.oops.UnknownOopException (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1903/head:pull/1903` \
`$ git checkout pull/1903`

Update a local copy of the PR: \
`$ git checkout pull/1903` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1903`

View PR using the GUI difftool: \
`$ git pr show -t 1903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1903.diff">https://git.openjdk.org/jdk17u-dev/pull/1903.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1903#issuecomment-1775378963)