### PR TITLE
8326666: Remove the Java Management Extension (JMX) Subject Delegation feature.

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
@@ -389,7 +389,7 @@ public class RMIConnector implements JMXConnector, Serializable, JMXAddressable 
     throws IOException {
         return getMBeanServerConnection(null);
     }
-
+    @SuppressWarnings("removal")
     public synchronized MBeanServerConnection
             getMBeanServerConnection(Subject delegationSubject)
             throws IOException {

--- a/src/java.management/share/classes/javax/management/remote/JMXConnector.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnector.java
@@ -168,8 +168,14 @@ public interface JMXConnector extends Closeable {
      * cannot be created, for instance because the connection to the remote
      * MBean server has not yet been established (with the {@link #connect(Map)
      * connect} method), or it has been closed, or it has broken.
+     *
+     * @deprecated This method supported the legacy Subject Delegation feature,
+     * and is only useful in conjunction with other APIs which are deprecated and
+     * subject to removal in a future release. Consequently, this method is also
+     * deprecated and subject to removal. There is no replacement.
      */
-    public MBeanServerConnection getMBeanServerConnection(
+     @Deprecated(since="21", forRemoval=true)
+     public MBeanServerConnection getMBeanServerConnection(
                                                Subject delegationSubject)
             throws IOException;
 


### PR DESCRIPTION
This feature has no known current usage.

The feature cannot be invoked without a Security Manager. The Security Manager is a legacy feature, and was deprecated for removal in Java 17 by JEP 411. The Subject Delegation feature will cease to be usable once the Security Manager is further degraded and eventually removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8326666](https://bugs.openjdk.org/browse/JDK-8326666) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8326691](https://bugs.openjdk.org/browse/JDK-8326691) to be approved

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8326666](https://bugs.openjdk.org/browse/JDK-8326666)

### Issues
 * [JDK-8326666](https://bugs.openjdk.org/browse/JDK-8326666): Remove the Java Management Extension (JMX) Subject Delegation feature (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.
 * [JDK-8326691](https://bugs.openjdk.org/browse/JDK-8326691): Remove the Java Management Extension (JMX) Subject Delegation feature (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2240/head:pull/2240` \
`$ git checkout pull/2240`

Update a local copy of the PR: \
`$ git checkout pull/2240` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2240`

View PR using the GUI difftool: \
`$ git pr show -t 2240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2240.diff">https://git.openjdk.org/jdk17u-dev/pull/2240.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2240#issuecomment-1965738813)