### PR TITLE
8303605: Memory leaks in Metaspace gtests

### DIFF
--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -92,6 +92,7 @@ static int init_jvm(int argc, char **argv, bool disable_error_handling, JavaVM**
   JNIEnv* env;
 
   int ret = JNI_CreateJavaVM(jvm_ptr, (void**)&env, &args);
+  delete[] options;
   if (ret == JNI_OK) {
     // CreateJavaVM leaves WXExec context, while gtests
     // calls internal functions assuming running in WXWwrite.

--- a/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
@@ -99,6 +99,10 @@ public:
     }
   }
 
+  ~SparseArray() {
+    FREE_C_HEAP_ARRAY(T, _slots);
+  }
+
   T at(int i)              { return _slots[i]; }
   const T at(int i) const  { return _slots[i]; }
   void set_at(int i, T e)  { _slots[i] = e; }

--- a/test/hotspot/gtest/metaspace/test_freeblocks.cpp
+++ b/test/hotspot/gtest/metaspace/test_freeblocks.cpp
@@ -79,7 +79,7 @@ class FreeBlocksTest {
     return false;
   }
 
-  void deallocate_top() {
+  bool deallocate_top() {
 
     allocation_t* a = _allocations;
     if (a != NULL) {
@@ -88,7 +88,13 @@ class FreeBlocksTest {
       _freeblocks.add_block(a->p, a->word_size);
       delete a;
       DEBUG_ONLY(_freeblocks.verify();)
+      return true;
     }
+    return false;
+  }
+
+  void deallocate_all() {
+    while (deallocate_top());
   }
 
   bool allocate() {
@@ -180,6 +186,10 @@ public:
     // some initial feeding
     _freeblocks.add_block(_fb.get(1024), 1024);
     CHECK_CONTENT(_freeblocks, 1, 1024);
+  }
+
+  ~FreeBlocksTest() {
+    deallocate_all();
   }
 
   static void test_small_allocations() {

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -532,6 +532,9 @@ TEST_VM(metaspace, virtual_space_node_test_basics) {
   ASSERT_EQ(node->committed_words(), scomm.get());
   DEBUG_ONLY(node->verify_locked();)
 
+  delete node;
+  ASSERT_EQ(scomm.get(), (size_t)0);
+  ASSERT_EQ(sres.get(), (size_t)0);
 }
 
 // Note: we unfortunately need TEST_VM even though the system tested


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

I resolved test_virtualspacenode.cpp due to an extra empty line, will mark as clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8303605](https://bugs.openjdk.org/browse/JDK-8303605) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303605](https://bugs.openjdk.org/browse/JDK-8303605): Memory leaks in Metaspace gtests (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2093/head:pull/2093` \
`$ git checkout pull/2093`

Update a local copy of the PR: \
`$ git checkout pull/2093` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2093`

View PR using the GUI difftool: \
`$ git pr show -t 2093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2093.diff">https://git.openjdk.org/jdk17u-dev/pull/2093.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2093#issuecomment-1875551791)