### PR TITLE
8320005: Allow loading of shared objects with .a extension on AIX

### DIFF
--- a/src/hotspot/os/aix/os_aix.hpp
+++ b/src/hotspot/os/aix/os_aix.hpp
@@ -177,6 +177,10 @@ class Aix {
   // (on AIX, using libperfstat, on PASE with libo4.so).
   // Returns true if ok, false if error.
   static bool get_meminfo(meminfo_t* pmi);
+
+  static bool platform_print_native_stack(outputStream* st, const void* context, char *buf, int buf_size, address& lastpc);
+  static void* resolve_function_descriptor(void* p);
+
 };
 
 #endif // OS_AIX_OS_AIX_HPP

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -21,6 +21,12 @@
  * questions.
  *
  */
+// needs to be defined first, so that the implicit loaded xcoff.h header defines
+// the right structures to analyze the loader header of 64 Bit executable files
+// this is needed for rtv_linkedin_libpath() to get the linked (burned) in library
+// search path of an XCOFF executable
+#define __XCOFF64__
+#include <xcoff.h>
 
 #include "asm/assembler.hpp"
 #include "compiler/disassembler.hpp"
@@ -889,6 +895,274 @@ bool AixMisc::query_stack_bounds_for_current_thread(stackbounds_t* out) {
 
 }
 
+// variables needed to emulate linux behavior in os::dll_load() if library is loaded twice
+static pthread_mutex_t g_handletable_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+struct TableLocker {
+  TableLocker() { pthread_mutex_lock(&g_handletable_mutex); }
+  ~TableLocker() { pthread_mutex_unlock(&g_handletable_mutex); }
+};
+struct handletableentry{
+    void*   handle;
+    ino64_t inode;
+    dev64_t devid;
+    uint    refcount;
+};
+constexpr unsigned init_num_handles = 128;
+static unsigned max_handletable = 0;
+static unsigned g_handletable_used = 0;
+// We start with an empty array. At first use we will dynamically allocate memory for 128 entries.
+// If this table is full we dynamically reallocate a memory reagion of double size, and so on.
+static struct handletableentry* p_handletable = nullptr;
 
+// get the library search path burned in to the executable file during linking
+// If the libpath cannot be retrieved return an empty path
+static const char* rtv_linkedin_libpath() {
+  constexpr int bufsize = 4096;
+  static char buffer[bufsize];
+  static const char* libpath = 0;
+
+  // we only try to retrieve the libpath once. After that try we
+  // let libpath point to buffer, which then contains a valid libpath
+  // or an empty string
+  if (libpath != nullptr) {
+    return libpath;
+  }
+
+  // retrieve the path to the currently running executable binary
+  // to open it
+  snprintf(buffer, 100, "/proc/%ld/object/a.out", (long)getpid());
+  FILE* f = nullptr;
+  struct xcoffhdr the_xcoff;
+  struct scnhdr the_scn;
+  struct ldhdr the_ldr;
+  constexpr size_t xcoffsz = FILHSZ + _AOUTHSZ_EXEC;
+  STATIC_ASSERT(sizeof(the_xcoff) == xcoffsz);
+  STATIC_ASSERT(sizeof(the_scn) == SCNHSZ);
+  STATIC_ASSERT(sizeof(the_ldr) == LDHDRSZ);
+  // read the generic XCOFF header and analyze the substructures
+  // to find the burned in libpath. In any case of error perform the assert
+  if (nullptr == (f = fopen(buffer, "r")) ||
+      xcoffsz != fread(&the_xcoff, 1, xcoffsz, f) ||
+      the_xcoff.filehdr.f_magic != U64_TOCMAGIC ||
+      0 != fseek(f, (FILHSZ + the_xcoff.filehdr.f_opthdr + (the_xcoff.aouthdr.o_snloader -1)*SCNHSZ), SEEK_SET) ||
+      SCNHSZ != fread(&the_scn, 1, SCNHSZ, f) ||
+      0 != strcmp(the_scn.s_name, ".loader") ||
+      0 != fseek(f, the_scn.s_scnptr, SEEK_SET) ||
+      LDHDRSZ != fread(&the_ldr, 1, LDHDRSZ, f) ||
+      0 != fseek(f, the_scn.s_scnptr + the_ldr.l_impoff, SEEK_SET) ||
+      0 == fread(buffer, 1, bufsize, f)) {
+    buffer[0] = 0;
+    assert(false, "could not retrieve burned in library path from executables loader section");
+  }
+
+  if (f) {
+    fclose(f);
+  }
+  libpath = buffer;
+
+  return libpath;
+}
+
+// Simulate the library search algorithm of dlopen() (in os::dll_load)
+static bool search_file_in_LIBPATH(const char* path, struct stat64x* stat) {
+  if (path == nullptr)
+    return false;
+
+  char* path2 = os::strdup(path);
+  // if exist, strip off trailing (shr_64.o) or similar
+  char* substr;
+  if (path2[strlen(path2) - 1] == ')' && (substr = strrchr(path2, '('))) {
+    *substr = 0;
+  }
+
+  bool ret = false;
+  // If FilePath contains a slash character, FilePath is used directly,
+  // and no directories are searched.
+  // But if FilePath does not start with / or . we have to prepend it with ./
+  if (strchr(path2, '/')) {
+    stringStream combined;
+    if (*path2 == '/' || *path2 == '.') {
+      combined.print("%s", path2);
+    } else {
+      combined.print("./%s", path2);
+    }
+    ret = (0 == stat64x(combined.base(), stat));
+    os::free(path2);
+    return ret;
+  }
+
+  const char* env = getenv("LIBPATH");
+  if (env == nullptr) {
+    // no LIBPATH, try with LD_LIBRARY_PATH
+    env = getenv("LD_LIBRARY_PATH");
+  }
+
+  stringStream Libpath;
+  if (env == nullptr) {
+    // no LIBPATH or LD_LIBRARY_PATH given -> try only with burned in libpath
+    Libpath.print("%s", rtv_linkedin_libpath());
+  } else if (*env == 0) {
+    // LIBPATH or LD_LIBRARY_PATH given but empty -> try first with burned
+    //  in libpath and with current working directory second
+    Libpath.print("%s:.", rtv_linkedin_libpath());
+  } else {
+    // LIBPATH or LD_LIBRARY_PATH given with content -> try first with
+    // LIBPATH or LD_LIBRARY_PATH and second with burned in libpath.
+    // No check against current working directory
+    Libpath.print("%s:%s", env, rtv_linkedin_libpath());
+  }
+
+  char* libpath = os::strdup(Libpath.base());
+
+  char *saveptr, *token;
+  for (token = strtok_r(libpath, ":", &saveptr); token != nullptr; token = strtok_r(nullptr, ":", &saveptr)) {
+    stringStream combined;
+    combined.print("%s/%s", token, path2);
+    if ((ret = (0 == stat64x(combined.base(), stat))))
+      break;
+  }
+
+  os::free(libpath);
+  os::free(path2);
+  return ret;
+}
+
+// specific AIX versions for ::dlopen() and ::dlclose(), which handles the struct g_handletable
+// This way we mimic dl handle equality for a library
+// opened a second time, as it is implemented on other platforms.
+void* Aix_dlopen(const char* filename, int Flags, const char** error_report) {
+  assert(error_report != nullptr, "error_report is nullptr");
+  void* result;
+  struct stat64x libstat;
+
+  if (false == search_file_in_LIBPATH(filename, &libstat)) {
+    // file with filename does not exist
+  #ifdef ASSERT
+    result = ::dlopen(filename, Flags);
+    assert(result == nullptr, "dll_load: Could not stat() file %s, but dlopen() worked; Have to improve stat()", filename);
+  #endif
+    *error_report = "Could not load module .\nSystem error: No such file or directory";
+    return nullptr;
+  }
+  else {
+    unsigned i = 0;
+    TableLocker lock;
+    // check if library belonging to filename is already loaded.
+    // If yes use stored handle from previous ::dlopen() and increase refcount
+    for (i = 0; i < g_handletable_used; i++) {
+      if ((p_handletable + i)->handle &&
+          (p_handletable + i)->inode == libstat.st_ino &&
+          (p_handletable + i)->devid == libstat.st_dev) {
+        (p_handletable + i)->refcount++;
+        result = (p_handletable + i)->handle;
+        break;
+      }
+    }
+    if (i == g_handletable_used) {
+      // library not yet loaded. Check if there is space left in array
+      // to store new ::dlopen() handle
+      if (g_handletable_used == max_handletable) {
+        // No place in array anymore; increase array.
+        unsigned new_max = MAX2(max_handletable * 2, init_num_handles);
+        struct handletableentry* new_tab = (struct handletableentry*)::realloc(p_handletable, new_max * sizeof(struct handletableentry));
+        assert(new_tab != nullptr, "no more memory for handletable");
+        if (new_tab == nullptr) {
+          *error_report = "dlopen: no more memory for handletable";
+          return nullptr;
+        }
+        max_handletable = new_max;
+        p_handletable = new_tab;
+      }
+      // Library not yet loaded; load it, then store its handle in handle table
+      result = ::dlopen(filename, Flags);
+      if (result != nullptr) {
+        g_handletable_used++;
+        (p_handletable + i)->handle = result;
+        (p_handletable + i)->inode = libstat.st_ino;
+        (p_handletable + i)->devid = libstat.st_dev;
+        (p_handletable + i)->refcount = 1;
+      }
+      else {
+        // error analysis when dlopen fails
+        *error_report = ::dlerror();
+        if (*error_report == nullptr) {
+          *error_report = "dlerror returned no error description";
+        }
+      }
+    }
+  }
+  return result;
+}
+
+bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
+  unsigned i = 0;
+  bool res = false;
+
+  if (ebuf && ebuflen > 0) {
+    ebuf[0] = '\0';
+    ebuf[ebuflen - 1] = '\0';
+  }
+
+  {
+    TableLocker lock;
+    // try to find handle in array, which means library was loaded by os::dll_load() call
+    for (i = 0; i < g_handletable_used; i++) {
+      if ((p_handletable + i)->handle == libhandle) {
+        // handle found, decrease refcount
+        assert((p_handletable + i)->refcount > 0, "Sanity");
+        (p_handletable + i)->refcount--;
+        if ((p_handletable + i)->refcount > 0) {
+          // if refcount is still >0 then we have to keep library and just return true
+          return true;
+        }
+        // refcount == 0, so we have to ::dlclose() the lib
+        // and delete the entry from the array.
+        break;
+      }
+    }
+
+    // If we reach this point either the libhandle was found with refcount == 0, or the libhandle
+    // was not found in the array at all. In both cases we have to ::dlclose the lib and perform
+    // the error handling. In the first case we then also have to delete the entry from the array
+    // while in the second case we simply have to nag.
+    res = (0 == ::dlclose(libhandle));
+    if (!res) {
+      // error analysis when dlopen fails
+      const char* error_report = ::dlerror();
+      if (error_report == nullptr) {
+        error_report = "dlerror returned no error description";
+      }
+      if (ebuf != nullptr && ebuflen > 0) {
+        snprintf(ebuf, ebuflen - 1, "%s", error_report);
+      }
+      assert(false, "os::pd_dll_unload() ::dlclose() failed");
+    }
+
+    if (i < g_handletable_used) {
+      if (res) {
+        // First case: libhandle was found (with refcount == 0) and ::dlclose successful,
+        // so delete entry from array
+        g_handletable_used--;
+        // If the entry was the last one of the array, the previous g_handletable_used--
+        // is sufficient to remove the entry from the array, otherwise we move the last
+        // entry of the array to the place of the entry we want to remove and overwrite it
+        if (i < g_handletable_used) {
+          *(p_handletable + i) = *(p_handletable + g_handletable_used);
+          (p_handletable + g_handletable_used)->handle = nullptr;
+        }
+      }
+    }
+    else {
+      // Second case: libhandle was not found (library was not loaded by os::dll_load())
+      // therefore nag
+      assert(false, "os::pd_dll_unload() library was not loaded by os::dll_load()");
+    }
+  }
+
+  // Update the dll cache
+  LoadedLibraries::reload();
+
+  return res;
+} // end: os::pd_dll_unload()
 

