### PR TITLE
8323994: gtest runner repeats test name for every single gtest assertion

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestResultParser.java
+++ b/test/hotspot/jtreg/gtest/GTestResultParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,10 @@ public class GTestResultParser {
                             testCase = xmlReader.getAttributeValue("", "name");
                             break;
                         case "failure":
-                            failedTests.add(testSuite + "::" + testCase);
+                            String failedStr = testSuite + "::" + testCase;
+                            if (!failedTests.contains(failedStr)) {
+                                failedTests.add(failedStr);
+                            }
                             break;
                         default:
                             // ignore


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323994](https://bugs.openjdk.org/browse/JDK-8323994) needs maintainer approval

### Issue
 * [JDK-8323994](https://bugs.openjdk.org/browse/JDK-8323994): gtest runner repeats test name for every single gtest assertion (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2336/head:pull/2336` \
`$ git checkout pull/2336`

Update a local copy of the PR: \
`$ git checkout pull/2336` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2336`

View PR using the GUI difftool: \
`$ git pr show -t 2336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2336.diff">https://git.openjdk.org/jdk17u-dev/pull/2336.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2336#issuecomment-2022374333)