### PR TITLE
8315680: java/lang/ref/ReachabilityFenceTest.java should run with -Xbatch

### DIFF
--- a/test/jdk/java/lang/ref/ReachabilityFenceTest.java
+++ b/test/jdk/java/lang/ref/ReachabilityFenceTest.java
@@ -27,11 +27,11 @@
  *
  * @requires vm.opt.DeoptimizeALot != true
  *
- * @run main/othervm -Xint                   -Dpremature=false ReachabilityFenceTest
- * @run main/othervm -XX:TieredStopAtLevel=1 -Dpremature=true  ReachabilityFenceTest
- * @run main/othervm -XX:TieredStopAtLevel=2 -Dpremature=true  ReachabilityFenceTest
- * @run main/othervm -XX:TieredStopAtLevel=3 -Dpremature=true  ReachabilityFenceTest
- * @run main/othervm -XX:TieredStopAtLevel=4 -Dpremature=true  ReachabilityFenceTest
+ * @run main/othervm -Xint                           -Dpremature=false ReachabilityFenceTest
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=1 -Dpremature=true  ReachabilityFenceTest
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=2 -Dpremature=true  ReachabilityFenceTest
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=3 -Dpremature=true  ReachabilityFenceTest
+ * @run main/othervm -Xbatch -XX:TieredStopAtLevel=4 -Dpremature=true  ReachabilityFenceTest
  */
 
 import java.lang.ref.Reference;
@@ -54,7 +54,7 @@ public class ReachabilityFenceTest {
      * the object cannot be finalized. There is no sense running a positive test when premature finalization
      * is not expected. It is a job for negative test to verify that invariant.
      *
-     * The test methods should be appropriately compiled, therefore we do several iterations.
+     * The test methods should be appropriately compiled, therefore we do several iterations and run with -Xbatch.
      */
 
     // Enough to OSR and compile


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a290256b](https://github.com/openjdk/jdk/commit/a290256bbf85a52fbeab24dab5fbe195cf58750f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Gergö Barany on 7 Nov 2023 and was reviewed by Doug Simon, Tom Rodriguez and Paul Sandoz.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315680](https://bugs.openjdk.org/browse/JDK-8315680) needs maintainer approval

### Issue
 * [JDK-8315680](https://bugs.openjdk.org/browse/JDK-8315680): java/lang/ref/ReachabilityFenceTest.java should run with -Xbatch (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2012/head:pull/2012` \
`$ git checkout pull/2012`

Update a local copy of the PR: \
`$ git checkout pull/2012` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2012`

View PR using the GUI difftool: \
`$ git pr show -t 2012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2012.diff">https://git.openjdk.org/jdk17u-dev/pull/2012.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2012#issuecomment-1840913307)