### PR TITLE
8286740: JFR: Active Setting event emitted incorrectly

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
@@ -37,13 +37,6 @@ import jdk.jfr.internal.Type;
 @StackTrace(false)
 public final class ActiveSettingEvent extends AbstractJDKEvent {
 
-    public static final ThreadLocal<ActiveSettingEvent> EVENT = new ThreadLocal<ActiveSettingEvent>() {
-        @Override
-        protected ActiveSettingEvent initialValue() {
-            return new ActiveSettingEvent();
-        }
-    };
-
     @Label("Event Id")
     public long id;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -290,13 +290,13 @@ public final class EventControl {
         if (!type.isRegistered()) {
             return;
         }
-        ActiveSettingEvent event = ActiveSettingEvent.EVENT.get();
         for (NamedControl nc : namedControls) {
             if (Utils.isSettingVisible(nc.control, type.hasEventHook())) {
                 String value = nc.control.getLastValue();
                 if (value == null) {
                     value = nc.control.getDefaultValue();
                 }
+                ActiveSettingEvent event = new ActiveSettingEvent();
                 event.id = type.getId();
                 event.name = nc.name;
                 event.value = value;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -144,7 +144,7 @@ public final class MetadataRepository {
         handler.setRegistered(true);
         typeLibrary.addType(handler.getPlatformEventType());
         if (jvm.isRecording()) {
-            settingsManager.setEventControl(handler.getEventControl());
+            settingsManager.setEventControl(handler.getEventControl(), true);
             settingsManager.updateRetransform(Collections.singletonList((eventClass)));
        }
        setStaleMetadata();
@@ -199,8 +199,8 @@ public final class MetadataRepository {
     }
 
 
-    public synchronized void setSettings(List<Map<String, String>> list) {
-        settingsManager.setSettings(list);
+    public synchronized void setSettings(List<Map<String, String>> list, boolean writeSettingEvents) {
+        settingsManager.setSettings(list, writeSettingEvents);
     }
 
     synchronized void disableEvents() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -256,7 +256,7 @@ public final class PlatformRecorder {
                 currentChunk.setStartTime(startTime);
             }
             recording.setState(RecordingState.RUNNING);
-            updateSettings();
+            updateSettings(false);
             recording.setStartTime(startTime);
             writeMetaEvents();
         } else {
@@ -275,7 +275,7 @@ public final class PlatformRecorder {
             startTime = Utils.epochNanosToInstant(startNanos);
             recording.setStartTime(startTime);
             recording.setState(RecordingState.RUNNING);
-            updateSettings();
+            updateSettings(false);
             writeMetaEvents();
             if (currentChunk != null) {
                 finishChunk(currentChunk, startTime, recording);
@@ -339,7 +339,7 @@ public final class PlatformRecorder {
         } else {
             RepositoryChunk newChunk = null;
             RequestEngine.doChunkEnd();
-            updateSettingsButIgnoreRecording(recording);
+            updateSettingsButIgnoreRecording(recording, false);
 
             String path = null;
             if (toDisk) {
@@ -383,11 +383,11 @@ public final class PlatformRecorder {
         MetadataRepository.getInstance().disableEvents();
     }
 
-    void updateSettings() {
-        updateSettingsButIgnoreRecording(null);
+    void updateSettings(boolean writeSettingEvents) {
+        updateSettingsButIgnoreRecording(null, writeSettingEvents);
     }
 
-    void updateSettingsButIgnoreRecording(PlatformRecording ignoreMe) {
+    void updateSettingsButIgnoreRecording(PlatformRecording ignoreMe, boolean writeSettingEvents) {
         List<PlatformRecording> recordings = getRunningRecordings();
         List<Map<String, String>> list = new ArrayList<>(recordings.size());
         for (PlatformRecording r : recordings) {
@@ -395,7 +395,7 @@ public final class PlatformRecorder {
                 list.add(r.getSettings());
             }
         }
-        MetadataRepository.getInstance().setSettings(list);
+        MetadataRepository.getInstance().setSettings(list, writeSettingEvents);
     }
 
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecording.java
@@ -468,7 +468,7 @@ public final class PlatformRecording implements AutoCloseable {
         synchronized (recorder) {
             this.settings.put(id, value);
             if (getState() == RecordingState.RUNNING) {
-                recorder.updateSettings();
+                recorder.updateSettings(true);
             }
         }
     }
@@ -489,7 +489,7 @@ public final class PlatformRecording implements AutoCloseable {
         synchronized (recorder) {
             this.settings = new LinkedHashMap<>(settings);
             if (getState() == RecordingState.RUNNING && update) {
-                recorder.updateSettings();
+                recorder.updateSettings(true);
             }
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -130,7 +130,7 @@ final class SettingsManager {
 
    private Map<String, InternalSetting> availableSettings = new LinkedHashMap<>();
 
-    void setSettings(List<Map<String, String>> activeSettings) {
+    void setSettings(List<Map<String, String>> activeSettings, boolean writeSettingEvents) {
         // store settings so they are available if a new event class is loaded
         availableSettings = createSettingsMap(activeSettings);
         List<EventControl> eventControls = MetadataRepository.getInstance().getEventControls();
@@ -143,7 +143,7 @@ final class SettingsManager {
                 Collections.sort(eventControls, (x,y) -> x.getEventType().getName().compareTo(y.getEventType().getName()));
             }
             for (EventControl ec : eventControls) {
-                setEventControl(ec);
+                setEventControl(ec, writeSettingEvents);
             }
         }
         if (JVM.getJVM().getAllowedToDoEventRetransforms()) {
@@ -211,7 +211,7 @@ final class SettingsManager {
       return internals.values();
     }
 
-    void setEventControl(EventControl ec) {
+    void setEventControl(EventControl ec, boolean writeSettingEvents) {
         InternalSetting is = getInternalSetting(ec);
         boolean shouldLog = Logger.shouldLog(LogTag.JFR_SETTING, LogLevel.INFO);
         if (shouldLog) {
@@ -250,7 +250,9 @@ final class SettingsManager {
                 }
             }
         }
-        ec.writeActiveSettingEvent();
+        if (writeSettingEvents) {
+            ec.writeActiveSettingEvent();
+        }
         if (shouldLog) {
             Logger.log(LogTag.JFR_SETTING, LogLevel.INFO, "}");
         }

--- a/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestActiveSettingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,10 @@
 package jdk.jfr.event.runtime;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import jdk.jfr.Configuration;
 import jdk.jfr.Event;
@@ -60,6 +62,7 @@ public final class TestActiveSettingEvent {
     public static void main(String[] args) throws Throwable {
         testDefaultSettings();;
         testProfileSettings();;
+        testOnlyOnce();
         testNewSettings();
         testChangedSetting();
         testUnregistered();
@@ -72,6 +75,39 @@ public final class TestActiveSettingEvent {
 
     private static void testDefaultSettings() throws Exception {
         testSettingConfiguration("default");
+    }
+
+    private static void testOnlyOnce() throws Exception {
+        Configuration c = Configuration.getConfiguration("default");
+        try (Recording r = new Recording(c)) {
+            r.enable(ACTIVE_SETTING_EVENT_NAME).withStackTrace();
+            r.start();
+            r.stop();
+            Map<String, RecordedEvent> settings = new HashMap<>();
+            List<RecordedEvent> events = Events.fromRecording(r);
+            for (RecordedEvent e : events) {
+                if (e.getEventType().getName().equals(ACTIVE_SETTING_EVENT_NAME)) {
+                    long id = e.getLong("id");
+                    String name = e.getString("name");
+                    String value = e.getString("value");
+                    String s = id + "#" + name + "=" + value;
+                    if (settings.containsKey(s)) {
+                        System.out.println("Event:");
+                        System.out.println(settings.get(s));
+                        System.out.println("Duplicated by:");
+                        System.out.println(e);
+                        String message = "Found duplicated setting '" + s + "'";
+                        for (EventType type : FlightRecorder.getFlightRecorder().getEventTypes()) {
+                            if (type.getId() == id) {
+                                throw new Exception(message+  " for " + type.getName());
+                            }
+                        }
+                        throw new Exception(message);
+                    }
+                    settings.put(s, e);
+                }
+            }
+        }
     }
 
     private static void testRegistration() throws Exception {


### PR DESCRIPTION
jtreg_jfr passed [here](https://github.com/DataDog/openjdk-jdk17/actions/runs/7928014975)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286740](https://bugs.openjdk.org/browse/JDK-8286740) needs maintainer approval

### Issue
 * [JDK-8286740](https://bugs.openjdk.org/browse/JDK-8286740): JFR: Active Setting event emitted incorrectly (**Bug** - P3 - Approved)


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.org/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2210/head:pull/2210` \
`$ git checkout pull/2210`

Update a local copy of the PR: \
`$ git checkout pull/2210` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2210`

View PR using the GUI difftool: \
`$ git pr show -t 2210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2210.diff">https://git.openjdk.org/jdk17u-dev/pull/2210.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2210#issuecomment-1948069022)