### PR TITLE
8307990: jspawnhelper must close its writing side of a pipe before reading from it

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -490,14 +490,14 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     pid_t resultPid;
     jboolean isCopy;
     int i, offset, rval, bufsize, magic;
-    char *buf, buf1[16];
+    char *buf, buf1[(3 * 11) + 3]; // "%d:%d:%d\0"
     char *hlpargs[3];
     SpawnInfo sp;
 
     /* need to tell helper which fd is for receiving the childstuff
      * and which fd to send response back on
      */
-    snprintf(buf1, sizeof(buf1), "%d:%d", c->childenv[0], c->fail[1]);
+    snprintf(buf1, sizeof(buf1), "%d:%d:%d", c->childenv[0], c->childenv[1], c->fail[1]);
     /* NULL-terminated argv array.
      * argv[0] contains path to jspawnhelper, to follow conventions.
      * argv[1] contains the fd string as argument to jspawnhelper
@@ -534,7 +534,7 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
         if (c->fds[i] != -1) {
             int flags = fcntl(c->fds[i], F_GETFD);
             if (flags & FD_CLOEXEC) {
-                fcntl(c->fds[i], F_SETFD, flags & (~1));
+                fcntl(c->fds[i], F_SETFD, flags & (~FD_CLOEXEC));
             }
         }
     }
@@ -544,6 +544,10 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     if (rval != 0) {
         return -1;
     }
+
+#ifdef DEBUG
+    jtregSimulateCrash(resultPid, 1);
+#endif
 
     /* now the lengths are known, copy the data */
     buf = NEW(char, bufsize);
@@ -560,11 +564,24 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     magic = magicNumber();
 
     /* write the two structs and the data buffer */
-    write(c->childenv[1], (char *)&magic, sizeof(magic)); // magic number first
-    write(c->childenv[1], (char *)c, sizeof(*c));
-    write(c->childenv[1], (char *)&sp, sizeof(sp));
-    write(c->childenv[1], buf, bufsize);
+    if (writeFully(c->childenv[1], (char *)&magic, sizeof(magic)) != sizeof(magic)) { // magic number first
+        return -1;
+    }
+#ifdef DEBUG
+    jtregSimulateCrash(resultPid, 2);
+#endif
+    if (writeFully(c->childenv[1], (char *)c, sizeof(*c)) != sizeof(*c) ||
+        writeFully(c->childenv[1], (char *)&sp, sizeof(sp)) != sizeof(sp) ||
+        writeFully(c->childenv[1], buf, bufsize) != bufsize) {
+        return -1;
+    }
+    /* We're done. Let jspwanhelper know he can't expect any more data from us. */
+    close(c->childenv[1]);
+    c->childenv[1] = -1;
     free(buf);
+#ifdef DEBUG
+    jtregSimulateCrash(resultPid, 3);
+#endif
 
     /* In this mode an external main() in invoked which calls back into
      * childProcess() in this file, rather than directly
@@ -617,6 +634,8 @@ Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
 
     in[0] = in[1] = out[0] = out[1] = err[0] = err[1] = fail[0] = fail[1] = -1;
     childenv[0] = childenv[1] = -1;
+    // Reset errno to protect against bogus error messages
+    errno = 0;
 
     if ((c = NEW(ChildStuff, 1)) == NULL) return -1;
     c->argv = NULL;
@@ -715,11 +734,9 @@ Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
                 goto Catch;
             }
         case sizeof(errnum):
-            assert(errnum == CHILD_IS_ALIVE);
             if (errnum != CHILD_IS_ALIVE) {
-                /* Should never happen since the first thing the spawn
-                 * helper should do is to send an alive ping to the parent,
-                 * before doing any subsequent work. */
+                /* This can happen if the spawn helper encounters an error
+                 * before or during the handshake with the parent. */
                 throwIOException(env, 0, "Bad code from spawn helper "
                                          "(Failed to exec spawn helper)");
                 goto Catch;
