### PR TITLE
8290901: Reduce use of -source in langtools tests

### DIFF
--- a/test/langtools/tools/javac/8074306/TestSyntheticNullChecks.java
+++ b/test/langtools/tools/javac/8074306/TestSyntheticNullChecks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8074306 8073432 8074501
  * @summary NULLCHK is emitted as Object.getClass
- * @compile -source 7 -target 7 TestSyntheticNullChecks.java
+ * @compile --release 7 TestSyntheticNullChecks.java
  * @run main TestSyntheticNullChecks 7
  * @clean *
  * @compile TestSyntheticNullChecks.java

--- a/test/langtools/tools/javac/AnonStaticMember_1.java
+++ b/test/langtools/tools/javac/AnonStaticMember_1.java
@@ -4,7 +4,7 @@
  * @summary Verify that an anonymous class can contain a static field only if source >= 16
  * @author maddox
  *
- * @compile/fail/ref=AnonStaticMember_1.out -source 15 -XDrawDiagnostics AnonStaticMember_1.java
+ * @compile/fail/ref=AnonStaticMember_1.out --release 15 -XDrawDiagnostics AnonStaticMember_1.java
  * @compile AnonStaticMember_1.java
  */
 

--- a/test/langtools/tools/javac/AnonStaticMember_1.out
+++ b/test/langtools/tools/javac/AnonStaticMember_1.out
@@ -1,4 +1,2 @@
-- compiler.warn.source.no.system.modules.path: 15
 AnonStaticMember_1.java:13:20: compiler.err.icls.cant.have.static.decl: compiler.misc.anonymous.class: AnonStaticMember_1$1
 1 error
-1 warning

--- a/test/langtools/tools/javac/AnonStaticMember_2.java
+++ b/test/langtools/tools/javac/AnonStaticMember_2.java
@@ -4,7 +4,7 @@
  * @summary Verify that an anonymous class can contain a static method only if source >= 16
  * @author maddox
  *
- * @compile/fail/ref=AnonStaticMember_2.out -source 15 -XDrawDiagnostics AnonStaticMember_2.java
+ * @compile/fail/ref=AnonStaticMember_2.out --release 15 -XDrawDiagnostics AnonStaticMember_2.java
  * @compile AnonStaticMember_2.java
  */
 

--- a/test/langtools/tools/javac/AnonStaticMember_2.out
+++ b/test/langtools/tools/javac/AnonStaticMember_2.out
@@ -1,4 +1,2 @@
-- compiler.warn.source.no.system.modules.path: 15
 AnonStaticMember_2.java:13:21: compiler.err.icls.cant.have.static.decl: compiler.misc.anonymous.class: AnonStaticMember_2$1
 1 error
-1 warning

--- a/test/langtools/tools/javac/InnerNamedConstant_2.java
+++ b/test/langtools/tools/javac/InnerNamedConstant_2.java
@@ -4,7 +4,7 @@
  * @summary Verify rejection of illegal static variables in inner classes.
  * @author William Maddox (maddox)
  *
- * @compile/fail/ref=InnerNamedConstant_2_A.out -XDrawDiagnostics -source 15 InnerNamedConstant_2.java
+ * @compile/fail/ref=InnerNamedConstant_2_A.out -XDrawDiagnostics --release 15 InnerNamedConstant_2.java
  * @compile/fail/ref=InnerNamedConstant_2_B.out -XDrawDiagnostics InnerNamedConstant_2.java
  */
 

--- a/test/langtools/tools/javac/InnerNamedConstant_2_A.out
+++ b/test/langtools/tools/javac/InnerNamedConstant_2_A.out
@@ -1,7 +1,5 @@
-- compiler.warn.source.no.system.modules.path: 15
 InnerNamedConstant_2.java:23:20: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner2
 InnerNamedConstant_2.java:24:29: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner2
 InnerNamedConstant_2.java:26:13: compiler.err.cant.assign.val.to.final.var: z
 InnerNamedConstant_2.java:35:26: compiler.err.icls.cant.have.static.decl: InnerNamedConstant_2.Inner3
 4 errors
-1 warning

--- a/test/langtools/tools/javac/InterfaceInInner.java
+++ b/test/langtools/tools/javac/InterfaceInInner.java
@@ -1,10 +1,10 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 4063740 6969184
- * @summary Interfaces can be declared in inner classes only for source >= 16
+ * @summary Interfaces can be declared in inner classes only for release >= 16
  * @author turnidge
  *
