### PR TITLE
8326101: [PPC64] Need to bailout cleanly if creation of stubs fails when code cache is out of space

### DIFF
--- a/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
@@ -475,6 +475,9 @@ void ArrayCopyStub::emit_code(LIR_Assembler* ce) {
   __ extsw(R7_ARG5, length()->as_register());
 
   ce->emit_static_call_stub();
+  if (ce->compilation()->bailed_out()) {
+    return; // CodeCache is full
+  }
 
   bool success = ce->emit_trampoline_stub_for_call(SharedRuntime::get_resolve_static_call_stub());
   if (!success) { return; }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2064,7 +2064,10 @@ int HandlerImpl::emit_exception_handler(CodeBuffer &cbuf) {
   C2_MacroAssembler _masm(&cbuf);
 
   address base = __ start_a_stub(size_exception_handler());
-  if (base == NULL) return 0; // CodeBuffer::expand failed
+  if (base == nullptr) {
+    ciEnv::current()->record_failure("CodeCache is full");
+    return 0;  // CodeBuffer::expand failed
+  }
 
   int offset = __ offset();
   __ b64_patchable((address)OptoRuntime::exception_blob()->content_begin(),
@@ -2081,7 +2084,10 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf) {
   C2_MacroAssembler _masm(&cbuf);
 
   address base = __ start_a_stub(size_deopt_handler());
-  if (base == NULL) return 0; // CodeBuffer::expand failed
+  if (base == nullptr) {
+    ciEnv::current()->record_failure("CodeCache is full");
+    return 0;  // CodeBuffer::expand failed
+  }
 
   int offset = __ offset();
   __ bl64_patchable((address)SharedRuntime::deopt_blob()->unpack(),


### PR DESCRIPTION
Clean backport of [JDK-8326101](https://bugs.openjdk.org/browse/JDK-8326101) from JDK 22u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326101](https://bugs.openjdk.org/browse/JDK-8326101) needs maintainer approval

### Issue
 * [JDK-8326101](https://bugs.openjdk.org/browse/JDK-8326101): [PPC64] Need to bailout cleanly if creation of stubs fails when code cache is out of space (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2289/head:pull/2289` \
`$ git checkout pull/2289`

Update a local copy of the PR: \
`$ git checkout pull/2289` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2289`

View PR using the GUI difftool: \
`$ git pr show -t 2289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2289.diff">https://git.openjdk.org/jdk17u-dev/pull/2289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2289#issuecomment-1991563368)