### PR TITLE
8277307: Pre shared key sent under both session_ticket and pre_shared_key extensions

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -403,11 +403,13 @@ final class SessionTicketExtension {
             chc.statelessResumption = true;
 
             // If resumption is not in progress, return an empty value
-            if (!chc.isResumption || chc.resumingSession == null) {
+            if (!chc.isResumption || chc.resumingSession == null
+                    || chc.resumingSession.getPskIdentity() == null
+                    || chc.resumingSession.getProtocolVersion().useTLS13PlusSpec()) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                     SSLLogger.fine("Stateless resumption supported");
                 }
-                return new SessionTicketSpec().getEncoded();
+                return new byte[0];
             }
 
             if (chc.localSupportedSignAlgs == null) {


### PR DESCRIPTION
Requesting backport for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8277307](https://bugs.openjdk.org/browse/JDK-8277307) needs maintainer approval

### Issue
 * [JDK-8277307](https://bugs.openjdk.org/browse/JDK-8277307): Pre shared key sent under both session_ticket and pre_shared_key extensions (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1946/head:pull/1946` \
`$ git checkout pull/1946`

Update a local copy of the PR: \
`$ git checkout pull/1946` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1946`

View PR using the GUI difftool: \
`$ git pr show -t 1946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1946.diff">https://git.openjdk.org/jdk17u-dev/pull/1946.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1946#issuecomment-1794644370)