- * @compile/fail/ref=InterfaceInInner.out -XDrawDiagnostics -source 15 InterfaceInInner.java
+ * @compile/fail/ref=InterfaceInInner.out -XDrawDiagnostics --release 15 InterfaceInInner.java
  * @compile InterfaceInInner.java
  */
 class InterfaceInInner {

--- a/test/langtools/tools/javac/InterfaceInInner.out
+++ b/test/langtools/tools/javac/InterfaceInInner.out
@@ -1,4 +1,2 @@
-- compiler.warn.source.no.system.modules.path: 15
 InterfaceInInner.java:13:13: compiler.err.icls.cant.have.static.decl: foo
 1 error
-1 warning

--- a/test/langtools/tools/javac/LocalInterface.java
+++ b/test/langtools/tools/javac/LocalInterface.java
@@ -2,7 +2,7 @@
  * @test  /nodynamiccopyright/
  * @bug 8242478 8246774
  * @summary test for local interfaces
- * @compile/fail/ref=LocalInterface.out -XDrawDiagnostics -source 15 LocalInterface.java
+ * @compile/fail/ref=LocalInterface.out -XDrawDiagnostics --release 15 LocalInterface.java
  * @compile LocalInterface.java
  */
 class LocalInterface {

--- a/test/langtools/tools/javac/LocalInterface.out
+++ b/test/langtools/tools/javac/LocalInterface.out
@@ -1,4 +1,2 @@
-- compiler.warn.source.no.system.modules.path: 15
 LocalInterface.java:10:9: compiler.err.intf.not.allowed.here
 1 error
-1 warning

--- a/test/langtools/tools/javac/StringConcat/TestIndyStringConcat.java
+++ b/test/langtools/tools/javac/StringConcat/TestIndyStringConcat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,15 +43,15 @@ import java.io.File;
  * @run main TestIndyStringConcat false
  *
  * @clean *
- * @compile -XDstringConcat=inline -source 9 -target 9 TestIndyStringConcat.java
+ * @compile -XDstringConcat=inline TestIndyStringConcat.java
  * @run main TestIndyStringConcat false
  *
  * @clean *
- * @compile -XDstringConcat=indy -source 9 -target 9 TestIndyStringConcat.java
+ * @compile -XDstringConcat=indy TestIndyStringConcat.java
  * @run main TestIndyStringConcat true
  *
  * @clean *
- * @compile -XDstringConcat=indyWithConstants -source 9 -target 9 TestIndyStringConcat.java
+ * @compile -XDstringConcat=indyWithConstants TestIndyStringConcat.java
  * @run main TestIndyStringConcat true
  */
 public class TestIndyStringConcat {

--- a/test/langtools/tools/javac/TryWithResources/TwrForVariable1.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrForVariable1.java
@@ -1,7 +1,7 @@
 /* @test /nodynamiccopyright/
  * @bug 7196163
  * @summary Verify that variables can be used as operands to try-with-resources
- * @compile/fail/ref=TwrForVariable1.out -source 8 -XDrawDiagnostics -Xlint:-options TwrForVariable1.java
+ * @compile/fail/ref=TwrForVariable1.out --release 8 -XDrawDiagnostics TwrForVariable1.java
  * @compile TwrForVariable1.java
  * @run main TwrForVariable1
  */

--- a/test/langtools/tools/javac/analyzer/AnalyzersCheckSourceLevel.java
+++ b/test/langtools/tools/javac/analyzer/AnalyzersCheckSourceLevel.java
@@ -1,10 +1,10 @@
 /*
  * @test /nodynamiccopyright/
  * @bug 8211102
- * @summary Ensure that the lambda analyzer does not run when -source 7 is specified,
+ * @summary Ensure that the lambda analyzer does not run when --release 7 is specified,
  *          even if explicitly requested
  * @compile/fail/ref=AnalyzersCheckSourceLevel.out -Werror -XDfind=lambda -XDrawDiagnostics AnalyzersCheckSourceLevel.java
- * @compile -Werror -source 7 -Xlint:-options -XDfind=lambda AnalyzersCheckSourceLevel.java
+ * @compile -Werror --release 7 -Xlint:-options -XDfind=lambda AnalyzersCheckSourceLevel.java
  */
 public class AnalyzersCheckSourceLevel {
     void t() {

--- a/test/langtools/tools/javac/analyzer/T8211102.java
+++ b/test/langtools/tools/javac/analyzer/T8211102.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8211102
  * @summary Verify javac does not crash in lambda analyzer
- * @compile -Werror -XDfind=lambda -source 7 -Xlint:-options T8211102.java
+ * @compile -Werror -XDfind=lambda --release 7 -Xlint:-options T8211102.java
  */
 import java.util.*;
 

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/WrongVersion.java
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/WrongVersion.java
@@ -3,7 +3,7 @@
  * @bug 8138822
  * @summary test that only Java 8+ allows repeating annotations
  * @compile WrongVersion.java
- * @compile -Xlint:-options -source 8 WrongVersion.java
+ * @compile --release 8 WrongVersion.java
  * @compile/fail/ref=WrongVersion7.out -XDrawDiagnostics -Xlint:-options -source 7 WrongVersion.java
  */
 import java.lang.annotation.Repeatable;

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotationVersion.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/AnnotationVersion.java
@@ -4,7 +4,7 @@
  * @summary test that only Java 8 allows type annotations
  * @author Mahmood Ali
  * @compile AnnotationVersion.java
- * @compile/fail/ref=AnnotationVersion7.out -XDrawDiagnostics -Xlint:-options -source 1.7 AnnotationVersion.java
+ * @compile/fail/ref=AnnotationVersion7.out -XDrawDiagnostics -Xlint:-options --release 7 AnnotationVersion.java
  */
 import java.lang.annotation.*;
 

--- a/test/langtools/tools/javac/conditional/Conditional.java
+++ b/test/langtools/tools/javac/conditional/Conditional.java
@@ -5,7 +5,7 @@
  * @author Tim Hanson, BEA
  *
  * @compile Conditional.java
- * @compile/fail/ref=Conditional.out -XDrawDiagnostics -source 7 -Xlint:-options Conditional.java
+ * @compile/fail/ref=Conditional.out -XDrawDiagnostics --release 7 -Xlint:-options Conditional.java
  */
 
 import java.util.*;

--- a/test/langtools/tools/javac/depDocComment/SuppressDeprecation.java
+++ b/test/langtools/tools/javac/depDocComment/SuppressDeprecation.java
@@ -5,7 +5,7 @@
  * @author gafter
  *
  * @compile/ref=SuppressDeprecation.out -Xlint:deprecation -XDrawDiagnostics SuppressDeprecation.java
- * @compile/ref=SuppressDeprecation8.out -source 8 -Xlint:deprecation -XDrawDiagnostics -Xlint:-options SuppressDeprecation.java
+ * @compile/ref=SuppressDeprecation8.out --release 8 -Xlint:deprecation -XDrawDiagnostics SuppressDeprecation.java
  */
 
 /* Test for the contexts in which deprecations warnings should

--- a/test/langtools/tools/javac/enum/LocalEnum.java
+++ b/test/langtools/tools/javac/enum/LocalEnum.java
@@ -3,7 +3,7 @@
  * @bug 5019609 8246774
  * @summary javac fails to reject local enums
  * @author gafter
- * @compile/fail/ref=LocalEnum.out -XDrawDiagnostics -source 15 LocalEnum.java
+ * @compile/fail/ref=LocalEnum.out -XDrawDiagnostics --release 15 LocalEnum.java
  * @compile LocalEnum.java
  */
 

--- a/test/langtools/tools/javac/enum/LocalEnum.out
+++ b/test/langtools/tools/javac/enum/LocalEnum.out
@@ -1,4 +1,2 @@
-- compiler.warn.source.no.system.modules.path: 15
 LocalEnum.java:12:9: compiler.err.local.enum
 1 error
-1 warning

--- a/test/langtools/tools/javac/enum/NestedEnum.java
+++ b/test/langtools/tools/javac/enum/NestedEnum.java
@@ -1,10 +1,10 @@
 /*
  * @test /nodynamiccopyright/
  * @bug 5071831
- * @summary javac allows enum in an inner class for source >= 16
+ * @summary javac allows enum in an inner class for release >= 16
  * @author gafter
  *
- * @compile/fail/ref=NestedEnum.out -XDrawDiagnostics -source 15 NestedEnum.java
+ * @compile/fail/ref=NestedEnum.out -XDrawDiagnostics --release 15 NestedEnum.java
  * @compile NestedEnum.java
  */
 

--- a/test/langtools/tools/javac/enum/NestedEnum.out
+++ b/test/langtools/tools/javac/enum/NestedEnum.out
@@ -1,4 +1,2 @@
-- compiler.warn.source.no.system.modules.path: 15
 NestedEnum.java:13:9: compiler.err.static.declaration.not.allowed.in.inner.classes
 1 error
-1 warning

--- a/test/langtools/tools/javac/enum/T5081785.java
+++ b/test/langtools/tools/javac/enum/T5081785.java
@@ -3,7 +3,7 @@
  * @bug 5081785
  * @summary enums should be allowed in non-static contexts
  * @author Peter von der Ah\u00e9
- * @compile/fail/ref=T5081785.out -XDrawDiagnostics -source 15 T5081785.java
+ * @compile/fail/ref=T5081785.out -XDrawDiagnostics --release 15 T5081785.java
  * @compile T5081785.java
  */
 

--- a/test/langtools/tools/javac/enum/T5081785.out
+++ b/test/langtools/tools/javac/enum/T5081785.out
@@ -1,7 +1,5 @@
-- compiler.warn.source.no.system.modules.path: 15
 T5081785.java:30:9: compiler.err.static.declaration.not.allowed.in.inner.classes
 T5081785.java:13:13: compiler.err.static.declaration.not.allowed.in.inner.classes
 T5081785.java:20:27: compiler.err.static.declaration.not.allowed.in.inner.classes
 T5081785.java:25:31: compiler.err.static.declaration.not.allowed.in.inner.classes
 4 errors
-1 warning

--- a/test/langtools/tools/javac/generics/6723444/T6723444.java
+++ b/test/langtools/tools/javac/generics/6723444/T6723444.java
@@ -4,7 +4,7 @@
  *
  * @summary javac fails to substitute type variables into a constructor's throws clause
  * @author Mark Mahieu
- * @compile/fail/ref=T6723444_1.out -Xlint:-options -source 7 -XDrawDiagnostics T6723444.java
+ * @compile/fail/ref=T6723444_1.out -Xlint:-options --release 7 -XDrawDiagnostics T6723444.java
  * @compile/fail/ref=T6723444_2.out -XDrawDiagnostics T6723444.java
  *
  */

--- a/test/langtools/tools/javac/generics/7015430/T7015430.java
+++ b/test/langtools/tools/javac/generics/7015430/T7015430.java
@@ -4,8 +4,8 @@
  *
  * @summary  Incorrect thrown type determined for unchecked invocations
  * @author Daniel Smith
- * @compile/fail/ref=T7015430_1.out -source 7 -Xlint:-options,unchecked -XDrawDiagnostics T7015430.java
- * @compile/fail/ref=T7015430_2.out -Xlint:unchecked -XDrawDiagnostics T7015430.java
+ * @compile/fail/ref=T7015430_1.out --release 7 -Xlint:-options,unchecked -XDrawDiagnostics T7015430.java
+ * @compile/fail/ref=T7015430_2.out             -Xlint:unchecked          -XDrawDiagnostics T7015430.java
  *
  */
 

--- a/test/langtools/tools/javac/generics/7022054/T7022054pos1.java
+++ b/test/langtools/tools/javac/generics/7022054/T7022054pos1.java
@@ -3,7 +3,7 @@
  * @bug 7022054
  *
  * @summary  Invalid compiler error on covariant overriding methods with the same erasure
- * @compile -source 7 T7022054pos1.java
+ * @compile --release 7 T7022054pos1.java
  * @compile/fail/ref=T7022054pos1.out -XDrawDiagnostics T7022054pos1.java
  *
  */

--- a/test/langtools/tools/javac/generics/7022054/T7022054pos2.java
+++ b/test/langtools/tools/javac/generics/7022054/T7022054pos2.java
@@ -3,7 +3,7 @@
  * @bug 7022054
  *
  * @summary  Invalid compiler error on covariant overriding methods with the same erasure
- * @compile -source 7 T7022054pos2.java
+ * @compile --release 7 T7022054pos2.java
  * @compile/fail/ref=T7022054pos2.out -XDrawDiagnostics T7022054pos2.java
  */
 

--- a/test/langtools/tools/javac/generics/InstanceOf3.java
+++ b/test/langtools/tools/javac/generics/InstanceOf3.java
@@ -4,7 +4,7 @@
  * @summary the type in an instanceof expression must be reifiable
  * @author seligman
  *
- * @compile/fail/ref=InstanceOf3.out -XDrawDiagnostics -source 15 -Xlint:-options InstanceOf3.java
+ * @compile/fail/ref=InstanceOf3.out -XDrawDiagnostics --release 15 InstanceOf3.java
  */
 
 public class InstanceOf3 {

--- a/test/langtools/tools/javac/generics/diamond/6939780/T6939780.java
+++ b/test/langtools/tools/javac/generics/diamond/6939780/T6939780.java
@@ -4,9 +4,9 @@
  *
  * @summary  add a warning to detect diamond sites (including anonymous class instance creation at source >= 9)
  * @author mcimadamore
- * @compile/ref=T6939780_7.out -Xlint:-options -source 7 T6939780.java -XDrawDiagnostics -XDfind=diamond
- * @compile/ref=T6939780_8.out -Xlint:-options -source 8 T6939780.java -XDrawDiagnostics -XDfind=diamond
- * @compile/ref=T6939780_9.out -Xlint:-options -source 9 T6939780.java -XDrawDiagnostics -XDfind=diamond
+ * @compile/ref=T6939780_7.out -Xlint:-options --release 7 T6939780.java -XDrawDiagnostics -XDfind=diamond
+ * @compile/ref=T6939780_8.out                 --release 8 T6939780.java -XDrawDiagnostics -XDfind=diamond
+ * @compile/ref=T6939780_9.out                             T6939780.java -XDrawDiagnostics -XDfind=diamond
  *
  */
 

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg09a.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg09a.java
@@ -4,8 +4,7 @@
  *
  * @summary  Check that diamond is not allowed with anonymous inner class expressions at source < 9
  * @author Maurizio Cimadamore
- * @compile/fail/ref=Neg09a.out Neg09a.java -source 8 -XDrawDiagnostics -Xlint:-options
- *
+ * @compile/fail/ref=Neg09a.out Neg09a.java --release 8 -XDrawDiagnostics
  */
 
 class Neg09a {

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg09a.out
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg09a.out
@@ -1,2 +1,2 @@
-Neg09a.java:15:34: compiler.err.cant.apply.diamond.1: Neg09a.Member<X>, (compiler.misc.feature.not.supported.in.source: (compiler.misc.feature.diamond.and.anon.class), 8, 9)
+Neg09a.java:14:34: compiler.err.cant.apply.diamond.1: Neg09a.Member<X>, (compiler.misc.feature.not.supported.in.source: (compiler.misc.feature.diamond.and.anon.class), 8, 9)
 1 error

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg09b.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg09b.java
@@ -4,8 +4,7 @@
  *
  * @summary  Check that diamond is not allowed with anonymous inner class expressions at source < 9
  * @author Maurizio Cimadamore
- * @compile/fail/ref=Neg09b.out Neg09b.java -source 8 -XDrawDiagnostics -Xlint:-options
- *
+ * @compile/fail/ref=Neg09b.out Neg09b.java --release 8 -XDrawDiagnostics
  */
 
 class Neg09b {

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg09b.out
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg09b.out
@@ -1,2 +1,2 @@
-Neg09b.java:16:34: compiler.err.cant.apply.diamond.1: Neg09b.Nested<X>, (compiler.misc.feature.not.supported.in.source: (compiler.misc.feature.diamond.and.anon.class), 8, 9)
+Neg09b.java:15:34: compiler.err.cant.apply.diamond.1: Neg09b.Nested<X>, (compiler.misc.feature.not.supported.in.source: (compiler.misc.feature.diamond.and.anon.class), 8, 9)
 1 error

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg09c.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg09c.java
@@ -4,8 +4,7 @@
  *
  * @summary  Check that diamond is not allowed with anonymous inner class expressions at source < 9
  * @author Maurizio Cimadamore
- * @compile/fail/ref=Neg09c.out Neg09c.java -source 8 -XDrawDiagnostics -Xlint:-options
- *
+ * @compile/fail/ref=Neg09c.out Neg09c.java --release 8 -XDrawDiagnostics
  */
 
 class Neg09c {

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg09c.out
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg09c.out
@@ -1,2 +1,2 @@
-Neg09c.java:15:39: compiler.err.cant.apply.diamond.1: Neg09c.Member<X>, (compiler.misc.feature.not.supported.in.source: (compiler.misc.feature.diamond.and.anon.class), 8, 9)
+Neg09c.java:14:39: compiler.err.cant.apply.diamond.1: Neg09c.Member<X>, (compiler.misc.feature.not.supported.in.source: (compiler.misc.feature.diamond.and.anon.class), 8, 9)
 1 error

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg09d.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg09d.java
@@ -4,8 +4,7 @@
  *
  * @summary  Check that diamond is not allowed with anonymous inner class expressions at source < 9
  * @author Maurizio Cimadamore
- * @compile/fail/ref=Neg09d.out Neg09d.java -source 8 -XDrawDiagnostics -Xlint:-options
- *
+ * @compile/fail/ref=Neg09d.out Neg09d.java --release 8 -XDrawDiagnostics
  */
 
 class Neg09d {

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg09d.out
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg09d.out
@@ -1,2 +1,2 @@
-Neg09d.java:16:33: compiler.err.doesnt.exist: Neg09
+Neg09d.java:15:33: compiler.err.doesnt.exist: Neg09
 1 error

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg10.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg10.java
@@ -4,7 +4,7 @@
  *
  * @summary  Check that 'complex' diamond can infer type that is too specific
  * @author mcimadamore
- * @compile/fail/ref=Neg10.out -source 7 -Xlint:-options Neg10.java -XDrawDiagnostics
+ * @compile/fail/ref=Neg10.out --release 7 -Xlint:-options Neg10.java -XDrawDiagnostics
  * @compile Neg10.java -XDrawDiagnostics
  *
  */

--- a/test/langtools/tools/javac/generics/inference/6278587/T6278587Neg.java
+++ b/test/langtools/tools/javac/generics/inference/6278587/T6278587Neg.java
@@ -3,7 +3,7 @@
  * @bug     6278587 8007464
  * @summary Inference broken for subtypes of subtypes of F-bounded types
  * @author  Peter von der Ah\u00e9
- * @compile/fail/ref=T6278587Neg.out -XDrawDiagnostics -source 7 -Xlint:-options T6278587Neg.java
+ * @compile/fail/ref=T6278587Neg.out -XDrawDiagnostics --release 7 -Xlint:-options T6278587Neg.java
  * @compile T6278587Neg.java
  */
 

--- a/test/langtools/tools/javac/generics/inference/7154127/T7154127.java
+++ b/test/langtools/tools/javac/generics/inference/7154127/T7154127.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 7154127 8007464
  * @summary Inference cleanup: remove bound check analysis from visitors in Types.java
- * @compile/fail/ref=T7154127.out -Xlint:-options -source 7 -XDrawDiagnostics T7154127.java
+ * @compile/fail/ref=T7154127.out -Xlint:-options --release 7 -XDrawDiagnostics T7154127.java
  * @compile T7154127.java
  */
 class T7154127 {

--- a/test/langtools/tools/javac/generics/inference/7177306/T7177306e.java
+++ b/test/langtools/tools/javac/generics/inference/7177306/T7177306e.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 7177306 8007464
  * @summary Regression: unchecked method call does not erase return type
- * @compile/fail/ref=T7177306e_7.out -XDrawDiagnostics -source 7 -Xlint:-options -XDrawDiagnostics T7177306e.java
+ * @compile/fail/ref=T7177306e_7.out -XDrawDiagnostics --release 7 -Xlint:-options -XDrawDiagnostics T7177306e.java
  * @compile/fail/ref=T7177306e.out -XDrawDiagnostics T7177306e.java
  */
 

--- a/test/langtools/tools/javac/generics/inference/8015505/T8015505.java
+++ b/test/langtools/tools/javac/generics/inference/8015505/T8015505.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8015505
  * @summary Spurious inference error when return type of generic method requires unchecked conversion to target
- * @compile/fail/ref=T8015505.out -Xlint:-options -source 7 -XDrawDiagnostics T8015505.java
+ * @compile/fail/ref=T8015505.out -Xlint:-options --release 7 -XDrawDiagnostics T8015505.java
  * @compile T8015505.java
  */
 

--- a/test/langtools/tools/javac/generics/inference/8043893/T8043893.java
+++ b/test/langtools/tools/javac/generics/inference/8043893/T8043893.java
@@ -3,8 +3,8 @@
  * @bug 8043893
  * @summary Inference doesn't report error on incompatible upper bounds
  *
- * @compile -source 7 T8043893.java
- * @compile/fail/ref=T8043893.out -Xlint:-options -XDrawDiagnostics -source 8 T8043893.java
+ * @compile --release 7 T8043893.java
+ * @compile/fail/ref=T8043893.out -XDrawDiagnostics T8043893.java
  */
 
 class T8043893<X> {

--- a/test/langtools/tools/javac/generics/inference/CaptureLowerBound.java
+++ b/test/langtools/tools/javac/generics/inference/CaptureLowerBound.java
@@ -3,7 +3,7 @@
  * @bug 8039214
  * @summary Capture variable as an inference variable's lower bound
  * @compile CaptureLowerBound.java
- * @compile/fail/ref=CaptureLowerBound7.out -Xlint:-options -source 7 -XDrawDiagnostics CaptureLowerBound.java
+ * @compile/fail/ref=CaptureLowerBound7.out -Xlint:-options --release 7 -XDrawDiagnostics CaptureLowerBound.java
  */
 
 public class CaptureLowerBound {

--- a/test/langtools/tools/javac/generics/inference/CaptureLowerBoundArray.java
+++ b/test/langtools/tools/javac/generics/inference/CaptureLowerBoundArray.java
@@ -3,7 +3,7 @@
  * @bug 8075793
  * @summary Capture variable as an inference lower bound followed by an array write
  * @compile/fail/ref=CaptureLowerBoundArray.out -XDrawDiagnostics CaptureLowerBoundArray.java
- * @compile -Xlint:-options -source 7 CaptureLowerBoundArray.java
+ * @compile --release 7 CaptureLowerBoundArray.java
  */
 
 class CaptureLowerBoundArray {

--- a/test/langtools/tools/javac/generics/inference/CaptureLowerBoundAssign.java
+++ b/test/langtools/tools/javac/generics/inference/CaptureLowerBoundAssign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8075793
  * @summary Capture variable as an inference lower bound followed by an invariant assignment
  * @compile CaptureLowerBoundAssign.java
- * @compile -Xlint:-options -source 7 CaptureLowerBoundAssign.java
+ * @compile --release 7 CaptureLowerBoundAssign.java
  */
 
 class CaptureLowerBoundAssign {

--- a/test/langtools/tools/javac/generics/inference/CaptureLowerBoundDeref.java
+++ b/test/langtools/tools/javac/generics/inference/CaptureLowerBoundDeref.java
@@ -3,7 +3,7 @@
  * @bug 8075793
  * @summary Capture variable as an inference lower bound followed by a member reference
  * @compile/fail/ref=CaptureLowerBoundDeref.out -XDrawDiagnostics CaptureLowerBoundDeref.java
- * @compile -Xlint:-options -source 7 CaptureLowerBoundDeref.java
+ * @compile --release 7 CaptureLowerBoundDeref.java
  */
 
 class CaptureLowerBoundDeref {

--- a/test/langtools/tools/javac/generics/inference/CaptureLowerBoundNeg.java
+++ b/test/langtools/tools/javac/generics/inference/CaptureLowerBoundNeg.java
@@ -3,7 +3,7 @@
  * @bug 8039214
  * @summary Capture variable as an inference variable's lower bound
  * @compile/fail/ref=CaptureLowerBoundNeg.out -XDrawDiagnostics CaptureLowerBoundNeg.java
- * @compile -Xlint:-options -source 7 CaptureLowerBoundNeg.java
+ * @compile --release 7 CaptureLowerBoundNeg.java
  */
 
 public class CaptureLowerBoundNeg {

--- a/test/langtools/tools/javac/generics/inference/CaptureUpperBoundDeref.java
+++ b/test/langtools/tools/javac/generics/inference/CaptureUpperBoundDeref.java
@@ -3,7 +3,7 @@
  * @bug 8075793
  * @summary Capture variable as an inference upper bound followed by a member reference
  * @compile/fail/ref=CaptureUpperBoundDeref.out -XDrawDiagnostics CaptureUpperBoundDeref.java
- * @compile -Xlint:-options -source 7 CaptureUpperBoundDeref.java
+ * @compile --release 7 CaptureUpperBoundDeref.java
  */
 
 class CaptureUpperBoundDeref {

--- a/test/langtools/tools/javac/generics/inference/NestedCapture.java
+++ b/test/langtools/tools/javac/generics/inference/NestedCapture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8039214
  * @summary Capture variable passed through multiple levels of nested inference
  * @compile NestedCapture.java
- * @compile -Xlint:-options -source 7 NestedCapture.java
+ * @compile --release 7 -Xlint:-options NestedCapture.java
  */
 
 abstract class NestedCapture {

--- a/test/langtools/tools/javac/generics/inference/NestedWildcards.java
+++ b/test/langtools/tools/javac/generics/inference/NestedWildcards.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8039214
  * @summary Nested generic methods that work on wildcard-parameterized types
  * @compile NestedWildcards.java
- * @compile -Xlint:-options -source 7 NestedWildcards.java
+ * @compile --release 7 NestedWildcards.java
  */
 
 public class NestedWildcards {

--- a/test/langtools/tools/javac/generics/odersky/BadTest.java
+++ b/test/langtools/tools/javac/generics/odersky/BadTest.java
@@ -3,7 +3,7 @@
  * @summary Negative regression test from odersky
  * @author odersky
  *
- * @compile/fail/ref=BadTest-old.out -XDrawDiagnostics -source 15 -Xlint:-options BadTest.java
+ * @compile/fail/ref=BadTest-old.out -XDrawDiagnostics --release 15 BadTest.java
  * @compile/fail/ref=BadTest.out -XDrawDiagnostics  BadTest.java
  */
 

--- a/test/langtools/tools/javac/generics/odersky/BadTest4.java
+++ b/test/langtools/tools/javac/generics/odersky/BadTest4.java
@@ -4,7 +4,7 @@
  * @summary Negative regression test from odersky
  * @author odersky
  *
- * @compile/fail/ref=BadTest4.out -XDrawDiagnostics -source 7 -Xlint:-options BadTest4.java
+ * @compile/fail/ref=BadTest4.out -XDrawDiagnostics --release 7 -Xlint:-options BadTest4.java
  * @compile BadTest4.java
  */
 

--- a/test/langtools/tools/javac/importChecks/ImportsObservable.java
+++ b/test/langtools/tools/javac/importChecks/ImportsObservable.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 4869999 8193302
  * @summary Verify that the compiler does not prematurely decide a package is not observable.
- * @compile -source 8 -Xlint:-options ImportsObservable.java
+ * @compile --release 8 ImportsObservable.java
  * @compile/fail/ref=ImportsObservable.out -XDrawDiagnostics ImportsObservable.java
  */
 

--- a/test/langtools/tools/javac/lambda/EffectivelyFinalTest.java
+++ b/test/langtools/tools/javac/lambda/EffectivelyFinalTest.java
@@ -4,7 +4,7 @@
  * @summary Add lambda tests
  *  Integrate effectively final check with DA/DU analysis
  * @compile/fail/ref=EffectivelyFinalTest01.out -XDrawDiagnostics EffectivelyFinalTest.java
- * @compile/fail/ref=EffectivelyFinalTest02.out -source 7 -Xlint:-options -XDrawDiagnostics EffectivelyFinalTest.java
+ * @compile/fail/ref=EffectivelyFinalTest02.out --release 7 -Xlint:-options -XDrawDiagnostics EffectivelyFinalTest.java
  */
 class EffectivelyFinalTest {
 

--- a/test/langtools/tools/javac/lambda/IdentifierTest.java
+++ b/test/langtools/tools/javac/lambda/IdentifierTest.java
@@ -3,7 +3,7 @@
  * @bug    8007401 8007427 8061549
  * @author sogoel
  * @summary Test generation of warnings when '_' is used an identifier
- * @compile/fail/ref=IdentifierTest8.out -source 8 -Xlint:-options -Werror -XDrawDiagnostics IdentifierTest.java
+ * @compile/fail/ref=IdentifierTest8.out --release 8 -Werror -XDrawDiagnostics IdentifierTest.java
  * @compile/fail/ref=IdentifierTest9.out -XDrawDiagnostics IdentifierTest.java
  */
 

--- a/test/langtools/tools/javac/lambda/SourceLevelTest.java
+++ b/test/langtools/tools/javac/lambda/SourceLevelTest.java
@@ -3,7 +3,7 @@
  * @bug 8003280
  * @summary Add lambda tests
  *  check that lambda features are not enabled with source < 8
- * @compile/fail/ref=SourceLevelTest.out -XDrawDiagnostics -source 7 -Xlint:-options SourceLevelTest.java
+ * @compile/fail/ref=SourceLevelTest.out -XDrawDiagnostics --release 7 -Xlint:-options SourceLevelTest.java
  */
 
 class SourceLevelTest {

--- a/test/langtools/tools/javac/lambda/UnderscoreAsIdent.java
+++ b/test/langtools/tools/javac/lambda/UnderscoreAsIdent.java
@@ -1,7 +1,7 @@
 /*
  * @test /nodynamiccopyright/
  * @summary Check usages of underscore as identifier generate warnings
- * @compile/fail/ref=UnderscoreAsIdent8.out -source 8 -Xlint:-options -XDrawDiagnostics -Werror UnderscoreAsIdent.java
+ * @compile/fail/ref=UnderscoreAsIdent8.out --release 8 -XDrawDiagnostics -Werror UnderscoreAsIdent.java
  * @compile/fail/ref=UnderscoreAsIdent9.out -XDrawDiagnostics -Werror UnderscoreAsIdent.java
  */
 package _._;

--- a/test/langtools/tools/javac/lvti/badTypeReference/BadTypeReference.java
+++ b/test/langtools/tools/javac/lvti/badTypeReference/BadTypeReference.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8177466
  * @summary Add compiler support for local variable type-inference
- * @compile -source 8 pkg/var.java
+ * @compile --release 8 pkg/var.java
  * @compile pkg/nested/var/A.java
  * @compile/fail/ref=BadTypeReference.out -XDrawDiagnostics BadTypeReference.java
  */

--- a/test/langtools/tools/javac/patterns/CaseDefault.java
+++ b/test/langtools/tools/javac/patterns/CaseDefault.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8262891
  * @summary Check null handling for non-pattern switches.
- * @compile/fail/ref=CaseDefault.out -source 16 -Xlint:-options -XDrawDiagnostics CaseDefault.java
+ * @compile/fail/ref=CaseDefault.out --release 16 -XDrawDiagnostics CaseDefault.java
  * @compile --enable-preview -source ${jdk.version} CaseDefault.java
  * @run main/othervm --enable-preview CaseDefault
  */

--- a/test/langtools/tools/javac/patterns/ReifiableOld.java
+++ b/test/langtools/tools/javac/patterns/ReifiableOld.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8231827
  * @summary Verify behavior w.r.t. non-reifiable types in instanceof
- * @compile/fail/ref=ReifiableOld-old.out -source 15 -Xlint:-options -XDrawDiagnostics ReifiableOld.java
+ * @compile/fail/ref=ReifiableOld-old.out --release 15 -XDrawDiagnostics ReifiableOld.java
  * @compile/fail/ref=ReifiableOld.out -XDrawDiagnostics ReifiableOld.java
  */
 

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitch.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitch.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8206986 8222169 8224031 8240964 8267119 8268670
  * @summary Check expression switch works.
- * @compile/fail/ref=ExpressionSwitch-old.out -source 9 -Xlint:-options -XDrawDiagnostics ExpressionSwitch.java
+ * @compile/fail/ref=ExpressionSwitch-old.out --release 9 -XDrawDiagnostics ExpressionSwitch.java
  * @compile ExpressionSwitch.java
  * @run main ExpressionSwitch
  */

--- a/test/langtools/tools/javac/switchexpr/WarnWrongYieldTest.java
+++ b/test/langtools/tools/javac/switchexpr/WarnWrongYieldTest.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8223305 8226522
  * @summary Verify correct warnings w.r.t. yield
- * @compile/ref=WarnWrongYieldTest.out -Xlint:-options -source 13 -XDrawDiagnostics -XDshould-stop.ifError=ATTR -XDshould-stop.ifNoError=ATTR WarnWrongYieldTest.java
+ * @compile/ref=WarnWrongYieldTest.out --release 13 -XDrawDiagnostics -XDshould-stop.ifError=ATTR -XDshould-stop.ifNoError=ATTR WarnWrongYieldTest.java
  */
 
 package t;

--- a/test/langtools/tools/javac/switchextra/MultipleLabelsExpression.java
+++ b/test/langtools/tools/javac/switchextra/MultipleLabelsExpression.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8206986
  * @summary Verify cases with multiple labels work properly.
- * @compile/fail/ref=MultipleLabelsExpression-old.out -source 9 -Xlint:-options -XDrawDiagnostics MultipleLabelsExpression.java
+ * @compile/fail/ref=MultipleLabelsExpression-old.out --release 9 -XDrawDiagnostics MultipleLabelsExpression.java
  * @compile MultipleLabelsExpression.java
  * @run main MultipleLabelsExpression
  */

--- a/test/langtools/tools/javac/switchextra/MultipleLabelsStatement.java
+++ b/test/langtools/tools/javac/switchextra/MultipleLabelsStatement.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8206986
  * @summary Verify cases with multiple labels work properly.
- * @compile/fail/ref=MultipleLabelsStatement-old.out -source 9 -Xlint:-options -XDrawDiagnostics MultipleLabelsStatement.java
+ * @compile/fail/ref=MultipleLabelsStatement-old.out --release 9 -XDrawDiagnostics MultipleLabelsStatement.java
  * @compile MultipleLabelsStatement.java
  * @run main MultipleLabelsStatement
  */

--- a/test/langtools/tools/javac/switchextra/SwitchStatementArrow.java
+++ b/test/langtools/tools/javac/switchextra/SwitchStatementArrow.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8206986
  * @summary Verify rule cases work properly.
- * @compile/fail/ref=SwitchStatementArrow-old.out -source 9 -Xlint:-options -XDrawDiagnostics SwitchStatementArrow.java
+ * @compile/fail/ref=SwitchStatementArrow-old.out --release 9 -XDrawDiagnostics SwitchStatementArrow.java
  * @compile SwitchStatementArrow.java
  * @run main SwitchStatementArrow
  */

--- a/test/langtools/tools/javac/switchnull/SwitchNullDisabled.java
+++ b/test/langtools/tools/javac/switchnull/SwitchNullDisabled.java
@@ -1,8 +1,8 @@
 /*
  * @test /nodynamiccopyright/
  * @bug 8206986
- * @summary Verify "case null" is not allowed for -source 16
- * @compile/fail/ref=SwitchNullDisabled.out -XDrawDiagnostics -source 16 -Xlint:-options SwitchNullDisabled.java
+ * @summary Verify "case null" is not allowed for --release 16
+ * @compile/fail/ref=SwitchNullDisabled.out -XDrawDiagnostics --release 16 SwitchNullDisabled.java
  * @compile/fail/ref=SwitchNullDisabled-preview.out -XDrawDiagnostics SwitchNullDisabled.java
  * @compile --enable-preview -source ${jdk.version} SwitchNullDisabled.java
  */

--- a/test/langtools/tools/javac/varargs/6313164/T6313164.java
+++ b/test/langtools/tools/javac/varargs/6313164/T6313164.java
@@ -3,7 +3,7 @@
  * @bug     6313164 8036953
  * @author mcimadamore
  * @summary  javac generates code that fails byte code verification for the varargs feature
- * @compile/fail/ref=T6313164Source7.out -source 7 -XDrawDiagnostics  -Xlint:-options T6313164.java
+ * @compile/fail/ref=T6313164Source7.out --release 7 -XDrawDiagnostics  -Xlint:-options T6313164.java
  * @compile/fail/ref=T6313164Source8AndHigher.out -XDrawDiagnostics T6313164.java
  */
 import p1.*;

--- a/test/langtools/tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest.java
+++ b/test/langtools/tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8049075
  * @summary javac, wildcards and generic vararg method invocation not accepted
  * @compile VarargsAndWildcardParameterizedTypeTest.java
- * @compile -source 8 VarargsAndWildcardParameterizedTypeTest.java
- * @compile -source 7 VarargsAndWildcardParameterizedTypeTest.java
+ * @compile --release 8 VarargsAndWildcardParameterizedTypeTest.java
+ * @compile --release 7 VarargsAndWildcardParameterizedTypeTest.java
  */
 
 class VarargsAndWildcardParameterizedTypeTest {

--- a/test/langtools/tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest2.java
+++ b/test/langtools/tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
  * @test
  * @bug 8075520
  * @summary Varargs access check mishandles capture variables
- * @compile VarargsAndWildcardParameterizedTypeTest2.java
- * @compile -source 8 VarargsAndWildcardParameterizedTypeTest2.java
- * @compile -source 7 VarargsAndWildcardParameterizedTypeTest2.java
+ * @compile             VarargsAndWildcardParameterizedTypeTest2.java
+ * @compile --release 8 VarargsAndWildcardParameterizedTypeTest2.java
+ * @compile --release 7 VarargsAndWildcardParameterizedTypeTest2.java
  */
 
 class VarargsAndWildcardParameterizedTypeTest2 {

--- a/test/langtools/tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest3.java
+++ b/test/langtools/tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
  * @test
  * @bug 8075520
  * @summary Varargs access check mishandles capture variables
- * @compile VarargsAndWildcardParameterizedTypeTest3.java
- * @compile -source 8 VarargsAndWildcardParameterizedTypeTest3.java
- * @compile -source 7 VarargsAndWildcardParameterizedTypeTest3.java
+ * @compile             VarargsAndWildcardParameterizedTypeTest3.java
+ * @compile --release 8 VarargsAndWildcardParameterizedTypeTest3.java
+ * @compile --release 7 VarargsAndWildcardParameterizedTypeTest3.java
  */
 
 class VarargsAndWildcardParameterizedTypeTest2 {

--- a/test/langtools/tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest4.java
+++ b/test/langtools/tools/javac/varargs/access/VarargsAndWildcardParameterizedTypeTest4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
  * @test
  * @bug 8075520
  * @summary Varargs access check mishandles capture variables
- * @compile VarargsAndWildcardParameterizedTypeTest4.java
- * @compile -source 8 VarargsAndWildcardParameterizedTypeTest4.java
- * @compile -source 7 VarargsAndWildcardParameterizedTypeTest4.java
+ * @compile             VarargsAndWildcardParameterizedTypeTest4.java
+ * @compile --release 8 VarargsAndWildcardParameterizedTypeTest4.java
+ * @compile --release 7 VarargsAndWildcardParameterizedTypeTest4.java
  */
 
 class VarargsAndWildcardParameterizedTypeTest2 {

--- a/test/langtools/tools/javac/varargs/access/VarargsInferredPrivateType.java
+++ b/test/langtools/tools/javac/varargs/access/VarargsInferredPrivateType.java
@@ -3,8 +3,8 @@
  * @bug 8077786
  * @summary Check varargs access against inferred signature
  * @compile/fail/ref=VarargsInferredPrivateType.out -nowarn -XDrawDiagnostics VarargsInferredPrivateType.java OtherPackage.java
- * @compile/fail/ref=VarargsInferredPrivateType.out -source 8 -nowarn -XDrawDiagnostics VarargsInferredPrivateType.java OtherPackage.java
- * @compile/fail/ref=VarargsInferredPrivateType-source7.out -source 7 -nowarn -XDrawDiagnostics VarargsInferredPrivateType.java OtherPackage.java
+ * @compile/fail/ref=VarargsInferredPrivateType.out --release 8 -nowarn -XDrawDiagnostics VarargsInferredPrivateType.java OtherPackage.java
+ * @compile/fail/ref=VarargsInferredPrivateType-source7.out --release 7 -nowarn -XDrawDiagnostics VarargsInferredPrivateType.java OtherPackage.java
  */
 
 class VarargsInferredPrivateType {

--- a/test/langtools/tools/javac/warnings/6594914/ImplicitCompilation.java
+++ b/test/langtools/tools/javac/warnings/6594914/ImplicitCompilation.java
@@ -3,9 +3,9 @@
  * @bug 8020586
  * @summary Warnings in the imports section should be attributed to the correct source file
  * @clean Auxiliary ImplicitCompilation
- * @compile/ref=ImplicitCompilation.out -source 8 -XDrawDiagnostics -Xlint:deprecation,-options -sourcepath . ImplicitCompilation.java
+ * @compile/ref=ImplicitCompilation.out --release 8 -XDrawDiagnostics -Xlint:deprecation,-options -sourcepath . ImplicitCompilation.java
  * @clean Auxiliary ImplicitCompilation
- * @compile/ref=ExplicitCompilation.out -source 8 -XDrawDiagnostics -Xlint:deprecation,-options ImplicitCompilation.java Auxiliary.java
+ * @compile/ref=ExplicitCompilation.out --release 8 -XDrawDiagnostics -Xlint:deprecation,-options ImplicitCompilation.java Auxiliary.java
  */
 
 public class ImplicitCompilation {

--- a/test/langtools/tools/javac/warnings/Deprecation.java
+++ b/test/langtools/tools/javac/warnings/Deprecation.java
@@ -1,10 +1,10 @@
 /**
  * @test  /nodynamiccopyright/
  * @bug 4986256 6598104 8032211 8194764
- * @compile/ref=Deprecation.noLint.out                                                 -XDrawDiagnostics Deprecation.java
- * @compile/ref=Deprecation.lintDeprecation.out  -Xlint:deprecation                    -XDrawDiagnostics Deprecation.java
- * @compile/ref=Deprecation.lintDeprecation.out  -Xlint:deprecation,-options -source 9 -XDrawDiagnostics Deprecation.java
- * @compile/ref=Deprecation.lintDeprecation8.out -Xlint:deprecation,-options -source 8 -XDrawDiagnostics Deprecation.java
+ * @compile/ref=Deprecation.noLint.out                                                   -XDrawDiagnostics Deprecation.java
+ * @compile/ref=Deprecation.lintDeprecation.out  -Xlint:deprecation                      -XDrawDiagnostics Deprecation.java
+ * @compile/ref=Deprecation.lintDeprecation.out  -Xlint:deprecation,-options --release 9 -XDrawDiagnostics Deprecation.java
+ * @compile/ref=Deprecation.lintDeprecation8.out -Xlint:deprecation,-options --release 8 -XDrawDiagnostics Deprecation.java
  */
 
 import java.io.StringBufferInputStream;

--- a/test/langtools/tools/javac/warnings/DeprecationSE8Test.java
+++ b/test/langtools/tools/javac/warnings/DeprecationSE8Test.java
@@ -3,7 +3,7 @@
  * @bug 8065219
  * @summary Deprecated warning in method reference are missing in some cases.
  * @compile/ref=DeprecationSE8Test.noLint.out -XDrawDiagnostics DeprecationSE8Test.java
- * @compile/ref=DeprecationSE8Test.out -Xlint:deprecation,-options -source 8 -XDrawDiagnostics DeprecationSE8Test.java
+ * @compile/ref=DeprecationSE8Test.out -Xlint:deprecation,-options --release 8 -XDrawDiagnostics DeprecationSE8Test.java
  */
 
 

--- a/test/langtools/tools/javac/warnings/suppress/ImplicitTest.java
+++ b/test/langtools/tools/javac/warnings/suppress/ImplicitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,5 +27,5 @@
  * @summary Verify that deprecated warning is printed correctly for import
  *          statement when processing a file on demand while attributing another file.
  * @clean pack.ImplicitUse pack.ImplicitMain pack.Dep
- * @compile/ref=ImplicitTest.out -source 8 -XDrawDiagnostics -Xlint:deprecation,-options pack/ImplicitMain.java
+ * @compile/ref=ImplicitTest.out --release 8 -XDrawDiagnostics -Xlint:deprecation,-options pack/ImplicitMain.java
  */

--- a/test/langtools/tools/javac/warnings/suppress/PackageInfo.java
+++ b/test/langtools/tools/javac/warnings/suppress/PackageInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,5 +26,5 @@
  * @bug 8021112
  * @summary Verify that deprecated warnings are printed correctly for package-info.java
  * @clean pack.*
- * @compile/ref=PackageInfo.out -source 8 -XDrawDiagnostics -Xlint:deprecation,-options pack/package-info.java pack/DeprecatedClass.java
+ * @compile/ref=PackageInfo.out --release 8 -XDrawDiagnostics -Xlint:deprecation,-options pack/package-info.java pack/DeprecatedClass.java
  */


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.


Applies clean except for patch of InstanceofTotalPattern.java which is a test that came with new feature "8282274: Compiler implementation for Pattern Matching for switch (Third Preview)".

Will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8290901](https://bugs.openjdk.org/browse/JDK-8290901) needs maintainer approval

### Issue
 * [JDK-8290901](https://bugs.openjdk.org/browse/JDK-8290901): Reduce use of -source in langtools tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2297/head:pull/2297` \
`$ git checkout pull/2297`

Update a local copy of the PR: \
`$ git checkout pull/2297` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2297`

View PR using the GUI difftool: \
`$ git pr show -t 2297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2297.diff">https://git.openjdk.org/jdk17u-dev/pull/2297.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2297#issuecomment-1994703576)