### PR TITLE
8320005: Allow loading of shared objects with .a extension on AIX

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1147,8 +1147,9 @@ bool os::dll_address_to_library_name(address addr, char* buf,
 // Loads .dll/.so and in case of error it checks if .dll/.so was built
 // for the same architecture as Hotspot is running on.
 void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
-    
+ 
   log_info(os)("attempting shared library load of %s", filename);
+  
   if (ebuf && ebuflen > 0) {
     ebuf[0] = '\0';
     ebuf[ebuflen - 1] = '\0';

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1146,7 +1146,7 @@ bool os::dll_address_to_library_name(address addr, char* buf,
 
 // Loads .dll/.so and in case of error it checks if .dll/.so was built
 // for the same architecture as Hotspot is running on.
-void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
+static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
 
   log_info(os)("attempting shared library load of %s", filename);
 

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1147,9 +1147,9 @@ bool os::dll_address_to_library_name(address addr, char* buf,
 // Loads .dll/.so and in case of error it checks if .dll/.so was built
 // for the same architecture as Hotspot is running on.
 void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
- 
+
   log_info(os)("attempting shared library load of %s", filename);
-  
+
   if (ebuf && ebuflen > 0) {
     ebuf[0] = '\0';
     ebuf[ebuflen - 1] = '\0';

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1146,8 +1146,9 @@ bool os::dll_address_to_library_name(address addr, char* buf,
 
 // Loads .dll/.so and in case of error it checks if .dll/.so was built
 // for the same architecture as Hotspot is running on.
+void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
+    
   log_info(os)("attempting shared library load of %s", filename);
-  
   if (ebuf && ebuflen > 0) {
     ebuf[0] = '\0';
     ebuf[ebuflen - 1] = '\0';

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1144,12 +1144,13 @@ bool os::dll_address_to_library_name(address addr, char* buf,
   return AixSymbols::get_module_name(addr, buf, buflen);
 }
 
+
+
 // Loads .dll/.so and in case of error it checks if .dll/.so was built
 // for the same architecture as Hotspot is running on.
-void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
-
+static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
+  printf("cjeclomg dll_load here %s",filename);
   log_info(os)("attempting shared library load of %s", filename);
-
   if (ebuf && ebuflen > 0) {
     ebuf[0] = '\0';
     ebuf[ebuflen - 1] = '\0';
@@ -1159,6 +1160,9 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     ::strncpy(ebuf, "dll_load: empty filename specified", ebuflen - 1);
     return NULL;
   }
+
+
+
 
   // RTLD_LAZY is currently not implemented. The dl is loaded immediately with all its dependants.
   void * result= ::dlopen(filename, RTLD_LAZY);
@@ -1184,6 +1188,26 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   return NULL;
 }
 
+// Load library named <filename>
+// If filename matches <name>.so, and loading fails, repeat with <name>.a.
+void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
+  void* result = nullptr;
+  char* const file_path = strdup(filename);
+  char* const pointer_to_dot = strrchr(file_path, '.');
+  const char old_extension[] = ".so";
+  const char new_extension[] = ".a";
+  STATIC_ASSERT(sizeof(old_extension) >= sizeof(new_extension));
+  // First try to load the existing file.
+  result = dll_load_library(filename, ebuf, ebuflen);
+  // If the load fails,we try to reload by changing the extension to .a for .so files only.
+  // Shared object in .so format dont have braces, hence they get removed for archives with members.
+  if (result == nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
+    snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
+    result = dll_load_library(file_path, ebuf, ebuflen);
+  }
+  FREE_C_HEAP_ARRAY(char, file_path);
+  return result;
+}
 void os::print_dll_info(outputStream *st) {
   st->print_cr("Dynamic libraries:");
   LoadedLibraries::print(st);

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1144,13 +1144,10 @@ bool os::dll_address_to_library_name(address addr, char* buf,
   return AixSymbols::get_module_name(addr, buf, buflen);
 }
 
-
-
 // Loads .dll/.so and in case of error it checks if .dll/.so was built
 // for the same architecture as Hotspot is running on.
-static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
-  printf("cjeclomg dll_load here %s",filename);
   log_info(os)("attempting shared library load of %s", filename);
+  
   if (ebuf && ebuflen > 0) {
     ebuf[0] = '\0';
     ebuf[ebuflen - 1] = '\0';
@@ -1160,9 +1157,6 @@ static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
     ::strncpy(ebuf, "dll_load: empty filename specified", ebuflen - 1);
     return NULL;
   }
-
-
-
 
   // RTLD_LAZY is currently not implemented. The dl is loaded immediately with all its dependants.
   void * result= ::dlopen(filename, RTLD_LAZY);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e85355ad](https://github.com/openjdk/jdk/commit/e85355ada4ac1061c49ee9f1247d37a437c7b5ab) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Suchismith Roy on 27 Feb 2024 and was reviewed by Amit Kumar, Thomas Stuefe, Joachim Kern and Martin Doerr.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8320005](https://bugs.openjdk.org/browse/JDK-8320005) needs maintainer approval

### Issue
 * [JDK-8320005](https://bugs.openjdk.org/browse/JDK-8320005): Allow loading of shared objects with .a extension on AIX (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2326/head:pull/2326` \
`$ git checkout pull/2326`

Update a local copy of the PR: \
`$ git checkout pull/2326` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2326`

View PR using the GUI difftool: \
`$ git pr show -t 2326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2326.diff">https://git.openjdk.org/jdk17u-dev/pull/2326.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2326#issuecomment-2018269570)