### PR TITLE
8328825: Google CAInterop test failures

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -207,8 +207,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsigneccrootcar4 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop globalsigneccrootcar4 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsigneccrootcar4 DEFAULT
  */
 
 /*
@@ -217,8 +216,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar1 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop gtsrootcar1 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar1 DEFAULT
  */
 
 /*
@@ -227,8 +225,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar2 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop gtsrootcar2 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar2 DEFAULT
  */
 
 /*
@@ -237,8 +234,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar3 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop gtsrootecccar3 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar3 DEFAULT
  */
 
 /*
@@ -247,8 +243,7 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar4 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop gtsrootecccar4 CRL
+ * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar4 DEFAULT
  */
 
 /*


### PR DESCRIPTION
Clean backport to fix some of the current failures in `CAInterop` test.

Additional testing:
 - [x] Affected subtests are now passing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328825](https://bugs.openjdk.org/browse/JDK-8328825) needs maintainer approval

### Issue
 * [JDK-8328825](https://bugs.openjdk.org/browse/JDK-8328825): Google CAInterop test failures (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2330/head:pull/2330` \
`$ git checkout pull/2330`

Update a local copy of the PR: \
`$ git checkout pull/2330` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2330`

View PR using the GUI difftool: \
`$ git pr show -t 2330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2330.diff">https://git.openjdk.org/jdk17u-dev/pull/2330.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2330#issuecomment-2018884834)