### PR TITLE
8325254: CKA_TOKEN private and secret keys are not necessarily sensitive

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Cipher.java
@@ -261,10 +261,8 @@ final class P11Cipher extends CipherSpi {
                 // no native padding support; use our own padding impl
                 paddingObj = new PKCS5Padding(blockSize);
                 padBuffer = new byte[blockSize];
-                char[] tokenLabel = token.tokenInfo.label;
                 // NSS requires block-sized updates in multi-part operations.
-                reqBlockUpdates = ((tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
-                        && tokenLabel[2] == 'S') ? true : false);
+                reqBlockUpdates = P11Util.isNSS(token);
             }
         } else {
             throw new NoSuchPaddingException("Unsupported padding " + padding);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -139,9 +139,7 @@ abstract class P11Key implements Key, Length {
         this.tokenObject = tokenObject;
         this.sensitive = sensitive;
         this.extractable = extractable;
-        char[] tokenLabel = this.token.tokenInfo.label;
-        isNSS = (tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
-                && tokenLabel[2] == 'S');
+        isNSS = P11Util.isNSS(this.token);
         boolean extractKeyInfo = (!DISABLE_NATIVE_KEYS_EXTRACTION && isNSS &&
                 extractable && !tokenObject);
         this.keyIDHolder = new NativeKeyHolder(this, keyID, session,
@@ -395,8 +393,9 @@ abstract class P11Key implements Key, Length {
                     new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
 
-        boolean keySensitive = (attrs[0].getBoolean() ||
-                attrs[1].getBoolean() || !attrs[2].getBoolean());
+        boolean keySensitive =
+                (attrs[0].getBoolean() && P11Util.isNSS(session.token)) ||
+                attrs[1].getBoolean() || !attrs[2].getBoolean();
 
         switch (algorithm) {
         case "RSA":

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -44,6 +44,15 @@ public final class P11Util {
         // empty
     }
 
+    static boolean isNSS(Token token) {
+        char[] tokenLabel = token.tokenInfo.label;
+        if (tokenLabel != null && tokenLabel.length >= 3) {
+            return (tokenLabel[0] == 'N' && tokenLabel[1] == 'S'
+                    && tokenLabel[2] == 'S');
+        }
+        return false;
+    }
+
     static Provider getSunProvider() {
         Provider p = sun;
         if (p == null) {


### PR DESCRIPTION
Hi, this is a second take of #2223, the backport of [JDK-8325254: CKA_TOKEN private and secret keys are not necessarily sensitive](https://bugs.openjdk.org/browse/JDK-8325254), backed out by #2249.

Even though the original patch applies cleanly to 17u, it introduces a dependency on `P11Util::isNSS()` from [JDK-8301553: Support Password-Based Cryptography in SunPKCS11](https://bugs.openjdk.org/browse/JDK-8301553).

I only picked the `P11Util::isNSS()` changes since the whole PBE patch would require a deeper assessment and testing.

### Testing

* Build `linux-x86_64-server-release` and `linux-x86_64-server-slowdebug`
* Locally execute _SunPKCS11_ tests (`test/jdk/sun/security/pkcs11`) in both builds
    * Ensure all the patched lines have coverage by attaching a debugger during the execution
* Locally execute `jdk:tier1` in both builds
* Review GitHub Actions from [run 8285374490 on `backport-8325254@franferrax/jdk17u-dev`](https://github.com/franferrax/jdk17u-dev/actions/runs/8285374490)
    * The only failure is due to [JDK-8326960: GHA: RISC-V linux-cross-compile is failing](https://bugs.openjdk.org/browse/JDK-8326960)

Regards,\
Francisco

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325254](https://bugs.openjdk.org/browse/JDK-8325254) needs maintainer approval

### Issue
 * [JDK-8325254](https://bugs.openjdk.org/browse/JDK-8325254): CKA_TOKEN private and secret keys are not necessarily sensitive (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2299/head:pull/2299` \
`$ git checkout pull/2299`

Update a local copy of the PR: \
`$ git checkout pull/2299` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2299`

View PR using the GUI difftool: \
`$ git pr show -t 2299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2299.diff">https://git.openjdk.org/jdk17u-dev/pull/2299.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2299#issuecomment-1998337896)