### PR TITLE
8316645: RISC-V: Remove dependency on libatomic by adding cmpxchg 1b

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -146,12 +146,6 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
     fi
   fi
 
-  # Because RISC-V only has word-sized atomics, it requries libatomic where
-  # other common architectures do not.  So link libatomic by default.
-  if test "x$OPENJDK_TARGET_OS" = xlinux && test "x$OPENJDK_TARGET_CPU" = xriscv64; then
-    BASIC_JVM_LIBS="$BASIC_JVM_LIBS -latomic"
-  fi
-
   # perfstat lib
   if test "x$OPENJDK_TARGET_OS" = xaix; then
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lperfstat"


### PR DESCRIPTION
Hi, I would like to backport this riscv-specific change to remove dependency on latomic libraries.
latomic is used for non native atomic operation which causes problems with extra dependency. This have been fixed in recent gcc, so latomic is no longer needed. this backport will work for older gcc versions as well,  it uses assembly code.
The backport is not clean because jdk17u-dev has no [JDK-8307806](https://bugs.openjdk.org/browse/JDK-8307806), and the original patch modified a test case(test/hotspot/gtest/runtime/test_atomic.cpp), but there is no corresponding test case in the jdk17u-dev.

### Testing:
qemu 8.1.50 with UseRVV:
- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8316645](https://bugs.openjdk.org/browse/JDK-8316645) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316645](https://bugs.openjdk.org/browse/JDK-8316645): RISC-V: Remove dependency on libatomic by adding cmpxchg 1b (**Enhancement** - P4 - Approved)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - no project role)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1970/head:pull/1970` \
`$ git checkout pull/1970`

Update a local copy of the PR: \
`$ git checkout pull/1970` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1970`

View PR using the GUI difftool: \
`$ git pr show -t 1970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1970.diff">https://git.openjdk.org/jdk17u-dev/pull/1970.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1970#issuecomment-1817468816)