### PR TITLE
8308245: Add -proc:full to describe current default annotation processing policy

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Option.java
@@ -285,7 +285,7 @@ public enum Option {
         }
     },
 
-    PROC("-proc:", "opt.proc.none.only", STANDARD, BASIC,  ONEOF, "none", "only"),
+    PROC("-proc:", "opt.proc.none.only", STANDARD, BASIC, ONEOF, "none", "only", "full"),
 
     PROCESSOR("-processor", "opt.arg.class.list", "opt.processor", STANDARD, BASIC),
 

--- a/test/langtools/tools/javac/processing/environment/round/TestContext.java
+++ b/test/langtools/tools/javac/processing/environment/round/TestContext.java
@@ -31,7 +31,7 @@
  *          jdk.compiler/com.sun.tools.javac.processing
  *          jdk.compiler/com.sun.tools.javac.util
  * @build JavacTestingAbstractProcessor TestContext
- * @compile/process -processor TestContext -XprintRounds TestContext
+ * @compile/process -processor TestContext -XprintRounds -proc:full TestContext
  */
 
 import java.io.*;

--- a/test/langtools/tools/javac/processing/options/TestProcOption.java
+++ b/test/langtools/tools/javac/processing/options/TestProcOption.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308245
+ * @summary Test trivial handling of -proc:full option
+ * @compile -proc:full TestProcOption.java
+ * @run main TestProcOption
+ */
+
+/*
+ * The test verifies that compilation takes place when -proc:full is used.
+ */
+public class TestProcOption {
+    private TestProcOption(){};
+
+    public static void main(String... args) {
+        ; // do nothing
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8308245](https://bugs.openjdk.org/browse/JDK-8308245) needs maintainer approval
- [x] Change requires CSR request [JDK-8321417](https://bugs.openjdk.org/browse/JDK-8321417) to be approved

### Issues
 * [JDK-8308245](https://bugs.openjdk.org/browse/JDK-8308245): Add -proc:full to describe current default annotation processing policy (**Enhancement** - P4 - Approved)
 * [JDK-8321417](https://bugs.openjdk.org/browse/JDK-8321417): Add -proc:full to describe current default annotation processing policy (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2161/head:pull/2161` \
`$ git checkout pull/2161`

Update a local copy of the PR: \
`$ git checkout pull/2161` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2161`

View PR using the GUI difftool: \
`$ git pr show -t 2161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2161.diff">https://git.openjdk.org/jdk17u-dev/pull/2161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2161#issuecomment-1905467276)