### PR TITLE
8266242: java/awt/GraphicsDevice/CheckDisplayModes.java failing on macOS 11 ARM

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@
 #define DEFAULT_DEVICE_HEIGHT 768
 #define DEFAULT_DEVICE_DPI 72
 
+static NSInteger architecture = -1;
 /*
  * Convert the mode string to the more convinient bits per pixel value
  */
@@ -58,7 +59,17 @@ static int getBPPFromModeString(CFStringRef mode)
     return 0;
 }
 
-static BOOL isValidDisplayMode(CGDisplayModeRef mode){
+static BOOL isValidDisplayMode(CGDisplayModeRef mode) {
+    // Workaround for apple bug FB13261205, since it only affects arm based macs
+    // and arm support started with macOS 11 ignore the workaround for previous versions
+    if (@available(macOS 11, *)) {
+        if (architecture == -1) {
+            architecture = [[NSRunningApplication currentApplication] executableArchitecture];
+        }
+        if (architecture == NSBundleExecutableArchitectureARM64) {
+            return (CGDisplayModeGetPixelWidth(mode) >= 800);
+        }
+    }
     return (1 < CGDisplayModeGetWidth(mode) && 1 < CGDisplayModeGetHeight(mode));
 }
 


### PR DESCRIPTION
Backport of [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242)
- `src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m` - clean backport
- `test/jdk/ProblemList.txt` - this file has been ignored because the line does not exist

Testing
- Local: Test passed
  - `CheckDisplayModes.java`: Test results: passed: 1

```
MacBook Pro
16-inch, 2021
Chip Apple M1 Max
Memory: 32 GB
MacOS: 14.3.1 (23D60)
```

- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-03-01,02,03`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242): java/awt/GraphicsDevice/CheckDisplayModes.java failing on macOS 11 ARM (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2245/head:pull/2245` \
`$ git checkout pull/2245`

Update a local copy of the PR: \
`$ git checkout pull/2245` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2245`

View PR using the GUI difftool: \
`$ git pr show -t 2245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2245.diff">https://git.openjdk.org/jdk17u-dev/pull/2245.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2245#issuecomment-1967624424)