### PR TITLE
8312428: PKCS11 tests fail with NSS 3.91

### DIFF
--- a/test/jdk/sun/security/pkcs11/MessageDigest/TestCloning.java
+++ b/test/jdk/sun/security/pkcs11/MessageDigest/TestCloning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,8 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.List;
 
+import jtreg.SkippedException;
+
 public class TestCloning extends PKCS11Test {
 
     public static void main(String[] args) throws Exception {
@@ -57,14 +59,30 @@ public class TestCloning extends PKCS11Test {
         r.nextBytes(data1);
         r.nextBytes(data2);
         System.out.println("Testing against provider " + p.getName());
+
+        boolean skipTest = true;
+
         for (String alg : ALGS) {
-            System.out.println("Testing " + alg);
+            System.out.println("Digest algo: " + alg);
             MessageDigest md = MessageDigest.getInstance(alg, p);
-            md = testCloning(md, p);
+            try {
+                md = testCloning(md, p);;
+            } catch (CloneNotSupportedException cnse) {
+                // skip test if clone isn't supported
+                System.out.println("=> Clone not supported; skip!");
+                continue;
+            }
+
+            // start testing below
+            skipTest = false;
+
             // repeat the test again after generating digest once
             for (int j = 0; j < 10; j++) {
                 md = testCloning(md, p);
             }
+        }
+        if (skipTest) {
+            throw new SkippedException("Test Skipped!");
         }
     }
 
@@ -125,4 +143,3 @@ public class TestCloning extends PKCS11Test {
         }
     }
 }
-

--- a/test/jdk/sun/security/pkcs11/PSSUtil.java
+++ b/test/jdk/sun/security/pkcs11/PSSUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Signature;
+
+public class PSSUtil {
+
+    /**
+     * ALGORITHM name, fixed as RSA for PKCS11
+     */
+    private static final String KEYALG = "RSA";
+    private static final String SIGALG = "RSASSA-PSS";
+
+    public static enum AlgoSupport {
+        NO, MAYBE, YES
+    };
+
+    public static boolean isSignatureSupported(Provider p) {
+        try {
+            Signature.getInstance(SIGALG, p);
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            System.out.println("Skip testing " + SIGALG +
+                " due to no support");
+            return false;
+        }
+    }
+
+    public static AlgoSupport isHashSupported(Provider p, String... hashAlgs) {
+
+        AlgoSupport status = AlgoSupport.YES;
+        for (String h : hashAlgs) {
+            String sigAlg = (h.startsWith("SHA3-") ?
+                    h : h.replace("-", "")) + "with" + SIGALG;
+            try {
+                Signature.getInstance(sigAlg, p);
+                // Yes, proceed to check next hash algorithm
+                continue;
+            } catch (NoSuchAlgorithmException e) {
+                // continue trying other checks
+            }
+            try {
+                MessageDigest.getInstance(h, p);
+                status = AlgoSupport.MAYBE;
+            } catch (NoSuchAlgorithmException e) {
+                // if not supported as a standalone digest algo, chance of it
+                // being supported by PSS is very very low
+                return AlgoSupport.NO;
+            }
+        }
+        return status;
+    }
+
+    public static KeyPair generateKeys(Provider p, int size)
+            throws NoSuchAlgorithmException {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(KEYALG, p);
+        kpg.initialize(size);
+        return kpg.generateKeyPair();
+    }
+}

--- a/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@ import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
 import java.util.stream.IntStream;
