### PR TITLE
8272853: improve `JavadocTester.runTests`

### DIFF
--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
@@ -58,6 +58,7 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -264,37 +265,127 @@ public abstract class JavadocTester {
 
     /**
      * Run all methods annotated with @Test, followed by printSummary.
-     * Typically called on a tester object in main()
+     * The methods are invoked in the order found using getDeclaredMethods.
+     * The arguments for the invocation are provided {@link #getTestArgs(Method)}.
      *
+     * Typically called on a tester object in main().
+     *
+     * @throws IllegalArgumentException if any test method does not have a recognized signature
      * @throws Exception if any errors occurred
      */
     public void runTests() throws Exception {
-        runTests(m -> new Object[0]);
+        runTests(this::getTestArgs);
     }
 
     /**
      * Runs all methods annotated with @Test, followed by printSummary.
+     * The methods are invoked in the order found using getDeclaredMethods.
+     * The arguments for the invocation are provided by a given function.
+     *
      * Typically called on a tester object in main()
      *
      * @param f a function which will be used to provide arguments to each
      *          invoked method
-     * @throws Exception if any errors occurred
+     * @throws Exception if any errors occurred while executing a test method
      */
     public void runTests(Function<Method, Object[]> f) throws Exception {
-        for (Method m: getClass().getDeclaredMethods()) {
+        for (Method m : getClass().getDeclaredMethods()) {
             Annotation a = m.getAnnotation(Test.class);
             if (a != null) {
-                try {
-                    out.println("Running test " + m.getName());
-                    m.invoke(this, f.apply(m));
-                } catch (InvocationTargetException e) {
-                    Throwable cause = e.getCause();
-                    throw (cause instanceof Exception) ? ((Exception) cause) : e;
-                }
+                runTest(m, f);
                 out.println();
             }
         }
         printSummary();
+    }
+
+    /**
+     * Run the specified methods annotated with @Test, or all methods annotated
+     * with @Test if none are specified, followed by printSummary.
+     * The methods are invoked in the order given in the methodNames argument,
+     * or the order returned by getDeclaredMethods if no names are provided.
+     * The arguments for the invocation are provided {@link #getTestArgs(Method)}.
+     *
+     * Typically called on a tester object in main(String[] args), perhaps using
+     * args as the list of method names.
+     *
+     * @throws IllegalStateException if any methods annotated with @Test are overloaded
+     * @throws IllegalArgumentException if any of the method names does not name a suitable method
+     * @throws NullPointerException if {@code methodNames} is {@code null}, or if any of the names are {@code null}
+     * @throws Exception if any errors occurred while executing a test method
+     */
+    public void runTests(String... methodNames) throws Exception {
+        runTests(this::getTestArgs, methodNames);
+    }
+
+    /**
+     * Run the specified methods annotated with @Test, or all methods annotated
+     * with @Test if non are specified, followed by printSummary.
+     * The methods are invoked in the order given in the methodNames argument,
+     * or the order returned by getDeclaredMethods if no names are provided.
+     * The arguments for the invocation are provided {@link #getTestArgs(Method)}.
+     *
+     * Typically called on a tester object in main(String[] args), perhaps using
+     * args as the list of method names.
+     *
+     * @throws IllegalStateException if any methods annotated with @Test are overloaded
+     * @throws IllegalArgumentException if any of the method names does not name a suitable method
+     * @throws NullPointerException if {@code methodNames} is {@code null}, or if any of the names are {@code null}
+     * @throws Exception if any errors occurred while executing a test method
+     */
+    public void runTests(Function<Method, Object[]> f, String... methodNames) throws Exception {
+        if (methodNames.length == 0) {
+            runTests(f);
+        } else {
+            Map<String, Method> testMethods = Stream.of(getClass().getDeclaredMethods())
+                    .filter(this::isTestMethod)
+                    .collect(Collectors.toMap(Method::getName, Function.identity(),
+                            (o, n) -> {
+                                throw new IllegalStateException("test method " + o.getName() + " is overloaded");
+                            }));
+
+            List<Method> list = new ArrayList<>();
+            for (String mn : methodNames) {
+                Method m = testMethods.get(mn);
+                if (m == null) {
+                    throw new IllegalArgumentException("test method " + mn + " not found");
+                }
+                list.add(m);
+            }
+
+            for (Method m : list) {
+                runTest(m, f);
+            }
+        }
+    }
+
+    protected boolean isTestMethod(Method m) {
+        return m.getAnnotation(Test.class) != null;
+    }
+
+    protected Object[] getTestArgs(Method m) throws IllegalArgumentException {
+        Class<?>[] paramTypes = m.getParameterTypes();
+        if (paramTypes.length == 0) {
+            return new Object[] {};
+        } else if (paramTypes.length == 1 && paramTypes[0] == Path.class) {
+            return new Object[] { Path.of(m.getName())};
+        } else {
+            throw new IllegalArgumentException("unknown signature for method "
+                    + m + Stream.of(paramTypes)
+                    .map(Class::toString)
+                    .collect(Collectors.joining(", ", "(", ")")))  ;
+        }
+    }
+
+    protected void runTest(Method m, Function<Method, Object[]> f) throws Exception {
+        try {
+            out.println("Running test " + m.getName());
+            m.invoke(this, f.apply(m));
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            throw (cause instanceof Exception) ? ((Exception) cause) : e;
+        }
+
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

Resolved one import, probably recognized clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8272853](https://bugs.openjdk.org/browse/JDK-8272853) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272853](https://bugs.openjdk.org/browse/JDK-8272853): improve `JavadocTester.runTests` (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2111/head:pull/2111` \
`$ git checkout pull/2111`

Update a local copy of the PR: \
`$ git checkout pull/2111` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2111`

View PR using the GUI difftool: \
`$ git pr show -t 2111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2111.diff">https://git.openjdk.org/jdk17u-dev/pull/2111.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2111#issuecomment-1881073239)