### PR TITLE
8319372: C2 compilation fails with "Bad immediate dominator info"

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -195,66 +195,6 @@ void ConstraintCastNode::dump_spec(outputStream *st) const {
 const Type* CastIINode::Value(PhaseGVN* phase) const {
   const Type *res = ConstraintCastNode::Value(phase);
 
-  // Try to improve the type of the CastII if we recognize a CmpI/If
-  // pattern.
-  if (_dependency != RegularDependency) {
-    if (in(0) != nullptr && in(0)->in(0) != nullptr && in(0)->in(0)->is_If()) {
-      assert(in(0)->is_IfFalse() || in(0)->is_IfTrue(), "should be If proj");
-      Node* proj = in(0);
-      if (proj->in(0)->in(1)->is_Bool()) {
-        Node* b = proj->in(0)->in(1);
-        if (b->in(1)->Opcode() == Op_CmpI) {
-          Node* cmp = b->in(1);
-          if (cmp->in(1) == in(1) && phase->type(cmp->in(2))->isa_int()) {
-            const TypeInt* in2_t = phase->type(cmp->in(2))->is_int();
-            const Type* t = TypeInt::INT;
-            BoolTest test = b->as_Bool()->_test;
-            if (proj->is_IfFalse()) {
-              test = test.negate();
-            }
-            BoolTest::mask m = test._test;
-            jlong lo_long = min_jint;
-            jlong hi_long = max_jint;
-            if (m == BoolTest::le || m == BoolTest::lt) {
-              hi_long = in2_t->_hi;
-              if (m == BoolTest::lt) {
-                hi_long -= 1;
-              }
-            } else if (m == BoolTest::ge || m == BoolTest::gt) {
-              lo_long = in2_t->_lo;
-              if (m == BoolTest::gt) {
-                lo_long += 1;
-              }
-            } else if (m == BoolTest::eq) {
-              lo_long = in2_t->_lo;
-              hi_long = in2_t->_hi;
-            } else if (m == BoolTest::ne) {
-              // can't do any better
-            } else {
-              stringStream ss;
-              test.dump_on(&ss);
-              fatal("unexpected comparison %s", ss.as_string());
-            }
-            int lo_int = (int)lo_long;
-            int hi_int = (int)hi_long;
-
-            if (lo_long != (jlong)lo_int) {
-              lo_int = min_jint;
-            }
-            if (hi_long != (jlong)hi_int) {
-              hi_int = max_jint;
-            }
-
-            t = TypeInt::make(lo_int, hi_int, Type::WidenMax);
-
-            res = res->filter_speculative(t);
-
-            return res;
-          }
-        }
-      }
-    }
-  }
   return res;
 }
 

--- a/test/hotspot/jtreg/compiler/c2/TestTopCastIIOnUndetectedDeadPath.java
+++ b/test/hotspot/jtreg/compiler/c2/TestTopCastIIOnUndetectedDeadPath.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8319372
+ * @summary CastII because of condition guarding it becomes top
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestTopCastIIOnUndetectedDeadPath::test -XX:CompileCommand=quiet -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:StressSeed=426264791 -XX:+StressIGVN TestTopCastIIOnUndetectedDeadPath
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestTopCastIIOnUndetectedDeadPath::test -XX:CompileCommand=quiet -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestTopCastIIOnUndetectedDeadPath
+ */
+
+public class TestTopCastIIOnUndetectedDeadPath {
+    static class X {
+        static void m(int[] a) {
+
+        }
+    }
+
+    static int array[] = new int[10];
+
+    static void test(int val) {
+        for (int i = 1; i < 10; ++i) {
+            for (int j = i; j < 10; ++j) {
+                if (i == 0 && j != 0) {
+                    X.m(array);
+                }
+                array[j - 1] = val;
+            }
+        }
+    }
+
+    public static void main(String[] arg) {
+        test(42);
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestTopCastIIOnUndetectedDeadPath2.java
+++ b/test/hotspot/jtreg/compiler/c2/TestTopCastIIOnUndetectedDeadPath2.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8319372
+ * @summary CastII because of condition guarding it becomes top
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,TestTopCastIIOnUndetectedDeadPath2::test -XX:-TieredCompilation
+ *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=256120824 TestTopCastIIOnUndetectedDeadPath2
+ * @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,TestTopCastIIOnUndetectedDeadPath2::test -XX:-TieredCompilation
+ *                   -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestTopCastIIOnUndetectedDeadPath2
+ */
+
+public class TestTopCastIIOnUndetectedDeadPath2 {
+    static int array[] = new int[100];
+
+    static int test() {
+        int res = 0;
+        for (int i = 1; i < 100; ++i) {
+            try {
+                res = array[i - 1];
+                int x = (42 % i);
+            } catch (ArithmeticException e) {
+            }
+        }
+        return res;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestTopCastIIOnUndetectedDeadPath3.java
+++ b/test/hotspot/jtreg/compiler/c2/TestTopCastIIOnUndetectedDeadPath3.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8319372
+ * @summary CastII because of condition guarding it becomes top
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestTopCastIIOnUndetectedDeadPath3::* -XX:-TieredCompilation TestTopCastIIOnUndetectedDeadPath3
+ */
+
+public class TestTopCastIIOnUndetectedDeadPath3 {
+
+    static long test() {
+        int x = 6, y = 5;
+        int[] iArr = new int[200];
+        for (int i = 129; i > 5; i -= 2) { // OSR compiled
+            try {
+                y = iArr[i - 1];
+                x = iArr[i + 1];
+                x = 1 / i;
+            } catch (ArithmeticException a_e) {
+            }
+        }
+        Foo.empty();
+        return x + y;
+    }
+
+    public static void main(String[] strArr) {
+        new TestTopCastIIOnUndetectedDeadPath3();
+        for (int i = 0; i < 2000; i++) {
+            test();
+        }
+    }
+}
+
+class Foo {
+    public static void empty() {}
+}


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

The change just removes one local optimization pattern in C2. 
The change did not apply well as there are differences in comment
and whitespace, and a different error message. 

Code wise the outermost if()  differs.
As the inner pattern matching is the same, the problem
exists similarly in 11.

Tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319372](https://bugs.openjdk.org/browse/JDK-8319372) needs maintainer approval

### Issue
 * [JDK-8319372](https://bugs.openjdk.org/browse/JDK-8319372): C2 compilation fails with "Bad immediate dominator info" (**Bug** - P2 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2274/head:pull/2274` \
`$ git checkout pull/2274`

Update a local copy of the PR: \
`$ git checkout pull/2274` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2274`

View PR using the GUI difftool: \
`$ git pr show -t 2274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2274.diff">https://git.openjdk.org/jdk17u-dev/pull/2274.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2274#issuecomment-1983867592)