### PR TITLE
8324234: Use reserved IP for java.net testing

### DIFF
--- a/test/jdk/java/net/Socket/B8312065.java
+++ b/test/jdk/java/net/Socket/B8312065.java
@@ -73,8 +73,8 @@ public class B8312065 {
 
         try {
             Socket socket = new Socket();
-            // There is no good way to mock SocketTimeoutException, just assume 192.168.255.255 is not in use
-            socket.connect(new InetSocketAddress("192.168.255.255", 8080), timeoutMillis);
+            // There is no good way to mock SocketTimeoutException, use reserved IP from https://www.rfc-editor.org/rfc/rfc5737
+            socket.connect(new InetSocketAddress("192.0.2.1", 8080), timeoutMillis);
         } catch (SocketTimeoutException e) {
             long duration = TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
             if (duration >= timeoutMillis) {


### PR DESCRIPTION
Some tests like test/jdk/java/net/Socket/B8312065.java use specific IPs (like 192.168.255.255) taking the assumption that the address is not going to be assigned. This doesn't always hold true, as 192.168.255.255 for example is a valid address.

[RFC 5737](https://www.rfc-editor.org/rfc/rfc5737) defines specific ranges of IP addresses that may are reserved for these exact purpose and that will never be assigned. Let's make sure to use an IP in this range, like 192.0.2.1 for example.

The specific test test/jdk/java/net/Socket/B8312065.java was introduced with https://git.openjdk.org/jdk17u-dev/pull/1639.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8324234](https://bugs.openjdk.org/browse/JDK-8324234) needs maintainer approval

### Issue
 * [JDK-8324234](https://bugs.openjdk.org/browse/JDK-8324234): Use reserved IP for java.net testing (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2149/head:pull/2149` \
`$ git checkout pull/2149`

Update a local copy of the PR: \
`$ git checkout pull/2149` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2149`

View PR using the GUI difftool: \
`$ git pr show -t 2149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2149.diff">https://git.openjdk.org/jdk17u-dev/pull/2149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2149#issuecomment-1903431110)