### PR TITLE
8313782: Add user-facing warning if THPs are enabled but cannot be used

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3860,15 +3860,17 @@ void os::large_page_init() {
     return;
   }
 
-  // 2) check if large pages are configured
-  if ( ( UseTransparentHugePages && HugePages::supports_thp() == false) ||
-       (!UseTransparentHugePages && HugePages::supports_static_hugepages() == false) ) {
-    // No large pages configured, return.
+  // 2) check if the OS supports THPs resp. static hugepages.
+  if (UseTransparentHugePages && !HugePages::supports_thp()) {
+    if (!FLAG_IS_DEFAULT(UseTransparentHugePages)) {
+      log_warning(pagesize)("UseTransparentHugePages disabled, transparent huge pages are not supported by the operating system.");
+    }
+    UseLargePages = UseTransparentHugePages = UseHugeTLBFS = UseSHM = false;
+    return;
+  }
+  if (!UseTransparentHugePages && !HugePages::supports_static_hugepages()) {
     warn_no_large_pages_configured();
-    UseLargePages = false;
-    UseTransparentHugePages = false;
-    UseHugeTLBFS = false;
-    UseSHM = false;
+    UseLargePages = UseTransparentHugePages = UseHugeTLBFS = UseSHM = false;
     return;
   }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8313782](https://bugs.openjdk.org/browse/JDK-8313782), commit [44b5b81f](https://github.com/openjdk/jdk21u/commit/44b5b81f76567d0b7fc4687e18c53d7ddbd2e982) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313782](https://bugs.openjdk.org/browse/JDK-8313782) needs maintainer approval

### Issue
 * [JDK-8313782](https://bugs.openjdk.org/browse/JDK-8313782): Add user-facing warning if THPs are enabled but cannot be used (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1978/head:pull/1978` \
`$ git checkout pull/1978`

Update a local copy of the PR: \
`$ git checkout pull/1978` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1978`

View PR using the GUI difftool: \
`$ git pr show -t 1978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1978.diff">https://git.openjdk.org/jdk17u-dev/pull/1978.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1978#issuecomment-1820794883)