### PR TITLE
8324824: AArch64: Detect Ampere-1B core and update default options for Ampere CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -143,10 +143,18 @@ void VM_Version::initialize() {
     }
   }
 
-  // Ampere CPUs: Ampere-1 and Ampere-1A
-  if (_cpu == CPU_AMPERE && ((_model == CPU_MODEL_AMPERE_1) || (_model == CPU_MODEL_AMPERE_1A))) {
+  // Ampere CPUs
+  if (_cpu == CPU_AMPERE && ((_model == CPU_MODEL_AMPERE_1)  ||
+                             (_model == CPU_MODEL_AMPERE_1A) ||
+                             (_model == CPU_MODEL_AMPERE_1B))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
+    }
+    if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
+      FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+    }
+    if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
+      FLAG_SET_DEFAULT(OnSpinWaitInstCount, 2);
     }
   }
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -107,8 +107,9 @@ public:
     CPU_MODEL_ALTRA     = 0xd0c, /* CPU implementer is CPU_ARM, Neoverse N1 */
     CPU_MODEL_ALTRAMAX  = 0xd0c, /* CPU implementer is CPU_ARM, Neoverse N1 */
     CPU_MODEL_AMPERE_1  = 0xac3, /* CPU implementer is CPU_AMPERE */
-    CPU_MODEL_AMPERE_1A = 0xac4  /* CPU implementer is CPU_AMPERE */
-  };
+    CPU_MODEL_AMPERE_1A = 0xac4, /* CPU implementer is CPU_AMPERE */
+    CPU_MODEL_AMPERE_1B = 0xac5  /* AMPERE_1B core Implements ARMv8.7 with CSSC, MTE, SM3/SM4 extensions */
+};
 
   enum Feature_Flag {
 #define CPU_FEATURE_FLAGS(decl)               \


### PR DESCRIPTION
Hi,

This pull request contains a backport of commit [9936aeea](https://github.com/openjdk/jdk/commit/9936aeea32b71509151099e6d28905e0322b2bc2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

Not a clean merge to 17u-dev. 
Manually resolved the merging conflicts due to line differences on `enum Ampere_CPU_Model` and `Feature_Flag`, removed redundant changes in order to limit the update to the code changes only from commit [9936aeea]. This can also lower the risk and limit the functionality impact to to particular Ampere new CPU cores Ampere-1/1A/1B. Same scope as that of the commit [9936aeea].

Passed pre-submit tests, ran Jtreg `tier1`, `tier2`, and `gtest` tests, no related issue found with the patch, also tested:
`make run-test TEST="jtreg:hotspot/jtreg/compiler/onSpinWait*" `
`make run-test TEST="micro:ThreadOnSpinWait*"`

Thanks for review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324824](https://bugs.openjdk.org/browse/JDK-8324824) needs maintainer approval

### Issue
 * [JDK-8324824](https://bugs.openjdk.org/browse/JDK-8324824): AArch64: Detect Ampere-1B core and update default options for Ampere CPUs (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2202/head:pull/2202` \
`$ git checkout pull/2202`

Update a local copy of the PR: \
`$ git checkout pull/2202` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2202`

View PR using the GUI difftool: \
`$ git pr show -t 2202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2202.diff">https://git.openjdk.org/jdk17u-dev/pull/2202.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2202#issuecomment-1936968203)