### PR TITLE
8328948: GHA: Restoring sysroot from cache skips the build after JDK-8326960

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -176,7 +176,7 @@ jobs:
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
-        if: steps.create-sysroot.outcome == 'success'
+        if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'
 
       - name: 'Build'
         id: build
@@ -184,4 +184,4 @@ jobs:
         with:
           make-target: 'hotspot ${{ inputs.make-arguments }}'
           platform: linux-${{ matrix.target-cpu }}
-        if: steps.create-sysroot.outcome == 'success'
+        if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'


### PR DESCRIPTION
Fixes a recent GHA regression.

Additional testing:
 - [x] GHA, first run passes cross-builds
 - [x] GHA, second run passes cross-builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328948](https://bugs.openjdk.org/browse/JDK-8328948) needs maintainer approval

### Issue
 * [JDK-8328948](https://bugs.openjdk.org/browse/JDK-8328948): GHA: Restoring sysroot from cache skips the build after JDK-8326960 (**Bug** - P1 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2329/head:pull/2329` \
`$ git checkout pull/2329`

Update a local copy of the PR: \
`$ git checkout pull/2329` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2329`

View PR using the GUI difftool: \
`$ git pr show -t 2329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2329.diff">https://git.openjdk.org/jdk17u-dev/pull/2329.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2329#issuecomment-2018639739)