### PR TITLE
Backport 26755a968665545a151adce79a5227c79724bb6b

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -11,14 +11,14 @@
       span.underline{text-decoration: underline;}
       div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
-  <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css" />
+  <link rel="stylesheet" href="../make/data/docs-resources/resources/jdk-default.css">
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
   <![endif]-->
   <style type="text/css">pre, code, tt { color: #1d6ae5; }</style>
 </head>
 <body>
-<header id="title-block-header">
+<header>
 <h1 class="title">Building the JDK</h1>
 </header>
 <nav id="TOC">
@@ -174,22 +174,22 @@
 <table>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Operating system</th>
-<th style="text-align: left;">Vendor/version used</th>
+<th>Operating system</th>
+<th>Vendor/version used</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">Linux</td>
-<td style="text-align: left;">Oracle Enterprise Linux 6.4 / 7.6</td>
+<td>Linux</td>
+<td>Oracle Enterprise Linux 6.4 / 7.6</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">macOS</td>
-<td style="text-align: left;">Mac OS X 10.13 (High Sierra)</td>
+<td>macOS</td>
+<td>Mac OS X 10.13 (High Sierra)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">Windows</td>
-<td style="text-align: left;">Windows Server 2012 R2</td>
+<td>Windows</td>
+<td>Windows Server 2012 R2</td>
 </tr>
 </tbody>
 </table>
@@ -544,27 +544,27 @@
 <table>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Supported devkit targets</th>
+<th>Supported devkit targets</th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">x86_64-linux-gnu</td>
+<td>x86_64-linux-gnu</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">aarch64-linux-gnu</td>
+<td>aarch64-linux-gnu</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">arm-linux-gnueabihf</td>
+<td>arm-linux-gnueabihf</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">ppc64-linux-gnu</td>
+<td>ppc64-linux-gnu</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">ppc64le-linux-gnu</td>
+<td>ppc64le-linux-gnu</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">s390x-linux-gnu</td>
+<td>s390x-linux-gnu</td>
 </tr>
 </tbody>
 </table>
@@ -678,103 +678,103 @@ ls build/linux-aarch64-server-release/</code></pre></li>
 <table>
 <thead>
 <tr class="header">
-<th style="text-align: left;">Target</th>
-<th style="text-align: left;">Debian tree</th>
-<th style="text-align: left;">Debian arch</th>
-<th style="text-align: left;"><code>--openjdk-target=...</code></th>
+<th>Target</th>
+<th>Debian tree</th>
+<th>Debian arch</th>
+<th><code>--openjdk-target=...</code></th>
 <th><code>--with-jvm-variants=...</code></th>
 </tr>
 </thead>
 <tbody>
 <tr class="odd">
-<td style="text-align: left;">x86</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">i386</td>
-<td style="text-align: left;">i386-linux-gnu</td>
+<td>x86</td>
+<td>buster</td>
+<td>i386</td>
+<td>i386-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">arm</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">armhf</td>
-<td style="text-align: left;">arm-linux-gnueabihf</td>
+<td>arm</td>
+<td>buster</td>
+<td>armhf</td>
+<td>arm-linux-gnueabihf</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">aarch64</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">arm64</td>
-<td style="text-align: left;">aarch64-linux-gnu</td>
+<td>aarch64</td>
+<td>buster</td>
+<td>arm64</td>
+<td>aarch64-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">ppc64le</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">ppc64el</td>
-<td style="text-align: left;">powerpc64le-linux-gnu</td>
+<td>ppc64le</td>
+<td>buster</td>
+<td>ppc64el</td>
+<td>powerpc64le-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">s390x</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">s390x</td>
-<td style="text-align: left;">s390x-linux-gnu</td>
+<td>s390x</td>
+<td>buster</td>
+<td>s390x</td>
+<td>s390x-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">mipsle</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">mipsel</td>
-<td style="text-align: left;">mipsel-linux-gnu</td>
+<td>mipsle</td>
+<td>buster</td>
+<td>mipsel</td>
+<td>mipsel-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">mips64le</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">mips64el</td>
-<td style="text-align: left;">mips64el-linux-gnueabi64</td>
+<td>mips64le</td>
+<td>buster</td>
+<td>mips64el</td>
+<td>mips64el-linux-gnueabi64</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">armel</td>
-<td style="text-align: left;">buster</td>
-<td style="text-align: left;">arm</td>
-<td style="text-align: left;">arm-linux-gnueabi</td>
+<td>armel</td>
+<td>buster</td>
+<td>arm</td>
+<td>arm-linux-gnueabi</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">ppc</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">powerpc</td>
-<td style="text-align: left;">powerpc-linux-gnu</td>
+<td>ppc</td>
+<td>sid</td>
+<td>powerpc</td>
+<td>powerpc-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">ppc64be</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">ppc64</td>
-<td style="text-align: left;">powerpc64-linux-gnu</td>
+<td>ppc64be</td>
+<td>sid</td>
+<td>ppc64</td>
+<td>powerpc64-linux-gnu</td>
 <td>(all)</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">m68k</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">m68k</td>
-<td style="text-align: left;">m68k-linux-gnu</td>
+<td>m68k</td>
+<td>sid</td>
+<td>m68k</td>
+<td>m68k-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="even">
-<td style="text-align: left;">alpha</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">alpha</td>
-<td style="text-align: left;">alpha-linux-gnu</td>
+<td>alpha</td>
+<td>sid</td>
+<td>alpha</td>
+<td>alpha-linux-gnu</td>
 <td>zero</td>
 </tr>
 <tr class="odd">
-<td style="text-align: left;">sh4</td>
-<td style="text-align: left;">sid</td>
-<td style="text-align: left;">sh4</td>
-<td style="text-align: left;">sh4-linux-gnu</td>
+<td>sh4</td>
+<td>sid</td>
+<td>sh4</td>
+<td>sh4-linux-gnu</td>
 <td>zero</td>
 </tr>
 </tbody>

--- a/doc/building.md
+++ b/doc/building.md
@@ -154,11 +154,11 @@ This table lists the OS versions used by Oracle when building the JDK. Such
 information is always subject to change, but this table is up to date at the
 time of writing.
 
- Operating system   Vendor/version used
- -----------------  -------------------------------------------------------
- Linux              Oracle Enterprise Linux 6.4 / 7.6
- macOS              Mac OS X 10.13 (High Sierra)
- Windows            Windows Server 2012 R2
+| Operating system  | Vendor/version used                |
+| ----------------- | ---------------------------------- |
+| Linux             | Oracle Enterprise Linux 6.4 / 7.6  |
+| macOS             | Mac OS X 10.13 (High Sierra)       |
+| Windows           | Windows Server 2012 R2             |
 
 The double version numbers for Linux are due to the hybrid model
 used at Oracle, where header files and external libraries from an older version
@@ -957,14 +957,14 @@ https://sourceware.org/autobook/autobook/autobook_17.html). If no
 targets are given, a native toolchain for the current platform will be
 created. Currently, at least the following targets are known to work:
 
- Supported devkit targets
- -------------------------
- x86_64-linux-gnu
- aarch64-linux-gnu
- arm-linux-gnueabihf
- ppc64-linux-gnu
- ppc64le-linux-gnu
- s390x-linux-gnu
+| Supported devkit targets |
+| ------------------------ |
+| x86_64-linux-gnu         |
+| aarch64-linux-gnu        |
+| arm-linux-gnueabihf      |
+| ppc64-linux-gnu          |
+| ppc64le-linux-gnu        |
+| s390x-linux-gnu          |
 
 `BASE_OS` must be one of "OEL6" for Oracle Enterprise Linux 6 or
 "Fedora" (if not specified "OEL6" will be the default). If the base OS
@@ -1184,21 +1184,21 @@ it might require a little nudge with:
 
 Architectures that are known to successfully cross-compile like this are:
 
-  Target        Debian tree  Debian arch   `--openjdk-target=...`   `--with-jvm-variants=...`
-  ------------  ------------ ------------- ------------------------ --------------
-  x86           buster       i386          i386-linux-gnu           (all)
-  arm           buster       armhf         arm-linux-gnueabihf      (all)
-  aarch64       buster       arm64         aarch64-linux-gnu        (all)
-  ppc64le       buster       ppc64el       powerpc64le-linux-gnu    (all)
-  s390x         buster       s390x         s390x-linux-gnu          (all)
-  mipsle        buster       mipsel        mipsel-linux-gnu         zero
-  mips64le      buster       mips64el      mips64el-linux-gnueabi64 zero
-  armel         buster       arm           arm-linux-gnueabi        zero
-  ppc           sid          powerpc       powerpc-linux-gnu        zero
-  ppc64be       sid          ppc64         powerpc64-linux-gnu      (all)
-  m68k          sid          m68k          m68k-linux-gnu           zero
-  alpha         sid          alpha         alpha-linux-gnu          zero
-  sh4           sid          sh4           sh4-linux-gnu            zero
+| Target       | Debian tree  | Debian arch   | `--openjdk-target=...`   | `--with-jvm-variants=...` |
+| ------------ | ------------ | ------------- | ------------------------ | ------------------------- |
+| x86          | buster       | i386          | i386-linux-gnu           | (all)                     |
+| arm          | buster       | armhf         | arm-linux-gnueabihf      | (all)                     |
+| aarch64      | buster       | arm64         | aarch64-linux-gnu        | (all)                     |
+| ppc64le      | buster       | ppc64el       | powerpc64le-linux-gnu    | (all)                     |
+| s390x        | buster       | s390x         | s390x-linux-gnu          | (all)                     |
+| mipsle       | buster       | mipsel        | mipsel-linux-gnu         | zero                      |
+| mips64le     | buster       | mips64el      | mips64el-linux-gnueabi64 | zero                      |
+| armel        | buster       | arm           | arm-linux-gnueabi        | zero                      |
+| ppc          | sid          | powerpc       | powerpc-linux-gnu        | zero                      |
+| ppc64be      | sid          | ppc64         | powerpc64-linux-gnu      | (all)                     |
+| m68k         | sid          | m68k          | m68k-linux-gnu           | zero                      |
+| alpha        | sid          | alpha         | alpha-linux-gnu          | zero                      |
+| sh4          | sid          | sh4           | sh4-linux-gnu            | zero                      |
 
 ### Building for ARM/aarch64
 


### PR DESCRIPTION
Backport fixing several tables in `doc/building.md`, so they would display correctly in GitHub. Change set applied almost cleanly to `doc/building.md` (only last table has one more target in original changeset). File `doc/building.html` was regenerated.