### PR TITLE
8293165: GHA: Provide necessary x86_32 packages for runtime/ErrorHandling/TestDwarf.java

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
-      apt-extra-packages: 'libfreetype-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386'
+      apt-extra-packages: 'libfreetype-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libc6-i386'
       extra-conf-options: '--with-target-bits=32'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}


### PR DESCRIPTION
Although not clean but a trivial backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8293165](https://bugs.openjdk.org/browse/JDK-8293165) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #2021 must be integrated first

### Issue
 * [JDK-8293165](https://bugs.openjdk.org/browse/JDK-8293165): GHA: Provide necessary x86_32 packages for runtime/ErrorHandling/TestDwarf.java (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2030/head:pull/2030` \
`$ git checkout pull/2030`

Update a local copy of the PR: \
`$ git checkout pull/2030` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2030`

View PR using the GUI difftool: \
`$ git pr show -t 2030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2030.diff">https://git.openjdk.org/jdk17u-dev/pull/2030.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2030#issuecomment-1847986059)