### PR TITLE
8275509: ModuleDescriptor.hashCode isn't reproducible across builds

### DIFF
--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -327,7 +327,7 @@ public class ModuleDescriptor
          */
         @Override
         public int hashCode() {
-            int hash = name.hashCode() * 43 + mods.hashCode();
+            int hash = name.hashCode() * 43 + modsHashCode(mods);
             if (compiledVersion != null)
                 hash = hash * 43 + compiledVersion.hashCode();
             if (rawCompiledVersion != null)
@@ -505,7 +505,7 @@ public class ModuleDescriptor
          */
         @Override
         public int hashCode() {
-            int hash = mods.hashCode();
+            int hash = modsHashCode(mods);
             hash = hash * 43 + source.hashCode();
             return hash * 43 + targets.hashCode();
         }
@@ -708,7 +708,7 @@ public class ModuleDescriptor
          */
         @Override
         public int hashCode() {
-            int hash = mods.hashCode();
+            int hash = modsHashCode(mods);
             hash = hash * 43 + source.hashCode();
             return hash * 43 + targets.hashCode();
         }
@@ -2261,7 +2261,7 @@ public class ModuleDescriptor
         int hc = hash;
         if (hc == 0) {
             hc = name.hashCode();
-            hc = hc * 43 + Objects.hashCode(modifiers);
+            hc = hc * 43 + modsHashCode(modifiers);
             hc = hc * 43 + requires.hashCode();
             hc = hc * 43 + Objects.hashCode(packages);
             hc = hc * 43 + exports.hashCode();
@@ -2544,6 +2544,18 @@ public class ModuleDescriptor
                                                       .toLowerCase(Locale.ROOT)),
                               Stream.of(what)))
                 .collect(Collectors.joining(" "));
+    }
+
+    /**
+     * Generates and returns a hashcode for the enum instances. The returned hashcode
+     * is a value based on the {@link Enum#name() name} of each enum instance.
+     */
+    private static int modsHashCode(Iterable<? extends Enum<?>> enums) {
+        int h = 0;
+        for (Enum<?> e : enums) {
+            h = h * 43 + Objects.hashCode(e.name());
+        }
+        return h;
     }
 
     private static <T extends Object & Comparable<? super T>>

--- a/test/jdk/java/lang/module/ModuleDescriptorHashCodeTest.java
+++ b/test/jdk/java/lang/module/ModuleDescriptorHashCodeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.module.ModuleDescriptor;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+
+/**
+ * @test
+ * @bug 8275509
+ * @run testng ModuleDescriptorHashCodeTest
+ * @run testng/othervm -Xshare:off ModuleDescriptorHashCodeTest
+ * @summary Tests the ModuleDescriptor.hashCode() for boot layer modules
+ */
+public class ModuleDescriptorHashCodeTest {
+
+    /**
+     * Verifies that the ModuleDescriptor.hashCode() returned by a boot layer module is
+     * the same as that returned by a ModuleDescriptor constructed from the ModuleDescriptor.Builder
+     * for the same module.
+     */
+    @Test
+    public void testBootModuleDescriptor() throws Exception {
+        Set<Module> bootModules = ModuleLayer.boot().modules();
+        for (Module bootModule : bootModules) {
+            System.out.println("Testing module descriptor of boot module " + bootModule);
+            ModuleDescriptor bootMD = bootModule.getDescriptor();
+            ModuleDescriptor mdFromBuilder = fromModuleInfoClass(bootModule);
+            // verify that this object is indeed a different object instance than the boot module descriptor
+            // to prevent any artificial passing of the test
+            assertNotSame(mdFromBuilder, bootMD, "ModuleDescriptor loaded from boot layer and " +
+                    "one created from module-info.class unexpectedly returned the same instance");
+            assertEquals(mdFromBuilder.hashCode(), bootMD.hashCode(),
+                    "Unexpected ModuleDescriptor.hashCode() for " + mdFromBuilder);
+            assertEquals(mdFromBuilder.compareTo(bootMD), 0,
+                    "Unexpected ModuleDescriptor.compareTo() for " + mdFromBuilder);
+        }
+    }
+
+    // Returns a ModuleDescriptor parsed out of the module-info.class of the passed Module
+    private static ModuleDescriptor fromModuleInfoClass(Module module) throws IOException {
+        try (InputStream moduleInfo = module.getResourceAsStream("module-info.class")) {
+            if (moduleInfo == null) {
+                throw new RuntimeException("Could not locate module-info.class in " + module);
+            }
+            // internally calls ModuleDescriptor.Builder
+            return ModuleDescriptor.read(moduleInfo);
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [396132ff](https://github.com/openjdk/jdk/commit/396132ff1e56463ad195cac5c9ac8e2eac5a16e8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jaikiran Pai on 5 Nov 2021 and was reviewed by Alan Bateman and Magnus Ihse Bursie.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8275509](https://bugs.openjdk.org/browse/JDK-8275509) needs maintainer approval

### Issue
 * [JDK-8275509](https://bugs.openjdk.org/browse/JDK-8275509): ModuleDescriptor.hashCode isn't reproducible across builds (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1913/head:pull/1913` \
`$ git checkout pull/1913`

Update a local copy of the PR: \
`$ git checkout pull/1913` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1913`

View PR using the GUI difftool: \
`$ git pr show -t 1913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1913.diff">https://git.openjdk.org/jdk17u-dev/pull/1913.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1913#issuecomment-1777980026)