### PR TITLE
8301457: Code in SendPortZero.java is uncommented even after JDK-8236852 was fixed

### DIFF
--- a/test/jdk/java/net/DatagramSocket/SendPortZero.java
+++ b/test/jdk/java/net/DatagramSocket/SendPortZero.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
 import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.net.SocketException;
@@ -70,7 +71,7 @@ public class SendPortZero {
 
         // Addresses
         loopbackAddr = InetAddress.getLoopbackAddress();
-        //wildcardAddr = new InetSocketAddress(0).getAddress();
+        wildcardAddr = new InetSocketAddress(0).getAddress();
 
         // Packets
         // loopback w/port 0
@@ -78,29 +79,30 @@ public class SendPortZero {
         loopbackZeroPkt.setAddress(loopbackAddr);
         loopbackZeroPkt.setPort(0);
 
-        /*
-        //Commented until JDK-8236852 is fixed
-
         // wildcard w/port 0
         wildcardZeroPkt = new DatagramPacket(buf, 0, buf.length);
         wildcardZeroPkt.setAddress(wildcardAddr);
         wildcardZeroPkt.setPort(0);
 
-        //Commented until JDK-8236807 is fixed
-
         // wildcard addr w/valid port
+        // Not currently tested. See JDK-8236807
         wildcardValidPkt = new DatagramPacket(buf, 0, buf.length);
-        var addr = socket.getAddress();
-        wildcardValidPkt.setAddress(addr);
-        wildcardValidPkt.setPort(socket.getLocalPort());
-      */
+        wildcardValidPkt.setAddress(wildcardAddr);
+        wildcardValidPkt.setPort(datagramSocket.getLocalPort());
     }
 
     @DataProvider(name = "data")
     public Object[][] variants() {
         return new Object[][]{
                 { datagramSocket,        loopbackZeroPkt },
+                { datagramSocket,        wildcardZeroPkt },
+                // Re-enable when JDK-8236807 fixed
+                //{ datagramSocket,        wildcardValidPkt },
+
                 { datagramSocketAdaptor, loopbackZeroPkt },
+                { datagramSocketAdaptor, wildcardZeroPkt },
+                // Re-enable when JDK-8236807 fixed
+                //{ datagramSocketAdaptor, wildcardValidPkt },
         };
     }
 

--- a/test/jdk/java/net/MulticastSocket/SendPortZero.java
+++ b/test/jdk/java/net/MulticastSocket/SendPortZero.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.MulticastSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
 import java.net.SocketException;
 import java.net.SocketPermission;
@@ -69,7 +70,7 @@ public class SendPortZero {
 
         // Addresses
         loopbackAddr = InetAddress.getLoopbackAddress();
-        //wildcardAddr = new InetSocketAddress(0).getAddress();
+        wildcardAddr = new InetSocketAddress(0).getAddress();
 
         // Packets
         // loopback w/port 0
@@ -77,28 +78,25 @@ public class SendPortZero {
         loopbackZeroPkt.setAddress(loopbackAddr);
         loopbackZeroPkt.setPort(0);
 
-        /*
-        //Commented until JDK-8236852 is fixed
-
         // wildcard w/port 0
         wildcardZeroPkt = new DatagramPacket(buf, 0, buf.length);
         wildcardZeroPkt.setAddress(wildcardAddr);
         wildcardZeroPkt.setPort(0);
 
-        //Commented until JDK-8236807 is fixed
-
         // wildcard addr w/valid port
+        // Not currently tested. See JDK-8236807
         wildcardValidPkt = new DatagramPacket(buf, 0, buf.length);
-        var addr = socket.getAddress();
-        wildcardValidPkt.setAddress(addr);
-        wildcardValidPkt.setPort(socket.getLocalPort());
-      */
+        wildcardValidPkt.setAddress(wildcardAddr);
+        wildcardValidPkt.setPort(multicastSocket.getLocalPort());
     }
 
     @DataProvider(name = "data")
     public Object[][] variants() {
         return new Object[][]{
-                { multicastSocket,       loopbackZeroPkt }
+                { multicastSocket,       loopbackZeroPkt },
+                { multicastSocket,       wildcardZeroPkt },
+                // Not currently tested. See JDK-8236807
+                //{ multicastSocket,       wildcardValidPkt }
         };
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301457](https://bugs.openjdk.org/browse/JDK-8301457) needs maintainer approval

### Issue
 * [JDK-8301457](https://bugs.openjdk.org/browse/JDK-8301457): Code in SendPortZero.java is uncommented even after JDK-8236852 was fixed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1937/head:pull/1937` \
`$ git checkout pull/1937`

Update a local copy of the PR: \
`$ git checkout pull/1937` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1937`

View PR using the GUI difftool: \
`$ git pr show -t 1937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1937.diff">https://git.openjdk.org/jdk17u-dev/pull/1937.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1937#issuecomment-1785416140)