### PR TITLE
8312612: handle WideCharToMultiByte return values

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Font.cpp
@@ -1790,10 +1790,16 @@ void CCombinedSegTable::GetEUDCFileName(LPWSTR lpszFileName, int cchFileName)
     DWORD dwBytes = sizeof(szFileName);
     // try Typeface-specific EUDC font
     char szTmpName[80];
-    VERIFY(::WideCharToMultiByte(CP_ACP, 0, szFamilyName, -1,
-        szTmpName, sizeof(szTmpName), NULL, NULL));
-    LONG lStatus = ::RegQueryValueExA(hKey, (LPCSTR) szTmpName,
-        NULL, &dwType, szFileName, &dwBytes);
+    int nb = ::WideCharToMultiByte(CP_ACP, 0, szFamilyName, -1,
+        szTmpName, sizeof(szTmpName), NULL, NULL);
+    VERIFY(nb);
+
+    LONG lStatus = 1;
+    if (nb > 0) {
+        lStatus = ::RegQueryValueExA(hKey, (LPCSTR) szTmpName,
+                                     NULL, &dwType, szFileName, &dwBytes);
+    }
+
     BOOL fUseDefault = FALSE;
     if (lStatus != ERROR_SUCCESS){ // try System default EUDC font
         if (m_fTTEUDCFileExist == FALSE)

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3925,9 +3925,13 @@ static void throwPrinterException(JNIEnv *env, DWORD err) {
                   sizeof(t_errStr),
                   NULL );
 
-    WideCharToMultiByte(CP_UTF8, 0, t_errStr, -1,
+    int nb = WideCharToMultiByte(CP_UTF8, 0, t_errStr, -1,
                         errStr, sizeof(errStr), NULL, NULL);
-    JNU_ThrowByName(env, PRINTEREXCEPTION_STR, errStr);
+    if (nb > 0) {
+        JNU_ThrowByName(env, PRINTEREXCEPTION_STR, errStr);
+    } else {
+        JNU_ThrowByName(env, PRINTEREXCEPTION_STR, "secondary error during OS message extraction");
+    }
 }
 
 

--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Charset_Util.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_Charset_Util.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,16 +35,25 @@ LPSTR UnicodeToUTF8(const LPCWSTR lpUnicodeStr)
 {
     DWORD dwUTF8Len = WideCharToMultiByte(CP_UTF8, 0, lpUnicodeStr, -1, nullptr, 0, nullptr, nullptr);
     LPSTR lpUTF8Str = new CHAR[dwUTF8Len];
+    if (lpUTF8Str == NULL) return NULL;
     memset(lpUTF8Str, 0, sizeof(CHAR) * (dwUTF8Len));
-    WideCharToMultiByte(CP_UTF8, 0, lpUnicodeStr, -1, lpUTF8Str, dwUTF8Len, nullptr, nullptr);
-    return lpUTF8Str;
+    int nb = WideCharToMultiByte(CP_UTF8, 0, lpUnicodeStr, -1, lpUTF8Str, dwUTF8Len, nullptr, nullptr);
+    if (nb > 0) {
+        return lpUTF8Str;
+    }
+    delete[] lpUTF8Str;
+    return NULL;
 }
 
 void UnicodeToUTF8AndCopy(LPSTR dest, LPCWSTR src, SIZE_T maxLength) {
     LPSTR utf8EncodedName = UnicodeToUTF8(src);
-    strncpy(dest, utf8EncodedName, maxLength - 1);
-    delete[] utf8EncodedName;
-    dest[maxLength - 1] = '\0';
+    if (utf8EncodedName != NULL) {
+        strncpy(dest, utf8EncodedName, maxLength - 1);
+        delete[] utf8EncodedName;
+        dest[maxLength - 1] = '\0';
+    } else {
+        if (maxLength > 0) dest[0] = '\0';
+    }
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312612](https://bugs.openjdk.org/browse/JDK-8312612) needs maintainer approval

### Issue
 * [JDK-8312612](https://bugs.openjdk.org/browse/JDK-8312612): handle WideCharToMultiByte return values (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1928/head:pull/1928` \
`$ git checkout pull/1928`

Update a local copy of the PR: \
`$ git checkout pull/1928` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1928`

View PR using the GUI difftool: \
`$ git pr show -t 1928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1928.diff">https://git.openjdk.org/jdk17u-dev/pull/1928.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1928#issuecomment-1782744364)