### PR TITLE
6445283: ProgressMonitorInputStream not large file aware (>2GB)

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ProgressMonitorInputStream.java
+++ b/src/java.desktop/share/classes/javax/swing/ProgressMonitorInputStream.java
@@ -67,7 +67,8 @@ public class ProgressMonitorInputStream extends FilterInputStream
     private ProgressMonitor monitor;
     private int             nread = 0;
     private int             size = 0;
-
+    Component parentComponent;
+    Object message;
 
     /**
      * Constructs an object to monitor the progress of an input stream.
@@ -88,6 +89,8 @@ public class ProgressMonitorInputStream extends FilterInputStream
         catch(IOException ioe) {
             size = 0;
         }
+        this.parentComponent = parentComponent;
+        this.message = message;
         monitor = new ProgressMonitor(parentComponent, message, null, 0, size);
     }
 
@@ -119,6 +122,25 @@ public class ProgressMonitorInputStream extends FilterInputStream
         return c;
     }
 
+    private void setProgress(int nr) throws IOException {
+        if (nr > 0) {
+            if (nread + nr > nread) {
+                monitor.setProgress(nread += nr);
+            } else {
+                size = in.available();
+                nread = 0;
+                monitor.close();
+                monitor = new ProgressMonitor(this.parentComponent,
+                                              this.message, null, 0, size);
+            }
+        }
+        if (monitor.isCanceled()) {
+            InterruptedIOException exc =
+                    new InterruptedIOException("progress");
+            exc.bytesTransferred = nread;
+            throw exc;
+        }
+    }
 
     /**
      * Overrides <code>FilterInputStream.read</code>
@@ -126,13 +148,7 @@ public class ProgressMonitorInputStream extends FilterInputStream
      */
     public int read(byte[] b) throws IOException {
         int nr = in.read(b);
-        if (nr > 0) monitor.setProgress(nread += nr);
-        if (monitor.isCanceled()) {
-            InterruptedIOException exc =
-                                    new InterruptedIOException("progress");
-            exc.bytesTransferred = nread;
-            throw exc;
-        }
+        setProgress(nr);
         return nr;
     }
 
@@ -145,13 +161,7 @@ public class ProgressMonitorInputStream extends FilterInputStream
                     int off,
                     int len) throws IOException {
         int nr = in.read(b, off, len);
-        if (nr > 0) monitor.setProgress(nread += nr);
-        if (monitor.isCanceled()) {
-            InterruptedIOException exc =
-                                    new InterruptedIOException("progress");
-            exc.bytesTransferred = nread;
-            throw exc;
-        }
+        setProgress(nr);
         return nr;
     }
 
@@ -162,7 +172,13 @@ public class ProgressMonitorInputStream extends FilterInputStream
      */
     public long skip(long n) throws IOException {
         long nr = in.skip(n);
-        if (nr > 0) monitor.setProgress(nread += nr);
+        if (nr > 0) {
+            if ((int)(nread + nr) > nread) {
+                monitor.setProgress(nread += nr);
+            } else {
+                monitor.setProgress(monitor.getMaximum());
+            }
+        }
         return nr;
     }
 

--- a/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8054572
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests if JComboBox displays correctly when editable/non-editable
+ * @run main/manual ProgressTest
+ */
+
+import java.io.InputStream;
+
+import javax.swing.JFrame;
+import javax.swing.ProgressMonitorInputStream;
+import javax.swing.SwingUtilities;
+
+public class ProgressTest {
+
+    private static final String instructionsText =
+            "A ProgressMonitor will be shown." +
+            " If it shows blank progressbar after 2048MB bytes read,"+
+            " press Fail else press Pass";
+
+    private static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+
+        PassFailJFrame pfjFrame = new PassFailJFrame("JScrollPane "
+                + "Test Instructions", instructionsText, 5);
+
+        final long SIZE = (long) (Integer.MAX_VALUE * 1.5);
+
+        InputStream fileIn = new InputStream() {
+            long read = 0;
+
+            @Override
+            public int available() {
+                return (int) Math.min(SIZE - read, Integer.MAX_VALUE);
+            }
+
+            @Override
+            public int read() {
+                return (SIZE - read++ > 0) ? 1 : -1;
+            }
+        };
+
+        ProgressMonitorInputStream pmis =
+            new ProgressMonitorInputStream(null, "Reading File", fileIn);
+
+        Thread thread = new Thread() {
+            public void run() {
+                byte[] buffer = new byte[512];
+                int nb = 0;
+                long total = 0;
+                while (true) {
+                    try {
+                        nb = pmis.read(buffer);
+                    } catch (Exception e){}
+                    if (nb == 0) break;
+                    total += nb;
+
+                    pmis.getProgressMonitor().setNote(total/(1024*1024)+" MB Read");
+                }
+            }
+        };
+        thread.start();
+        pfjFrame.awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this well reproducible fix. 
Test needs follow-up JDK-8298905

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-6445283](https://bugs.openjdk.org/browse/JDK-6445283) needs maintainer approval

### Issue
 * [JDK-6445283](https://bugs.openjdk.org/browse/JDK-6445283): ProgressMonitorInputStream not large file aware (&gt;2GB) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1924/head:pull/1924` \
`$ git checkout pull/1924`

Update a local copy of the PR: \
`$ git checkout pull/1924` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1924`

View PR using the GUI difftool: \
`$ git pr show -t 1924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1924.diff">https://git.openjdk.org/jdk17u-dev/pull/1924.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1924#issuecomment-1780978365)