### PR TITLE
8289401: Add dump output to TestRawRSACipher.java

### DIFF
--- a/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6994008
+ * @bug 6994008 8289401
  * @summary basic test for RSA/ECB/NoPadding cipher
  * @author Valerie Peng
  * @library /test/lib ..
@@ -38,6 +38,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
 import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.Random;
 import javax.crypto.Cipher;
 
@@ -71,6 +72,9 @@ public class TestRawRSACipher extends PKCS11Test {
         cipherText = c1.doFinal(plainText);
         recoveredText = c2.doFinal(cipherText);
         if (!Arrays.equals(plainText, recoveredText)) {
+            System.out.println("*** E/D Test:");
+            System.out.println("\tplainText = " + HexFormat.of().formatHex(plainText));
+            System.out.println("\trecoveredText = " + HexFormat.of().formatHex(recoveredText));
             throw new RuntimeException("E/D Test against SunJCE Failed!");
         }
 
@@ -79,6 +83,9 @@ public class TestRawRSACipher extends PKCS11Test {
         cipherText = c2.doFinal(plainText);
         recoveredText = c1.doFinal(cipherText);
         if (!Arrays.equals(plainText, recoveredText)) {
+            System.out.println("*** D/E Test:");
+            System.out.println("\tplainText = " + HexFormat.of().formatHex(plainText));
+            System.out.println("\trecoveredText = " + HexFormat.of().formatHex(recoveredText));
             throw new RuntimeException("D/E Test against SunJCE Failed!");
         }
 


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8289401](https://bugs.openjdk.org/browse/JDK-8289401) needs maintainer approval

### Issue
 * [JDK-8289401](https://bugs.openjdk.org/browse/JDK-8289401): Add dump output to TestRawRSACipher.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2296/head:pull/2296` \
`$ git checkout pull/2296`

Update a local copy of the PR: \
`$ git checkout pull/2296` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2296`

View PR using the GUI difftool: \
`$ git pr show -t 2296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2296.diff">https://git.openjdk.org/jdk17u-dev/pull/2296.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2296#issuecomment-1994630239)