### PR TITLE
8293343: sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java failed with "Agent communication error: java.io.EOFException"

### DIFF
--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiBootstrapTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiBootstrapTest.java
@@ -58,7 +58,7 @@ import java.util.Set;
  *
  * @library /test/lib
  *
- * @run main/timeout=300 RmiBootstrapTest .*_test.*.in
+ * @run main/othervm/timeout=300 RmiBootstrapTest .*_test.*.in
  * */
 
 /*
@@ -69,7 +69,7 @@ import java.util.Set;
  *
  * @library /test/lib
  *
- * @run main/timeout=300 RmiBootstrapTest .*_ssltest.*.in
+ * @run main/othervm/timeout=300 RmiBootstrapTest .*_ssltest.*.in
  * */
 
 /**

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java
@@ -48,7 +48,7 @@ import javax.management.remote.JMXConnectorServer;
  *
  * @library /test/lib
  *
- * @run main/timeout=300 RmiSslNoKeyStoreTest .*_ssltest.*.in
+ * @run main/othervm/timeout=300 RmiSslNoKeyStoreTest .*_ssltest.*.in
  * */
 
 /**

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiTestBase.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiTestBase.java
@@ -141,7 +141,7 @@ public class RmiTestBase {
 
         grantFilesAccess(propertyFiles, AccessControl.OWNER);
 
-        return Collections.unmodifiableList(files);
+        return Collections.unmodifiableList(propertyFiles);
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

Skipped change to ProblemList as not problem listed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8293335](https://bugs.openjdk.org/browse/JDK-8293335) needs maintainer approval
- [x] [JDK-8293343](https://bugs.openjdk.org/browse/JDK-8293343) needs maintainer approval

### Issues
 * [JDK-8293343](https://bugs.openjdk.org/browse/JDK-8293343): sun/management/jmxremote/bootstrap/RmiSslNoKeyStoreTest.java failed with "Agent communication error: java.io.EOFException" (**Bug** - P4 - Approved)
 * [JDK-8293335](https://bugs.openjdk.org/browse/JDK-8293335): sun/management/jmxremote/bootstrap/RmiBootstrapTest.java#id1failed with "Agent communication error: java.io.EOFException" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1980/head:pull/1980` \
`$ git checkout pull/1980`

Update a local copy of the PR: \
`$ git checkout pull/1980` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1980`

View PR using the GUI difftool: \
`$ git pr show -t 1980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1980.diff">https://git.openjdk.org/jdk17u-dev/pull/1980.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1980#issuecomment-1820852335)