+import jtreg.SkippedException;
 
 /**
  * @test
@@ -35,8 +36,6 @@ import java.util.stream.IntStream;
  */
 public class SignatureTestPSS extends PKCS11Test {
 
-    // PKCS11 does not support RSASSA-PSS keys yet
-    private static final String KEYALG = "RSA";
     private static final String SIGALG = "RSASSA-PSS";
 
     private static final int[] KEYSIZES = { 2048, 3072 };
@@ -44,7 +43,7 @@ public class SignatureTestPSS extends PKCS11Test {
             "SHA-224", "SHA-256", "SHA-384" , "SHA-512",
             "SHA3-224", "SHA3-256", "SHA3-384" , "SHA3-512",
     };
-    private Provider prov;
+    private static final byte[] DATA = generateData(100);
 
     /**
      * How much times signature updated.
@@ -56,88 +55,72 @@ public class SignatureTestPSS extends PKCS11Test {
      */
     private static final int UPDATE_TIMES_HUNDRED = 100;
 
+    private static boolean skipTest = true;
+
     public static void main(String[] args) throws Exception {
         main(new SignatureTestPSS(), args);
     }
 
     @Override
     public void main(Provider p) throws Exception {
-        Signature sig;
-        try {
-            sig = Signature.getInstance(SIGALG, p);
-        } catch (NoSuchAlgorithmException e) {
-            System.out.println("Skip testing RSASSA-PSS" +
-                " due to no support");
-            return;
+        if (!PSSUtil.isSignatureSupported(p)) {
+            throw new SkippedException("Skip due to no support for " + SIGALG);
         }
-        this.prov = p;
-        for (int i : KEYSIZES) {
-            runTest(i);
-        }
-    }
 
-    private void runTest(int keySize) throws Exception {
-        byte[] data = new byte[100];
-        IntStream.range(0, data.length).forEach(j -> {
-            data[j] = (byte) j;
-        });
-        System.out.println("[KEYSIZE = " + keySize + "]");
-
-        // create a key pair
-        KeyPair kpair = generateKeys(KEYALG, keySize);
-        test(DIGESTS, kpair.getPrivate(), kpair.getPublic(), data);
-    }
-
-    private void test(String[] digestAlgs, PrivateKey privKey,
-            PublicKey pubKey, byte[] data) throws RuntimeException {
-        // For signature algorithm, create and verify a signature
-        for (String hash : digestAlgs) {
-            for (String mgfHash : digestAlgs) {
-                try {
-                    checkSignature(data, pubKey, privKey, hash, mgfHash);
-                } catch (NoSuchAlgorithmException | InvalidKeyException |
-                         SignatureException | NoSuchProviderException ex) {
-                    throw new RuntimeException(ex);
-                } catch (InvalidAlgorithmParameterException ex2) {
-                    System.out.println("Skip test due to " + ex2);
+        for (int kSize : KEYSIZES) {
+            System.out.println("[KEYSIZE = " + kSize + "]");
+            KeyPair kp = PSSUtil.generateKeys(p, kSize);
+            PrivateKey privKey = kp.getPrivate();
+            PublicKey pubKey = kp.getPublic();
+            for (String hash : DIGESTS) {
+                for (String mgfHash : DIGESTS) {
+                    System.out.println("    [Hash  = " + hash +
+                            ", MGF1 Hash = " + mgfHash + "]");
+                    PSSUtil.AlgoSupport s =
+                            PSSUtil.isHashSupported(p, hash, mgfHash);
+                    if (s == PSSUtil.AlgoSupport.NO) {
+                        System.out.println("    => Skip; no support");
+                        continue;
+                    }
+                    checkSignature(p, DATA, pubKey, privKey, hash, mgfHash, s);
                 }
-            }
-        };
+            };
+        }
+
+        // start testing below
+        if (skipTest) {
+            throw new SkippedException("Test Skipped");
+        }
     }
 
-    private KeyPair generateKeys(String keyalg, int size)
-            throws NoSuchAlgorithmException {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyalg, prov);
-        kpg.initialize(size);
-        return kpg.generateKeyPair();
-    }
-
-    private void checkSignature(byte[] data, PublicKey pub,
-            PrivateKey priv, String hash, String mgfHash)
+    private static void checkSignature(Provider p, byte[] data, PublicKey pub,
+            PrivateKey priv, String hash, String mgfHash, PSSUtil.AlgoSupport s)
             throws NoSuchAlgorithmException, InvalidKeyException,
             SignatureException, NoSuchProviderException,
             InvalidAlgorithmParameterException {
 
-        String testName = hash + " and MGF1_" + mgfHash;
         // only test RSASSA-PSS signature against the supplied hash/mgfHash
         // if they are supported; otherwise PKCS11 library will throw
         // CKR_MECHANISM_PARAM_INVALID at Signature.initXXX calls
-        try {
-            MessageDigest md = MessageDigest.getInstance(hash, prov);
-            if (!hash.equalsIgnoreCase(mgfHash)) {
-                md = MessageDigest.getInstance(mgfHash, prov);
-            }
-        } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip testing " + hash + "/" + mgfHash);
-            return;
-        }
-
-        System.out.println("Testing against " + testName);
-        Signature sig = Signature.getInstance(SIGALG, prov);
+        Signature sig = Signature.getInstance(SIGALG, p);
         AlgorithmParameterSpec params = new PSSParameterSpec(
-            hash, "MGF1", new MGF1ParameterSpec(mgfHash), 0, 1);
-        sig.setParameter(params);
+                hash, "MGF1", new MGF1ParameterSpec(mgfHash), 0, 1);
         sig.initSign(priv);
+
+        try {
+            sig.setParameter(params);
+        } catch (InvalidAlgorithmParameterException iape) {
+            if (s == PSSUtil.AlgoSupport.MAYBE) {
+                // confirmed to be unsupported; skip the rest of the test
+                System.out.println("    => Skip; no PSS support");
+                return;
+            } else {
+                throw new RuntimeException("Unexpected Exception", iape);
+            }
+        }
+        // start testing below
+        skipTest = false;
+
         for (int i = 0; i < UPDATE_TIMES_HUNDRED; i++) {
             sig.update(data);
         }
@@ -163,5 +146,6 @@ public class SignatureTestPSS extends PKCS11Test {
         if (sig.verify(signedData)) {
             throw new RuntimeException("Failed to detect bad signature");
         }
+        System.out.println("    => Passed");
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8312428](https://bugs.openjdk.org/browse/JDK-8312428) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312428](https://bugs.openjdk.org/browse/JDK-8312428): PKCS11 tests fail with NSS 3.91 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2145/head:pull/2145` \
`$ git checkout pull/2145`

Update a local copy of the PR: \
`$ git checkout pull/2145` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2145`

View PR using the GUI difftool: \
`$ git pr show -t 2145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2145.diff">https://git.openjdk.org/jdk17u-dev/pull/2145.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2145#issuecomment-1900128589)