### PR TITLE
8293547: Add relaxed add_and_fetch for macos aarch64 atomics

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/atomic_bsd_aarch64.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/atomic_bsd_aarch64.hpp
@@ -37,9 +37,13 @@ template<size_t byte_size>
 struct Atomic::PlatformAdd {
   template<typename D, typename I>
   D add_and_fetch(D volatile* dest, I add_value, atomic_memory_order order) const {
-    D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
-    FULL_MEM_BARRIER;
-    return res;
+    if (order == memory_order_relaxed) {
+      return __atomic_add_fetch(dest, add_value, __ATOMIC_RELAXED);
+    } else {
+      D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
+      FULL_MEM_BARRIER;
+      return res;
+    }
   }
 
   template<typename D, typename I>


### PR DESCRIPTION
Clean backport to improve Atomics performance for the code that opts-in to relaxed CASes.

Additional testing:
 - [x] macos-server-aarch64-fastdebug, `gtest:Atomic` passes
 - [x]  macos-server-aarch64-fastdebug, `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8293547](https://bugs.openjdk.org/browse/JDK-8293547) needs maintainer approval

### Issue
 * [JDK-8293547](https://bugs.openjdk.org/browse/JDK-8293547): Add relaxed add_and_fetch for macos aarch64 atomics (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2097/head:pull/2097` \
`$ git checkout pull/2097`

Update a local copy of the PR: \
`$ git checkout pull/2097` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2097`

View PR using the GUI difftool: \
`$ git pr show -t 2097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2097.diff">https://git.openjdk.org/jdk17u-dev/pull/2097.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2097#issuecomment-1875825642)