--- a/src/hotspot/os/aix/porting_aix.hpp
+++ b/src/hotspot/os/aix/porting_aix.hpp
@@ -107,4 +107,6 @@ class AixMisc {
 
 };
 
+void* Aix_dlopen(const char* filename, int Flags, const char** error_report);
+
 #endif // OS_AIX_PORTING_AIX_HPP

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2615,3 +2615,55 @@ bool os::start_debugging(char *buf, int buflen) {
 }
 
 void os::print_memory_mappings(char* addr, size_t bytes, outputStream* st) {}
+
+#if INCLUDE_JFR
+
+void os::jfr_report_memory_info() {
+#ifdef __APPLE__
+  mach_task_basic_info info;
+  mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+
+  kern_return_t ret = task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)&info, &count);
+  if (ret == KERN_SUCCESS) {
+    // Send the RSS JFR event
+    EventResidentSetSize event;
+    event.set_size(info.resident_size);
+    // We've seen that resident_size_max sometimes trails resident_size with one page.
+    // Make sure we always report size <= peak
+    event.set_peak(MAX2(info.resident_size_max, info.resident_size));
+    event.commit();
+  } else {
+    // Log a warning
+    static bool first_warning = true;
+    if (first_warning) {
+      log_warning(jfr)("Error fetching RSS values: task_info failed");
+      first_warning = false;
+    }
+  }
+
+#endif // __APPLE__
+}
+
+#endif // INCLUDE_JFR
+
+bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
+
+  if (ebuf && ebuflen > 0) {
+    ebuf[0] = '\0';
+    ebuf[ebuflen - 1] = '\0';
+  }
+
+  bool res = (0 == ::dlclose(libhandle));
+  if (!res) {
+    // error analysis when dlopen fails
+    const char* error_report = ::dlerror();
+    if (error_report == nullptr) {
+      error_report = "dlerror returned no error description";
+    }
+    if (ebuf != nullptr && ebuflen > 0) {
+      snprintf(ebuf, ebuflen - 1, "%s", error_report);
+    }
+  }
+
+  return res;
+} // end: os::pd_dll_unload()

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -5560,3 +5560,25 @@ bool os::trim_native_heap(os::size_change_t* rss_change) {
   return false; // musl
 #endif
 }
