### PR TITLE
8268433: serviceability/dcmd/framework/VMVersionTest.java fails with Unable to send object throw not established PipeIO Listener Thread connection

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -44,7 +44,3 @@ serviceability/sa/TestJmapCoreMetaspace.java                  8268722,8268636   
 serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#id0                       8248912   generic-all
 serviceability/sa/ClhsdbPstack.java#id1                       8248912   generic-all
-
-serviceability/dcmd/framework/HelpTest.java                   8268433 windows-x64
-serviceability/dcmd/framework/InvalidCommandTest.java         8268433 windows-x64
-serviceability/dcmd/framework/VMVersionTest.java              8268433 windows-x64

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessLauncher.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessLauncher.java
@@ -77,7 +77,11 @@ public class TestProcessLauncher {
 
     public void quit() {
         if (pipe != null) {
-            pipe.println("quit");
+            if (pipe.isConnected()) {
+                pipe.println("quit");
+            } else {
+                System.out.println("WARNING: IOPipe is not connected");
+            }
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

I resolved the ProblemLIst. Probably clean anyways, else will mark as such.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8268433](https://bugs.openjdk.org/browse/JDK-8268433) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268433](https://bugs.openjdk.org/browse/JDK-8268433): serviceability/dcmd/framework/VMVersionTest.java fails with Unable to send object throw not established PipeIO Listener Thread connection (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1956/head:pull/1956` \
`$ git checkout pull/1956`

Update a local copy of the PR: \
`$ git checkout pull/1956` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1956`

View PR using the GUI difftool: \
`$ git pr show -t 1956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1956.diff">https://git.openjdk.org/jdk17u-dev/pull/1956.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1956#issuecomment-1805284985)