### PR TITLE
8301846: Invalid TargetDataLine after screen lock when using JFileChooser or COM library

### DIFF
--- a/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_DirectSound.cpp
+++ b/src/java.desktop/windows/native/libjsound/PLATFORM_API_WinOS_DirectSound.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,6 +184,12 @@ INT32 DAUDIO_GetDirectAudioDeviceCount() {
         return 0;
     }
 
+    HRESULT hr = ::CoInitializeEx(NULL, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+        DS_unlockCache();
+        return 0;
+    }
+
     if (g_lastCacheRefreshTime == 0
         || (UINT64) timeGetTime() > (UINT64) (g_lastCacheRefreshTime + WAIT_BETWEEN_CACHE_REFRESH_MILLIS)) {
         /* first, initialize any old cache items */
@@ -224,6 +230,11 @@ INT32 DAUDIO_GetDirectAudioDeviceCount() {
 
         g_lastCacheRefreshTime = (UINT64) timeGetTime();
     }
+
+    if (hr != RPC_E_CHANGED_MODE) {
+        ::CoUninitialize();
+    }
+
     DS_unlockCache();
     /*TRACE1("DirectSound: %d installed devices\n", g_mixerCount);*/
     return g_mixerCount;
@@ -258,6 +269,13 @@ INT32 DAUDIO_GetDirectAudioDeviceDescription(INT32 mixerIndex, DirectAudioDevice
         DS_unlockCache();
         return FALSE;
     }
+
+    HRESULT hr = ::CoInitializeEx(NULL, COINIT_MULTITHREADED | COINIT_DISABLE_OLE1DDE);
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+        DS_unlockCache();
+        return 0;
+    }
+
     desc->maxSimulLines = 0;
     if (g_audioDeviceCache[desc->deviceID].isSource) {
         DirectSoundEnumerateW((LPDSENUMCALLBACKW) DS_GetDescEnum, desc);
@@ -265,6 +283,10 @@ INT32 DAUDIO_GetDirectAudioDeviceDescription(INT32 mixerIndex, DirectAudioDevice
     } else {
         DirectSoundCaptureEnumerateW((LPDSENUMCALLBACKW) DS_GetDescEnum, desc);
         strncpy(desc->description, "DirectSound Capture", DAUDIO_STRING_LENGTH);
+    }
+
+    if (hr != RPC_E_CHANGED_MODE) {
+        ::CoUninitialize();
     }
 
     /*desc->vendor;

--- a/test/jdk/javax/sound/sampled/Lines/OpenLineAfterScreenLock.java
+++ b/test/jdk/javax/sound/sampled/Lines/OpenLineAfterScreenLock.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Line;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.Mixer;
+import javax.sound.sampled.TargetDataLine;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+import static javax.swing.SwingUtilities.invokeAndWait;
+
+/*
+ * @test
+ * @bug 8301846
+ * @requires (os.family == "windows")
+ * @summary Sound recording fails after screen lock and unlock.
+ * @run main/manual OpenLineAfterScreenLock
+ */
+public class OpenLineAfterScreenLock {
+
+    private static final String INSTRUCTIONS = """
+            This test verifies it can record sound from the first sound capture device after
+            locking and unlocking the screen. The first part of the test has already completed.
+
+            Lock the screen and unlock it. Then click Continue to complete the test.
+
+            The test will finish automatically.
+            """;
+
+    private static final CountDownLatch latch = new CountDownLatch(1);
+
+    private static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            runTest();
+
+            // Creating JFileChooser initializes COM
+            // which affects ability to open audio lines
+            new JFileChooser();
+
+            invokeAndWait(OpenLineAfterScreenLock::createInstructionsUI);
+            if (!latch.await(2, TimeUnit.MINUTES)) {
+                throw new RuntimeException("Test failed: Test timed out!!");
+            }
+
+            runTest();
+        } finally {
+            invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+        System.out.println("Test Passed");
+    }
+
+    private static void runTest() {
+        try {
+            Mixer mixer = getMixer();
+            TargetDataLine line =
+                    (TargetDataLine) mixer.getLine(mixer.getTargetLineInfo()[0]);
+            line.open();
+            line.close();
+        } catch (LineUnavailableException e) {
+            throw new RuntimeException("Test failed: Line unavailable", e);
+        }
+    }
+
+    private static Mixer getMixer() {
+        return Arrays.stream(AudioSystem.getMixerInfo())
+                     .map(AudioSystem::getMixer)
+                     .filter(OpenLineAfterScreenLock::isRecordingDevice)
+                     .skip(1) // Skip the primary driver and choose one directly
+                     .findAny()
+                     .orElseThrow();
+    }
+
+    private static boolean isRecordingDevice(Mixer mixer) {
+        Line.Info[] lineInfos = mixer.getTargetLineInfo();
+        return lineInfos.length > 0
+               && lineInfos[0].getLineClass() == TargetDataLine.class;
+    }
+
+    private static void createInstructionsUI() {
+        frame = new JFrame("Instructions for OpenLineAfterScreenLock");
+
+        JTextArea textArea = new JTextArea(INSTRUCTIONS);
+        textArea.setEditable(false);
+
+        JScrollPane pane = new JScrollPane(textArea);
+        frame.getContentPane().add(pane, BorderLayout.NORTH);
+
+        JButton button = new JButton("Continue");
+        button.addActionListener(e -> latch.countDown());
+        frame.getContentPane().add(button, BorderLayout.PAGE_END);
+
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+
+        frame.addWindowListener(new CloseWindowHandler());
+        frame.setVisible(true);
+    }
+
+    private static class CloseWindowHandler extends WindowAdapter {
+        @Override
+        public void windowClosing(WindowEvent e) {
+            latch.countDown();
+            throw new RuntimeException("Test window closed abruptly");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301846](https://bugs.openjdk.org/browse/JDK-8301846) needs maintainer approval

### Issue
 * [JDK-8301846](https://bugs.openjdk.org/browse/JDK-8301846): Invalid TargetDataLine after screen lock when using JFileChooser or COM library (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2007/head:pull/2007` \
`$ git checkout pull/2007`

Update a local copy of the PR: \
`$ git checkout pull/2007` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2007`

View PR using the GUI difftool: \
`$ git pr show -t 2007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2007.diff">https://git.openjdk.org/jdk17u-dev/pull/2007.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2007#issuecomment-1833569558)