### PR TITLE
Backport ea8d3c92c69c393cdbc6c62398f1e9c6adc708d3

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -117,7 +117,7 @@ abstract class P11Key implements Key, Length {
     }
 
     P11Key(String type, Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes) {
+            int keyLength, CK_ATTRIBUTE[] attrs) {
         this.type = type;
         this.token = session.token;
         this.algorithm = algorithm;
@@ -125,15 +125,15 @@ abstract class P11Key implements Key, Length {
         boolean tokenObject = false;
         boolean sensitive = false;
         boolean extractable = true;
-        int n = (attributes == null) ? 0 : attributes.length;
-        for (int i = 0; i < n; i++) {
-            CK_ATTRIBUTE attr = attributes[i];
-            if (attr.type == CKA_TOKEN) {
-                tokenObject = attr.getBoolean();
-            } else if (attr.type == CKA_SENSITIVE) {
-                sensitive = attr.getBoolean();
-            } else if (attr.type == CKA_EXTRACTABLE) {
-                extractable = attr.getBoolean();
+        if (attrs != null) {
+            for (CK_ATTRIBUTE attr : attrs) {
+                if (attr.type == CKA_TOKEN) {
+                    tokenObject = attr.getBoolean();
+                } else if (attr.type == CKA_SENSITIVE) {
+                    sensitive = attr.getBoolean();
+                } else if (attr.type == CKA_EXTRACTABLE) {
+                    extractable = attr.getBoolean();
+                }
             }
         }
         this.tokenObject = tokenObject;
@@ -250,7 +250,7 @@ abstract class P11Key implements Key, Length {
     public String toString() {
         token.ensureValid();
         String s1 = token.provider.getName() + " " + algorithm + " " + type
-                + " key, " + keyLength + " bits";
+                + " key, " + keyLength + " bits ";
         s1 += (tokenObject ? "token" : "session") + " object";
         if (isPublic()) {
             s1 += ")";
@@ -281,19 +281,31 @@ abstract class P11Key implements Key, Length {
         return type == SECRET;
     }
 
-    void fetchAttributes(CK_ATTRIBUTE[] attributes) {
+    CK_ATTRIBUTE[] fetchAttributes(CK_ATTRIBUTE[] attrs) {
+        Objects.requireNonNull(attrs, "attrs must be non-null");
         Session tempSession = null;
         long keyID = this.getKeyID();
         try {
             tempSession = token.getOpSession();
             token.p11.C_GetAttributeValue(tempSession.id(), keyID,
-                        attributes);
+                    attrs);
         } catch (PKCS11Exception e) {
             throw new ProviderException(e);
         } finally {
             this.releaseKeyID();
             token.releaseSession(tempSession);
         }
+        return attrs;
+    }
+
+    // convenience method which returns the attribute values as BigInteger[]
+    BigInteger[] fetchAttributesAsInts(CK_ATTRIBUTE[] attrs) {
+        attrs = fetchAttributes(attrs);
+        BigInteger[] res = new BigInteger[attrs.length];
+        for (int i = 0; i < attrs.length; i++) {
+            res[i] = attrs[i].getBigInteger();
+        }
+        return res;
     }
 
     private static final CK_ATTRIBUTE[] A0 = new CK_ATTRIBUTE[0];
@@ -332,44 +344,43 @@ abstract class P11Key implements Key, Length {
     }
 
     static SecretKey secretKey(Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes) {
-        attributes = getAttributes(session, keyID, attributes, new CK_ATTRIBUTE[] {
-            new CK_ATTRIBUTE(CKA_TOKEN),
-            new CK_ATTRIBUTE(CKA_SENSITIVE),
-            new CK_ATTRIBUTE(CKA_EXTRACTABLE),
+            int keyLength, CK_ATTRIBUTE[] attrs) {
+        attrs = getAttributes(session, keyID, attrs, new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_TOKEN),
+                    new CK_ATTRIBUTE(CKA_SENSITIVE),
+                    new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        return new P11SecretKey(session, keyID, algorithm, keyLength,
-                attributes);
+        return new P11SecretKey(session, keyID, algorithm, keyLength, attrs);
     }
 
-    static SecretKey masterSecretKey(Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes, int major, int minor) {
-        attributes = getAttributes(session, keyID, attributes, new CK_ATTRIBUTE[] {
-            new CK_ATTRIBUTE(CKA_TOKEN),
-            new CK_ATTRIBUTE(CKA_SENSITIVE),
-            new CK_ATTRIBUTE(CKA_EXTRACTABLE),
+    static SecretKey masterSecretKey(Session session, long keyID,
+            String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+            int major, int minor) {
+        attrs = getAttributes(session, keyID, attrs, new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_TOKEN),
+                    new CK_ATTRIBUTE(CKA_SENSITIVE),
+                    new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        return new P11TlsMasterSecretKey(
-                session, keyID, algorithm, keyLength, attributes, major,
-                minor);
+        return new P11TlsMasterSecretKey(session, keyID, algorithm, keyLength,
+                attrs, major, minor);
     }
 
     // we assume that all components of public keys are always accessible
     static PublicKey publicKey(Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes) {
+            int keyLength, CK_ATTRIBUTE[] attrs) {
         switch (algorithm) {
             case "RSA":
                 return new P11RSAPublicKey(session, keyID, algorithm,
-                        keyLength, attributes);
+                        keyLength, attrs);
             case "DSA":
                 return new P11DSAPublicKey(session, keyID, algorithm,
-                        keyLength, attributes);
+                        keyLength, attrs);
             case "DH":
                 return new P11DHPublicKey(session, keyID, algorithm,
-                        keyLength, attributes);
+                        keyLength, attrs);
             case "EC":
                 return new P11ECPublicKey(session, keyID, algorithm,
-                        keyLength, attributes);
+                        keyLength, attrs);
             default:
                 throw new ProviderException
                     ("Unknown public key algorithm " + algorithm);
@@ -377,73 +388,45 @@ abstract class P11Key implements Key, Length {
     }
 
     static PrivateKey privateKey(Session session, long keyID, String algorithm,
-            int keyLength, CK_ATTRIBUTE[] attributes) {
-        attributes = getAttributes(session, keyID, attributes, new CK_ATTRIBUTE[] {
-            new CK_ATTRIBUTE(CKA_TOKEN),
-            new CK_ATTRIBUTE(CKA_SENSITIVE),
-            new CK_ATTRIBUTE(CKA_EXTRACTABLE),
+            int keyLength, CK_ATTRIBUTE[] attrs) {
+        attrs = getAttributes(session, keyID, attrs, new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_TOKEN),
+                    new CK_ATTRIBUTE(CKA_SENSITIVE),
+                    new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
-            return new P11PrivateKey
-                (session, keyID, algorithm, keyLength, attributes);
-        } else {
-            switch (algorithm) {
-                case "RSA":
-                    // In order to decide if this is RSA CRT key, we first query
-                    // and see if all extra CRT attributes are available.
-                    CK_ATTRIBUTE[] attrs2 = new CK_ATTRIBUTE[] {
-                        new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
-                        new CK_ATTRIBUTE(CKA_PRIME_1),
-                        new CK_ATTRIBUTE(CKA_PRIME_2),
-                        new CK_ATTRIBUTE(CKA_EXPONENT_1),
-                        new CK_ATTRIBUTE(CKA_EXPONENT_2),
-                        new CK_ATTRIBUTE(CKA_COEFFICIENT),
-                    };
-                    boolean crtKey;
-                    try {
-                        session.token.p11.C_GetAttributeValue
-                            (session.id(), keyID, attrs2);
-                        crtKey = ((attrs2[0].pValue instanceof byte[]) &&
-                                  (attrs2[1].pValue instanceof byte[]) &&
-                                  (attrs2[2].pValue instanceof byte[]) &&
-                                  (attrs2[3].pValue instanceof byte[]) &&
-                                  (attrs2[4].pValue instanceof byte[]) &&
-                                  (attrs2[5].pValue instanceof byte[])) ;
-                    } catch (PKCS11Exception e) {
-                        // ignore, assume not available
-                        crtKey = false;
-                    }
-                    if (crtKey) {
-                        return new P11RSAPrivateKey(session, keyID, algorithm,
-                                keyLength, attributes, attrs2);
-                    } else {
-                        return new P11RSAPrivateNonCRTKey(session, keyID,
-                                algorithm, keyLength, attributes);
-                    }
-                case "DSA":
-                    return new P11DSAPrivateKey(session, keyID, algorithm,
-                            keyLength, attributes);
-                case "DH":
-                    return new P11DHPrivateKey(session, keyID, algorithm,
-                            keyLength, attributes);
-                case "EC":
-                    return new P11ECPrivateKey(session, keyID, algorithm,
-                            keyLength, attributes);
-                default:
-                    throw new ProviderException
-                            ("Unknown private key algorithm " + algorithm);
-            }
+
+        boolean keySensitive = (attrs[0].getBoolean() ||
+                attrs[1].getBoolean() || !attrs[2].getBoolean());
+
+        switch (algorithm) {
+        case "RSA":
+            return P11RSAPrivateKeyInternal.of(session, keyID, algorithm,
+                    keyLength, attrs, keySensitive);
+        case "DSA":
+            return P11DSAPrivateKeyInternal.of(session, keyID, algorithm,
+                    keyLength, attrs, keySensitive);
+        case "DH":
+            return P11DHPrivateKeyInternal.of(session, keyID, algorithm,
+                    keyLength, attrs, keySensitive);
+        case "EC":
+            return P11ECPrivateKeyInternal.of(session, keyID, algorithm,
+                    keyLength, attrs, keySensitive);
+        default:
+            throw new ProviderException
+                    ("Unknown private key algorithm " + algorithm);
         }
     }
 
-    // class for sensitive and unextractable private keys
-    private static final class P11PrivateKey extends P11Key
-                                                implements PrivateKey {
+    // base class for all PKCS11 private keys
+    private static abstract class P11PrivateKey extends P11Key implements
+            PrivateKey {
         private static final long serialVersionUID = -2138581185214187615L;
 
+        protected byte[] encoded; // guard by synchronized
+
         P11PrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(PRIVATE, session, keyID, algorithm, keyLength, attrs);
         }
         // XXX temporary encoding for serialization purposes
         public String getFormat() {
@@ -458,11 +441,14 @@ abstract class P11Key implements Key, Length {
 
     private static class P11SecretKey extends P11Key implements SecretKey {
         private static final long serialVersionUID = -7828241727014329084L;
-        private volatile byte[] encoded;
+
+        private volatile byte[] encoded; // guard by double-checked locking
+
         P11SecretKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(SECRET, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(SECRET, session, keyID, algorithm, keyLength, attrs);
         }
+
         public String getFormat() {
             token.ensureValid();
             if (sensitive || !extractable || (isNSS && tokenObject)) {
@@ -471,37 +457,39 @@ abstract class P11Key implements Key, Length {
                 return "RAW";
             }
         }
+
         byte[] getEncodedInternal() {
             token.ensureValid();
             if (getFormat() == null) {
                 return null;
             }
+
             byte[] b = encoded;
             if (b == null) {
                 synchronized (this) {
                     b = encoded;
                     if (b == null) {
-                        Session tempSession = null;
-                        long keyID = this.getKeyID();
-                        try {
-                            tempSession = token.getOpSession();
-                            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+                        b = fetchAttributes(new CK_ATTRIBUTE[] {
                                 new CK_ATTRIBUTE(CKA_VALUE),
-                            };
-                            token.p11.C_GetAttributeValue
-                                    (tempSession.id(), keyID, attributes);
-                            b = attributes[0].getByteArray();
-                        } catch (PKCS11Exception e) {
-                            throw new ProviderException(e);
-                        } finally {
-                            this.releaseKeyID();
-                            token.releaseSession(tempSession);
-                        }
+                        })[0].getByteArray();
                         encoded = b;
                     }
                 }
             }
             return b;
+        }
+    }
+
+    // base class for all PKCS11 public keys
+    private static abstract class P11PublicKey extends P11Key implements
+            PublicKey {
+        private static final long serialVersionUID = 1L;
+
+        protected byte[] encoded; // guard by synchronized
+
+        P11PublicKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(PUBLIC, session, keyID, algorithm, keyLength, attrs);
         }
     }
 
@@ -512,8 +500,8 @@ abstract class P11Key implements Key, Length {
 
         private final int majorVersion, minorVersion;
         P11TlsMasterSecretKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes, int major, int minor) {
-            super(session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs, int major, int minor) {
+            super(session, keyID, algorithm, keyLength, attrs);
             this.majorVersion = major;
             this.minorVersion = minor;
         }
@@ -526,17 +514,92 @@ abstract class P11Key implements Key, Length {
         }
     }
 
+    // impl class for sensitive/unextractable RSA private keys
+    static class P11RSAPrivateKeyInternal extends P11PrivateKey {
+        private static final long serialVersionUID = -2138581185214187615L;
+
+        static P11RSAPrivateKeyInternal of(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+                boolean keySensitive) {
+            if (keySensitive) {
+                return new P11RSAPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            } else {
+                CK_ATTRIBUTE[] rsaAttrs = new CK_ATTRIBUTE[] {
+                        new CK_ATTRIBUTE(CKA_MODULUS),
+                        new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
+                        new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
+                        new CK_ATTRIBUTE(CKA_PRIME_1),
+                        new CK_ATTRIBUTE(CKA_PRIME_2),
+                        new CK_ATTRIBUTE(CKA_EXPONENT_1),
+                        new CK_ATTRIBUTE(CKA_EXPONENT_2),
+                        new CK_ATTRIBUTE(CKA_COEFFICIENT),
+                };
+                boolean isCRT = true;
+                Session tempSession = null;
+                try {
+                    tempSession = session.token.getOpSession();
+                    session.token.p11.C_GetAttributeValue(tempSession.id(),
+                            keyID, rsaAttrs);
+                    for (CK_ATTRIBUTE attr : rsaAttrs) {
+                        isCRT &= (attr.pValue instanceof byte[]);
+                        if (!isCRT) break;
+                    }
+                } catch (PKCS11Exception e) {
+                    // ignore, assume not available
+                    isCRT = false;
+                } finally {
+                    session.token.releaseSession(tempSession);
+                }
+                BigInteger n = rsaAttrs[0].getBigInteger();
+                BigInteger d = rsaAttrs[1].getBigInteger();
+                if (isCRT) {
+                    return new P11RSAPrivateKey(session, keyID, algorithm,
+                           keyLength, attrs, n, d,
+                           Arrays.copyOfRange(rsaAttrs, 2, rsaAttrs.length));
+                } else {
+                    return new P11RSAPrivateNonCRTKey(session, keyID,
+                           algorithm, keyLength, attrs, n, d);
+                }
+            }
+        }
+
+        protected transient BigInteger n;
+
+        private P11RSAPrivateKeyInternal(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
+        private synchronized void fetchValues() {
+            token.ensureValid();
+            if (n != null) return;
+
+            n = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_MODULUS)
+            })[0];
+        }
+
+        public BigInteger getModulus() {
+            fetchValues();
+            return n;
+        }
+    }
+
     // RSA CRT private key
-    private static final class P11RSAPrivateKey extends P11Key
-                implements RSAPrivateCrtKey {
+    private static final class P11RSAPrivateKey extends P11RSAPrivateKeyInternal
+            implements RSAPrivateCrtKey {
         private static final long serialVersionUID = 9215872438913515220L;
 
-        private BigInteger n, e, d, p, q, pe, qe, coeff;
-        private byte[] encoded;
-        P11RSAPrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attrs, CK_ATTRIBUTE[] crtAttrs) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attrs);
+        private transient BigInteger e, d, p, q, pe, qe, coeff;
 
+        private P11RSAPrivateKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs, BigInteger n, BigInteger d,
+                CK_ATTRIBUTE[] crtAttrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+
+            this.n = n;
+            this.d = d;
             for (CK_ATTRIBUTE a : crtAttrs) {
                 if (a.type == CKA_PUBLIC_EXPONENT) {
                     e = a.getBigInteger();
@@ -553,28 +616,15 @@ abstract class P11Key implements Key, Length {
                 }
             }
         }
-        private synchronized void fetchValues() {
-            token.ensureValid();
-            if (n != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_MODULUS),
-                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-            };
-            fetchAttributes(attributes);
-            n = attributes[0].getBigInteger();
-            d = attributes[1].getBigInteger();
-        }
 
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
-                fetchValues();
                 try {
                     Key newKey = RSAPrivateCrtKeyImpl.newKey
                         (KeyType.RSA, null, n, e, d, p, q, pe, qe, coeff);
@@ -585,15 +635,15 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
+        @Override
         public BigInteger getModulus() {
-            fetchValues();
             return n;
         }
         public BigInteger getPublicExponent() {
             return e;
         }
         public BigInteger getPrivateExponent() {
-            fetchValues();
             return d;
         }
         public BigInteger getPrimeP() {
@@ -614,37 +664,28 @@ abstract class P11Key implements Key, Length {
     }
 
     // RSA non-CRT private key
-    private static final class P11RSAPrivateNonCRTKey extends P11Key
-                implements RSAPrivateKey {
+    private static final class P11RSAPrivateNonCRTKey extends
+            P11RSAPrivateKeyInternal implements RSAPrivateKey {
         private static final long serialVersionUID = 1137764983777411481L;
 
-        private BigInteger n, d;
-        private byte[] encoded;
+        private transient BigInteger d;
+
         P11RSAPrivateNonCRTKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs, BigInteger n,
+                BigInteger d) {
+            super(session, keyID, algorithm, keyLength, attrs);
+            this.n = n;
+            this.d = d;
         }
-        private synchronized void fetchValues() {
-            token.ensureValid();
-            if (n != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_MODULUS),
-                new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-            };
-            fetchAttributes(attributes);
-            n = attributes[0].getBigInteger();
-            d = attributes[1].getBigInteger();
-        }
+
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
-                fetchValues();
                 try {
                     // XXX make constructor in SunRsaSign provider public
                     // and call it directly
@@ -658,42 +699,43 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
+        @Override
         public BigInteger getModulus() {
-            fetchValues();
             return n;
         }
         public BigInteger getPrivateExponent() {
-            fetchValues();
             return d;
         }
     }
 
-    private static final class P11RSAPublicKey extends P11Key
+    private static final class P11RSAPublicKey extends P11PublicKey
                                                 implements RSAPublicKey {
         private static final long serialVersionUID = -826726289023854455L;
-        private BigInteger n, e;
-        private byte[] encoded;
+        private transient BigInteger n, e;
+
         P11RSAPublicKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PUBLIC, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (n != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+            if (n != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_MODULUS),
-                new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
-            };
-            fetchAttributes(attributes);
-            n = attributes[0].getBigInteger();
-            e = attributes[1].getBigInteger();
+                new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT)
+            });
+            n = res[0];
+            e = res[1];
         }
+
         public String getFormat() {
             token.ensureValid();
             return "X.509";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -707,6 +749,7 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
         public BigInteger getModulus() {
             fetchValues();
             return n;
@@ -722,40 +765,37 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static final class P11DSAPublicKey extends P11Key
+    private static final class P11DSAPublicKey extends P11PublicKey
                                                 implements DSAPublicKey {
         private static final long serialVersionUID = 5989753793316396637L;
 
-        private BigInteger y;
-        private DSAParams params;
-        private byte[] encoded;
+        private transient BigInteger y;
+        private transient DSAParams params;
+
         P11DSAPublicKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PUBLIC, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (y != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+            if (y != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_VALUE),
                 new CK_ATTRIBUTE(CKA_PRIME),
                 new CK_ATTRIBUTE(CKA_SUBPRIME),
-                new CK_ATTRIBUTE(CKA_BASE),
-            };
-            fetchAttributes(attributes);
-            y = attributes[0].getBigInteger();
-            params = new DSAParameterSpec(
-                attributes[1].getBigInteger(),
-                attributes[2].getBigInteger(),
-                attributes[3].getBigInteger()
-            );
+                new CK_ATTRIBUTE(CKA_BASE)
+            });
+            y = res[0];
+            params = new DSAParameterSpec(res[1], res[2], res[3]);
         }
+
         public String getFormat() {
             token.ensureValid();
             return "X.509";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -785,40 +825,76 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static final class P11DSAPrivateKey extends P11Key
-                                                implements DSAPrivateKey {
+    static class P11DSAPrivateKeyInternal extends P11PrivateKey {
         private static final long serialVersionUID = 3119629997181999389L;
 
-        private BigInteger x;
-        private DSAParams params;
-        private byte[] encoded;
-        P11DSAPrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+        protected transient DSAParams params;
+
+        static P11DSAPrivateKeyInternal of(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+                boolean keySensitive) {
+            if (keySensitive) {
+                return new P11DSAPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            } else {
+                return new P11DSAPrivateKey(session, keyID, algorithm,
+                        keyLength, attrs);
+            }
         }
+
+        private P11DSAPrivateKeyInternal(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (x != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE),
-                new CK_ATTRIBUTE(CKA_PRIME),
-                new CK_ATTRIBUTE(CKA_SUBPRIME),
-                new CK_ATTRIBUTE(CKA_BASE),
-            };
-            fetchAttributes(attributes);
-            x = attributes[0].getBigInteger();
-            params = new DSAParameterSpec(
-                attributes[1].getBigInteger(),
-                attributes[2].getBigInteger(),
-                attributes[3].getBigInteger()
-            );
+            if (params != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_SUBPRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            params = new DSAParameterSpec(res[0], res[1], res[2]);
         }
+
+        protected DSAParams getParams() {
+            fetchValues();
+            return params;
+        }
+    }
+
+    private static final class P11DSAPrivateKey extends P11DSAPrivateKeyInternal
+                                        implements DSAPrivateKey {
+        private static final long serialVersionUID = 3119629997181999389L;
+
+        private transient BigInteger x; // params inside P11DSAPrivateKeyInternal
+
+        P11DSAPrivateKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
+        private synchronized void fetchValues() {
+            token.ensureValid();
+            if (x != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_VALUE),
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_SUBPRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            x = res[0];
+            params = new DSAParameterSpec(res[1], res[2], res[3]);
+        }
+
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -829,48 +905,87 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
         public BigInteger getX() {
             fetchValues();
             return x;
         }
+
+        @Override
         public DSAParams getParams() {
             fetchValues();
             return params;
         }
     }
 
-    private static final class P11DHPrivateKey extends P11Key
+    static class P11DHPrivateKeyInternal extends P11PrivateKey {
+        private static final long serialVersionUID = 1L;
+
+        protected transient DHParameterSpec params;
+
+        static P11DHPrivateKeyInternal of(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+                boolean keySensitive) {
+            if (keySensitive) {
+                return new P11DHPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            } else {
+                return new P11DHPrivateKey(session, keyID, algorithm,
+                        keyLength, attrs);
+            }
+        }
+
+        private P11DHPrivateKeyInternal(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
+        private synchronized void fetchValues() {
+            token.ensureValid();
+            if (params != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            params = new DHParameterSpec(res[0], res[1]);
+        }
+
+        public DHParameterSpec getParams() {
+            fetchValues();
+            return params;
+        }
+    }
+
+    private static final class P11DHPrivateKey extends P11DHPrivateKeyInternal
                                                 implements DHPrivateKey {
         private static final long serialVersionUID = -1698576167364928838L;
 
-        private BigInteger x;
-        private DHParameterSpec params;
-        private byte[] encoded;
+        private transient BigInteger x; // params in P11DHPrivateKeyInternal
+
         P11DHPrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (x != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE),
-                new CK_ATTRIBUTE(CKA_PRIME),
-                new CK_ATTRIBUTE(CKA_BASE),
-            };
-            fetchAttributes(attributes);
-            x = attributes[0].getBigInteger();
-            params = new DHParameterSpec(
-                attributes[1].getBigInteger(),
-                attributes[2].getBigInteger()
-            );
+            if (x != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_VALUE),
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            x = res[0];
+            params = new DHParameterSpec(res[1], res[2]);
         }
+
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -897,10 +1012,10 @@ abstract class P11Key implements Key, Length {
             return params;
         }
         public int hashCode() {
+            fetchValues();
             if (!token.isValid()) {
                 return 0;
             }
-            fetchValues();
             return Objects.hash(x, params.getP(), params.getG());
         }
         public boolean equals(Object obj) {
@@ -921,38 +1036,36 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static final class P11DHPublicKey extends P11Key
+    private static final class P11DHPublicKey extends P11PublicKey
                                                 implements DHPublicKey {
         static final long serialVersionUID = -598383872153843657L;
 
-        private BigInteger y;
-        private DHParameterSpec params;
-        private byte[] encoded;
+        private transient BigInteger y;
+        private transient DHParameterSpec params;
+
         P11DHPublicKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PUBLIC, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (y != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE),
-                new CK_ATTRIBUTE(CKA_PRIME),
-                new CK_ATTRIBUTE(CKA_BASE),
-            };
-            fetchAttributes(attributes);
-            y = attributes[0].getBigInteger();
-            params = new DHParameterSpec(
-                attributes[1].getBigInteger(),
-                attributes[2].getBigInteger()
-            );
+            if (y != null) return;
+
+            BigInteger[] res = fetchAttributesAsInts(new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_VALUE),
+                    new CK_ATTRIBUTE(CKA_PRIME),
+                    new CK_ATTRIBUTE(CKA_BASE),
+            });
+            y = res[0];
+            params = new DHParameterSpec(res[1], res[2]);
         }
+
         public String getFormat() {
             token.ensureValid();
             return "X.509";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -1008,44 +1121,88 @@ abstract class P11Key implements Key, Length {
         }
     }
 
-    private static final class P11ECPrivateKey extends P11Key
-                                                implements ECPrivateKey {
-        private static final long serialVersionUID = -7786054399510515515L;
+    static class P11ECPrivateKeyInternal extends P11PrivateKey {
 
-        private BigInteger s;
-        private ECParameterSpec params;
-        private byte[] encoded;
-        P11ECPrivateKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PRIVATE, session, keyID, algorithm, keyLength, attributes);
+        private static final long serialVersionUID = 1L;
+
+        protected transient ECParameterSpec params;
+
+        static P11ECPrivateKeyInternal of(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
+                boolean keySensitive) {
+            if (keySensitive) {
+                return new P11ECPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            } else {
+                return new P11ECPrivateKey(session, keyID, algorithm,
+                        keyLength, attrs);
+            }
         }
+
+        private P11ECPrivateKeyInternal(Session session, long keyID,
+                String algorithm, int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (s != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
-                new CK_ATTRIBUTE(CKA_VALUE),
-                new CK_ATTRIBUTE(CKA_EC_PARAMS, params),
-            };
-            fetchAttributes(attributes);
-            s = attributes[0].getBigInteger();
+            if (params != null) return;
+
             try {
-                params = P11ECKeyFactory.decodeParameters
-                            (attributes[1].getByteArray());
+                byte[] paramBytes = fetchAttributes(new CK_ATTRIBUTE[] {
+                        new CK_ATTRIBUTE(CKA_EC_PARAMS)
+                })[0].getByteArray();
+
+                params = P11ECKeyFactory.decodeParameters(paramBytes);
             } catch (Exception e) {
                 throw new RuntimeException("Could not parse key values", e);
             }
         }
+
+        protected ECParameterSpec getParams() {
+            fetchValues();
+            return params;
+        }
+    }
+
+    private static final class P11ECPrivateKey extends P11ECPrivateKeyInternal
+                                                implements ECPrivateKey {
+        private static final long serialVersionUID = -7786054399510515515L;
+
+        private transient BigInteger s; // params in P11ECPrivateKeyInternal
+
+        P11ECPrivateKey(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
+        }
+
+        private synchronized void fetchValues() {
+            token.ensureValid();
+            if (s != null) return;
+
+            CK_ATTRIBUTE[] attrs = fetchAttributes(new CK_ATTRIBUTE[] {
+                new CK_ATTRIBUTE(CKA_VALUE),
+                new CK_ATTRIBUTE(CKA_EC_PARAMS),
+            });
+
+            s = attrs[0].getBigInteger();
+            try {
+                params = P11ECKeyFactory.decodeParameters
+                            (attrs[1].getByteArray());
+            } catch (Exception e) {
+                throw new RuntimeException("Could not parse key values", e);
+            }
+        }
+
         public String getFormat() {
             token.ensureValid();
             return "PKCS#8";
         }
+
         synchronized byte[] getEncodedInternal() {
-            token.ensureValid();
             if (encoded == null) {
-                fetchValues();
                 try {
+                    fetchValues();
                     Key key = ECUtil.generateECPrivateKey(s, params);
                     encoded = key.getEncoded();
                 } catch (InvalidKeySpecException e) {
@@ -1054,42 +1211,43 @@ abstract class P11Key implements Key, Length {
             }
             return encoded;
         }
+
         public BigInteger getS() {
             fetchValues();
             return s;
         }
+
         public ECParameterSpec getParams() {
             fetchValues();
             return params;
         }
     }
 
-    private static final class P11ECPublicKey extends P11Key
+    private static final class P11ECPublicKey extends P11PublicKey
                                                 implements ECPublicKey {
         private static final long serialVersionUID = -6371481375154806089L;
 
-        private ECPoint w;
-        private ECParameterSpec params;
-        private byte[] encoded;
+        private transient ECPoint w;
+        private transient ECParameterSpec params;
+
         P11ECPublicKey(Session session, long keyID, String algorithm,
-                int keyLength, CK_ATTRIBUTE[] attributes) {
-            super(PUBLIC, session, keyID, algorithm, keyLength, attributes);
+                int keyLength, CK_ATTRIBUTE[] attrs) {
+            super(session, keyID, algorithm, keyLength, attrs);
         }
+
         private synchronized void fetchValues() {
             token.ensureValid();
-            if (w != null) {
-                return;
-            }
-            CK_ATTRIBUTE[] attributes = new CK_ATTRIBUTE[] {
+            if (w != null) return;
+
+            CK_ATTRIBUTE[] attrs = fetchAttributes(new CK_ATTRIBUTE[] {
                 new CK_ATTRIBUTE(CKA_EC_POINT),
                 new CK_ATTRIBUTE(CKA_EC_PARAMS),
-            };
-            fetchAttributes(attributes);
+            });
 
             try {
                 params = P11ECKeyFactory.decodeParameters
-                            (attributes[1].getByteArray());
-                byte[] ecKey = attributes[0].getByteArray();
+                            (attrs[1].getByteArray());
+                byte[] ecKey = attrs[0].getByteArray();
 
                 // Check whether the X9.63 encoding of an EC point is wrapped
                 // in an ASN.1 OCTET STRING
@@ -1111,10 +1269,12 @@ abstract class P11Key implements Key, Length {
                 throw new RuntimeException("Could not parse key values", e);
             }
         }
+
         public String getFormat() {
             token.ensureValid();
             return "X.509";
         }
+
         synchronized byte[] getEncodedInternal() {
             token.ensureValid();
             if (encoded == null) {
@@ -1413,3 +1573,4 @@ final class SessionKeyRef extends PhantomReference<P11Key> {
         this.clear();
     }
 }
+

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Signature.java
@@ -119,6 +119,9 @@ final class P11Signature extends SignatureSpi {
     // key instance used, if init*() was called
     private P11Key p11Key;
 
+    // signature length expected or 0 for unknown
+    private int sigLen;
+
     // message digest, if we do the digesting ourselves
     private final MessageDigest md;
 
@@ -285,7 +288,7 @@ final class P11Signature extends SignatureSpi {
         try {
             if (mode == M_SIGN) {
                 if (type == T_UPDATE) {
-                    token.p11.C_SignFinal(session.id(), 0);
+                    token.p11.C_SignFinal(session.id(), sigLen);
                 } else {
                     byte[] digest;
                     if (type == T_DIGEST) {
@@ -296,12 +299,7 @@ final class P11Signature extends SignatureSpi {
                     token.p11.C_Sign(session.id(), digest);
                 }
             } else { // M_VERIFY
-                byte[] signature;
-                if (mechanism == CKM_DSA) {
-                    signature = new byte[64]; // assume N = 256
-                } else {
-                    signature = new byte[(p11Key.length() + 7) >> 3];
-                }
+                byte[] signature = new byte[sigLen];
                 if (type == T_UPDATE) {
                     token.p11.C_VerifyFinal(session.id(), signature);
                 } else {
@@ -371,6 +369,15 @@ final class P11Signature extends SignatureSpi {
             bytesProcessed = 0;
             if (md != null) {
                 md.reset();
+            }
+        }
+        sigLen = 0;
+        if ("DSA".equals(p11Key.getAlgorithm())) {
+            if (p11Key instanceof P11Key.P11DSAPrivateKeyInternal) {
+                sigLen = ((P11Key.P11DSAPrivateKeyInternal)p11Key).getParams()
+                        .getQ().bitLength() >> 2;
+            } else if (p11Key instanceof DSAKey) {
+                sigLen = ((DSAKey)p11Key).getParams().getQ().bitLength() >> 2;
             }
         }
         initialized = true;
@@ -618,7 +625,7 @@ final class P11Signature extends SignatureSpi {
         try {
             byte[] signature;
             if (type == T_UPDATE) {
-                signature = token.p11.C_SignFinal(session.id(), 0);
+                signature = token.p11.C_SignFinal(session.id(), sigLen);
             } else {
                 byte[] digest;
                 if (type == T_DIGEST) {
@@ -685,7 +692,7 @@ final class P11Signature extends SignatureSpi {
         try {
             if (!p1363Format) {
                 if (keyAlgorithm.equals("DSA")) {
-                    signature = asn1ToDSA(signature);
+                    signature = asn1ToDSA(signature, sigLen);
                 } else if (keyAlgorithm.equals("EC")) {
                     signature = asn1ToECDSA(signature);
                 }
@@ -809,7 +816,8 @@ final class P11Signature extends SignatureSpi {
         }
     }
 
-    private static byte[] asn1ToDSA(byte[] sig) throws SignatureException {
+    private static byte[] asn1ToDSA(byte[] sig, int sigLen)
+            throws SignatureException {
         try {
             // Enforce strict DER checking for signatures
             DerInputStream in = new DerInputStream(sig, 0, sig.length, false);
@@ -824,8 +832,8 @@ final class P11Signature extends SignatureSpi {
             BigInteger r = values[0].getPositiveBigInteger();
             BigInteger s = values[1].getPositiveBigInteger();
 
-            byte[] br = toByteArray(r, 20);
-            byte[] bs = toByteArray(s, 20);
+            byte[] br = toByteArray(r, sigLen/2);
+            byte[] bs = toByteArray(s, sigLen/2);
             if ((br == null) || (bs == null)) {
                 throw new SignatureException("Out of range value for R or S");
             }
@@ -837,7 +845,7 @@ final class P11Signature extends SignatureSpi {
         }
     }
 
-    private byte[] asn1ToECDSA(byte[] sig) throws SignatureException {
+    private static byte[] asn1ToECDSA(byte[] sig) throws SignatureException {
         try {
             // Enforce strict DER checking for signatures
             DerInputStream in = new DerInputStream(sig, 0, sig.length, false);
@@ -917,3 +925,4 @@ final class P11Signature extends SignatureSpi {
         return null;
     }
 }
+


### PR DESCRIPTION
Hi,

I would like to request a review for the backport of [8271566](https://bugs.openjdk.org/browse/JDK-8271566) to jdk17u-dev.

The original patch does not apply cleanly due to context differences in some parts of P11Key.java. In particular, jdk17u lacks of [8274393](https://bugs.openjdk.org/browse/JDK-8274393) that introduces `@SuppressWarnings("serial")` lines. jdk17u does not have the [8160675](https://bugs.openjdk.org/browse/JDK-8160675) enhancement so it does not need [8274393](https://bugs.openjdk.org/browse/JDK-8274393) to be backported as a dependency.

No regressions observed in the "jdk/sun/security/pkcs11" tests category.

Thanks,
Martin.-
