### PR TITLE
8325137: com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java can fail in Xcomp with out of expected range

### DIFF
--- a/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
+++ b/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @summary Basic test of ThreadMXBean.getThreadCpuTime(long[]) and
  *          getThreadUserTime(long[]).
  * @author  Paul Hohensee
+ * @requires vm.compMode != "Xcomp"
  */
 
 import java.lang.management.*;


### PR DESCRIPTION
Backport of [JDK-8325137](https://bugs.openjdk.org/browse/JDK-8325137)

Testing
- Local: Test passed
  - `ThreadCpuTimeArray.java` - Test results: passed: 1
- :yellow_heart: Pipeline: All `GHA Sanity Checks` passed except `linux-cross-compile / build (riscv64)`
  - :x: It failed with message `Error: Unable to find an artifact with the name: bundles-linux-x64`
- Testing Machine: SAP nightlies passed on `2024-03-01,02,03`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325137](https://bugs.openjdk.org/browse/JDK-8325137) needs maintainer approval

### Issue
 * [JDK-8325137](https://bugs.openjdk.org/browse/JDK-8325137): com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java can fail in Xcomp with out of expected range (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2255/head:pull/2255` \
`$ git checkout pull/2255`

Update a local copy of the PR: \
`$ git checkout pull/2255` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2255`

View PR using the GUI difftool: \
`$ git pr show -t 2255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2255.diff">https://git.openjdk.org/jdk17u-dev/pull/2255.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2255#issuecomment-1970229472)