@@ -755,8 +772,12 @@ Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
     /* Always clean up fail and childEnv descriptors */
     closeSafely(fail[0]);
     closeSafely(fail[1]);
-    closeSafely(childenv[0]);
-    closeSafely(childenv[1]);
+    /* We use 'c->childenv' here rather than 'childenv' because 'spawnChild()' might have
+     * already closed 'c->childenv[1]' and signaled this by setting 'c->childenv[1]' to '-1'.
+     * Otherwise 'c->childenv' and 'childenv' are the same because we just copied 'childenv'
+     * to 'c->childenv' (with 'copyPipe()') before calling 'startChild()'. */
+    closeSafely(c->childenv[0]);
+    closeSafely(c->childenv[1]);
 
     releaseBytes(env, helperpath, phelperpath);
     releaseBytes(env, prog,       pprog);

--- a/src/java.base/unix/native/libjava/childproc.h
+++ b/src/java.base/unix/native/libjava/childproc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,6 @@ extern char **environ;
 #define MODE_FORK 1
 #define MODE_POSIX_SPAWN 2
 #define MODE_VFORK 3
-#define MODE_CLONE 4
 
 typedef struct _ChildStuff
 {
@@ -128,7 +127,7 @@ typedef struct _SpawnInfo {
  */
 extern const char * const *parentPathv;
 
-ssize_t restartableWrite(int fd, const void *buf, size_t count);
+ssize_t writeFully(int fd, const void *buf, size_t count);
 int restartableDup2(int fd_from, int fd_to);
 int closeSafely(int fd);
 int isAsciiDigit(char c);
@@ -148,5 +147,15 @@ void JDK_execvpe(int mode, const char *file,
                  const char *argv[],
                  const char *const envp[]);
 int childProcess(void *arg);
+
+#ifdef DEBUG
+/* This method is only used in debug builds for testing MODE_POSIX_SPAWN
+ * in the light of abnormal program termination of either the parent JVM
+ * or the newly created jspawnhelper child process during the execution of
+ * Java_java_lang_ProcessImpl_forkAndExec().
+ * See: test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
+ */
+void jtregSimulateCrash(pid_t child, int stage);
+#endif
 
 #endif

--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8307990
+ * @requires (os.family == "linux") | (os.family == "aix")
+ * @requires vm.debug
+ * @library /test/lib
+ * @run main/othervm/timeout=300 JspawnhelperProtocol
+ */
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import jdk.test.lib.process.ProcessTools;
+
+public class JspawnhelperProtocol {
+    // Timout in seconds
+    private static final int TIMEOUT = 60;
+    // Base error code to communicate various error states from the parent process to the top-level test
+    private static final int ERROR = 10;
+    private static final String[] CMD = { "pwd" };
+    private static final String ENV_KEY = "JTREG_JSPAWNHELPER_PROTOCOL_TEST";
+
+    private static void parentCode(String arg) throws IOException, InterruptedException {
+        System.out.println("Recursively executing 'JspawnhelperProtocol " + arg + "'");
+        Process p = null;
+        try {
+            p = Runtime.getRuntime().exec(CMD);
+        } catch (Exception e) {
+            e.printStackTrace(System.out);
+            System.exit(ERROR);
+        }
+        if (!p.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+            System.out.println("Child process timed out");
+            System.exit(ERROR + 1);
+        }
+        if (p.exitValue() == 0) {
+            String pwd = p.inputReader().readLine();
+            String realPwd = Path.of("").toAbsolutePath().toString();
+            if (!realPwd.equals(pwd)) {
+                System.out.println("Child process returned '" + pwd + "' (expected '" + realPwd + "')");
+                System.exit(ERROR + 2);
+            }
+            System.out.println("  Successfully executed '" + CMD[0] + "'");
+            System.exit(0);
+        } else {
+            System.out.println("  Failed to executed '" + CMD[0] + "' (exitValue=" + p.exitValue() + ")");
+            System.exit(ERROR + 3);
+        }
+    }
+
+    private static void normalExec() throws Exception {
+        ProcessBuilder pb;
+        pb = ProcessTools.createJavaProcessBuilder("-Djdk.lang.Process.launchMechanism=posix_spawn",
+                                                   "JspawnhelperProtocol",
+                                                   "normalExec");
+        pb.inheritIO();
+        Process p = pb.start();
+        if (!p.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+            throw new Exception("Parent process timed out");
+        }
+        if (p.exitValue() != 0) {
+            throw new Exception("Parent process exited with " + p.exitValue());
+        }
+    }
+
+    private static void simulateCrashInChild(int stage) throws Exception {
+        ProcessBuilder pb;
+        pb = ProcessTools.createJavaProcessBuilder("-Djdk.lang.Process.launchMechanism=posix_spawn",
+                                                   "JspawnhelperProtocol",
+                                                   "simulateCrashInChild" + stage);
+        pb.environment().put(ENV_KEY, Integer.toString(stage));
+        Process p = pb.start();
+
+        boolean foundCrashInfo = false;
+        try (BufferedReader br = p.inputReader()) {
+            String line = br.readLine();
+            while (line != null) {
+                System.out.println(line);
+                if (line.equals("posix_spawn:0")) {
+                    foundCrashInfo = true;
+                }
+                line = br.readLine();
+            }
+        }
+        if (!foundCrashInfo) {
+            throw new Exception("Wrong output from child process");
+        }
+        if (!p.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+            throw new Exception("Parent process timed out");
+        }
+
+        int ret = p.exitValue();
+        if (ret == 0) {
+            throw new Exception("Expected error during child execution");
+        }
+        System.out.println("Parent exit code: " + ret);
+    }
+
+    private static void simulateCrashInParent(int stage) throws Exception {
+        ProcessBuilder pb;
+        pb = ProcessTools.createJavaProcessBuilder("-Djdk.lang.Process.launchMechanism=posix_spawn",
+                                                   "JspawnhelperProtocol",
+                                                   "simulateCrashInParent" + stage);
+        pb.environment().put(ENV_KEY, Integer.toString(stage));
+        Process p = pb.start();
+
+        String line = null;
+        try (BufferedReader br = p.inputReader()) {
+            line = br.readLine();
+            while (line != null && !line.startsWith("posix_spawn:")) {
+                System.out.println(line);
+                line = br.readLine();
+            }
+        }
+        if (line == null) {
+            throw new Exception("Wrong output from parent process");
+        }
+        System.out.println(line);
+        long childPid = Integer.parseInt(line.substring(line.indexOf(':') + 1));
+
+        if (!p.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+            throw new Exception("Parent process timed out");
+        }
+
+        Optional<ProcessHandle> oph = ProcessHandle.of(childPid);
+        if (!oph.isEmpty()) {
+            ProcessHandle ph = oph.get();
+            try {
+                // Give jspawnhelper a chance to exit gracefully
+                ph.onExit().get(TIMEOUT, TimeUnit.SECONDS);
+            } catch (TimeoutException te) {
+                Optional<String> cmd = ph.info().command();
+                if (cmd.isPresent() && cmd.get().endsWith("jspawnhelper")) {
+                    throw new Exception("jspawnhelper still alive after parent Java process terminated");
+                }
+            }
+        }
+        int ret = p.exitValue();
+        if (ret != stage) {
+            throw new Exception("Expected exit code " + stage + " but got " + ret);
+        }
+        System.out.println("Parent exit code: " + ret);
+    }
+
+    private static void simulateTruncatedWriteInParent(int stage) throws Exception {
+        ProcessBuilder pb;
+        pb = ProcessTools.createJavaProcessBuilder("-Djdk.lang.Process.launchMechanism=posix_spawn",
+                                                   "JspawnhelperProtocol",
+                                                   "simulateTruncatedWriteInParent" + stage);
+        pb.environment().put(ENV_KEY, Integer.toString(stage));
+        Process p = pb.start();
+
+        BufferedReader br = p.inputReader();
+        String line = br.readLine();
+        while (line != null && !line.startsWith("posix_spawn:")) {
+            System.out.println(line);
+            line = br.readLine();
+        }
+        if (line == null) {
+            throw new Exception("Wrong output from parent process");
+        }
+        System.out.println(line);
+
+        if (!p.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+            throw new Exception("Parent process timed out");
+        }
+        line = br.readLine();
+        while (line != null) {
+            System.out.println(line);
+            line = br.readLine();
+        }
+
+        int ret = p.exitValue();
+        if (ret != ERROR) {
+            throw new Exception("Expected exit code " + ERROR + " but got " + ret);
+        }
+        System.out.println("Parent exit code: " + ret);
+    }
+
+    public static void main(String[] args) throws Exception {
+        // This test works as follows:
+        //  - jtreg executes the test class `JspawnhelperProtocol` without arguments.
+        //    This is the initial "grandparent" process.
+        //  - For each sub-test (i.e. `normalExec()`, `simulateCrashInParent()` and
+        //    `simulateCrashInChild()`), a new sub-process (called the "parent") will be
+        //    forked which executes `JspawnhelperProtocol` recursively with a corresponding
+        //    command line argument.
+        //  - The forked `JspawnhelperProtocol` process (i.e. the "parent") runs
+        //    `JspawnhelperProtocol::parentCode()` which forks off yet another sub-process
+        //    (called the "child").
+        //  - The sub-tests in the "grandparent" check that various abnormal program
+        //    terminations in the "parent" or the "child" process are handled gracefully and
+        //    don't lead to deadlocks or zombie processes.
+        if (args.length > 0) {
+            // Entry point for recursive execution in the "parent" process
+            parentCode(args[0]);
+        } else {
+            // Main test entry for execution from jtreg
+            normalExec();
+            simulateCrashInParent(1);
+            simulateCrashInParent(2);
+            simulateCrashInParent(3);
+            simulateCrashInChild(4);
+            simulateCrashInChild(5);
+            simulateCrashInChild(6);
+            simulateTruncatedWriteInParent(99);
+        }
+    }
+}


### PR DESCRIPTION
Backporting the jspwanhelper fixes from [JDK-8307990](https://bugs.openjdk.org/browse/JDK-8307990) because we constantly see customers hitting this issue in production. For more details about the problem please refer to the corresponding release notes in https://bugs.openjdk.org/browse/JDK-8308297. The original change was pushed to JDK 21 in June so it had quite some time to mature.

The backport was not clean because of some trivial copyright changes and because [JDK-8310265: (process) jspawnhelper should not use argv[0]](https://bugs.openjdk.org/browse/JDK-8310265), which was done after this change, already got backported to JDK 17u before this change.

Once this backport will be reviewed and approved, I'll also plan to backport [JDK-8311645: Memory leak in jspawnhelper spawnChild after JDK-8307990](https://bugs.openjdk.org/browse/JDK-8311645) which was a follow-up fix for this change (and clean backport - see [pr/2017](https://github.com/openjdk/jdk17u-dev/pull/2017)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307990](https://bugs.openjdk.org/browse/JDK-8307990) needs maintainer approval

### Issue
 * [JDK-8307990](https://bugs.openjdk.org/browse/JDK-8307990): jspawnhelper must close its writing side of a pipe before reading from it (**Bug** - P3 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2013/head:pull/2013` \
`$ git checkout pull/2013`

Update a local copy of the PR: \
`$ git checkout pull/2013` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2013`

View PR using the GUI difftool: \
`$ git pr show -t 2013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2013.diff">https://git.openjdk.org/jdk17u-dev/pull/2013.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2013#issuecomment-1841319893)