### PR TITLE
8323806: [17u] VS2017 build fails with warning after 8293117.

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -171,6 +171,8 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       if test "x$TOOLCHAIN_VERSION" = x2017; then
         # VS2017 incorrectly triggers this warning for constexpr
         DISABLED_WARNINGS+=" 4307"
+        # VS2017 incorrectly triggers this warning for static cast (test_atomic.cpp)
+        DISABLED_WARNINGS+=" 4309"
       fi
       ;;
 


### PR DESCRIPTION
We need this to fix our build with VS2017.
The warning is disabled limited to this one compiler version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8323806](https://bugs.openjdk.org/browse/JDK-8323806) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323806](https://bugs.openjdk.org/browse/JDK-8323806): [17u] VS2017 build fails with warning after 8293117. (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2133/head:pull/2133` \
`$ git checkout pull/2133`

Update a local copy of the PR: \
`$ git checkout pull/2133` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2133`

View PR using the GUI difftool: \
`$ git pr show -t 2133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2133.diff">https://git.openjdk.org/jdk17u-dev/pull/2133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2133#issuecomment-1893809266)