### PR TITLE
8316563: test tools/jpackage/linux/LinuxResourceTest.java fails on CentOS Linux release 8.5.2111 and Fedora 27

### DIFF
--- a/test/jdk/tools/jpackage/linux/LinuxResourceTest.java
+++ b/test/jdk/tools/jpackage/linux/LinuxResourceTest.java
@@ -102,6 +102,7 @@ public class LinuxResourceTest {
                 "License: APPLICATION_LICENSE_TYPE",
                 "Prefix: %{dirname:APPLICATION_DIRECTORY}",
                 "Provides: dont-install-me",
+                "%define _build_id_links none",
                 "%description",
                 "APPLICATION_DESCRIPTION",
                 "%prep",


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8316563](https://bugs.openjdk.org/browse/JDK-8316563) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316563](https://bugs.openjdk.org/browse/JDK-8316563): test tools/jpackage/linux/LinuxResourceTest.java fails on CentOS Linux release 8.5.2111 and Fedora 27 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2151/head:pull/2151` \
`$ git checkout pull/2151`

Update a local copy of the PR: \
`$ git checkout pull/2151` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2151`

View PR using the GUI difftool: \
`$ git pr show -t 2151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2151.diff">https://git.openjdk.org/jdk17u-dev/pull/2151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2151#issuecomment-1903783969)