### PR TITLE
8301306: java/net/httpclient/* fail with -Xcomp

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
@@ -729,7 +729,7 @@ public abstract class AbstractThrowingPushPromises implements HttpServerAdapters
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(5000);
         try {
             http2TestServer.stop();
             https2TestServer.stop();

--- a/test/jdk/java/net/httpclient/ByteArrayPublishers.java
+++ b/test/jdk/java/net/httpclient/ByteArrayPublishers.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8222968
  * @summary ByteArrayPublisher is not thread-safe resulting in broken re-use of HttpRequests
- * @run main/othervm ByteArrayPublishers
+ * @run main/othervm -Dsun.net.httpserver.idleInterval=50000 ByteArrayPublishers
  */
 
 import java.net.InetAddress;

--- a/test/jdk/java/net/httpclient/ManyRequestsLegacy.java
+++ b/test/jdk/java/net/httpclient/ManyRequestsLegacy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,10 @@
  * @compile ../../../com/sun/net/httpserver/LogFilter.java
  * @compile ../../../com/sun/net/httpserver/EchoHandler.java
  * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
- * @run main/othervm/timeout=40 ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.insertDelay=true ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.chunkSize=64 ManyRequestsLegacy
- * @run main/othervm/timeout=40 -Dtest.insertDelay=true
+ * @run main/othervm/timeout=80 -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.insertDelay=true -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.chunkSize=64 -Dsun.net.httpserver.idleInterval=50000 ManyRequestsLegacy
+ * @run main/othervm/timeout=80 -Dtest.insertDelay=true -Dsun.net.httpserver.idleInterval=50000
  *                              -Dtest.chunkSize=64 ManyRequestsLegacy
  * @summary Send a large number of requests asynchronously using the legacy
  *          URL.openConnection(), to help sanitize results of the test

--- a/test/jdk/java/net/httpclient/Response204V2Test.java
+++ b/test/jdk/java/net/httpclient/Response204V2Test.java
@@ -291,7 +291,7 @@ public class Response204V2Test implements HttpServerAdapters {
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(5000);
         try {
             http2TestServer.stop();
             https2TestServer.stop();

--- a/test/jdk/java/net/httpclient/SpecialHeadersTest.java
+++ b/test/jdk/java/net/httpclient/SpecialHeadersTest.java
@@ -35,6 +35,7 @@
  * @library /test/lib http2/server
  * @build Http2TestServer HttpServerAdapters SpecialHeadersTest
  * @build jdk.test.lib.net.SimpleSSLContext
+ * @requests (vm.compMode != "Xcomp")
  * @run testng/othervm
  *       -Djdk.httpclient.HttpClient.log=requests,headers,errors
  *       SpecialHeadersTest

--- a/test/jdk/java/net/httpclient/SpecialHeadersTest.java
+++ b/test/jdk/java/net/httpclient/SpecialHeadersTest.java
@@ -35,7 +35,7 @@
  * @library /test/lib http2/server
  * @build Http2TestServer HttpServerAdapters SpecialHeadersTest
  * @build jdk.test.lib.net.SimpleSSLContext
- * @requests (vm.compMode != "Xcomp")
+ * @requires (vm.compMode != "Xcomp")
  * @run testng/othervm
  *       -Djdk.httpclient.HttpClient.log=requests,headers,errors
  *       SpecialHeadersTest


### PR DESCRIPTION
I backport this because we see issues with these tests in our CI.

HttpClientLocalAddrTest.java and HttpALot.java are not in 17, skipped.

SpecialHeadersTest.java resolved due to context.

I also include follow-up 8301787: java/net/httpclient/SpecialHeadersTest failing after JDK-8301306
to avoid the test to fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301787](https://bugs.openjdk.org/browse/JDK-8301787) needs maintainer approval
- [x] [JDK-8301306](https://bugs.openjdk.org/browse/JDK-8301306) needs maintainer approval

### Issues
 * [JDK-8301306](https://bugs.openjdk.org/browse/JDK-8301306): java/net/httpclient/* fail with -Xcomp (**Bug** - P4 - Approved)
 * [JDK-8301787](https://bugs.openjdk.org/browse/JDK-8301787): java/net/httpclient/SpecialHeadersTest failing after JDK-8301306 (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2011/head:pull/2011` \
`$ git checkout pull/2011`

Update a local copy of the PR: \
`$ git checkout pull/2011` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2011`

View PR using the GUI difftool: \
`$ git pr show -t 2011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2011.diff">https://git.openjdk.org/jdk17u-dev/pull/2011.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2011#issuecomment-1838722814)