### PR TITLE
8324937: GHA: Avoid multiple test suites per job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           - 'hs/tier1 compiler part 1'
           - 'hs/tier1 compiler part 2'
           - 'hs/tier1 compiler part 3'
+          - 'hs/tier1 compiler not-xcomp'
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
@@ -90,11 +91,15 @@ jobs:
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 compiler part 2'
-            test-suite: 'test/hotspot/jtreg/:tier1_compiler_2 test/hotspot/jtreg/:tier1_compiler_not_xcomp'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_2'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 compiler part 3'
             test-suite: 'test/hotspot/jtreg/:tier1_compiler_3'
+            debug-suffix: -debug
+
+          - test-name: 'hs/tier1 compiler not-xcomp'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_not_xcomp'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 gc'


### PR DESCRIPTION
Clean backport to cover GHA testing gap.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324937](https://bugs.openjdk.org/browse/JDK-8324937) needs maintainer approval

### Issue
 * [JDK-8324937](https://bugs.openjdk.org/browse/JDK-8324937): GHA: Avoid multiple test suites per job (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2188/head:pull/2188` \
`$ git checkout pull/2188`

Update a local copy of the PR: \
`$ git checkout pull/2188` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2188`

View PR using the GUI difftool: \
`$ git pr show -t 2188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2188.diff">https://git.openjdk.org/jdk17u-dev/pull/2188.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2188#issuecomment-1920776740)