### PR TITLE
8316001: GC: Make TestArrayAllocatorMallocLimit use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class TestArrayAllocatorMallocLimit {
   private static final String printFlagsFinalPattern = " *size_t *" + flagName + " *:?= *(\\d+) *\\{experimental\\} *";
 
   public static void testDefaultValue()  throws Exception {
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createTestJvm(
       "-XX:+UnlockExperimentalVMOptions", "-XX:+PrintFlagsFinal", "-version");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316001](https://bugs.openjdk.org/browse/JDK-8316001) needs maintainer approval

### Issue
 * [JDK-8316001](https://bugs.openjdk.org/browse/JDK-8316001): GC: Make TestArrayAllocatorMallocLimit use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2088/head:pull/2088` \
`$ git checkout pull/2088`

Update a local copy of the PR: \
`$ git checkout pull/2088` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2088`

View PR using the GUI difftool: \
`$ git pr show -t 2088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2088.diff">https://git.openjdk.org/jdk17u-dev/pull/2088.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2088#issuecomment-1872191721)