### PR TITLE
8280241: (aio) AsynchronousSocketChannel init fails in IPv6 only Windows env

### DIFF
--- a/src/java.base/windows/native/libnio/ch/WindowsAsynchronousServerSocketChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/WindowsAsynchronousServerSocketChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,10 @@ Java_sun_nio_ch_WindowsAsynchronousServerSocketChannelImpl_initIDs(JNIEnv* env, 
     DWORD dwBytes;
 
     s = socket(AF_INET, SOCK_STREAM, 0);
+    if (s == INVALID_SOCKET && WSAGetLastError() == WSAEAFNOSUPPORT) {
+        /* IPv4 unavailable... try IPv6 instead */
+        s = socket(AF_INET6, SOCK_STREAM, 0);
+    }
     if (s == INVALID_SOCKET) {
         JNU_ThrowIOExceptionWithLastError(env, "socket failed");
         return;

--- a/src/java.base/windows/native/libnio/ch/WindowsAsynchronousSocketChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/WindowsAsynchronousSocketChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,10 @@ Java_sun_nio_ch_WindowsAsynchronousSocketChannelImpl_initIDs(JNIEnv* env, jclass
     DWORD dwBytes;
 
     s = socket(AF_INET, SOCK_STREAM, 0);
+    if (s == INVALID_SOCKET && WSAGetLastError() == WSAEAFNOSUPPORT) {
+        /* IPv4 unavailable... try IPv6 instead */
+        s = socket(AF_INET6, SOCK_STREAM, 0);
+    }
     if (s == INVALID_SOCKET) {
         JNU_ThrowIOExceptionWithLastError(env, "socket failed");
         return;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8280241](https://bugs.openjdk.org/browse/JDK-8280241) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280241](https://bugs.openjdk.org/browse/JDK-8280241): (aio) AsynchronousSocketChannel init fails in IPv6 only Windows env (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2124/head:pull/2124` \
`$ git checkout pull/2124`

Update a local copy of the PR: \
`$ git checkout pull/2124` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2124`

View PR using the GUI difftool: \
`$ git pr show -t 2124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2124.diff">https://git.openjdk.org/jdk17u-dev/pull/2124.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2124#issuecomment-1889345606)