### PR TITLE
8318953: RISC-V: Small refactoring for MacroAssembler::test_bit

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4518,11 +4518,17 @@ void MacroAssembler::cmp_l2i(Register dst, Register src1, Register src2, Registe
   bind(done);
 }
 
-void MacroAssembler::test_bit(Register Rd, Register Rs, uint32_t bit_pos, Register tmp) {
+void MacroAssembler::test_bit(Register Rd, Register Rs, uint32_t bit_pos) {
   assert(bit_pos < 64, "invalid bit range");
   if (UseZbs) {
     bexti(Rd, Rs, bit_pos);
     return;
   }
-  andi(Rd, Rs, 1UL << bit_pos, tmp);
+  int64_t imm = (int64_t)(1UL << bit_pos);
+  if (is_simm12(imm)) {
+    and_imm12(Rd, Rs, imm);
+  } else {
+    srli(Rd, Rs, bit_pos);
+    and_imm12(Rd, Rd, 1);
+  }
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1144,7 +1144,7 @@ public:
   void shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
 
   // test single bit in Rs, result is set to Rd
-  void test_bit(Register Rd, Register Rs, uint32_t bit_pos, Register tmp = t0);
+  void test_bit(Register Rd, Register Rs, uint32_t bit_pos);
 
   // Here the float instructions with safe deal with some exceptions.
   // e.g. convert from NaN, +Inf, -Inf to int, float, double

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2318,7 +2318,7 @@ encode %{
     if (DiagnoseSyncOnValueBasedClasses != 0) {
       __ load_klass(flag, oop);
       __ lwu(flag, Address(flag, Klass::access_flags_offset()));
-      __ test_bit(flag, flag, exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS), tmp /* tmp */);
+      __ test_bit(flag, flag, exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
       __ bnez(flag, cont, true /* is_far */);
     }
 


### PR DESCRIPTION
Hi, this backport to make the test_bit assember function more simpler and to improve performance when the parameter (1UL << bit_pos) exceeds 32-bit range. This is a risc-v specific change.
Backport is not clean. because the fastlock needs to call test_bit, in the mainline version, the fastlock function is renamed and moved to c2_MacroAssembler_riscv.cpp, but in jdk17u-dev, fastlock is still in riscv.ad.
### Testing:
qemu 8.1.50:
- [x] Tier1 tests (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318953](https://bugs.openjdk.org/browse/JDK-8318953) needs maintainer approval

### Issue
 * [JDK-8318953](https://bugs.openjdk.org/browse/JDK-8318953): RISC-V: Small refactoring for MacroAssembler::test_bit (**Enhancement** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1941/head:pull/1941` \
`$ git checkout pull/1941`

Update a local copy of the PR: \
`$ git checkout pull/1941` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1941`

View PR using the GUI difftool: \
`$ git pr show -t 1941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1941.diff">https://git.openjdk.org/jdk17u-dev/pull/1941.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1941#issuecomment-1789985004)