### PR TITLE
Backport 401c3dea5d8823bc9c0f40506ddad46e983ebf68

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -565,6 +565,7 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
 
     /* write the two structs and the data buffer */
     if (writeFully(c->childenv[1], (char *)&magic, sizeof(magic)) != sizeof(magic)) { // magic number first
+        free(buf);
         return -1;
     }
 #ifdef DEBUG
@@ -573,6 +574,7 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     if (writeFully(c->childenv[1], (char *)c, sizeof(*c)) != sizeof(*c) ||
         writeFully(c->childenv[1], (char *)&sp, sizeof(sp)) != sizeof(sp) ||
         writeFully(c->childenv[1], buf, bufsize) != bufsize) {
+        free(buf);
         return -1;
     }
     /* We're done. Let jspwanhelper know he can't expect any more data from us. */


### PR DESCRIPTION
This is a clean backport of [JDK-8311645: Memory leak in jspawnhelper spawnChild after JDK-8307990](https://bugs.openjdk.org/browse/JDK-8311645) which is a follow-up fix for [JDK-8307990: jspawnhelper must close its writing side of a pipe before reading from it](https://bugs.openjdk.org/browse/JDK-8307990) which is currently [under review](https://github.com/openjdk/jdk17u-dev/pull/2013).

This backport depends on [pr/2013](https://github.com/openjdk/jdk17u-dev/pull/2013) and will be pushed once that one has been reviewed and approved.