### PR TITLE
8283400: [macos] a11y : Screen magnifier does not reflect JRadioButton value change

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessible.java
@@ -184,6 +184,16 @@ class CAccessible extends CFRetainedResource implements Accessible {
                     if (thisRole == AccessibleRole.CHECK_BOX) {
                         valueChanged(ptr);
                     }
+
+                    // Do send radio button state changes to native side
+                    if (thisRole == AccessibleRole.RADIO_BUTTON) {
+                        valueChanged(ptr);
+                    }
+
+                    // Do send toggle button state changes to native side
+                    if (thisRole == AccessibleRole.TOGGLE_BUTTON) {
+                        valueChanged(ptr);
+                    }
                 } else if (name.equals(ACCESSIBLE_NAME_PROPERTY)) {
                     //for now trigger only for JTabbedPane.
                     if (e.getSource() instanceof JTabbedPane) {


### PR DESCRIPTION
Improve accessability in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8283400](https://bugs.openjdk.org/browse/JDK-8283400) needs maintainer approval

### Issue
 * [JDK-8283400](https://bugs.openjdk.org/browse/JDK-8283400): [macos] a11y : Screen magnifier does not reflect JRadioButton value change (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2050/head:pull/2050` \
`$ git checkout pull/2050`

Update a local copy of the PR: \
`$ git checkout pull/2050` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2050`

View PR using the GUI difftool: \
`$ git pr show -t 2050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2050.diff">https://git.openjdk.org/jdk17u-dev/pull/2050.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2050#issuecomment-1854092346)