### PR TITLE
8309462: [AIX] vmTestbase/nsk/jvmti/RunAgentThread/agentthr001/TestDescription.java crashing due to empty while loop

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RunAgentThread/agentthr001/agentthr001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RunAgentThread/agentthr001/agentthr001.cpp
@@ -136,7 +136,11 @@ sys_thread_2(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
 
 static void JNICALL
 sys_thread_3(jvmtiEnv* jvmti, JNIEnv* jni, void *p) {
-    while (1) {
+    /* The volatile variable in the loop body is necessary
+     * to avoid the compiler optimization to elide the loop. */
+    volatile int i = 1;
+    while (i) {
+      i += 2;
     }
 }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cf9e6353](https://github.com/openjdk/jdk/commit/cf9e6353cc6fe9e57a7a9883813d09892e7e7621) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by JoKern65 on 12 Jun 2023 and was reviewed by Matthias Baesken, Martin Doerr and Christoph Langer.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309462](https://bugs.openjdk.org/browse/JDK-8309462) needs maintainer approval

### Issue
 * [JDK-8309462](https://bugs.openjdk.org/browse/JDK-8309462): [AIX] vmTestbase/nsk/jvmti/RunAgentThread/agentthr001/TestDescription.java crashing due to empty while loop (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2125/head:pull/2125` \
`$ git checkout pull/2125`

Update a local copy of the PR: \
`$ git checkout pull/2125` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2125`

View PR using the GUI difftool: \
`$ git pr show -t 2125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2125.diff">https://git.openjdk.org/jdk17u-dev/pull/2125.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2125#issuecomment-1891467805)