### PR TITLE
8328524: [x86] StringRepeat.java failure on linux-x86: Could not reserve enough space for 2097152KB object heap

### DIFF
--- a/test/jdk/java/lang/String/StringRepeat.java
+++ b/test/jdk/java/lang/String/StringRepeat.java
@@ -31,7 +31,7 @@
  * @test
  * @summary This exercises String#repeat patterns with 16 * 1024 * 1024 repeats.
  * @requires os.maxMemory >= 2G
- * @requires !(os.family == "windows" & sun.arch.data.model == "32")
+ * @requires vm.bits == "64"
  * @run main/othervm -Xmx2g StringRepeat 16777216
  */
 


### PR DESCRIPTION
I backport this to fix the GHA failures of this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328524](https://bugs.openjdk.org/browse/JDK-8328524) needs maintainer approval

### Issue
 * [JDK-8328524](https://bugs.openjdk.org/browse/JDK-8328524): [x86] StringRepeat.java failure on linux-x86: Could not reserve enough space for 2097152KB object heap (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2313/head:pull/2313` \
`$ git checkout pull/2313`

Update a local copy of the PR: \
`$ git checkout pull/2313` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2313`

View PR using the GUI difftool: \
`$ git pr show -t 2313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2313.diff">https://git.openjdk.org/jdk17u-dev/pull/2313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2313#issuecomment-2008967069)