### PR TITLE
8314164: java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails intermittently in timeout

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -431,7 +431,6 @@ public class HttpURLConnectionExpectContinueTest {
 
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoOutput(true);
-        connection.setConnectTimeout(1000);
         connection.setReadTimeout(5000);
         connection.setUseCaches(false);
         connection.setInstanceFollowRedirects(false);


### PR DESCRIPTION
This is a backport of JDK-8314164: java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails intermittently in timeout

It is required for backport of JDK-8054022 / https://github.com/openjdk/jdk11u-dev/pull/2523 so i'm trying to bring it back all the way to 11u-dev.

The patch applies clean.

Testing: x86_64 build, affected test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8314164](https://bugs.openjdk.org/browse/JDK-8314164) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314164](https://bugs.openjdk.org/browse/JDK-8314164): java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails intermittently in timeout (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2213/head:pull/2213` \
`$ git checkout pull/2213`

Update a local copy of the PR: \
`$ git checkout pull/2213` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2213`

View PR using the GUI difftool: \
`$ git pr show -t 2213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2213.diff">https://git.openjdk.org/jdk17u-dev/pull/2213.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2213#issuecomment-1953737947)