### PR TITLE
8314283: Support for NSS tests on aarch64 platforms

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
@@ -389,6 +389,10 @@ public class ClientAuth extends PKCS11Test {
                      * Our client thread just died.
                      */
                     System.err.println("Client died...");
+                    // if the exception is thrown before connecting to the
+                    // server, the test will time out and the exception will
+                    // be lost/hidden.
+                    e.printStackTrace(System.err);
                     clientException = e;
                 }
             });

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -74,6 +74,11 @@ public abstract class PKCS11Test {
     private static final String PKCS11_REL_PATH = "sun/security/pkcs11";
     private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
 
+    // Version of the NSS artifact. This coincides with the version of
+    // the NSS version
+    private static final String NSS_BUNDLE_VERSION = "3.91";
+    private static final String NSSLIB = "jpg.tests.jdk.nsslib";
+
     static double nss_version = -1;
     static ECCState nss_ecc_status = ECCState.Basic;
 
@@ -744,17 +749,20 @@ public abstract class PKCS11Test {
 
     private static String fetchNssLib(String osId) {
         switch (osId) {
-            case "Windows-x86-32":
-                return fetchNssLib(WINDOWS_X86.class);
-
             case "Windows-amd64-64":
                 return fetchNssLib(WINDOWS_X64.class);
 
             case "MacOSX-x86_64-64":
                 return fetchNssLib(MACOSX_X64.class);
 
+            case "MacOSX-aarch64-64":
+                return fetchNssLib(MACOSX_AARCH64.class);
+
             case "Linux-amd64-64":
                 return fetchNssLib(LINUX_X64.class);
+
+            case "Linux-aarch64-64":
+                return fetchNssLib(LINUX_AARCH64.class);
 
             default:
                 return null;
@@ -765,8 +773,8 @@ public abstract class PKCS11Test {
         String path = null;
         try {
             path = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue() + File.separator + "nsslib"
-                    + File.separator;
+                    .findAny().get().getValue() + File.separator + "nss"
+                    + File.separator + "lib" + File.separator;
         } catch (ArtifactResolverException e) {
             Throwable cause = e.getCause();
             if (cause == null) {
@@ -868,34 +876,43 @@ public abstract class PKCS11Test {
     public static enum ECCState {None, Basic, Extended}
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
             name = "nsslib-windows_x64",
-            revision = "3.46-VS2017",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class WINDOWS_X64 {
     }
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
-            name = "nsslib-windows_x86",
-            revision = "3.46-VS2017",
-            extension = "zip")
-    private static class WINDOWS_X86 {
-    }
-
-    @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
             name = "nsslib-macosx_x64",
-            revision = "3.46",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class MACOSX_X64 {
     }
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
+            name = "nsslib-macosx_aarch64",
+            revision = NSS_BUNDLE_VERSION,
+            extension = "zip")
+    private static class MACOSX_AARCH64 {
+    }
+
+    @Artifact(
+            organization = NSSLIB,
             name = "nsslib-linux_x64",
-            revision = "3.46",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class LINUX_X64 {
+    }
+
+    @Artifact(
+            organization = NSSLIB,
+            name = "nsslib-linux_aarch64",
+            revision = NSS_BUNDLE_VERSION,
+            extension = "zip"
+    )
+    private static class LINUX_AARCH64{
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8314283](https://bugs.openjdk.org/browse/JDK-8314283) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314283](https://bugs.openjdk.org/browse/JDK-8314283): Support for NSS tests on aarch64 platforms (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2284/head:pull/2284` \
`$ git checkout pull/2284`

Update a local copy of the PR: \
`$ git checkout pull/2284` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2284`

View PR using the GUI difftool: \
`$ git pr show -t 2284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2284.diff">https://git.openjdk.org/jdk17u-dev/pull/2284.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2284#issuecomment-1987856229)