### PR TITLE
8304696: Duplicate class names in dynamicArchive tests can lead to test failure

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LinkClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LinkClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes
  * @build LinkClassApp
  * @build jdk.test.whitebox.WhiteBox
- * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar link_class_app.jar LinkClassApp Parent Child Parent2 Child2 MyShutdown
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar link_class_app.jar LinkClassApp Parent Child Parent2 Child2 LinkClassApp$MyShutdown
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. LinkClassTest
  */

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/LinkClassApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/LinkClassApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,13 +46,13 @@ class Child2 extends Parent2 {
     int get() {return 4;}
 }
 
-class MyShutdown extends Thread{
-    public void run(){
-        System.out.println("shut down hook invoked...");
-    }
-}
-
 class LinkClassApp {
+    static class MyShutdown extends Thread{
+        public void run(){
+            System.out.println("shut down hook invoked...");
+        }
+    }
+
     public static void main(String args[]) {
         Runtime r=Runtime.getRuntime();
         r.addShutdownHook(new MyShutdown());


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8304696](https://bugs.openjdk.org/browse/JDK-8304696) needs maintainer approval

### Issue
 * [JDK-8304696](https://bugs.openjdk.org/browse/JDK-8304696): Duplicate class names in dynamicArchive tests can lead to test failure (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2087/head:pull/2087` \
`$ git checkout pull/2087`

Update a local copy of the PR: \
`$ git checkout pull/2087` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2087`

View PR using the GUI difftool: \
`$ git pr show -t 2087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2087.diff">https://git.openjdk.org/jdk17u-dev/pull/2087.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2087#issuecomment-1872188941)