### PR TITLE
8320877: Shenandoah: Remove ShenandoahUnloadClassesFrequency support

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAggressiveHeuristics.cpp
@@ -37,12 +37,6 @@ ShenandoahAggressiveHeuristics::ShenandoahAggressiveHeuristics() : ShenandoahHeu
 
   // Aggressive evacuates everything, so it needs as much evac space as it can get
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahEvacReserveOverflow);
-
-  // If class unloading is globally enabled, aggressive does unloading even with
-  // concurrent cycles.
-  if (ClassUnloading) {
-    SHENANDOAH_ERGO_OVERRIDE_DEFAULT(ShenandoahUnloadClassesFrequency, 1);
-  }
 }
 
 void ShenandoahAggressiveHeuristics::choose_collection_set_from_regiondata(ShenandoahCollectionSet* cset,
@@ -62,7 +56,7 @@ bool ShenandoahAggressiveHeuristics::should_start_gc() {
 }
 
 bool ShenandoahAggressiveHeuristics::should_unload_classes() {
-  if (!can_unload_classes_normal()) return false;
+  if (!can_unload_classes()) return false;
   if (has_metaspace_oom()) return true;
   // Randomly unload classes with 50% chance.
   return (os::random() & 1) == 1;

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -53,11 +53,6 @@ ShenandoahHeuristics::ShenandoahHeuristics() :
   _gc_time_history(new TruncatedSeq(10, ShenandoahAdaptiveDecayFactor)),
   _metaspace_oom()
 {
-  // No unloading during concurrent mark? Communicate that to heuristics
-  if (!ClassUnloadingWithConcurrentMark) {
-    FLAG_SET_DEFAULT(ShenandoahUnloadClassesFrequency, 0);
-  }
-
   size_t num_regions = ShenandoahHeap::heap()->num_regions();
   assert(num_regions > 0, "Sanity");
 
@@ -262,23 +257,10 @@ bool ShenandoahHeuristics::can_unload_classes() {
   return true;
 }
 
-bool ShenandoahHeuristics::can_unload_classes_normal() {
+bool ShenandoahHeuristics::should_unload_classes() {
   if (!can_unload_classes()) return false;
   if (has_metaspace_oom()) return true;
-  if (!ClassUnloadingWithConcurrentMark) return false;
-  if (ShenandoahUnloadClassesFrequency == 0) return false;
-  return true;
-}
-
-bool ShenandoahHeuristics::should_unload_classes() {
-  if (!can_unload_classes_normal()) return false;
-  if (has_metaspace_oom()) return true;
-  size_t cycle = ShenandoahHeap::heap()->shenandoah_policy()->cycle_counter();
-  // Unload classes every Nth GC cycle.
-  // This should not happen in the same cycle as process_references to amortize costs.
-  // Offsetting by one is enough to break the rendezvous when periods are equal.
-  // When periods are not equal, offsetting by one is just as good as any other guess.
-  return (cycle + 1) % ShenandoahUnloadClassesFrequency == 0;
+  return ClassUnloadingWithConcurrentMark;
 }
 
 void ShenandoahHeuristics::initialize() {

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -121,7 +121,6 @@ public:
   virtual void choose_collection_set(ShenandoahCollectionSet* collection_set);
 
   virtual bool can_unload_classes();
-  virtual bool can_unload_classes_normal();
   virtual bool should_unload_classes();
 
   virtual const char* name() = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -76,11 +76,6 @@
           " compact - run GC more frequently and with deeper targets to "   \
           "free up more memory.")                                           \
                                                                             \
-  product(uintx, ShenandoahUnloadClassesFrequency, 1, EXPERIMENTAL,         \
-          "Unload the classes every Nth cycle. Normally affects concurrent "\
-          "GC cycles, as degenerated and full GCs would try to unload "     \
-          "classes regardless. Set to zero to disable class unloading.")    \
-                                                                            \
   product(uintx, ShenandoahGarbageThreshold, 25, EXPERIMENTAL,              \
           "How much garbage a region has to contain before it would be "    \
           "taken for collection. This a guideline only, as GC heuristics "  \

--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestClassLoaderLeak.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestClassLoaderLeak.java
@@ -140,14 +140,10 @@ public class TestClassLoaderLeak {
 
                 // Even when concurrent unloading is disabled, Full GC has to recover
                 passWith("-XX:ShenandoahGCMode=" + mode, "-XX:ShenandoahGCHeuristics=" + h, "-XX:+ClassUnloading", "-XX:-ClassUnloadingWithConcurrentMark");
-                passWith("-XX:ShenandoahGCMode=" + mode, "-XX:ShenandoahGCHeuristics=" + h, "-XX:+ClassUnloading", "-XX:-ClassUnloadingWithConcurrentMark", "-XX:ShenandoahUnloadClassesFrequency=0");
-                passWith("-XX:ShenandoahGCMode=" + mode, "-XX:ShenandoahGCHeuristics=" + h, "-XX:+ClassUnloading", "-XX:+ClassUnloadingWithConcurrentMark", "-XX:ShenandoahUnloadClassesFrequency=0");
 
                 // Should OOME when unloading forcefully disabled, even if local flags try to enable it back
                 failWith("-XX:ShenandoahGCMode=" + mode, "-XX:ShenandoahGCHeuristics=" + h, "-XX:-ClassUnloading");
                 failWith("-XX:ShenandoahGCMode=" + mode, "-XX:ShenandoahGCHeuristics=" + h, "-XX:-ClassUnloading", "-XX:+ClassUnloadingWithConcurrentMark");
-                failWith("-XX:ShenandoahGCMode=" + mode, "-XX:ShenandoahGCHeuristics=" + h, "-XX:-ClassUnloading", "-XX:+ClassUnloadingWithConcurrentMark", "-XX:ShenandoahUnloadClassesFrequency=1");
-                failWith("-XX:ShenandoahGCMode=" + mode, "-XX:ShenandoahGCHeuristics=" + h, "-XX:-ClassUnloading", "-XX:-ClassUnloadingWithConcurrentMark", "-XX:ShenandoahUnloadClassesFrequency=1");
             }
         }
     }


### PR DESCRIPTION
Clean backport to improve Shenandoah maintainability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8320877](https://bugs.openjdk.org/browse/JDK-8320877) needs maintainer approval

### Issue
 * [JDK-8320877](https://bugs.openjdk.org/browse/JDK-8320877): Shenandoah: Remove ShenandoahUnloadClassesFrequency support (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2115/head:pull/2115` \
`$ git checkout pull/2115`

Update a local copy of the PR: \
`$ git checkout pull/2115` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2115`

View PR using the GUI difftool: \
`$ git pr show -t 2115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2115.diff">https://git.openjdk.org/jdk17u-dev/pull/2115.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2115#issuecomment-1882935715)