### PR TITLE
8298087: XML Schema Validation reports an required attribute twice via ErrorHandler

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XMLSchemaValidator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/XMLSchemaValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -112,7 +112,7 @@ import jdk.xml.internal.JdkXmlUtils;
  * @author Elena Litani IBM
  * @author Andy Clark IBM
  * @author Neeraj Bajaj, Sun Microsystems, inc.
- * @LastModified: May 2021
+ * @LastModified: Apr 2023
  */
 public class XMLSchemaValidator
     implements XMLComponent, XMLDocumentFilter, FieldActivator, RevalidationHandler, XSElementDeclHelper {
@@ -3217,10 +3217,6 @@ public class XMLSchemaValidator
             // {required} is true matches one of the attribute information items in the element
             // information item's [attributes] as per clause 3.1 above.
             if (currUse.fUse == SchemaSymbols.USE_REQUIRED) {
-                if (!isSpecified)
-                    reportSchemaError(
-                        "cvc-complex-type.4",
-                        new Object[] { element.rawname, currDecl.fName });
                 if (!isSpecified) {
                     if (currDecl.fTargetNamespace != null) {
                        reportSchemaError(

--- a/test/jaxp/javax/xml/jaxp/unittest/validation/ErrorHandlingTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/ErrorHandlingTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package validation;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import static java.util.Collections.unmodifiableList;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/*
+ * @test
+ * @bug 8298087
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @run testng validation.ErrorHandlingTest
+ * @summary Verifies error handling.
+ */
+public class ErrorHandlingTest {
+    private final static String xsd = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
+            +"<schema xmlns=\"http://www.w3.org/2001/XMLSchema\""
+            +"       targetNamespace=\"https://errorhandlingtest/schema/Example\""
+            +"        elementFormDefault=\"qualified\">"
+            +"\n"
+            +"    <element name=\"root\">"
+            +"        <complexType>"
+            +"            <sequence>"
+            +"                <element name=\"a\">"
+            +"                    <complexType>"
+            +"                        <simpleContent>"
+            +"                            <extension base=\"string\">"
+            +"                                <attribute name=\"enabled\" type=\"boolean\" use=\"required\"/>"
+            +"                            </extension>"
+            +"                        </simpleContent>"
+            +"                    </complexType>"
+            +"                </element>"
+            +"            </sequence>"
+            +"        </complexType>"
+            +"    </element>"
+            +"\n"
+            +"</schema>";
+
+    private final static String xml = "<e:root xmlns:e=\"https://errorhandlingtest/schema/Example\">\n"
+            +"    <e:a>string</e:a>\n"
+            +"</e:root>";
+
+    /**
+     * Verifies that validation error is reported properly (once rather than twice).
+     *
+     * @throws Exception if the test fails
+     */
+    @Test
+    public void test() throws Exception {
+        List<SAXParseException> ex = validateXMLWithSchema(new StreamSource(new StringReader(xsd)),
+                new StreamSource(new StringReader(xml)));
+        Assert.assertEquals(ex.size(), 1);
+    }
+
+    public static List<SAXParseException> validateXMLWithSchema(final Source xsd, final Source xml) {
+        final List<SAXParseException> exceptions = new ArrayList<>();
+        try {
+            final SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            final Schema schema = factory.newSchema(xsd);
+            final Validator validator = schema.newValidator();
+            validator.setErrorHandler(new ErrorHandler() {
+                @Override
+                public void warning(final SAXParseException exception) {
+                    System.err.printf("Warning: %s%n", exception);
+                    exceptions.add(exception);
+                }
+
+                @Override
+                public void error(final SAXParseException exception) {
+                    System.err.printf("Error: %s%n", exception);
+                    exceptions.add(exception);
+                }
+
+                @Override
+                public void fatalError(final SAXParseException exception) {
+                    System.err.printf("Fatal: %s%n", exception);
+                    exceptions.add(exception);
+                }
+            });
+
+            validator.validate(xml);
+
+        } catch (final SAXException | IOException e) {
+            System.err.printf("Exception: %s%n", e.getMessage());
+        }
+        return unmodifiableList(exceptions);
+    }
+
+}


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8298087](https://bugs.openjdk.org/browse/JDK-8298087) needs maintainer approval

### Issue
 * [JDK-8298087](https://bugs.openjdk.org/browse/JDK-8298087): XML Schema Validation reports an required attribute twice via ErrorHandler (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/1996/head:pull/1996` \
`$ git checkout pull/1996`

Update a local copy of the PR: \
`$ git checkout pull/1996` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/1996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1996`

View PR using the GUI difftool: \
`$ git pr show -t 1996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/1996.diff">https://git.openjdk.org/jdk17u-dev/pull/1996.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/1996#issuecomment-1832015269)