### PR TITLE
8324659: GHA: Generic jtreg errors are not reported

### DIFF
--- a/.github/scripts/gen-test-summary.sh
+++ b/.github/scripts/gen-test-summary.sh
@@ -42,6 +42,7 @@ error_count=$(echo $errors | wc -w || true)
 
 if [[ "$failures" = "" && "$errors" = "" ]]; then
   # We know something went wrong, but not what
+  echo 'failure=true' >> $GITHUB_OUTPUT
   echo 'error-message=Unspecified test suite failure. Please see log for job for details.' >> $GITHUB_OUTPUT
   exit 0
 fi


### PR DESCRIPTION
Clean backport to close GHA testing gap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324659](https://bugs.openjdk.org/browse/JDK-8324659) needs maintainer approval

### Issue
 * [JDK-8324659](https://bugs.openjdk.org/browse/JDK-8324659): GHA: Generic jtreg errors are not reported (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2181/head:pull/2181` \
`$ git checkout pull/2181`

Update a local copy of the PR: \
`$ git checkout pull/2181` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2181`

View PR using the GUI difftool: \
`$ git pr show -t 2181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2181.diff">https://git.openjdk.org/jdk17u-dev/pull/2181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2181#issuecomment-1911723549)