### PR TITLE
8278363: Create extented container test groups

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -71,6 +71,13 @@ hotspot_native_sanity = \
 hotspot_containers = \
   containers
 
+# Test sets for running inside container environment
+hotspot_containers_extended = \
+  runtime \
+  serviceability \
+  vmTestbase/nsk/jvmti \
+  vmTestbase/nsk/monitoring
+
 hotspot_vector_1 = \
   compiler/c2/cr6340864 \
   compiler/codegen \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -583,3 +583,8 @@ jdk_core_manual_requires_human_input = \
     java/util/TimeZone/DefaultTimeZoneTest.java
 
 
+# Test sets for running inside container environment
+jdk_containers_extended = \
+    :jdk_io \
+    :jdk_nio \
+    :jdk_svc


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8278363](https://bugs.openjdk.org/browse/JDK-8278363) needs maintainer approval

### Issue
 * [JDK-8278363](https://bugs.openjdk.org/browse/JDK-8278363): Create extented container test groups (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2069/head:pull/2069` \
`$ git checkout pull/2069`

Update a local copy of the PR: \
`$ git checkout pull/2069` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2069`

View PR using the GUI difftool: \
`$ git pr show -t 2069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2069.diff">https://git.openjdk.org/jdk17u-dev/pull/2069.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2069#issuecomment-1866496065)