### PR TITLE
8228990: JFR: TestNetworkUtilizationEvent.java expects 2+ Network interfaces on Linux but finding 1

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -797,7 +797,6 @@ javax/script/Test7.java                                         8239361 generic-
 
 # jdk_jfr
 
-jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java          8228990,8229370    generic-all
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    generic-all
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64

--- a/test/jdk/jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNetworkUtilizationEvent.java
@@ -59,25 +59,17 @@ public class TestNetworkUtilizationEvent {
         String msg = "hello!";
         byte[] buf = msg.getBytes();
         forceEndChunk();
-        // Send a few packets both to the loopback address as well to an
-        // external
+        // Send a few packets to the loopback address
         DatagramPacket packet = new DatagramPacket(buf, buf.length, InetAddress.getLoopbackAddress(), 12345);
-        for (int i = 0; i < packetSendCount; ++i) {
-            socket.send(packet);
-        }
-        packet = new DatagramPacket(buf, buf.length, InetAddress.getByName("10.0.0.0"), 12345);
         for (int i = 0; i < packetSendCount; ++i) {
             socket.send(packet);
         }
         forceEndChunk();
         socket.close();
-        // Now there should have been traffic on at least two different
-        // interfaces
         recording.stop();
 
         Set<String> networkInterfaces = new HashSet<>();
         List<RecordedEvent> events = Events.fromRecording(recording);
-        Events.hasEvents(events);
         for (RecordedEvent event : events) {
             System.out.println(event);
             Events.assertField(event, "writeRate").atLeast(0L).atMost(1000L * Integer.MAX_VALUE);
@@ -87,13 +79,10 @@ public class TestNetworkUtilizationEvent {
                 networkInterfaces.add(event.getString("networkInterface"));
             }
         }
-
-        if (Platform.isWindows()) {
-            // Windows does not track statistics for the loopback
-            // interface
+        // Windows does not track statistics for the loopback
+        // interface
+        if (!Platform.isWindows()) {
             Asserts.assertGreaterThanOrEqual(networkInterfaces.size(), 1);
-        } else {
-            Asserts.assertGreaterThanOrEqual(networkInterfaces.size(), 2);
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

Resolved Problemlist. It mentioned another bug that was closed as duplicate. Will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8228990](https://bugs.openjdk.org/browse/JDK-8228990) needs maintainer approval

### Issue
 * [JDK-8228990](https://bugs.openjdk.org/browse/JDK-8228990): JFR: TestNetworkUtilizationEvent.java expects 2+ Network interfaces on Linux but finding 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1918/head:pull/1918` \
`$ git checkout pull/1918`

Update a local copy of the PR: \
`$ git checkout pull/1918` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1918`

View PR using the GUI difftool: \
`$ git pr show -t 1918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1918.diff">https://git.openjdk.org/jdk17u-dev/pull/1918.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1918#issuecomment-1779119174)