### PR TITLE
8296137: diags-examples.xml is broken

### DIFF
--- a/make/langtools/diags-examples.xml
+++ b/make/langtools/diags-examples.xml
@@ -35,20 +35,20 @@ Usage:
 By default, the reports will be generated in langtools/build/diags-examples/report/.
 -->
 
-<project name="diags-examples" default="diags-examples" basedir="..">
+<project name="diags-examples" default="diags-examples" basedir="../..">
     <import file="build.xml"/>
 
     <!-- specify working directory for the tool -->
     <property name="diags.examples.dir" location="${build.dir}/diag-examples"/>
 
     <!-- compiled classes for the tool -->
-    <property name="diags.examples.classes" location="${diags.examples.dir}/classes}"/>
+    <property name="diags.examples.classes" location="${diags.examples.dir}/classes"/>
 
     <!-- directory for generated reports -->
     <property name="diags.examples.report" location="${diags.examples.dir}/report"/>
 
     <!-- default target, generates reports for all available locales -->
-    <target name="diags-examples" depends="run-en_US,run-ja,run-zh_CN"/>
+    <target name="diags-examples" depends="run-en_US,run-ja,run-zh_CN,run-de"/>
 
     <!-- generate report for US English locale -->
     <target name="run-en_US" depends="-build-runner,-def-runner">
@@ -68,12 +68,18 @@ By default, the reports will be generated in langtools/build/diags-examples/repo
         <runner lang="zh" country="CN" outfile="${diags.examples.report}/zh_CN.html"/>
     </target>
 
+    <!-- generate report for German locale -->
+    <target name="run-de" depends="-build-runner,-def-runner">
+        <mkdir dir="${diags.examples.report}"/>
+        <runner lang="de" outfile="${diags.examples.report}/de.html"/>
+    </target>
+
     <!-- compile the tool that runs the examples -->
     <target name="-build-runner" depends="build">
         <mkdir dir="${diags.examples.classes}"/>
         <javac fork="true"
             executable="${build.bin}/javac"
-            srcdir="test/tools/javac/diags"
+            srcdir="test/langtools/tools/javac/diags"
             destdir="${diags.examples.classes}"
             includes="ArgTypeCompilerFactory.java,Example.java,FileManager.java,HTMLWriter.java,RunExamples.java,DocCommentProcessor.java"
             sourcepath=""
@@ -98,7 +104,7 @@ By default, the reports will be generated in langtools/build/diags-examples/repo
             <sequential>
             <java fork="true"
                   jvm="${langtools.jdk.home}/bin/java"
-                  dir="test/tools/javac/diags"
+                  dir="test/langtools/tools/javac/diags"
                   classpath="${diags.examples.classes};${dist.lib.dir}/javac.jar;${dist.lib.dir}/javap.jar"
                   classname="RunExamples">
                 <jvmarg value="-Duser.language=@{lang}"/>

--- a/test/langtools/tools/javac/diags/Example.java
+++ b/test/langtools/tools/javac/diags/Example.java
@@ -234,7 +234,7 @@ class Example implements Comparable<Example> {
                 //automatic modules:
                 Map<String, List<Path>> module2Files =
                         modulePathFiles.stream()
-                                       .map(f -> f.toPath())
+                                       .map(f -> f.toPath().toAbsolutePath())
                                        .collect(Collectors.groupingBy(p -> modulePath.relativize(p)
                                                                             .getName(0)
                                                                             .toString()));


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8296137](https://bugs.openjdk.org/browse/JDK-8296137) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296137](https://bugs.openjdk.org/browse/JDK-8296137): diags-examples.xml is broken (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2346/head:pull/2346` \
`$ git checkout pull/2346`

Update a local copy of the PR: \
`$ git checkout pull/2346` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2346`

View PR using the GUI difftool: \
`$ git pr show -t 2346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2346.diff">https://git.openjdk.org/jdk17u-dev/pull/2346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2346#issuecomment-2025800297)