### PR TITLE
8311893: Interactive component with ARIA role 'tabpanel' does not have a programmatically associated name

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -415,7 +415,7 @@ public class Table extends Content {
             HtmlTree tabpanel = new HtmlTree(TagName.DIV)
                     .setId(HtmlIds.forTabPanel(id))
                     .put(HtmlAttr.ROLE, "tabpanel")
-                    .put(HtmlAttr.ARIA_LABELLEDBY, HtmlIds.forTab(id, tabIndex).name());
+                    .put(HtmlAttr.ARIA_LABELLEDBY, HtmlIds.forTab(id, 0).name());
             table.add(getTableBody());
             tabpanel.add(table);
             main.add(tablist);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -402,12 +402,12 @@ public class Table extends Content {
 
             int tabIndex = 0;
             tablist.add(createTab(HtmlIds.forTab(id, tabIndex), activeTabStyle, true, defaultTab));
-            table.put(HtmlAttr.ARIA_LABELLEDBY, HtmlIds.forTab(id, tabIndex).name());
             for (Content tabLabel : tabMap.keySet()) {
                 tabIndex++;
                 if (tabs.contains(tabLabel)) {
                     HtmlTree tab = createTab(HtmlIds.forTab(id, tabIndex), tabStyle, false, tabLabel);
                     tablist.add(tab);
+
                 }
             }
             if (id == null) {
@@ -415,7 +415,8 @@ public class Table extends Content {
             }
             HtmlTree tabpanel = new HtmlTree(TagName.DIV)
                     .setId(HtmlIds.forTabPanel(id))
-                    .put(HtmlAttr.ROLE, "tabpanel");
+                    .put(HtmlAttr.ROLE, "tabpanel")
+                    .put(HtmlAttr.ARIA_LABELLEDBY, HtmlIds.forTab(id, tabIndex).name());
             table.add(getTableBody());
             tabpanel.add(table);
             main.add(tablist);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Table.java
@@ -407,7 +407,6 @@ public class Table extends Content {
                 if (tabs.contains(tabLabel)) {
                     HtmlTree tab = createTab(HtmlIds.forTab(id, tabIndex), tabStyle, false, tabLabel);
                     tablist.add(tab);
-
                 }
             }
             if (id == null) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/script.js
@@ -63,7 +63,7 @@ function show(tableId, selected, columns) {
 }
 
 function updateTabs(tableId, selected) {
-    document.querySelector('div#' + tableId +' .summary-table')
+    document.getElementById(tableId + '.tabpanel')
         .setAttribute('aria-labelledby', selected);
     document.querySelectorAll('button[id^="' + tableId + '"]')
         .forEach(function(tab, index) {

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableStyles/TestHtmlTableStyles.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableStyles/TestHtmlTableStyles.java
@@ -65,7 +65,7 @@ public class TestHtmlTableStyles extends JavadocTester {
                     <div class="caption"><span>Constructors</span></div>
                     <div class="summary-table two-column-summary">""",
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">""");
+                    <div class="summary-table three-column-summary">""");
 
         checkOutput("pkg1/package-summary.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -84,24 +84,24 @@ public class TestHtmlTableTags extends JavadocTester {
         //Package summary
         checkOutput("pkg1/package-summary.html", true,
                 """
-                    <div class="summary-table two-column-summary" aria-labelledby="class-summary-tab0">""");
+                    <div class="summary-table two-column-summary">""");
 
         checkOutput("pkg2/package-summary.html", true,
                 """
-                    <div class="summary-table two-column-summary" aria-labelledby="class-summary-tab0">""");
+                    <div class="summary-table two-column-summary">""");
 
         // Class documentation
         checkOutput("pkg1/C1.html", true,
                 """
                     <div class="summary-table three-column-summary">""",
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">""");
+                    <div class="summary-table three-column-summary">""");
 
         checkOutput("pkg2/C2.html", true,
                 """
                     <div class="summary-table three-column-summary">""",
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">""");
+                    <div class="summary-table three-column-summary">""");
 
         checkOutput("pkg2/C2.ModalExclusionType.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
@@ -97,7 +97,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <div class="summary-table two-column-summary" aria-labelledby="class-summary-tab0">""",
+                    <div class="summary-table two-column-summary">""",
                 """
                     <header role="banner" class="flex-header">
                     <nav role="navigation">
@@ -413,7 +413,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <div class="caption"><span>Enum Constants</span></div>
                     """,
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">
+                    <div class="summary-table three-column-summary">
                     """,
                 """
                     <section class="method-summary" id="method-summary">
@@ -454,7 +454,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <div id="method-summary-table">
                     """,
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">
+                    <div class="summary-table three-column-summary">
                     """,
                 """
                     <section class="method-details" id="method-detail">

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1183,8 +1183,8 @@ public class TestModules extends JavadocTester {
                     ck="show('all-modules-table', 'all-modules-table-tab3', 2)" class="table-tab">Ot\
                     her Modules</button>\
                     </div>
-                    <div id="all-modules-table.tabpanel" role="tabpanel">
-                    <div class="summary-table two-column-summary" aria-labelledby="all-modules-table-tab0">""",
+                    <div id="all-modules-table.tabpanel" role="tabpanel" aria-labelledby="all-modules-table-tab0">
+                    <div class="summary-table two-column-summary">""",
                 """
                     var evenRowColor = "even-row-color";
                     var oddRowColor = "odd-row-color";
@@ -1269,8 +1269,8 @@ public class TestModules extends JavadocTester {
                     ck="show('all-packages-table', 'all-packages-table-tab2', 2)" class="table-tab">P\
                     ackage Group 1</button>\
                     </div>
-                    <div id="all-packages-table.tabpanel" role="tabpanel">
-                    <div class="summary-table two-column-summary" aria-labelledby="all-packages-table-tab0">""",
+                    <div id="all-packages-table.tabpanel" role="tabpanel"  aria-labelledby="all-packages-table-tab0">
+                    <div class="summary-table two-column-summary">""",
                 """
                     var evenRowColor = "even-row-color";
                     var oddRowColor = "odd-row-color";
@@ -1423,7 +1423,7 @@ public class TestModules extends JavadocTester {
                     """);
         checkOutput("allclasses-index.html", found,
                 """
-                    <div class="summary-table two-column-summary" aria-labelledby="all-classes-table-tab0">
+                    <div class="summary-table two-column-summary">
                     """);
         checkOutput("allpackages-index.html", found,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1183,7 +1183,7 @@ public class TestModules extends JavadocTester {
                     ck="show('all-modules-table', 'all-modules-table-tab3', 2)" class="table-tab">Ot\
                     her Modules</button>\
                     </div>
-                    <div id="all-modules-table.tabpanel" role="tabpanel" aria-labelledby="all-modules-table-tab3">
+                    <div id="all-modules-table.tabpanel" role="tabpanel" aria-labelledby="all-modules-table-tab0">
                     <div class="summary-table two-column-summary">""",
                 """
                     var evenRowColor = "even-row-color";
@@ -1269,7 +1269,7 @@ public class TestModules extends JavadocTester {
                     ck="show('all-packages-table', 'all-packages-table-tab2', 2)" class="table-tab">P\
                     ackage Group 1</button>\
                     </div>
-                    <div id="all-packages-table.tabpanel" role="tabpanel" aria-labelledby="all-packages-table-tab2">
+                    <div id="all-packages-table.tabpanel" role="tabpanel" aria-labelledby="all-packages-table-tab0">
                     <div class="summary-table two-column-summary">""",
                 """
                     var evenRowColor = "even-row-color";

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1183,7 +1183,7 @@ public class TestModules extends JavadocTester {
                     ck="show('all-modules-table', 'all-modules-table-tab3', 2)" class="table-tab">Ot\
                     her Modules</button>\
                     </div>
-                    <div id="all-modules-table.tabpanel" role="tabpanel" aria-labelledby="all-modules-table-tab0">
+                    <div id="all-modules-table.tabpanel" role="tabpanel" aria-labelledby="all-modules-table-tab3">
                     <div class="summary-table two-column-summary">""",
                 """
                     var evenRowColor = "even-row-color";
@@ -1269,7 +1269,7 @@ public class TestModules extends JavadocTester {
                     ck="show('all-packages-table', 'all-packages-table-tab2', 2)" class="table-tab">P\
                     ackage Group 1</button>\
                     </div>
-                    <div id="all-packages-table.tabpanel" role="tabpanel"  aria-labelledby="all-packages-table-tab0">
+                    <div id="all-packages-table.tabpanel" role="tabpanel" aria-labelledby="all-packages-table-tab2">
                     <div class="summary-table two-column-summary">""",
                 """
                     var evenRowColor = "even-row-color";

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
@@ -136,8 +136,8 @@ public class TestNewApiList extends JavadocTester {
                 table-tab">New Modules</button><button id="module-tab2" role="tab" aria-selected="fa\
                 lse" aria-controls="module.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncl\
                 ick="show('module', 'module-tab2', 2)" class="table-tab">Added in 3.2</button></div>
-                <div id="module.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="module-tab0">
+                <div id="module.tabpanel" role="tabpanel" aria-labelledby="module-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Module</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color module module-tab2"><a href="mdl/module-summary.html">mdl</a></div>
@@ -153,8 +153,8 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="package.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('package', 'package-tab5', 2)" class="table-tab">Added in v1.0</but\
                 ton></div>
-                <div id="package.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="package-tab0">
+                <div id="package.tabpanel" role="tabpanel" aria-labelledby="package-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Package</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color package package-tab5"><a href="mdl/pkg/package-summary.html">pkg</a></div>
@@ -170,8 +170,8 @@ public class TestNewApiList extends JavadocTester {
                  aria-selected="false" aria-controls="interface.tabpanel" tabindex="-1" onkeydown="s\
                 witchTab(event)" onclick="show('interface', 'interface-tab6', 2)" class="table-tab">\
                 Added in 0.9</button></div>
-                <div id="interface.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="interface-tab0">
+                <div id="interface.tabpanel" role="tabpanel" aria-labelledby="interface-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Interface</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color interface interface-tab6"><a href="\
@@ -187,8 +187,8 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Classes</button><button id="class-tab4" role="tab" aria-selected="false" \
                 aria-controls="class.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="s\
                 how('class', 'class-tab4', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="class.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="class-tab0">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Class</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color class class-tab4"><a href="mdl/pkg/\
@@ -205,8 +205,8 @@ public class TestNewApiList extends JavadocTester {
                 e="tab" aria-selected="false" aria-controls="enum-class.tabpanel" tabindex="-1" onke\
                 ydown="switchTab(event)" onclick="show('enum-class', 'enum-class-tab6', 2)" class="t\
                 able-tab">Added in 0.9</button></div>
-                <div id="enum-class.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="enum-class-tab0">
+                <div id="enum-class.tabpanel" role="tabpanel" aria-labelledby="enum-class-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Class</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color enum-class enum-class-tab6"><a href\
@@ -223,8 +223,8 @@ public class TestNewApiList extends JavadocTester {
                  aria-selected="false" aria-controls="exception.tabpanel" tabindex="-1" onkeydown="s\
                 witchTab(event)" onclick="show('exception', 'exception-tab6', 2)" class="table-tab">\
                 Added in 0.9</button></div>
-                <div id="exception.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="exception-tab0">
+                <div id="exception.tabpanel" role="tabpanel" aria-labelledby="exception-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Exceptions</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color exception exception-tab6"><a href="\
@@ -240,8 +240,8 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Errors</button><button id="error-tab3" role="tab" aria-selected="false" a\
                 ria-controls="error.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="sh\
                 ow('error', 'error-tab3', 2)" class="table-tab">Added in 2.0b</button></div>
-                <div id="error.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="error-tab0">
+                <div id="error.tabpanel" role="tabpanel" aria-labelledby="error-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Errors</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color error error-tab3"><a href="mdl/pkg/\
@@ -258,8 +258,8 @@ public class TestNewApiList extends JavadocTester {
                 ss-tab2" role="tab" aria-selected="false" aria-controls="record-class.tabpanel" tabi\
                 ndex="-1" onkeydown="switchTab(event)" onclick="show('record-class', 'record-class-t\
                 ab2', 2)" class="table-tab">Added in 3.2</button></div>
-                <div id="record-class.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="record-class-tab0">
+                <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Record Class</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color record-class record-class-tab2"><a \
@@ -277,8 +277,8 @@ public class TestNewApiList extends JavadocTester {
                 lse" aria-controls="annotation-interface.tabpanel" tabindex="-1" onkeydown="switchTa\
                 b(event)" onclick="show('annotation-interface', 'annotation-interface-tab3', 2)" cla\
                 ss="table-tab">Added in 2.0b</button></div>
-                <div id="annotation-interface.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="annotation-interface-tab0">
+                <div id="annotation-interface.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color annotation-interface annotation-int\
@@ -303,8 +303,8 @@ public class TestNewApiList extends JavadocTester {
                 field-tab5" role="tab" aria-selected="false" aria-controls="field.tabpanel" tabindex\
                 ="-1" onkeydown="switchTab(event)" onclick="show('field', 'field-tab5', 2)" class="t\
                 able-tab">Added in v1.0</button></div>
-                <div id="field.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="field-tab0">
+                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Field</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color field field-tab4"><a href="mdl/pkg/\
@@ -346,8 +346,8 @@ public class TestNewApiList extends JavadocTester {
                 " aria-selected="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="swi\
                 tchTab(event)" onclick="show('method', 'method-tab5', 2)" class="table-tab">Added in\
                  v1.0</button></div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color method method-tab2"><a href="mdl/pk\
@@ -412,8 +412,8 @@ public class TestNewApiList extends JavadocTester {
                 ria-controls="constructor.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncli\
                 ck="show('constructor', 'constructor-tab3', 2)" class="table-tab">Added in 2.0b</but\
                 ton></div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color constructor constructor-tab3"><a hr\
@@ -455,8 +455,8 @@ public class TestNewApiList extends JavadocTester {
                 ria-selected="false" aria-controls="enum-constant.tabpanel" tabindex="-1" onkeydown=\
                 "switchTab(event)" onclick="show('enum-constant', 'enum-constant-tab6', 2)" class="t\
                 able-tab">Added in 0.9</button></div>
-                <div id="enum-constant.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="enum-constant-tab0">
+                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Constant</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color enum-constant enum-constant-tab2"><\
@@ -493,8 +493,8 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="annotation-interface-member.tabpanel" tabindex="-1" onkeyd\
                 own="switchTab(event)" onclick="show('annotation-interface-member', 'annotation-inte\
                 rface-member-tab3', 2)" class="table-tab">Added in 2.0b</button></div>
-                <div id="annotation-interface-member.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="annotation-interface-member-tab0">
+                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface Element</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color annotation-interface-member annotat\
@@ -522,8 +522,8 @@ public class TestNewApiList extends JavadocTester {
                 r-removal-tab1" role="tab" aria-selected="false" aria-controls="for-removal.tabpanel\
                 " tabindex="-1" onkeydown="switchTab(event)" onclick="show('for-removal', 'for-remov\
                 al-tab1', 2)" class="table-tab">Terminally Deprecated in 5</button></div>
-                <div id="for-removal.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="for-removal-tab0">
+                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Element</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color for-removal for-removal-tab1"><a hr\
@@ -539,8 +539,8 @@ public class TestNewApiList extends JavadocTester {
                 ted="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('method', 'method-tab1', 2)" class="table-tab">Deprecated in 5</but\
                 ton></div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color method method-tab1"><a href="mdl/pk\
@@ -556,8 +556,8 @@ public class TestNewApiList extends JavadocTester {
                 or-tab1" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color constructor constructor-tab1"><a hr\
@@ -573,8 +573,8 @@ public class TestNewApiList extends JavadocTester {
                 "enum-constant-tab1" role="tab" aria-selected="false" aria-controls="enum-constant.t\
                 abpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="show('enum-constant', '\
                 enum-constant-tab1', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="enum-constant.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="enum-constant-tab0">
+                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Constant</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color enum-constant enum-constant-tab1"><\
@@ -592,8 +592,8 @@ public class TestNewApiList extends JavadocTester {
                 erface-member.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="show('an\
                 notation-interface-member', 'annotation-interface-member-tab1', 2)" class="table-tab\
                 ">Deprecated in 5</button></div>
-                <div id="annotation-interface-member.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="annotation-interface-member-tab0">
+                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface Element</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color annotation-interface-member annotat\
@@ -626,8 +626,8 @@ public class TestNewApiList extends JavadocTester {
                 table-tab">New Methods</button><button id="method-tab1" role="tab" aria-selected="fa\
                 lse" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncl\
                 ick="show('method', 'method-tab1', 2)" class="table-tab">New Methods</button></div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color method method-tab1"><a href="mdl/pk\
@@ -650,8 +650,8 @@ public class TestNewApiList extends JavadocTester {
                 " role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabindex="-1\
                 " onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1', 2)" \
                 class="table-tab">New Constructors</button></div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color constructor constructor-tab1"><a hr\
@@ -689,8 +689,8 @@ public class TestNewApiList extends JavadocTester {
                 r-removal-tab1" role="tab" aria-selected="false" aria-controls="for-removal.tabpanel\
                 " tabindex="-1" onkeydown="switchTab(event)" onclick="show('for-removal', 'for-remov\
                 al-tab1', 2)" class="table-tab">Terminally Deprecated in 5</button></div>
-                <div id="for-removal.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="for-removal-tab0">
+                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Element</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color for-removal for-removal-tab1"><a hr\
@@ -706,8 +706,8 @@ public class TestNewApiList extends JavadocTester {
                 ted="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('method', 'method-tab1', 2)" class="table-tab">Deprecated in 5</but\
                 ton></div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color method method-tab1"><a href="mdl/pk\
@@ -723,8 +723,8 @@ public class TestNewApiList extends JavadocTester {
                 or-tab1" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color constructor constructor-tab1"><a hr\
@@ -761,8 +761,8 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Classes</button><button id="class-tab5" role="tab" aria-selected="false" \
                 aria-controls="class.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="s\
                 how('class', 'class-tab5', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="class.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="class-tab0">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Class</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color class class-tab5"><a href="pkg/Test\
@@ -778,8 +778,8 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Fields</button><button id="field-tab5" role="tab" aria-selected="false" a\
                 ria-controls="field.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="sh\
                 ow('field', 'field-tab5', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="field.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="field-tab0">
+                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Field</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color field field-tab5"><a href="pkg/Test\
@@ -801,8 +801,8 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event)\
                 " onclick="show('method', 'method-tab4', 2)" class="table-tab">Added in 2.0b</button\
                 ></div>
-                <div id="method.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color method method-tab4"><a href="pkg/Te\
@@ -833,8 +833,8 @@ public class TestNewApiList extends JavadocTester {
                 -selected="false" aria-controls="constructor.tabpanel" tabindex="-1" onkeydown="swit\
                 chTab(event)" onclick="show('constructor', 'constructor-tab4', 2)" class="table-tab"\
                 >Added in 2.0b</button></div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color constructor constructor-tab4"><a hr\
@@ -872,8 +872,8 @@ public class TestNewApiList extends JavadocTester {
                 or-tab2" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab2\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel">
-                <div class="summary-table two-column-summary" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
                 <div class="col-summary-item-name even-row-color constructor constructor-tab2"><a hr\

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
@@ -136,7 +136,7 @@ public class TestNewApiList extends JavadocTester {
                 table-tab">New Modules</button><button id="module-tab2" role="tab" aria-selected="fa\
                 lse" aria-controls="module.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncl\
                 ick="show('module', 'module-tab2', 2)" class="table-tab">Added in 3.2</button></div>
-                <div id="module.tabpanel" role="tabpanel" aria-labelledby="module-tab6">
+                <div id="module.tabpanel" role="tabpanel" aria-labelledby="module-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Module</div>
                 <div class="table-header col-last">Description</div>
@@ -153,7 +153,7 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="package.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('package', 'package-tab5', 2)" class="table-tab">Added in v1.0</but\
                 ton></div>
-                <div id="package.tabpanel" role="tabpanel" aria-labelledby="package-tab6">
+                <div id="package.tabpanel" role="tabpanel" aria-labelledby="package-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Package</div>
                 <div class="table-header col-last">Description</div>
@@ -170,7 +170,7 @@ public class TestNewApiList extends JavadocTester {
                  aria-selected="false" aria-controls="interface.tabpanel" tabindex="-1" onkeydown="s\
                 witchTab(event)" onclick="show('interface', 'interface-tab6', 2)" class="table-tab">\
                 Added in 0.9</button></div>
-                <div id="interface.tabpanel" role="tabpanel" aria-labelledby="interface-tab6">
+                <div id="interface.tabpanel" role="tabpanel" aria-labelledby="interface-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Interface</div>
                 <div class="table-header col-last">Description</div>
@@ -187,7 +187,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Classes</button><button id="class-tab4" role="tab" aria-selected="false" \
                 aria-controls="class.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="s\
                 how('class', 'class-tab4', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab6">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Class</div>
                 <div class="table-header col-last">Description</div>
@@ -205,7 +205,7 @@ public class TestNewApiList extends JavadocTester {
                 e="tab" aria-selected="false" aria-controls="enum-class.tabpanel" tabindex="-1" onke\
                 ydown="switchTab(event)" onclick="show('enum-class', 'enum-class-tab6', 2)" class="t\
                 able-tab">Added in 0.9</button></div>
-                <div id="enum-class.tabpanel" role="tabpanel" aria-labelledby="enum-class-tab6">
+                <div id="enum-class.tabpanel" role="tabpanel" aria-labelledby="enum-class-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Class</div>
                 <div class="table-header col-last">Description</div>
@@ -223,7 +223,7 @@ public class TestNewApiList extends JavadocTester {
                  aria-selected="false" aria-controls="exception.tabpanel" tabindex="-1" onkeydown="s\
                 witchTab(event)" onclick="show('exception', 'exception-tab6', 2)" class="table-tab">\
                 Added in 0.9</button></div>
-                <div id="exception.tabpanel" role="tabpanel" aria-labelledby="exception-tab6">
+                <div id="exception.tabpanel" role="tabpanel" aria-labelledby="exception-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Exceptions</div>
                 <div class="table-header col-last">Description</div>
@@ -240,7 +240,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Errors</button><button id="error-tab3" role="tab" aria-selected="false" a\
                 ria-controls="error.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="sh\
                 ow('error', 'error-tab3', 2)" class="table-tab">Added in 2.0b</button></div>
-                <div id="error.tabpanel" role="tabpanel" aria-labelledby="error-tab6">
+                <div id="error.tabpanel" role="tabpanel" aria-labelledby="error-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Errors</div>
                 <div class="table-header col-last">Description</div>
@@ -258,7 +258,7 @@ public class TestNewApiList extends JavadocTester {
                 ss-tab2" role="tab" aria-selected="false" aria-controls="record-class.tabpanel" tabi\
                 ndex="-1" onkeydown="switchTab(event)" onclick="show('record-class', 'record-class-t\
                 ab2', 2)" class="table-tab">Added in 3.2</button></div>
-                <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab6">
+                <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Record Class</div>
                 <div class="table-header col-last">Description</div>
@@ -277,7 +277,7 @@ public class TestNewApiList extends JavadocTester {
                 lse" aria-controls="annotation-interface.tabpanel" tabindex="-1" onkeydown="switchTa\
                 b(event)" onclick="show('annotation-interface', 'annotation-interface-tab3', 2)" cla\
                 ss="table-tab">Added in 2.0b</button></div>
-                <div id="annotation-interface.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-tab6">
+                <div id="annotation-interface.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface</div>
                 <div class="table-header col-last">Description</div>
@@ -303,7 +303,7 @@ public class TestNewApiList extends JavadocTester {
                 field-tab5" role="tab" aria-selected="false" aria-controls="field.tabpanel" tabindex\
                 ="-1" onkeydown="switchTab(event)" onclick="show('field', 'field-tab5', 2)" class="t\
                 able-tab">Added in v1.0</button></div>
-                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab6">
+                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Field</div>
                 <div class="table-header col-last">Description</div>
@@ -346,7 +346,7 @@ public class TestNewApiList extends JavadocTester {
                 " aria-selected="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="swi\
                 tchTab(event)" onclick="show('method', 'method-tab5', 2)" class="table-tab">Added in\
                  v1.0</button></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab6">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -412,7 +412,7 @@ public class TestNewApiList extends JavadocTester {
                 ria-controls="constructor.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncli\
                 ck="show('constructor', 'constructor-tab3', 2)" class="table-tab">Added in 2.0b</but\
                 ton></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab6">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -455,7 +455,7 @@ public class TestNewApiList extends JavadocTester {
                 ria-selected="false" aria-controls="enum-constant.tabpanel" tabindex="-1" onkeydown=\
                 "switchTab(event)" onclick="show('enum-constant', 'enum-constant-tab6', 2)" class="t\
                 able-tab">Added in 0.9</button></div>
-                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab6">
+                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Constant</div>
                 <div class="table-header col-last">Description</div>
@@ -493,7 +493,7 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="annotation-interface-member.tabpanel" tabindex="-1" onkeyd\
                 own="switchTab(event)" onclick="show('annotation-interface-member', 'annotation-inte\
                 rface-member-tab3', 2)" class="table-tab">Added in 2.0b</button></div>
-                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab6">
+                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface Element</div>
                 <div class="table-header col-last">Description</div>
@@ -522,7 +522,7 @@ public class TestNewApiList extends JavadocTester {
                 r-removal-tab1" role="tab" aria-selected="false" aria-controls="for-removal.tabpanel\
                 " tabindex="-1" onkeydown="switchTab(event)" onclick="show('for-removal', 'for-remov\
                 al-tab1', 2)" class="table-tab">Terminally Deprecated in 5</button></div>
-                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab6">
+                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Element</div>
                 <div class="table-header col-last">Description</div>
@@ -539,7 +539,7 @@ public class TestNewApiList extends JavadocTester {
                 ted="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('method', 'method-tab1', 2)" class="table-tab">Deprecated in 5</but\
                 ton></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab6">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -556,7 +556,7 @@ public class TestNewApiList extends JavadocTester {
                 or-tab1" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab6">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -573,7 +573,7 @@ public class TestNewApiList extends JavadocTester {
                 "enum-constant-tab1" role="tab" aria-selected="false" aria-controls="enum-constant.t\
                 abpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="show('enum-constant', '\
                 enum-constant-tab1', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab6">
+                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Constant</div>
                 <div class="table-header col-last">Description</div>
@@ -592,7 +592,7 @@ public class TestNewApiList extends JavadocTester {
                 erface-member.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="show('an\
                 notation-interface-member', 'annotation-interface-member-tab1', 2)" class="table-tab\
                 ">Deprecated in 5</button></div>
-                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab6">
+                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface Element</div>
                 <div class="table-header col-last">Description</div>
@@ -626,7 +626,7 @@ public class TestNewApiList extends JavadocTester {
                 table-tab">New Methods</button><button id="method-tab1" role="tab" aria-selected="fa\
                 lse" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncl\
                 ick="show('method', 'method-tab1', 2)" class="table-tab">New Methods</button></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab1">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -650,7 +650,7 @@ public class TestNewApiList extends JavadocTester {
                 " role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabindex="-1\
                 " onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1', 2)" \
                 class="table-tab">New Constructors</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab1">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -689,7 +689,7 @@ public class TestNewApiList extends JavadocTester {
                 r-removal-tab1" role="tab" aria-selected="false" aria-controls="for-removal.tabpanel\
                 " tabindex="-1" onkeydown="switchTab(event)" onclick="show('for-removal', 'for-remov\
                 al-tab1', 2)" class="table-tab">Terminally Deprecated in 5</button></div>
-                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab1">
+                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Element</div>
                 <div class="table-header col-last">Description</div>
@@ -706,7 +706,7 @@ public class TestNewApiList extends JavadocTester {
                 ted="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('method', 'method-tab1', 2)" class="table-tab">Deprecated in 5</but\
                 ton></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab1">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -723,7 +723,7 @@ public class TestNewApiList extends JavadocTester {
                 or-tab1" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab1">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -761,7 +761,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Classes</button><button id="class-tab5" role="tab" aria-selected="false" \
                 aria-controls="class.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="s\
                 how('class', 'class-tab5', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab5">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab50">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Class</div>
                 <div class="table-header col-last">Description</div>
@@ -778,7 +778,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Fields</button><button id="field-tab5" role="tab" aria-selected="false" a\
                 ria-controls="field.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="sh\
                 ow('field', 'field-tab5', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab5">
+                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Field</div>
                 <div class="table-header col-last">Description</div>
@@ -801,7 +801,7 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event)\
                 " onclick="show('method', 'method-tab4', 2)" class="table-tab">Added in 2.0b</button\
                 ></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab5">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -833,7 +833,7 @@ public class TestNewApiList extends JavadocTester {
                 -selected="false" aria-controls="constructor.tabpanel" tabindex="-1" onkeydown="swit\
                 chTab(event)" onclick="show('constructor', 'constructor-tab4', 2)" class="table-tab"\
                 >Added in 2.0b</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab5">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -872,7 +872,7 @@ public class TestNewApiList extends JavadocTester {
                 or-tab2" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab2\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab5">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
@@ -136,7 +136,7 @@ public class TestNewApiList extends JavadocTester {
                 table-tab">New Modules</button><button id="module-tab2" role="tab" aria-selected="fa\
                 lse" aria-controls="module.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncl\
                 ick="show('module', 'module-tab2', 2)" class="table-tab">Added in 3.2</button></div>
-                <div id="module.tabpanel" role="tabpanel" aria-labelledby="module-tab0">
+                <div id="module.tabpanel" role="tabpanel" aria-labelledby="module-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Module</div>
                 <div class="table-header col-last">Description</div>
@@ -153,7 +153,7 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="package.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('package', 'package-tab5', 2)" class="table-tab">Added in v1.0</but\
                 ton></div>
-                <div id="package.tabpanel" role="tabpanel" aria-labelledby="package-tab0">
+                <div id="package.tabpanel" role="tabpanel" aria-labelledby="package-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Package</div>
                 <div class="table-header col-last">Description</div>
@@ -170,7 +170,7 @@ public class TestNewApiList extends JavadocTester {
                  aria-selected="false" aria-controls="interface.tabpanel" tabindex="-1" onkeydown="s\
                 witchTab(event)" onclick="show('interface', 'interface-tab6', 2)" class="table-tab">\
                 Added in 0.9</button></div>
-                <div id="interface.tabpanel" role="tabpanel" aria-labelledby="interface-tab0">
+                <div id="interface.tabpanel" role="tabpanel" aria-labelledby="interface-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Interface</div>
                 <div class="table-header col-last">Description</div>
@@ -187,7 +187,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Classes</button><button id="class-tab4" role="tab" aria-selected="false" \
                 aria-controls="class.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="s\
                 how('class', 'class-tab4', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Class</div>
                 <div class="table-header col-last">Description</div>
@@ -205,7 +205,7 @@ public class TestNewApiList extends JavadocTester {
                 e="tab" aria-selected="false" aria-controls="enum-class.tabpanel" tabindex="-1" onke\
                 ydown="switchTab(event)" onclick="show('enum-class', 'enum-class-tab6', 2)" class="t\
                 able-tab">Added in 0.9</button></div>
-                <div id="enum-class.tabpanel" role="tabpanel" aria-labelledby="enum-class-tab0">
+                <div id="enum-class.tabpanel" role="tabpanel" aria-labelledby="enum-class-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Class</div>
                 <div class="table-header col-last">Description</div>
@@ -223,7 +223,7 @@ public class TestNewApiList extends JavadocTester {
                  aria-selected="false" aria-controls="exception.tabpanel" tabindex="-1" onkeydown="s\
                 witchTab(event)" onclick="show('exception', 'exception-tab6', 2)" class="table-tab">\
                 Added in 0.9</button></div>
-                <div id="exception.tabpanel" role="tabpanel" aria-labelledby="exception-tab0">
+                <div id="exception.tabpanel" role="tabpanel" aria-labelledby="exception-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Exceptions</div>
                 <div class="table-header col-last">Description</div>
@@ -240,7 +240,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Errors</button><button id="error-tab3" role="tab" aria-selected="false" a\
                 ria-controls="error.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="sh\
                 ow('error', 'error-tab3', 2)" class="table-tab">Added in 2.0b</button></div>
-                <div id="error.tabpanel" role="tabpanel" aria-labelledby="error-tab0">
+                <div id="error.tabpanel" role="tabpanel" aria-labelledby="error-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Errors</div>
                 <div class="table-header col-last">Description</div>
@@ -258,7 +258,7 @@ public class TestNewApiList extends JavadocTester {
                 ss-tab2" role="tab" aria-selected="false" aria-controls="record-class.tabpanel" tabi\
                 ndex="-1" onkeydown="switchTab(event)" onclick="show('record-class', 'record-class-t\
                 ab2', 2)" class="table-tab">Added in 3.2</button></div>
-                <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab0">
+                <div id="record-class.tabpanel" role="tabpanel" aria-labelledby="record-class-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Record Class</div>
                 <div class="table-header col-last">Description</div>
@@ -277,7 +277,7 @@ public class TestNewApiList extends JavadocTester {
                 lse" aria-controls="annotation-interface.tabpanel" tabindex="-1" onkeydown="switchTa\
                 b(event)" onclick="show('annotation-interface', 'annotation-interface-tab3', 2)" cla\
                 ss="table-tab">Added in 2.0b</button></div>
-                <div id="annotation-interface.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-tab0">
+                <div id="annotation-interface.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface</div>
                 <div class="table-header col-last">Description</div>
@@ -303,7 +303,7 @@ public class TestNewApiList extends JavadocTester {
                 field-tab5" role="tab" aria-selected="false" aria-controls="field.tabpanel" tabindex\
                 ="-1" onkeydown="switchTab(event)" onclick="show('field', 'field-tab5', 2)" class="t\
                 able-tab">Added in v1.0</button></div>
-                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
+                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Field</div>
                 <div class="table-header col-last">Description</div>
@@ -346,7 +346,7 @@ public class TestNewApiList extends JavadocTester {
                 " aria-selected="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="swi\
                 tchTab(event)" onclick="show('method', 'method-tab5', 2)" class="table-tab">Added in\
                  v1.0</button></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -412,7 +412,7 @@ public class TestNewApiList extends JavadocTester {
                 ria-controls="constructor.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncli\
                 ck="show('constructor', 'constructor-tab3', 2)" class="table-tab">Added in 2.0b</but\
                 ton></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -455,7 +455,7 @@ public class TestNewApiList extends JavadocTester {
                 ria-selected="false" aria-controls="enum-constant.tabpanel" tabindex="-1" onkeydown=\
                 "switchTab(event)" onclick="show('enum-constant', 'enum-constant-tab6', 2)" class="t\
                 able-tab">Added in 0.9</button></div>
-                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
+                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Constant</div>
                 <div class="table-header col-last">Description</div>
@@ -493,7 +493,7 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="annotation-interface-member.tabpanel" tabindex="-1" onkeyd\
                 own="switchTab(event)" onclick="show('annotation-interface-member', 'annotation-inte\
                 rface-member-tab3', 2)" class="table-tab">Added in 2.0b</button></div>
-                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
+                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface Element</div>
                 <div class="table-header col-last">Description</div>
@@ -522,7 +522,7 @@ public class TestNewApiList extends JavadocTester {
                 r-removal-tab1" role="tab" aria-selected="false" aria-controls="for-removal.tabpanel\
                 " tabindex="-1" onkeydown="switchTab(event)" onclick="show('for-removal', 'for-remov\
                 al-tab1', 2)" class="table-tab">Terminally Deprecated in 5</button></div>
-                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
+                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Element</div>
                 <div class="table-header col-last">Description</div>
@@ -539,7 +539,7 @@ public class TestNewApiList extends JavadocTester {
                 ted="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('method', 'method-tab1', 2)" class="table-tab">Deprecated in 5</but\
                 ton></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -556,7 +556,7 @@ public class TestNewApiList extends JavadocTester {
                 or-tab1" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -573,7 +573,7 @@ public class TestNewApiList extends JavadocTester {
                 "enum-constant-tab1" role="tab" aria-selected="false" aria-controls="enum-constant.t\
                 abpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="show('enum-constant', '\
                 enum-constant-tab1', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab0">
+                <div id="enum-constant.tabpanel" role="tabpanel" aria-labelledby="enum-constant-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Enum Constant</div>
                 <div class="table-header col-last">Description</div>
@@ -592,7 +592,7 @@ public class TestNewApiList extends JavadocTester {
                 erface-member.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="show('an\
                 notation-interface-member', 'annotation-interface-member-tab1', 2)" class="table-tab\
                 ">Deprecated in 5</button></div>
-                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab0">
+                <div id="annotation-interface-member.tabpanel" role="tabpanel" aria-labelledby="annotation-interface-member-tab6">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Annotation Interface Element</div>
                 <div class="table-header col-last">Description</div>
@@ -626,7 +626,7 @@ public class TestNewApiList extends JavadocTester {
                 table-tab">New Methods</button><button id="method-tab1" role="tab" aria-selected="fa\
                 lse" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event)" oncl\
                 ick="show('method', 'method-tab1', 2)" class="table-tab">New Methods</button></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab1">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -650,7 +650,7 @@ public class TestNewApiList extends JavadocTester {
                 " role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabindex="-1\
                 " onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1', 2)" \
                 class="table-tab">New Constructors</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab1">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -689,7 +689,7 @@ public class TestNewApiList extends JavadocTester {
                 r-removal-tab1" role="tab" aria-selected="false" aria-controls="for-removal.tabpanel\
                 " tabindex="-1" onkeydown="switchTab(event)" onclick="show('for-removal', 'for-remov\
                 al-tab1', 2)" class="table-tab">Terminally Deprecated in 5</button></div>
-                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab0">
+                <div id="for-removal.tabpanel" role="tabpanel" aria-labelledby="for-removal-tab1">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Element</div>
                 <div class="table-header col-last">Description</div>
@@ -706,7 +706,7 @@ public class TestNewApiList extends JavadocTester {
                 ted="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event\
                 )" onclick="show('method', 'method-tab1', 2)" class="table-tab">Deprecated in 5</but\
                 ton></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab1">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -723,7 +723,7 @@ public class TestNewApiList extends JavadocTester {
                 or-tab1" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab1\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab1">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -761,7 +761,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Classes</button><button id="class-tab5" role="tab" aria-selected="false" \
                 aria-controls="class.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="s\
                 how('class', 'class-tab5', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab5">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Class</div>
                 <div class="table-header col-last">Description</div>
@@ -778,7 +778,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Fields</button><button id="field-tab5" role="tab" aria-selected="false" a\
                 ria-controls="field.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="sh\
                 ow('field', 'field-tab5', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab0">
+                <div id="field.tabpanel" role="tabpanel" aria-labelledby="field-tab5">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Field</div>
                 <div class="table-header col-last">Description</div>
@@ -801,7 +801,7 @@ public class TestNewApiList extends JavadocTester {
                 ed="false" aria-controls="method.tabpanel" tabindex="-1" onkeydown="switchTab(event)\
                 " onclick="show('method', 'method-tab4', 2)" class="table-tab">Added in 2.0b</button\
                 ></div>
-                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab0">
+                <div id="method.tabpanel" role="tabpanel" aria-labelledby="method-tab5">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Method</div>
                 <div class="table-header col-last">Description</div>
@@ -833,7 +833,7 @@ public class TestNewApiList extends JavadocTester {
                 -selected="false" aria-controls="constructor.tabpanel" tabindex="-1" onkeydown="swit\
                 chTab(event)" onclick="show('constructor', 'constructor-tab4', 2)" class="table-tab"\
                 >Added in 2.0b</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab5">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>
@@ -872,7 +872,7 @@ public class TestNewApiList extends JavadocTester {
                 or-tab2" role="tab" aria-selected="false" aria-controls="constructor.tabpanel" tabin\
                 dex="-1" onkeydown="switchTab(event)" onclick="show('constructor', 'constructor-tab2\
                 ', 2)" class="table-tab">Deprecated in 5</button></div>
-                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab0">
+                <div id="constructor.tabpanel" role="tabpanel" aria-labelledby="constructor-tab5">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Constructor</div>
                 <div class="table-header col-last">Description</div>

--- a/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewApiList/TestNewApiList.java
@@ -761,7 +761,7 @@ public class TestNewApiList extends JavadocTester {
                 e-tab">New Classes</button><button id="class-tab5" role="tab" aria-selected="false" \
                 aria-controls="class.tabpanel" tabindex="-1" onkeydown="switchTab(event)" onclick="s\
                 how('class', 'class-tab5', 2)" class="table-tab">Added in 1.2</button></div>
-                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab50">
+                <div id="class.tabpanel" role="tabpanel" aria-labelledby="class-tab0">
                 <div class="summary-table two-column-summary">
                 <div class="table-header col-first">Class</div>
                 <div class="table-header col-last">Description</div>

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
@@ -315,7 +315,7 @@ public class TestOverrideMethods  extends JavadocTester {
         // Only those should be shown in summary; m1, m3, m9 should listed as declared in Base
         checkOutput("pkg6/Sub.html", true,
                 """
-                    <div class="summary-table three-column-summary" aria-labelledby="method-summary-table-tab0">
+                    <div class="summary-table three-column-summary">
                     <div class="table-header col-first">Modifier and Type</div>
                     <div class="table-header col-second">Method</div>
                     <div class="table-header col-last">Description</div>

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -822,8 +822,8 @@ public class TestSearch extends JavadocTester {
                     ck="show('all-classes-table', 'all-classes-table-tab7', 2)" class="table-tab">An\
                     notation Interfaces</button>\
                     </div>
-                    <div id="all-classes-table.tabpanel" role="tabpanel">
-                    <div class="summary-table two-column-summary" aria-labelledby="all-classes-table-tab0">
+                    <div id="all-classes-table.tabpanel" role="tabpanel" aria-labelledby="all-classes-table-tab0">
+                    <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Class</div>
                     <div class="table-header col-last">Description</div>""");
         checkOutput("allpackages-index.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -822,7 +822,7 @@ public class TestSearch extends JavadocTester {
                     ck="show('all-classes-table', 'all-classes-table-tab7', 2)" class="table-tab">An\
                     notation Interfaces</button>\
                     </div>
-                    <div id="all-classes-table.tabpanel" role="tabpanel" aria-labelledby="all-classes-table-tab7">
+                    <div id="all-classes-table.tabpanel" role="tabpanel" aria-labelledby="all-classes-table-tab0">
                     <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Class</div>
                     <div class="table-header col-last">Description</div>""");

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -822,7 +822,7 @@ public class TestSearch extends JavadocTester {
                     ck="show('all-classes-table', 'all-classes-table-tab7', 2)" class="table-tab">An\
                     notation Interfaces</button>\
                     </div>
-                    <div id="all-classes-table.tabpanel" role="tabpanel" aria-labelledby="all-classes-table-tab0">
+                    <div id="all-classes-table.tabpanel" role="tabpanel" aria-labelledby="all-classes-table-tab7">
                     <div class="summary-table two-column-summary">
                     <div class="table-header col-first">Class</div>
                     <div class="table-header col-last">Description</div>""");


### PR DESCRIPTION
This PR is a backport of https://github.com/openjdk/jdk/pull/16148

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311893](https://bugs.openjdk.org/browse/JDK-8311893) needs maintainer approval

### Issue
 * [JDK-8311893](https://bugs.openjdk.org/browse/JDK-8311893): Interactive component with ARIA role 'tabpanel' does not have a programmatically associated name (**Enhancement** - P4 - Approved)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2196/head:pull/2196` \
`$ git checkout pull/2196`

Update a local copy of the PR: \
`$ git checkout pull/2196` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2196`

View PR using the GUI difftool: \
`$ git pr show -t 2196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2196.diff">https://git.openjdk.org/jdk17u-dev/pull/2196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2196#issuecomment-1929346551)