### PR TITLE
8319128: sun/security/pkcs11 tests fail on OL 7.9 aarch64

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
@@ -389,6 +389,10 @@ public class ClientAuth extends PKCS11Test {
                      * Our client thread just died.
                      */
                     System.err.println("Client died...");
+                    // if the exception is thrown before connecting to the
+                    // server, the test will time out and the exception will
+                    // be lost/hidden.
+                    e.printStackTrace(System.err);
                     clientException = e;
                 }
             });

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -54,7 +54,11 @@ import java.util.Properties;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
 import jdk.test.lib.artifacts.ArtifactResolverException;
@@ -759,11 +763,18 @@ public abstract class PKCS11Test {
                 return fetchNssLib(MACOSX_AARCH64.class);
 
             case "Linux-amd64-64":
-                return fetchNssLib(LINUX_X64.class);
+                if (Platform.isOracleLinux7()) {
+                    throw new SkippedException("Skipping Oracle Linux prior to v8");
+                } else {
+                    return fetchNssLib(LINUX_X64.class);
+                }
 
             case "Linux-aarch64-64":
-                return fetchNssLib(LINUX_AARCH64.class);
-
+                if (Platform.isOracleLinux7()) {
+                    throw new SkippedException("Skipping Oracle Linux prior to v8");
+                } else {
+                    return fetchNssLib(LINUX_AARCH64.class);
+                }
             default:
                 return null;
         }

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -74,6 +74,11 @@ public abstract class PKCS11Test {
     private static final String PKCS11_REL_PATH = "sun/security/pkcs11";
     private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
 
+    // Version of the NSS artifact. This coincides with the version of
+    // the NSS version
+    private static final String NSS_BUNDLE_VERSION = "3.91";
+    private static final String NSSLIB = "jpg.tests.jdk.nsslib";
+
     static double nss_version = -1;
     static ECCState nss_ecc_status = ECCState.Basic;
 
@@ -744,17 +749,20 @@ public abstract class PKCS11Test {
 
     private static String fetchNssLib(String osId) {
         switch (osId) {
-            case "Windows-x86-32":
-                return fetchNssLib(WINDOWS_X86.class);
-
             case "Windows-amd64-64":
                 return fetchNssLib(WINDOWS_X64.class);
 
             case "MacOSX-x86_64-64":
                 return fetchNssLib(MACOSX_X64.class);
 
+            case "MacOSX-aarch64-64":
+                return fetchNssLib(MACOSX_AARCH64.class);
+
             case "Linux-amd64-64":
                 return fetchNssLib(LINUX_X64.class);
+
+            case "Linux-aarch64-64":
+                return fetchNssLib(LINUX_AARCH64.class);
 
             default:
                 return null;
@@ -765,8 +773,8 @@ public abstract class PKCS11Test {
         String path = null;
         try {
             path = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue() + File.separator + "nsslib"
-                    + File.separator;
+                    .findAny().get().getValue() + File.separator + "nss"
+                    + File.separator + "lib" + File.separator;
         } catch (ArtifactResolverException e) {
             Throwable cause = e.getCause();
             if (cause == null) {
@@ -868,34 +876,43 @@ public abstract class PKCS11Test {
     public static enum ECCState {None, Basic, Extended}
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
             name = "nsslib-windows_x64",
-            revision = "3.46-VS2017",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class WINDOWS_X64 {
     }
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
-            name = "nsslib-windows_x86",
-            revision = "3.46-VS2017",
-            extension = "zip")
-    private static class WINDOWS_X86 {
-    }
-
-    @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
             name = "nsslib-macosx_x64",
-            revision = "3.46",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class MACOSX_X64 {
     }
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
+            name = "nsslib-macosx_aarch64",
+            revision = NSS_BUNDLE_VERSION,
+            extension = "zip")
+    private static class MACOSX_AARCH64 {
+    }
+
+    @Artifact(
+            organization = NSSLIB,
             name = "nsslib-linux_x64",
-            revision = "3.46",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class LINUX_X64 {
+    }
+
+    @Artifact(
+            organization = NSSLIB,
+            name = "nsslib-linux_aarch64",
+            revision = NSS_BUNDLE_VERSION,
+            extension = "zip"
+    )
+    private static class LINUX_AARCH64{
     }
 }

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+
 import sun.security.pkcs11.SunPKCS11;
 
 import javax.security.auth.Subject;
@@ -32,12 +33,10 @@ import javax.security.auth.login.LoginException;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.security.*;
-import java.util.Iterator;
 import java.util.PropertyPermission;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
 
 import jdk.test.lib.util.ForceGC;
+import jtreg.SkippedException;
 
 public class MultipleLogins {
     private static final String KS_TYPE = "PKCS11";
@@ -46,7 +45,13 @@ public class MultipleLogins {
     static final Policy DEFAULT_POLICY = Policy.getPolicy();
 
     public static void main(String[] args) throws Exception {
-        String nssConfig = PKCS11Test.getNssConfig();
+        String nssConfig = null;
+        try {
+            nssConfig = PKCS11Test.getNssConfig();
+        } catch (SkippedException exc) {
+            System.out.println("Skipping test: " + exc.getMessage());
+        }
+
         if (nssConfig == null) {
             // No test framework support yet. Ignore
             System.out.println("No NSS config found. Skipping.");

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
@@ -26,6 +26,7 @@
 # @summary
 # @library /test/lib/
 # @build jdk.test.lib.util.ForceGC
+#        jdk.test.lib.Platform
 # @run shell MultipleLogins.sh
 
 # set a few environment variables so that the shell-script can run stand-alone

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -53,7 +53,7 @@ public class TestMutuallyExclusivePlatformPredicates {
         IGNORED("isEmulatedClient", "isDebugBuild", "isFastDebugBuild", "isMusl",
                 "isSlowDebugBuild", "hasSA", "isRoot", "isTieredSupported",
                 "areCustomLoadersSupportedForCDS", "isDefaultCDSArchiveSupported",
-                "isHardenedOSX", "hasOSXPlistEntries");
+                "isHardenedOSX", "hasOSXPlistEntries", "isOracleLinux7");
 
         public final List<String> methodNames;
 

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Platform {
@@ -342,6 +343,20 @@ public class Platform {
         return Pattern.compile(archnameRE, Pattern.CASE_INSENSITIVE)
                       .matcher(osArch)
                       .matches();
+    }
+
+    public static boolean isOracleLinux7() {
+        if (System.getProperty("os.name").toLowerCase().contains("linux") &&
+                System.getProperty("os.version").toLowerCase().contains("el")) {
+            Pattern p = Pattern.compile("el(\\d+)");
+            Matcher m = p.matcher(System.getProperty("os.version"));
+            if (m.find()) {
+                try {
+                    return Integer.parseInt(m.group(1)) <= 7;
+                } catch (NumberFormatException nfe) {}
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.
Follow 21-dev backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8319128](https://bugs.openjdk.org/browse/JDK-8319128) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8319136](https://bugs.openjdk.org/browse/JDK-8319136) needs maintainer approval

### Issues
 * [JDK-8319128](https://bugs.openjdk.org/browse/JDK-8319128): sun/security/pkcs11 tests fail on OL 7.9 aarch64 (**Bug** - P3 - Approved)
 * [JDK-8319136](https://bugs.openjdk.org/browse/JDK-8319136): Skip pkcs11 tests on linux-aarch64 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2287/head:pull/2287` \
`$ git checkout pull/2287`

Update a local copy of the PR: \
`$ git checkout pull/2287` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2287`

View PR using the GUI difftool: \
`$ git pr show -t 2287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2287.diff">https://git.openjdk.org/jdk17u-dev/pull/2287.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2287#issuecomment-1991093851)