### PR TITLE
8291911: java/io/File/GetXSpace.java fails with "53687091200 != 161051996160"

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -66,9 +66,11 @@ ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeCallerAccessTest := jvm.lib
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libAsyncStackWalk := /EHsc
+  BUILD_JDK_JTREG_LIBRARIES_LIBS_libGetXSpace := $(WIN_LIB_JAVA)
 else
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libstringPlatformChars := -ljava
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libDirectIO := -ljava
+  BUILD_JDK_JTREG_LIBRARIES_LIBS_libGetXSpace := -ljava
   BUILD_JDK_JTREG_EXCLUDE += exerevokeall.c
   ifeq ($(call isTargetOs, linux), true)
     BUILD_JDK_JTREG_LIBRARIES_LIBS_libInheritedChannel := -ljava

--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @summary Basic functionality of File.get-X-Space methods.
  * @library .. /test/lib
  * @build jdk.test.lib.Platform
- * @run main/othervm -Djava.security.manager=allow GetXSpace
+ * @run main/othervm/native -Djava.security.manager=allow GetXSpace
  */
 
 import java.io.BufferedReader;
@@ -52,12 +52,12 @@ import static java.lang.System.out;
 
 @SuppressWarnings("removal")
 public class GetXSpace {
+    static {
+        System.loadLibrary("GetXSpace");
+    }
 
     private static SecurityManager [] sma = { null, new Allow(), new DenyFSA(),
                                               new DenyRead() };
-
-    // FileSystem Total Used Available Use% MountedOn
-    private static final Pattern DF_PATTERN = Pattern.compile("([^\\s]+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+\\d+%\\s+([^\\s].*)\n");
 
     private static int fail = 0;
     private static int pass = 0;
@@ -100,34 +100,36 @@ public class GetXSpace {
     }
 
     private static class Space {
-        private static final long KSIZE = 1024;
         private final String name;
+        private final long size;
         private final long total;
-        private final long used;
+        private final long free;
         private final long available;
 
-        Space(String name, String total, String used, String available) {
+        Space(String name) {
             this.name = name;
-            try {
-                this.total = Long.parseLong(total) * KSIZE;
-                this.used = Long.parseLong(used) * KSIZE;
-                this.available = Long.parseLong(available) * KSIZE;
-            } catch (NumberFormatException x) {
-                throw new RuntimeException("the regex should have caught this", x);
-            }
+            long[] sizes = new long[4];
+            if (getSpace0(name, sizes))
+                System.err.println("WARNING: total space is estimated");
+            this.size = sizes[0];
+            this.total = sizes[1];
+            this.free = sizes[2];
+            this.available = sizes[3];
         }
 
         String name() { return name; }
+        long size() { return size; }
         long total() { return total; }
-        long used() { return used; }
         long available() { return available; }
-        long free() { return total - used; }
+        long free() { return free; }
+
         boolean woomFree(long freeSpace) {
             return ((freeSpace >= (available / 10)) &&
                     (freeSpace <= (available * 10)));
         }
+
         public String toString() {
-            return String.format("%s (%d/%d/%d)", name, total, used, available);
+            return String.format("%s (%d/%d/%d)", name, total, free, available);
         }
     }
 
@@ -149,49 +151,16 @@ public class GetXSpace {
         out.println(sb);
     }
 
-    private static ArrayList<Space> space(String f) throws IOException {
-        ArrayList<Space> al = new ArrayList<>();
+    private static ArrayList<String> paths() throws IOException {
+        ArrayList<String> al = new ArrayList<>();
 
-        String cmd = "df -k -P" + (f == null ? "" : " " + f);
-        StringBuilder sb = new StringBuilder();
-        Process p = Runtime.getRuntime().exec(cmd);
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
-            String s;
-            int i = 0;
-            while ((s = in.readLine()) != null) {
-                // skip header
-                if (i++ == 0) continue;
-                sb.append(s).append("\n");
-            }
-        }
-        out.println(sb);
-
-        Matcher m = DF_PATTERN.matcher(sb);
-        int j = 0;
-        while (j < sb.length()) {
-            if (m.find(j)) {
-                // swap can change while this test is running
-                if (!m.group(1).equals("swap")) {
-                    String name = f;
-                    if (name == null) {
-                        // cygwin's df lists windows path as FileSystem (1st group)
-                        name = Platform.isWindows() ? m.group(1) : m.group(5);
-                    }
-                    al.add(new Space(name, m.group(2), m.group(3), m.group(4)));;
-                }
-                j = m.end();
-            } else {
-                throw new RuntimeException("unrecognized df output format: "
-                                           + "charAt(" + j + ") = '"
-                                           + sb.charAt(j) + "'");
-            }
+        File[] roots = File.listRoots();
+        long[] space = new long[4];
+        for (File root : roots) {
+            String path = root.toString();
+            al.add(path);
         }
 
-        if (al.size() == 0) {
-            // df did not produce output
-            String name = (f == null ? "" : f);
-            al.add(new Space(name, "0", "0", "0"));
-        }
         return al;
     }
 
@@ -231,14 +200,15 @@ public class GetXSpace {
         long fs = f.getFreeSpace();
         long us = f.getUsableSpace();
 
-        out.format("%s:%n", s.name());
+        out.format("%s (%d):%n", s.name(), s.size());
         String fmt = "  %-4s total = %12d free = %12d usable = %12d%n";
-        out.format(fmt, "df", s.total(), s.free(), s.available());
-        out.format(fmt, "getX", ts, fs, us);
+        out.format(fmt, "getSpace0", s.total(), s.free(), s.available());
+        out.format(fmt, "getXSpace", ts, fs, us);
 
         // If the file system can dynamically change size, this check will fail.
         // This can happen on macOS for the /dev files system.
-        if (ts != s.total() && (!Platform.isOSX() || !s.name().equals("/dev"))) {
+        if (ts != s.total()
+            && (!Platform.isOSX() || !s.name().equals("/dev"))) {
             long blockSize = 1;
             long numBlocks = 0;
             try {
@@ -255,32 +225,18 @@ public class GetXSpace {
                 throw new RuntimeException(e);
             }
 
-            // On macOS, the number of 1024 byte blocks might be incorrectly
-            // calculated by 'df' using integer division by 2 of the number of
-            // 512 byte blocks, resulting in a size smaller than the actual
-            // value when the number of blocks is odd.
-            if (!Platform.isOSX() || blockSize != 512 || numBlocks % 2 == 0 ||
-                ts - s.total() != 512) {
-                if (Platform.isWindows()) {
-                    //
-                    // In Cygwin, 'df' has been observed to account for quotas
-                    // when reporting the total disk size, but the total size
-                    // reported by GetDiskFreeSpaceExW() has been observed not
-                    // to account for the quota in which case the latter value
-                    // should be larger.
-                    //
-                    if (s.total() > ts) {
-                        fail(s.name() + " total space", s.total(), ">", ts);
-                    }
-                } else {
-                    fail(s.name() + " total space", s.total(), "!=", ts);
+            if (Platform.isWindows()) {
+                if (ts > s.total()) {
+                    fail(s.name() + " total space", ts, ">", s.total());
                 }
+            } else if (ts != s.total()) {
+                fail(s.name() + " total space", ts, "!=", s.total());
             }
         } else {
             pass();
         }
 
-        // unix df returns statvfs.f_bavail
+        // unix usable space is from statvfs.f_bavail
         long tsp = (!Platform.isWindows() ? us : fs);
         if (!s.woomFree(tsp)) {
             fail(s.name(), s.available(), "??", tsp);
@@ -288,14 +244,57 @@ public class GetXSpace {
             pass();
         }
 
-        if (fs > s.total()) {
-            fail(s.name(), s.total(), ">", fs);
+        //
+        // Invariants are:
+        // total space <= size
+        // total space == size (Unix)
+        // free space <= total space (if no quotas in effect) (Windows)
+        // free space < size (if quotas in effect) (Windows)
+        // usable space <= total space
+        // usable space <= free space
+        //
+
+        // total space <= size
+        if (ts > s.size()) {
+            fail(s.name() + " size", ts, ">", s.size());
         } else {
             pass();
         }
 
+        // On Unix the total space should always be the volume size
+        if (Platform.isWindows()) {
+            // ts != s.size() indicates that quotas are in effect
+            if (ts == s.size() && fs > s.total()) {
+                fail(s.name() + " free space", fs, ">", s.total());
+            } else if (ts < s.size() && fs > s.size()) {
+                fail(s.name() + " free space (quota)", fs, ">", s.size());
+            } else {
+                pass();
+            }
+        } else { // not Windows
+            if (ts != s.size()) {
+                fail(s.name() + " total space", ts, "!=", s.size());
+            } else {
+                pass();
+            }
+        }
+
+        // usable space <= total space
         if (us > s.total()) {
-            fail(s.name(), s.total(), ">", us);
+            fail(s.name() + " usable space", us, ">", s.total());
+        } else {
+            pass();
+        }
+
+        // usable space <= free space
+        if (us > s.free()) {
+            // free and usable change dynamically
+            System.err.println("Warning: us > s.free()");
+            if (1.0 - Math.abs((double)s.free()/(double)us) > 0.01) {
+                fail(s.name() + " usable vs. free space", us, ">", s.free());
+            } else {
+                pass();
+            }
         } else {
             pass();
         }
@@ -352,14 +351,14 @@ public class GetXSpace {
         public void checkPermission(Permission p) {
             if (p.implies(new RuntimePermission("setSecurityManager"))
                 || p.implies(new RuntimePermission("getProtectionDomain")))
-              return;
+                return;
             super.checkPermission(p);
         }
 
         public void checkPermission(Permission p, Object context) {
             if (p.implies(new RuntimePermission("setSecurityManager"))
                 || p.implies(new RuntimePermission("getProtectionDomain")))
-              return;
+                return;
             super.checkPermission(p, context);
         }
     }
@@ -391,17 +390,11 @@ public class GetXSpace {
     private static int testFile(Path dir) {
         String dirName = dir.toString();
         out.format("--- Testing %s%n", dirName);
-        ArrayList<Space> l;
-        try {
-            l = space(dirName);
-        } catch (IOException x) {
-            throw new RuntimeException(dirName + " can't get file system information", x);
-        }
-        compare(l.get(0));
+        compare(new Space(dir.getRoot().toString()));
 
         if (fail != 0) {
             err.format("%d tests: %d failure(s); first: %s%n",
-                fail + pass, fail, first);
+                       fail + pass, fail, first);
         } else {
             out.format("all %d tests passed%n", fail + pass);
         }
@@ -409,13 +402,13 @@ public class GetXSpace {
         return fail != 0 ? 1 : 0;
     }
 
-    private static int testDF() {
-        out.println("--- Testing df");
-        // Find all of the partitions on the machine and verify that the size
-        // returned by "df" is equivalent to File.getXSpace() values.
-        ArrayList<Space> l;
+    private static int testVolumes() {
+        out.println("--- Testing volumes");
+        // Find all of the partitions on the machine and verify that the sizes
+        // returned by File::getXSpace are equivalent to those from getSpace0
+        ArrayList<String> l;
         try {
-            l = space(null);
+            l = paths();
             if (Platform.isWindows()) {
                 diskFree();
             }
@@ -434,7 +427,8 @@ public class GetXSpace {
 
             out.format("%nSecurityManager = %s%n" ,
                        (sm == null ? "null" : sm.getClass().getName()));
-            for (var s : l) {
+            for (var p : l) {
+                Space s = new Space(p);
                 if (sm instanceof Deny) {
                     tryCatch(s);
                 } else {
@@ -449,7 +443,7 @@ public class GetXSpace {
 
         if (fail != 0) {
             err.format("%d tests: %d failure(s); first: %s%n",
-                fail + pass, fail, first);
+                       fail + pass, fail, first);
         } else {
             out.format("all %d tests passed%n", fail + pass);
         }
@@ -472,7 +466,7 @@ public class GetXSpace {
     }
 
     public static void main(String[] args) throws Exception {
-        int failedTests = testDF();
+        int failedTests = testVolumes();
         reset();
 
         Path tmpDir = Files.createTempDirectory(null);
@@ -491,4 +485,13 @@ public class GetXSpace {
             throw new RuntimeException(failedTests + " test(s) failed");
         }
     }
+
+    //
+    // root     the root of the volume
+    // size[0]  total size:   number of bytes in the volume
+    // size[1]  total space:  number of bytes visible to the caller
+    // size[2]  free space:   number of free bytes in the volume
+    // size[3]  usable space: number of bytes available to the caller
+    //
+    private static native boolean getSpace0(String root, long[] space);
 }

--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -175,9 +175,9 @@ public class GetXSpace {
                     String name = f;
                     if (name == null) {
                         // cygwin's df lists windows path as FileSystem (1st group)
-                        name = Platform.isWindows() ? m.group(1) : m.group(4);
+                        name = Platform.isWindows() ? m.group(1) : m.group(5);
                     }
-                    al.add(new Space(m.group(2), m.group(3), name));;
+                    al.add(new Space(name, m.group(2), m.group(3), m.group(4)));;
                 }
                 j = m.end();
             } else {

--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -57,7 +57,7 @@ public class GetXSpace {
                                               new DenyRead() };
 
     // FileSystem Total Used Available Use% MountedOn
-    private static final Pattern DF_PATTERN = Pattern.compile("([^\\s]+)\\s+(\\d+)\\s+\\d+\\s+(\\d+)\\s+\\d+%\\s+([^\\s].*)\n");
+    private static final Pattern DF_PATTERN = Pattern.compile("([^\\s]+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+\\d+%\\s+([^\\s].*)\n");
 
     private static int fail = 0;
     private static int pass = 0;
@@ -103,27 +103,50 @@ public class GetXSpace {
         private static final long KSIZE = 1024;
         private final String name;
         private final long total;
-        private final long free;
+        private final long used;
+        private final long available;
 
-        Space(String total, String free, String name) {
+        Space(String name, String total, String used, String available) {
+            this.name = name;
             try {
                 this.total = Long.parseLong(total) * KSIZE;
-                this.free = Long.parseLong(free) * KSIZE;
+                this.used = Long.parseLong(used) * KSIZE;
+                this.available = Long.parseLong(available) * KSIZE;
             } catch (NumberFormatException x) {
                 throw new RuntimeException("the regex should have caught this", x);
             }
-            this.name = name;
         }
 
         String name() { return name; }
         long total() { return total; }
-        long free() { return free; }
+        long used() { return used; }
+        long available() { return available; }
+        long free() { return total - used; }
         boolean woomFree(long freeSpace) {
-            return ((freeSpace >= (free / 10)) && (freeSpace <= (free * 10)));
+            return ((freeSpace >= (available / 10)) &&
+                    (freeSpace <= (available * 10)));
         }
         public String toString() {
-            return String.format("%s (%d/%d)", name, free, total);
+            return String.format("%s (%d/%d/%d)", name, total, used, available);
         }
+    }
+
+    private static void diskFree() throws IOException {
+        ArrayList<Space> al = new ArrayList<>();
+
+        String cmd = "fsutil volume diskFree C:\\";
+        StringBuilder sb = new StringBuilder();
+        Process p = Runtime.getRuntime().exec(cmd);
+        try (BufferedReader in = p.inputReader()) {
+            String s;
+            int i = 0;
+            while ((s = in.readLine()) != null) {
+                // skip header
+                if (i++ == 0) continue;
+                sb.append(s).append("\n");
+            }
+        }
+        out.println(sb);
     }
 
     private static ArrayList<Space> space(String f) throws IOException {
@@ -167,7 +190,7 @@ public class GetXSpace {
         if (al.size() == 0) {
             // df did not produce output
             String name = (f == null ? "" : f);
-            al.add(new Space("0", "0", name));
+            al.add(new Space(name, "0", "0", "0"));
         }
         return al;
     }
@@ -209,8 +232,8 @@ public class GetXSpace {
         long us = f.getUsableSpace();
 
         out.format("%s:%n", s.name());
-        String fmt = "  %-4s total= %12d free = %12d usable = %12d%n";
-        out.format(fmt, "df", s.total(), 0, s.free());
+        String fmt = "  %-4s total = %12d free = %12d usable = %12d%n";
+        out.format(fmt, "df", s.total(), s.free(), s.available());
         out.format(fmt, "getX", ts, fs, us);
 
         // If the file system can dynamically change size, this check will fail.
@@ -236,9 +259,22 @@ public class GetXSpace {
             // calculated by 'df' using integer division by 2 of the number of
             // 512 byte blocks, resulting in a size smaller than the actual
             // value when the number of blocks is odd.
-            if (!Platform.isOSX() || blockSize != 512 || numBlocks % 2 == 0
-                || ts - s.total() != 512) {
-                fail(s.name(), s.total(), "!=", ts);
+            if (!Platform.isOSX() || blockSize != 512 || numBlocks % 2 == 0 ||
+                ts - s.total() != 512) {
+                if (Platform.isWindows()) {
+                    //
+                    // In Cygwin, 'df' has been observed to account for quotas
+                    // when reporting the total disk size, but the total size
+                    // reported by GetDiskFreeSpaceExW() has been observed not
+                    // to account for the quota in which case the latter value
+                    // should be larger.
+                    //
+                    if (s.total() > ts) {
+                        fail(s.name() + " total space", s.total(), ">", ts);
+                    }
+                } else {
+                    fail(s.name() + " total space", s.total(), "!=", ts);
+                }
             }
         } else {
             pass();
@@ -247,7 +283,7 @@ public class GetXSpace {
         // unix df returns statvfs.f_bavail
         long tsp = (!Platform.isWindows() ? us : fs);
         if (!s.woomFree(tsp)) {
-            fail(s.name(), s.free(), "??", tsp);
+            fail(s.name(), s.available(), "??", tsp);
         } else {
             pass();
         }
@@ -380,6 +416,9 @@ public class GetXSpace {
         ArrayList<Space> l;
         try {
             l = space(null);
+            if (Platform.isWindows()) {
+                diskFree();
+            }
         } catch (IOException x) {
             throw new RuntimeException("can't get file system information", x);
         }

--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -60,8 +60,8 @@ Java_GetXSpace_getSpace0
 {
     jboolean totalSpaceIsEstimated = JNI_FALSE;
     jlong array[4];
-    const jchar* chars = (*env)->GetStringChars(env, root, NULL);
-    if (chars == NULL) {
+    const jchar* strchars = (*env)->GetStringChars(env, root, NULL);
+    if (strchars == NULL) {
         JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
                                      "GetStringChars");
         return JNI_FALSE;
@@ -77,12 +77,13 @@ Java_GetXSpace_getSpace0
         }
     }
 
-    LPCWSTR path = (LPCWSTR)chars;
+    LPCWSTR path = (LPCWSTR)strchars;
 
     if (pfnGetDiskSpaceInformation != NULL) {
         // use GetDiskSpaceInformationW
         DISK_SPACE_INFORMATION diskSpaceInfo;
         BOOL hres = pfnGetDiskSpaceInformation(path, &diskSpaceInfo);
+        (*env)->ReleaseStringChars(env, root, strchars);
         if (FAILED(hres)) {
             JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
                                          "GetDiskSpaceInformationW");
@@ -108,8 +109,10 @@ Java_GetXSpace_getSpace0
         ULARGE_INTEGER totalNumberOfBytes;
         ULARGE_INTEGER totalNumberOfFreeBytes;
 
-        if (GetDiskFreeSpaceExW(path, &freeBytesAvailable, &totalNumberOfBytes,
-            &totalNumberOfFreeBytes) == 0) {
+        BOOL hres = GetDiskFreeSpaceExW(path, &freeBytesAvailable,
+            &totalNumberOfBytes, &totalNumberOfFreeBytes);
+        (*env)->ReleaseStringChars(env, root, strchars);
+        if (FAILED(hres)) {
             JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
                                          "GetDiskFreeSpaceExW");
             return totalSpaceIsEstimated;
@@ -124,9 +127,24 @@ Java_GetXSpace_getSpace0
         array[3] = (jlong)freeBytesAvailable.QuadPart;
     }
 #else
+    int len = (int)(*env)->GetStringLength(env, root);
+    char* chars = (char*)malloc((len + 1)*sizeof(char));
+    if (chars == NULL) {
+        (*env)->ReleaseStringChars(env, root, strchars);
+        JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+                                     "malloc");
+        return JNI_FALSE;
+    }
+
+    for (int i = 0; i < len; i++) {
+        chars[i] = (char)strchars[i];
+    }
+    chars[len] = '\0';
+    (*env)->ReleaseStringChars(env, root, strchars);
+
     struct statfs buf;
     int result = statfs((const char*)chars, &buf);
-    (*env)->ReleaseStringChars(env, root, chars);
+    free(chars);
     if (result < 0) {
         JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
                                      strerror(errno));

--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include <stdlib.h>
+#include "jni.h"
+#include "jni_util.h"
+#ifdef _WIN64
+#include <windows.h>
+#include <fileapi.h>
+#include <winerror.h>
+#else
+#include <sys/errno.h>
+#include <string.h>
+#if __APPLE__
+#include <sys/param.h>
+#include <sys/mount.h>
+#else
+#include <sys/statfs.h>
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _WIN64
+jboolean initialized = JNI_FALSE;
+BOOL(WINAPI * pfnGetDiskSpaceInformation)(LPCWSTR, LPVOID) = NULL;
+#endif
+
+//
+// root      the root of the volume
+// sizes[0]  total size:   number of bytes in the volume
+// sizes[1]  total space:  number of bytes visible to the caller
+// sizes[2]  free space:   number of free bytes in the volume
+// sizes[3]  usable space: number of bytes available to the caller
+//
+JNIEXPORT jboolean JNICALL
+Java_GetXSpace_getSpace0
+    (JNIEnv *env, jclass cls, jstring root, jlongArray sizes)
+{
+    jboolean totalSpaceIsEstimated = JNI_FALSE;
+    jlong array[4];
+    const jchar* chars = (*env)->GetStringChars(env, root, NULL);
+    if (chars == NULL) {
+        JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+                                     "GetStringChars");
+        return JNI_FALSE;
+    }
+
+#ifdef _WIN64
+    if (initialized == JNI_FALSE) {
+        initialized = JNI_TRUE;
+        HMODULE hmod = GetModuleHandleW(L"kernel32");
+        if (hmod != NULL) {
+            *(FARPROC*)&pfnGetDiskSpaceInformation =
+                GetProcAddress(hmod, "GetDiskSpaceInformationW");
+        }
+    }
+
+    LPCWSTR path = (LPCWSTR)chars;
+
+    if (pfnGetDiskSpaceInformation != NULL) {
+        // use GetDiskSpaceInformationW
+        DISK_SPACE_INFORMATION diskSpaceInfo;
+        BOOL hres = pfnGetDiskSpaceInformation(path, &diskSpaceInfo);
+        if (FAILED(hres)) {
+            JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+                                         "GetDiskSpaceInformationW");
+            return totalSpaceIsEstimated;
+        }
+
+        ULONGLONG bytesPerAllocationUnit =
+            diskSpaceInfo.SectorsPerAllocationUnit*diskSpaceInfo.BytesPerSector;
+        array[0] = (jlong)(diskSpaceInfo.ActualTotalAllocationUnits*
+                           bytesPerAllocationUnit);
+        array[1] = (jlong)(diskSpaceInfo.CallerTotalAllocationUnits*
+                           bytesPerAllocationUnit);
+        array[2] = (jlong)(diskSpaceInfo.ActualAvailableAllocationUnits*
+                           bytesPerAllocationUnit);
+        array[3] = (jlong)(diskSpaceInfo.CallerAvailableAllocationUnits*
+                           bytesPerAllocationUnit);
+    } else {
+        totalSpaceIsEstimated = JNI_TRUE;
+
+        // if GetDiskSpaceInformationW is unavailable ("The specified
+        // procedure could not be found"), fall back to GetDiskFreeSpaceExW
+        ULARGE_INTEGER freeBytesAvailable;
+        ULARGE_INTEGER totalNumberOfBytes;
+        ULARGE_INTEGER totalNumberOfFreeBytes;
+
+        if (GetDiskFreeSpaceExW(path, &freeBytesAvailable, &totalNumberOfBytes,
+            &totalNumberOfFreeBytes) == 0) {
+            JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+                                         "GetDiskFreeSpaceExW");
+            return totalSpaceIsEstimated;
+        }
+
+        // If quotas are in effect, it is impossible to obtain the volume size,
+        // so estimate it as free + used = free + (visible - available)
+        ULONGLONG used = totalNumberOfBytes.QuadPart - freeBytesAvailable.QuadPart;
+        array[0] = (jlong)(totalNumberOfFreeBytes.QuadPart + used);
+        array[1] = (jlong)totalNumberOfBytes.QuadPart;
+        array[2] = (jlong)totalNumberOfFreeBytes.QuadPart;
+        array[3] = (jlong)freeBytesAvailable.QuadPart;
+    }
+#else
+    struct statfs buf;
+    int result = statfs((const char*)chars, &buf);
+    (*env)->ReleaseStringChars(env, root, chars);
+    if (result < 0) {
+        JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+                                     strerror(errno));
+        return totalSpaceIsEstimated;
+    }
+
+    array[0] = (jlong)(buf.f_blocks*buf.f_bsize);
+    array[1] = array[0]; // number visible is the same as the total size
+    array[2] = (jlong)(buf.f_bfree*buf.f_bsize);
+    array[3] = (jlong)(buf.f_bavail*buf.f_bsize);
+#endif
+    (*env)->SetLongArrayRegion(env, sizes, 0, 4, array);
+    return totalSpaceIsEstimated;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -28,7 +28,7 @@
 #include <fileapi.h>
 #include <winerror.h>
 #else
-#include <sys/errno.h>
+#include <errno.h>
 #include <string.h>
 #if __APPLE__
 #include <sys/param.h>


### PR DESCRIPTION
I backport this for parity with 17.0.*-oracle.
This is a chain of 4 fixes to that test. I backport them as one piece as parts always cause errors here and there.

https://bugs.openjdk.org/browse/JDK-8291911 

I had to resolve because of the double ;;.
Also it is not problemlisted in 17.

https://bugs.openjdk.org/browse/JDK-8298619

I had to resolve JtregNativeJdk.gmk due to context.

https://bugs.openjdk.org/browse/JDK-8305646
https://bugs.openjdk.org/browse/JDK-8309216
both clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8298619](https://bugs.openjdk.org/browse/JDK-8298619) needs maintainer approval
- [x] [JDK-8305646](https://bugs.openjdk.org/browse/JDK-8305646) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8309216](https://bugs.openjdk.org/browse/JDK-8309216) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8291911](https://bugs.openjdk.org/browse/JDK-8291911) needs maintainer approval

### Issues
 * [JDK-8291911](https://bugs.openjdk.org/browse/JDK-8291911): java/io/File/GetXSpace.java fails with "53687091200 != 161051996160" (**Bug** - P3 - Approved)
 * [JDK-8298619](https://bugs.openjdk.org/browse/JDK-8298619): java/io/File/GetXSpace.java is failing (**Bug** - P4 - Approved)
 * [JDK-8305646](https://bugs.openjdk.org/browse/JDK-8305646): compile error on Alpine with gcc12 after 8298619 in libGetXSpace.c (**Bug** - P3 - Approved)
 * [JDK-8309216](https://bugs.openjdk.org/browse/JDK-8309216): Cast from jchar* to char* in test java/io/GetXSpace.java (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1912/head:pull/1912` \
`$ git checkout pull/1912`

Update a local copy of the PR: \
`$ git checkout pull/1912` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1912`

View PR using the GUI difftool: \
`$ git pr show -t 1912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1912.diff">https://git.openjdk.org/jdk17u-dev/pull/1912.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1912#issuecomment-1778608379)