### PR TITLE
8315677: Open source few swing JFileChooser and other tests

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/bug4624353.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4624353.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4624353
+ * @summary Tests that Motif FileChooser is not able to show control buttons
+ * @key headful
+ * @run main bug4624353
+ */
+
+import java.awt.Component;
+import java.awt.Container;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug4624353 {
+    static volatile boolean passed = true;
+    static JFrame fr;
+    static JFileChooser fc;
+
+    public static void main(String args[]) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("bug4624353");
+                fc = new JFileChooser();
+                fc.setControlButtonsAreShown(false);
+                fr.getContentPane().add(fc);
+                fr.pack();
+                fr.setVisible(true);
+
+                passAround(fc);
+            });
+            if (!passed) {
+                throw new RuntimeException("Test failed");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    public static void passAround(Container c) {
+        Component[] list = c.getComponents();
+        if (list.length == 0) {
+            return;
+        }
+        for (int i = 0; i < list.length; i++) {
+            if (list[i] != null) {
+                if ((list[i] instanceof JButton) &&
+                        "OK".equals(((JButton)list[i]).getText())) {
+                    passed = false;
+                    return;
+                }
+                passAround((Container)list[i]);
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4673161.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4673161.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4673161
+ * @requires (os.family == "windows")
+ * @summary Tests if JFileChooser preferred size depends on selected files
+ * @run main bug4673161
+ */
+
+import java.awt.Dimension;
+import java.io.File;
+import javax.swing.JFileChooser;
+import javax.swing.UIManager;
+
+public class bug4673161 {
+
+  public static void main(String[] args) throws Exception {
+    JFileChooser fc = new JFileChooser();
+    Dimension d = fc.getPreferredSize();
+    JFileChooser fc2 = new JFileChooser();
+    File[] files = new File[50];
+    for (int i = 0; i < 50; i++) {
+      files[i] = new File("file" + i);
+    }
+    fc2.setSelectedFiles(files);
+    Dimension d2 = fc2.getPreferredSize();
+    if (!d.equals(d2)) {
+      throw new RuntimeException("Test failed: JFileChooser preferred " +
+              "size depends on selected files");
+    }
+
+    UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+
+    JFileChooser fc3 = new JFileChooser();
+    d = fc3.getPreferredSize();
+    fc2 = new JFileChooser();
+    files = new File[50];
+    for (int i = 0; i < 50; i++) {
+      files[i] = new File("file" + i);
+    }
+    fc2.setSelectedFiles(files);
+    d2 = fc2.getPreferredSize();
+    if (!d.equals(d2)) {
+      throw new RuntimeException("Test failed: JFileChooser preferred " +
+              "size depends on selected files");
+    }
+  }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4782168.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4782168.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4782168
+ * @summary Tests if DefaultShellFolder.isHidden() crashes for the
+           root folder on Solaris
+ * @modules java.desktop/sun.awt.shell
+ * @run main bug4782168
+ */
+
+public class bug4782168 {
+
+    public static void main(String args[]) throws Exception {
+        sun.awt.shell.ShellFolder sf = sun.awt.shell.ShellFolder.
+                getShellFolder(new java.io.File("/"));
+        sf.isHidden();
+    }
+}

--- a/test/jdk/javax/swing/JLabel/bug4822331.java
+++ b/test/jdk/javax/swing/JLabel/bug4822331.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4822331
+ * @summary setLaberFor does not transfer focus to the JSpinner editor
+ * @library /test/lib
+ * @key headful
+ * @run main bug4822331
+ */
+
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.awt.FlowLayout;
+import java.awt.Robot;
+import javax.swing.JButton;
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JSpinner;
+import javax.swing.SwingUtilities;
+import jdk.test.lib.Platform;
+
+public class bug4822331 {
+
+    static JFrame fr;
+    static JButton button;
+    static JSpinner spinner;
+    static volatile boolean tfFocused = false;
+    static volatile boolean passed = false;
+
+    public static void main(String []args) throws Exception {
+        bug4822331 test = new bug4822331();
+        test.init();
+    }
+
+    public void init() throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("Test");
+                fr.getContentPane().setLayout(new FlowLayout());
+
+                button = new JButton("Button");
+                fr.getContentPane().add(button);
+
+                spinner = new JSpinner();
+                JLabel spinnerLabel = new JLabel("spinner");
+                spinnerLabel.setDisplayedMnemonic(KeyEvent.VK_S);
+                spinnerLabel.setLabelFor(spinner);
+                fr.getContentPane().add(spinnerLabel);
+                fr.getContentPane().add(spinner);
+
+                JSpinner.DefaultEditor editor =
+                        (JSpinner.DefaultEditor) spinner.getEditor();
+                JFormattedTextField ftf = editor.getTextField();
+                ftf.addFocusListener(new FocusAdapter() {
+                    public void focusGained(FocusEvent e) {
+                        passed = true;
+                    }
+                });
+                fr.pack();
+                fr.setVisible(true);
+            });
+            start();
+            if ( !passed ) {
+                throw new RuntimeException("The activation of spinner's " +
+                        "mnemonic didn't focus the editor component.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    public void start() throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.delay(1000);
+        robot.waitForIdle();
+        button.requestFocus();
+        if (Platform.isOSX()) {
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_S);
+            robot.keyRelease(KeyEvent.VK_S);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+        } else {
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_S);
+            robot.keyRelease(KeyEvent.VK_S);
+            robot.keyRelease(KeyEvent.VK_ALT);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JOptionPane/bug4191835.java
+++ b/test/jdk/javax/swing/JOptionPane/bug4191835.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4191835
+ * @summary JOptionPane should allow Dialog as window owner.
+ * @key headful
+ * @run main bug4191835
+ */
+
+import java.awt.Dialog;
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+
+public class bug4191835 {
+
+  public static void main(String[] args) {
+    JOptionPane op = new JOptionPane();
+    Dialog dlg = new Dialog(new JDialog());
+    JDialog jd = op.createDialog(dlg, "Dialog");
+  }
+}


### PR DESCRIPTION
Backport of [JDK-8315677](https://bugs.openjdk.org/browse/JDK-8315677)

Testing
- Local: Test passed
  - `bug4624353.java` - Test results: passed: 1
  - `bug4673161.java` - Test results: no tests selected
  - `bug4782168.java` - Test results: passed: 1
  - `bug4822331.java` - Test results: passed: 1
  - `bug4191835.java` - Test results: passed: 1
- Pipeline: 
- Testing Machine: SAP nightlies passed on `2024-03-01,02,03`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315677](https://bugs.openjdk.org/browse/JDK-8315677) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315677](https://bugs.openjdk.org/browse/JDK-8315677): Open source few swing JFileChooser and other tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2251/head:pull/2251` \
`$ git checkout pull/2251`

Update a local copy of the PR: \
`$ git checkout pull/2251` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2251`

View PR using the GUI difftool: \
`$ git pr show -t 2251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2251.diff">https://git.openjdk.org/jdk17u-dev/pull/2251.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2251#issuecomment-1969696590)