### PR TITLE
8269425: 2 jdk/jfr/api/consumer/streaming tests failed to attach

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import jdk.jfr.consumer.EventStream;
  * @library /test/lib /test/jdk
  * @modules jdk.jfr jdk.attach java.base/jdk.internal.misc
  *
- * @run main/othervm jdk.jfr.api.consumer.streaming.TestJVMCrash
+ * @run main/othervm -Dsun.tools.attach.attachTimeout=100000 jdk.jfr.api.consumer.streaming.TestJVMCrash
  */
 public class TestJVMCrash {
 

--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMExit.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import jdk.jfr.consumer.EventStream;
  * @library /test/lib /test/jdk
  * @modules jdk.jfr jdk.attach java.base/jdk.internal.misc
  *
- * @run main/othervm jdk.jfr.api.consumer.streaming.TestJVMExit
+ * @run main/othervm -Dsun.tools.attach.attachTimeout=100000 jdk.jfr.api.consumer.streaming.TestJVMExit
  */
 public class TestJVMExit {
 

--- a/test/lib/jdk/test/lib/jfr/StreamingUtils.java
+++ b/test/lib/jdk/test/lib/jfr/StreamingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,8 +51,8 @@ public class StreamingUtils {
             try {
                 VirtualMachine vm = VirtualMachine.attach(String.valueOf(process.pid()));
                 String repo = vm.getSystemProperties().getProperty("jdk.jfr.repository");
+                vm.detach();
                 if (repo != null) {
-                    vm.detach();
                     System.out.println("JFR repository: " + repo);
                     return Paths.get(repo);
                 }


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8269425](https://bugs.openjdk.org/browse/JDK-8269425) needs maintainer approval

### Issue
 * [JDK-8269425](https://bugs.openjdk.org/browse/JDK-8269425): 2 jdk/jfr/api/consumer/streaming tests failed to attach (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1935/head:pull/1935` \
`$ git checkout pull/1935`

Update a local copy of the PR: \
`$ git checkout pull/1935` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1935`

View PR using the GUI difftool: \
`$ git pr show -t 1935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1935.diff">https://git.openjdk.org/jdk17u-dev/pull/1935.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1935#issuecomment-1785214440)