### PR TITLE
8281377: Remove vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Deadlock/JavaDeadlock001/TestDescription.java from problemlist.

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -135,7 +135,6 @@ serviceability/sa/TestJmapCoreMetaspace.java  8294316,8267433 macosx-x64
 
 #############################################################################
 
-vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Deadlock/JavaDeadlock001/TestDescription.java 8060733 generic-all
 
 vmTestbase/nsk/jdi/HiddenClass/events/events001.java                 8257705 generic-all
 vmTestbase/nsk/jdi/ThreadReference/stop/stop001/TestDescription.java 7034630 generic-all


### PR DESCRIPTION
Backport of [JDK-8281377](https://bugs.openjdk.org/browse/JDK-8281377)

- Clean backport
- About Testing
  - This PR is saying the [JDK-8060733](https://bugs.openjdk.org/browse/JDK-8060733) issue has been gone
  - [JDK-8060733](https://bugs.openjdk.org/browse/JDK-8060733) is related to `test/hotspot/jtreg/vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Deadlock/JavaDeadlock001/TestDescription.java`
  - I have tested the `TestDescription.java` in local dev laptop, MacOS M1, it passed

Validation
- PR: All checks have passed
- SAP nightlies passed on `2023-12-26`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8281377](https://bugs.openjdk.org/browse/JDK-8281377) needs maintainer approval

### Issue
 * [JDK-8281377](https://bugs.openjdk.org/browse/JDK-8281377): Remove vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Deadlock/JavaDeadlock001/TestDescription.java from problemlist. (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2082/head:pull/2082` \
`$ git checkout pull/2082`

Update a local copy of the PR: \
`$ git checkout pull/2082` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2082`

View PR using the GUI difftool: \
`$ git pr show -t 2082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2082.diff">https://git.openjdk.org/jdk17u-dev/pull/2082.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2082#issuecomment-1868744361)