### PR TITLE
8326942: [17u] Backout "8325254: CKA_TOKEN private and secret keys are not necessarily sensitive"

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -395,9 +395,8 @@ abstract class P11Key implements Key, Length {
                     new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
 
-        boolean keySensitive =
-                (attrs[0].getBoolean() && P11Util.isNSS(session.token)) ||
-                attrs[1].getBoolean() || !attrs[2].getBoolean();
+        boolean keySensitive = (attrs[0].getBoolean() ||
+                attrs[1].getBoolean() || !attrs[2].getBoolean());
 
         switch (algorithm) {
         case "RSA":


### PR DESCRIPTION
…e not necessarily sensitive"

Backout this change that breaks the 17u build.

https://bugs.openjdk.org/browse/JDK-8325254

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326942](https://bugs.openjdk.org/browse/JDK-8326942) needs maintainer approval

### Issue
 * [JDK-8326942](https://bugs.openjdk.org/browse/JDK-8326942): [17u] Backout "8325254: CKA_TOKEN private and secret keys are not necessarily sensitive" (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2249/head:pull/2249` \
`$ git checkout pull/2249`

Update a local copy of the PR: \
`$ git checkout pull/2249` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2249`

View PR using the GUI difftool: \
`$ git pr show -t 2249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2249.diff">https://git.openjdk.org/jdk17u-dev/pull/2249.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2249#issuecomment-1968702119)