### PR TITLE
8312320: Remove javax/rmi/ssl/SSLSocketParametersTest.sh from ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -788,8 +788,6 @@ sun/tools/jstat/jstatLineCounts4.sh                             8248691,8268211 
 
 # jdk_other
 
-javax/rmi/ssl/SSLSocketParametersTest.sh                        8162906 generic-all
-
 javax/script/Test7.java                                         8239361 generic-all
 
 ############################################################################


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

Resolved ProblemList, will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8312320](https://bugs.openjdk.org/browse/JDK-8312320) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312320](https://bugs.openjdk.org/browse/JDK-8312320): Remove javax/rmi/ssl/SSLSocketParametersTest.sh from ProblemList (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2302/head:pull/2302` \
`$ git checkout pull/2302`

Update a local copy of the PR: \
`$ git checkout pull/2302` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2302`

View PR using the GUI difftool: \
`$ git pr show -t 2302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2302.diff">https://git.openjdk.org/jdk17u-dev/pull/2302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2302#issuecomment-2003450694)