### PR TITLE
8317771: [macos14] Expand/collapse a JTree using keyboard freezes the application in macOS 14 Sonoma

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -35,6 +35,7 @@ import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.annotation.Native;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -63,6 +64,7 @@ import javax.swing.JTextArea;
 import javax.swing.JList;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
+import javax.swing.tree.TreePath;
 
 import sun.awt.AWTAccessor;
 import sun.lwawt.LWWindowPeer;
@@ -740,14 +742,75 @@ class CAccessibility implements PropertyChangeListener {
         return new Object[]{childrenAndRoles.get(whichChildren * 2), childrenAndRoles.get((whichChildren * 2) + 1)};
     }
 
+    private static Accessible createAccessibleTreeNode(JTree t, TreePath p) {
+        Accessible a = null;
+
+        try {
+            Class<?> accessibleJTreeNodeClass = Class.forName("javax.swing.JTree$AccessibleJTree$AccessibleJTreeNode");
+            Constructor<?> constructor = accessibleJTreeNodeClass.getConstructor(t.getAccessibleContext().getClass(), JTree.class, TreePath.class, Accessible.class);
+            constructor.setAccessible(true);
+            a = ((Accessible) constructor.newInstance(t.getAccessibleContext(), t, p, null));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return a;
+    }
+
     // This method is called from the native
     // Each child takes up three entries in the array: one for itself, one for its role, and one for the recursion level
     private static Object[] getChildrenAndRolesRecursive(final Accessible a, final Component c, final int whichChildren, final boolean allowIgnored, final int level) {
         if (a == null) return null;
         return invokeAndWait(new Callable<Object[]>() {
             public Object[] call() throws Exception {
-                ArrayList<Object> currentLevelChildren = new ArrayList<Object>();
                 ArrayList<Object> allChildren = new ArrayList<Object>();
+
+                Accessible at = null;
+                if (a instanceof CAccessible) {
+                    at = CAccessible.getSwingAccessible(a);
+                } else {
+                    at = a;
+                }
+
+                if (at instanceof JTree) {
+                    JTree tree = ((JTree) at);
+
+                    if (whichChildren == JAVA_AX_ALL_CHILDREN) {
+                        int count = tree.getRowCount();
+                        for (int i = 0; i < count; i++) {
+                            TreePath path = tree.getPathForRow(i);
+                            Accessible an = createAccessibleTreeNode(tree, path);
+                            if (an != null) {
+                                AccessibleContext ac = an.getAccessibleContext();
+                                if (ac != null) {
+                                    allChildren.add(an);
+                                    allChildren.add(ac.getAccessibleRole());;
+                                    allChildren.add(String.valueOf((tree.isRootVisible() ? path.getPathCount() : path.getPathCount() - 1)));
+                                }
+                            }
+                        }
+                    }
+
+                    if (whichChildren == JAVA_AX_SELECTED_CHILDREN) {
+                        int count = tree.getSelectionCount();
+                        for (int i = 0; i < count; i++) {
+                            TreePath path = tree.getSelectionPaths()[i];
+                            Accessible an = createAccessibleTreeNode(tree, path);
+                            if (an != null) {
+                                AccessibleContext ac = an.getAccessibleContext();
+                                if (ac != null) {
+                                    allChildren.add(an);
+                                    allChildren.add(ac.getAccessibleRole());
+                                    allChildren.add(String.valueOf((tree.isRootVisible() ? path.getPathCount() : path.getPathCount() - 1)));
+                                }
+                            }
+                        }
+                    }
+
+                    return allChildren.toArray();
+                }
+
+                ArrayList<Object> currentLevelChildren = new ArrayList<Object>();
                 ArrayList<Accessible> parentStack = new ArrayList<Accessible>();
                 parentStack.add(a);
                 ArrayList<Integer> indexses = new ArrayList<Integer>();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ffa33d7b](https://github.com/openjdk/jdk/commit/ffa33d7b807bfef6ff05c9adba869dddf813cf68) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Artem Semenov on 17 Jan 2024 and was reviewed by Alexander Zuev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317771](https://bugs.openjdk.org/browse/JDK-8317771) needs maintainer approval

### Issue
 * [JDK-8317771](https://bugs.openjdk.org/browse/JDK-8317771): [macos14] Expand/collapse a JTree using keyboard freezes the application in macOS 14 Sonoma (**Bug** - P3 - Approved)


### Reviewers
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2140/head:pull/2140` \
`$ git checkout pull/2140`

Update a local copy of the PR: \
`$ git checkout pull/2140` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2140`

View PR using the GUI difftool: \
`$ git pr show -t 2140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2140.diff">https://git.openjdk.org/jdk17u-dev/pull/2140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2140#issuecomment-1898515083)