### PR TITLE
8315898: Open source swing JMenu tests

### DIFF
--- a/test/jdk/javax/swing/JMenu/bug4143592.java
+++ b/test/jdk/javax/swing/JMenu/bug4143592.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4143592
+ * @summary Tests the method add(Component, int) of JMenu for insertion
+            the given component to a specified position of menu
+ * @run main bug4143592
+ */
+
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+
+public class bug4143592 {
+
+    public static void main(String[] argv) {
+        JMenuBar mb = new JMenuBar();
+        JMenu m = mb.add(new JMenu("Order"));
+        m.add("beginning");
+        m.add("middle");
+        m.add("end");
+        m.add(new JMenuItem("in between"), 1);
+        if (!m.getItem(1).getText().equals("in between")) {
+            throw new RuntimeException("Item was inserted incorrectly.");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4148154.java
+++ b/test/jdk/javax/swing/JMenu/bug4148154.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4148154
+ * @summary Tests that menu items created by JMenu.add(Action) method
+           have right HorizontalTextPosition.
+ * @run main bug4148154
+ */
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+
+public class bug4148154
+{
+    public static void main(String[] args) {
+        JMenu menu = new JMenu();
+        JMenuItem mi = menu.add(new AbstractAction() {
+                public void actionPerformed(ActionEvent ev) {}
+            });
+        if (mi.getHorizontalTextPosition() != JMenu.LEADING &&
+            mi.getHorizontalTextPosition() != JMenu.TRAILING) {
+
+            throw new RuntimeException("Failed:");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4156316.java
+++ b/test/jdk/javax/swing/JMenu/bug4156316.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4156316
+ * @summary checks if JMenu.add(Component) throws NullPointerException
+ * @run main bug4156316
+ */
+
+import javax.swing.JComponent;
+import javax.swing.JMenu;
+
+public class bug4156316 {
+
+    public static void main(String[] args) {
+        JMenu m = new JMenu("test");
+        m.add(new XComponent());
+    }
+
+    static class XComponent extends JComponent {
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4161866.java
+++ b/test/jdk/javax/swing/JMenu/bug4161866.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4161866
+ * @summary Method AccessibleJMenu.removeAccessibleSelection does not
+            remove selections correctly
+ * @run main bug4161866
+ */
+
+import javax.accessibility.AccessibleSelection;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+
+public class bug4161866 {
+
+  public static void main(String[] argv) {
+      JMenuBar mb = new JMenuBar();
+      JMenu mnu = new JMenu();
+      AccessibleSelection acs = mnu.getAccessibleContext().
+              getAccessibleSelection();
+      mb.add(mnu);
+      JMenu jm = new JMenu();
+      mnu.add(jm);
+      jm.setSelected(true);
+      acs.addAccessibleSelection(0);
+      if (!jm.isSelected()) {
+          throw new RuntimeException("Selection should be non-empty...");
+      }
+
+      acs.removeAccessibleSelection(0);
+      if (jm.isSelected()) {
+          throw new RuntimeException("Selection still non-empty after " +
+                  "it was removed");
+      }
+  }
+}

--- a/test/jdk/javax/swing/JMenu/bug4244796.java
+++ b/test/jdk/javax/swing/JMenu/bug4244796.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4244796
+ * @summary Tests that JMenu has JMenu(Action) constructor
+ * @run main bug4244796
+ */
+
+import java.awt.event.ActionEvent;
+import java.beans.PropertyChangeListener;
+import javax.swing.Action;
+import javax.swing.JMenu;
+
+public class bug4244796 {
+
+    /**
+      * Auxilliary class implementing Action
+     */
+    static class NullAction implements Action {
+        public void addPropertyChangeListener(
+                       PropertyChangeListener listener) {}
+        public void removePropertyChangeListener(
+                       PropertyChangeListener listener) {}
+        public void putValue(String key, Object value) {}
+        public void setEnabled(boolean b) {}
+        public void actionPerformed(ActionEvent e) {}
+
+        public Object getValue(String key) { return null; }
+        public boolean isEnabled() { return false; }
+    }
+
+    public static void main(String[] argv) {
+        Action action = new NullAction();
+        JMenu menu = new JMenu(action);
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4767393.java
+++ b/test/jdk/javax/swing/JMenu/bug4767393.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4767393
+ * @summary Disabled JMenu is selectable via mnemonic
+ * @key headful
+ * @run main bug4767393
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.SwingUtilities;
+
+public class bug4767393 {
+
+    public static JFrame mainFrame;
+    public static JMenuBar menuBar;
+    public static JMenu menu;
+    public static JMenu disabled;
+    public static volatile boolean disabledMenuSelected = true;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robo = new Robot();
+            robo.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(() -> {
+                mainFrame = new JFrame("Bug4767393");
+                menuBar = new JMenuBar();
+                menu = new JMenu("File");
+                disabled = new JMenu("Disabled");
+                menuBar.add(menu);
+                menu.add("Menu Item 1");
+                menu.add("Menu Item 2");
+                disabled.setEnabled(false);
+                disabled.setMnemonic('D');
+                disabled.add("Dummy menu item");
+                menu.add(disabled);
+                menu.add("Menu Item 3");
+                menu.add("Menu Item 4");
+                mainFrame.setJMenuBar(menuBar);
+
+                mainFrame.setSize(200, 200);
+                mainFrame.setLocationRelativeTo(null);
+                mainFrame.setVisible(true);
+            });
+            robo.waitForIdle();
+            robo.delay(500);
+
+            robo.keyPress(KeyEvent.VK_F10);
+            robo.keyRelease(KeyEvent.VK_F10);
+            robo.keyPress(KeyEvent.VK_DOWN);
+            robo.keyRelease(KeyEvent.VK_DOWN);
+            robo.delay(500);
+            robo.keyPress(KeyEvent.VK_D);
+            robo.keyRelease(KeyEvent.VK_D);
+            robo.delay(100);
+
+            SwingUtilities.invokeAndWait(() -> {
+                disabledMenuSelected = disabled.isSelected();
+            });
+
+            if (disabledMenuSelected) {
+                throw new RuntimeException("Disabled JMenu is selected" +
+                        " by the mnemonic. Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (mainFrame != null) {
+                    mainFrame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fecd2fd8](https://github.com/openjdk/jdk/commit/fecd2fd8f26d0e8905a519e30e9aa171683c9df1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Abhishek Kumar on 13 Sep 2023 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315898](https://bugs.openjdk.org/browse/JDK-8315898) needs maintainer approval

### Issue
 * [JDK-8315898](https://bugs.openjdk.org/browse/JDK-8315898): Open source swing JMenu tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2275/head:pull/2275` \
`$ git checkout pull/2275`

Update a local copy of the PR: \
`$ git checkout pull/2275` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2275`

View PR using the GUI difftool: \
`$ git pr show -t 2275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2275.diff">https://git.openjdk.org/jdk17u-dev/pull/2275.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2275#issuecomment-1985935545)