### PR TITLE
8315731: Open source several Swing Text related tests

### DIFF
--- a/test/jdk/javax/swing/text/CompositeView/bug4398059.java
+++ b/test/jdk/javax/swing/text/CompositeView/bug4398059.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Robot;
+import java.awt.Shape;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.Position;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.ParagraphView;
+
+/*
+ * @test
+ * @bug 4398059
+ * @key headful
+ * @summary Tests that CompositeView doesn't throw NPE.
+ */
+
+public class bug4398059 {
+    private static JFrame jFrame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            SwingUtilities.invokeAndWait(bug4398059::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (jFrame != null) {
+                    jFrame.dispose();
+                }
+            });
+        }
+    }
+
+    public static void createAndShowUI() {
+        String text = "<H1>text";
+        jFrame = new JFrame("CompositeView Test");
+        JEditorPane jep = new JEditorPane();
+        jep.setEditorKit(new MyHTMLEditorKit());
+        jep.setText(text);
+
+        Document doc = jep.getDocument();
+        jep.setCaretPosition(doc.getLength() - 1);
+
+        jFrame.getContentPane().add(jep);
+        jFrame.setSize(200,200);
+        jFrame.setVisible(true);
+    }
+
+    static class MyHTMLEditorKit extends HTMLEditorKit {
+        private static final ViewFactory defaultFactory = new MyHTMLFactory();
+
+        public ViewFactory getViewFactory() {
+            return defaultFactory;
+        }
+
+        static class MyHTMLFactory extends HTMLEditorKit.HTMLFactory {
+            public View create(Element elem) {
+                Object obj = elem.getAttributes().getAttribute(StyleConstants.NameAttribute);
+                if (obj instanceof HTML.Tag kind) {
+                    if (kind == HTML.Tag.H1) {
+                        return new MyParagraphView(elem);
+                    }
+                }
+                return super.create(elem);
+            }
+        }
+
+        static class MyParagraphView extends ParagraphView {
+            public MyParagraphView(Element elem) {
+                super(elem);
+            }
+
+            public Shape getChildAllocation(int index, Shape a) {
+                return null;
+            }
+
+            public Shape modelToView(int pos, Shape a, Position.Bias b)
+                                      throws BadLocationException {
+                return super.modelToView(pos, a, b);
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/DefaultCaret/bug4197894.java
+++ b/test/jdk/javax/swing/text/DefaultCaret/bug4197894.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4197894
+ * @key headful
+ * @summary Tests if shift-click adjusts selection in text areas.
+ */
+
+public class bug4197894 {
+    private static JFrame jFrame;
+    private static JTextArea ta;
+
+    private static volatile Point point = null;
+    private static volatile Rectangle bounds;
+
+    private static volatile boolean passed = true;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+            robot.setAutoWaitForIdle(true);
+
+            SwingUtilities.invokeAndWait(bug4197894::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                point = ta.getLocationOnScreen();
+                bounds = ta.getBounds();
+            });
+            robot.waitForIdle();
+            robot.delay(300);
+
+            robot.mouseMove((point.x + bounds.width / 4),
+                    (point.y + bounds.height / 4));
+
+            robot.keyPress(KeyEvent.VK_SHIFT);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyRelease(KeyEvent.VK_SHIFT);
+            robot.delay(300);
+
+            if (!passed) {
+                throw new RuntimeException("Test failed." +
+                        " Shift-Click Text Selection does not work!");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (jFrame != null) {
+                    jFrame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        jFrame = new JFrame("Shift-Click Text Selection");
+        ta = new JTextArea();
+        ta.addKeyListener(new KeyAdapter() {
+            public void keyReleased(KeyEvent e) {
+                String selText = ta.getSelectedText();
+                passed = !(selText == null || (selText.length() == 0));
+            }
+        });
+        ta.setText("12345\n12345\n12345\n12345\n12345\n12345\n12345");
+        ta.setCaretPosition(ta.getDocument().getLength());
+        jFrame.getContentPane().add(ta);
+        jFrame.pack();
+        jFrame.setLocationRelativeTo(null);
+        jFrame.setAlwaysOnTop(true);
+        jFrame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/text/DefaultCaret/bug4203175.java
+++ b/test/jdk/javax/swing/text/DefaultCaret/bug4203175.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Container;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4203175
+ * @key headful
+ * @summary Tests that double-click on disabled JTextField doesn't
+ *          cause other text-field to select content.
+ */
+
+public class bug4203175 {
+    private static JFrame jFrame;
+    private static JTextField tf1, tf2;
+    private static JButton b;
+    private static volatile Point point;
+    private static volatile boolean passed = true;
+    private static int clicks = 0;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(50);
+            robot.setAutoWaitForIdle(true);
+
+            SwingUtilities.invokeAndWait(bug4203175::createAndShowUI);
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> point = tf1.getLocationOnScreen());
+            robot.mouseMove(point.x, point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(200);
+
+            SwingUtilities.invokeAndWait(() -> point = b.getLocationOnScreen());
+            robot.mouseMove(point.x, point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(200);
+
+            SwingUtilities.invokeAndWait(() -> point = tf2.getLocationOnScreen());
+            robot.mouseMove(point.x, point.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(200);
+
+            if (!passed) {
+                throw new RuntimeException("Test failed!! Text selection on disabled" +
+                                           " TextField does not work as expected!");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (jFrame != null) {
+                    jFrame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        jFrame = new JFrame("JTextField Text Selection");
+        Container cont = jFrame.getContentPane();
+        cont.setLayout(new BoxLayout(cont, BoxLayout.Y_AXIS));
+
+        tf1 = new JTextField(20);
+        tf1.setText("sometext");
+        tf1.setName("Field 1");
+        tf1.setCaretPosition(tf1.getDocument().getLength());
+        cont.add(tf1);
+
+        tf2 = new JTextField(20);
+        tf2.setName("Field 2");
+        tf2.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                super.mouseClicked(e);
+                clicks++;
+                if (clicks == 2) {
+                    String selText = tf1.getSelectedText();
+                    passed = (selText == null || (selText.length() == 0));
+                }
+            }
+        });
+        cont.add(tf2);
+
+        b = new JButton("Toggle Enabled");
+        cont.add(b);
+        b.addActionListener(e -> {
+            if (e.getSource() == b) {
+                boolean b = tf1.isEnabled();
+                tf1.setEnabled(!b);
+                tf2.setEnabled(!b);
+            }
+        });
+
+        jFrame.pack();
+        jFrame.setLocationRelativeTo(null);
+        jFrame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/text/DefaultEditorKit/bug4265242.java
+++ b/test/jdk/javax/swing/text/DefaultEditorKit/bug4265242.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.event.ActionEvent;
+import javax.swing.Action;
+import javax.swing.JTextPane;
+import javax.swing.text.DefaultEditorKit;
+
+/*
+ * @test
+ * @bug 4265242
+ * @summary Tests endParagraphAction in JTextPane
+ */
+
+public class bug4265242 {
+    public static void main(String[] args) {
+        JTextPane jTextPane = new JTextPane();
+        jTextPane.setText("Merry sparrow");
+
+        Action[] actions = jTextPane.getActions();
+        Action endPara = null;
+        for (Action action : actions) {
+            String name = (String) action.getValue(Action.NAME);
+            if (name.equals(DefaultEditorKit.endParagraphAction)) {
+                endPara = action;
+            }
+        }
+        endPara.actionPerformed(new ActionEvent(jTextPane,
+                ActionEvent.ACTION_PERFORMED,
+                DefaultEditorKit.endParagraphAction));
+    }
+}

--- a/test/jdk/javax/swing/text/DefaultStyledDocument/bug4472852.java
+++ b/test/jdk/javax/swing/text/DefaultStyledDocument/bug4472852.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import javax.swing.text.DefaultStyledDocument;
+import javax.swing.text.Element;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
+
+/*
+ * @test
+ * @bug 4472852
+ * @summary Tests DefaultStyledDocument.split(int, int)
+ */
+
+public class bug4472852 {
+
+    public static void main(String[] args) throws Exception {
+        // create a Document and insert some text there
+        StyledDocument doc = new DefaultStyledDocument();
+        doc.insertString(0, "this", null);
+
+        // add style to the last word
+        Element root = doc.getDefaultRootElement();
+        int end = root.getEndOffset();
+        MutableAttributeSet as = new SimpleAttributeSet();
+        StyleConstants.setBackground(as, Color.BLUE);
+        doc.setCharacterAttributes(end-5, 5, as, true);
+
+        // inspect Elements of the only Paragraph --
+        // there should be no empty Elements
+        Element para = root.getElement(0);
+        for (int i = 0; i < para.getElementCount(); i++) {
+            Element el = para.getElement(i);
+            if (el.getStartOffset() == el.getEndOffset()) {
+                throw new RuntimeException("Failed: empty Element found");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of 5 newly-opensourced Swing tests. All the tests pass in 17u-dev. For Oracle parity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315731](https://bugs.openjdk.org/browse/JDK-8315731) needs maintainer approval

### Issue
 * [JDK-8315731](https://bugs.openjdk.org/browse/JDK-8315731): Open source several Swing Text related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2101/head:pull/2101` \
`$ git checkout pull/2101`

Update a local copy of the PR: \
`$ git checkout pull/2101` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2101`

View PR using the GUI difftool: \
`$ git pr show -t 2101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2101.diff">https://git.openjdk.org/jdk17u-dev/pull/2101.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2101#issuecomment-1876870138)