### PR TITLE
8310031: Parallel: Implement better work distribution for large object arrays in old gen

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -33,6 +33,7 @@
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/prefetch.inline.hpp"
+#include "utilities/spinYield.hpp"
 #include "utilities/align.hpp"
 
 // Checks an individual oop for missing precise marks. Mark
@@ -123,70 +124,184 @@ static void prefetch_write(void *p) {
   }
 }
 
-// postcondition: ret is a dirty card or end_card
-CardTable::CardValue* PSCardTable::find_first_dirty_card(CardValue* const start_card,
-                                                         CardValue* const end_card) {
-  for (CardValue* i_card = start_card; i_card < end_card; ++i_card) {
-    if (*i_card != PSCardTable::clean_card_val()) {
-      return i_card;
-    }
+void PSCardTable::scan_obj_with_limit(PSPromotionManager* pm,
+                                      oop obj,
+                                      HeapWord* start,
+                                      HeapWord* end) {
+  if (!obj->is_typeArray()) {
+    prefetch_write(start);
+    pm->push_contents_bounded(obj, start, end);
   }
-  return end_card;
 }
 
-// postcondition: ret is a clean card or end_card
-// Note: if a part of an object is on a dirty card, all cards this object
-// resides on are considered dirty.
-CardTable::CardValue* PSCardTable::find_first_clean_card(ObjectStartArray* const start_array,
-                                                         CardValue* const start_card,
-                                                         CardValue* const end_card) {
-  assert(start_card == end_card ||
-         *start_card != PSCardTable::clean_card_val(), "precondition");
-  // Skip the first dirty card.
-  CardValue* i_card = start_card + 1;
-  while (i_card < end_card) {
-    if (*i_card != PSCardTable::clean_card_val()) {
-      i_card++;
+void PSCardTable::pre_scavenge(HeapWord* old_gen_bottom, uint active_workers) {
+  _preprocessing_active_workers = active_workers;
+}
+
+// The "shadow" table is a copy of the card table entries of the current stripe.
+// It is used to separate card reading, clearing and redirtying which reduces
+// complexity significantly.
+class PSStripeShadowCardTable {
+  typedef CardTable::CardValue CardValue;
+
+  const uint _card_shift;
+  const uint _card_size;
+  CardValue _table[PSCardTable::num_cards_in_stripe];
+  const CardValue* _table_base;
+
+public:
+  PSStripeShadowCardTable(PSCardTable* pst, HeapWord* const start, HeapWord* const end) :
+    _card_shift(CardTable::card_shift()),
+    _card_size(CardTable::card_size()),
+    _table_base(_table - (uintptr_t(start) >> _card_shift)) {
+    size_t stripe_byte_size = pointer_delta(end, start) * HeapWordSize;
+    size_t copy_length = align_up(stripe_byte_size, _card_size) >> _card_shift;
+    // The end of the last stripe may not be card aligned as it is equal to old
+    // gen top at scavenge start. We should not clear the card containing old gen
+    // top if not card aligned because there can be promoted objects on that
+    // same card. If it was marked dirty because of the promoted objects and we
+    // cleared it, we would loose a card mark.
+    size_t clear_length = align_down(stripe_byte_size, _card_size) >> _card_shift;
+    CardValue* stripe_start_card = pst->byte_for(start);
+    memcpy(_table, stripe_start_card, copy_length);
+    memset(stripe_start_card, CardTable::clean_card_val(), clear_length);
+  }
+
+  HeapWord* addr_for(const CardValue* const card) {
+    assert(card >= _table && card <=  &_table[PSCardTable::num_cards_in_stripe], "out of bounds");
+    return (HeapWord*) ((card - _table_base) << _card_shift);
+  }
+
+  const CardValue* card_for(HeapWord* addr) {
+    return &_table_base[uintptr_t(addr) >> _card_shift];
+  }
+
+  bool is_dirty(const CardValue* const card) {
+    return !is_clean(card);
+  }
+
+  bool is_clean(const CardValue* const card) {
+    assert(card >= _table && card <  &_table[PSCardTable::num_cards_in_stripe], "out of bounds");
+    return *card == PSCardTable::clean_card_val();
+  }
+
+  const CardValue* find_first_dirty_card(const CardValue* const start,
+                                         const CardValue* const end) {
+    for (const CardValue* i = start; i < end; ++i) {
+      if (is_dirty(i)) {
+        return i;
+      }
+    }
+    return end;
+  }
+
+  const CardValue* find_first_clean_card(const CardValue* const start,
+                                         const CardValue* const end) {
+    for (const CardValue* i = start; i < end; ++i) {
+      if (is_clean(i)) {
+        return i;
+      }
+    }
+    return end;
+  }
+};
+
+template <typename Func>
+void PSCardTable::process_range(Func&& object_start,
+                                PSPromotionManager* pm,
+                                HeapWord* const start,
+                                HeapWord* const end) {
+  assert(start < end, "precondition");
+  assert(is_card_aligned(start), "precondition");
+
+  PSStripeShadowCardTable sct(this, start, end);
+
+  // end might not be card-aligned.
+  const CardValue* end_card = sct.card_for(end - 1) + 1;
+
+  for (HeapWord* i_addr = start; i_addr < end; /* empty */) {
+    const CardValue* dirty_l = sct.find_first_dirty_card(sct.card_for(i_addr), end_card);
+    const CardValue* dirty_r = sct.find_first_clean_card(dirty_l, end_card);
+
+    assert(dirty_l <= dirty_r, "inv");
+
+    if (dirty_l == dirty_r) {
+      assert(dirty_r == end_card, "inv");
+      break;
+    }
+
+    // Located a non-empty dirty chunk [dirty_l, dirty_r).
+    HeapWord* addr_l = sct.addr_for(dirty_l);
+    HeapWord* addr_r = MIN2(sct.addr_for(dirty_r), end);
+
+    // Scan objects overlapping [addr_l, addr_r) limited to [start, end).
+    HeapWord* obj_addr = object_start(addr_l);
+
+    while (true) {
+      assert(obj_addr < addr_r, "inv");
+
+      oop obj = cast_to_oop(obj_addr);
+      const bool is_obj_array = obj->is_objArray();
+      HeapWord* const obj_end_addr = obj_addr + obj->size();
+
+      if (is_obj_array) {
+        // Always scan obj arrays precisely (they are always marked precisely)
+        // to avoid unnecessary work.
+        scan_obj_with_limit(pm, obj, addr_l, addr_r);
+      } else {
+        if (obj_addr < i_addr && i_addr > start) {
+          // Already scanned this object. Has been one that spans multiple dirty chunks.
+          // The second condition makes sure objects reaching in the stripe are scanned once.
+        } else {
+          scan_obj_with_limit(pm, obj, addr_l, end);
+        }
+      }
+
+      if (obj_end_addr >= addr_r) {
+        i_addr = is_obj_array ? addr_r : obj_end_addr;
+        break;
+      }
+
+      // Move to next obj inside this dirty chunk.
+      obj_addr = obj_end_addr;
+    }
+
+    // Finished a dirty chunk.
+    pm->drain_stacks_cond_depth();
+  }
+}
+
+template <typename Func>
+void PSCardTable::preprocess_card_table_parallel(Func&& object_start,
+                                                 HeapWord* old_gen_bottom,
+                                                 HeapWord* old_gen_top,
+                                                 uint stripe_index,
+                                                 uint n_stripes) {
+  const size_t num_cards_in_slice = num_cards_in_stripe * n_stripes;
+  CardValue* cur_card = byte_for(old_gen_bottom) + stripe_index * num_cards_in_stripe;
+  CardValue* const end_card = byte_for(old_gen_top - 1) + 1;
+
+  for (/* empty */; cur_card < end_card; cur_card += num_cards_in_slice) {
+    HeapWord* stripe_addr = addr_for(cur_card);
+    if (is_dirty(cur_card)) {
+      // The first card of this stripe is already dirty, no need to see if the
+      // reaching-in object is a potentially imprecisely marked non-array
+      // object.
       continue;
     }
-    assert(i_card - 1 >= start_card, "inv");
-    assert(*(i_card - 1) != PSCardTable::clean_card_val(), "prev card must be dirty");
-    // Find the final obj on the prev dirty card.
-    HeapWord* obj_addr = start_array->object_start(addr_for(i_card)-1);
-    HeapWord* obj_end_addr = obj_addr + cast_to_oop(obj_addr)->size();
-    CardValue* final_card_by_obj = byte_for(obj_end_addr - 1);
-    assert(final_card_by_obj < end_card, "inv");
-    if (final_card_by_obj <= i_card) {
-      return i_card;
+    HeapWord* first_obj_addr = object_start(stripe_addr);
+    if (first_obj_addr == stripe_addr) {
+      // No object reaching into this stripe.
+      continue;
     }
-    // This final obj extends beyond i_card, check if this new card is dirty.
-    if (*final_card_by_obj == PSCardTable::clean_card_val()) {
-      return final_card_by_obj;
+    oop first_obj = cast_to_oop(first_obj_addr);
+    if (!first_obj->is_array() && is_dirty(byte_for(first_obj_addr))) {
+      // Found a non-array object reaching into the stripe that has
+      // potentially been marked imprecisely. Mark first card of the stripe
+      // dirty so it will be processed later.
+      *cur_card = dirty_card_val();
     }
-    // This new card is dirty, continuing the search...
-    i_card = final_card_by_obj + 1;
   }
-  return end_card;
-}
-
-void PSCardTable::clear_cards(CardValue* const start, CardValue* const end) {
-  for (CardValue* i_card = start; i_card < end; ++i_card) {
-    *i_card = clean_card;
-  }
-}
-
-void PSCardTable::scan_objects_in_range(PSPromotionManager* pm,
-                                        HeapWord* start,
-                                        HeapWord* end) {
-  HeapWord* obj_addr = start;
-  while (obj_addr < end) {
-    oop obj = cast_to_oop(obj_addr);
-    assert(oopDesc::is_oop(obj), "inv");
-    prefetch_write(obj_addr);
-    pm->push_contents(obj);
-    obj_addr += obj->size();
-  }
-  pm->drain_stacks_cond_depth();
 }
 
 // We get passed the space_top value to prevent us from traversing into
@@ -227,103 +342,61 @@ void PSCardTable::scan_objects_in_range(PSPromotionManager* pm,
 // slice_size_in_words to the start of stripe 0 in slice 0 to get to the start
 // of stripe 0 in slice 1.
 
+// Scavenging and accesses to the card table are strictly limited to the stripe.
+// In particular scavenging of an object crossing stripe boundaries is shared
+// among the threads assigned to the stripes it resides on. This reduces
+// complexity and enables shared scanning of large objects.
+// It requires preprocessing of the card table though where imprecise card marks of
+// objects crossing stripe boundaries are propagated to the first card of
+// each stripe covered by the individual object.
+
 void PSCardTable::scavenge_contents_parallel(ObjectStartArray* start_array,
-                                             MutableSpace* sp,
-                                             HeapWord* space_top,
+                                             HeapWord* old_gen_bottom,
+                                             HeapWord* old_gen_top,
                                              PSPromotionManager* pm,
                                              uint stripe_index,
                                              uint n_stripes) {
-  const size_t num_cards_in_stripe = 128;
+  // ObjectStartArray queries can be expensive for large objects. We cache known objects.
+  struct {
+    HeapWord* start_addr;
+    HeapWord* end_addr;
+  } cached_obj {nullptr, old_gen_bottom};
+
+  // Queries must be monotonic because we don't check addr >= cached_obj.start_addr.
+  auto object_start = [&] (HeapWord* addr) {
+    if (addr < cached_obj.end_addr) {
+      assert(cached_obj.start_addr != nullptr, "inv");
+      return cached_obj.start_addr;
+    }
+    HeapWord* result = start_array->object_start(addr);
+
+    cached_obj.start_addr = result;
+    cached_obj.end_addr = result + cast_to_oop(result)->size();
+
+    return result;
+  };
+
+  // Prepare scavenge.
+  preprocess_card_table_parallel(object_start, old_gen_bottom, old_gen_top, stripe_index, n_stripes);
+
+  // Sync with other workers.
+  Atomic::dec(&_preprocessing_active_workers);
+  SpinYield spin_yield;
+  while (Atomic::load_acquire(&_preprocessing_active_workers) > 0) {
+    spin_yield.wait();
+  }
+
+  // Scavenge
+  cached_obj = {nullptr, old_gen_bottom};
   const size_t stripe_size_in_words = num_cards_in_stripe * _card_size_in_words;
   const size_t slice_size_in_words = stripe_size_in_words * n_stripes;
+  HeapWord* cur_addr = old_gen_bottom + stripe_index * stripe_size_in_words;
+  for (/* empty */; cur_addr < old_gen_top; cur_addr += slice_size_in_words) {
+    HeapWord* const stripe_l = cur_addr;
+    HeapWord* const stripe_r = MIN2(cur_addr + stripe_size_in_words,
+                                    old_gen_top);
 
-  HeapWord* cur_stripe_addr = sp->bottom() + stripe_index * stripe_size_in_words;
-
-  for (/* empty */; cur_stripe_addr < space_top; cur_stripe_addr += slice_size_in_words) {
-    // exclusive
-    HeapWord* const cur_stripe_end_addr = MIN2(cur_stripe_addr + stripe_size_in_words,
-                                               space_top);
-
-    // Process a stripe iff it contains any obj-start
-    if (!start_array->object_starts_in_range(cur_stripe_addr, cur_stripe_end_addr)) {
-      continue;
-    }
-
-    // Constraints:
-    // 1. range of cards checked for being dirty or clean: [iter_limit_l, iter_limit_r)
-    // 2. range of cards can be cleared: [clear_limit_l, clear_limit_r)
-    // 3. range of objs (obj-start) can be scanned: [first_obj_addr, cur_stripe_end_addr)
-
-    CardValue* iter_limit_l;
-    CardValue* iter_limit_r;
-    CardValue* clear_limit_l;
-    CardValue* clear_limit_r;
-
-    // Identify left ends and the first obj-start inside this stripe.
-    HeapWord* first_obj_addr = start_array->object_start(cur_stripe_addr);
-    if (first_obj_addr < cur_stripe_addr) {
-      // this obj belongs to previous stripe; can't clear any cards it occupies
-      first_obj_addr += cast_to_oop(first_obj_addr)->size();
-      clear_limit_l = byte_for(first_obj_addr - 1) + 1;
-      iter_limit_l = byte_for(first_obj_addr);
-    } else {
-      assert(first_obj_addr == cur_stripe_addr, "inv");
-      iter_limit_l = clear_limit_l = byte_for(cur_stripe_addr);
-    }
-
-    assert(cur_stripe_addr <= first_obj_addr, "inside this stripe");
-    assert(first_obj_addr <= cur_stripe_end_addr, "can be empty");
-
-    {
-      // Identify right ends.
-      HeapWord* obj_addr = start_array->object_start(cur_stripe_end_addr - 1);
-      HeapWord* obj_end_addr = obj_addr + cast_to_oop(obj_addr)->size();
-      assert(obj_end_addr >= cur_stripe_end_addr, "inv");
-      clear_limit_r = byte_for(obj_end_addr);
-      iter_limit_r = byte_for(obj_end_addr - 1) + 1;
-    }
-
-    assert(iter_limit_l <= clear_limit_l &&
-           clear_limit_r <= iter_limit_r, "clear cards only if we iterate over them");
-
-    // Process dirty chunks, i.e. consecutive dirty cards [dirty_l, dirty_r),
-    // chunk by chunk inside [iter_limit_l, iter_limit_r).
-    CardValue* dirty_l;
-    CardValue* dirty_r;
-
-    for (CardValue* cur_card = iter_limit_l; cur_card < iter_limit_r; cur_card = dirty_r + 1) {
-      dirty_l = find_first_dirty_card(cur_card, iter_limit_r);
-      dirty_r = find_first_clean_card(start_array, dirty_l, iter_limit_r);
-      assert(dirty_l <= dirty_r, "inv");
-
-      // empty
-      if (dirty_l == dirty_r) {
-        assert(dirty_r == iter_limit_r, "no more dirty cards in this stripe");
-        break;
-      }
-
-      assert(*dirty_l != clean_card, "inv");
-      assert(*dirty_r == clean_card || dirty_r >= clear_limit_r,
-             "clean card or belonging to next stripe");
-
-      // Process this non-empty dirty chunk in two steps:
-      {
-        // 1. Clear card in [dirty_l, dirty_r) subject to [clear_limit_l, clear_limit_r) constraint
-        clear_cards(MAX2(dirty_l, clear_limit_l),
-                    MIN2(dirty_r, clear_limit_r));
-      }
-
-      {
-        // 2. Scan objs in [dirty_l, dirty_r) subject to [first_obj_addr, cur_stripe_end_addr) constraint
-        HeapWord* obj_l = MAX2(start_array->object_start(addr_for(dirty_l)),
-                               first_obj_addr);
-
-        HeapWord* obj_r = MIN2(addr_for(dirty_r),
-                               cur_stripe_end_addr);
-
-        scan_objects_in_range(pm, obj_l, obj_r);
-      }
-    }
+    process_range(object_start, pm, stripe_l, stripe_r);
   }
 }
 

--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -151,8 +151,8 @@ class PSStripeShadowCardTable {
 
 public:
   PSStripeShadowCardTable(PSCardTable* pst, HeapWord* const start, HeapWord* const end) :
-    _card_shift(CardTable::card_shift()),
-    _card_size(CardTable::card_size()),
+    _card_shift(CardTable::card_shift),
+    _card_size(CardTable::card_size),
     _table_base(_table - (uintptr_t(start) >> _card_shift)) {
     size_t stripe_byte_size = pointer_delta(end, start) * HeapWordSize;
     size_t copy_length = align_up(stripe_byte_size, _card_size) >> _card_shift;
@@ -388,7 +388,7 @@ void PSCardTable::scavenge_contents_parallel(ObjectStartArray* start_array,
 
   // Scavenge
   cached_obj = {nullptr, old_gen_bottom};
-  const size_t stripe_size_in_words = num_cards_in_stripe * _card_size_in_words;
+  const size_t stripe_size_in_words = num_cards_in_stripe * card_size_in_words;
   const size_t slice_size_in_words = stripe_size_in_words * n_stripes;
   HeapWord* cur_addr = old_gen_bottom + stripe_index * stripe_size_in_words;
   for (/* empty */; cur_addr < old_gen_top; cur_addr += slice_size_in_words) {

--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -234,7 +234,7 @@ void PSCardTable::scavenge_contents_parallel(ObjectStartArray* start_array,
                                              uint stripe_index,
                                              uint n_stripes) {
   const size_t num_cards_in_stripe = 128;
-  const size_t stripe_size_in_words = num_cards_in_stripe * card_size_in_words;
+  const size_t stripe_size_in_words = num_cards_in_stripe * _card_size_in_words;
   const size_t slice_size_in_words = stripe_size_in_words * n_stripes;
 
   HeapWord* cur_stripe_addr = sp->bottom() + stripe_index * stripe_size_in_words;

--- a/src/hotspot/share/gc/parallel/psCardTable.hpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.hpp
@@ -33,7 +33,36 @@ class ObjectStartArray;
 class PSPromotionManager;
 
 class PSCardTable: public CardTable {
- private:
+  friend class PSStripeShadowCardTable;
+  static constexpr size_t num_cards_in_stripe = 128;
+  static_assert(num_cards_in_stripe >= 1, "progress");
+
+  volatile int _preprocessing_active_workers;
+
+  bool is_dirty(CardValue* card) {
+    return !is_clean(card);
+  }
+
+  bool is_clean(CardValue* card) {
+    return *card == clean_card_val();
+  }
+
+  // Iterate the stripes with the given index and copy imprecise card marks of
+  // objects reaching into a stripe to its first card.
+  template <typename Func>
+  void preprocess_card_table_parallel(Func&& object_start,
+                                      HeapWord* old_gen_bottom,
+                                      HeapWord* old_gen_top,
+                                      uint stripe_index,
+                                      uint n_stripes);
+
+  // Scavenge contents on dirty cards of the given stripe [start, end).
+  template <typename Func>
+  void process_range(Func&& object_start,
+                     PSPromotionManager* pm,
+                     HeapWord* const start,
+                     HeapWord* const end);
+
   // Support methods for resizing the card table.
   // resize_commit_uncommit() returns true if the pages were committed or
   // uncommitted
@@ -50,29 +79,24 @@ class PSCardTable: public CardTable {
     verify_card       = CT_MR_BS_last_reserved + 5
   };
 
-  CardValue* find_first_dirty_card(CardValue* const start_card,
-                                   CardValue* const end_card);
-
-  CardValue* find_first_clean_card(ObjectStartArray* start_array,
-                                   CardValue* const start_card,
-                                   CardValue* const end_card);
-
-  void clear_cards(CardValue* const start, CardValue* const end);
-
-  void scan_objects_in_range(PSPromotionManager* pm,
-                             HeapWord* start,
-                             HeapWord* end);
+  void scan_obj_with_limit(PSPromotionManager* pm,
+                           oop obj,
+                           HeapWord* start,
+                           HeapWord* end);
 
  public:
-  PSCardTable(MemRegion whole_heap) : CardTable(whole_heap) {}
+  PSCardTable(MemRegion whole_heap) : CardTable(whole_heap),
+                                      _preprocessing_active_workers(0) {}
 
   static CardValue youngergen_card_val() { return youngergen_card; }
   static CardValue verify_card_val()     { return verify_card; }
 
   // Scavenge support
+  void pre_scavenge(HeapWord* old_gen_bottom, uint active_workers);
+  // Scavenge contents of stripes with the given index.
   void scavenge_contents_parallel(ObjectStartArray* start_array,
-                                  MutableSpace* sp,
-                                  HeapWord* space_top,
+                                  HeapWord* old_gen_bottom,
+                                  HeapWord* old_gen_top,
                                   PSPromotionManager* pm,
                                   uint stripe_index,
                                   uint n_stripes);

--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -174,6 +174,7 @@ class PSPromotionManager {
   TASKQUEUE_STATS_ONLY(inline void record_steal(ScannerTask task);)
 
   void push_contents(oop obj);
+  void push_contents_bounded(oop obj, HeapWord* left, HeapWord* right);
 };
 
 #endif // SHARE_GC_PARALLEL_PSPROMOTIONMANAGER_HPP

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -128,6 +128,11 @@ inline void PSPromotionManager::push_contents(oop obj) {
   }
 }
 
+inline void PSPromotionManager::push_contents_bounded(oop obj, HeapWord* left, HeapWord* right) {
+  PSPushContentsClosure pcc(this);
+  obj->oop_iterate(&pcc, MemRegion(left, right));
+}
+
 template<bool promote_immediately>
 inline oop PSPromotionManager::copy_to_survivor_space(oop o) {
   assert(should_scavenge(&o), "Sanity");

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -300,8 +300,6 @@ public:
       _active_workers(active_workers),
       _is_empty(is_empty),
       _terminator(active_workers, PSPromotionManager::vm_thread_promotion_manager()->stack_array_depth()) {
-    assert(_old_gen != nullptr, "Sanity");
-
     if (!_is_empty) {
       PSCardTable* card_table = ParallelScavengeHeap::heap()->card_table();
       card_table->pre_scavenge(_old_gen->object_space()->bottom(), active_workers);

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -302,7 +302,7 @@ public:
       _terminator(active_workers, PSPromotionManager::vm_thread_promotion_manager()->stack_array_depth()) {
     assert(_old_gen != nullptr, "Sanity");
 
-    if (!_is_old_gen_empty) {
+    if (!_is_empty) {
       PSCardTable* card_table = ParallelScavengeHeap::heap()->card_table();
       card_table->pre_scavenge(_old_gen->object_space()->bottom(), active_workers);
     }

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -88,7 +88,6 @@ static void scavenge_roots_work(ParallelRootType::Value root_type, uint worker_i
   assert(ParallelScavengeHeap::heap()->is_gc_active(), "called outside gc");
 
   PSPromotionManager* pm = PSPromotionManager::gc_thread_promotion_manager(worker_id);
-  PSScavengeRootsClosure roots_closure(pm);
   PSPromoteRootsClosure  roots_to_old_closure(pm);
 
   switch (root_type) {
@@ -301,6 +300,12 @@ public:
       _active_workers(active_workers),
       _is_empty(is_empty),
       _terminator(active_workers, PSPromotionManager::vm_thread_promotion_manager()->stack_array_depth()) {
+    assert(_old_gen != nullptr, "Sanity");
+
+    if (!_is_old_gen_empty) {
+      PSCardTable* card_table = ParallelScavengeHeap::heap()->card_table();
+      card_table->pre_scavenge(_old_gen->object_space()->bottom(), active_workers);
+    }
   }
 
   virtual void work(uint worker_id) {
@@ -320,8 +325,9 @@ public:
         PSPromotionManager* pm = PSPromotionManager::gc_thread_promotion_manager(worker_id);
         PSCardTable* card_table = ParallelScavengeHeap::heap()->card_table();
 
+        // The top of the old gen changes during scavenge when objects are promoted.
         card_table->scavenge_contents_parallel(_old_gen->start_array(),
-                                               _old_gen->object_space(),
+                                               _old_gen->object_space()->bottom(),
                                                _gen_top,
                                                pm,
                                                worker_id,


### PR DESCRIPTION
I would like to backport this as a performance bug fix.

We received bug reports from users which have some young pauses of 30s, and even up to 50s (normally <1s) running large Gerrit instances (200GB heap, 100 gc threads).
We have tried to tune ParallelGC. Reducing the number of gc threads helps to make the pause time spikes smaller but this makes average pause times longer.

This pr depends on
https://github.com/openjdk/jdk17u-dev/pull/2226
https://github.com/openjdk/jdk17u-dev/pull/2227
https://github.com/openjdk/jdk17u-dev/pull/2228

All hunks except the following 2 applied after a trivial preparation change.
The 1st hunk of psCardTable.hpp did not apply because of different context. Resolved by inserting the new lines.
The 2nd hunk of psScavenge.cpp did not apply because of different context. Resolved by inserting the new lines. I accidentally added an assertion `_old_gen != nullptr`. I guess this does not harm (in head the assertion is superfluous as the pointer is dereferenced before the assertion is reached).
Finally a few trivial changes are required (renaming and the like).

Risk is medium. We've done the downstream backport already many weeks ago.

I've tested on x86_64:
jdk:tier1       TEST_VM_OPTS="-XX:+UseParallelGC"
langtools:tier1 TEST_VM_OPTS="-XX:+UseParallelGC"

Local CI Testing:
The fix passed our CI testing (e.g. 2024-02-22): JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests (also with ParallelGC).
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8310031](https://bugs.openjdk.org/browse/JDK-8310031) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #2228 must be integrated first

### Issue
 * [JDK-8310031](https://bugs.openjdk.org/browse/JDK-8310031): Parallel: Implement better work distribution for large object arrays in old gen (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2229/head:pull/2229` \
`$ git checkout pull/2229`

Update a local copy of the PR: \
`$ git checkout pull/2229` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2229`

View PR using the GUI difftool: \
`$ git pr show -t 2229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2229.diff">https://git.openjdk.org/jdk17u-dev/pull/2229.diff</a>

</details>
