### PR TITLE
8326764: Missing license header in ArenaAllocator.java

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.MemorySegment;


### PR DESCRIPTION
This PR adds the missing CE & GPL header in `src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ArenaAllocator.java` file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8326764](https://bugs.openjdk.org/browse/JDK-8326764) needs maintainer approval
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Issue of type `Backport` is not allowed for integrations

### Issue
 * [JDK-8326764](https://bugs.openjdk.org/browse/JDK-8326764): Missing license header in ArenaAllocator.java (**Backport** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2241/head:pull/2241` \
`$ git checkout pull/2241`

Update a local copy of the PR: \
`$ git checkout pull/2241` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2241`

View PR using the GUI difftool: \
`$ git pr show -t 2241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2241.diff">https://git.openjdk.org/jdk17u-dev/pull/2241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2241#issuecomment-1965782293)