### PR TITLE
8299241: jdk/jfr/api/consumer/streaming/TestJVMCrash.java generates unnecessary core file

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMCrash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class TestJVMCrash {
     public static void main(String... args) throws Exception  {
         int id = 1;
         while (true) {
-            try (TestProcess process = new TestProcess("crash-application-" + id++))  {
+            try (TestProcess process = new TestProcess("crash-application-" + id++, false /* createCore */))  {
                 AtomicInteger eventCounter = new AtomicInteger();
                 try (EventStream es = EventStream.openRepository(process.getRepository())) {
                     // Start from first event in repository

--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestProcess.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,11 +54,16 @@ public final class TestProcess implements AutoCloseable {
     private final Path path;
 
     public TestProcess(String name) throws IOException {
+        this(name, true /* createCore */);
+    }
+
+    public TestProcess(String name, boolean createCore) throws IOException {
         this.path = Paths.get("action-" + System.currentTimeMillis()).toAbsolutePath();
         String[] args = {
                 "--add-exports",
                 "java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-XX:StartFlightRecording:settings=none",
+                "-XX:" + (createCore ? "+" : "-") + "CreateCoredumpOnCrash",
                 TestProcess.class.getName(), path.toString()
             };
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(args);


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8299241](https://bugs.openjdk.org/browse/JDK-8299241) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299241](https://bugs.openjdk.org/browse/JDK-8299241): jdk/jfr/api/consumer/streaming/TestJVMCrash.java generates unnecessary core file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1947/head:pull/1947` \
`$ git checkout pull/1947`

Update a local copy of the PR: \
`$ git checkout pull/1947` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1947`

View PR using the GUI difftool: \
`$ git pr show -t 1947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1947.diff">https://git.openjdk.org/jdk17u-dev/pull/1947.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1947#issuecomment-1794795687)