### PR TITLE
8298905: Test "java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java" fails because the frames of instruction does not display

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java
@@ -54,6 +54,7 @@ public class PrintARGBImage implements Printable {
                     """;
 
             PassFailJFrame passFailJFrame = new PassFailJFrame(instruction, 10);
+            PassFailJFrame.positionTestWindow(null, PassFailJFrame.Position.HORIZONTAL);
             try {
                 PrinterJob pj = PrinterJob.getPrinterJob();
                 pj.setPrintable(new PrintARGBImage());

--- a/test/jdk/java/awt/print/PrinterJob/PageRangesDlgTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageRangesDlgTest.java
@@ -81,6 +81,7 @@ public class PageRangesDlgTest implements Printable {
                 """;
 
         PassFailJFrame passFailJFrame = new PassFailJFrame(instruction, 10);
+        PassFailJFrame.positionTestWindow(null, PassFailJFrame.Position.HORIZONTAL);
         showPrintDialogs();
         passFailJFrame.awaitAndCheck();
     }

--- a/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressTest.java
@@ -22,32 +22,29 @@
  */
 
 /* @test
- * @bug 8054572
+ * @bug 6445283
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
- * @summary Tests if JComboBox displays correctly when editable/non-editable
+ * @summary Tests if ProgressMonitorInputStream reports progress accurately
  * @run main/manual ProgressTest
  */
 
 import java.io.InputStream;
 
-import javax.swing.JFrame;
 import javax.swing.ProgressMonitorInputStream;
-import javax.swing.SwingUtilities;
 
 public class ProgressTest {
 
     private static final String instructionsText =
-            "A ProgressMonitor will be shown." +
-            " If it shows blank progressbar after 2048MB bytes read,"+
+            "A ProgressMonitor will be shown.\n" +
+            " If it shows blank progressbar after 2048MB bytes read,\n"+
             " press Fail else press Pass";
-
-    private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
 
         PassFailJFrame pfjFrame = new PassFailJFrame("JScrollPane "
                 + "Test Instructions", instructionsText, 5);
+        PassFailJFrame.positionTestWindow(null, PassFailJFrame.Position.VERTICAL);
 
         final long SIZE = (long) (Integer.MAX_VALUE * 1.5);
 
@@ -85,6 +82,7 @@ public class ProgressTest {
             }
         };
         thread.start();
+
         pfjFrame.awaitAndCheck();
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8298905](https://bugs.openjdk.org/browse/JDK-8298905) needs maintainer approval

### Issue
 * [JDK-8298905](https://bugs.openjdk.org/browse/JDK-8298905): Test "java/awt/print/PrinterJob/ImagePrinting/PrintARGBImage.java" fails because the frames of instruction does not display (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1932/head:pull/1932` \
`$ git checkout pull/1932`

Update a local copy of the PR: \
`$ git checkout pull/1932` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1932`

View PR using the GUI difftool: \
`$ git pr show -t 1932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1932.diff">https://git.openjdk.org/jdk17u-dev/pull/1932.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1932#issuecomment-1784993227)