### PR TITLE
8286045: Use ForceGC for cleaner test cases

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -650,7 +650,6 @@ com/sun/security/sasl/gsskerb/ConfSecurityLayer.java            8039280 generic-
 com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-all
 javax/security/auth/kerberos/KerberosHashEqualsTest.java        8039280 generic-all
 javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-all
-javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java 8286045 generic-all
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all

--- a/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
+++ b/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
@@ -49,8 +49,7 @@ public final class CheckCleanerBound {
         // Check if the object has been collected.  The collection will not
         // happen if the cleaner implementation in PasswordCallback is bound
         // to the PasswordCallback object.
-        ForceGC gc = new ForceGC();
-        if (!gc.await(() -> weakRef.get() == null)) {
+        if (!ForceGC.wait(() -> weakRef.refersTo(null))) {
             throw new RuntimeException(
                 "PasswordCallback object is not released");
         }

--- a/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
+++ b/test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java
@@ -25,14 +25,16 @@
  * @test
  * @bug 8284910
  * @summary Check that the cleaner is not bound to the PasswordCallback object
+ * @library /test/lib/
+ * @build jdk.test.lib.util.ForceGC
+ * @run main/othervm CheckCleanerBound
  */
 
 import javax.security.auth.callback.PasswordCallback;
-import java.util.WeakHashMap;
+import java.lang.ref.WeakReference;
+import jdk.test.lib.util.ForceGC;
 
 public final class CheckCleanerBound {
-    private final static WeakHashMap<PasswordCallback, ?> weakHashMap =
-            new WeakHashMap<>();
 
     public static void main(String[] args) throws Exception {
         // Create an object
@@ -40,20 +42,15 @@ public final class CheckCleanerBound {
                 new PasswordCallback("Password: ", false);
         passwordCallback.setPassword("ThisIsAPassword".toCharArray());
 
-        weakHashMap.put(passwordCallback, null);
+        WeakReference<PasswordCallback> weakRef =
+                new WeakReference<>(passwordCallback);
         passwordCallback = null;
-
-        // Check if the PasswordCallback object could be collected.
-        // Wait to trigger the cleanup.
-        for (int i = 0; i < 10 && weakHashMap.size() != 0; i++) {
-            System.gc();
-            Thread.sleep(100);
-        }
 
         // Check if the object has been collected.  The collection will not
         // happen if the cleaner implementation in PasswordCallback is bound
         // to the PasswordCallback object.
-        if (weakHashMap.size() > 0) {
+        ForceGC gc = new ForceGC();
+        if (!gc.await(() -> weakRef.get() == null)) {
             throw new RuntimeException(
                 "PasswordCallback object is not released");
         }


### PR DESCRIPTION
[JDK-8286045](https://bugs.openjdk.org/browse/JDK-8286045) is a test fix which aims to make GC usage within test cases more reliable by using the `ForceGC` library added by [JDK-8238358](https://bugs.openjdk.org/browse/JDK-8238358).

It adjusts three test cases:

* `test/jdk/javax/security/auth/callback/PasswordCallback/CheckCleanerBound.java`
* `test/jdk/sun/security/jgss/GssContextCleanup.java`
* `test/jdk/sun/security/jgss/GssNameCleanup.java`

The two `jgss` tests are introduced by a finalization cleanup, [JDK-8284490](https://bugs.openjdk.org/browse/JDK-8284490): "Remove finalizer method in java.security.jgss", which is not in 17u, so this backport only includes the changes to `CheckCleanerBound.java`, which was introduced in the 2023-10 security update.

The changes to `CheckCleanerBound.java` apply cleanly, but the test still fails as `CheckCleanerBound.java` never received the changes in the backport of [JDK-8285796](https://bugs.openjdk.org/browse/JDK-8285796) as this backport was introduced in 17u about a week before `CheckCleanerBound.java`. With that additional fragment cherry-picked from the trunk version of 8285796, the test passes.

Finally, we drop the `ProblemList.txt` addition made by [JDK-8285785](https://bugs.openjdk.org/browse/JDK-8285785) as the test now passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8286045](https://bugs.openjdk.org/browse/JDK-8286045) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286045](https://bugs.openjdk.org/browse/JDK-8286045): Use ForceGC for cleaner test cases (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1987/head:pull/1987` \
`$ git checkout pull/1987`

Update a local copy of the PR: \
`$ git checkout pull/1987` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1987`

View PR using the GUI difftool: \
`$ git pr show -t 1987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1987.diff">https://git.openjdk.org/jdk17u-dev/pull/1987.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1987#issuecomment-1826397184)