### PR TITLE
8313252: Java_sun_awt_windows_ThemeReader_paintBackground release resources in early returns

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -427,6 +427,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
             NULL, 0);
     if (hDibSection == NULL) {
         DTRACE_PRINTLN("Error creating DIB section");
+        DeleteDC(memDC);
         ReleaseDC(NULL,defaultDC);
         return;
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8313252](https://bugs.openjdk.org/browse/JDK-8313252) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313252](https://bugs.openjdk.org/browse/JDK-8313252): Java_sun_awt_windows_ThemeReader_paintBackground release resources in early returns (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1915/head:pull/1915` \
`$ git checkout pull/1915`

Update a local copy of the PR: \
`$ git checkout pull/1915` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1915`

View PR using the GUI difftool: \
`$ git pr show -t 1915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1915.diff">https://git.openjdk.org/jdk17u-dev/pull/1915.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1915#issuecomment-1778740192)