### PR TITLE
8320798: Console read line with zero out should zero out underlying buffer

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -445,6 +445,9 @@ public final class Console implements Flushable
             System.arraycopy(rcb, 0, b, 0, len);
             if (zeroOut) {
                 Arrays.fill(rcb, 0, len, ' ');
+                if (reader instanceof LineReader lr) {
+                    lr.zeroOut();
+                }
             }
         }
         return b;
@@ -468,6 +471,11 @@ public final class Console implements Flushable
             cb = new char[1024];
             nextChar = nChars = 0;
             leftoverLF = false;
+        }
+        public void zeroOut() throws IOException {
+            if (in instanceof StreamDecoder sd) {
+                sd.fillZeroToPosition();
+            }
         }
         public void close () {}
         public boolean ready() throws IOException {

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -42,6 +42,7 @@ import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.Arrays;
 
 public class StreamDecoder extends Reader {
 
@@ -212,6 +213,16 @@ public class StreamDecoder extends Reader {
         return !closed;
     }
 
+    public void fillZeroToPosition() throws IOException {
+        Object lock = this.lock;
+        synchronized (lock) {
+            lockedFillZeroToPosition();
+        }
+    }
+
+    private void lockedFillZeroToPosition() {
+        Arrays.fill(bb.array(), bb.arrayOffset(), bb.arrayOffset() + bb.position(), (byte)0);
+    }
 
     // -- Charset-based stream decoder impl --
 


### PR DESCRIPTION
I think thsi should be backported to fix the underlying issue. 

Console has been improved a lot in 21 and later, so the original patch does not apply well.
Console was turned into a sealed class. The implementation was moved to JdkConsoleImpl.
(8298416: Console should be declared sealed, 8298971: Move Console implementation into jdk internal package)
Later,  the class moved to jdk.internal.le and JLine was added (8295803: Console should be usable in jshell and other environments).
I moved the coding to Console.java. We verified with our testcase that the issue is actually fixed.  The two follow up fixes are not needed as 8295803 is not in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320798](https://bugs.openjdk.org/browse/JDK-8320798) needs maintainer approval

### Issue
 * [JDK-8320798](https://bugs.openjdk.org/browse/JDK-8320798): Console read line with zero out should zero out underlying buffer (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2053/head:pull/2053` \
`$ git checkout pull/2053`

Update a local copy of the PR: \
`$ git checkout pull/2053` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2053`

View PR using the GUI difftool: \
`$ git pr show -t 2053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2053.diff">https://git.openjdk.org/jdk17u-dev/pull/2053.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2053#issuecomment-1856585820)