### PR TITLE
7148092: [macosx] When Alt+down arrow key is pressed, the combobox popup does not appear.

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaComboBoxUI.java
@@ -324,6 +324,8 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
         actionMap.put("aquaSelectPageDown", highlightPageDownAction);
 
         actionMap.put("aquaHidePopup", hideAction);
+        actionMap.put("aquaOpenPopupOrhighlightLast", openPopupOrHighlightLast);
+        actionMap.put("aquaOpenPopupOrhighlightFirst", openPopupOrHighlightFirst);
 
         SwingUtilities.replaceUIActionMap(comboBox, actionMap);
     }
@@ -579,6 +581,27 @@ public class AquaComboBoxUI extends BasicComboBoxUI implements Sizeable {
         @Override
         public boolean isEnabled() {
             return comboBox.isPopupVisible() && super.isEnabled();
+        }
+    };
+
+    @SuppressWarnings("serial") // anonymous class
+    private final Action openPopupOrHighlightLast = new ComboBoxAction() {
+        @Override
+        void performComboBoxAction(final AquaComboBoxUI ui) {
+            final int size = listBox.getModel().getSize();
+            listBox.setSelectedIndex(size - 1);
+            listBox.ensureIndexIsVisible(size - 1);
+            comboBox.setSelectedIndex(ui.getPopup().getList().getSelectedIndex());
+        }
+    };
+
+    @SuppressWarnings("serial") // anonymous class
+    private final Action openPopupOrHighlightFirst = new ComboBoxAction() {
+        @Override
+        void performComboBoxAction(final AquaComboBoxUI ui) {
+           listBox.setSelectedIndex(0);
+           listBox.ensureIndexIsVisible(0);
+           comboBox.setSelectedIndex(ui.getPopup().getList().getSelectedIndex());
         }
     };
 

--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaKeyBindings.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaKeyBindings.java
@@ -220,6 +220,10 @@ public class AquaKeyBindings {
             "KP_UP", "aquaSelectPrevious",
             "DOWN", "aquaSelectNext",
             "KP_DOWN", "aquaSelectNext",
+            "alt DOWN", "aquaOpenPopupOrhighlightLast",
+            "alt KP_DOWN", "aquaOpenPopupOrhighlightLast",
+            "alt UP", "aquaOpenPopupOrhighlightFirst",
+            "alt KP_UP", "aquaOpenPopupOrhighlightFirst",
             "SPACE", "aquaSpacePressed" // "spacePopup"
         }));
     }

--- a/test/jdk/javax/swing/plaf/aqua/TestAltUpDownComboBox.java
+++ b/test/jdk/javax/swing/plaf/aqua/TestAltUpDownComboBox.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/* @test
+ * @bug 7148092
+ * @requires (os.family == "mac")
+ * @summary Tests that alt+down arrow pulls down JComboBox popup
+ * @key headful
+ * @run main TestAltUpDownComboBox
+*/
+
+import java.awt.Container;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.JComboBox;
+import javax.swing.SwingUtilities;
+
+public class TestAltUpDownComboBox {
+
+    private static JFrame frame;
+    private static JComboBox combo;
+
+    public static void main(String[] argv) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("");
+                Object[] fruits = {"Banana", "Pear", "Apple"};
+                combo = new JComboBox(fruits);
+                Container pane = frame.getContentPane();
+                pane.setLayout(new BoxLayout(pane, BoxLayout.X_AXIS));
+                pane.add(combo);
+
+                frame.pack();
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.delay(1000);
+
+            if (!combo.isPopupVisible()) {
+                throw new RuntimeException("comboBox is not visible");
+            }
+
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.delay(1000);
+
+            if (combo.getSelectedIndex() != combo.getItemCount() - 1) {
+                System.out.println(combo.getSelectedIndex());
+                throw new RuntimeException("Alt+Down did not select last entry");
+            }
+
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_UP);
+            robot.keyRelease(KeyEvent.VK_UP);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.delay(1000);
+
+            if (combo.getSelectedIndex() != 0) {
+                System.out.println(combo.getSelectedIndex());
+                throw new RuntimeException("Alt+Up did not select first entry");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
A fix useful for mac in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-7148092](https://bugs.openjdk.org/browse/JDK-7148092) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-7148092](https://bugs.openjdk.org/browse/JDK-7148092): [macosx] When Alt+down arrow key is pressed, the combobox popup does not appear. (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2024/head:pull/2024` \
`$ git checkout pull/2024`

Update a local copy of the PR: \
`$ git checkout pull/2024` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2024`

View PR using the GUI difftool: \
`$ git pr show -t 2024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2024.diff">https://git.openjdk.org/jdk17u-dev/pull/2024.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2024#issuecomment-1843035889)