### PR TITLE
8312126: NullPointerException in CertStore.getCRLs after 8297955

### DIFF
--- a/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
+++ b/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
@@ -779,9 +779,13 @@ final class LDAPCertStoreImpl {
                 } catch (IllegalArgumentException e) {
                     continue;
                 }
-            } else {
+            } else if (nameObject instanceof String) {
                 issuerName = (String)nameObject;
+            } else {
+                throw new CertStoreException(
+                    "unrecognized issuerName: must be String or byte[]");
             }
+
             // If all we want is CA certs, try to get the (probably shorter) ARL
             Collection<X509CRL> entryCRLs = Collections.emptySet();
             if (certChecking == null || certChecking.getBasicConstraints() != -1) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3c743cfe](https://github.com/openjdk/jdk/commit/3c743cfea00692d0b938cb1cbde936084eecf369) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sean Mullan on 15 Sep 2023 and was reviewed by Weijun Wang.

It is a simple fix and clean backport for a regression introduced by [JDK-8297955](https://bugs.openjdk.org/browse/JDK-8297955) which was backported in 17.0.8. The new code in JDK-8297955 failed to catch a `null  IssuerName`, allowing a `NullPointerException` to be thrown instead of the specified `CertStoreException`.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312126](https://bugs.openjdk.org/browse/JDK-8312126) needs maintainer approval

### Issue
 * [JDK-8312126](https://bugs.openjdk.org/browse/JDK-8312126): NullPointerException in CertStore.getCRLs after 8297955 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1951/head:pull/1951` \
`$ git checkout pull/1951`

Update a local copy of the PR: \
`$ git checkout pull/1951` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1951`

View PR using the GUI difftool: \
`$ git pr show -t 1951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1951.diff">https://git.openjdk.org/jdk17u-dev/pull/1951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1951#issuecomment-1800742924)