### PR TITLE
8318410: jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh fails on Japanese Windows

### DIFF
--- a/test/jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh
+++ b/test/jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,18 @@ echo "Creating manifest file..."
 # java Setup <workdir> <premain-class>
 # - outputs boot class path to boot.dir
 
-"$JAVA" ${TESTVMOPTS} -classpath "${TESTCLASSES}" Setup "${TESTCLASSES}" Agent
+OS=`uname -s`
+case ${OS} in
+    CYGWIN*)
+        CYGWIN="CYGWIN"
+        ;;
+    *)
+        CYGWIN=""
+        ;;
+esac
+
+"$JAVA" ${TESTVMOPTS} -classpath "${TESTCLASSES}" Setup "${TESTCLASSES}" Agent "${CYGWIN}"
+
 BOOTDIR=`cat ${TESTCLASSES}/boot.dir`
 
 echo "Created ${BOOTDIR}"

--- a/test/jdk/java/lang/instrument/BootClassPath/Setup.java
+++ b/test/jdk/java/lang/instrument/BootClassPath/Setup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,10 @@ public class Setup {
         }
         String workDir = args[0];
         String premainClass = args[1];
+        boolean isCygwin = false;
+        if (args.length==3 && args[2].equals("CYGWIN")) {
+            isCygwin = true;
+        }
 
         String manifestFile = workDir + fileSeparator + "MANIFEST.MF";
         String bootClassPath = "boot" + suffix();
@@ -94,7 +98,12 @@ public class Setup {
          */
         f = new File(workDir + fileSeparator + "boot.dir");
         try (FileOutputStream out = new FileOutputStream(f)) {
-            out.write(bootDir.getBytes(defaultEncoding));
+            if (osName.startsWith("Windows") && isCygwin) {
+                out.write(bootDir.getBytes("UTF-8"));
+            }
+            else {
+                out.write(bootDir.getBytes(defaultEncoding));
+            }
         }
     }
 


### PR DESCRIPTION
I would like to fix this issue because the test dose not work as intended.
8318410 resolved two issues. However, the first issue related to JEP400 is not relevant to JDK17.
Therefore, I would like to backport only the second issue,
which is the problem of tests not running properly on Windows cygwin.

Could someone please review it?

Thanks,
Kimura Yukihiro

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318410](https://bugs.openjdk.org/browse/JDK-8318410) needs maintainer approval

### Issue
 * [JDK-8318410](https://bugs.openjdk.org/browse/JDK-8318410): jdk/java/lang/instrument/BootClassPath/BootClassPathTest.sh fails on Japanese Windows (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1990/head:pull/1990` \
`$ git checkout pull/1990`

Update a local copy of the PR: \
`$ git checkout pull/1990` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1990`

View PR using the GUI difftool: \
`$ git pr show -t 1990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1990.diff">https://git.openjdk.org/jdk17u-dev/pull/1990.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1990#issuecomment-1829373650)