### PR TITLE
8297968: Crash in PrintOptoAssembly

### DIFF
--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -276,6 +276,7 @@ void Matcher::match( ) {
     // Permit args to have no register
     _calling_convention_mask[i].Clear();
     if( !vm_parm_regs[i].first()->is_valid() && !vm_parm_regs[i].second()->is_valid() ) {
+      _parm_regs[i].set_bad();
       continue;
     }
     // calling_convention returns stack arguments as a count of


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297968](https://bugs.openjdk.org/browse/JDK-8297968) needs maintainer approval

### Issue
 * [JDK-8297968](https://bugs.openjdk.org/browse/JDK-8297968): Crash in PrintOptoAssembly (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2051/head:pull/2051` \
`$ git checkout pull/2051`

Update a local copy of the PR: \
`$ git checkout pull/2051` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2051`

View PR using the GUI difftool: \
`$ git pr show -t 2051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2051.diff">https://git.openjdk.org/jdk17u-dev/pull/2051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2051#issuecomment-1854114995)