### PR TITLE
8286846: test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java fails on mac aarch64

### DIFF
--- a/test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java
+++ b/test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,15 @@
  * @test
  * @key headful
  * @bug     8073001 8081764
+ * @requires (os.family == "mac")
  * @summary Test verifies that combo box with custom editor renders
  *          focus ring around arrow button correctly.
- * @library /test/lib
- * @build jdk.test.lib.Platform
  * @run     main CustomComboBoxFocusTest
  */
 
 import java.awt.AWTException;
 import java.awt.Component;
+import java.awt.Color;
 import java.awt.GridLayout;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -55,29 +55,24 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
-import jdk.test.lib.Platform;
-
 public class CustomComboBoxFocusTest {
 
     private static CustomComboBoxFocusTest test = null;
+    static int colorTolerance = 5;
 
-    public static void main(String[] args) {
-        if (!Platform.isOSX()) {
+    public static void main(String[] args) throws Exception {
+        if (!System.getProperty("os.name").toLowerCase().contains("os x")) {
             System.out.println("Only Mac platform test. Test is skipped for other OS.");
             return;
         }
 
-        try {
-            SwingUtilities.invokeAndWait(new Runnable() {
-                public void run() {
-                    test = new CustomComboBoxFocusTest();
-                }
-            });
-        } catch (InterruptedException | InvocationTargetException e ) {
-            throw new RuntimeException("Test failed.", e);
-        }
+        SwingUtilities.invokeAndWait(new Runnable() {
+            public void run() {
+                test = new CustomComboBoxFocusTest();
+            }
+        });
 
-        SwingUtilities.invokeLater(test.init);
+        SwingUtilities.invokeAndWait(test.init);
 
         try {
             System.out.println("Wait for screenshots...");
@@ -130,7 +125,23 @@ public class CustomComboBoxFocusTest {
 
         for (int y = 0; y < h; y++) {
             for (int x = 0; x < w; x++) {
-                if (a.getRGB(x, y) != b.getRGB(x, y)) {
+                Color refRGB = new Color(a.getRGB(x,y));
+                Color customRGB = new Color(b.getRGB(x,y));
+
+                int red1 = refRGB.getRed();
+                int blue1 = refRGB.getBlue();
+                int green1 = refRGB.getGreen();
+
+                int red2 = customRGB.getRed();
+                int blue2 = customRGB.getBlue();
+                int green2 = customRGB.getGreen();
+
+                if ((Math.abs(red1 - red2) > colorTolerance) ||
+                    (Math.abs(green1 - green2) > colorTolerance) ||
+                    (Math.abs(blue1 - blue2) > colorTolerance)) {
+                    System.out.println("x " + x + " y " + y +
+                                       " refRGB " + refRGB +
+                                       " customRGB " + customRGB);
                     return false;
                 }
             }
@@ -222,6 +233,7 @@ public class CustomComboBoxFocusTest {
             f.add(p);
 
             f.pack();
+            f.setLocationRelativeTo(null);
             f.setVisible(true);
         }
 


### PR DESCRIPTION
I backport this to stabilize the  tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286846](https://bugs.openjdk.org/browse/JDK-8286846) needs maintainer approval

### Issue
 * [JDK-8286846](https://bugs.openjdk.org/browse/JDK-8286846): test/jdk/javax/swing/plaf/aqua/CustomComboBoxFocusTest.java fails on mac aarch64 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2026/head:pull/2026` \
`$ git checkout pull/2026`

Update a local copy of the PR: \
`$ git checkout pull/2026` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2026`

View PR using the GUI difftool: \
`$ git pr show -t 2026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2026.diff">https://git.openjdk.org/jdk17u-dev/pull/2026.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2026#issuecomment-1844985397)