+
+bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
+
+  if (ebuf && ebuflen > 0) {
+    ebuf[0] = '\0';
+    ebuf[ebuflen - 1] = '\0';
+  }
+
+  bool res = (0 == ::dlclose(libhandle));
+  if (!res) {
+    // error analysis when dlopen fails
+    const char* error_report = ::dlerror();
+    if (error_report == nullptr) {
+      error_report = "dlerror returned no error description";
+    }
+    if (ebuf != nullptr && ebuflen > 0) {
+      snprintf(ebuf, ebuflen - 1, "%s", error_report);
+    }
+  }
+
+  return res;
+} // end: os::pd_dll_unload()

--- a/src/hotspot/share/prims/jvmtiAgent.cpp
+++ b/src/hotspot/share/prims/jvmtiAgent.cpp
@@ -1,0 +1,643 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "prims/jvmtiAgent.hpp"
+
+#include "cds/cds_globals.hpp"
+#include "cds/cdsConfig.hpp"
+#include "jni.h"
+#include "jvm_io.h"
+#include "jvmtifiles/jvmtiEnv.hpp"
+#include "prims/jvmtiEnvBase.hpp"
+#include "prims/jvmtiExport.hpp"
+#include "prims/jvmtiAgentList.hpp"
+#include "runtime/arguments.hpp"
+#include "runtime/handles.inline.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/java.hpp"
+#include "runtime/jniHandles.hpp"
+#include "runtime/globals_extension.hpp"
+#include "runtime/os.inline.hpp"
+#include "runtime/thread.inline.hpp"
+#include "utilities/defaultStream.hpp"
+
+static inline const char* copy_string(const char* str) {
+  return str != nullptr ? os::strdup(str, mtServiceability) : nullptr;
+}
+
+// Returns the lhs before '=', parsed_options output param gets the rhs.
+static const char* split_options_and_allocate_copy(const char* options, const char** parsed_options) {
+  assert(options != nullptr, "invariant");
+  assert(parsed_options != nullptr, "invariant");
+  const char* const equal_sign = strchr(options, '=');
+  const size_t length = strlen(options);
+  size_t name_length = length;
+  if (equal_sign != nullptr) {
+    name_length = equal_sign - options;
+    const size_t options_length = length - name_length - 1;
+    *parsed_options = copy_string(equal_sign + 1);
+  } else {
+    *parsed_options = nullptr;
+    name_length = length;
+  }
+  char* const name = AllocateHeap(name_length + 1, mtServiceability);
+  jio_snprintf(name, name_length + 1, "%s", options);
+  assert(strncmp(name, options, name_length) == 0, "invariant");
+  return name;
+}
+
+JvmtiAgent::JvmtiAgent(const char* name, const char* options, bool is_absolute_path, bool dynamic /* false */) :
+  _initialization_time(),
+  _initialization_duration(),
+  _next(nullptr),
+  _name(copy_string(name)),
+  _options(copy_string(options)),
+  _os_lib(nullptr),
+  _os_lib_path(nullptr),
+  _jplis(nullptr),
+  _loaded(false),
+  _absolute_path(is_absolute_path),
+  _static_lib(false),
+  _instrument_lib(strcmp(name, "instrument") == 0),
+  _dynamic(dynamic),
+  _xrun(false) {}
+
+JvmtiAgent* JvmtiAgent::next() const {
+  return _next;
+}
+
+void JvmtiAgent::set_next(JvmtiAgent* agent) {
+  _next = agent;
+}
+
+const char* JvmtiAgent::name() const {
+  return _name;
+}
+
+const char* JvmtiAgent::options() const {
+  return _options;
+}
+
+void* JvmtiAgent::os_lib() const {
+  return _os_lib;
+}
+
+void JvmtiAgent::set_os_lib(void* os_lib) {
+  _os_lib = os_lib;
+}
+
+void JvmtiAgent::set_os_lib_path(const char* path) {
+  assert(path != nullptr, "invariant");
+  if (_os_lib_path == nullptr) {
+    _os_lib_path = copy_string(path);
+  }
+  assert(strcmp(_os_lib_path, path) == 0, "invariant");
+}
+
+const char* JvmtiAgent::os_lib_path() const {
+  return _os_lib_path;
+}
+
+bool JvmtiAgent::is_loaded() const {
+  return _loaded;
+}
+
+void JvmtiAgent::set_loaded() {
+  _loaded = true;
+}
+
+bool JvmtiAgent::is_absolute_path() const {
+  return _absolute_path;
+}
+
+bool JvmtiAgent::is_static_lib() const {
+  return _static_lib;
+}
+
+void JvmtiAgent::set_static_lib() {
+  _static_lib = true;
+}
+
+bool JvmtiAgent::is_dynamic() const {
+  return _dynamic;
+}
+
+bool JvmtiAgent:: is_instrument_lib() const {
+  return _instrument_lib;
+}
+
+bool JvmtiAgent::is_xrun() const {
+  return _xrun;
+}
+
+void JvmtiAgent::set_xrun() {
+  _xrun = true;
+}
+
+bool JvmtiAgent::is_jplis() const {
+  return _jplis != nullptr;
+}
+
+const Ticks& JvmtiAgent::initialization_time() const {
+  return _initialization_time;
+}
+
+const Tickspan& JvmtiAgent::initialization_duration() const {
+  return _initialization_duration;
+}
+
+bool JvmtiAgent::is_initialized() const {
+  return _initialization_time.value() != 0;
+}
+
+void JvmtiAgent::initialization_begin() {
+  assert(!is_initialized(), "invariant");
+  _initialization_time = Ticks::now();
+}
+
+void JvmtiAgent::initialization_end() {
+  assert(is_initialized(), "invariant");
+  assert(_initialization_duration.value() == 0, "invariant");
+  _initialization_duration = Ticks::now() - initialization_time();
+}
+
+/*
+ * The implementation builds a mapping bewteen JvmtiEnvs and JPLIS agents,
+ * using internal JDK implementation knowledge about the way JPLIS agents
+ * store data in their JvmtiEnv local storage.
+ *
+ * Please see JPLISAgent.h and JPLISAgent.c in module java.instrument.
+ *
+ * jvmtierror = (*jvmtienv)->SetEnvironmentLocalStorage( jvmtienv, &(agent->mNormalEnvironment));
+ *
+ * It is the pointer to the field agent->mNormalEnvironment that is stored in the jvmtiEnv local storage.
+ * It has the following type:
+ *
+ * struct _JPLISEnvironment {
+ *   jvmtiEnv*   mJVMTIEnv;         // the JVMTI environment
+ *   JPLISAgent* mAgent;            // corresponding agent
+ *   jboolean    mIsRetransformer;  // indicates if special environment
+ * };
+ *
+ * We mirror this struct to get the mAgent field as an identifier.
+ */
+
+struct JPLISEnvironmentMirror {
+  jvmtiEnv* mJVMTIEnv; // the JVMTI environment
+  const void* mAgent;  // corresponding agent
+  jboolean mIsRetransformer; // indicates if special environment
+};
+
+static inline const JPLISEnvironmentMirror* get_env_local_storage(JvmtiEnv* env) {
+  assert(env != nullptr, "invariant");
+  return reinterpret_cast<const JPLISEnvironmentMirror*>(env->get_env_local_storage());
+}
+
+bool JvmtiAgent::is_jplis(JvmtiEnv* env) const {
+  assert(env != nullptr, "invariant");
+  assert(is_instrument_lib(), "invariant");
+  const JPLISEnvironmentMirror* const jplis_env = get_env_local_storage(env);
+  return jplis_env != nullptr && _jplis == jplis_env->mAgent;
+}
+
+void JvmtiAgent::set_jplis(const void* jplis) {
+  assert(jplis != nullptr, "invaiant");
+  assert(is_instrument_lib(), "invariant");
+  assert(_jplis == nullptr, "invariant");
+  if (_options != nullptr) {
+    // For JPLIS agents, update with the java name and options.
+    os::free(const_cast<char*>(_name));
+    const char* options = _options;
+    _name = split_options_and_allocate_copy(options, &_options);
+    os::free(const_cast<char*>(options));
+  }
+  _jplis = jplis;
+}
+
+static const char* not_found_error_msg = "Could not find agent library ";
+static const char* missing_module_error_msg = "\nModule java.instrument may be missing from runtime image.";
+static char ebuf[1024];
+static char buffer[JVM_MAXPATHLEN];
+
+static void vm_exit(const JvmtiAgent* agent, const char* sub_msg1, const char* sub_msg2) {
+  assert(agent != nullptr, "invariant");
+  assert(sub_msg1 != nullptr, "invariant");
+  assert(!agent->is_instrument_lib() || sub_msg2 != nullptr, "invariant");
+  const size_t len = strlen(not_found_error_msg) + strlen(agent->name()) + strlen(sub_msg1) + strlen(&ebuf[0]) + 1 + (agent->is_instrument_lib() ? strlen(sub_msg2) : 0);
+  char* buf = NEW_C_HEAP_ARRAY(char, len, mtServiceability);
+  if (agent->is_instrument_lib()) {
+    jio_snprintf(buf, len, "%s%s%s%s%s", not_found_error_msg, agent->name(), sub_msg1, &ebuf[0], sub_msg2);
+  } else {
+    jio_snprintf(buf, len, "%s%s%s%s", not_found_error_msg, agent->name(), sub_msg1, &ebuf[0]);
+  }
+  vm_exit_during_initialization(buf, nullptr);
+  FREE_C_HEAP_ARRAY(char, buf);
+}
+
+#ifdef ASSERT
+static void assert_preload(const JvmtiAgent* agent) {
+  assert(agent != nullptr, "invariant");
+  assert(!agent->is_loaded(), "invariant");
+}
+#endif
+
+// Check for a statically linked-in agent, i.e. in the executable.
+// This should be the first function called when loading an agent. It is a bit special:
+// For statically linked agents we can't rely on os_lib == nullptr because
+// statically linked agents could have a handle of RTLD_DEFAULT which == 0 on some platforms.
+// If this function returns true, then agent->is_static_lib() && agent->is_loaded().
+static bool load_agent_from_executable(JvmtiAgent* agent, const char* on_load_symbols[], size_t num_symbol_entries) {
+  DEBUG_ONLY(assert_preload(agent);)
+  assert(on_load_symbols != nullptr, "invariant");
+  return os::find_builtin_agent(agent, &on_load_symbols[0], num_symbol_entries);
+}
+
+// Load the library from the absolute path of the agent, if available.
+static void* load_agent_from_absolute_path(JvmtiAgent* agent, bool vm_exit_on_error) {
+  DEBUG_ONLY(assert_preload(agent);)
+  assert(agent->is_absolute_path(), "invariant");
+  assert(!agent->is_instrument_lib(), "invariant");
+  void* const library = os::dll_load(agent->name(), &ebuf[0], sizeof ebuf);
+  if (library == nullptr && vm_exit_on_error) {
+    vm_exit(agent, " in absolute path, with error: ", nullptr);
+  }
+  return library;
+}
+
+// Agents with relative paths are loaded from the standard dll directory.
+static void* load_agent_from_relative_path(JvmtiAgent* agent, bool vm_exit_on_error) {
+  DEBUG_ONLY(assert_preload(agent);)
+  assert(!agent->is_absolute_path(), "invariant");
+  const char* const name = agent->name();
+  void* library = nullptr;
+  // Try to load the agent from the standard dll directory
+  if (os::dll_locate_lib(&buffer[0], sizeof buffer, Arguments::get_dll_dir(), name)) {
+    library = os::dll_load(&buffer[0], &ebuf[0], sizeof ebuf);
+  }
+  if (library == nullptr && os::dll_build_name(&buffer[0], sizeof buffer, name)) {
+    // Try the library path directory.
+    library = os::dll_load(&buffer[0], &ebuf[0], sizeof ebuf);
+    if (library != nullptr) {
+      return library;
+    }
+    if (vm_exit_on_error) {
+      vm_exit(agent, " on the library path, with error: ", missing_module_error_msg);
+    }
+  }
+  return library;
+}
+
+// For absolute and relative paths.
+static void* load_library(JvmtiAgent* agent, const char* on_symbols[], size_t num_symbol_entries, bool vm_exit_on_error) {
+  return agent->is_absolute_path() ? load_agent_from_absolute_path(agent, vm_exit_on_error) :
+                                     load_agent_from_relative_path(agent, vm_exit_on_error);
+}
+
+// Type for the Agent_OnLoad and JVM_OnLoad entry points.
+extern "C" {
+  typedef jint(JNICALL* OnLoadEntry_t)(JavaVM*, char*, void*);
+}
+
+// Find the OnLoad entry point for -agentlib:  -agentpath:   -Xrun agents.
+// num_symbol_entries must be passed-in since only the caller knows the number of symbols in the array.
+static OnLoadEntry_t lookup_On_Load_entry_point(JvmtiAgent* agent, const char* on_load_symbols[], size_t num_symbol_entries) {
+  assert(agent != nullptr, "invariant");
+  if (!agent->is_loaded()) {
+    if (!load_agent_from_executable(agent, on_load_symbols, num_symbol_entries)) {
+      void* const library = load_library(agent, on_load_symbols, num_symbol_entries, /* vm exit on error */ true);
+      assert(library != nullptr, "invariant");
+      agent->set_os_lib(library);
+      agent->set_loaded();
+    }
+  }
+  assert(agent->is_loaded(), "invariant");
+  // Find the OnLoad function.
+  return CAST_TO_FN_PTR(OnLoadEntry_t, os::find_agent_function(agent, false, on_load_symbols, num_symbol_entries));
+}
+
+static OnLoadEntry_t lookup_JVM_OnLoad_entry_point(JvmtiAgent* lib) {
+  const char* on_load_symbols[] = JVM_ONLOAD_SYMBOLS;
+  return lookup_On_Load_entry_point(lib, on_load_symbols, sizeof(on_load_symbols) / sizeof(char*));
+}
+
+static OnLoadEntry_t lookup_Agent_OnLoad_entry_point(JvmtiAgent* agent) {
+  const char* on_load_symbols[] = AGENT_ONLOAD_SYMBOLS;
+  return lookup_On_Load_entry_point(agent, on_load_symbols, sizeof(on_load_symbols) / sizeof(char*));
+}
+
+void JvmtiAgent::convert_xrun_agent() {
+  assert(is_xrun(), "invariant");
+  assert(!is_loaded(), "invariant");
+  assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_PRIMORDIAL, "invalid init sequence");
+  OnLoadEntry_t on_load_entry = lookup_JVM_OnLoad_entry_point(this);
+  // If there is an JVM_OnLoad function it will get called later,
+  // otherwise see if there is an Agent_OnLoad.
+  if (on_load_entry == nullptr) {
+    on_load_entry = lookup_Agent_OnLoad_entry_point(this);
+    if (on_load_entry == nullptr) {
+      vm_exit_during_initialization("Could not find JVM_OnLoad or Agent_OnLoad function in the library", name());
+    }
+    _xrun = false; // converted
+  }
+}
+
+// Called after the VM is initialized for -Xrun agents which have not been converted to JVMTI agents.
+static bool invoke_JVM_OnLoad(JvmtiAgent* agent) {
+  assert(agent != nullptr, "invariant");
+  assert(agent->is_xrun(), "invariant");
+  assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_PRIMORDIAL, "invalid init sequence");
+  OnLoadEntry_t on_load_entry = lookup_JVM_OnLoad_entry_point(agent);
+  if (on_load_entry == nullptr) {
+    vm_exit_during_initialization("Could not find JVM_OnLoad function in -Xrun library", agent->name());
+  }
+  // Invoke the JVM_OnLoad function
+  JavaThread* thread = JavaThread::current();
+  ThreadToNativeFromVM ttn(thread);
+  HandleMark hm(thread);
+  extern struct JavaVM_ main_vm;
+  const jint err = (*on_load_entry)(&main_vm, const_cast<char*>(agent->options()), nullptr);
+  if (err != JNI_OK) {
+    vm_exit_during_initialization("-Xrun library failed to init", agent->name());
+  }
+  return true;
+}
+
+// The newest jvmtiEnv is appended to the list,
+// hence the JvmtiEnvIterator order is from oldest to newest.
+static JvmtiEnv* get_last_jplis_jvmtienv() {
+  JvmtiEnvIterator it;
+  JvmtiEnv* env = it.first();
+  assert(env != nullptr, "invariant");
+  JvmtiEnv* next = it.next(env);
+  while (next != nullptr) {
+    assert(env != nullptr, "invariant");
+    // get_env_local_storage() lets us find which JVMTI env map to which JPLIS agent.
+    if (next->get_env_local_storage() == nullptr) {
+      JvmtiEnv* temp = it.next(next);
+      if (temp != nullptr) {
+        next = temp;
+        continue;
+      }
+      break;
+    }
+    env = next;
+    next = it.next(env);
+  }
+  assert(env != nullptr, "invariant");
+  assert(env->get_env_local_storage() != nullptr, "invariant");
+  return env;
+}
+
+// Associate the last, i.e. most recent, JvmtiEnv that is a JPLIS agent with the current agent.
+static void convert_to_jplis(JvmtiAgent* agent) {
+  assert(agent != nullptr, "invariant");
+  assert(agent->is_instrument_lib(), "invariant");
+  JvmtiEnv* const env = get_last_jplis_jvmtienv();
+  assert(env != nullptr, "invariant");
+  const JPLISEnvironmentMirror* const jplis_env = get_env_local_storage(env);
+  assert(jplis_env != nullptr, "invaiant");
+  assert(reinterpret_cast<JvmtiEnv*>(jplis_env->mJVMTIEnv) == env, "invariant");
+  agent->set_jplis(jplis_env->mAgent);
+}
+
+// Use this for JavaThreads and state is _thread_in_vm.
+class AgentJavaThreadEventTransition : StackObj {
+ private:
+  ResourceMark _rm;
+  ThreadToNativeFromVM _transition;
+  HandleMark _hm;
+ public:
+  AgentJavaThreadEventTransition(JavaThread* thread) : _rm(), _transition(thread), _hm(thread) {};
+};
+
+class AgentEventMark : StackObj {
+ private:
+  JavaThread* _thread;
+  JNIEnv* _jni_env;
+  JvmtiThreadState::ExceptionState _saved_exception_state;
+
+ public:
+  AgentEventMark(JavaThread* thread) : _thread(thread),
+                                       _jni_env(thread->jni_environment()),
+                                       _saved_exception_state(JvmtiThreadState::ES_CLEARED) {
+    JvmtiThreadState* state = thread->jvmti_thread_state();
+    // we are before an event.
+    // Save current jvmti thread exception state.
+    if (state != nullptr) {
+      _saved_exception_state = state->get_exception_state();
+    }
+    thread->push_jni_handle_block();
+    assert(thread == JavaThread::current(), "thread must be current!");
+    thread->frame_anchor()->make_walkable();
+  }
+
+  ~AgentEventMark() {
+    _thread->pop_jni_handle_block();
+    JvmtiThreadState* state = _thread->jvmti_thread_state();
+    // we are continuing after an event.
+    if (state != nullptr) {
+      // Restore the jvmti thread exception state.
+      state->restore_exception_state(_saved_exception_state);
+    }
+  }
+};
+
+class AgentThreadEventMark : public AgentEventMark {
+ private:
+  jobject _jthread;
+ public:
+  AgentThreadEventMark(JavaThread* thread) : AgentEventMark(thread),
+                                             _jthread(JNIHandles::make_local(thread, thread->threadObj())) {}
+  jthread jni_thread() { return (jthread)_jthread; }
+};
+
+static void unload_library(JvmtiAgent* agent, void* library) {
+  assert(agent != nullptr, "invariant");
+  assert(agent->is_loaded(), "invariant");
+  if (!agent->is_static_lib()) {
+    assert(library != nullptr, "invariant");
+    os::dll_unload(library);
+  }
+}
+
+// type for the Agent_OnAttach entry point
+extern "C" {
+  typedef jint(JNICALL* OnAttachEntry_t)(JavaVM*, char*, void*);
+}
+
+// Loading the agent by invoking Agent_OnAttach.
+// This function is called before the agent is added to JvmtiAgentList.
+static bool invoke_Agent_OnAttach(JvmtiAgent* agent, outputStream* st) {
+  if (!EnableDynamicAgentLoading) {
+    st->print_cr("Dynamic agent loading is not enabled. "
+                 "Use -XX:+EnableDynamicAgentLoading to launch target VM.");
+    return false;
+  }
+  DEBUG_ONLY(assert_preload(agent);)
+  assert(agent->is_dynamic(), "invariant");
+  assert(st != nullptr, "invariant");
+  assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_LIVE, "not in live phase!");
+  const char* on_attach_symbols[] = AGENT_ONATTACH_SYMBOLS;
+  const size_t num_symbol_entries = ARRAY_SIZE(on_attach_symbols);
+  void* library = nullptr;
+  bool previously_loaded;
+  if (load_agent_from_executable(agent, &on_attach_symbols[0], num_symbol_entries)) {
+    previously_loaded = JvmtiAgentList::is_static_lib_loaded(agent->name());
+  } else {
+    library = load_library(agent, &on_attach_symbols[0], num_symbol_entries, /* vm_exit_on_error */ false);
+    if (library == nullptr) {
+      st->print_cr("%s was not loaded.", agent->name());
+      if (*ebuf != '\0') {
+        st->print_cr("%s", &ebuf[0]);
+      }
+      return false;
+    }
+    agent->set_os_lib_path(&buffer[0]);
+    agent->set_os_lib(library);
+    agent->set_loaded();
+    previously_loaded = JvmtiAgentList::is_dynamic_lib_loaded(library);
+  }
+
+  // Print warning if agent was not previously loaded and EnableDynamicAgentLoading not enabled on the command line.
+  if (!previously_loaded && !FLAG_IS_CMDLINE(EnableDynamicAgentLoading) && !agent->is_instrument_lib()) {
+    jio_fprintf(defaultStream::error_stream(),
+      "WARNING: A JVM TI agent has been loaded dynamically (%s)\n"
+      "WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning\n"
+      "WARNING: Dynamic loading of agents will be disallowed by default in a future release\n", agent->name());
+  }
+
+  assert(agent->is_loaded(), "invariant");
+  // The library was loaded so we attempt to lookup and invoke the Agent_OnAttach function.
+  OnAttachEntry_t on_attach_entry = CAST_TO_FN_PTR(OnAttachEntry_t,
+                                                   os::find_agent_function(agent, false, &on_attach_symbols[0], num_symbol_entries));
+
+  if (on_attach_entry == nullptr) {
+    st->print_cr("%s is not available in %s", on_attach_symbols[0], agent->name());
+    unload_library(agent, library);
+    return false;
+  }
+
+  // Invoke the Agent_OnAttach function
+  JavaThread* thread = JavaThread::current();
+  jint result = JNI_ERR;
+  {
+    extern struct JavaVM_ main_vm;
+    AgentThreadEventMark jem(thread);
+    AgentJavaThreadEventTransition jet(thread);
+
+    agent->initialization_begin();
+
+    result = (*on_attach_entry)(&main_vm, (char*)agent->options(), nullptr);
+
+    agent->initialization_end();
+
+    // Agent_OnAttach may have used JNI
+    if (thread->is_pending_jni_exception_check()) {
+      thread->clear_pending_jni_exception_check();
+    }
+  }
+
+  // Agent_OnAttach may have used JNI
+  if (thread->has_pending_exception()) {
+    thread->clear_pending_exception();
+  }
+
+  st->print_cr("return code: %d", result);
+
+  if (result != JNI_OK) {
+    unload_library(agent, library);
+    return false;
+  }
+
+  if (agent->is_instrument_lib()) {
+    // Convert the instrument lib to the actual JPLIS / javaagent it represents.
+    convert_to_jplis(agent);
+  }
+  return true;
+}
+
+// CDS dumping does not support native JVMTI agent.
+// CDS dumping supports Java agent if the AllowArchivingWithJavaAgent diagnostic option is specified.
+static void check_cds_dump(JvmtiAgent* agent) {
+  assert(agent != nullptr, "invariant");
+  assert(CDSConfig::is_dumping_archive(), "invariant");
+  if (!agent->is_instrument_lib()) {
+    vm_exit_during_cds_dumping("CDS dumping does not support native JVMTI agent, name", agent->name());
+  }
+  if (!AllowArchivingWithJavaAgent) {
+    vm_exit_during_cds_dumping(
+      "Must enable AllowArchivingWithJavaAgent in order to run Java agent during CDS dumping");
+  }
+}
+
+// Loading the agent by invoking Agent_OnLoad.
+static bool invoke_Agent_OnLoad(JvmtiAgent* agent) {
+  assert(agent != nullptr, "invariant");
+  assert(!agent->is_xrun(), "invariant");
+  assert(!agent->is_dynamic(), "invariant");
+  assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_ONLOAD, "invariant");
+  if (CDSConfig::is_dumping_archive()) {
+    check_cds_dump(agent);
+  }
+  OnLoadEntry_t on_load_entry = lookup_Agent_OnLoad_entry_point(agent);
+  if (on_load_entry == nullptr) {
+    vm_exit_during_initialization("Could not find Agent_OnLoad function in the agent library", agent->name());
+  }
+  // Invoke the Agent_OnLoad function
+  extern struct JavaVM_ main_vm;
+  if ((*on_load_entry)(&main_vm, const_cast<char*>(agent->options()), nullptr) != JNI_OK) {
+    vm_exit_during_initialization("agent library failed Agent_OnLoad", agent->name());
+  }
+  // Convert the instrument lib to the actual JPLIS / javaagent it represents.
+  if (agent->is_instrument_lib()) {
+    convert_to_jplis(agent);
+  }
+  return true;
+}
+
+bool JvmtiAgent::load(outputStream* st /* nullptr */) {
+  if (is_xrun()) {
+    return invoke_JVM_OnLoad(this);
+  }
+  return is_dynamic() ? invoke_Agent_OnAttach(this, st) : invoke_Agent_OnLoad(this);
+}
+
+extern "C" {
+  typedef void (JNICALL* Agent_OnUnload_t)(JavaVM*);
+}
+
+void JvmtiAgent::unload() {
+  const char* on_unload_symbols[] = AGENT_ONUNLOAD_SYMBOLS;
+  // Find the Agent_OnUnload function.
+  Agent_OnUnload_t unload_entry = CAST_TO_FN_PTR(Agent_OnUnload_t,
+                                                 os::find_agent_function(this, false, &on_unload_symbols[0], ARRAY_SIZE(on_unload_symbols)));
+  if (unload_entry != nullptr) {
+    // Invoke the Agent_OnUnload function
+    JavaThread* thread = JavaThread::current();
+    ThreadToNativeFromVM ttn(thread);
+    HandleMark hm(thread);
+    extern struct JavaVM_ main_vm;
+    (*unload_entry)(&main_vm);
+  }
+}

