### PR TITLE
8295068: SSLEngine throws NPE parsing CertificateRequests

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateRequest.java
@@ -135,7 +135,7 @@ final class CertificateRequest {
             ArrayList<String> keyTypes = new ArrayList<>(3);
             for (byte id : ids) {
                 ClientCertificateType cct = ClientCertificateType.valueOf(id);
-                if (cct.isAvailable) {
+                if (cct != null && cct.isAvailable) {
                     cct.keyAlgorithm.forEach(key -> {
                         if (!keyTypes.contains(key)) {
                             keyTypes.add(key);


### PR DESCRIPTION
Clean backport to resolve a corner case in certificate handling.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `jdk_security`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8295068](https://bugs.openjdk.org/browse/JDK-8295068) needs maintainer approval

### Issue
 * [JDK-8295068](https://bugs.openjdk.org/browse/JDK-8295068): SSLEngine throws NPE parsing CertificateRequests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2046/head:pull/2046` \
`$ git checkout pull/2046`

Update a local copy of the PR: \
`$ git checkout pull/2046` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2046`

View PR using the GUI difftool: \
`$ git pr show -t 2046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2046.diff">https://git.openjdk.org/jdk17u-dev/pull/2046.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2046#issuecomment-1851760245)