### PR TITLE
8317834: java/lang/Thread/IsAlive.java timed out

### DIFF
--- a/test/jdk/java/lang/Thread/IsAlive.java
+++ b/test/jdk/java/lang/Thread/IsAlive.java
@@ -25,7 +25,7 @@
  * @test
  * @bug     8305425
  * @summary Check Thread.isAlive
- * @run main/othervm/timeout=10 IsAlive
+ * @run main/othervm IsAlive
  */
 
 public class IsAlive {


### PR DESCRIPTION
Clean backport to improve reliability of recently added test.

Additional testing:
 - [x] MacOS AArch64 fastdebug, affected test still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317834](https://bugs.openjdk.org/browse/JDK-8317834) needs maintainer approval

### Issue
 * [JDK-8317834](https://bugs.openjdk.org/browse/JDK-8317834): java/lang/Thread/IsAlive.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1975/head:pull/1975` \
`$ git checkout pull/1975`

Update a local copy of the PR: \
`$ git checkout pull/1975` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1975`

View PR using the GUI difftool: \
`$ git pr show -t 1975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1975.diff">https://git.openjdk.org/jdk17u-dev/pull/1975.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1975#issuecomment-1819227315)