### PR TITLE
8312383: Log X509ExtendedKeyManager implementation class name in TLS/SSL connection

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/X509Authentication.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509Authentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,6 +203,10 @@ enum X509Authentication implements SSLAuthentication {
     private static SSLPossession createClientPossession(
             ClientHandshakeContext chc, String[] keyTypes) {
         X509ExtendedKeyManager km = chc.sslContext.getX509KeyManager();
+        if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+            SSLLogger.finest("X509KeyManager class: " +
+                    km.getClass().getName());
+        }
         String clientAlias = null;
         if (chc.conContext.transport instanceof SSLSocketImpl socket) {
             clientAlias = km.chooseClientAlias(
@@ -272,6 +276,10 @@ enum X509Authentication implements SSLAuthentication {
     private static SSLPossession createServerPossession(
             ServerHandshakeContext shc, String[] keyTypes) {
         X509ExtendedKeyManager km = shc.sslContext.getX509KeyManager();
+        if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+            SSLLogger.finest("X509KeyManager class: " +
+                    km.getClass().getName());
+        }
         String serverAlias = null;
         for (String keyType : keyTypes) {
             if (shc.conContext.transport instanceof SSLSocketImpl socket) {


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312383](https://bugs.openjdk.org/browse/JDK-8312383) needs maintainer approval

### Issue
 * [JDK-8312383](https://bugs.openjdk.org/browse/JDK-8312383): Log X509ExtendedKeyManager implementation class name in TLS/SSL connection (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2303/head:pull/2303` \
`$ git checkout pull/2303`

Update a local copy of the PR: \
`$ git checkout pull/2303` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2303`

View PR using the GUI difftool: \
`$ git pr show -t 2303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2303.diff">https://git.openjdk.org/jdk17u-dev/pull/2303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2303#issuecomment-2003445339)