### PR TITLE
8308336: Test java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java failed: java.net.BindException: Address already in use

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -27,8 +27,11 @@
  * @summary Verify that expect 100-continue doesn't hang
  * @library /test/lib
  * @run junit/othervm HttpURLConnectionExpectContinueTest
+ * @run junit/othervm -Djava.net.preferIPv4Stack=true HttpURLConnectionExpectContinueTest
+ * @run junit/othervm -Djava.net.preferIPv6Addresses=true HttpURLConnectionExpectContinueTest
  */
 
+import jdk.test.lib.net.URIBuilder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -73,7 +76,7 @@ public class HttpURLConnectionExpectContinueTest {
 
         control.serverSocket = new ServerSocket();
         control.serverSocket.setReuseAddress(true);
-        control.serverSocket.bind(new InetSocketAddress("127.0.0.1", 54321));
+        control.serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         Runnable runnable = () -> {
             while (!control.stop) {
                 try {
@@ -419,8 +422,12 @@ public class HttpURLConnectionExpectContinueTest {
     }
 
     // Creates a connection with all the common settings used in each test
-    private HttpURLConnection createConnection() throws IOException {
-        URL url = new URL("http://localhost:" + control.serverSocket.getLocalPort());
+    private HttpURLConnection createConnection() throws Exception {
+        URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(control.serverSocket.getLocalPort())
+                .toURL();
 
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoOutput(true);


### PR DESCRIPTION
This is a backport of JDK-8308336: Test java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java failed: java.net.BindException: Address already in use

It is required for backport of JDK-8054022 / https://github.com/openjdk/jdk11u-dev/pull/2523 to 11u-dev.

The patch applies clean.

Testing: x86_64 build, affected test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8308336](https://bugs.openjdk.org/browse/JDK-8308336) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308336](https://bugs.openjdk.org/browse/JDK-8308336): Test java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java failed: java.net.BindException: Address already in use (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2211/head:pull/2211` \
`$ git checkout pull/2211`

Update a local copy of the PR: \
`$ git checkout pull/2211` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2211`

View PR using the GUI difftool: \
`$ git pr show -t 2211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2211.diff">https://git.openjdk.org/jdk17u-dev/pull/2211.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2211#issuecomment-1948730586)