### PR TITLE
8310265: (process) jspawnhelper should not use argv[0]

### DIFF
--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -134,10 +134,10 @@ int main(int argc, char *argv[]) {
     ChildStuff c;
     int t;
     struct stat buf;
-    /* argv[0] contains the fd number to read all the child info */
+    /* argv[1] contains the fd number to read all the child info */
     int r, fdin, fdout;
 
-    r = sscanf (argv[argc-1], "%d:%d", &fdin, &fdout);
+    r = sscanf (argv[1], "%d:%d", &fdin, &fdout);
     if (r == 2 && fcntl(fdin, F_GETFD) != -1) {
         fstat(fdin, &buf);
         if (!S_ISFIFO(buf.st_mode))

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -491,16 +491,20 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     jboolean isCopy;
     int i, offset, rval, bufsize, magic;
     char *buf, buf1[16];
-    char *hlpargs[2];
+    char *hlpargs[3];
     SpawnInfo sp;
 
     /* need to tell helper which fd is for receiving the childstuff
      * and which fd to send response back on
      */
     snprintf(buf1, sizeof(buf1), "%d:%d", c->childenv[0], c->fail[1]);
-    /* put the fd string as argument to the helper cmd */
-    hlpargs[0] = buf1;
-    hlpargs[1] = 0;
+    /* NULL-terminated argv array.
+     * argv[0] contains path to jspawnhelper, to follow conventions.
+     * argv[1] contains the fd string as argument to jspawnhelper
+     */
+    hlpargs[0] = (char*)helperpath;
+    hlpargs[1] = buf1;
+    hlpargs[2] = NULL;
 
     /* Following items are sent down the pipe to the helper
      * after it is spawned.


### PR DESCRIPTION
That patch makes sure that launching processes from Java works when running using QEMU user-space emulation. See
https://mail.openjdk.org/pipermail/core-libs-dev/2023-June/107738.html for details of the bug.

The backport doesn't apply cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8310265](https://bugs.openjdk.org/browse/JDK-8310265) needs maintainer approval

### Issue
 * [JDK-8310265](https://bugs.openjdk.org/browse/JDK-8310265): (process) jspawnhelper should not use argv[0] (**Bug** - P3 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1922/head:pull/1922` \
`$ git checkout pull/1922`

Update a local copy of the PR: \
`$ git checkout pull/1922` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1922`

View PR using the GUI difftool: \
`$ git pr show -t 1922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1922.diff">https://git.openjdk.org/jdk17u-dev/pull/1922.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1922#issuecomment-1780950952)