### PR TITLE
8315692: Parallelize gc/stress/TestStressRSetCoarsening.java test

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -27,13 +27,12 @@ import java.util.concurrent.TimeoutException;
 import jdk.test.whitebox.WhiteBox;
 
 /*
- * @test TestStressRSetCoarsening.java
+ * @test
  * @key stress
  * @bug 8146984 8147087
  * @requires vm.gc.G1
  * @requires os.maxMemory > 3G
  * @requires vm.opt.MaxGCPauseMillis == "null"
- *
  * @summary Stress G1 Remembered Set by creating a lot of cross region links
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -42,27 +41,82 @@ import jdk.test.whitebox.WhiteBox;
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  1  0 300
+ *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 1 0 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=8m gc.stress.TestStressRSetCoarsening  1 10 300
+ *     -Xmx500m -XX:G1HeapRegionSize=8m gc.stress.TestStressRSetCoarsening 1 10 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
  *     -Xmx500m -XX:G1HeapRegionSize=32m gc.stress.TestStressRSetCoarsening 42 10 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  2 0 300
+ *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 2 0 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 500 0  1800
+ *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 500 0 1800
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
- *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 10  10 1800
+ *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 10 10 1800
  */
 
 /**
@@ -95,7 +149,7 @@ public class TestStressRSetCoarsening {
         }
         int objectsPerRegion = Integer.parseInt(args[0]); // 1 means humongous
         int regsToRefresh = Integer.parseInt(args[1]);  // 0 means no regions to refresh at the end of cycle
-        int timeout = Integer.parseInt(args[2]); // in seconds, test should stop working eariler
+        int timeout = Integer.parseInt(args[2]); // in seconds, test should stop working earlier
         new TestStressRSetCoarsening(objectsPerRegion, regsToRefresh, timeout).go();
     }
 

--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The commit includes backporting a564d436c722f14041231158f21c4ad3a2f6a3a5 from upstream tp jdk17u-dev. The hunks were applied cleanly. Below are the results upon running in AL2_x86_64:

* before_release: 1564.96s user 70.36s system 593% cpu 4:35.47 total
* before_debug: 9727.35s user 5080.61s system 2332% cpu 10:34.74 total
* after_release: 1662.45s user 57.04s system 1204% cpu 2:22.76 total
* after_debug: 11742.37s user 2687.01s system 3985% cpu 6:02.06 total

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315692](https://bugs.openjdk.org/browse/JDK-8315692) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315692](https://bugs.openjdk.org/browse/JDK-8315692): Parallelize gc/stress/TestStressRSetCoarsening.java test (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1985/head:pull/1985` \
`$ git checkout pull/1985`

Update a local copy of the PR: \
`$ git checkout pull/1985` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1985`

View PR using the GUI difftool: \
`$ git pr show -t 1985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1985.diff">https://git.openjdk.org/jdk17u-dev/pull/1985.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1985#issuecomment-1824547732)