### PR TITLE
8299858: [Metrics] Swap memory limit reported incorrectly when too large

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
@@ -122,9 +122,11 @@ public class CgroupMetrics implements Metrics {
     @Override
     public long getMemoryLimit() {
         long subsMem = subsystem.getMemoryLimit();
+        long systemTotal = getTotalMemorySize0();
+        assert(systemTotal > 0);
         // Catch the cgroup memory limit exceeding host physical memory.
         // Treat this as unlimited.
-        if (subsMem >= getTotalMemorySize0()) {
+        if (subsMem >= systemTotal) {
             return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
         }
         return subsMem;
@@ -142,7 +144,15 @@ public class CgroupMetrics implements Metrics {
 
     @Override
     public long getMemoryAndSwapLimit() {
-        return subsystem.getMemoryAndSwapLimit();
+        long totalSystemMemSwap = getTotalMemorySize0() + getTotalSwapSize0();
+        assert(totalSystemMemSwap > 0);
+        // Catch the cgroup memory and swap limit exceeding host physical swap
+        // and memory. Treat this case as unlimited.
+        long subsSwapMem = subsystem.getMemoryAndSwapLimit();
+        if (subsSwapMem >= totalSystemMemSwap) {
+            return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
+        }
+        return subsSwapMem;
     }
 
     @Override
@@ -185,5 +195,6 @@ public class CgroupMetrics implements Metrics {
 
     private static native boolean isUseContainerSupport();
     private static native long getTotalMemorySize0();
+    private static native long getTotalSwapSize0();
 
 }

--- a/src/java.base/linux/native/libjava/CgroupMetrics.c
+++ b/src/java.base/linux/native/libjava/CgroupMetrics.c
@@ -23,6 +23,7 @@
  * questions.
  */
 #include <unistd.h>
+#include <sys/sysinfo.h>
 
 #include "jni.h"
 #include "jvm.h"
@@ -42,4 +43,16 @@ Java_jdk_internal_platform_CgroupMetrics_getTotalMemorySize0
     jlong pages = sysconf(_SC_PHYS_PAGES);
     jlong page_size = sysconf(_SC_PAGESIZE);
     return pages * page_size;
+}
+
+JNIEXPORT jlong JNICALL
+Java_jdk_internal_platform_CgroupMetrics_getTotalSwapSize0
+  (JNIEnv *env, jclass ignored)
+{
+    struct sysinfo si;
+    int retval = sysinfo(&si);
+    if (retval < 0) {
+         return 0; // syinfo failed, treat as no swap
+    }
+    return (jlong)si.totalswap;
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8299858](https://bugs.openjdk.org/browse/JDK-8299858) needs maintainer approval

### Issue
 * [JDK-8299858](https://bugs.openjdk.org/browse/JDK-8299858): [Metrics] Swap memory limit reported incorrectly when too large (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2285/head:pull/2285` \
`$ git checkout pull/2285`

Update a local copy of the PR: \
`$ git checkout pull/2285` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2285`

View PR using the GUI difftool: \
`$ git pr show -t 2285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2285.diff">https://git.openjdk.org/jdk17u-dev/pull/2285.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2285#issuecomment-1988500532)