### PR TITLE
8275334: Move class loading Events to a separate section in hs_err files

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1141,7 +1141,7 @@ InstanceKlass* ClassLoader::load_class(Symbol* name, bool search_append_only, TR
 
   const char* const class_name = name->as_C_string();
 
-  EventMark m("loading class %s", class_name);
+  EventMarkClassLoading m("Loading class %s", class_name);
 
   const char* const file_name = file_name_for_class_name(class_name,
                                                          name->utf8_length());

--- a/src/hotspot/share/utilities/events.cpp
+++ b/src/hotspot/share/utilities/events.cpp
@@ -39,6 +39,7 @@ StringEventLog* Events::_vm_operations = NULL;
 ExceptionsEventLog* Events::_exceptions = NULL;
 StringEventLog* Events::_redefinitions = NULL;
 UnloadingEventLog* Events::_class_unloading = NULL;
+StringEventLog* Events::_class_loading = NULL;
 StringEventLog* Events::_deopt_messages = NULL;
 StringEventLog* Events::_dll_messages = NULL;
 
@@ -97,6 +98,7 @@ void Events::init() {
     _exceptions = new ExceptionsEventLog("Internal exceptions", "exc");
     _redefinitions = new StringEventLog("Classes redefined", "redef");
     _class_unloading = new UnloadingEventLog("Classes unloaded", "unload");
+    _class_loading = new StringEventLog("Classes loaded", "load");
     _deopt_messages = new StringEventLog("Deoptimization events", "deopt");
     _dll_messages = new StringEventLog("Dll operation events", "dll");
   }

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -238,6 +238,9 @@ class Events : AllStatic {
 
   // Class unloading events
   static UnloadingEventLog* _class_unloading;
+
+  // Class loading events
+  static StringEventLog* _class_loading;
  public:
 
   // Print all event logs; limit number of events per event log to be printed with max
@@ -262,6 +265,8 @@ class Events : AllStatic {
   static void log_redefinition(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
 
   static void log_class_unloading(Thread* thread, InstanceKlass* ik);
+
+  static void log_class_loading(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
 
   static void log_deopt_message(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
 
@@ -316,6 +321,15 @@ inline void Events::log_redefinition(Thread* thread, const char* format, ...) {
 inline void Events::log_class_unloading(Thread* thread, InstanceKlass* ik) {
   if (LogEvents && _class_unloading != NULL) {
     _class_unloading->log(thread, ik);
+  }
+}
+
+inline void Events::log_class_loading(Thread* thread, const char* format, ...) {
+  if (LogEvents && _class_loading != NULL) {
+    va_list ap;
+    va_start(ap, format);
+    _class_loading->logv(thread, format, ap);
+    va_end(ap);
   }
 }
 
@@ -486,5 +500,8 @@ typedef EventMarkWithLogFunction<Events::log> EventMark;
 
 // These end up in the vm_operation log.
 typedef EventMarkWithLogFunction<Events::log_vm_operation> EventMarkVMOperation;
+
+// These end up in the class loading log.
+typedef EventMarkWithLogFunction<Events::log_class_loading> EventMarkClassLoading;
 
 #endif // SHARE_UTILITIES_EVENTS_HPP


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8275334](https://bugs.openjdk.org/browse/JDK-8275334) needs maintainer approval

### Issue
 * [JDK-8275334](https://bugs.openjdk.org/browse/JDK-8275334): Move class loading Events to a separate section in hs_err files (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2344/head:pull/2344` \
`$ git checkout pull/2344`

Update a local copy of the PR: \
`$ git checkout pull/2344` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2344`

View PR using the GUI difftool: \
`$ git pr show -t 2344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2344.diff">https://git.openjdk.org/jdk17u-dev/pull/2344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2344#issuecomment-2025528053)