### PR TITLE
8317804: com/sun/jdi/JdwpAllowTest.java fails on Alpine 3.17 / 3.18

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -759,7 +759,7 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
 
         if (isEqualIPv6Addr(listenAddr, mappedAny)) {
             for (ai = addrInfo; ai != NULL; ai = ai->ai_next) {
-                if (isEqualIPv6Addr(listenAddr, in6addr_any)) {
+                if (isEqualIPv6Addr(ai, in6addr_any)) {
                     listenAddr = ai;
                     break;
                 }


### PR DESCRIPTION
Backport-Fix the JdwpAllowTest.java test exception issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8317804](https://bugs.openjdk.org/browse/JDK-8317804) needs maintainer approval

### Issue
 * [JDK-8317804](https://bugs.openjdk.org/browse/JDK-8317804): com/sun/jdi/JdwpAllowTest.java fails on Alpine 3.17 / 3.18 (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2132/head:pull/2132` \
`$ git checkout pull/2132`

Update a local copy of the PR: \
`$ git checkout pull/2132` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2132`

View PR using the GUI difftool: \
`$ git pr show -t 2132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2132.diff">https://git.openjdk.org/jdk17u-dev/pull/2132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2132#issuecomment-1893438528)