### PR TITLE
8319961: JvmtiEnvBase doesn't zero _ext_event_callbacks

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -207,7 +207,8 @@ JvmtiEnvBase::JvmtiEnvBase(jint version) : _env_event_enable() {
   _is_retransformable = true;
 
   // all callbacks initially NULL
-  memset(&_event_callbacks,0,sizeof(jvmtiEventCallbacks));
+  memset(&_event_callbacks, 0, sizeof(jvmtiEventCallbacks));
+  memset(&_ext_event_callbacks, 0, sizeof(jvmtiExtEventCallbacks));
 
   // all capabilities initially off
   memset(&_current_capabilities, 0, sizeof(_current_capabilities));


### PR DESCRIPTION
Clean backport.
No tier1 regressions

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8319961](https://bugs.openjdk.org/browse/JDK-8319961) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319961](https://bugs.openjdk.org/browse/JDK-8319961): JvmtiEnvBase doesn't zero _ext_event_callbacks (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1961/head:pull/1961` \
`$ git checkout pull/1961`

Update a local copy of the PR: \
`$ git checkout pull/1961` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1961`

View PR using the GUI difftool: \
`$ git pr show -t 1961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1961.diff">https://git.openjdk.org/jdk17u-dev/pull/1961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1961#issuecomment-1814462996)