--- a/src/hotspot/share/prims/jvmtiAgent.hpp
+++ b/src/hotspot/share/prims/jvmtiAgent.hpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_PRIMS_JVMTIAGENT_HPP
+#define SHARE_PRIMS_JVMTIAGENT_HPP
+
+#include "memory/allocation.hpp"
+#include "utilities/ticks.hpp"
+
+class JvmtiEnv;
+class outputStream;
+
+// Represents an agent launched on the command-line by -agentlib, -agentpath or -Xrun.
+// Also agents loaded dynamically during runtime, for example using the Attach API.
+class JvmtiAgent : public CHeapObj<mtServiceability> {
+  friend class JvmtiAgentList;
+ private:
+  Ticks _initialization_time;
+  Tickspan _initialization_duration;
+  JvmtiAgent* _next;
+  const char* _name;
+  const char* _options;
+  void* _os_lib;
+  const char* _os_lib_path;
+  const void* _jplis;
+  bool _loaded;
+  bool _absolute_path;
+  bool _static_lib;
+  bool _instrument_lib;
+  bool _dynamic;
+  bool _xrun;
+
+  JvmtiAgent* next() const;
+  void set_next(JvmtiAgent* agent);
+  void convert_xrun_agent();
+  void set_xrun();
+
+ public:
+  JvmtiAgent(const char* name, const char* options, bool is_absolute_path, bool dynamic = false);
+  const char* name() const NOT_JVMTI_RETURN_(nullptr);
+  const char* options() const;
+  bool is_absolute_path() const NOT_JVMTI_RETURN_(false);
+  void* os_lib() const NOT_JVMTI_RETURN_(nullptr);
+  void set_os_lib(void* os_lib) NOT_JVMTI_RETURN;
+  const char* os_lib_path() const;
+  void set_os_lib_path(const char* path) NOT_JVMTI_RETURN;
+  bool is_static_lib() const NOT_JVMTI_RETURN_(false);
+  void set_static_lib() NOT_JVMTI_RETURN;
+  bool is_dynamic() const;
+  bool is_xrun() const;
+  bool is_instrument_lib() const;
+  bool is_loaded() const NOT_JVMTI_RETURN_(false);
+  void set_loaded() NOT_JVMTI_RETURN;
+  bool is_jplis() const;
+  bool is_jplis(JvmtiEnv* env) const;
+  void set_jplis(const void* jplis);
+  bool is_initialized() const;
+  void initialization_begin();
+  void initialization_end();
+  const Ticks& initialization_time() const;
+  const Tickspan& initialization_duration() const;
+
+  bool load(outputStream* st = nullptr);
+  void unload();
+};
+
+#endif // SHARE_PRIMS_JVMTIAGENT_HPP

