### PR TITLE
8293201: Library detection in runtime/ErrorHandling/TestDwarf.java fails on some systems

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestDwarf.java
@@ -176,7 +176,7 @@ public class TestDwarf {
      * There are some valid cases where we cannot find source information. Check these.
      */
     private static void checkNoSourceLine(String crashOutputString, String line) {
-        Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+][\\s\\t]+.*\\+0x");
+        Pattern pattern = Pattern.compile("[CV][\\s\\t]+\\[([a-zA-Z0-9_.]+)\\+0x.+]");
         Matcher matcher = pattern.matcher(line);
         Asserts.assertTrue(matcher.find(), "Must find library in \"" + line + "\"");
         // Check if there are symbols available for library. If not, then we cannot find any source information for this library.


### PR DESCRIPTION
Clean backport over #2021

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8293201](https://bugs.openjdk.org/browse/JDK-8293201) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #2021 must be integrated first

### Issue
 * [JDK-8293201](https://bugs.openjdk.org/browse/JDK-8293201): Library detection in runtime/ErrorHandling/TestDwarf.java fails on some systems (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2031/head:pull/2031` \
`$ git checkout pull/2031`

Update a local copy of the PR: \
`$ git checkout pull/2031` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2031`

View PR using the GUI difftool: \
`$ git pr show -t 2031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2031.diff">https://git.openjdk.org/jdk17u-dev/pull/2031.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2031#issuecomment-1847986496)