### PR TITLE
8280030: [REDO] Parallel: More precise boundary in ObjectStartArray::object_starts_in_range

### DIFF
--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -130,8 +130,15 @@ bool ObjectStartArray::object_starts_in_range(HeapWord* start_addr,
          "Range is wrong. start_addr (" PTR_FORMAT ") is after end_addr (" PTR_FORMAT ")",
          p2i(start_addr), p2i(end_addr));
 
+  assert(is_aligned(start_addr, _card_size), "precondition");
+
+  if (start_addr == end_addr) {
+    // No objects in empty range.
+    return false;
+  }
+
   jbyte* start_block = block_for_addr(start_addr);
-  jbyte* end_block = block_for_addr(end_addr);
+  jbyte* end_block = block_for_addr(end_addr - 1);
 
   for (jbyte* block = start_block; block <= end_block; block++) {
     if (*block != clean_block) {

--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -130,7 +130,7 @@ bool ObjectStartArray::object_starts_in_range(HeapWord* start_addr,
          "Range is wrong. start_addr (" PTR_FORMAT ") is after end_addr (" PTR_FORMAT ")",
          p2i(start_addr), p2i(end_addr));
 
-  assert(is_aligned(start_addr, _card_size), "precondition");
+  assert(is_aligned(start_addr, CardTable::card_size), "precondition");
 
   if (start_addr == end_addr) {
     // No objects in empty range.

--- a/src/hotspot/share/gc/parallel/objectStartArray.hpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.hpp
@@ -147,9 +147,11 @@ class ObjectStartArray : public CHeapObj<mtGC> {
     return *block != clean_block;
   }
 
-  // Return true if an object starts in the range of heap addresses.
-  // If an object starts at an address corresponding to
-  // "start", the method will return true.
+  // Return true iff an object starts in
+  //   [start_addr, end_addr_aligned_up)
+  // where
+  //   end_addr_aligned_up = align_up(end_addr, _card_size)
+  // Precondition: start_addr is card-size aligned
   bool object_starts_in_range(HeapWord* start_addr, HeapWord* end_addr) const;
 };
 


### PR DESCRIPTION
This backport is a transitive dependency for the backport of https://bugs.openjdk.org/browse/JDK-8310031

8310031 requires 8282094: [REDO] Parallel: Refactor PSCardTable::scavenge_contents_parallel
and 8282094 requires this backport.

8310031 could be backported w/o this backport if 8282094 could be squashed into it because with 8310031 `ObjectStartArray::object_starts_in_range()` is not reached anymore from `PSCardTable::scavenge_contents_parallel()`.

This backport applies cleanly but needs a trivial renaming (see 2nd commit).

Risk is low: it's a small change. The changed method has just 2 callers of which one is for diagnostics.

Manual testing on x86_64:
jdk:tier1       TEST_VM_OPTS="-XX:+UseParallelGC"
langtools:tier1 TEST_VM_OPTS="-XX:+UseParallelGC"

Local CI Testing:
The fix passed our CI testing (e.g. 2024-02-22): JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests (also with ParallelGC).
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8280030](https://bugs.openjdk.org/browse/JDK-8280030) needs maintainer approval

### Issue
 * [JDK-8280030](https://bugs.openjdk.org/browse/JDK-8280030): [REDO] Parallel: More precise boundary in ObjectStartArray::object_starts_in_range (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2226/head:pull/2226` \
`$ git checkout pull/2226`

Update a local copy of the PR: \
`$ git checkout pull/2226` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2226`

View PR using the GUI difftool: \
`$ git pr show -t 2226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2226.diff">https://git.openjdk.org/jdk17u-dev/pull/2226.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2226#issuecomment-1961095756)