### PR TITLE
8322583: RISC-V: Enable fast class initialization checks

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -199,6 +199,9 @@ class VM_Version : public Abstract_VM_Version {
   static void initialize_cpu_information();
 
   constexpr static bool supports_stack_watermark_barrier() { return true; }
+
+  // RISCV64 supports fast class initialization checks
+  static bool supports_fast_class_init_checks() { return true; }
 };
 
 #endif // CPU_RISCV_VM_VERSION_RISCV_HPP


### PR DESCRIPTION
Hi, The same issue also exists in the JDK17u. Since corresponding fixes for the other ports are already there in jdk17u, I would like to backport this to jdk17u too. So I would like to backport this to JDK17u. Tier1-3 tested with release build using qemu systems. This is a risc-v specific change. Backport is clean, risk is low.

The original performance issue reported by JDK-8219233 is resolved when this optimization is enabled (x2.1 improvement for reported case on linux-riscv64).

OpenJDK17 linux-riscv64 when setting VM_Version::supports_fast_class_init_checks returns false(default):

```
$ clojure -A:user
"Elapsed time: 78459.498421 msecs"
$ clojure -A:user
"Elapsed time: 77513.115408 msecs"
$ clojure -A:user
"Elapsed time: 75132.908155 msecs"
$ clojure foo.clj
"Elapsed time: 36337.585315 msecs"
$ clojure foo.clj
"Elapsed time: 35009.33778 msecs"
$ clojure foo.clj
"Elapsed time: 35490.216435 msecs"
```

OpenJDK17 linux-riscv64 when setting VM_Version::supports_fast_class_init_checks returns true:

```
$ clojure -A:user
"Elapsed time: 37013.598933 msecs"
$ clojure -A:user
"Elapsed time: 36210.164686 msecs"
$ clojure -A:user
"Elapsed time: 36674.069441 msecs"
$ clojure foo.clj
"Elapsed time: 36813.877226 msecs"
$ clojure foo.clj
"Elapsed time: 37079.673782 msecs"
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8322583](https://bugs.openjdk.org/browse/JDK-8322583) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322583](https://bugs.openjdk.org/browse/JDK-8322583): RISC-V: Enable fast class initialization checks (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2110/head:pull/2110` \
`$ git checkout pull/2110`

Update a local copy of the PR: \
`$ git checkout pull/2110` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2110`

View PR using the GUI difftool: \
`$ git pr show -t 2110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2110.diff">https://git.openjdk.org/jdk17u-dev/pull/2110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2110#issuecomment-1880996336)