### PR TITLE
8325213: Flags introduced by configure script are not passed to ADLC build

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -48,7 +48,7 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   endif
 
   # Set the C++ standard
-  ADLC_CFLAGS += $(ADLC_LANGSTD_CXXFLAG)
+  ADLC_CFLAGS += $(ADLC_LANGSTD_CXXFLAGS)
 
   # NOTE: The old build didn't set -DASSERT for windows but it doesn't seem to
   # hurt.


### PR DESCRIPTION
Clean backport of the trivial ADLC build fix [JDK-8325213](https://bugs.openjdk.org/browse/JDK-8325213).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325213](https://bugs.openjdk.org/browse/JDK-8325213) needs maintainer approval

### Issue
 * [JDK-8325213](https://bugs.openjdk.org/browse/JDK-8325213): Flags introduced by configure script are not passed to ADLC build (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2248/head:pull/2248` \
`$ git checkout pull/2248`

Update a local copy of the PR: \
`$ git checkout pull/2248` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2248`

View PR using the GUI difftool: \
`$ git pr show -t 2248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2248.diff">https://git.openjdk.org/jdk17u-dev/pull/2248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2248#issuecomment-1968472517)