### PR TITLE
8314220: Configurable InlineCacheBuffer size

### DIFF
--- a/src/hotspot/share/code/icBuffer.cpp
+++ b/src/hotspot/share/code/icBuffer.cpp
@@ -140,7 +140,7 @@ void ICStub::print() {
 
 void InlineCacheBuffer::initialize() {
   if (_buffer != NULL) return; // already initialized
-  _buffer = new StubQueue(new ICStubInterface, 10*K, InlineCacheBuffer_lock, "InlineCacheBuffer");
+  _buffer = new StubQueue(new ICStubInterface, checked_cast<int>(InlineCacheBufferSize), InlineCacheBuffer_lock, "InlineCacheBuffer");
   assert (_buffer != NULL, "cannot allocate InlineCacheBuffer");
 }
 

--- a/src/hotspot/share/code/stubs.cpp
+++ b/src/hotspot/share/code/stubs.cpp
@@ -214,8 +214,6 @@ void StubQueue::verify() {
   guarantee(0 <= _queue_begin  && _queue_begin  <  _buffer_limit, "_queue_begin out of bounds");
   guarantee(0 <= _queue_end    && _queue_end    <= _buffer_limit, "_queue_end   out of bounds");
   // verify alignment
-  guarantee(_buffer_size  % CodeEntryAlignment == 0, "_buffer_size  not aligned");
-  guarantee(_buffer_limit % CodeEntryAlignment == 0, "_buffer_limit not aligned");
   guarantee(_queue_begin  % CodeEntryAlignment == 0, "_queue_begin  not aligned");
   guarantee(_queue_end    % CodeEntryAlignment == 0, "_queue_end    not aligned");
   // verify buffer limit/size relationship

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -479,6 +479,11 @@ bool CompilerConfig::check_args_consistency(bool status) {
                 "Invalid NonNMethodCodeHeapSize=%dK. Must be at least %uK.\n", NonNMethodCodeHeapSize/K,
                 min_code_cache_size/K);
     status = false;
+  } else if (InlineCacheBufferSize > NonNMethodCodeHeapSize / 2) {
+    jio_fprintf(defaultStream::error_stream(),
+                "Invalid InlineCacheBufferSize=" SIZE_FORMAT "K. Must be less than or equal to " SIZE_FORMAT "K.\n",
+                InlineCacheBufferSize/K, NonNMethodCodeHeapSize/2/K);
+    status = false;
   }
 
 #ifdef _LP64

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -292,6 +292,9 @@ const intx ObjectAlignmentInBytes = 8;
   product(bool, UseInlineCaches, true,                                      \
           "Use Inline Caches for virtual calls ")                           \
                                                                             \
+  product(size_t, InlineCacheBufferSize, 10*K, EXPERIMENTAL,                \
+          "InlineCacheBuffer size")                                         \
+                                                                            \
   product(bool, InlineArrayCopy, true, DIAGNOSTIC,                          \
           "Inline arraycopy native that is known to be part of "            \
           "base library DLL")                                               \


### PR DESCRIPTION
Unclean backport to allow a tunable for IC buffer size, to avoid excess `ICBufferFull` safepoints in some workloads.

The backport is not clean for two reasons:
 1. Usual `NULL` and `nullptr` context conflict.
 2. `% CodeEntryAlignment` and `% stub_alignment()` conflict due to missing [JDK-8284578](https://bugs.openjdk.org/browse/JDK-8284578) in JDK 17u. We could backport that one first, as we expect some other backports in this area as well, like [JDK-8321137](https://bugs.openjdk.org/browse/JDK-8321137). But it was rejected one time, so I would rather see JDK-8321137 to pan out, and then resolve a little conflict introduced by this change later.

Additional testing:
 - [x] Eyeballing `-XX:+TraceICBuffer` output on ad-hoc workloads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314220](https://bugs.openjdk.org/browse/JDK-8314220) needs maintainer approval

### Issue
 * [JDK-8314220](https://bugs.openjdk.org/browse/JDK-8314220): Configurable InlineCacheBuffer size (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2015/head:pull/2015` \
`$ git checkout pull/2015`

Update a local copy of the PR: \
`$ git checkout pull/2015` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2015`

View PR using the GUI difftool: \
`$ git pr show -t 2015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2015.diff">https://git.openjdk.org/jdk17u-dev/pull/2015.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2015#issuecomment-1841353522)