--- a/src/hotspot/share/prims/jvmtiAgentList.cpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "prims/jvmtiAgentList.hpp"
+
+#include "prims/jvmtiEnvBase.hpp"
+#include "prims/jvmtiExport.hpp"
+#include "runtime/atomic.hpp"
+#include "runtime/os.inline.hpp"
+
+JvmtiAgent* JvmtiAgentList::_list = nullptr;
+
+// Selection as a function of the filter.
+JvmtiAgent* JvmtiAgentList::Iterator::select(JvmtiAgent* agent) const {
+  while (agent != nullptr) {
+    if (_filter == ALL) {
+      return agent;
+    } else if (_filter == NOT_XRUN) {
+      if (!agent->is_xrun()) {
+        return agent;
+      }
+    } else if (_filter == JAVA) {
+      if (agent->is_jplis()) {
+        return agent;
+      }
+    } else if (_filter == NATIVE) {
+      if (!agent->is_jplis() && !agent->is_xrun()) {
+        return agent;
+      }
+    } else {
+      assert(_filter == XRUN, "invariant");
+      if (agent->is_xrun()) {
+        return agent;
+      }
+    }
+    agent = agent->next();
+  }
+  return nullptr;
+}
+
+static inline JvmtiAgent* head(JvmtiAgent** list) {
+  assert(list != nullptr, "invariant");
+  return Atomic::load_acquire(list);
+}
+
+
+// The storage list is a single cas-linked-list, to allow for concurrent iterations.
+// Especially during initial loading of agents, there exist an order requirement to iterate oldest -> newest.
+// Our concurrent storage linked-list is newest -> oldest.
+// The correct order is preserved by the iterator, by storing a filtered set of entries in a stack.
+JvmtiAgentList::Iterator::Iterator(JvmtiAgent** list, Filter filter) :
+  _stack(new GrowableArrayCHeap<JvmtiAgent*, mtServiceability>(16)), _filter(filter) {
+  JvmtiAgent* next = head(list);
+  while (next != nullptr) {
+    next = select(next);
+    if (next != nullptr) {
+      _stack->push(next);
+      next = next->next();
+    }
+  }
+}
+
+bool JvmtiAgentList::Iterator::has_next() const {
+  assert(_stack != nullptr, "invariant");
+  return _stack->is_nonempty();
+}
+
+const JvmtiAgent* JvmtiAgentList::Iterator::next() const {
+  assert(has_next(), "invariant");
+  return _stack->pop();
+}
+
+JvmtiAgent* JvmtiAgentList::Iterator::next() {
+  return const_cast<JvmtiAgent*>(const_cast<const Iterator*>(this)->next());
+}
+
+JvmtiAgentList::Iterator JvmtiAgentList::agents() {
+  return Iterator(&_list, Iterator::NOT_XRUN);
+}
+
+JvmtiAgentList::Iterator JvmtiAgentList::java_agents() {
+  return Iterator(&_list, Iterator::JAVA);
+}
+
+JvmtiAgentList::Iterator JvmtiAgentList::native_agents() {
+  return Iterator(&_list, Iterator::NATIVE);
+}
+
+JvmtiAgentList::Iterator JvmtiAgentList::xrun_agents() {
+  return Iterator(&_list, Iterator::XRUN);
+}
+
+JvmtiAgentList::Iterator JvmtiAgentList::all() {
+  return Iterator(&_list, Iterator::ALL);
+}
+
+void JvmtiAgentList::add(JvmtiAgent* agent) {
+  assert(agent != nullptr, "invariant");
+  JvmtiAgent* next;
+  do {
+    next = head(&_list);
+    agent->set_next(next);
+  } while (Atomic::cmpxchg(&_list, next, agent) != next);
+}
+
+void JvmtiAgentList::add(const char* name, char* options, bool absolute_path) {
+  add(new JvmtiAgent(name, options, absolute_path));
+}
+
+void JvmtiAgentList::add_xrun(const char* name, char* options, bool absolute_path) {
+  JvmtiAgent* agent = new JvmtiAgent(name, options, absolute_path);
+  agent->set_xrun();
+  add(agent);
+}
+
+#ifdef ASSERT
+static void assert_initialized(JvmtiAgentList::Iterator& it) {
+  while (it.has_next()) {
+    assert(it.next()->is_initialized(), "invariant");
+  }
+}
+#endif
+
+// In case an agent did not enable the VMInit callback, or if it is an -Xrun agent,
+// it gets an initializiation timestamp here.
+void JvmtiAgentList::initialize() {
+  Iterator it = all();
+  while (it.has_next()) {
+    JvmtiAgent* agent = it.next();
+    if (!agent->is_initialized()) {
+      agent->initialization_begin();
+    }
+  }
+  DEBUG_ONLY(Iterator assert_it = all(); assert_initialized(assert_it);)
+}
+
+void JvmtiAgentList::convert_xrun_agents() {
+  Iterator it = xrun_agents();
+  while (it.has_next()) {
+    it.next()->convert_xrun_agent();
+  }
+}
+
+class JvmtiPhaseTransition : public StackObj {
+ public:
+  JvmtiPhaseTransition() {
+    assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_PRIMORDIAL, "invalid init sequence");
+    JvmtiExport::enter_onload_phase();
+  }
+  ~JvmtiPhaseTransition() {
+    assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_ONLOAD, "invariant");
+    JvmtiExport::enter_primordial_phase();
+  }
+};
+
+static void load_agents(JvmtiAgentList::Iterator& it) {
+  while (it.has_next()) {
+    it.next()->load();
+  }
+}
+
+// Invokes Agent_OnLoad for -agentlib:.. -agentpath:  and converted -Xrun agents.
+// Called very early -- before JavaThreads exist
+void JvmtiAgentList::load_agents() {
+  // Convert -Xrun to -agentlib: if there is no JVM_OnLoad
+  convert_xrun_agents();
+  JvmtiPhaseTransition transition;
+  Iterator it = agents();
+  ::load_agents(it);
+}
+
+// Launch -Xrun agents
+void JvmtiAgentList::load_xrun_agents() {
+  assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_PRIMORDIAL, "invalid init sequence");
+  Iterator it = xrun_agents();
+  ::load_agents(it);
+}
+
+// Invokes Agent_OnAttach for agents loaded dynamically during runtime.
+jint JvmtiAgentList::load_agent(const char* agent_name, const char* absParam,
+                           const char* options, outputStream* st) {
+  // The abs parameter should be "true" or "false"
+  const bool is_absolute_path = (absParam != nullptr) && (strcmp(absParam, "true") == 0);
+  JvmtiAgent* const agent = new JvmtiAgent(agent_name, options, is_absolute_path, /* dynamic agent */ true);
+  if (agent->load(st)) {
+    add(agent);
+  } else {
+    delete agent;
+  }
+  // Agent_OnAttach executed so completion status is JNI_OK
+  return JNI_OK;
+}
+
+// Send any Agent_OnUnload notifications
+void JvmtiAgentList::unload_agents() {
+  Iterator it = agents();
+  while (it.has_next()) {
+    it.next()->unload();
+  }
+}
+
+// Return true if a statically linked agent is on the list
+bool JvmtiAgentList::is_static_lib_loaded(const char* name) {
+  JvmtiAgentList::Iterator it = JvmtiAgentList::agents();
+  while (it.has_next()) {
+    JvmtiAgent* const agent = it.next();
+    if (agent->is_static_lib() && strcmp(agent->name(), name) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Return true if a agent library on the list
+bool JvmtiAgentList::is_dynamic_lib_loaded(void* os_lib) {
+  JvmtiAgentList::Iterator it = JvmtiAgentList::agents();
+  while (it.has_next()) {
+    JvmtiAgent* const agent = it.next();
+    if (!agent->is_static_lib() && agent->os_lib() == os_lib) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool match(JvmtiEnv* env, const JvmtiAgent* agent, const void* os_module_address) {
+  assert(env != nullptr, "invariant");
+  assert(agent != nullptr, "invariant");
+  if (agent->is_static_lib()) {
+    return os::get_default_process_handle() == os_module_address;
+  }
+  if (agent->os_lib() != os_module_address) {
+    return false;
+  }
+  return agent->is_instrument_lib() ? agent->is_jplis(env) : true;
+}
+
+// The function pointer is a JVMTI callback function.
+// Find the os module (dll) that exports this function.
+// Now we can map a JVMTI env to its corresponding agent.
+JvmtiAgent* JvmtiAgentList::lookup(JvmtiEnv* env, void* f_ptr) {
+  assert(env != nullptr, "invariant");
+  assert(f_ptr != nullptr, "invariant");
+  static char ebuf[1024];
+  static char buffer[JVM_MAXPATHLEN];
+  int offset;
+  if (!os::dll_address_to_library_name(reinterpret_cast<address>(f_ptr), &buffer[0], JVM_MAXPATHLEN, &offset)) {
+    return nullptr;
+  }
+  assert(buffer[0] != '\0', "invariant");
+  const void* const os_module_address = reinterpret_cast<address>(f_ptr) - offset;
+
+  JvmtiAgentList::Iterator it = JvmtiAgentList::agents();
+  while (it.has_next()) {
+    JvmtiAgent* const agent = it.next();
+    if (match(env, agent, os_module_address)) {
+      agent->set_os_lib_path(&buffer[0]);
+      return agent;
+    }
+  }
+  return nullptr;
+}

--- a/src/hotspot/share/prims/jvmtiAgentList.hpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.hpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_PRIMS_JVMTIAGENTLIST_HPP
+#define SHARE_PRIMS_JVMTIAGENTLIST_HPP
+
+#include "memory/allocation.hpp"
+#include "prims/jvmtiAgent.hpp"
+#include "utilities/growableArray.hpp"
+
+class JvmtiEnv;
+
+// Maintains a single cas linked-list of JvmtiAgents.
+class JvmtiAgentList : AllStatic {
+  friend class Iterator;
+  friend class JvmtiExport;
+ public:
+  class Iterator {
+    friend class JvmtiAgentList;
+   private:
+    enum Filter {
+      JAVA,
+      NATIVE,
+      XRUN,
+      NOT_XRUN,
+      ALL
+    };
+    GrowableArrayCHeap<JvmtiAgent*, mtServiceability>* _stack;
+    const Filter _filter;
+    Iterator() : _stack(nullptr), _filter(ALL) {}
+    Iterator(JvmtiAgent** list, Filter filter);
+    JvmtiAgent* select(JvmtiAgent* agent) const;
+   public:
+    bool has_next() const NOT_JVMTI_RETURN_(false);
+    JvmtiAgent* next() NOT_JVMTI_RETURN_(nullptr);
+    const JvmtiAgent* next() const NOT_JVMTI_RETURN_(nullptr);
+    ~Iterator() { delete _stack; }
+  };
+
+ private:
+  static JvmtiAgent* _list;
+
+  static Iterator all();
+  static void initialize();
+  static void convert_xrun_agents();
+
+ public:
+  static void add(JvmtiAgent* agent) NOT_JVMTI_RETURN;
+  static void add(const char* name, char* options, bool absolute_path) NOT_JVMTI_RETURN;
+  static void add_xrun(const char* name, char* options, bool absolute_path) NOT_JVMTI_RETURN;
+
+  static void load_agents() NOT_JVMTI_RETURN;
+  static jint load_agent(const char* agent, const char* absParam,
+                         const char* options, outputStream* st) NOT_JVMTI_RETURN_(0);
+  static void load_xrun_agents() NOT_JVMTI_RETURN;
+  static void unload_agents() NOT_JVMTI_RETURN;
+
+  static bool is_static_lib_loaded(const char* name);
+  static bool is_dynamic_lib_loaded(void* os_lib);
+
+  static JvmtiAgent* lookup(JvmtiEnv* env, void* f_ptr);
+
+  static Iterator agents() NOT_JVMTI({ Iterator it; return it; });
+  static Iterator java_agents();
+  static Iterator native_agents();
+  static Iterator xrun_agents();
+};
+
+#endif // SHARE_PRIMS_JVMTIAGENTLIST_HPP

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -1039,6 +1039,7 @@ class os: AllStatic {
                                 char pathSep);
   static bool set_boot_path(char fileSep, char pathSep);
 
+  static bool pd_dll_unload(void* libhandle, char* ebuf, int ebuflen);
 };
 
 // Note that "PAUSE" is almost always used with synchronization


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b8ae4a8c](https://github.com/openjdk/jdk/commit/b8ae4a8c0985d1763ac48ba78943d8b992d7be77) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Joachim Kern on 11 Jan 2024 and was reviewed by Thomas Stuefe and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8320005](https://bugs.openjdk.org/browse/JDK-8320005) needs maintainer approval

### Issue
 * [JDK-8320005](https://bugs.openjdk.org/browse/JDK-8320005): Allow loading of shared objects with .a extension on AIX (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2271/head:pull/2271` \
`$ git checkout pull/2271`

Update a local copy of the PR: \
`$ git checkout pull/2271` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2271`

View PR using the GUI difftool: \
`$ git pr show -t 2271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2271.diff">https://git.openjdk.org/jdk17u-dev/pull/2271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2271#issuecomment-1983432614)