### PR TITLE
8274632: Possible pointer overflow in PretouchTask chunk claiming

### DIFF
--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -36,7 +36,6 @@ PretouchTask::PretouchTask(const char* task_name,
                            size_t chunk_size) :
     AbstractGangTask(task_name),
     _cur_addr(start_address),
-    _start_addr(start_address),
     _end_addr(end_address),
     _page_size(page_size),
     _chunk_size(chunk_size) {
@@ -52,14 +51,13 @@ size_t PretouchTask::chunk_size() {
 
 void PretouchTask::work(uint worker_id) {
   while (true) {
-    char* touch_addr = Atomic::fetch_and_add(&_cur_addr, _chunk_size);
-    if (touch_addr < _start_addr || touch_addr >= _end_addr) {
+    char* cur_start = Atomic::load(&_cur_addr);
+    char* cur_end = cur_start + MIN2(_chunk_size, pointer_delta(_end_addr, cur_start, 1));
+    if (cur_start >= cur_end) {
       break;
-    }
-
-    char* end_addr = touch_addr + MIN2(_chunk_size, pointer_delta(_end_addr, touch_addr, sizeof(char)));
-
-    os::pretouch_memory(touch_addr, end_addr, _page_size);
+    } else if (cur_start == Atomic::cmpxchg(&_cur_addr, cur_start, cur_end)) {
+      os::pretouch_memory(cur_start, cur_end, _page_size);
+    } // Else attempt to claim chunk failed, so try again.
   }
 }
 

--- a/src/hotspot/share/gc/shared/pretouchTask.hpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 
 class PretouchTask : public AbstractGangTask {
   char* volatile _cur_addr;
-  char* const _start_addr;
   char* const _end_addr;
   size_t _page_size;
   size_t _chunk_size;


### PR DESCRIPTION
Clean backport to improve pre-touching reliability. There is no recorded bugtail for 2 years.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `hotspot:tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8274632](https://bugs.openjdk.org/browse/JDK-8274632) needs maintainer approval

### Issue
 * [JDK-8274632](https://bugs.openjdk.org/browse/JDK-8274632): Possible pointer overflow in PretouchTask chunk claiming (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2047/head:pull/2047` \
`$ git checkout pull/2047`

Update a local copy of the PR: \
`$ git checkout pull/2047` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2047`

View PR using the GUI difftool: \
`$ git pr show -t 2047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2047.diff">https://git.openjdk.org/jdk17u-dev/pull/2047.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2047#issuecomment-1851819355)