### PR TITLE
8326661: sun/java2d/cmm/ColorConvertOp/ColConvTest.java assumes profiles were generated by LCMS

### DIFF
--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/ColConvCCMTest.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/ColConvCCMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 6476665 7033534 6830714 8052162 8196572
+ * @bug 6476665 7033534 6830714 8052162 8196572 8326661
  * @summary Verifies color conversion of Component Color Model based images
  * @run main ColConvCCMTest
  */
@@ -59,8 +59,8 @@ public class ColConvCCMTest extends ColConvTest {
         2.5,        // sRGB
         (isOpenProfile() ? 45.0 : 10.1), // LINEAR_RGB
         10.5,       // GRAY
-        (isOpenProfile() ? 215.0 : 45.5), // PYCC
-        (isOpenProfile() ? 56.0 : 47.5) // CIEXYZ
+        (isOpenProfile() ? 215.0 : 64.5), // PYCC
+        (isOpenProfile() ? 56.0 : 55.5) // CIEXYZ
     };
 
     final static String [] gldImgNames = {


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8326661](https://bugs.openjdk.org/browse/JDK-8326661) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326661](https://bugs.openjdk.org/browse/JDK-8326661): sun/java2d/cmm/ColorConvertOp/ColConvTest.java assumes profiles were generated by LCMS (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2331/head:pull/2331` \
`$ git checkout pull/2331`

Update a local copy of the PR: \
`$ git checkout pull/2331` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2331`

View PR using the GUI difftool: \
`$ git pr show -t 2331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2331.diff">https://git.openjdk.org/jdk17u-dev/pull/2331.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2331#issuecomment-2019554454)