### PR TITLE
8316929: Shenandoah: Shenandoah degenerated GC and full GC need to cleanup old OopMapCache entries

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -32,6 +32,7 @@
 #include "gc/shenandoah/shenandoahOopClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahUtils.hpp"
 #include "gc/shenandoah/shenandoahVMOperations.hpp"
+#include "interpreter/oopMapCache.hpp"
 #include "memory/universe.hpp"
 
 bool VM_ShenandoahReferenceOperation::doit_prologue() {
@@ -40,6 +41,7 @@ bool VM_ShenandoahReferenceOperation::doit_prologue() {
 }
 
 void VM_ShenandoahReferenceOperation::doit_epilogue() {
+  OopMapCache::cleanup_old_entries();
   if (Universe::has_reference_pending_list()) {
     Heap_lock->notify_all();
   }


### PR DESCRIPTION
Clean backport to eliminate Shenandoah memory leak.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316929](https://bugs.openjdk.org/browse/JDK-8316929) needs maintainer approval

### Issue
 * [JDK-8316929](https://bugs.openjdk.org/browse/JDK-8316929): Shenandoah: Shenandoah degenerated GC and full GC need to cleanup old OopMapCache entries (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2037/head:pull/2037` \
`$ git checkout pull/2037`

Update a local copy of the PR: \
`$ git checkout pull/2037` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2037`

View PR using the GUI difftool: \
`$ git pr show -t 2037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2037.diff">https://git.openjdk.org/jdk17u-dev/pull/2037.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2037#issuecomment-1850244008)