### PR TITLE
8319922: libCreationTimeHelper.so fails to link in JDK 21

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -100,7 +100,7 @@ ifeq ($(call isTargetOs, linux), true)
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libFib := -g
   BUILD_JDK_JTREG_LIBRARIES_STRIP_SYMBOLS_libFib := false
   # nio tests' libCreationTimeHelper native needs -ldl linker flag
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libCreationTimeHelper := -ldl
+  BUILD_JDK_JTREG_LIBRARIES_LIBS_libCreationTimeHelper := -ldl
 endif
 
 # This evaluation is expensive and should only be done if this target was


### PR DESCRIPTION
Clean backport for a potential compilation issue on some systems when the test libs get compiled. Test lib only change. No risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319922](https://bugs.openjdk.org/browse/JDK-8319922) needs maintainer approval

### Issue
 * [JDK-8319922](https://bugs.openjdk.org/browse/JDK-8319922): libCreationTimeHelper.so fails to link in JDK 21 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2176/head:pull/2176` \
`$ git checkout pull/2176`

Update a local copy of the PR: \
`$ git checkout pull/2176` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2176`

View PR using the GUI difftool: \
`$ git pr show -t 2176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2176.diff">https://git.openjdk.org/jdk17u-dev/pull/2176.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2176#issuecomment-1910589394)