### PR TITLE
8316679: C2 SuperWord: wrong result, load should not be moved before store if not comparable

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2460,18 +2460,18 @@ bool SuperWord::output() {
       if (n->is_Load()) {
         Node* ctl = n->in(MemNode::Control);
         Node* mem = first->in(MemNode::Memory);
+        // Set the memory dependency of the LoadVector as early as possible.
+        // Walk up the memory chain, and ignore any StoreVector that provably
+        // does not have any memory dependency.
         SWPointer p1(n->as_Mem(), this, nullptr, false);
-        // Identify the memory dependency for the new loadVector node by
-        // walking up through memory chain.
-        // This is done to give flexibility to the new loadVector node so that
-        // it can move above independent storeVector nodes.
         while (mem->is_StoreVector()) {
           SWPointer p2(mem->as_Mem(), this, nullptr, false);
-          int cmp = p1.cmp(p2);
-          if (SWPointer::not_equal(cmp) || !SWPointer::comparable(cmp)) {
+          if (p1.not_equal(p2)) {
+            // Either Less or Greater -> provably no overlap between the two memory regions.
             mem = mem->in(MemNode::Memory);
           } else {
-            break; // dependent memory
+            // No proof that there is no overlap. Stop here.
+            break;
           }
         }
         Node* adr = low_adr->in(MemNode::Address);

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMovingLoadBeforeStore.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMovingLoadBeforeStore.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/**
+ * @test
+ * @requires vm.compiler2.enabled
+ * @bug 8316679
+ * @summary In SuperWord::output, LoadVector can be moved before StoreVector, but only if it is proven to be safe.
+ * @key randomness
+ * @library /test/lib
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestMovingLoadBeforeStore::test*
+ *                   -Xbatch -XX:LoopUnrollLimit=100
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressLCM
+ *                   compiler.loopopts.superword.TestMovingLoadBeforeStore
+ */
+
+package compiler.loopopts.superword;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+public class TestMovingLoadBeforeStore {
+    static int RANGE = 1024*64;
+
+    private static final Random random = Utils.getRandomInstance();
+
+    public static void main(String[] strArr) {
+        byte a[] = new byte[RANGE];
+        for (int i = 0; i < 100; i++) {
+            for (int j = 0; j < a.length; j++) {
+                a[j] = (byte)random.nextInt();
+            }
+            byte[] a_ref = a.clone();
+            byte[] a_res = a.clone();
+            ref1(a_ref, a_ref, i % 2);
+            test1(a_res, a_res, i % 2);
+            verify("a in test1", a_ref, a_res, a);
+        }
+    }
+
+    static void verify(String name, byte[] ref, byte[] res, byte[] orig) {
+        boolean fail = false;
+        for (int j = 0; j < ref.length; j++) {
+            if (ref[j] != res[j]) {
+                System.out.println("Wrong: " + j + ":" + ref[j] + " vs " + res[j] + " from " + orig[j]);
+                fail = true;
+            }
+        }
+        if (fail) {
+            throw new RuntimeException("wrong result for array " + name);
+        }
+    }
+
+    static void test1(byte[] a, byte[] b, int inv) {
+        for (int i = 0; i < RANGE-4; i+=4) {
+            a[i + 0]++;
+            a[i + 1]++;
+            a[i + 2]++;
+            a[i + 3]++;
+            b[inv + i + 0]++;
+            b[inv + i + 1]++;
+            b[inv + i + 2]++;
+            b[inv + i + 3]++;
+        }
+    }
+
+    static void ref1(byte[] a, byte[] b, int inv) {
+        for (int i = 0; i < RANGE-4; i+=4) {
+            a[i + 0]++;
+            a[i + 1]++;
+            a[i + 2]++;
+            a[i + 3]++;
+            b[inv + i + 0]++;
+            b[inv + i + 1]++;
+            b[inv + i + 2]++;
+            b[inv + i + 3]++;
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

I had to resolve because in the context SWPointer was renamed to VPointer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316679](https://bugs.openjdk.org/browse/JDK-8316679) needs maintainer approval

### Issue
 * [JDK-8316679](https://bugs.openjdk.org/browse/JDK-8316679): C2 SuperWord: wrong result, load should not be moved before store if not comparable (**Bug** - P3 - Approved)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2071/head:pull/2071` \
`$ git checkout pull/2071`

Update a local copy of the PR: \
`$ git checkout pull/2071` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2071`

View PR using the GUI difftool: \
`$ git pr show -t 2071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2071.diff">https://git.openjdk.org/jdk17u-dev/pull/2071.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2071#issuecomment-1866578414)