### PR TITLE
8328066: WhiteBoxResizeTest failure on linux-x86: Could not reserve enough space for 2097152KB object heap

### DIFF
--- a/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
+++ b/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2018, 2024, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,8 @@ import static org.testng.Assert.assertNull;
  * @modules java.base/java.util:open
  * @summary White box tests for HashMap internals around table resize
  * @run testng WhiteBoxResizeTest
+ * @comment skip running this test on 32 bit VM
+ * @requires vm.bits == "64"
  * @key randomness
  */
 public class WhiteBoxResizeTest {


### PR DESCRIPTION
I would like to backport this to 17 to avoid GHA failures. 
I had to resolve as some previous changes are not in 17 yet.
I don't think excluding this considerably reduces the testing scope on x86, but I definitely want to avoid GHA failures due to this in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8328066](https://bugs.openjdk.org/browse/JDK-8328066) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328066](https://bugs.openjdk.org/browse/JDK-8328066): WhiteBoxResizeTest failure on linux-x86: Could not reserve enough space for 2097152KB object heap (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2307/head:pull/2307` \
`$ git checkout pull/2307`

Update a local copy of the PR: \
`$ git checkout pull/2307` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2307`

View PR using the GUI difftool: \
`$ git pr show -t 2307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2307.diff">https://git.openjdk.org/jdk17u-dev/pull/2307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2307#issuecomment-2006710957)