### PR TITLE
8321972: test runtime/Unsafe/InternalErrorTest.java timeout on linux-riscv64 platform

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2782,6 +2782,17 @@ public:
     return uabs(target - branch) < branch_range;
   }
 
+  // Decode the given instruction, checking if it's a 16-bit compressed
+  // instruction and return the address of the next instruction.
+  static address locate_next_instruction(address inst) {
+    // Instruction wider than 16 bits has the two least-significant bits set.
+    if ((0x3 & *inst) == 0x3) {
+      return inst + instruction_size;
+    } else {
+      return inst + compressed_instruction_size;
+    }
+  }
+
   Assembler(CodeBuffer* code) : AbstractAssembler(code), _in_compressible_region(false) {}
 
   virtual ~Assembler() {}

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -231,7 +231,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         CompiledMethod* nm = (cb != NULL) ? cb->as_compiled_method_or_null() : NULL;
         bool is_unsafe_arraycopy = (thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc));
         if ((nm != NULL && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
-          address next_pc = pc + NativeCall::instruction_size;
+          address next_pc = Assembler::locate_next_instruction(pc);
           if (is_unsafe_arraycopy) {
             next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
           }
@@ -272,7 +272,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                 thread->thread_state() == _thread_in_native) &&
                 sig == SIGBUS && /* info->si_code == BUS_OBJERR && */
                 thread->doing_unsafe_access()) {
-      address next_pc = pc + NativeCall::instruction_size;
+      address next_pc = Assembler::locate_next_instruction(pc);
       if (UnsafeCopyMemory::contains_pc(pc)) {
         next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
       }


### PR DESCRIPTION
Hi, The same issue also exists in the JDK17U: I can reproduce it locally by applying fix for JDK-8320886 and running test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java test. So I would like to backport this to JDK17U. Tier1-3 tested with fastdebug build using qemu systems. This is a risc-v specific change. Backport is clean, risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321972](https://bugs.openjdk.org/browse/JDK-8321972) needs maintainer approval

### Issue
 * [JDK-8321972](https://bugs.openjdk.org/browse/JDK-8321972): test runtime/Unsafe/InternalErrorTest.java timeout on linux-riscv64 platform (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2078/head:pull/2078` \
`$ git checkout pull/2078`

Update a local copy of the PR: \
`$ git checkout pull/2078` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2078`

View PR using the GUI difftool: \
`$ git pr show -t 2078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2078.diff">https://git.openjdk.org/jdk17u-dev/pull/2078.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2078#issuecomment-1867196010)