### PR TITLE
8324184: Windows VS2010 build failed with "error C2275: 'int64_t'"

### DIFF
--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -1678,12 +1678,13 @@ static int instruction_length(unsigned char *iptr, unsigned char *end)
     switch (instruction) {
         case JVM_OPC_tableswitch: {
             int *lpc = (int *)UCALIGN(iptr + 1);
+            int64_t low, high, index;
             if (lpc + 2 >= (int *)end) {
                 return -1; /* do not read pass the end */
             }
-            int64_t low  = _ck_ntohl(lpc[1]);
-            int64_t high = _ck_ntohl(lpc[2]);
-            int64_t index = high - low;
+            low  = _ck_ntohl(lpc[1]);
+            high = _ck_ntohl(lpc[2]);
+            index = high - low;
             // The value of low must be less than or equal to high - i.e. index >= 0
             if ((index < 0) || (index > 65535)) {
                 return -1;      /* illegal */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4d078930](https://github.com/openjdk/jdk21u/commit/4d078930eecfacb28a7c8324f233080eaf649334) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository.

The commit being backported was authored by Coleen Phillimore on 2 Oct 2023 and had no reviewers.

The backport is primarily for 8u, where the VS2010 build seems to be broken because of the placing of the declarations of `low`, `high` and `index` in JDK-8314295; see https://github.com/gnu-andrew/jdk8u-dev/actions/runs/7549766959/job/20554342418. This is fixed by this private bug fix, JDK-8317331: `Solaris build failed with "declaration can not follow a statement (E_DECLARATION_IN_CODE)"`. However, it makes sense to have the code in sync everywhere and this change is already in 21u: https://github.com/openjdk/jdk21u/commit/4d078930eecfacb28a7c8324f233080eaf649334

~~I don't know if the new approval commands will work with a private bug. I guess we will see.~~ It didn't, so we created a new bug.

Backport was clean and built fine on GNU/Linux with GCC 12.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8324184](https://bugs.openjdk.org/browse/JDK-8324184) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324184](https://bugs.openjdk.org/browse/JDK-8324184): Windows VS2010 build failed with "error C2275: 'int64_t'" (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2136/head:pull/2136` \
`$ git checkout pull/2136`

Update a local copy of the PR: \
`$ git checkout pull/2136` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2136`

View PR using the GUI difftool: \
`$ git pr show -t 2136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2136.diff">https://git.openjdk.org/jdk17u-dev/pull/2136.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2136#issuecomment-1899473814)