### PR TITLE
8324280: RISC-V: Incorrect implementation in VM_Version::parse_satp_mode

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -168,13 +168,13 @@ void VM_Version::os_aux_features() {
 }
 
 VM_Version::VM_MODE VM_Version::parse_satp_mode(const char* vm_mode) {
-  if (!strcmp(vm_mode, "sv39")) {
+  if (!strncmp(vm_mode, "sv39", sizeof "sv39" - 1)) {
     return VM_SV39;
-  } else if (!strcmp(vm_mode, "sv48")) {
+  } else if (!strncmp(vm_mode, "sv48", sizeof "sv48" - 1)) {
     return VM_SV48;
-  } else if (!strcmp(vm_mode, "sv57")) {
+  } else if (!strncmp(vm_mode, "sv57", sizeof "sv57" - 1)) {
     return VM_SV57;
-  } else if (!strcmp(vm_mode, "sv64")) {
+  } else if (!strncmp(vm_mode, "sv64", sizeof "sv64" - 1)) {
     return VM_SV64;
   } else {
     return VM_MBARE;
@@ -196,7 +196,7 @@ char* VM_Version::os_uarch_additional_features() {
     if ((p = strchr(buf, ':')) != nullptr) {
       if (mode == VM_NOTSET) {
         if (strncmp(buf, "mmu", sizeof "mmu" - 1) == 0) {
-          mode = VM_Version::parse_satp_mode(p);
+          mode = VM_Version::parse_satp_mode(p + 2);
         }
       }
       if (ret == nullptr) {


### PR DESCRIPTION
Hi, The same issue also exists in the JDK17U: I can reproduce it locally and use this clean patch can fix that issue, So I would like to backport this to JDK17U. The parse_satp_mode function is used to parse SATP. Use SATP (Supervised Address Translation and Protection) mode at JVM startup and explicitly warn and stop early when sv57 is enabled [1]. Tier1 tested with fastdebug build using qemu systems. This is a risc-v specific change. Backport is clean, risk is low.

[1] https://github.com/openjdk/jdk/pull/11388

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324280](https://bugs.openjdk.org/browse/JDK-8324280) needs maintainer approval

### Issue
 * [JDK-8324280](https://bugs.openjdk.org/browse/JDK-8324280): RISC-V: Incorrect implementation in VM_Version::parse_satp_mode (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2178/head:pull/2178` \
`$ git checkout pull/2178`

Update a local copy of the PR: \
`$ git checkout pull/2178` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2178`

View PR using the GUI difftool: \
`$ git pr show -t 2178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2178.diff">https://git.openjdk.org/jdk17u-dev/pull/2178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2178#issuecomment-1911367288)