### PR TITLE
8305169: java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java -- test server didn't start in timely manner

### DIFF
--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java
@@ -63,15 +63,13 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import sun.security.testlibrary.SimpleOCSPServer;
-import sun.security.testlibrary.SimpleOCSPServer;
-import sun.security.testlibrary.SimpleOCSPServer;
 import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
-import sun.security.testlibrary.SimpleOCSPServer;
 
 public class GetAndPostTests {
     private static final String PASS = "passphrase";
+    private static final int SERVER_WAIT_SECS = 60;
     private static CertificateFactory certFac;
 
     public static void main(String args[]) throws Exception {
@@ -114,13 +112,8 @@ public class GetAndPostTests {
                     endEntCert.getSerialNumber(),
                     new SimpleOCSPServer.CertStatusInfo(
                             SimpleOCSPServer.CertStatus.CERT_STATUS_GOOD)));
-            ocspResponder.start();
-            // Wait 5 seconds for server ready
-            boolean readyStatus =
-                    ocspResponder.awaitServerReady(5, TimeUnit.SECONDS);
-            if (!readyStatus) {
-                throw new RuntimeException("Server not ready");
-            }
+
+            startOcspServer(ocspResponder);
 
             int ocspPort = ocspResponder.getPort();
             URI ocspURI = new URI("http://localhost:" + ocspPort);
@@ -167,6 +160,14 @@ public class GetAndPostTests {
                 ocspResponder.stop();
             }
         }
+    }
+
+    private static void startOcspServer(SimpleOCSPServer ocspResponder) throws InterruptedException, IOException {
+            ocspResponder.start();
+            if (!ocspResponder.awaitServerReady(SERVER_WAIT_SECS, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Server not ready after " + SERVER_WAIT_SECS
+                        + " seconds.");
+            }
     }
 
     /**

--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -288,7 +288,15 @@ public class SimpleOCSPServer {
     public synchronized void stop() {
         if (started) {
             receivedShutdown = true;
+            started = false;
             log("Received shutdown notification");
+        }
+    }
+
+    public synchronized void shutdownNow() {
+        stop();
+        if (threadPool != null) {
+            threadPool.shutdownNow();
         }
     }
 
@@ -577,7 +585,7 @@ public class SimpleOCSPServer {
      * @param message the message to log
      */
     private static synchronized void err(String message) {
-        System.out.println("[" + Thread.currentThread().getName() + "]: " +
+        System.err.println("[" + Thread.currentThread().getName() + "]: " +
                 message);
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305169](https://bugs.openjdk.org/browse/JDK-8305169) needs maintainer approval

### Issue
 * [JDK-8305169](https://bugs.openjdk.org/browse/JDK-8305169): java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java -- test server didn't start in timely manner (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2317/head:pull/2317` \
`$ git checkout pull/2317`

Update a local copy of the PR: \
`$ git checkout pull/2317` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2317`

View PR using the GUI difftool: \
`$ git pr show -t 2317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2317.diff">https://git.openjdk.org/jdk17u-dev/pull/2317.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2317#issuecomment-2010013890)