### PR TITLE
8316461: Fix: make test outputs TEST SUCCESS after unsuccessful exit

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -841,8 +841,9 @@ define SetupRunJtregTestBody
     endif
   endif
 
-  clean-workdir-$1:
+  clean-outputdirs-$1:
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
+	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
   $1_COMMAND_LINE := \
       $$(JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
@@ -887,7 +888,7 @@ define SetupRunJtregTestBody
         done
   endif
 
-  run-test-$1: pre-run-test clean-workdir-$1
+  run-test-$1: pre-run-test clean-outputdirs-$1
 	$$(call LogWarn)
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR) \
@@ -924,9 +925,9 @@ define SetupRunJtregTestBody
 	  $$(eval $1_TOTAL := 1) \
 	)
 
-  $1: run-test-$1 parse-test-$1 clean-workdir-$1
+  $1: run-test-$1 parse-test-$1 clean-outputdirs-$1
 
-  TARGETS += $1 run-test-$1 parse-test-$1 clean-workdir-$1
+  TARGETS += $1 run-test-$1 parse-test-$1 clean-outputdirs-$1
   TEST_TARGETS += parse-test-$1
 
 endef


### PR DESCRIPTION
I backport this for parity with 17.0.10-oracle.

Locally, I could patch it clean, but the /backport command did not manage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316461](https://bugs.openjdk.org/browse/JDK-8316461) needs maintainer approval

### Issue
 * [JDK-8316461](https://bugs.openjdk.org/browse/JDK-8316461): Fix: make test outputs TEST SUCCESS after unsuccessful exit (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1953/head:pull/1953` \
`$ git checkout pull/1953`

Update a local copy of the PR: \
`$ git checkout pull/1953` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1953`

View PR using the GUI difftool: \
`$ git pr show -t 1953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1953.diff">https://git.openjdk.org/jdk17u-dev/pull/1953.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1953#issuecomment-1801301843)