### PR TITLE
8317327: Remove JT_JAVA dead code in jib-profiles.js

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -917,10 +917,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: input.build_os,
             target_cpu: input.build_cpu,
             dependencies: [ "jtreg", "gnumake", "boot_jdk", "devkit", "jib" ],
-            labels: "test",
-            environment: {
-                "JT_JAVA": common.boot_jdk_home
-            }
+            labels: "test"
         }
     };
     profiles = concatObjects(profiles, testOnlyProfiles);


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317327](https://bugs.openjdk.org/browse/JDK-8317327) needs maintainer approval

### Issue
 * [JDK-8317327](https://bugs.openjdk.org/browse/JDK-8317327): Remove JT_JAVA dead code in jib-profiles.js (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1938/head:pull/1938` \
`$ git checkout pull/1938`

Update a local copy of the PR: \
`$ git checkout pull/1938` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1938`

View PR using the GUI difftool: \
`$ git pr show -t 1938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1938.diff">https://git.openjdk.org/jdk17u-dev/pull/1938.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1938#issuecomment-1787103340)