### PR TITLE
8318078: ADLC: pass ASSERT and PRODUCT flags

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -125,6 +125,21 @@ ifeq ($(call check-jvm-feature, compiler2), true)
     ADLCFLAGS += -DARM=1
   endif
 
+  # Set ASSERT, NDEBUG and PRODUCT flags just like in JvmFlags.gmk
+  ifeq ($(DEBUG_LEVEL), release)
+    # release builds disable uses of assert macro from <assert.h>.
+    ADLCFLAGS += -DNDEBUG
+    # For hotspot, release builds differ internally between "optimized" and "product"
+    # in that "optimize" does not define PRODUCT.
+    ifneq ($(HOTSPOT_DEBUG_LEVEL), optimized)
+      ADLCFLAGS += -DPRODUCT
+    endif
+  else ifeq ($(DEBUG_LEVEL), fastdebug)
+    ADLCFLAGS += -DASSERT
+  else ifeq ($(DEBUG_LEVEL), slowdebug)
+    ADLCFLAGS += -DASSERT
+  endif
+
   ##############################################################################
   # Concatenate all ad source files into a single file, which will be fed to
   # adlc. Also include a #line directive at the start of every included file


### PR DESCRIPTION
Clean backport to make sure the asserts work in `.ad` files.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `hotspot:tier1`
 - [ ] linux-aarch64-server-fastdebug, `tier1`
 - [ ] linux-x86_64-server-fastdebug, `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8318078](https://bugs.openjdk.org/browse/JDK-8318078) needs maintainer approval

### Issue
 * [JDK-8318078](https://bugs.openjdk.org/browse/JDK-8318078): ADLC: pass ASSERT and PRODUCT flags (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2034/head:pull/2034` \
`$ git checkout pull/2034`

Update a local copy of the PR: \
`$ git checkout pull/2034` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2034`

View PR using the GUI difftool: \
`$ git pr show -t 2034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2034.diff">https://git.openjdk.org/jdk17u-dev/pull/2034.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2034#issuecomment-1850178468)