### PR TITLE
8308910: Allow executeAndLog to accept running process

### DIFF
--- a/test/lib/jdk/test/lib/cds/CDSTestUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSTestUtils.java
@@ -594,8 +594,12 @@ public class CDSTestUtils {
 
     // ============================= Logging
     public static OutputAnalyzer executeAndLog(ProcessBuilder pb, String logName) throws Exception {
+        return executeAndLog(pb.start(), logName);
+    }
+
+    public static OutputAnalyzer executeAndLog(Process process, String logName) throws Exception {
         long started = System.currentTimeMillis();
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        OutputAnalyzer output = new OutputAnalyzer(process);
         String logFileNameStem =
             String.format("%04d", getNextLogCounter()) + "-" + logName;
 


### PR DESCRIPTION
I backport this for parity with 17.0.9-oracle.

I had to resolve because handleCDSRuntimeOptions(pb); is not in the context. Probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8308910](https://bugs.openjdk.org/browse/JDK-8308910) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308910](https://bugs.openjdk.org/browse/JDK-8308910): Allow executeAndLog to accept running process (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1910/head:pull/1910` \
`$ git checkout pull/1910`

Update a local copy of the PR: \
`$ git checkout pull/1910` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1910`

View PR using the GUI difftool: \
`$ git pr show -t 1910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1910.diff">https://git.openjdk.org/jdk17u-dev/pull/1910.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1910#issuecomment-1776927471)