### PR TITLE
8307926: Support byte-sized atomic bitset operations

### DIFF
--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -173,7 +173,7 @@ public:
   //
   // Requirements:
   // - T is an integral type
-  // - sizeof(T) == sizeof(int) || sizeof(T) == sizeof(void*)
+  // - sizeof(T) == 1 || sizeof(T) == sizeof(int) || sizeof(T) == sizeof(void*)
 
   // Performs atomic bitwise-and of *dest and bits, storing the result in
   // *dest.  Returns the prior value of *dest.  That is, atomically performs

--- a/test/hotspot/gtest/runtime/test_atomic.cpp
+++ b/test/hotspot/gtest/runtime/test_atomic.cpp
@@ -205,14 +205,15 @@ struct AtomicBitopsTestSupport {
   volatile T _test_value;
 
   // At least one byte differs between _old_value and _old_value op _change_value.
-  static const T _old_value =    static_cast<T>(UCONST64(0x7f5300007f530000));
-  static const T _change_value = static_cast<T>(UCONST64(0x3800530038005300));
+  static const T _old_value =    static_cast<T>(UCONST64(0x7f5300007f530044));
+  static const T _change_value = static_cast<T>(UCONST64(0x3800530038005322));
 
   AtomicBitopsTestSupport() : _test_value(0) {}
 
   void fetch_then_and() {
     Atomic::store(&_test_value, _old_value);
     T expected = _old_value & _change_value;
+    EXPECT_NE(_old_value, expected);
     T result = Atomic::fetch_then_and(&_test_value, _change_value);
     EXPECT_EQ(_old_value, result);
     EXPECT_EQ(expected, Atomic::load(&_test_value));
@@ -221,6 +222,7 @@ struct AtomicBitopsTestSupport {
   void fetch_then_or() {
     Atomic::store(&_test_value, _old_value);
     T expected = _old_value | _change_value;
+    EXPECT_NE(_old_value, expected);
     T result = Atomic::fetch_then_or(&_test_value, _change_value);
     EXPECT_EQ(_old_value, result);
     EXPECT_EQ(expected, Atomic::load(&_test_value));
@@ -229,6 +231,7 @@ struct AtomicBitopsTestSupport {
   void fetch_then_xor() {
     Atomic::store(&_test_value, _old_value);
     T expected = _old_value ^ _change_value;
+    EXPECT_NE(_old_value, expected);
     T result = Atomic::fetch_then_xor(&_test_value, _change_value);
     EXPECT_EQ(_old_value, result);
     EXPECT_EQ(expected, Atomic::load(&_test_value));
@@ -237,6 +240,7 @@ struct AtomicBitopsTestSupport {
   void and_then_fetch() {
     Atomic::store(&_test_value, _old_value);
     T expected = _old_value & _change_value;
+    EXPECT_NE(_old_value, expected);
     T result = Atomic::and_then_fetch(&_test_value, _change_value);
     EXPECT_EQ(expected, result);
     EXPECT_EQ(expected, Atomic::load(&_test_value));
@@ -245,6 +249,7 @@ struct AtomicBitopsTestSupport {
   void or_then_fetch() {
     Atomic::store(&_test_value, _old_value);
     T expected = _old_value | _change_value;
+    EXPECT_NE(_old_value, expected);
     T result = Atomic::or_then_fetch(&_test_value, _change_value);
     EXPECT_EQ(expected, result);
     EXPECT_EQ(expected, Atomic::load(&_test_value));
@@ -253,6 +258,7 @@ struct AtomicBitopsTestSupport {
   void xor_then_fetch() {
     Atomic::store(&_test_value, _old_value);
     T expected = _old_value ^ _change_value;
+    EXPECT_NE(_old_value, expected);
     T result = Atomic::xor_then_fetch(&_test_value, _change_value);
     EXPECT_EQ(expected, result);
     EXPECT_EQ(expected, Atomic::load(&_test_value));
@@ -277,6 +283,14 @@ const T AtomicBitopsTestSupport<T>::_old_value;
 
 template<typename T>
 const T AtomicBitopsTestSupport<T>::_change_value;
+
+TEST(AtomicBitopsTest, int8) {
+  AtomicBitopsTestSupport<int8_t>()();
+}
+
+TEST(AtomicBitopsTest, uint8) {
+  AtomicBitopsTestSupport<uint8_t>()();
+}
 
 TEST(AtomicBitopsTest, int32) {
   AtomicBitopsTestSupport<int32_t>()();


### PR DESCRIPTION
Clean backport to improve Atomic support in JDK 17 and align it with mainline JDKs, simplifying future backports. Note the patch basically adds documentation that byte-level support is available, and adds a few tests. Therefore, there is no direct product impact.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `Atomic` gtests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8307926](https://bugs.openjdk.org/browse/JDK-8307926) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307926](https://bugs.openjdk.org/browse/JDK-8307926): Support byte-sized atomic bitset operations (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2061/head:pull/2061` \
`$ git checkout pull/2061`

Update a local copy of the PR: \
`$ git checkout pull/2061` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2061`

View PR using the GUI difftool: \
`$ git pr show -t 2061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2061.diff">https://git.openjdk.org/jdk17u-dev/pull/2061.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2061#issuecomment-1862603615)