### PR TITLE
8271118: C2: StressGCM should have higher priority than frequency-based policy

### DIFF
--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -438,6 +438,12 @@ class PhaseCFG : public Phase {
   // Compute the instruction global latency with a backwards walk
   void compute_latencies_backwards(VectorSet &visited, Node_Stack &stack);
 
+  // Check if a block between early and LCA block of uses is cheaper by
+  // frequency-based policy, latency-based policy and random-based policy
+  bool is_cheaper_block(Block* LCA, Node* self, uint target_latency,
+                        uint end_latency, double least_freq,
+                        int cand_cnt, bool in_latency);
+
   // Pick a block between early and late that is a cheaper alternative
   // to late. Helper for schedule_late.
   Block* hoist_to_cheaper_block(Block* LCA, Block* early, Node* self);


### PR DESCRIPTION
Clean backport to greatly extend the scope of `StressGCM`. This would allow better compiler testing, including test backports (which rely on `StressGCM` with given seed to reproduce sometimes), and jcstress runs (which automatically opts in to `StressGCM`).

There seem to be a bunch of compiler bugfixes found/triggered by wider scope, recorded as related issues in duplicate [JDK-8257146](https://bugs.openjdk.org/browse/JDK-8257146), all of which are resolved in current 17u.

I inspected the code again, and it looks that patch does not change anything else functionally, only takes `StressGCM` path before frequency policy.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `hotspot:tier1`
 - [x] linux-aarch64-server-fastdebug, `tier{1,2,3}` with `-XX:+StressGCM`
 - [x] linux-x86_64-server-fastdebug, `tier{1,2,3}` with `-XX:+StressGCM`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8271118](https://bugs.openjdk.org/browse/JDK-8271118) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8271118](https://bugs.openjdk.org/browse/JDK-8271118): C2: StressGCM should have higher priority than frequency-based policy (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2038/head:pull/2038` \
`$ git checkout pull/2038`

Update a local copy of the PR: \
`$ git checkout pull/2038` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2038`

View PR using the GUI difftool: \
`$ git pr show -t 2038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2038.diff">https://git.openjdk.org/jdk17u-dev/pull/2038.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2038#issuecomment-1850296382)