### PR TITLE
8321215: Incorrect x86 instruction encoding for VSIB addressing mode

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -318,7 +318,7 @@ class Address {
   }
 
   bool xmmindex_needs_rex() const {
-    return _xmmindex->is_valid() && _xmmindex->encoding() >= 8;
+    return _xmmindex->is_valid() && ((_xmmindex->encoding() & 8) == 8);
   }
 
   relocInfo::relocType reloc() const { return _rspec.type(); }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321215](https://bugs.openjdk.org/browse/JDK-8321215) needs maintainer approval

### Issue
 * [JDK-8321215](https://bugs.openjdk.org/browse/JDK-8321215): Incorrect x86 instruction encoding for VSIB addressing mode (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2014/head:pull/2014` \
`$ git checkout pull/2014`

Update a local copy of the PR: \
`$ git checkout pull/2014` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2014`

View PR using the GUI difftool: \
`$ git pr show -t 2014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2014.diff">https://git.openjdk.org/jdk17u-dev/pull/2014.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2014#issuecomment-1841329513)