### PR TITLE
8313082: Enable CreateCoredumpOnCrash for testing in makefiles

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -785,8 +785,10 @@ define SetupRunJtregTestBody
   $1_JTREG_BASIC_OPTIONS += -e:JDK8_HOME=$$(BOOT_JDK)
   # If running on Windows, propagate the _NT_SYMBOL_PATH to enable
   # symbol lookup in hserr files
+  # The minidumps are disabled by default on client Windows, so enable them
   ifeq ($$(call isTargetOs, windows), true)
     $1_JTREG_BASIC_OPTIONS += -e:_NT_SYMBOL_PATH
+    $1_JTREG_BASIC_OPTIONS += -vmoption:-XX:+CreateCoredumpOnCrash
   endif
 
   $1_JTREG_BASIC_OPTIONS += \


### PR DESCRIPTION
Backport for JDK-8313082

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313082](https://bugs.openjdk.org/browse/JDK-8313082) needs maintainer approval

### Issue
 * [JDK-8313082](https://bugs.openjdk.org/browse/JDK-8313082): Enable CreateCoredumpOnCrash for testing in makefiles (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2059/head:pull/2059` \
`$ git checkout pull/2059`

Update a local copy of the PR: \
`$ git checkout pull/2059` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2059`

View PR using the GUI difftool: \
`$ git pr show -t 2059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2059.diff">https://git.openjdk.org/jdk17u-dev/pull/2059.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2059#issuecomment-1862321348)