### PR TITLE
8325585: Remove no longer necessary calls to set/unset-in-asgct flag in JDK 17

### DIFF
--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -595,9 +595,6 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  // !important! make sure all to call thread->set_in_asgct(false) before every return
-  thread->set_in_asgct(true);
-
   // signify to other code in the VM that we're in ASGCT
   ThreadInAsgct tia(thread);
 
@@ -658,7 +655,6 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     trace->num_frames = ticks_unknown_state; // -7
     break;
   }
-  thread->set_in_asgct(false);
 }
 
 


### PR DESCRIPTION
Remove two duplicate calls introduced by the backport of [JDK-8304725](https://bugs.openjdk.org/browse/JDK-8304725).
Tested locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325585](https://bugs.openjdk.org/browse/JDK-8325585) needs maintainer approval

### Issue
 * [JDK-8325585](https://bugs.openjdk.org/browse/JDK-8325585): Remove no longer necessary calls to set/unset-in-asgct flag in JDK 17 (**Task** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2207/head:pull/2207` \
`$ git checkout pull/2207`

Update a local copy of the PR: \
`$ git checkout pull/2207` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2207`

View PR using the GUI difftool: \
`$ git pr show -t 2207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2207.diff">https://git.openjdk.org/jdk17u-dev/pull/2207.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2207#issuecomment-1941292954)