### PR TITLE
8307123: Fix deprecation warnings in DPrinter

### DIFF
--- a/test/langtools/tools/javac/lib/DPrinter.java
+++ b/test/langtools/tools/javac/lib/DPrinter.java
@@ -601,6 +601,7 @@ public class DPrinter {
     protected Object getField(Object o, Class<?> clazz, String name) {
         try {
             Field f = clazz.getDeclaredField(name);
+            @SuppressWarnings("deprecation")
             boolean prev = f.isAccessible();
             f.setAccessible(true);
             try {
@@ -618,6 +619,7 @@ public class DPrinter {
     protected Object callMethod(Object o, Class<?> clazz, String name) {
         try {
             Method m = clazz.getDeclaredMethod(name);
+            @SuppressWarnings("deprecation")
             boolean prev = m.isAccessible();
             m.setAccessible(true);
             try {


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8307123](https://bugs.openjdk.org/browse/JDK-8307123) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307123](https://bugs.openjdk.org/browse/JDK-8307123): Fix deprecation warnings in DPrinter (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1943/head:pull/1943` \
`$ git checkout pull/1943`

Update a local copy of the PR: \
`$ git checkout pull/1943` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1943`

View PR using the GUI difftool: \
`$ git pr show -t 1943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1943.diff">https://git.openjdk.org/jdk17u-dev/pull/1943.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1943#issuecomment-1791068982)