### PR TITLE
8323210: Update the usage of cmsFLAGS_COPY_ALPHA

### DIFF
--- a/src/java.desktop/share/native/liblcms/LCMS.c
+++ b/src/java.desktop/share/native/liblcms/LCMS.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,8 +188,13 @@ JNIEXPORT jlong JNICALL Java_sun_java2d_cmm_lcms_LCMS_createNativeTransform
         }
     }
 
+    cmsUInt32Number dwFlags = 0;
+    if (T_EXTRA(inFormatter) > 0 && T_EXTRA(outFormatter) > 0) {
+        dwFlags |= cmsFLAGS_COPY_ALPHA;
+    }
+
     sTrans = cmsCreateMultiprofileTransform(iccArray, j,
-        inFormatter, outFormatter, renderType, cmsFLAGS_COPY_ALPHA);
+        inFormatter, outFormatter, renderType, dwFlags);
 
     (*env)->ReleaseLongArrayElements(env, profileIDs, ids, 0);
 

--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/ColCvtAlphaDifferentSrcDst.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/ColCvtAlphaDifferentSrcDst.java
@@ -43,7 +43,7 @@ import static java.awt.image.BufferedImage.TYPE_USHORT_GRAY;
 
 /*
  * @test
- * @bug 8012229
+ * @bug 8012229 8323210
  * @summary one more test to check the alpha channel
  */
 public final class ColCvtAlphaDifferentSrcDst {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit https://github.com/openjdk/jdk/commit/aba19334eaeb46d37169cddeef929b13e050a60e from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 9 Jan 2024 and was reviewed by Philip Race.

The patch is functionally the same but different in context due to the next patch is missing in 17:
https://bugs.openjdk.org/browse/JDK-8294488 I do not plan to backport that cleanup

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323210](https://bugs.openjdk.org/browse/JDK-8323210) needs maintainer approval

### Issue
 * [JDK-8323210](https://bugs.openjdk.org/browse/JDK-8323210): Update the usage of cmsFLAGS_COPY_ALPHA (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2118/head:pull/2118` \
`$ git checkout pull/2118`

Update a local copy of the PR: \
`$ git checkout pull/2118` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2118`

View PR using the GUI difftool: \
`$ git pr show -t 2118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2118.diff">https://git.openjdk.org/jdk17u-dev/pull/2118.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2118#issuecomment-1884132468)