### PR TITLE
8324123: aarch64: fix prfm literal encoding in assembler

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -156,6 +156,26 @@ void Assembler::adrp(Register reg1, const Address &dest, uint64_t &byte_offset) 
     rf(Rd, 0);
   }
 
+// This encoding is similar (but not quite identical) to the encoding used
+// by literal ld/st. see JDK-8324123.
+// PRFM does not support writeback or pre/post index.
+void Assembler::prfm(const Address &adr, prfop pfop) {
+  Address::mode mode = adr.getMode();
+  // PRFM does not support pre/post index
+  guarantee((mode != Address::pre) && (mode != Address::post), "prfm does not support pre/post indexing");
+  if (mode == Address::literal) {
+    starti;
+    f(0b11, 31, 30), f(0b011, 29, 27), f(0b000, 26, 24);
+    f(pfop, 4, 0);
+    int64_t offset = (adr.target() - pc()) >> 2;
+    sf(offset, 23, 5);
+  } else {
+    assert((mode == Address::base_plus_offset)
+            || (mode == Address::base_plus_offset_reg), "must be base_plus_offset/base_plus_offset_reg");
+    ld_st2(as_Register(pfop), adr, 0b11, 0b10);
+  }
+}
+
 #undef starti
 
 Address::Address(address target, relocInfo::relocType rtype) : _mode(literal){

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -763,6 +763,8 @@ public:
 
   void adrp(Register Rd, const Address &dest, uint64_t &offset);
 
+  void prfm(const Address &adr, prfop pfop = PLDL1KEEP);
+
 #undef INSN
 
   void add_sub_immediate(Register Rd, Register Rn, unsigned uimm, int op,
@@ -1495,17 +1497,6 @@ public:
   INSN(ldrsh, 0b01, 0b10);
   INSN(ldrshw, 0b01, 0b11);
   INSN(ldrsw, 0b10, 0b10);
-
-#undef INSN
-
-#define INSN(NAME, size, op)                                    \
-  void NAME(const Address &adr, prfop pfop = PLDL1KEEP) {       \
-    ld_st2((Register)pfop, adr, size, op);                      \
-  }
-
-  INSN(prfm, 0b11, 0b10); // FIXME: PRFM should not be used with
-                          // writeback modes, but the assembler
-                          // doesn't enfore that.
 
 #undef INSN
 


### PR DESCRIPTION
Unclean backport of fixing aarch64 PRFM (literal) encoding.

Additional testing:
 - [x] Linux aarch64 server fastdebug, tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8324123](https://bugs.openjdk.org/browse/JDK-8324123) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324123](https://bugs.openjdk.org/browse/JDK-8324123): aarch64: fix prfm literal encoding in assembler (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2256/head:pull/2256` \
`$ git checkout pull/2256`

Update a local copy of the PR: \
`$ git checkout pull/2256` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2256`

View PR using the GUI difftool: \
`$ git pr show -t 2256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2256.diff">https://git.openjdk.org/jdk17u-dev/pull/2256.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2256#issuecomment-1970601950)