### PR TITLE
8318689: jtreg is confused when folder name is the same as the test name

### DIFF
--- a/test/jdk/javax/security/auth/Subject/DoAsTest.java
+++ b/test/jdk/javax/security/auth/Subject/DoAsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.security.auth.Subject;
 
-public class DoAs {
+public class DoAsTest {
 
     public static void main(String[] args) throws Exception {
         final Set<String> outer = new HashSet<>(Arrays.asList("Outer"));


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle. 
Will mark clean if not recognized as such.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318689](https://bugs.openjdk.org/browse/JDK-8318689) needs maintainer approval

### Issue
 * [JDK-8318689](https://bugs.openjdk.org/browse/JDK-8318689): jtreg is confused when folder name is the same as the test name (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2072/head:pull/2072` \
`$ git checkout pull/2072`

Update a local copy of the PR: \
`$ git checkout pull/2072` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2072`

View PR using the GUI difftool: \
`$ git pr show -t 2072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2072.diff">https://git.openjdk.org/jdk17u-dev/pull/2072.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2072#issuecomment-1866601950)