### PR TITLE
8275329: ZGC: vmTestbase/gc/gctests/SoftReference/soft004/soft004.java fails with assert(_phases->length() <= 1000) failed: Too many recored phases?

### DIFF
--- a/src/hotspot/share/gc/shared/gcTimer.cpp
+++ b/src/hotspot/share/gc/shared/gcTimer.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gcTimer.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "utilities/growableArray.hpp"
 
 // the "time" parameter for most functions
@@ -130,7 +131,7 @@ void TimePartitions::clear() {
 }
 
 void TimePartitions::report_gc_phase_start(const char* name, const Ticks& time, GCPhase::PhaseType type) {
-  assert(_phases->length() <= 1000, "Too many recorded phases? (count: %d)", _phases->length());
+  assert(UseZGC || _phases->length() <= 1000, "Too many recorded phases? (count: %d)", _phases->length());
 
   int level = _active_phases.count();
 


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8275329](https://bugs.openjdk.org/browse/JDK-8275329) needs maintainer approval

### Issue
 * [JDK-8275329](https://bugs.openjdk.org/browse/JDK-8275329): ZGC: vmTestbase/gc/gctests/SoftReference/soft004/soft004.java fails with assert(_phases-&gt;length() &lt;= 1000) failed: Too many recored phases? (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1904/head:pull/1904` \
`$ git checkout pull/1904`

Update a local copy of the PR: \
`$ git checkout pull/1904` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1904`

View PR using the GUI difftool: \
`$ git pr show -t 1904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1904.diff">https://git.openjdk.org/jdk17u-dev/pull/1904.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1904#issuecomment-1775409111)