### PR TITLE
8313307: java/util/Formatter/Padding.java fails on some Locales

### DIFF
--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -29,6 +29,8 @@
  * @run junit Padding
  */
 
+import java.util.Locale;
+
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -307,7 +309,7 @@ public class Padding {
     @ParameterizedTest
     @MethodSource
     void padding(String expected, String format, Object value) {
-        assertEquals(expected, String.format(format, value));
+        assertEquals(expected, String.format(Locale.US, format, value));
     }
 
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8313307](https://bugs.openjdk.org/browse/JDK-8313307), commit [bd634d2e](https://github.com/openjdk/jdk21u-dev/commit/bd634d2ec77f0208a2db54bc00567777ee7c8661) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by Aleksey Shipilev on 15 Aug 2023 and had no reviewers.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313307](https://bugs.openjdk.org/browse/JDK-8313307) needs maintainer approval

### Issue
 * [JDK-8313307](https://bugs.openjdk.org/browse/JDK-8313307): java/util/Formatter/Padding.java fails on some Locales (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2291/head:pull/2291` \
`$ git checkout pull/2291`

Update a local copy of the PR: \
`$ git checkout pull/2291` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2291`

View PR using the GUI difftool: \
`$ git pr show -t 2291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2291.diff">https://git.openjdk.org/jdk17u-dev/pull/2291.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2291#issuecomment-1993779055)