### PR TITLE
8322968: [17u] Amend Atomics gtest with 1-byte tests

### DIFF
--- a/test/hotspot/gtest/runtime/test_atomic.cpp
+++ b/test/hotspot/gtest/runtime/test_atomic.cpp
@@ -146,6 +146,51 @@ TEST(AtomicCmpxchgTest, int64) {
   Support().test();
 }
 
+struct AtomicCmpxchg1ByteStressSupport {
+  char _default_val;
+  int  _base;
+  char _array[7+32+7];
+
+  AtomicCmpxchg1ByteStressSupport() : _default_val(0xaa), _base(7), _array{} {}
+
+  void validate(char val, char val2, int index) {
+    for (int i = 0; i < 7; i++) {
+      EXPECT_EQ(_array[i], _default_val);
+    }
+    for (int i = 7; i < (7+32); i++) {
+      if (i == index) {
+        EXPECT_EQ(_array[i], val2);
+      } else {
+        EXPECT_EQ(_array[i], val);
+      }
+    }
+    for (int i = 0; i < 7; i++) {
+      EXPECT_EQ(_array[i], _default_val);
+    }
+  }
+
+  void test_index(int index) {
+    char one = 1;
+    Atomic::cmpxchg(&_array[index], _default_val, one);
+    validate(_default_val, one, index);
+
+    Atomic::cmpxchg(&_array[index], one, _default_val);
+    validate(_default_val, _default_val, index);
+  }
+
+  void test() {
+    memset(_array, _default_val, sizeof(_array));
+    for (int i = _base; i < (_base+32); i++) {
+      test_index(i);
+    }
+  }
+};
+
+TEST(AtomicCmpxchg1Byte, stress) {
+  AtomicCmpxchg1ByteStressSupport support;
+  support.test();
+}
+
 template<typename T>
 struct AtomicEnumTestSupport {
   volatile T _test_value;

--- a/test/hotspot/gtest/runtime/test_atomic.cpp
+++ b/test/hotspot/gtest/runtime/test_atomic.cpp
@@ -151,7 +151,7 @@ struct AtomicCmpxchg1ByteStressSupport {
   int  _base;
   char _array[7+32+7];
 
-  AtomicCmpxchg1ByteStressSupport() : _default_val(0xaa), _base(7), _array{} {}
+  AtomicCmpxchg1ByteStressSupport() : _default_val(0x7a), _base(7), _array{} {}
 
   void validate(char val, char val2, int index) {
     for (int i = 0; i < 7; i++) {


### PR DESCRIPTION
[JDK-8316645](https://bugs.openjdk.org/browse/JDK-8316645) was backported to 17u without the relevant test additions, because the test file was missing. But now, after the series of atomic support backports, we have the test file, so we can now complete the backport with the test hunks.

Compare 17u-dev version:
 https://github.com/openjdk/jdk17u-dev/commit/db83123c5cc054cee5663201ead92410e6487d81

...and the mainline:
 https://github.com/openjdk/jdk/commit/fb055e7e5300958b2a6a290aa6783e8ede929d9a

This change adds the missing hunk from mainline change. It includes [JDK-8317335](https://bugs.openjdk.org/browse/JDK-8317335) fix as well.

cc: @zifeihan, @RealFYang

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `Atomics` test still passes