### PR TITLE
8320300: Adjust hs_err output in malloc/mmap error cases

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -402,7 +402,7 @@ static void print_oom_reasons(outputStream* st) {
   st->print_cr("# Possible reasons:");
   st->print_cr("#   The system is out of physical RAM or swap space");
   if (UseCompressedOops) {
-    st->print_cr("#   The process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap");
+    st->print_cr("#   This process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap");
   }
   if (LogBytesPerWord == 2) {
     st->print_cr("#   In 32 bit mode, the process size limit was hit");
@@ -638,9 +638,9 @@ void VMError::report(outputStream* st, bool _verbose) {
                                                       "(mprotect) failed to protect ");
            jio_snprintf(buf, sizeof(buf), SIZE_FORMAT, _size);
            st->print("%s", buf);
-           st->print(" bytes");
+           st->print(" bytes.");
            if (strlen(_detail_msg) > 0) {
-             st->print(" for ");
+             st->print(" Error detail: ");
              st->print("%s", _detail_msg);
            }
            st->cr();


### PR DESCRIPTION
Backport 8320300

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320300](https://bugs.openjdk.org/browse/JDK-8320300) needs maintainer approval

### Issue
 * [JDK-8320300](https://bugs.openjdk.org/browse/JDK-8320300): Adjust hs_err output in malloc/mmap error cases (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2123/head:pull/2123` \
`$ git checkout pull/2123`

Update a local copy of the PR: \
`$ git checkout pull/2123` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2123`

View PR using the GUI difftool: \
`$ git pr show -t 2123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2123.diff">https://git.openjdk.org/jdk17u-dev/pull/2123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2123#issuecomment-1889280437)