### PR TITLE
JDK-8317804: com/sun/jdi/JdwpAllowTest.java fails on Alpine 3.17 / 3.18

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -759,7 +759,7 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
 
         if (isEqualIPv6Addr(listenAddr, mappedAny)) {
             for (ai = addrInfo; ai != NULL; ai = ai->ai_next) {
-                if (isEqualIPv6Addr(listenAddr, in6addr_any)) {
+                if (isEqualIPv6Addr(ai, in6addr_any)) {
                     listenAddr = ai;
                     break;
                 }


### PR DESCRIPTION
Backport-Fix the JdwpAllowTest.java test exception issue.