### PR TITLE
Goetz backport 8312434

### DIFF
--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -49,7 +49,6 @@ class SharedClassPathEntry {
   enum {
     modules_image_entry,
     jar_entry,
-    signed_jar_entry,
     dir_entry,
     non_existent_entry,
     unknown_entry
@@ -78,10 +77,6 @@ public:
   bool is_dir()           const { return _type == dir_entry; }
   bool is_modules_image() const { return _type == modules_image_entry; }
   bool is_jar()           const { return _type == jar_entry; }
-  bool is_signed()        const { return _type == signed_jar_entry; }
-  void set_is_signed() {
-    _type = signed_jar_entry;
-  }
   bool from_class_path_attr() { return _from_class_path_attr; }
   time_t timestamp() const { return _timestamp; }
   const char* name() const;

--- a/test/hotspot/jtreg/runtime/cds/appcds/SealingViolation.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SealingViolation.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8312434
+ * @summary A jar file containing classes in the same package. Sign the jar file with
+ *          a disabled algorithm. The jar will be treated as unsigned.
+ *          Dump only one class into the CDS archive. During runtime, load the class
+ *          stored in the archive and then load another class not from the archive
+ *          but from the same pacakge. Loading of the second class should not result
+ *          in sealing violation.
+ *
+ * @requires vm.cds
+ * @library /test/lib
+ * @compile test-classes/GenericTestApp.java test-classes/pkg/ClassInPackage.java test-classes/C2.java
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
+ * @run driver SealingViolation
+ */
+
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class SealingViolation {
+    public static void main(String[] args) throws Exception {
+        String[] classList = {"pkg/ClassInPackage"};
+        String appJar = ClassFileInstaller.writeJar("pkg-classes-sealed.jar",
+            ClassFileInstaller.Manifest.fromSourceFile("test-classes/pkg/package_seal.mf"),
+            "GenericTestApp", "pkg/ClassInPackage", "pkg/C2");
+
+        JarBuilder.signJarWithDisabledAlgorithm("pkg-classes-sealed");
+        String signedJar = TestCommon.getTestJar("pkg-classes-sealed.jar");
+
+        // GenericTestApp requires WhiteBox
+        String wbJar = ClassFileInstaller.getJarPath("WhiteBox.jar");
+        String bootclasspath = "-Xbootclasspath/a:" + wbJar;
+
+        OutputAnalyzer output = TestCommon.dump(signedJar, classList, bootclasspath,
+                                     "-Xlog:cds+class=debug");
+        output.shouldMatch("cds.class.*klasses.*app   pkg.ClassInPackage")
+              .shouldHaveExitValue(0);
+
+        output = TestCommon.exec(signedJar, "-Xlog:cds=debug,class+load",
+                                 bootclasspath,
+                                 "-XX:+UnlockDiagnosticVMOptions",
+                                 "-XX:+WhiteBoxAPI",
+                                 "GenericTestApp",
+                                 "assertShared:pkg.ClassInPackage",
+                                 "assertNotShared:pkg.C2");
+        output.shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/SealingViolation.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SealingViolation.java
@@ -58,7 +58,7 @@ public class SealingViolation {
 
         OutputAnalyzer output = TestCommon.dump(signedJar, classList, bootclasspath,
                                      "-Xlog:cds+class=debug");
-        output.shouldMatch("cds.class.*klasses.*app   pkg.ClassInPackage")
+        output.shouldMatch("cds.class.*klasses.* pkg.ClassInPackage")
               .shouldHaveExitValue(0);
 
         output = TestCommon.exec(signedJar, "-Xlog:cds=debug,class+load",

--- a/test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java
@@ -37,7 +37,7 @@ import java.io.File;
 public class SignedJar {
     public static void main(String[] args) throws Exception {
         String unsignedJar = JarBuilder.getOrCreateHelloJar();
-        JarBuilder.signJar();
+        JarBuilder.signJar("hello");
 
         // Test class exists in signed JAR
         String signedJar = TestCommon.getTestJar("signed_hello.jar");

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/pkg/ClassInPackage.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/pkg/ClassInPackage.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package pkg;
+
+public class ClassInPackage {
+
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/pkg/package_seal.mf
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/pkg/package_seal.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Created-By: 1.9.0-internal (Oracle Corporation)
+
+Name: pkg/
+Sealed: true
+


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

I added a test file that was originally added by JDK-8293182: Improve testing of CDS archive heap.

I also had to adapt the pattern checked in the new test as the tracing in 17 does not list the kind of cds klass. (boot, app, array).