### PR TITLE
8286490: JvmtiEventControllerPrivate::set_event_callbacks CLEARING_MASK computation is incorrect

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -719,11 +719,14 @@ void JvmtiEventControllerPrivate::set_event_callbacks(JvmtiEnvBase *env,
   flush_object_free_events(env);
 
   env->set_event_callbacks(callbacks, size_of_callbacks);
-  jlong enabled_bits = 0;
+  jlong enabled_bits = env->env_event_enable()->_event_callback_enabled.get_bits();
   for (int ei = JVMTI_MIN_EVENT_TYPE_VAL; ei <= JVMTI_MAX_EVENT_TYPE_VAL; ++ei) {
     jvmtiEvent evt_t = (jvmtiEvent)ei;
+    jlong bit_for = JvmtiEventEnabled::bit_for(evt_t);
     if (env->has_callback(evt_t)) {
-      enabled_bits |= JvmtiEventEnabled::bit_for(evt_t);
+      enabled_bits |= bit_for;
+    } else {
+      enabled_bits &= ~bit_for;
     }
   }
   env->env_event_enable()->_event_callback_enabled.set_bits(enabled_bits);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/Test.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ *
+ * @summary Tests subscribing ClassUnload JVMTI extension event after unsubscribing all events.
+ * @bug 8286490
+ * @requires vm.jvmti
+ * @library /vmTestbase
+ *          /test/lib
+ * @run driver nsk.share.ExtraClassesBuilder loadClass
+ * @run main/othervm/native nsk.jvmti.unit.extcallback.Test
+ */
+
+package nsk.jvmti.unit.extcallback;
+
+import jdk.test.lib.process.ProcessTools;
+
+public class Test {
+
+    public static void main(String[] args) throws Exception {
+        ProcessTools.executeTestJvm("-agentlib:extcallback", Test1.class.getName())
+                    .shouldHaveExitValue(0)
+                    .shouldContain("callbackClassUnload called");
+    }
+
+    public static class Test1 {
+        public static void main(String[] args) throws Exception {
+            System.out.println("App started");
+            {
+                var unloader = new nsk.share.ClassUnloader();
+                unloader.loadClass("nsk.jvmti.unit.extcallback.Test2", "./bin/loadClass");
+                unloader.unloadClass();
+                unloader = null;
+            }
+            System.gc();
+            System.out.println("App finished");
+        }
+    }
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/libextcallback.c
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/libextcallback.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jvmti.h>
+#include <string.h>
+
+void JNICALL callbackClassUnload(jvmtiEnv* jvmti_env, ...) {
+    printf("callbackClassUnload called\n");
+    fflush(NULL);
+}
+
+void JNICALL callbackClassLoad(jvmtiEnv* jvmti_env, JNIEnv* jni_env, jthread thread, jclass klass) {
+    // nothing to do, just a stub
+}
+
+JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM* jvm, char* options, void* reserved) {
+    printf("%s:%d : %s : JVMTI agent loading...\n", __FILE__, __LINE__, __FUNCTION__);
+
+    jvmtiEnv* jvmti = NULL;
+    jint extensionEventCount = 0;
+    jvmtiExtensionEventInfo* extensionEvents = NULL;
+    (*jvm)->GetEnv(jvm, (void**)&jvmti, JVMTI_VERSION_1_0);
+
+    // Set extension event callback
+    (*jvmti)->GetExtensionEvents(jvmti, &extensionEventCount, &extensionEvents);
+    for (int i = 0; i < extensionEventCount; ++i) {
+        if (0 == strcmp("com.sun.hotspot.events.ClassUnload", extensionEvents[i].id)) {
+            (*jvmti)->SetExtensionEventCallback(jvmti, extensionEvents[i].extension_event_index, &callbackClassUnload);
+        }
+    }
+
+    {
+        // Set some event callbacks
+        jvmtiEventCallbacks callbacks;
+        memset(&callbacks, 0, sizeof(callbacks));
+        callbacks.ClassLoad = &callbackClassLoad;
+        (*jvmti)->SetEventCallbacks(jvmti, &callbacks, sizeof(callbacks));
+
+        // Clear event callbacks
+        memset(&callbacks, 0, sizeof(callbacks));
+        (*jvmti)->SetEventCallbacks(jvmti, &callbacks, sizeof(callbacks));
+    }
+
+    return JNI_OK;
+}
+
+JNIEXPORT void JNICALL Agent_OnUnload(JavaVM* jvm) {
+    printf("%s:%d : %s : JVMTI agent unloading...\n", __FILE__, __LINE__, __FUNCTION__);
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/loadClass/Test2.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/loadClass/Test2.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Azul Systems, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package nsk.jvmti.unit.extcallback;
+
+public class Test2 {
+    public Test2() {}
+}


### PR DESCRIPTION
This is a backport of JDK-8286490: JvmtiEventControllerPrivate::set_event_callbacks CLEARING_MASK computation is incorrect.

Backporting this because this issue can be reproduced in JDK17 as well.

The backport isn't clean:
1. Resolved a conflict in `src/hotspot/share/prims/jvmtiEventController.cpp` with an empty line.
2. Removed files as VThreads are not implemented in jdk17:
      - `test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/libVThreadTest.cpp` 
      - `test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTest/VThreadTest.java`
3. Added new test:
      - `test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/Test.java`
      - `test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/libextcallback.c`
      - `test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/extcallback/loadClass/Test2.java`

Actually, backporting the fix only.
The new test fails without the fix, and successfully passes with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286490](https://bugs.openjdk.org/browse/JDK-8286490) needs maintainer approval

### Issue
 * [JDK-8286490](https://bugs.openjdk.org/browse/JDK-8286490): JvmtiEventControllerPrivate::set_event_callbacks CLEARING_MASK computation is incorrect (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2276/head:pull/2276` \
`$ git checkout pull/2276`

Update a local copy of the PR: \
`$ git checkout pull/2276` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2276`

View PR using the GUI difftool: \
`$ git pr show -t 2276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2276.diff">https://git.openjdk.org/jdk17u-dev/pull/2276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2276#issuecomment-1985133751)