### PR TITLE
8295274: HelidonAppTest.java fails "assert(event->should_commit()) failed: invariant" from compiled frame"

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -571,7 +571,6 @@ InstanceKlass* SystemDictionary::handle_parallel_loading(JavaThread* current,
 void SystemDictionary::post_class_load_event(EventClassLoad* event, const InstanceKlass* k, const ClassLoaderData* init_cld) {
   assert(event != NULL, "invariant");
   assert(k != NULL, "invariant");
-  assert(event->should_commit(), "invariant");
   event->set_loadedClass(k);
   event->set_definingClassLoader(k->class_loader_data());
   event->set_initiatingClassLoader(init_cld);

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -798,7 +798,6 @@ UNSAFE_ENTRY(jboolean, Unsafe_CompareAndSetLong(JNIEnv *env, jobject unsafe, job
 
 static void post_thread_park_event(EventThreadPark* event, const oop obj, jlong timeout_nanos, jlong until_epoch_millis) {
   assert(event != NULL, "invariant");
-  assert(event->should_commit(), "invariant");
   event->set_parkedClass((obj != NULL) ? obj->klass() : NULL);
   event->set_timeout(timeout_nanos);
   event->set_until(until_epoch_millis);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1224,7 +1224,6 @@ static void post_monitor_inflate_event(EventJavaMonitorInflate* event,
                                        const oop obj,
                                        ObjectSynchronizer::InflateCause cause) {
   assert(event != NULL, "invariant");
-  assert(event->should_commit(), "invariant");
   event->set_monitorClass(obj->klass());
   event->set_address((uintptr_t)(void*)obj);
   event->set_cause((u1)cause);

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -245,7 +245,6 @@ void VMThread::wait_for_vm_thread_exit() {
 
 static void post_vm_operation_event(EventExecuteVMOperation* event, VM_Operation* op) {
   assert(event != NULL, "invariant");
-  assert(event->should_commit(), "invariant");
   assert(op != NULL, "invariant");
   const bool evaluate_at_safepoint = op->evaluate_at_safepoint();
   event->set_operation(op->type());


### PR DESCRIPTION
This is a follow-up to https://github.com/openjdk/jdk17u-dev/pull/1986
Original patch is applied cleanly.

Testing: tier1, tier2, jdk_jfr, gc/stress/jfr on (linux-aarch64 fastdebug).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8295274](https://bugs.openjdk.org/browse/JDK-8295274) needs maintainer approval

### Issue
 * [JDK-8295274](https://bugs.openjdk.org/browse/JDK-8295274): HelidonAppTest.java fails "assert(event-&gt;should_commit()) failed: invariant" from compiled frame" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1992/head:pull/1992` \
`$ git checkout pull/1992`

Update a local copy of the PR: \
`$ git checkout pull/1992` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1992`

View PR using the GUI difftool: \
`$ git pr show -t 1992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1992.diff">https://git.openjdk.org/jdk17u-dev/pull/1992.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1992#issuecomment-1830678694)