### PR TITLE
8322321: Add man page doc for -XX:+VerifySharedSpaces

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1642,6 +1642,15 @@ Specifies the path and name of the class data sharing (CDS) archive file
 See \f[B]Application Class Data Sharing\f[R].
 .RE
 .TP
+\f[V]-XX:+VerifySharedSpaces\f[R]
+If this option is specified, the JVM will load a CDS archive file only
+if it passes an integrity check based on CRC32 checksums.
+The purpose of this flag is to check for unintentional damage to CDS
+archive files in transmission or storage.
+To guarantee the security and proper operation of CDS, the user must
+ensure that the CDS archive files used by Java applications cannot be
+modified without proper authorization.
+.TP
 .B \f[CB]\-XX:SharedArchiveConfigFile\f[R]=\f[I]shared_config_file\f[R]
 Specifies additional shared data added to the archive file.
 .RS


### PR DESCRIPTION
This is an unclean backport of a manpage fix, for Oracle parity. The conflict was trivial to resolve manually and was due to the troff source being updated post-17u for 8297164, which is unlikely to be backported itself.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322321](https://bugs.openjdk.org/browse/JDK-8322321) needs maintainer approval

### Issue
 * [JDK-8322321](https://bugs.openjdk.org/browse/JDK-8322321): Add man page doc for -XX:+VerifySharedSpaces (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2098/head:pull/2098` \
`$ git checkout pull/2098`

Update a local copy of the PR: \
`$ git checkout pull/2098` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2098`

View PR using the GUI difftool: \
`$ git pr show -t 2098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2098.diff">https://git.openjdk.org/jdk17u-dev/pull/2098.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2098#issuecomment-1876835794)