### PR TITLE
8209595: MonitorVmStartTerminate.java timed out

### DIFF
--- a/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
+++ b/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
@@ -98,6 +98,7 @@ public final class MonitorVmStartTerminate {
         System.out.println("Waiting for all processes to get started notification");
         listener.started.acquire(PROCESS_COUNT);
 
+        System.out.println("Terminating all processes");
         for (JavaProcess javaProcess : javaProcesses) {
             javaProcess.terminate();
         }
@@ -138,7 +139,7 @@ public final class MonitorVmStartTerminate {
         }
 
         private void releaseStarted(Set<Integer> ids) {
-            System.out.println("realeaseStarted(" + ids + ")");
+            System.out.println("releaseStarted(" + ids + ")");
             for (Integer id : ids) {
                 releaseStarted(id);
             }
@@ -149,11 +150,12 @@ public final class MonitorVmStartTerminate {
                 if (hasMainArgs(id, jp.getMainArgsIdentifier())) {
                     // store id for terminated identification
                     jp.setId(id);
-                    System.out.println("RELEASED (id=" + jp.getId() + ", args=" + jp.getMainArgsIdentifier() + ")");
+                    System.out.println("RELEASED started (id=" + jp.getId() + ", args=" + jp.getMainArgsIdentifier() + ")");
                     started.release();
                     return;
                 }
             }
+            System.out.println("releaseStarted: not a test pid: " + id);
         }
 
         private void releaseTerminated(Set<Integer> ids) {
@@ -166,23 +168,44 @@ public final class MonitorVmStartTerminate {
         private void releaseTerminated(Integer id) {
             for (JavaProcess jp : processes) {
                 if (id.equals(jp.getId())) {
-                    System.out.println("RELEASED (id=" + jp.getId() + ", args=" + jp.getMainArgsIdentifier() + ")");
+                    System.out.println("RELEASED terminated (id=" + jp.getId() + ", args=" + jp.getMainArgsIdentifier() + ")");
                     terminated.release();
                     return;
                 }
             }
         }
 
+        private static final int ARGS_ATTEMPTS = 3;
+
         private boolean hasMainArgs(Integer id, String args) {
+            VmIdentifier vmid = null;
             try {
-                VmIdentifier vmid = new VmIdentifier("//" + id.intValue());
-                MonitoredVm target = host.getMonitoredVm(vmid);
-                String monitoredArgs = MonitoredVmUtil.mainArgs(target);
-                if (monitoredArgs != null && monitoredArgs.contains(args)) {
-                    return true;
+                vmid = new VmIdentifier("//" + id.intValue());
+            } catch (URISyntaxException e) {
+                System.out.println("hasMainArgs(" + id + "): " + e);
+                return false;
+            }
+            // Retry a failing attempt to check arguments for a match,
+            // as not recognizing a test process will cause timeout and failure.
+            for (int i = 0; i < ARGS_ATTEMPTS; i++) {
+                try {
+                    MonitoredVm target = host.getMonitoredVm(vmid);
+                    String monitoredArgs = MonitoredVmUtil.mainArgs(target);
+                    System.out.println("hasMainArgs(" + id + "): has main args: '" + monitoredArgs + "'");
+                    if (monitoredArgs == null || monitoredArgs.equals("Unknown")) {
+                        System.out.println("hasMainArgs(" + id + "): retry" );
+                        takeNap();
+                        continue;
+                    } else if (monitoredArgs.contains(args)) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                } catch (MonitorException e) {
+                    // Process probably not running or not ours, e.g.
+                    // sun.jvmstat.monitor.MonitorException: Could not attach to PID
+                    System.out.println("hasMainArgs(" + id + "): " + e);
                 }
-            } catch (URISyntaxException | MonitorException e) {
-                // ok. process probably not running
             }
             return false;
         }
@@ -244,14 +267,6 @@ public final class MonitorVmStartTerminate {
                     System.exit(1);
                 }
                 takeNap();
-            }
-        }
-
-        private static void takeNap() {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                // ignore
             }
         }
 
@@ -321,6 +336,14 @@ public final class MonitorVmStartTerminate {
 
         public String getMainArgsIdentifier() {
             return mainArgsIdentifier;
+        }
+    }
+
+    public static void takeNap() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            // ignore
         }
     }
 }


### PR DESCRIPTION
Backport of [JDK-8209595](https://bugs.openjdk.org/browse/JDK-8209595)

Testing
- Local: Test passed
  - `MonitorVmStartTerminate.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-25`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8209595](https://bugs.openjdk.org/browse/JDK-8209595) needs maintainer approval

### Issue
 * [JDK-8209595](https://bugs.openjdk.org/browse/JDK-8209595): MonitorVmStartTerminate.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2160/head:pull/2160` \
`$ git checkout pull/2160`

Update a local copy of the PR: \
`$ git checkout pull/2160` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2160`

View PR using the GUI difftool: \
`$ git pr show -t 2160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2160.diff">https://git.openjdk.org/jdk17u-dev/pull/2160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2160#issuecomment-1905338600)