### PR TITLE
8260540: serviceability/jdwp/AllModulesCommandTest.java failed with "Debuggee error: 'ERROR: transport error 202: bind failed: Address already in use'"

### DIFF
--- a/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ public class AllModulesCommandTest implements DebuggeeLauncher.Listener {
         try {
             // Establish JDWP socket connection
             channel = new JdwpChannel();
-            channel.connect();
+            channel.connect(launcher.getJdwpPort());
             // Send out ALLMODULES JDWP command
             // and verify the reply
             JdwpAllModulesReply reply = new JdwpAllModulesCmd().send(channel);

--- a/test/hotspot/jtreg/serviceability/jdwp/JdwpChannel.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/JdwpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,8 @@ public class JdwpChannel {
 
     private Socket sock;
 
-    public void connect() throws IOException {
-        sock = new Socket("localhost", DebuggeeLauncher.getJdwpPort());
+    public void connect(int jdwpPort) throws IOException {
+        sock = new Socket("localhost", jdwpPort);
         handshake();
     }
 

--- a/test/jdk/com/sun/jdi/JdwpAllowTest.java
+++ b/test/jdk/com/sun/jdi/JdwpAllowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,16 +34,14 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketException;
 
+import jdk.test.lib.JDWP;
 import jdk.test.lib.Utils;
 import jdk.test.lib.apps.LingeredApp;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 public class JdwpAllowTest {
@@ -76,16 +74,14 @@ public class JdwpAllowTest {
          return new String[] { jdwpArgs };
     }
 
-    private static Pattern listenRegexp = Pattern.compile("Listening for transport \\b(.+)\\b at address: \\b(\\d+)\\b");
     private static int detectPort(LingeredApp app) {
         long maxWaitTime = System.currentTimeMillis()
                 + Utils.adjustTimeout(10000);  // 10 seconds adjusted for TIMEOUT_FACTOR
         while (true) {
             String s = app.getProcessStdout();
-            Matcher m = listenRegexp.matcher(s);
-            if (m.find()) {
-                // m.group(1) is transport, m.group(2) is port
-                return Integer.parseInt(m.group(2));
+            JDWP.ListenAddress addr = JDWP.parseListenAddress(s);
+            if (addr != null) {
+                return Integer.parseInt(addr.address());
             }
             if (System.currentTimeMillis() > maxWaitTime) {
                 throw new RuntimeException("Could not detect port from '" + s + "' (timeout)");

--- a/test/jdk/com/sun/jdi/RunToExit.java
+++ b/test/jdk/com/sun/jdi/RunToExit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,9 +40,9 @@ import java.util.Map;
 import java.util.List;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import jdk.test.lib.JDWP;
 import jdk.test.lib.process.ProcessTools;
 
 public class RunToExit {
@@ -95,16 +95,12 @@ public class RunToExit {
         return p;
     }
 
-    /* warm-up predicate for debuggee */
-    private static Pattern listenRegexp = Pattern.compile("Listening for transport \\b(.+)\\b at address: \\b(.+)\\b");
-
     private static boolean isTransportListening(String line) {
-        Matcher m = listenRegexp.matcher(line);
-        if (!m.matches()) {
+        JDWP.ListenAddress addr = JDWP.parseListenAddress(line);
+        if (addr == null) {
             return false;
         }
-        // address is 2nd group
-        address = m.group(2);
+        address = addr.address();
         return true;
     }
 

--- a/test/lib/jdk/test/lib/JDWP.java
+++ b/test/lib/jdk/test/lib/JDWP.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class JDWP {
+
+    public record ListenAddress(String transport, String address) {
+    }
+
+    // lazy initialized
+    private static Pattern listenRegexp;
+
+    /**
+     * Parses debuggee output to get listening transport and address.
+     * Returns null if the string specified does not contain required info.
+     */
+    public static ListenAddress parseListenAddress(String debuggeeOutput) {
+        if (listenRegexp == null) {
+            listenRegexp = Pattern.compile("Listening for transport \\b(.+)\\b at address: \\b(.+)\\b");
+        }
+        Matcher m = listenRegexp.matcher(debuggeeOutput);
+        if (m.find()) {
+            return new ListenAddress(m.group(1), m.group(2));
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.


I had to resolve Debuggee.java. Several later changes were already
backported, so I compared it with the last of these, where 21 and
17 should be equal again: '8318736: com/sun/jdi/JdwpOnThrowTest.java failed with "transport error 202: bind failed: Address already in use"'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8260540](https://bugs.openjdk.org/browse/JDK-8260540) needs maintainer approval

### Issue
 * [JDK-8260540](https://bugs.openjdk.org/browse/JDK-8260540): serviceability/jdwp/AllModulesCommandTest.java failed with "Debuggee error: 'ERROR: transport error 202: bind failed: Address already in use'" (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2319/head:pull/2319` \
`$ git checkout pull/2319`

Update a local copy of the PR: \
`$ git checkout pull/2319` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2319`

View PR using the GUI difftool: \
`$ git pr show -t 2319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2319.diff">https://git.openjdk.org/jdk17u-dev/pull/2319.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2319#issuecomment-2011845523)