### PR TITLE
8278028: [test-library] Warnings cleanup of the test library

### DIFF
--- a/test/lib-test/jdk/test/lib/AssertsTest.java
+++ b/test/lib-test/jdk/test/lib/AssertsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class AssertsTest {
         }
 
         public int compareTo(Foo f) {
-            return new Integer(id).compareTo(new Integer(f.id));
+            return Integer.valueOf(id).compareTo(Integer.valueOf(f.id));
         }
         public String toString() {
             return "Foo(" + Integer.toString(id) + ")";

--- a/test/lib-test/jdk/test/lib/TestPlatformIsTieredSupported.java
+++ b/test/lib-test/jdk/test/lib/TestPlatformIsTieredSupported.java
@@ -39,6 +39,7 @@ import jdk.test.whitebox.WhiteBox;
  */
 public class TestPlatformIsTieredSupported {
     public static void main(String args[]) {
+        @SuppressWarnings("deprecation")
         WhiteBox whiteBox = WhiteBox.getWhiteBox();
         boolean tieredCompilation = whiteBox.getBooleanVMFlag(
                 "TieredCompilation");

--- a/test/lib-test/jdk/test/lib/format/ArrayDiffTest.java
+++ b/test/lib-test/jdk/test/lib/format/ArrayDiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -274,6 +274,7 @@ public class ArrayDiffTest {
         class StrObj {
             private final String value;
             public boolean equals(Object another) { return ((StrObj)another).value.equals(value); }
+            public int hashCode() { return value.hashCode(); }
             public StrObj(String value) { this.value = value; }
             public String toString() { return value; }
         }
@@ -363,7 +364,7 @@ public class ArrayDiffTest {
         }
 
         public void assertTwoWay() {
-            ArrayDiff diff;
+            ArrayDiff<?> diff;
 
             // Direct
             if (defaultParameters) {

--- a/test/lib-test/jdk/test/whitebox/vm_flags/VmFlagTest.java
+++ b/test/lib-test/jdk/test/whitebox/vm_flags/VmFlagTest.java
@@ -72,9 +72,9 @@ public final class VmFlagTest<T> {
     protected static <T> void runTest(String existentFlag, T[] tests,
             T[] results, BiConsumer<String, T> set, Function<String, T> get) {
         if (existentFlag != null) {
-            new VmFlagTest(existentFlag, set, get, true).test(tests, results);
+            new VmFlagTest<T>(existentFlag, set, get, true).test(tests, results);
         }
-        new VmFlagTest(NONEXISTENT_FLAG, set, get, false).test(tests, results);
+        new VmFlagTest<T>(NONEXISTENT_FLAG, set, get, false).test(tests, results);
     }
 
     public final void test(T[] tests, T[] results) {

--- a/test/lib/RedefineClassHelper.java
+++ b/test/lib/RedefineClassHelper.java
@@ -47,7 +47,7 @@ public class RedefineClassHelper {
      * @param clazz Class to redefine
      * @param javacode String with the new java code for the class to be redefined
      */
-    public static void redefineClass(Class clazz, String javacode) throws Exception {
+    public static void redefineClass(Class<?> clazz, String javacode) throws Exception {
         byte[] bytecode = InMemoryJavaCompiler.compile(clazz.getName(), javacode);
         redefineClass(clazz, bytecode);
     }
@@ -58,7 +58,7 @@ public class RedefineClassHelper {
      * @param clazz Class to redefine
      * @param bytecode byte[] with the new class
      */
-    public static void redefineClass(Class clazz, byte[] bytecode) throws Exception {
+    public static void redefineClass(Class<?> clazz, byte[] bytecode) throws Exception {
         instrumentation.redefineClasses(new ClassDefinition(clazz, bytecode));
     }
 

--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -451,6 +451,7 @@ public class NetworkConfiguration {
     }
 
     /** Prints all the system interface information to the give stream. */
+    @SuppressWarnings("removal")
     public static void printSystemConfiguration(PrintStream out) {
         PrivilegedAction<Void> pa = () -> {
         try {

--- a/test/lib/jdk/test/lib/compiler/InMemoryJavaCompiler.java
+++ b/test/lib/jdk/test/lib/compiler/InMemoryJavaCompiler.java
@@ -107,7 +107,7 @@ public class InMemoryJavaCompiler {
         }
     }
 
-    private static class FileManagerWrapper extends ForwardingJavaFileManager {
+    private static class FileManagerWrapper extends ForwardingJavaFileManager<JavaFileManager> {
         private static final Location PATCH_LOCATION = new Location() {
             @Override
             public String getName() {

--- a/test/lib/jdk/test/lib/format/ArrayCodec.java
+++ b/test/lib/jdk/test/lib/format/ArrayCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,7 +141,7 @@ public class ArrayCodec<E> {
      * @throws IllegalArgumentException if {@code array}'s component type is not supported
      * @return an ArrayCodec for the provided array
      */
-    public static ArrayCodec of(Object array) {
+    public static ArrayCodec<?> of(Object array) {
         var type = array.getClass().getComponentType();
         if (type == byte.class) {
             return ArrayCodec.of((byte[])array);

--- a/test/lib/jdk/test/lib/format/ArrayDiff.java
+++ b/test/lib/jdk/test/lib/format/ArrayDiff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class ArrayDiff<E> implements Diff {
      * @param second the second array
      * @return an ArrayDiff instance for the two arrays
      */
-    public static ArrayDiff of(Object first, Object second) {
+    public static ArrayDiff<?> of(Object first, Object second) {
         return ArrayDiff.of(first, second, Diff.Defaults.WIDTH, Diff.Defaults.CONTEXT_BEFORE);
     }
 
@@ -109,7 +109,8 @@ public class ArrayDiff<E> implements Diff {
      * @throws NullPointerException if at least one of the arrays is null
      * @return an ArrayDiff instance for the two arrays and formatting parameters provided
      */
-    public static ArrayDiff of(Object first, Object second, int width, int contextBefore) {
+    @SuppressWarnings("rawtypes")
+    public static ArrayDiff<?> of(Object first, Object second, int width, int contextBefore) {
         Objects.requireNonNull(first);
         Objects.requireNonNull(second);
 
@@ -204,4 +205,3 @@ public class ArrayDiff<E> implements Diff {
     }
 
 }
-

--- a/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
+++ b/test/lib/jdk/test/lib/hexdump/ASN1Formatter.java
@@ -626,6 +626,7 @@ public class ASN1Formatter implements HexPrinter.Formatter {
      * @return the InputStream or the wrapped decoder of Base64Mime.
      * @throws IOException if an I/O error occurs
      */
+    @SuppressWarnings("deprecation")
     private static InputStream wrapIfBase64Mime(BufferedInputStream bis) throws IOException {
         bis.mark(256);
         DataInputStream dis = new DataInputStream(bis);

--- a/test/lib/jdk/test/lib/hexdump/StreamDump.java
+++ b/test/lib/jdk/test/lib/hexdump/StreamDump.java
@@ -165,6 +165,7 @@ public class StreamDump {
      * @return an InputStream, unchanged unless it is Base64 Mime
      * @throws IOException if an I/O Error occurs
      */
+    @SuppressWarnings("deprecation")
     static InputStream decodeMaybe(InputStream is) throws IOException {
         DataInputStream dis = new DataInputStream(is);
         is.mark(1024);

--- a/test/lib/jdk/test/lib/process/Proc.java
+++ b/test/lib/jdk/test/lib/process/Proc.java
@@ -113,8 +113,8 @@ public class Proc {
 
     private List<String> args = new ArrayList<>();
     private Map<String,String> env = new HashMap<>();
-    private Map<String,String> prop = new HashMap();
-    private Map<String,String> secprop = new HashMap();
+    private Map<String,String> prop = new HashMap<>();
+    private Map<String,String> secprop = new HashMap<>();
     private boolean inheritIO = false;
     private boolean noDump = false;
 

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -432,6 +432,7 @@ public final class ProcessTools {
      *              the default charset.
      * @return The {@linkplain OutputAnalyzer} instance wrapping the process.
      */
+    @SuppressWarnings("removal")
     public static OutputAnalyzer executeProcess(ProcessBuilder pb, String input,
                                                 Charset cs) throws Exception {
         OutputAnalyzer output = null;
@@ -604,6 +605,7 @@ public final class ProcessTools {
         return pb;
     }
 
+    @SuppressWarnings("removal")
     private static Process privilegedStart(ProcessBuilder pb) throws IOException {
         try {
             return AccessController.doPrivileged(


### PR DESCRIPTION
I think this is good to have in 17 to reduce the warnings and to simplify further test backports 

Skipped patch to OldWhiteBox.java, file not in 17.
Resolved InMemoryJavaCompiler.java: Copyright, import. Changes already backported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8278028](https://bugs.openjdk.org/browse/JDK-8278028) needs maintainer approval

### Issue
 * [JDK-8278028](https://bugs.openjdk.org/browse/JDK-8278028): [test-library] Warnings cleanup of the test library (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2092/head:pull/2092` \
`$ git checkout pull/2092`

Update a local copy of the PR: \
`$ git checkout pull/2092` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2092`

View PR using the GUI difftool: \
`$ git pr show -t 2092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2092.diff">https://git.openjdk.org/jdk17u-dev/pull/2092.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2092#issuecomment-1875049780)