### PR TITLE
8322417: Console read line with zero out should zero out when throwing exception

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -335,8 +335,17 @@ public final class Console implements Flushable
                         else
                             ioe.addSuppressed(x);
                     }
-                    if (ioe != null)
+                    if (ioe != null) {
+                        java.util.Arrays.fill(passwd, ' ');
+                        try {
+                            if (reader instanceof LineReader lr) {
+                                lr.zeroOut();
+                            }
+                        } catch (IOException x) {
+                            // ignore
+                        }
                         throw ioe;
+                    }
                 }
                 pw.println();
             }


### PR DESCRIPTION
I want to fix this issue in 17, too.

The patch goes to another file, but after adaptin the path in the patch applied clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322417](https://bugs.openjdk.org/browse/JDK-8322417) needs maintainer approval

### Issue
 * [JDK-8322417](https://bugs.openjdk.org/browse/JDK-8322417): Console read line with zero out should zero out when throwing exception (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2081/head:pull/2081` \
`$ git checkout pull/2081`

Update a local copy of the PR: \
`$ git checkout pull/2081` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2081`

View PR using the GUI difftool: \
`$ git pr show -t 2081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2081.diff">https://git.openjdk.org/jdk17u-dev/pull/2081.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2081#issuecomment-1867785728)