### PR TITLE
8311081: KeytoolReaderP12Test.java fail on localized Windows platform

### DIFF
--- a/test/jdk/java/security/KeyStore/PKCS12/Utils.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,11 +59,14 @@ public class Utils {
 
     public static OutputAnalyzer executeKeytoolCommand(String[] command,
             int exitCode) {
-        String[] keytoolCmd = new String[command.length + 1];
+        String[] keytoolCmd = new String[command.length + 3];
         OutputAnalyzer output = null;
         try {
             keytoolCmd[0] = JDKToolFinder.getJDKTool(KEYTOOL);
-            System.arraycopy(command, 0, keytoolCmd, 1, command.length);
+            // Ensure the keytool process is always ran under English locale
+            keytoolCmd[1] = "-J-Duser.language=en";
+            keytoolCmd[2] = "-J-Duser.country=US";
+            System.arraycopy(command, 0, keytoolCmd, 3, command.length);
             output = ProcessTools.executeCommand(keytoolCmd);
             output.shouldHaveExitValue(exitCode);
             out.println("Executed keytool command sucessfully:"


### PR DESCRIPTION
Backport of [JDK-8311081](https://bugs.openjdk.org/browse/JDK-8311081)

Testing
- Local: Not applicable
  - jtreg message: Not a test or directory containing tests: `java/security/KeyStore/PKCS12/Utils.java`
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-01-25,26`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8311081](https://bugs.openjdk.org/browse/JDK-8311081) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311081](https://bugs.openjdk.org/browse/JDK-8311081): KeytoolReaderP12Test.java fail on localized Windows platform (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2163/head:pull/2163` \
`$ git checkout pull/2163`

Update a local copy of the PR: \
`$ git checkout pull/2163` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2163`

View PR using the GUI difftool: \
`$ git pr show -t 2163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2163.diff">https://git.openjdk.org/jdk17u-dev/pull/2163.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2163#issuecomment-1905577945)