### PR TITLE
8272811: Document the effects of building with _GNU_SOURCE in os_posix.hpp

### DIFF
--- a/src/hotspot/os/posix/os_posix.hpp
+++ b/src/hotspot/os/posix/os_posix.hpp
@@ -25,6 +25,15 @@
 #ifndef OS_POSIX_OS_POSIX_HPP
 #define OS_POSIX_OS_POSIX_HPP
 
+// Note: the Posix API aims to capture functionality available on all Posix
+// compliant platforms, but in practice the implementations may depend on
+// non-Posix functionality. For example, the use of lseek64 and ftruncate64.
+// This use of non-Posix API's is made possible by compiling/linking in a mode
+// that is not restricted to being fully Posix complaint, such as by declaring
+// -D_GNU_SOURCE. But be aware that in doing so we may enable non-Posix
+// behaviour in API's that are defined by Posix. For example, that SIGSTKSZ
+// is not defined as a constant as of Glibc 2.34.
+
 // File conventions
 static const char* file_separator() { return "/"; }
 static const char* line_separator() { return "\n"; }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8272811](https://bugs.openjdk.org/browse/JDK-8272811) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272811](https://bugs.openjdk.org/browse/JDK-8272811): Document the effects of building with _GNU_SOURCE in os_posix.hpp (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2164/head:pull/2164` \
`$ git checkout pull/2164`

Update a local copy of the PR: \
`$ git checkout pull/2164` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2164`

View PR using the GUI difftool: \
`$ git pr show -t 2164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2164.diff">https://git.openjdk.org/jdk17u-dev/pull/2164.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2164#issuecomment-1905600884)