### PR TITLE
8305900: Use loopback IP addresses in security policy files of httpclient tests

### DIFF
--- a/test/jdk/java/net/httpclient/AsFileDownloadTest.java
+++ b/test/jdk/java/net/httpclient/AsFileDownloadTest.java
@@ -21,25 +21,6 @@
  * questions.
  */
 
-/*
- * @test
- * @summary Basic test for ofFileDownload
- * @bug 8196965 8302475
- * @modules java.base/sun.net.www.http
- *          java.net.http/jdk.internal.net.http.common
- *          java.net.http/jdk.internal.net.http.frame
- *          java.net.http/jdk.internal.net.http.hpack
- *          java.logging
- *          jdk.httpserver
- * @library /test/lib http2/server
- * @build Http2TestServer
- * @build jdk.test.lib.net.SimpleSSLContext
- * @build jdk.test.lib.Platform
- * @build jdk.test.lib.util.FileUtils
- * @run testng/othervm AsFileDownloadTest
- * @run testng/othervm/java.security.policy=AsFileDownloadTest.policy AsFileDownloadTest
- */
-
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -80,6 +61,25 @@ import static java.nio.file.StandardOpenOption.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+
+/*
+ * @test
+ * @summary Basic test for ofFileDownload
+ * @bug 8196965 8302475
+ * @modules java.base/sun.net.www.http
+ *          java.net.http/jdk.internal.net.http.common
+ *          java.net.http/jdk.internal.net.http.frame
+ *          java.net.http/jdk.internal.net.http.hpack
+ *          java.logging
+ *          jdk.httpserver
+ * @library /test/lib http2/server
+ * @build Http2TestServer
+ * @build jdk.test.lib.net.SimpleSSLContext
+ * @build jdk.test.lib.Platform
+ * @build jdk.test.lib.util.FileUtils
+ * @run testng/othervm AsFileDownloadTest
+ * @run testng/othervm/java.security.policy=AsFileDownloadTest.policy AsFileDownloadTest
+ */
 
 public class AsFileDownloadTest {
 
@@ -267,8 +267,10 @@ public class AsFileDownloadTest {
     // -- Infrastructure
 
     static String serverAuthority(HttpServer server) {
-        return InetAddress.getLoopbackAddress().getHostName() + ":"
-                + server.getAddress().getPort();
+        final String hostIP = InetAddress.getLoopbackAddress().getHostAddress();
+        // escape for ipv6
+        final String h = hostIP.contains(":") ? "[" + hostIP + "]" : hostIP;
+        return h + ":" + server.getAddress().getPort();
     }
 
     @BeforeTest

--- a/test/jdk/java/net/httpclient/AsFileDownloadTest.policy
+++ b/test/jdk/java/net/httpclient/AsFileDownloadTest.policy
@@ -34,7 +34,8 @@ grant codeBase "file:${test.classes}/../../../../java/net/httpclient/http2/serve
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.hpack";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www.http";
 
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
     permission java.lang.RuntimePermission "modifyThread";
 };
 
@@ -42,10 +43,15 @@ grant codeBase "file:${test.classes}/*" {
     permission java.io.FilePermission "${user.dir}${/}asFileDownloadTest.tmp.dir", "read,write";
     permission java.io.FilePermission "${user.dir}${/}asFileDownloadTest.tmp.dir/-", "read,write";
 
-    permission java.net.URLPermission "http://localhost:*/http1/afdt",   "POST";
-    permission java.net.URLPermission "https://localhost:*/https1/afdt", "POST";
-    permission java.net.URLPermission "http://localhost:*/http2/afdt",   "POST";
-    permission java.net.URLPermission "https://localhost:*/https2/afdt", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http1/afdt",   "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/afdt", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/afdt",   "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/afdt", "POST";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/http1/afdt",   "POST";
+    permission java.net.URLPermission "https://[::1]:*/https1/afdt", "POST";
+    permission java.net.URLPermission "http://[::1]:*/http2/afdt",   "POST";
+    permission java.net.URLPermission "https://[::1]:*/https2/afdt", "POST";
 
 
     // needed to grant permission to the HTTP/2 server
@@ -58,7 +64,8 @@ grant codeBase "file:${test.classes}/*" {
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP servers
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/FilePublisher/FilePublisherPermsTest1.policy
+++ b/test/jdk/java/net/httpclient/FilePublisher/FilePublisherPermsTest1.policy
@@ -34,19 +34,29 @@ grant codeBase "file:${test.classes}/../../../../../java/net/httpclient/http2/se
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.hpack";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www.http";
 
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
     permission java.lang.RuntimePermission "modifyThread";
 };
 
 grant codeBase "file:${test.classes}/*" {
-    permission java.net.URLPermission "http://localhost:*/http1/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "POST";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/http1/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "GET";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "GET";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "GET";
 
     // file permissions
     permission java.io.FilePermission "${user.dir}${/}defaultFile.txt", "read,write,delete";
@@ -69,7 +79,8 @@ grant codeBase "file:${test.classes}/*" {
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP servers
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/FilePublisher/FilePublisherPermsTest2.policy
+++ b/test/jdk/java/net/httpclient/FilePublisher/FilePublisherPermsTest2.policy
@@ -36,19 +36,29 @@ grant codeBase "file:${test.classes}/../../../../../java/net/httpclient/http2/se
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.hpack";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www.http";
 
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
     permission java.lang.RuntimePermission "modifyThread";
 };
 
 grant codeBase "file:${test.classes}/*" {
-    permission java.net.URLPermission "http://localhost:*/http1/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "POST";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/http1/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "GET";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "GET";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "GET";
 
     // file permissions
     permission java.io.FilePermission "${user.dir}${/}defaultFile.txt", "read,write,delete";
@@ -74,7 +84,8 @@ grant codeBase "file:${test.classes}/*" {
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP servers
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/FilePublisher/FilePublisherPermsTest3.policy
+++ b/test/jdk/java/net/httpclient/FilePublisher/FilePublisherPermsTest3.policy
@@ -41,19 +41,29 @@ grant codeBase "file:${test.classes}/../../../../../java/net/httpclient/http2/se
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.hpack";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www.http";
 
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
     permission java.lang.RuntimePermission "modifyThread";
 };
 
 grant codeBase "file:${test.classes}/*" {
-    permission java.net.URLPermission "http://localhost:*/http1/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "POST";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/http1/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "GET";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "GET";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "GET";
 
     // file permissions
     permission java.io.FilePermission "${user.dir}${/}defaultFile.txt", "read,write,delete";
@@ -77,7 +87,8 @@ grant codeBase "file:${test.classes}/*" {
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP servers
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/FilePublisher/FilePublisherTest.policy
+++ b/test/jdk/java/net/httpclient/FilePublisher/FilePublisherTest.policy
@@ -34,19 +34,29 @@ grant codeBase "file:${test.classes}/../../../../../java/net/httpclient/http2/se
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.hpack";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www.http";
 
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
     permission java.lang.RuntimePermission "modifyThread";
 };
 
 grant codeBase "file:${test.classes}/*" {
-    permission java.net.URLPermission "http://localhost:*/http1/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "POST";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/http1/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "GET";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "GET";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "GET";
 
     // file permissions
     permission java.io.FilePermission "${user.dir}${/}defaultFile.txt", "read,write,delete";
@@ -62,7 +72,8 @@ grant codeBase "file:${test.classes}/*" {
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP servers
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/HttpServerAdapters.java
@@ -530,8 +530,15 @@ public interface HttpServerAdapters {
         public abstract Version getVersion();
 
         public String serverAuthority() {
-            return InetAddress.getLoopbackAddress().getHostName() + ":"
-                    + getAddress().getPort();
+            InetSocketAddress address = getAddress();
+            String hostString = address.getHostString();
+            hostString = address.getAddress().isLoopbackAddress() || hostString.equals("localhost")
+                    ? address.getAddress().getHostAddress() // use the raw IP address, if loopback
+                    : hostString; // use whatever host string was used to construct the address
+            hostString = hostString.contains(":")
+                    ? "[" + hostString + "]"
+                    : hostString;
+            return hostString + ":" + address.getPort();
         }
 
         public static HttpTestServer of(HttpServer server) {

--- a/test/jdk/java/net/httpclient/LightWeightHttpServer.java
+++ b/test/jdk/java/net/httpclient/LightWeightHttpServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,12 +119,19 @@ public class LightWeightHttpServer {
         System.out.println("HTTP server port = " + port);
         httpsport = httpsServer.getAddress().getPort();
         System.out.println("HTTPS server port = " + httpsport);
-        httproot = "http://localhost:" + port + "/";
-        httpsroot = "https://localhost:" + httpsport + "/";
+        httproot = "http://" + makeServerAuthority(httpServer.getAddress()) + "/";
+        httpsroot = "https://" + makeServerAuthority(httpsServer.getAddress()) + "/";
 
         proxy = new ProxyServer(0, false);
         proxyPort = proxy.getPort();
         System.out.println("Proxy port = " + proxyPort);
+    }
+
+    private static String makeServerAuthority(final InetSocketAddress addr) {
+        final String hostIP = addr.getAddress().getHostAddress();
+        // escape for ipv6
+        final String h = hostIP.contains(":") ? "[" + hostIP + "]" : hostIP;
+        return h + ":" + addr.getPort();
     }
 
     public static void stop() throws IOException {

--- a/test/jdk/java/net/httpclient/PathSubscriber/ofFile.policy
+++ b/test/jdk/java/net/httpclient/PathSubscriber/ofFile.policy
@@ -45,19 +45,29 @@ grant codeBase "file:${test.classes}/../../../../../java/net/httpclient/http2/se
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.hpack";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www.http";
 
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
     permission java.lang.RuntimePermission "modifyThread";
 };
 
 grant codeBase "file:${test.classes}/*" {
-    permission java.net.URLPermission "http://localhost:*/http1/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "POST";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/http1/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "GET";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "GET";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "GET";
 
     // file permissions for test files
     permission java.io.FilePermission "${user.dir}${/}defaultFile.txt", "read,write,delete";
@@ -77,7 +87,8 @@ grant codeBase "file:${test.classes}/*" {
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP servers
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/PathSubscriber/ofFileDownload.policy
+++ b/test/jdk/java/net/httpclient/PathSubscriber/ofFileDownload.policy
@@ -45,19 +45,29 @@ grant codeBase "file:${test.classes}/../../../../../java/net/httpclient/http2/se
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.hpack";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www.http";
 
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
     permission java.lang.RuntimePermission "modifyThread";
 };
 
 grant codeBase "file:${test.classes}/*" {
-    permission java.net.URLPermission "http://localhost:*/http1/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "POST";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "POST";
-    permission java.net.URLPermission "https://localhost:*/http1/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https1/echo", "GET";
-    permission java.net.URLPermission "http://localhost:*/http2/echo", "GET";
-    permission java.net.URLPermission "https://localhost:*/https2/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/echo", "GET";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/http1/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "POST";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "POST";
+    permission java.net.URLPermission "https://[::1]:*/http1/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https1/echo", "GET";
+    permission java.net.URLPermission "http://[::1]:*/http2/echo", "GET";
+    permission java.net.URLPermission "https://[::1]:*/https2/echo", "GET";
 
     // file permissions for test files
     permission java.io.FilePermission "${user.dir}${/}file.zip", "read,write";
@@ -74,7 +84,8 @@ grant codeBase "file:${test.classes}/*" {
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP servers
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/RequestBodyTest.java
+++ b/test/jdk/java/net/httpclient/RequestBodyTest.java
@@ -21,24 +21,6 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 8087112
- * @modules java.net.http
- *          java.logging
- *          jdk.httpserver
- * @library /test/lib
- * @compile ../../../com/sun/net/httpserver/LogFilter.java
- * @compile ../../../com/sun/net/httpserver/EchoHandler.java
- * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
- * @build jdk.test.lib.net.SimpleSSLContext
- * @build LightWeightHttpServer
- * @build jdk.test.lib.Platform
- * @build jdk.test.lib.util.FileUtils
- * @run testng/othervm RequestBodyTest
- * @run testng/othervm/java.security.policy=RequestBodyTest.policy RequestBodyTest
- */
-
 import java.io.*;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -74,6 +56,23 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
+/*
+ * @test
+ * @bug 8087112
+ * @modules java.net.http
+ *          java.logging
+ *          jdk.httpserver
+ * @library /test/lib
+ * @compile ../../../com/sun/net/httpserver/LogFilter.java
+ * @compile ../../../com/sun/net/httpserver/EchoHandler.java
+ * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
+ * @build jdk.test.lib.net.SimpleSSLContext
+ * @build LightWeightHttpServer
+ * @build jdk.test.lib.Platform
+ * @build jdk.test.lib.util.FileUtils
+ * @run testng/othervm RequestBodyTest
+ * @run testng/othervm/java.security.policy=RequestBodyTest.policy RequestBodyTest
+ */
 public class RequestBodyTest {
 
     static final String fileroot = System.getProperty("test.src", ".") + "/docs";

--- a/test/jdk/java/net/httpclient/RequestBodyTest.policy
+++ b/test/jdk/java/net/httpclient/RequestBodyTest.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -38,14 +38,17 @@ grant codeBase "file:${test.classes}/*" {
     permission java.io.FilePermission "${test.src}${/}docs${/}files${/}notsobigfile.txt", "read";
     permission java.io.FilePermission "RequestBodyTest.tmp", "read,write,delete";
 
-    permission java.net.URLPermission "http://localhost:*/echo/foo",   "POST";
-    permission java.net.URLPermission "https://localhost:*/echo/foo",  "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/echo/foo",   "POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/echo/foo",  "POST";
+    permission java.net.URLPermission "http://[::1]:*/echo/foo",   "POST";
+    permission java.net.URLPermission "https://[::1]:*/echo/foo",  "POST";
 
     // for HTTP/1.1 server logging
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP server
-    permission java.net.SocketPermission "localhost:*", "accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/dependent.policy
+++ b/test/jdk/java/net/httpclient/dependent.policy
@@ -34,7 +34,8 @@ grant codeBase "file:${test.classes}/../../../../java/net/httpclient/http2/serve
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.hpack";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www.http";
 
-    permission java.net.SocketPermission "localhost:*", "listen,accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "listen,accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "listen,accept,resolve";
     permission java.lang.RuntimePermission "modifyThread";
 };
 
@@ -42,11 +43,15 @@ grant codeBase "file:${test.classes}/*" {
     permission java.io.FilePermission "${user.dir}${/}asFileDownloadTest.tmp.dir", "read,write";
     permission java.io.FilePermission "${user.dir}${/}asFileDownloadTest.tmp.dir/-", "read,write";
 
-    permission java.net.URLPermission "http://localhost:*/http1/-",   "GET,POST";
-    permission java.net.URLPermission "https://localhost:*/https1/-", "GET,POST";
-    permission java.net.URLPermission "http://localhost:*/http2/-",   "GET,POST";
-    permission java.net.URLPermission "https://localhost:*/https2/-", "GET,POST";
-
+    permission java.net.URLPermission "http://127.0.0.1:*/http1/-",   "GET,POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https1/-", "GET,POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/http2/-",   "GET,POST";
+    permission java.net.URLPermission "https://127.0.0.1:*/https2/-", "GET,POST";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/http1/-",   "GET,POST";
+    permission java.net.URLPermission "https://[::1]:*/https1/-", "GET,POST";
+    permission java.net.URLPermission "http://[::1]:*/http2/-",   "GET,POST";
+    permission java.net.URLPermission "https://[::1]:*/https2/-", "GET,POST";
 
     // needed to grant permission to the HTTP/2 server
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.net.http.common";
@@ -58,7 +63,8 @@ grant codeBase "file:${test.classes}/*" {
     permission java.util.logging.LoggingPermission "control";
 
     // needed to grant the HTTP servers
-    permission java.net.SocketPermission "localhost:*", "listen,accept,resolve";
+    permission java.net.SocketPermission "127.0.0.1:*", "listen,accept,resolve";
+    permission java.net.SocketPermission "[::1]:*", "listen,accept,resolve";
 
     permission java.util.PropertyPermission "*", "read";
     permission java.lang.RuntimePermission "modifyThread";

--- a/test/jdk/java/net/httpclient/http2/server/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/http2/server/Http2TestServer.java
@@ -81,8 +81,11 @@ public class Http2TestServer implements AutoCloseable {
     }
 
     public String serverAuthority() {
-        return InetAddress.getLoopbackAddress().getHostName() + ":"
-                + getAddress().getPort();
+        final InetSocketAddress inetSockAddr = getAddress();
+        final String hostIP = inetSockAddr.getAddress().getHostAddress();
+        // escape for ipv6
+        final String h = hostIP.contains(":") ? "[" + hostIP + "]" : hostIP;
+        return h + ":" + inetSockAddr.getPort();
     }
 
     public Http2TestServer(boolean secure,

--- a/test/jdk/java/net/httpclient/security/0.policy
+++ b/test/jdk/java/net/httpclient/security/0.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,8 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
@@ -39,8 +40,8 @@ grant {
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };
 
 

--- a/test/jdk/java/net/httpclient/security/1.policy
+++ b/test/jdk/java/net/httpclient/security/1.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:${port.number}/files/foo.txt", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:${port.number}/files/foo.txt", "GET";
+    permission java.net.URLPermission "http://[::1]:${port.number}/files/foo.txt", "GET";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/10.policy
+++ b/test/jdk/java/net/httpclient/security/10.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,16 +28,18 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:${port.number}/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "http://127.0.0.1:${port.number}/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "http://[::1]:${port.number}/files/foo.txt", "GET:*";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/11.policy
+++ b/test/jdk/java/net/httpclient/security/11.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,18 +28,26 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:${port.number}/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "http://127.0.0.1:${port.number}/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "socket://127.0.0.1:${port.number1}", "CONNECT";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:${port.number}/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "socket://[::1]:${port.number1}", "CONNECT";
+    // this specific test uses a proxy configured to loopback address. the httpclient implementation
+    // during permissions check uses the InetAddress.hostString() API which can return resolved
+    // hostname, so we use include a permission for "localhost" to cover that case too
     permission java.net.URLPermission "socket://localhost:${port.number1}", "CONNECT";
 };
 
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/12.policy
+++ b/test/jdk/java/net/httpclient/security/12.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,18 +28,26 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:${port.number}/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "http://127.0.0.1:${port.number}/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "socket://127.0.0.1:${port.number1}", "CONNECT";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:${port.number}/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "socket://[::1]:${port.number1}", "CONNECT";
+    // this specific test uses a proxy configured to loopback address. the httpclient implementation
+    // during permissions check uses the InetAddress.hostString() API which can return resolved
+    // hostname, so we use include a permission for "localhost" to cover that case too
     permission java.net.URLPermission "socket://localhost:${port.number1}", "CONNECT";
 };
 
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/14.policy
+++ b/test/jdk/java/net/httpclient/security/14.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/files/foo.txt", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/files/foo.txt", "GET";
+    permission java.net.URLPermission "http://[::1]:*/files/foo.txt", "GET";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/15.policy
+++ b/test/jdk/java/net/httpclient/security/15.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,12 +28,14 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "http://127.0.0.1:*/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "http://[::1]:*/files/foo.txt", "GET:*";
 
     // Test checks for this explicitly
     permission java.lang.RuntimePermission "foobar";
@@ -42,6 +44,6 @@ grant {
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/16.policy
+++ b/test/jdk/java/net/httpclient/security/16.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -29,17 +29,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:${port.number}/files/foo.txt", "GET:Host";
+    permission java.net.URLPermission "http://127.0.0.1:${port.number}/files/foo.txt", "GET:Host";
+    permission java.net.URLPermission "http://[::1]:${port.number}/files/foo.txt", "GET:Host";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/17.policy
+++ b/test/jdk/java/net/httpclient/security/17.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,18 +28,20 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:${port.number}/files/foo.txt", "GET:Host";
+    permission java.net.URLPermission "http://127.0.0.1:${port.number}/files/foo.txt", "GET:Host";
+    permission java.net.URLPermission "http://[::1]:${port.number}/files/foo.txt", "GET:Host";
     permission java.net.URLPermission "http://foohost:123/files/foo.txt", "GET:Host";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/2.policy
+++ b/test/jdk/java/net/httpclient/security/2.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/files/*", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/files/*", "GET";
+    permission java.net.URLPermission "http://[::1]:*/files/*", "GET";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/3.policy
+++ b/test/jdk/java/net/httpclient/security/3.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/redirect/foo.txt", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/redirect/foo.txt", "GET";
+    permission java.net.URLPermission "http://[::1]:*/redirect/foo.txt", "GET";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/4.policy
+++ b/test/jdk/java/net/httpclient/security/4.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,18 +28,22 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/redirect/foo.txt", "GET";
-    permission java.net.URLPermission "http://localhost:*/redirect/bar.txt", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/redirect/foo.txt", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/redirect/bar.txt", "GET";
+    // ipv6
+    permission java.net.URLPermission "http://[::1]:*/redirect/foo.txt", "GET";
+    permission java.net.URLPermission "http://[::1]:*/redirect/bar.txt", "GET";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/5.policy
+++ b/test/jdk/java/net/httpclient/security/5.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/redirect/bar.txt", "GET";
+    permission java.net.URLPermission "http://127.0.0.1:*/redirect/bar.txt", "GET";
+    permission java.net.URLPermission "http://[::1]:*/redirect/bar.txt", "GET";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/6.policy
+++ b/test/jdk/java/net/httpclient/security/6.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/files/foo.txt", "POST";
+    permission java.net.URLPermission "http://127.0.0.1:*/files/foo.txt", "POST";
+    permission java.net.URLPermission "http://[::1]:*/files/foo.txt", "POST";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/7.policy
+++ b/test/jdk/java/net/httpclient/security/7.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,20 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/files/foo.txt", "GET:X-Bar";
+    permission java.net.URLPermission "http://127.0.0.1:*/files/foo.txt", "GET:X-Bar";
+    permission java.net.URLPermission "http://[::1]:*/files/foo.txt", "GET:X-Bar";
+
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/8.policy
+++ b/test/jdk/java/net/httpclient/security/8.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/files/foo.txt", "GET:X-Foo1,X-Foo,X-Bar";
+    permission java.net.URLPermission "http://127.0.0.1:*/files/foo.txt", "GET:X-Foo1,X-Foo,X-Bar";
+    permission java.net.URLPermission "http://[::1]:*/files/foo.txt", "GET:X-Foo1,X-Foo,X-Bar";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };

--- a/test/jdk/java/net/httpclient/security/9.policy
+++ b/test/jdk/java/net/httpclient/security/9.policy
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,19 @@ grant {
     permission java.io.FilePermission "${test.classes}${/}-", "read,write,delete";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.util.logging.LoggingPermission "control", "";
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen";
     permission java.io.FilePermission "${test.src}${/}docs${/}-", "read";
     permission java.lang.RuntimePermission "createClassLoader";
 
 
     // permissions specific to this test
-    permission java.net.URLPermission "http://localhost:*/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "http://127.0.0.1:*/files/foo.txt", "GET:*";
+    permission java.net.URLPermission "http://[::1]:*/files/foo.txt", "GET:*";
 };
 
 // For proxy only. Not being tested
 grant codebase "file:${test.classes}/proxydir/-" {
-    permission java.net.SocketPermission "localhost:1024-", "accept,listen,connect";
-    permission java.net.SocketPermission "localhost:1024-", "connect,resolve";
+    permission java.net.SocketPermission "127.0.0.1:1024-", "accept,listen,connect,resolve";
+    permission java.net.SocketPermission "[::1]:1024-", "accept,listen,connect,resolve";
 };


### PR DESCRIPTION
I backport this to fix testing issues with ConnectionReueseTest.java that showed after backporting https://bugs.openjdk.org/browse/JDK-8305906.

Jaikiran proposes to do a local fix, but I think backporting this test-only changes keeps the test suite better up-to-date. Also later similar issues will be avoided.

Some simple adaptions were needed: 

test/jdk/java/net/httpclient/AsFileDownloadTest.java
Trivial resolve.

test/jdk/java/net/httpclient/httpclient-localaddr-security.policy
File not in 17. Skipped.

test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
Trivial resolve, file in other loction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8305900](https://bugs.openjdk.org/browse/JDK-8305900) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305900](https://bugs.openjdk.org/browse/JDK-8305900): Use loopback IP addresses in security policy files of httpclient tests (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2260/head:pull/2260` \
`$ git checkout pull/2260`

Update a local copy of the PR: \
`$ git checkout pull/2260` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2260`

View PR using the GUI difftool: \
`$ git pr show -t 2260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2260.diff">https://git.openjdk.org/jdk17u-dev/pull/2260.diff</a>

</details>
