### PR TITLE
8320209: VectorMaskGen clobbers rflags on x86_64

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -8195,9 +8195,9 @@ instruct vmasked_load64(vec dst, memory mem, kReg mask) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vmask_gen(kReg dst, rRegL len, rRegL temp) %{
+instruct vmask_gen(kReg dst, rRegL len, rRegL temp, rFlagsReg cr) %{
   match(Set dst (VectorMaskGen len));
-  effect(TEMP temp);
+  effect(TEMP temp, KILL cr);
   format %{ "vector_mask_gen32 $dst, $len \t! vector mask generator" %}
   ins_encode %{
     __ genmask($dst$$KRegister, $len$$Register, $temp$$Register);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320209](https://bugs.openjdk.org/browse/JDK-8320209) needs maintainer approval

### Issue
 * [JDK-8320209](https://bugs.openjdk.org/browse/JDK-8320209): VectorMaskGen clobbers rflags on x86_64 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1969/head:pull/1969` \
`$ git checkout pull/1969`

Update a local copy of the PR: \
`$ git checkout pull/1969` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1969`

View PR using the GUI difftool: \
`$ git pr show -t 1969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1969.diff">https://git.openjdk.org/jdk17u-dev/pull/1969.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1969#issuecomment-1817264193)