### PR TITLE
8325254: CKA_TOKEN private and secret keys are not necessarily sensitive

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -395,8 +395,9 @@ abstract class P11Key implements Key, Length {
                     new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
 
-        boolean keySensitive = (attrs[0].getBoolean() ||
-                attrs[1].getBoolean() || !attrs[2].getBoolean());
+        boolean keySensitive =
+                (attrs[0].getBoolean() && P11Util.isNSS(session.token)) ||
+                attrs[1].getBoolean() || !attrs[2].getBoolean();
 
         switch (algorithm) {
         case "RSA":


### PR DESCRIPTION
Hello,

I would like to propose a backport of the 8325254 fix to 17u as this release is affected by the bug. Note: all releases that have 8271566 are affected. Risk is minimal.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325254](https://bugs.openjdk.org/browse/JDK-8325254) needs maintainer approval

### Issue
 * [JDK-8325254](https://bugs.openjdk.org/browse/JDK-8325254): CKA_TOKEN private and secret keys are not necessarily sensitive (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2223/head:pull/2223` \
`$ git checkout pull/2223`

Update a local copy of the PR: \
`$ git checkout pull/2223` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2223`

View PR using the GUI difftool: \
`$ git pr show -t 2223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2223.diff">https://git.openjdk.org/jdk17u-dev/pull/2223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2223#issuecomment-1960872809)