### PR TITLE
Backport d725b73df01ae4478dfaabc47c48cd7231d91afa

### DIFF
--- a/src/java.desktop/share/native/libjsound/MidiOutDevice.c
+++ b/src/java.desktop/share/native/libjsound/MidiOutDevice.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,6 +121,7 @@ Java_com_sun_media_sound_MidiOutDevice_nSendLongMessage(JNIEnv* e, jobject thisO
                                                         jbyteArray jData, jint size, jlong timeStamp) {
 #if USE_PLATFORM_MIDI_OUT == TRUE
     UBYTE* data;
+    UBYTE* msg;
 #endif
 
     TRACE0("Java_com_sun_media_sound_MidiOutDevice_nSendLongMessage.\n");
@@ -133,11 +134,12 @@ Java_com_sun_media_sound_MidiOutDevice_nSendLongMessage(JNIEnv* e, jobject thisO
     }
     /* "continuation" sysex messages start with F7 (instead of F0), but
        are sent without the F7. */
+    msg = data;
     if (data[0] == 0xF7 && size > 1) {
-        data++;
+        msg++;
         size--;
     }
-    MIDI_OUT_SendLongMessage((MidiDeviceHandle*) (UINT_PTR) deviceHandle, data,
+    MIDI_OUT_SendLongMessage((MidiDeviceHandle*) (UINT_PTR) deviceHandle, msg,
                              (UINT32) size, (UINT32)timeStamp);
     // release the byte array
     (*e)->ReleaseByteArrayElements(e, jData, (jbyte*) data, JNI_ABORT);

--- a/test/jdk/javax/sound/midi/SysexMessage/SendRawSysexMessage.java
+++ b/test/jdk/javax/sound/midi/SysexMessage/SendRawSysexMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,9 @@ import static javax.sound.midi.SysexMessage.SYSTEM_EXCLUSIVE;
 
 /**
  * @test
- * @bug 8237495
- * @summary fail with a dereferenced memory error when asked to send a raw 0xF7
+ * @bug 8237495 8301310
+ * @summary fail with memory errors when asked to send a sysex message starting
+ *          with 0xF7
  */
 public final class SendRawSysexMessage {
 
@@ -113,6 +114,16 @@ public final class SendRawSysexMessage {
                         (byte) SPECIAL_SYSTEM_EXCLUSIVE}), -1);
                 System.err.println("note off");
                 r.send(new ShortMessage(ShortMessage.NOTE_OFF, 5, 5), -1);
+                System.err.println("sysex part 1 of 3");
+                r.send(new SysexMessage(new byte[]{
+                        (byte) SYSTEM_EXCLUSIVE, 0x7D, 0x01, 0x02}, 4), -1);
+                System.err.println("sysex part 2 of 3");
+                r.send(new SysexMessage(new byte[]{
+                        (byte) SPECIAL_SYSTEM_EXCLUSIVE, 0x03, 0x04}, 3), -1);
+                System.err.println("sysex part 3 of 3");
+                r.send(new SysexMessage(new byte[]{
+                        (byte) SPECIAL_SYSTEM_EXCLUSIVE, 0x05, 0x06, 0x07,
+                        (byte) SPECIAL_SYSTEM_EXCLUSIVE}, 4), -1);
                 System.err.println("done, should quit");
                 System.err.println();
             }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [d725b73d](https://github.com/openjdk/jdk/commit/d725b73df01ae4478dfaabc47c48cd7231d91afa) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alec Su on 14 Nov 2023 and was reviewed by Sergey Bylokhov.

Thanks!