### PR TITLE
8288846: misc tests fail "assert(ms < 1000) failed: Un-interruptable sleep, short time use only"

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -34,6 +34,7 @@
 #include "jfr/utilities/jfrTime.hpp"
 #include "jfrfiles/jfrEventClasses.hpp"
 #include "logging/log.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/os.hpp"
 #include "runtime/semaphore.hpp"
@@ -350,8 +351,8 @@ class JfrThreadSampler : public NonJavaThread {
   void run();
   static Monitor* transition_block() { return JfrThreadSampler_lock; }
   static void on_javathread_suspend(JavaThread* thread);
-  int64_t get_java_period() const { return _java_period_millis; };
-  int64_t get_native_period() const { return _native_period_millis; };
+  int64_t get_java_period() const { return Atomic::load(&_java_period_millis); };
+  int64_t get_native_period() const { return Atomic::load(&_native_period_millis); };
 };
 
 static void clear_transition_block(JavaThread* jt) {
@@ -412,12 +413,12 @@ JfrThreadSampler::~JfrThreadSampler() {
 
 void JfrThreadSampler::set_java_period(int64_t period_millis) {
   assert(period_millis >= 0, "invariant");
-  _java_period_millis = period_millis;
+  Atomic::store(&_java_period_millis, period_millis);
 }
 
 void JfrThreadSampler::set_native_period(int64_t period_millis) {
   assert(period_millis >= 0, "invariant");
-  _native_period_millis = period_millis;
+  Atomic::store(&_native_period_millis, period_millis);
 }
 
 static inline bool is_released(JavaThread* jt) {
@@ -496,8 +497,17 @@ void JfrThreadSampler::run() {
       last_native_ms = last_java_ms;
     }
     _sample.signal();
-    const int64_t java_period_millis = _java_period_millis == 0 ? max_jlong : MAX2<int64_t>(_java_period_millis, 1);
-    const int64_t native_period_millis = _native_period_millis == 0 ? max_jlong : MAX2<int64_t>(_native_period_millis, 1);
+
+    int64_t java_period_millis = get_java_period();
+    java_period_millis = java_period_millis == 0 ? max_jlong : MAX2<int64_t>(java_period_millis, 1);
+    int64_t native_period_millis = get_native_period();
+    native_period_millis = native_period_millis == 0 ? max_jlong : MAX2<int64_t>(native_period_millis, 1);
+
+    // If both periods are max_jlong, it implies the sampler is in the process of
+    // disenrolling. Loop back for graceful disenroll by means of the semaphore.
+    if (java_period_millis == max_jlong && native_period_millis == max_jlong) {
+      continue;
+    }
 
     const int64_t now_ms = get_monotonic_ms();
 
@@ -516,7 +526,7 @@ void JfrThreadSampler::run() {
     const int64_t sleep_to_next = MIN2<int64_t>(next_j, next_n);
 
     if (sleep_to_next > 0) {
-      os::naked_short_sleep(sleep_to_next);
+      os::naked_sleep(sleep_to_next);
     }
 
     if ((next_j - sleep_to_next) <= 0) {

--- a/test/jdk/jdk/jfr/event/sampling/TestNative.java
+++ b/test/jdk/jdk/jfr/event/sampling/TestNative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,9 +48,12 @@ public class TestNative {
 
     static volatile boolean alive = true;
 
+    // Please resist the temptation to speed up the test by decreasing
+    // the period. It is explicity set to 1100 ms to provoke the 1000 ms
+    // threshold in the JVM for os::naked_short_sleep().
     public static void main(String[] args) throws Exception {
         try (RecordingStream rs = new RecordingStream()) {
-            rs.enable(NATIVE_EVENT).withPeriod(Duration.ofMillis(1));
+            rs.enable(NATIVE_EVENT).withPeriod(Duration.ofMillis(1100));
             rs.onEvent(NATIVE_EVENT, e -> {
                 alive = false;
                 rs.close();


### PR DESCRIPTION
I want to backport this to fix the regression brought to 17.0.11 by JDK-8288663.

We saw three failures of jdk/jfr/startupargs/TestMemoryOptions.java since Nov 23 in our CI because of this.
assert(ms < 1000) failed: Un-interruptable sleep, short time use only

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8288846](https://bugs.openjdk.org/browse/JDK-8288846) needs maintainer approval

### Issue
 * [JDK-8288846](https://bugs.openjdk.org/browse/JDK-8288846): misc tests fail "assert(ms &lt; 1000) failed: Un-interruptable sleep, short time use only" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2219/head:pull/2219` \
`$ git checkout pull/2219`

Update a local copy of the PR: \
`$ git checkout pull/2219` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2219`

View PR using the GUI difftool: \
`$ git pr show -t 2219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2219.diff">https://git.openjdk.org/jdk17u-dev/pull/2219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2219#issuecomment-1959097298)