### PR TITLE
8213714: AttachingConnector/attach/attach001 failed due to "bind failed: Address already in use"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attach/attach001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import jdk.test.lib.JDWP;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
@@ -69,9 +70,6 @@ public class attach001 {
     }
 
     private int runIt(String argv[], PrintStream out) {
-        String port;
-        String listenPort;
-        Process proc;
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
 // pass if "com.sun.jdi.SocketAttach" is not implemented
@@ -96,19 +94,17 @@ public class attach001 {
         long timeout = argHandler.getWaitTime() * 60 * 1000;
         attempts = (int)(timeout / delay);
 
-        port = argHandler.getTransportPort();
-        listenPort = argHandler.getTransportPort();
-
         String java = argHandler.getLaunchExecPath()
                         + " " + argHandler.getLaunchOptions();
-        String cmd = java +
-                " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,address=" +
-                listenPort + " " + DEBUGEE_CLASS;
+        String cmd = java
+                + " -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,address=0"
+                + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);
         log.display("command: " + cmd);
         Debugee debugee = binder.startLocalDebugee(cmd);
-        debugee.redirectOutput(log);
+        JDWP.ListenAddress listenAddress = debugee.redirectOutputAndDetectListeningAddress(log);
+        String port = listenAddress.address();
 
         if ((vm = attachTarget(argHandler.getTestHost(), port)) == null) {
             log.complain("TEST: Unable to attach the debugee VM");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/AttachingConnector/attachnosuspend/attachnosuspend001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import jdk.test.lib.JDWP;
 import nsk.share.*;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
@@ -69,9 +70,6 @@ public class attachnosuspend001 {
     }
 
     private int runIt(String argv[], PrintStream out) {
-        String port;
-        String listenPort;
-        Process proc;
         ArgumentHandler argHandler = new ArgumentHandler(argv);
 
 // pass if "com.sun.jdi.SocketAttach" is not implemented
@@ -96,19 +94,17 @@ public class attachnosuspend001 {
         long timeout = argHandler.getWaitTime() * 60 * 1000;
         attempts = (int)(timeout / delay);
 
-        port = argHandler.getTransportPort();
-        listenPort = argHandler.getTransportPort();
-
         String java = argHandler.getLaunchExecPath()
                         + " " + argHandler.getLaunchOptions();
-        String cmd = java +
-                " -Xdebug -Xnoagent -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" +
-                listenPort + " " + DEBUGEE_CLASS;
+        String cmd = java
+                + " -Xdebug -Xnoagent -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0"
+                + " " + DEBUGEE_CLASS;
 
         Binder binder = new Binder(argHandler, log);
         log.display("command: " + cmd);
         Debugee debugee = binder.startLocalDebugee(cmd);
-        debugee.redirectOutput(log);
+        JDWP.ListenAddress listenAddress = debugee.redirectOutputAndDetectListeningAddress(log);
+        String port = listenAddress.address();
 
         if ((vm = attachTarget(argHandler.getTestHost(), port)) == null) {
             log.complain("TEST: Unable to attach the debugee VM");


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8213714](https://bugs.openjdk.org/browse/JDK-8213714) needs maintainer approval

### Issue
 * [JDK-8213714](https://bugs.openjdk.org/browse/JDK-8213714): AttachingConnector/attach/attach001 failed due to "bind failed: Address already in use" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2333/head:pull/2333` \
`$ git checkout pull/2333`

Update a local copy of the PR: \
`$ git checkout pull/2333` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2333`

View PR using the GUI difftool: \
`$ git pr show -t 2333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2333.diff">https://git.openjdk.org/jdk17u-dev/pull/2333.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2333#issuecomment-2020439976)