### PR TITLE
8313206: PKCS11 tests silently skip execution

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyStore/Basic.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/Basic.java
@@ -58,6 +58,8 @@ import javax.security.auth.Subject;
 
 import com.sun.security.auth.module.*;
 import com.sun.security.auth.callback.*;
+import jtreg.SkippedException;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -113,7 +115,11 @@ public class Basic extends PKCS11Test {
     @Test
     public void testBasic() throws Exception {
         String[] args = {"sm", "Basic.policy"};
-        main(new Basic(), args);
+        try {
+            main(new Basic(), args);
+        } catch (SkippedException se) {
+            throw new SkipException("One or more tests are skipped");
+        }
     }
 
     private static class FooEntry implements KeyStore.Entry { }

--- a/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
  * @run testng/othervm ClientAuth
  */
 
+import jtreg.SkippedException;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -119,7 +121,11 @@ public class ClientAuth extends PKCS11Test {
     private void runTest(String[] args) throws Exception {
         System.out.println("Running with args: " + Arrays.toString(args));
         parseArguments(args);
-        main(new ClientAuth());
+        try {
+            main(new ClientAuth());
+        } catch (SkippedException se) {
+            throw new SkipException("One or more tests are skipped");
+        }
     }
 
     /*

--- a/test/jdk/sun/security/pkcs11/KeyStore/SecretKeysBasic.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/SecretKeysBasic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @library /test/lib ..
  * @run testng/othervm SecretKeysBasic
  */
+import jtreg.SkippedException;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -62,7 +64,11 @@ public class SecretKeysBasic extends PKCS11Test {
 
     @Test
     public void testBasic() throws Exception {
-        main(new SecretKeysBasic());
+        try {
+            main(new SecretKeysBasic());
+        } catch (SkippedException se) {
+            throw new SkipException("One or more tests are skipped");
+        }
     }
 
     public void main(Provider p) throws Exception {

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -58,27 +58,37 @@ import java.util.Set;
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
 import jdk.test.lib.artifacts.ArtifactResolverException;
+import jtreg.SkippedException;
 
 public abstract class PKCS11Test {
 
-    private boolean enableSM = false;
-
     static final Properties props = System.getProperties();
-
     static final String PKCS11 = "PKCS11";
-
     // directory of the test source
     static final String BASE = System.getProperty("test.src", ".");
-
     static final String TEST_CLASSES = System.getProperty("test.classes", ".");
-
     static final char SEP = File.separatorChar;
-
-    private static final String DEFAULT_POLICY =
-            BASE + SEP + ".." + SEP + "policy";
-
     // directory corresponding to BASE in the /closed hierarchy
     static final String CLOSED_BASE;
+    private static final String DEFAULT_POLICY = BASE + SEP + ".." + SEP + "policy";
+    private static final String PKCS11_REL_PATH = "sun/security/pkcs11";
+    private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
+
+    static double nss_version = -1;
+    static ECCState nss_ecc_status = ECCState.Basic;
+
+    // The NSS library we need to search for in getNSSLibDir()
+    // Default is "libsoftokn3.so", listed as "softokn3"
+    // The other is "libnss3.so", listed as "nss3".
+    static String nss_library = "softokn3";
+
+    // NSS versions of each library.  It is simpler to keep nss_version
+    // for quick checking for generic testing than many if-else statements.
+    static double softoken3_version = -1;
+    static double nss3_version = -1;
+    static Provider pkcs11 = newPKCS11Provider();
+    private static String PKCS11_BASE;
+    private static Map<String, String[]> osMap;
 
     static {
         // hack
@@ -93,24 +103,18 @@ public abstract class PKCS11Test {
         System.setProperty("closed.base", CLOSED_BASE);
     }
 
-    // NSS version info
-    public static enum ECCState { None, Basic, Extended };
-    static double nss_version = -1;
-    static ECCState nss_ecc_status = ECCState.Basic;
+    static {
+        try {
+            PKCS11_BASE = getBase();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
 
-    // The NSS library we need to search for in getNSSLibDir()
-    // Default is "libsoftokn3.so", listed as "softokn3"
-    // The other is "libnss3.so", listed as "nss3".
-    static String nss_library = "softokn3";
-
-    // NSS versions of each library.  It is simplier to keep nss_version
-    // for quick checking for generic testing than many if-else statements.
-    static double softoken3_version = -1;
-    static double nss3_version = -1;
-    static Provider pkcs11 = newPKCS11Provider();
+    private boolean enableSM = false;
 
     public static Provider newPKCS11Provider() {
-        ServiceLoader sl = ServiceLoader.load(java.security.Provider.class);
+        ServiceLoader<Provider> sl = ServiceLoader.load(java.security.Provider.class);
         Iterator<Provider> iter = sl.iterator();
         Provider p = null;
         boolean found = false;
@@ -128,8 +132,8 @@ public abstract class PKCS11Test {
         // Nothing found through ServiceLoader; fall back to reflection
         if (!found) {
             try {
-                Class clazz = Class.forName("sun.security.pkcs11.SunPKCS11");
-                p = (Provider) clazz.newInstance();
+                Class<?> clazz = Class.forName("sun.security.pkcs11.SunPKCS11");
+                p = (Provider) clazz.getDeclaredConstructor().newInstance();
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
@@ -148,38 +152,6 @@ public abstract class PKCS11Test {
             throw new NoSuchProviderException("No PKCS11 provider available");
         }
         return p.configure(config);
-    }
-
-    public abstract void main(Provider p) throws Exception;
-
-    protected boolean skipTest(Provider p) {
-        return false;
-    }
-
-    private void premain(Provider p) throws Exception {
-        if (skipTest(p)) {
-            return;
-        }
-
-        // set a security manager and policy before a test case runs,
-        // and disable them after the test case finished
-        try {
-            if (enableSM) {
-                System.setSecurityManager(new SecurityManager());
-            }
-            long start = System.currentTimeMillis();
-            System.out.printf(
-                    "Running test with provider %s (security manager %s) ...%n",
-                        p.getName(), enableSM ? "enabled" : "disabled");
-            main(p);
-            long stop = System.currentTimeMillis();
-            System.out.println("Completed test with provider " + p.getName() +
-                " (" + (stop - start) + " ms).");
-        } finally {
-            if (enableSM) {
-                System.setSecurityManager(null);
-            }
-        }
     }
 
     public static void main(PKCS11Test test) throws Exception {
@@ -206,9 +178,39 @@ public abstract class PKCS11Test {
         Provider[] oldProviders = Security.getProviders();
         try {
             System.out.println("Beginning test run " + test.getClass().getName() + "...");
-            testDefault(test);
-            testNSS(test);
-            testDeimos(test);
+            boolean skippedDefault = false;
+            boolean skippedNSS = false;
+            boolean skippedDeimos = false;
+
+            // Use separate try-catch for each test to allow all test run
+            try {
+                testDefault(test);
+            } catch (SkippedException se) {
+                System.out.println("testDefault: Skipped");
+                skippedDefault = true;
+                se.printStackTrace(System.out);
+            }
+
+            try {
+                testNSS(test);
+            } catch (SkippedException se) {
+                System.out.println("testNSS: Skipped");
+                skippedNSS = true;
+                se.printStackTrace(System.out);
+            }
+
+            try {
+                testDeimos(test);
+            } catch (SkippedException se) {
+                System.out.println("testDeimos: Skipped");
+                skippedDeimos = true;
+                se.printStackTrace(System.out);
+            }
+
+            if (skippedDefault && skippedNSS && skippedDeimos) {
+                throw new SkippedException("All tests are skipped, check logs");
+            }
+
         } finally {
             // NOTE: Do not place a 'return' in any finally block
             // as it will suppress exceptions and hide test failures.
@@ -218,7 +220,7 @@ public abstract class PKCS11Test {
             // useful for ./Provider/Login.sh, where a SecurityManager exists.
             if (oldProviders.length == newProviders.length) {
                 found = false;
-                for (int i = 0; i<oldProviders.length; i++) {
+                for (int i = 0; i < oldProviders.length; i++) {
                     if (oldProviders[i] != newProviders[i]) {
                         found = true;
                         break;
@@ -226,10 +228,10 @@ public abstract class PKCS11Test {
                 }
             }
             if (found) {
-                for (Provider p: newProviders) {
+                for (Provider p : newProviders) {
                     Security.removeProvider(p.getName());
                 }
-                for (Provider p: oldProviders) {
+                for (Provider p : oldProviders) {
                     Security.addProvider(p);
                 }
             }
@@ -237,42 +239,49 @@ public abstract class PKCS11Test {
     }
 
     public static void testDeimos(PKCS11Test test) throws Exception {
-        if (new File("/opt/SUNWconn/lib/libpkcs11.so").isFile() == false ||
-            "true".equals(System.getProperty("NO_DEIMOS"))) {
+        System.out.println("===> testDeimos: Starting test run");
+        if ("true".equals(System.getProperty("NO_DEIMOS"))) {
+            System.out.println("Skip Deimos software as test configured with NO_DEIMOS");
             return;
         }
+
+        if (!new File("/opt/SUNWconn/lib/libpkcs11.so").isFile()) {
+            throw new SkippedException("testDeimos: \"/opt/SUNWconn/lib/libpkcs11.so\" " +
+                    "file required for Deimos not found");
+        }
+
         String base = getBase();
         String p11config = base + SEP + "nss" + SEP + "p11-deimos.txt";
         Provider p = getSunPKCS11(p11config);
         test.premain(p);
+        System.out.println("testDeimos: Completed");
     }
 
+    // Run test for default configured PKCS11 providers (if any)
     public static void testDefault(PKCS11Test test) throws Exception {
-        // run test for default configured PKCS11 providers (if any)
+        System.out.println("===> testDefault: Starting test run");
+        boolean foundPKCS11 = false;
 
         if ("true".equals(System.getProperty("NO_DEFAULT"))) {
+            System.out.println("Skip default provider as test configured with NO_DEFAULT");
             return;
         }
 
         Provider[] providers = Security.getProviders();
-        for (int i = 0; i < providers.length; i++) {
-            Provider p = providers[i];
+        for (Provider p : providers) {
             if (p.getName().startsWith("SunPKCS11-")) {
+                foundPKCS11 = true;
                 test.premain(p);
             }
         }
-    }
 
-    private static String PKCS11_BASE;
-    static {
-        try {
-            PKCS11_BASE = getBase();
-        } catch (Exception e) {
-            // ignore
+        if (!foundPKCS11) {
+            throw new SkippedException("testDefault: Skip default test as SunPKCS11 " +
+                    "provider is not configured");
         }
-    }
 
-    private final static String PKCS11_REL_PATH = "sun/security/pkcs11";
+        System.out.println("testDefault: Completed");
+    }
 
     public static String getBase() throws Exception {
         if (PKCS11_BASE != null) {
@@ -286,7 +295,7 @@ public abstract class PKCS11Test {
             }
             cwd = cwd.getParentFile();
             if (cwd == null) {
-                throw new Exception("Test root directory not found");
+                throw new RuntimeException("Test root directory not found");
             }
         }
         PKCS11_BASE = new File(cwd, PKCS11_REL_PATH.replace('/', SEP)).getAbsolutePath();
@@ -318,7 +327,7 @@ public abstract class PKCS11Test {
         String[] nssLibDirs = getNssLibPaths(osid);
         if (nssLibDirs == null) {
             System.out.println("Warning: unsupported OS: " + osid
-                    + ", please initialize NSS librarys location firstly, skipping test");
+                    + ", please initialize NSS library location, skipping test");
             return null;
         }
         if (nssLibDirs.length == 0) {
@@ -335,7 +344,7 @@ public abstract class PKCS11Test {
             }
         }
         if (nssLibPath == null) {
-            System.out.println("Warning: can't find NSS librarys on this machine, skipping test");
+            System.out.println("Warning: can't find NSS library on this machine, skipping test");
             return null;
         }
         return nssLibPath;
@@ -348,9 +357,8 @@ public abstract class PKCS11Test {
         } else if (osName.equals("Mac OS X")) {
             osName = "MacOSX";
         }
-        String osid = osName + "-" + props.getProperty("os.arch") + "-"
+        return osName + "-" + props.getProperty("os.arch") + "-"
                 + props.getProperty("sun.arch.data.model");
-        return osid;
     }
 
     static boolean isBadNSSVersion(Provider p) {
@@ -363,7 +371,7 @@ public abstract class PKCS11Test {
         return false;
     }
 
-    protected static void safeReload(String lib) throws Exception {
+    protected static void safeReload(String lib) {
         try {
             System.load(lib);
         } catch (UnsatisfiedLinkError e) {
@@ -373,11 +381,9 @@ public abstract class PKCS11Test {
         }
     }
 
-    static boolean loadNSPR(String libdir) throws Exception {
+    static boolean loadNSPR(String libdir) {
         // load NSS softoken dependencies in advance to avoid resolver issues
-        String dir = libdir.endsWith(File.separator)
-                     ? libdir
-                     : libdir + File.separator;
+        String dir = libdir.endsWith(File.separator) ? libdir : libdir + File.separator;
         safeReload(dir + System.mapLibraryName("nspr4"));
         safeReload(dir + System.mapLibraryName("plc4"));
         safeReload(dir + System.mapLibraryName("plds4"));
@@ -388,7 +394,7 @@ public abstract class PKCS11Test {
 
     // Check the provider being used is NSS
     public static boolean isNSS(Provider p) {
-        return p.getName().toUpperCase().equals("SUNPKCS11-NSS");
+        return p.getName().equalsIgnoreCase("SUNPKCS11-NSS");
     }
 
     static double getNSSVersion() {
@@ -484,25 +490,25 @@ public abstract class PKCS11Test {
 
         // the index after whitespace after nssHeader
         int afterheader = s.indexOf("NSS", i) + 4;
-        String version = String.valueOf(s.charAt(afterheader));
+        StringBuilder version = new StringBuilder(String.valueOf(s.charAt(afterheader)));
         for (char c = s.charAt(++afterheader);
-                c == '.' || (c >= '0' && c <= '9');
-                c = s.charAt(++afterheader)) {
-            version += c;
+             c == '.' || (c >= '0' && c <= '9');
+             c = s.charAt(++afterheader)) {
+            version.append(c);
         }
 
         // If a "dot dot" release, strip the extra dots for double parsing
-        String[] dot = version.split("\\.");
+        String[] dot = version.toString().split("\\.");
         if (dot.length > 2) {
-            version = dot[0]+"."+dot[1];
+            version = new StringBuilder(dot[0] + "." + dot[1]);
             for (int j = 2; dot.length > j; j++) {
-                version += dot[j];
+                version.append(dot[j]);
             }
         }
 
         // Convert to double for easier version value checking
         try {
-            nss_version = Double.parseDouble(version);
+            nss_version = Double.parseDouble(version.toString());
         } catch (NumberFormatException e) {
             System.out.println("===== Content start =====");
             System.out.println(s);
@@ -512,7 +518,7 @@ public abstract class PKCS11Test {
             e.printStackTrace();
         }
 
-        System.out.print("lib" + library + " version = "+version+".  ");
+        System.out.print("library: " + library + ", version: " + version + ".  ");
 
         // Check for ECC
         if (s.indexOf("Basic") > 0) {
@@ -541,13 +547,15 @@ public abstract class PKCS11Test {
 
     // Run NSS testing on a Provider p configured with test nss config
     public static void testNSS(PKCS11Test test) throws Exception {
+        System.out.println("===> testNSS: Starting test run");
         String nssConfig = getNssConfig();
         if (nssConfig == null) {
-            // issue loading libraries
-            return;
+            throw new SkippedException("testNSS: Problem loading NSS libraries");
         }
+
         Provider p = getSunPKCS11(nssConfig);
         test.premain(p);
+        System.out.println("testNSS: Completed");
     }
 
     public static String getNssConfig() throws Exception {
@@ -556,7 +564,7 @@ public abstract class PKCS11Test {
             return null;
         }
 
-        if (loadNSPR(libdir) == false) {
+        if (!loadNSPR(libdir)) {
             return null;
         }
 
@@ -594,12 +602,12 @@ public abstract class PKCS11Test {
 
         if (kcProp == null) {
             throw new RuntimeException(
-            "\"AlgorithmParameters.EC SupportedCurves property\" not found");
+                    "\"AlgorithmParameters.EC SupportedCurves property\" not found");
         }
 
         System.out.println("Finding supported curves using list from SunEC\n");
         index = 0;
-        for (;;) {
+        for (; ; ) {
             // Each set of curve names is enclosed with brackets.
             begin = kcProp.indexOf('[', index);
             end = kcProp.indexOf(']', index);
@@ -616,12 +624,12 @@ public abstract class PKCS11Test {
             end = kcProp.indexOf(',', begin);
             if (end == -1) {
                 // Only one name in the set.
-                end = index -1;
+                end = index - 1;
             }
 
             curve = kcProp.substring(begin, end);
             getSupportedECParameterSpec(curve, p)
-                .ifPresent(spec -> results.add(spec));
+                    .ifPresent(spec -> results.add(spec));
         }
 
         if (results.size() == 0) {
@@ -632,9 +640,9 @@ public abstract class PKCS11Test {
     }
 
     static Optional<ECParameterSpec> getSupportedECParameterSpec(String curve,
-            Provider p) throws Exception {
+                                                                 Provider p) throws Exception {
         ECParameterSpec e = getECParameterSpec(p, curve);
-        System.out.print("\t "+ curve + ": ");
+        System.out.print("\t " + curve + ": ");
         try {
             KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", p);
             kpg.initialize(e);
@@ -656,25 +664,12 @@ public abstract class PKCS11Test {
             throws Exception {
 
         AlgorithmParameters parameters =
-            AlgorithmParameters.getInstance("EC", p);
+                AlgorithmParameters.getInstance("EC", p);
 
         parameters.init(new ECGenParameterSpec(name));
 
         return parameters.getParameterSpec(ECParameterSpec.class);
     }
-
-    // Check support for a curve with a provided Vector of EC support
-    boolean checkSupport(List<ECParameterSpec> supportedEC,
-            ECParameterSpec curve) {
-        for (ECParameterSpec ec: supportedEC) {
-            if (ec.equals(curve)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static Map<String,String[]> osMap;
 
     // Location of the NSS libraries on each supported platform
     private static Map<String, String[]> getOsMap() {
@@ -683,23 +678,23 @@ public abstract class PKCS11Test {
         }
 
         osMap = new HashMap<>();
-        osMap.put("Linux-i386-32", new String[] {
+        osMap.put("Linux-i386-32", new String[]{
                 "/usr/lib/i386-linux-gnu/",
                 "/usr/lib32/",
-                "/usr/lib/" });
-        osMap.put("Linux-amd64-64", new String[] {
+                "/usr/lib/"});
+        osMap.put("Linux-amd64-64", new String[]{
                 "/usr/lib/x86_64-linux-gnu/",
                 "/usr/lib/x86_64-linux-gnu/nss/",
-                "/usr/lib64/" });
-        osMap.put("Linux-ppc64-64", new String[] { "/usr/lib64/" });
-        osMap.put("Linux-ppc64le-64", new String[] { "/usr/lib64/" });
-        osMap.put("Linux-s390x-64", new String[] { "/usr/lib64/" });
-        osMap.put("Windows-x86-32", new String[] {});
-        osMap.put("Windows-amd64-64", new String[] {});
-        osMap.put("MacOSX-x86_64-64", new String[] {});
-        osMap.put("Linux-arm-32", new String[] {
+                "/usr/lib64/"});
+        osMap.put("Linux-ppc64-64", new String[]{"/usr/lib64/"});
+        osMap.put("Linux-ppc64le-64", new String[]{"/usr/lib64/"});
+        osMap.put("Linux-s390x-64", new String[]{"/usr/lib64/"});
+        osMap.put("Windows-x86-32", new String[]{});
+        osMap.put("Windows-amd64-64", new String[]{});
+        osMap.put("MacOSX-x86_64-64", new String[]{});
+        osMap.put("Linux-arm-32", new String[]{
                 "/usr/lib/arm-linux-gnueabi/nss/",
-                "/usr/lib/arm-linux-gnueabihf/nss/" });
+                "/usr/lib/arm-linux-gnueabihf/nss/"});
         // Exclude linux-aarch64 at the moment until the following bug is fixed:
         // 8296631: NSS tests failing on OL9 linux-aarch64 hosts
 //        osMap.put("Linux-aarch64-64", new String[] {
@@ -740,10 +735,8 @@ public abstract class PKCS11Test {
             }
         }
 
-        return nssLibPaths.toArray(new String[nssLibPaths.size()]);
+        return nssLibPaths.toArray(new String[0]);
     }
-
-    private final static char[] hexDigits = "0123456789abcdef".toCharArray();
 
     public static String toString(byte[] b) {
         if (b == null) {
@@ -755,8 +748,8 @@ public abstract class PKCS11Test {
             if (i != 0) {
                 sb.append(':');
             }
-            sb.append(hexDigits[k >>> 4]);
-            sb.append(hexDigits[k & 0xf]);
+            sb.append(HEX_DIGITS[k >>> 4]);
+            sb.append(HEX_DIGITS[k & 0xf]);
         }
         return sb.toString();
     }
@@ -802,20 +795,11 @@ public abstract class PKCS11Test {
         }
     }
 
-    <T> T[] concat(T[] a, T[] b) {
-        if ((b == null) || (b.length == 0)) {
-            return a;
-        }
-        T[] r = Arrays.copyOf(a, a.length + b.length);
-        System.arraycopy(b, 0, r, a.length, b.length);
-        return r;
-    }
-
     /**
      * Returns supported algorithms of specified type.
      */
     static List<String> getSupportedAlgorithms(String type, String alg,
-            Provider p) {
+                                               Provider p) {
         // prepare a list of supported algorithms
         List<String> algorithms = new ArrayList<>();
         Set<Provider.Service> services = p.getServices();
@@ -830,7 +814,7 @@ public abstract class PKCS11Test {
 
     static byte[] generateData(int length) {
         byte data[] = new byte[length];
-        for (int i=0; i<data.length; i++) {
+        for (int i = 0; i < data.length; i++) {
             data[i] = (byte) (i % 256);
         }
         return data;
@@ -838,20 +822,20 @@ public abstract class PKCS11Test {
 
     private static String fetchNssLib(String osId) {
         switch (osId) {
-        case "Windows-x86-32":
-            return fetchNssLib(WINDOWS_X86.class);
+            case "Windows-x86-32":
+                return fetchNssLib(WINDOWS_X86.class);
 
-        case "Windows-amd64-64":
-            return fetchNssLib(WINDOWS_X64.class);
+            case "Windows-amd64-64":
+                return fetchNssLib(WINDOWS_X64.class);
 
-        case "MacOSX-x86_64-64":
-            return fetchNssLib(MACOSX_X64.class);
+            case "MacOSX-x86_64-64":
+                return fetchNssLib(MACOSX_X64.class);
 
-        case "Linux-amd64-64":
-            return fetchNssLib(LINUX_X64.class);
+            case "Linux-amd64-64":
+                return fetchNssLib(LINUX_X64.class);
 
-        default:
-            return null;
+            default:
+                return null;
         }
     }
 
@@ -873,6 +857,58 @@ public abstract class PKCS11Test {
         }
         Policy.setPolicy(null); // Clear the policy created by JIB if any
         return path;
+    }
+
+    public abstract void main(Provider p) throws Exception;
+
+    protected boolean skipTest(Provider p) {
+        return false;
+    }
+
+    private void premain(Provider p) throws Exception {
+        if (skipTest(p)) {
+            return;
+        }
+
+        // set a security manager and policy before a test case runs,
+        // and disable them after the test case finished
+        try {
+            if (enableSM) {
+                System.setSecurityManager(new SecurityManager());
+            }
+            long start = System.currentTimeMillis();
+            System.out.printf(
+                    "Running test with provider %s (security manager %s) ...%n",
+                    p.getName(), enableSM ? "enabled" : "disabled");
+            main(p);
+            long stop = System.currentTimeMillis();
+            System.out.println("Completed test with provider " + p.getName() +
+                    " (" + (stop - start) + " ms).");
+        } finally {
+            if (enableSM) {
+                System.setSecurityManager(null);
+            }
+        }
+    }
+
+    // Check support for a curve with a provided Vector of EC support
+    boolean checkSupport(List<ECParameterSpec> supportedEC,
+                         ECParameterSpec curve) {
+        for (ECParameterSpec ec : supportedEC) {
+            if (ec.equals(curve)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    <T> T[] concat(T[] a, T[] b) {
+        if ((b == null) || (b.length == 0)) {
+            return a;
+        }
+        T[] r = Arrays.copyOf(a, a.length + b.length);
+        System.arraycopy(b, 0, r, a.length, b.length);
+        return r;
     }
 
     protected void setCommonSystemProps() {
@@ -900,31 +936,38 @@ public abstract class PKCS11Test {
                 StandardCopyOption.REPLACE_EXISTING);
     }
 
+    // NSS version info
+    public static enum ECCState {None, Basic, Extended}
+
     @Artifact(
             organization = "jpg.tests.jdk.nsslib",
             name = "nsslib-windows_x64",
             revision = "3.46-VS2017",
             extension = "zip")
-    private static class WINDOWS_X64 { }
+    private static class WINDOWS_X64 {
+    }
 
     @Artifact(
             organization = "jpg.tests.jdk.nsslib",
             name = "nsslib-windows_x86",
             revision = "3.46-VS2017",
             extension = "zip")
-    private static class WINDOWS_X86 { }
+    private static class WINDOWS_X86 {
+    }
 
     @Artifact(
             organization = "jpg.tests.jdk.nsslib",
             name = "nsslib-macosx_x64",
             revision = "3.46",
             extension = "zip")
-    private static class MACOSX_X64 { }
+    private static class MACOSX_X64 {
+    }
 
     @Artifact(
             organization = "jpg.tests.jdk.nsslib",
             name = "nsslib-linux_x64",
             revision = "3.46",
             extension = "zip")
-    private static class LINUX_X64 { }
+    private static class LINUX_X64 {
+    }
 }

--- a/test/jdk/sun/security/pkcs11/Provider/ConfigQuotedString.java
+++ b/test/jdk/sun/security/pkcs11/Provider/ConfigQuotedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@
  * @run testng/othervm ConfigQuotedString
  */
 
+import jtreg.SkippedException;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,7 +46,11 @@ public class ConfigQuotedString extends PKCS11Test {
 
     @Test
     public void testQuotedString() throws Exception {
-        main(new ConfigQuotedString());
+        try {
+            main(new ConfigQuotedString());
+        } catch (SkippedException se) {
+            throw new SkipException("One or more tests are skipped");
+        }
     }
 
     public void main(Provider p) throws Exception {

--- a/test/jdk/sun/security/pkcs11/Provider/Login.java
+++ b/test/jdk/sun/security/pkcs11/Provider/Login.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@
  * @run testng/othervm -Djava.security.manager=allow Login
  */
 
+import jtreg.SkippedException;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -55,7 +57,11 @@ public class Login extends PKCS11Test {
     @Test
     public void testLogin() throws Exception {
         String[] args = new String[]{ "sm", "Login.policy"};
-        main(new Login(), args);
+        try {
+            main(new Login(), args);
+        } catch (SkippedException se) {
+            throw new SkipException("One or more tests are skipped");
+        }
     }
 
     public void main(Provider p) throws Exception {

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -111,6 +111,7 @@ ${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} \
         --add-modules jdk.crypto.cryptoki \
         --add-exports jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED \
         ${TESTSRC}${FS}..${FS}..${FS}..${FS}..${FS}..${FS}lib${FS}jdk${FS}test${FS}lib${FS}artifacts${FS}*.java \
+        ${TESTSRC}${FS}..${FS}..${FS}..${FS}..${FS}..${FS}lib${FS}jtreg${FS}*.java \
         ${TESTSRC}${FS}MultipleLogins.java \
         ${TESTSRC}${FS}..${FS}PKCS11Test.java
 

--- a/test/jdk/sun/security/pkcs11/SecmodTest.java
+++ b/test/jdk/sun/security/pkcs11/SecmodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
 
 // common infrastructure for Secmod tests
 
+import jtreg.SkippedException;
+
 import java.io.*;
 
 import java.security.Provider;
@@ -43,13 +45,11 @@ public class SecmodTest extends PKCS11Test {
     static boolean initSecmod() throws Exception {
         useNSS();
         LIBPATH = getNSSLibDir();
-        if (LIBPATH == null) {
-            return false;
-        }
         // load all the libraries except libnss3 into memory
-        if (loadNSPR(LIBPATH) == false) {
-            return false;
+        if ((LIBPATH == null) || (!loadNSPR(LIBPATH))) {
+            throw new SkippedException("Failed to load NSS libraries");
         }
+
         safeReload(LIBPATH + System.mapLibraryName("softokn3"));
         safeReload(LIBPATH + System.mapLibraryName("nssckbi"));
 

--- a/test/jdk/sun/security/pkcs11/SecureRandom/Basic.java
+++ b/test/jdk/sun/security/pkcs11/SecureRandom/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

I had to do trivial adaptions:

test/jdk/sun/security/pkcs11/KeyStore/CertChainRemoval.java
  It was introduced by 8301154, a bigger bugfix in PKCS11. I don't want to backport this.
  Patch omitted.
  
test/jdk/sun/security/pkcs11/PKCS11Test.java
  trivial resolve, Skipped whitespace fixes in code that was only introduced by "8301553: Support Password-Based Cryptography in SunPKCS11"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8313206](https://bugs.openjdk.org/browse/JDK-8313206) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313206](https://bugs.openjdk.org/browse/JDK-8313206): PKCS11 tests silently skip execution (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2143/head:pull/2143` \
`$ git checkout pull/2143`

Update a local copy of the PR: \
`$ git checkout pull/2143` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2143`

View PR using the GUI difftool: \
`$ git pr show -t 2143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2143.diff">https://git.openjdk.org/jdk17u-dev/pull/2143.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2143#issuecomment-1900058202)