### PR TITLE
8327036: [macosx-aarch64] SIGBUS in MarkActivationClosure::do_code_blob reached from Unsafe_CopySwapMemory0

### DIFF
--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -464,6 +464,7 @@ extern "C" {                                                         \
 #define JVM_ENTRY_FROM_LEAF(env, result_type, header)                \
   { {                                                                \
     JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
     VM_ENTRY_BASE_FROM_LEAF(result_type, header, thread)


### PR DESCRIPTION
This pull request contains a backport of commit [ad1d3248](https://github.com/openjdk/jdk21u-dev/commit/ad1d32484a8130c9b641cff38c07e8544b3fd271) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

With the change the current thread switches to `WXWrite` mode before transitioning into the vm in `JVM_ENTRY_FROM_LEAF`.

Testing:
`test/jdk/sun/nio/cs/FindDecoderBugs.java` with `-XX:+AssertWXAtThreadSync`

The fix passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests (also with ParallelGC).
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327036](https://bugs.openjdk.org/browse/JDK-8327036) needs maintainer approval

### Issue
 * [JDK-8327036](https://bugs.openjdk.org/browse/JDK-8327036): [macosx-aarch64] SIGBUS in MarkActivationClosure::do_code_blob reached from Unsafe_CopySwapMemory0 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2269/head:pull/2269` \
`$ git checkout pull/2269`

Update a local copy of the PR: \
`$ git checkout pull/2269` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2269`

View PR using the GUI difftool: \
`$ git pr show -t 2269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2269.diff">https://git.openjdk.org/jdk17u-dev/pull/2269.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2269#issuecomment-1985344447)