### PR TITLE
8326666: Remove the Java Management Extension (JMX) Subject Delegation feature.

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
@@ -389,7 +389,8 @@ public class RMIConnector implements JMXConnector, Serializable, JMXAddressable 
     throws IOException {
         return getMBeanServerConnection(null);
     }
-
+    
+    @SuppressWarnings("removal")
     public synchronized MBeanServerConnection
             getMBeanServerConnection(Subject delegationSubject)
             throws IOException {

--- a/src/java.management/share/classes/javax/management/remote/JMXConnector.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnector.java
@@ -169,7 +169,8 @@ public interface JMXConnector extends Closeable {
      * MBean server has not yet been established (with the {@link #connect(Map)
      * connect} method), or it has been closed, or it has broken.
      */
-    public MBeanServerConnection getMBeanServerConnection(
+     @Deprecated(since="21", forRemoval=true)
+     public MBeanServerConnection getMBeanServerConnection(
                                                Subject delegationSubject)
             throws IOException;
 


### PR DESCRIPTION
This feature has no known current usage.

The feature cannot be invoked without a Security Manager. The Security Manager is a legacy feature, and was deprecated for removal in Java 17 by JEP 411. The Subject Delegation feature will cease to be usable once the Security Manager is further degraded and eventually removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8326666](https://bugs.openjdk.org/browse/JDK-8326666) needs maintainer approval
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8326691](https://bugs.openjdk.org/browse/JDK-8326691) to be approved

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8326666](https://bugs.openjdk.org/browse/JDK-8326666)

### Issues
 * [JDK-8326666](https://bugs.openjdk.org/browse/JDK-8326666): Remove the Java Management Extension (JMX) Subject Delegation feature (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.
 * [JDK-8326691](https://bugs.openjdk.org/browse/JDK-8326691): Remove the Java Management Extension (JMX) Subject Delegation feature (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2239/head:pull/2239` \
`$ git checkout pull/2239`

Update a local copy of the PR: \
`$ git checkout pull/2239` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2239`

View PR using the GUI difftool: \
`$ git pr show -t 2239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2239.diff">https://git.openjdk.org/jdk17u-dev/pull/2239.diff</a>

</details>
