### PR TITLE
8161536: sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java fails with ProviderException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -630,8 +630,6 @@ com/sun/nio/sctp/SctpChannel/SocketOptionTests.java             8141694 linux-al
 
 # jdk_security
 
-sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8161536 generic-all
-
 javax/net/ssl/DTLS/CipherSuite.java                             8202059 macosx-x64
 
 sun/security/smartcardio/TestChannel.java                       8039280 generic-all

--- a/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
+++ b/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1"
  *      ClientJSSEServerJSSE
  * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1"
- *      ClientJSSEServerJSSE sm policy
+ *      -Djava.security.manager=allow ClientJSSEServerJSSE sm policy
  */
 
 import java.security.Provider;


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

Resolved ProblemList. Might be recognized clean, if not will mark as such.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8161536](https://bugs.openjdk.org/browse/JDK-8161536) needs maintainer approval

### Issue
 * [JDK-8161536](https://bugs.openjdk.org/browse/JDK-8161536): sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java fails with ProviderException (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1944/head:pull/1944` \
`$ git checkout pull/1944`

Update a local copy of the PR: \
`$ git checkout pull/1944` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1944`

View PR using the GUI difftool: \
`$ git pr show -t 1944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1944.diff">https://git.openjdk.org/jdk17u-dev/pull/1944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1944#issuecomment-1791079684)