### PR TITLE
8315034: File.mkdirs() occasionally fails to create folders on Windows shared folder

### DIFF
--- a/src/java.base/windows/native/libjava/canonicalize_md.c
+++ b/src/java.base/windows/native/libjava/canonicalize_md.c
@@ -138,7 +138,8 @@ lastErrorReportable()
         || (errval == ERROR_BAD_NET_NAME)
         || (errval == ERROR_ACCESS_DENIED)
         || (errval == ERROR_NETWORK_UNREACHABLE)
-        || (errval == ERROR_NETWORK_ACCESS_DENIED)) {
+        || (errval == ERROR_NETWORK_ACCESS_DENIED)
+        || (errval == ERROR_NO_MORE_FILES)) {
         return 0;
     }
     return 1;


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315034](https://bugs.openjdk.org/browse/JDK-8315034) needs maintainer approval

### Issue
 * [JDK-8315034](https://bugs.openjdk.org/browse/JDK-8315034): File.mkdirs() occasionally fails to create folders on Windows shared folder (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2079/head:pull/2079` \
`$ git checkout pull/2079`

Update a local copy of the PR: \
`$ git checkout pull/2079` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2079`

View PR using the GUI difftool: \
`$ git pr show -t 2079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2079.diff">https://git.openjdk.org/jdk17u-dev/pull/2079.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2079#issuecomment-1867380392)