### PR TITLE
8163229: several regression tests have a main method that is never executed

### DIFF
--- a/test/langtools/tools/javac/4980495/static/Test.java
+++ b/test/langtools/tools/javac/4980495/static/Test.java
@@ -11,7 +11,7 @@ import static p2.A2.f;
 
 public class Test {
 
-    public static void main(String argv[]) {
+    public static void meth() {
         f = 1;
     }
 }

--- a/test/langtools/tools/javac/4980495/std/Test.java
+++ b/test/langtools/tools/javac/4980495/std/Test.java
@@ -12,7 +12,7 @@ import p2.A2.f;
 
 public class Test {
 
-    public static void main(String argv[]) {
+    public static void meth() {
         new f();
     }
 }

--- a/test/langtools/tools/javac/6491592/T6491592.java
+++ b/test/langtools/tools/javac/6491592/T6491592.java
@@ -7,7 +7,7 @@
  */
 
 public class T6491592 {
-    public static void main(String... args) {
+    public static void meth() {
         Object o = null;
         o += null;
     }

--- a/test/langtools/tools/javac/6857948/T6857948.java
+++ b/test/langtools/tools/javac/6857948/T6857948.java
@@ -12,7 +12,7 @@ class Foo {
 };
 
 class Test {
-   public static void main() {
+   public static void meth() {
       Foo f = new Foo("Hello!",nosuchfunction()) {};
    }
 }

--- a/test/langtools/tools/javac/8062359/UnresolvableClassNPEInAttrTest.java
+++ b/test/langtools/tools/javac/8062359/UnresolvableClassNPEInAttrTest.java
@@ -7,7 +7,7 @@
  */
 
 public class UnresolvableClassNPEInAttrTest {
-    public static void main(String[] args) {
+    public static void meth() {
         new Undefined() {
             void test() {
                 new Object() {};

--- a/test/langtools/tools/javac/8161985/T8161985a.java
+++ b/test/langtools/tools/javac/8161985/T8161985a.java
@@ -6,7 +6,7 @@
  */
 
 class T8161985 {
-    public static void main(String [] arg) {
+    public static void meth() {
         T8161985 t = new T8161985();
         t.getClass();
 

--- a/test/langtools/tools/javac/8238735/T8238735.java
+++ b/test/langtools/tools/javac/8238735/T8238735.java
@@ -6,7 +6,7 @@
  */
 
 class T8238735 {
-     public static void main(String[] args) {
+     public static void meth() {
         boolean first = true;
         first = first ? false : (boolean)(() -> false) ;
     }

--- a/test/langtools/tools/javac/AnonymousClass/AnonymousInSuperCallNegTest.java
+++ b/test/langtools/tools/javac/AnonymousClass/AnonymousInSuperCallNegTest.java
@@ -24,8 +24,4 @@ public class AnonymousInSuperCallNegTest {
                 }
             }); }
     }
-
-    public static void main(String[] args) {
-        new JavacBug();
-    }
 }

--- a/test/langtools/tools/javac/BreakAcrossClass.java
+++ b/test/langtools/tools/javac/BreakAcrossClass.java
@@ -8,7 +8,7 @@
  */
 
 class BreakAcrossClass {
-     public static void main(String argv[]) {
+     public static void meth() {
         final int i = 6;
     M:  {
             class A {

--- a/test/langtools/tools/javac/CaptureInSubtype.java
+++ b/test/langtools/tools/javac/CaptureInSubtype.java
@@ -37,14 +37,4 @@ public class CaptureInSubtype {
 
         Flaw<?> m(){return fn;}
     }
-
-    public static void main(String[] args) {
-        SuperOfShowFlaw sosf = new ShowFlaw();
-        SuperOfFlaw<List<?>> sof = sosf.m();
-        List<String> ls = new ArrayList<String>();
-        ls.add("Smalltalk rules!");
-        sof.put(ls);
-        Number n = ShowFlaw.fn.get().get(0);
-    }
-
 }

--- a/test/langtools/tools/javac/DefiniteAssignment/DASwitch.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/DASwitch.java
@@ -8,7 +8,7 @@
  */
 
 public class DASwitch {
-    public static void main(final String[] args) {
+    public static void meth() {
         int t = 1;
         {
             final int x;

--- a/test/langtools/tools/javac/DefiniteAssignment/DUParam1.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/DUParam1.java
@@ -8,7 +8,7 @@
  */
 
 public class DUParam1 {
-    public static void main(final String[] args) {
+    public static void meth(final String[] args) {
         // 8.4.1 makes it illegal to assign to a final parameter.
         if (false) args = null;
     }

--- a/test/langtools/tools/javac/DefiniteAssignment/DefAssignAfterTry1.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/DefAssignAfterTry1.java
@@ -11,7 +11,7 @@ class E1 extends Exception {}
 class E2 extends Exception {}
 
 public class DefAssignAfterTry1 {
-    public static void main(String argv[]) {
+    public static void meth() {
         boolean t = true;
         E1 se1 = new E1();
         E2 se2 = new E2();

--- a/test/langtools/tools/javac/DefiniteAssignment/DefAssignAfterTry2.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/DefAssignAfterTry2.java
@@ -11,7 +11,7 @@ class E1 extends Exception {}
 class E2 extends Exception {}
 
 public class DefAssignAfterTry2 {
-    public static void main(String argv[]) {
+    public static void meth() {
         boolean t = true;
         E1 se1 = new E1();
         E2 se2 = new E2();

--- a/test/langtools/tools/javac/DefiniteAssignment/DefAssignAfterTry3.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/DefAssignAfterTry3.java
@@ -11,7 +11,7 @@ class E1 extends Exception {}
 class E2 extends Exception {}
 
 public class DefAssignAfterTry3 {
-    public static void main(String argv[]) {
+    public static void meth() {
         boolean t = true;
         E1 se1 = new E1();
         E2 se2 = new E2();

--- a/test/langtools/tools/javac/DefiniteAssignment/T4717164.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/T4717164.java
@@ -8,7 +8,7 @@
  */
 
 class T4717164 {
-    public static void main(String[] args) {
+    public static void meth() {
         try {
             try {
                 throw new ClassNotFoundException();

--- a/test/langtools/tools/javac/DefiniteAssignment/T4718142.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/T4718142.java
@@ -12,7 +12,7 @@ class T4718142 {
     static void thr() throws E {
         throw new E();
     }
-    public static void main(String[] args) {
+    public static void meth() {
         int count = 0;
         final int i;
         while (true) {

--- a/test/langtools/tools/javac/DefiniteAssignment/T4718142a.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/T4718142a.java
@@ -8,7 +8,7 @@
  */
 
 class T4718142a {
-    public static void main(String[] args) {
+    public static void meth() {
         final int i;
         for (int n=0; n<10; n++) {
             b: {

--- a/test/langtools/tools/javac/DefiniteAssignment/UncaughtException.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/UncaughtException.java
@@ -21,8 +21,4 @@ class B extends A implements I {
 }
 
 public class UncaughtException {
-    public static void main (String[] args) {
-        I b = new B();
-        b.throwCheckedException();
-    }
 }

--- a/test/langtools/tools/javac/OverrideChecks/T4721069.java
+++ b/test/langtools/tools/javac/OverrideChecks/T4721069.java
@@ -18,7 +18,7 @@ interface I {
                 x.getClass();
             }
         }
-        public static void main(String[] args) {
+        public static void meth() {
             f(null);
         }
     }

--- a/test/langtools/tools/javac/ParseConditional.java
+++ b/test/langtools/tools/javac/ParseConditional.java
@@ -9,7 +9,7 @@
  */
 
 public class ParseConditional {
-    public static void main(String[] args) {
+    public static void meth() {
         boolean condition = true;
         int a = 1;
         int b = 2;

--- a/test/langtools/tools/javac/SwitchScope.java
+++ b/test/langtools/tools/javac/SwitchScope.java
@@ -8,7 +8,7 @@
  */
 
 public class SwitchScope {
-    public static void main(String[] args) {
+    public static void meth(String[] args) {
         switch (args.length) {
         case 0:
             final int k;

--- a/test/langtools/tools/javac/SynthName2.java
+++ b/test/langtools/tools/javac/SynthName2.java
@@ -10,7 +10,7 @@
 import java.io.PrintStream;
 
 class SynthName2 {
-    public static void main(String args[]) {
+    public static void meth(String args[]) {
         run(args, System.out);
     }
     public static void run(String args[],PrintStream out) {

--- a/test/langtools/tools/javac/T5003235/T5003235b.java
+++ b/test/langtools/tools/javac/T5003235/T5003235b.java
@@ -22,7 +22,7 @@ class Outer {
 }
 
 class Access {
-    public static void main(String[] args) {
+    public static void meth() {
         Outer outer = new Outer();
         outer.create();
         System.out.println("Value of k: " + outer.inner.k);

--- a/test/langtools/tools/javac/T6306967.java
+++ b/test/langtools/tools/javac/T6306967.java
@@ -7,7 +7,7 @@
  */
 
 public class T6306967 {
-    public static void main(String[] args) {
+    public static void meth() {
         final int x;
         while(true) {
             if (true) {

--- a/test/langtools/tools/javac/T6326754.java
+++ b/test/langtools/tools/javac/T6326754.java
@@ -42,7 +42,7 @@ class TestC<T>{
     }
 }
 public class T6326754{
-    public static void main(String... arg){
+    public static void meth() {
         TestC tC =new TestC();
         tC.setT();
         TestConstructor tc = new TestConstructor("saaa");

--- a/test/langtools/tools/javac/T6379327.java
+++ b/test/langtools/tools/javac/T6379327.java
@@ -8,7 +8,7 @@
 
 import java.security.*;
 public class T6379327 {
-    public static void main(String[] args) {
+    public static void meth(String[] args) {
         final String name = args[0];
         try {
             new PrivilegedExceptionAction() {

--- a/test/langtools/tools/javac/T6407257.java
+++ b/test/langtools/tools/javac/T6407257.java
@@ -9,7 +9,4 @@
 class T6407257a extends T6407257a {}
 
 public class T6407257 extends T6407257a {
-    public static void main(String... args) {
-        main(args);
-    }
 }

--- a/test/langtools/tools/javac/TryWithResources/BadTwr.java
+++ b/test/langtools/tools/javac/TryWithResources/BadTwr.java
@@ -7,7 +7,7 @@
  */
 
 public class BadTwr implements AutoCloseable {
-    public static void main(String... args) {
+    public static void meth(String... args) {
         // illegal repeated name
         try(BadTwr r1 = new BadTwr(); BadTwr r1 = new BadTwr()) {
             System.out.println(r1.toString());

--- a/test/langtools/tools/javac/TryWithResources/BadTwr.out
+++ b/test/langtools/tools/javac/TryWithResources/BadTwr.out
@@ -1,5 +1,5 @@
-BadTwr.java:12:46: compiler.err.already.defined: kindname.variable, r1, kindname.method, main(java.lang.String...)
-BadTwr.java:17:20: compiler.err.already.defined: kindname.variable, args, kindname.method, main(java.lang.String...)
+BadTwr.java:12:46: compiler.err.already.defined: kindname.variable, r1, kindname.method, meth(java.lang.String...)
+BadTwr.java:17:20: compiler.err.already.defined: kindname.variable, args, kindname.method, meth(java.lang.String...)
 BadTwr.java:20:13: compiler.err.cant.assign.val.to.final.var: thatsIt
-BadTwr.java:25:24: compiler.err.already.defined: kindname.variable, name, kindname.method, main(java.lang.String...)
+BadTwr.java:25:24: compiler.err.already.defined: kindname.variable, name, kindname.method, meth(java.lang.String...)
 4 errors

--- a/test/langtools/tools/javac/TryWithResources/BadTwrSyntax.java
+++ b/test/langtools/tools/javac/TryWithResources/BadTwrSyntax.java
@@ -8,7 +8,7 @@
 
 import java.io.IOException;
 public class BadTwrSyntax implements AutoCloseable {
-    public static void main(String... args) throws Exception {
+    public static void meth() {
         // illegal double semicolon ending resources
         try(BadTwr twrflow = new BadTwr();;) {
             System.out.println(twrflow.toString());

--- a/test/langtools/tools/javac/TryWithResources/DuplicateResourceDecl.java
+++ b/test/langtools/tools/javac/TryWithResources/DuplicateResourceDecl.java
@@ -8,7 +8,7 @@
 
 class DuplicateResourceDecl {
 
-    public static void main(String[] args) {
+    public static void meth() {
         try(MyResource c = new MyResource();MyResource c = new MyResource()) {
         //do something
         } catch (Exception e) { }

--- a/test/langtools/tools/javac/TryWithResources/DuplicateResourceDecl.out
+++ b/test/langtools/tools/javac/TryWithResources/DuplicateResourceDecl.out
@@ -1,2 +1,2 @@
-DuplicateResourceDecl.java:12:56: compiler.err.already.defined: kindname.variable, c, kindname.method, main(java.lang.String[])
+DuplicateResourceDecl.java:12:56: compiler.err.already.defined: kindname.variable, c, kindname.method, meth()
 1 error

--- a/test/langtools/tools/javac/TryWithResources/ImplicitFinal.java
+++ b/test/langtools/tools/javac/TryWithResources/ImplicitFinal.java
@@ -9,7 +9,7 @@
 import java.io.IOException;
 
 class ImplicitFinal implements AutoCloseable {
-    public static void main(String... args) {
+    public static void meth() {
         try(ImplicitFinal r = new ImplicitFinal()) {
             r = null; //disallowed
         } catch (IOException ioe) { // Not reachable

--- a/test/langtools/tools/javac/TryWithResources/PlainTry.java
+++ b/test/langtools/tools/javac/TryWithResources/PlainTry.java
@@ -6,7 +6,7 @@
  * @compile/fail/ref=PlainTry.out  -XDrawDiagnostics                           PlainTry.java
  */
 public class PlainTry {
-    public static void main(String... args) {
+    public static void meth() {
         try {
             ;
         }

--- a/test/langtools/tools/javac/TryWithResources/T7022711.java
+++ b/test/langtools/tools/javac/TryWithResources/T7022711.java
@@ -8,7 +8,7 @@
 import java.io.*;
 
 class T7022711 {
-    public static void main (String args[]) throws Exception {
+    public static void meth() {
         // declared resource
         try (DataInputStream is = new DataInputStream(new FileInputStream("x"))) {
             while (true) {

--- a/test/langtools/tools/javac/TryWithResources/TwrAndLambda.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrAndLambda.java
@@ -7,7 +7,7 @@
 
 public class TwrAndLambda {
 
-    public static void main(String... args) {
+    public static void meth() {
 
         // Lambda expression
         AutoCloseable v1 = () -> {};

--- a/test/langtools/tools/javac/TryWithResources/TwrFlow.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrFlow.java
@@ -8,7 +8,7 @@
 
 import java.io.IOException;
 public class TwrFlow implements AutoCloseable {
-    public static void main(String... args) {
+    public static void meth() {
         try(TwrFlow twrFlow = new TwrFlow()) {
             System.out.println(twrFlow.toString());
         } catch (IOException ioe) { // Not reachable

--- a/test/langtools/tools/javac/TryWithResources/TwrForVariable2.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrForVariable2.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=TwrForVariable2.out -XDrawDiagnostics -Xlint:-options TwrForVariable2.java
  */
 public class TwrForVariable2 implements AutoCloseable {
-    public static void main(String... args) {
+    public static void meth() {
         TwrForVariable2 v = new TwrForVariable2();
         TwrForVariable3[] v2 = new TwrForVariable3[1];
         TwrForVariable3[][] v3 = new TwrForVariable3[1][1];

--- a/test/langtools/tools/javac/TryWithResources/TwrForVariable3.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrForVariable3.java
@@ -4,7 +4,7 @@
  * @compile/fail/ref=TwrForVariable3.out -XDrawDiagnostics -Xlint:-options TwrForVariable3.java
  */
 public class TwrForVariable3 implements AutoCloseable {
-    public static void main(String... args) {
+    public static void meth() {
         TwrForVariable3 v1 = new TwrForVariable3();
         Object v2 = new Object();
         Object v3 = new Object() {

--- a/test/langtools/tools/javac/TryWithResources/TwrForVariable4.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrForVariable4.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=TwrForVariable4.out -XDrawDiagnostics -Xlint:-options TwrForVariable4.java
  */
 public class TwrForVariable4 implements AutoCloseable {
-    public static void main(String... args) {
+    public static void meth() {
         TwrForVariable4 uninitialized;
 
         try (uninitialized) {

--- a/test/langtools/tools/javac/TryWithResources/TwrOnNonResource.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrOnNonResource.java
@@ -7,7 +7,7 @@
  */
 
 class TwrOnNonResource {
-    public static void main(String... args) {
+    public static void meth() {
         try(TwrOnNonResource aonr = new TwrOnNonResource()) {
             System.out.println(aonr.toString());
         }

--- a/test/langtools/tools/javac/TryWithResources/TwrVarKinds.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrVarKinds.java
@@ -12,7 +12,7 @@ public class TwrVarKinds implements AutoCloseable {
     static TwrVarKinds r3 = new TwrVarKinds();
     TwrVarKinds r4 = new TwrVarKinds();
 
-    public static void main(String... args) {
+    public static void meth() {
 
         TwrVarKinds r5 = new TwrVarKinds();
 

--- a/test/langtools/tools/javac/TryWithResources/TwrVarRedeclaration.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrVarRedeclaration.java
@@ -7,7 +7,7 @@
 
 public class TwrVarRedeclaration implements AutoCloseable {
 
-    public static void main(String... args) {
+    public static void meth() {
         TwrVarRedeclaration r = new TwrVarRedeclaration();
 
         try (r) {

--- a/test/langtools/tools/javac/TryWithResources/TwrVarRedeclaration.out
+++ b/test/langtools/tools/javac/TryWithResources/TwrVarRedeclaration.out
@@ -1,4 +1,4 @@
-TwrVarRedeclaration.java:14:33: compiler.err.already.defined: kindname.variable, r, kindname.method, main(java.lang.String...)
-TwrVarRedeclaration.java:18:20: compiler.err.already.defined: kindname.variable, r, kindname.method, main(java.lang.String...)
-TwrVarRedeclaration.java:23:23: compiler.err.already.defined: kindname.variable, r, kindname.method, main(java.lang.String...)
+TwrVarRedeclaration.java:14:33: compiler.err.already.defined: kindname.variable, r, kindname.method, meth()
+TwrVarRedeclaration.java:18:20: compiler.err.already.defined: kindname.variable, r, kindname.method, meth()
+TwrVarRedeclaration.java:23:23: compiler.err.already.defined: kindname.variable, r, kindname.method, meth()
 3 errors

--- a/test/langtools/tools/javac/UseEnum.java
+++ b/test/langtools/tools/javac/UseEnum.java
@@ -10,7 +10,7 @@ import static java.lang.System.out;
 
 class UseEnum {
     enum Animal {cat, dog, bird, fish};
-    public static void main(String args[]) {
+    public static void meth() {
         Animal pet;
 
         pet = Animal.cat;

--- a/test/langtools/tools/javac/annotations/neg/Cycle3.java
+++ b/test/langtools/tools/javac/annotations/neg/Cycle3.java
@@ -19,8 +19,4 @@ import static java.lang.annotation.RetentionPolicy.*;
 
 @A
 class Main {
-    public static void main(String[] args) {
-        A a = Main.class.getAnnotation(A.class);
-        System.out.println(a);
-    }
 }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/StaticFields.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/StaticFields.java
@@ -18,7 +18,7 @@ class C {
   // static method
   static int f() { return @A C.f; }
   // main
-  public static void main(String... args) {
+  public static void meth() {
     int a = @A C.f;
   }
 }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/target/DotClass.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/target/DotClass.java
@@ -30,7 +30,7 @@ class T0x1E {
 }
 
 class ClassLiterals {
-    public static void main(String[] args) {
+    public static void meth() {
         if (String.class != @A String.class) throw new Error();
         if (@A int.class != int.class) throw new Error();
         if (@A int.class != Integer.TYPE) throw new Error();

--- a/test/langtools/tools/javac/capture/Martin.java
+++ b/test/langtools/tools/javac/capture/Martin.java
@@ -9,7 +9,7 @@
 import java.util.List;
 
 public class Martin {
-    public static void main(String[] args) throws Throwable {
+    public static void meth() {
         List<?> x1 = null;
         List<?> x2 = null;
         x1.addAll(x2);

--- a/test/langtools/tools/javac/defaultMethods/private/Private06.java
+++ b/test/langtools/tools/javac/defaultMethods/private/Private06.java
@@ -17,14 +17,14 @@ public class Private06 {
         void foo(NAFI nafi);
     }
 
-    public static void main(String [] args) {
+    public static void meth() {
         Private06.NAFI nafi = () -> {};
         Private06.FI fi = Private06.NAFI::foo; // OK.
     }
 }
 
 class Private06_01 {
-    public static void main(String [] args) {
+    public static void meth() {
         Private06.FI fi = Private06.NAFI::foo; // NOT OK.
     }
 }

--- a/test/langtools/tools/javac/defaultMethods/static/Static02.java
+++ b/test/langtools/tools/javac/defaultMethods/static/Static02.java
@@ -11,7 +11,7 @@ class Static02 {
         public static void test() { }
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
         I.test(); //ok
         I i = new I() {};
         i.test(); //no!

--- a/test/langtools/tools/javac/depDocComment/DeprecatedDocComment.java
+++ b/test/langtools/tools/javac/depDocComment/DeprecatedDocComment.java
@@ -23,7 +23,7 @@
 
 public class DeprecatedDocComment {
 
-    public static void main(String argv[]) {
+    public static void meth() {
       DeprecatedDocComment2.deprecatedTest1();
       DeprecatedDocComment2.deprecatedTest2();
       DeprecatedDocComment2.deprecatedTest3();

--- a/test/langtools/tools/javac/generics/6245699/T6245699b.java
+++ b/test/langtools/tools/javac/generics/6245699/T6245699b.java
@@ -6,7 +6,7 @@
  */
 
 public class T6245699b {
-    public static void main(String[] args) {
+    public static void meth() {
         IBar b = new Bar();
         String x = b.doIt();
     }

--- a/test/langtools/tools/javac/generics/6413682/T6413682.java
+++ b/test/langtools/tools/javac/generics/6413682/T6413682.java
@@ -6,7 +6,7 @@
  */
 
 public class T6413682 {
-    public static void main(String... args) {
+    public static void meth() {
         Object[] text = new
 <Wow,thanks.Mr<List>,and.thanks.Mr<Javac>.Vince>Object[5];
     }

--- a/test/langtools/tools/javac/generics/6495506/T6495506.java
+++ b/test/langtools/tools/javac/generics/6495506/T6495506.java
@@ -7,7 +7,7 @@
  */
 
 public class T6495506 {
-    public static void main(String... args) {
+    public static void meth() {
         a.A myA = new a.A();
         myA.p = myA.vec.get(0);
     }

--- a/test/langtools/tools/javac/generics/6723444/T6723444.java
+++ b/test/langtools/tools/javac/generics/6723444/T6723444.java
@@ -23,7 +23,7 @@ public class T6723444 {
     <X1 extends Throwable, X2 extends Throwable> T6723444(Foo<X1> foo, int i)
         throws X1, X2 {}
 
-    public static void main(String[] args) throws Exception {
+    public static void meth() throws Exception {
 
         // the following 8 statements should compile without error
 

--- a/test/langtools/tools/javac/generics/GetClass.java
+++ b/test/langtools/tools/javac/generics/GetClass.java
@@ -8,7 +8,7 @@
  */
 
 public class GetClass {
-    public static void main(String[] args) {
+    public static void meth() {
         Class<? extends Class<GetClass>> x = GetClass.class.getClass();
     }
 }

--- a/test/langtools/tools/javac/generics/Nonlinear.java
+++ b/test/langtools/tools/javac/generics/Nonlinear.java
@@ -21,7 +21,7 @@ public class Nonlinear {
     // when executed, even though there are no explicit casts in
     // the program.
 
-    public static void main (String [] args) {
+    public static void meth() {
         Integer x = Integer.valueOf(5);
         String y = castit (x);
         System.out.println (y);

--- a/test/langtools/tools/javac/generics/UnsoundInference.java
+++ b/test/langtools/tools/javac/generics/UnsoundInference.java
@@ -12,7 +12,7 @@ import java.util.Collection;
 
 public class UnsoundInference {
 
-    public static void main(String[] args) {
+    public static void meth() {
         Object[] objArray = {new Object()};
         ArrayList<String> strList = new ArrayList<String>();
         transferBug(objArray, strList);

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg08.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg08.java
@@ -9,7 +9,7 @@
  */
 
 class Neg08 {
-   public static void main(String[] args) {
+   public static void meth() {
      String s = new String<>("foo");
    }
 }

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg13.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg13.java
@@ -15,7 +15,7 @@ class Neg13 {
 
     static void foo(A<String> as) {}
 
-    public static void main(String[] args) {
+    public static void meth() {
 
         // Method invocation context - good <>(){}
         foo(new A<>() {

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg14.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg14.java
@@ -15,7 +15,7 @@ class Neg14 {
 
     static void foo(A<String> as) {}
 
-    public static void main(String[] args) {
+    public static void meth() {
 
         // Method invocation context - good <>(){}
         foo(new A<>() {

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg15.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg15.java
@@ -23,7 +23,7 @@ class Neg15 {
             throw new Error("Blew it");
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
 
         someMethod(new Predicate<Integer>() {
             public boolean test(Integer n) {

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg17.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg17.java
@@ -11,7 +11,7 @@ abstract class Neg17<T> {
 
    abstract void m();
 
-   public static void main(String[] args) {
+   void meth() {
        Collections.singletonList(new Neg17<>() { void m() {} }).get(0).m(); // good.
        Collections.singletonList(new Neg17<>() {
                  void m() {}

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg18.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg18.java
@@ -10,7 +10,7 @@ import pkg.Neg18_01;
 
 class Neg18 {
 
-   public static void main(String[] args) {
+   public static void meth() {
         new Neg18_01<>() {};
    }
 }

--- a/test/langtools/tools/javac/generics/diamond/neg/Neg19.java
+++ b/test/langtools/tools/javac/generics/diamond/neg/Neg19.java
@@ -8,7 +8,7 @@
 
 
 class Neg19 {
-    public static void main(String[] args) {
+    public static void meth() {
         new Neg19_01<Neg19>().foo(new Neg19_01<>()); // OK.
         new Neg19_01<Neg19>().foo(new Neg19_01<>() {}); // ERROR.
     }

--- a/test/langtools/tools/javac/generics/inference/4972073/T4972073.java
+++ b/test/langtools/tools/javac/generics/inference/4972073/T4972073.java
@@ -22,9 +22,4 @@ public class T4972073 {
     }
 
     static class B<E extends MyClass & MyInterface<E> & MyInterface<E>> extends D {}
-
-
-    public static void main(String[] args) {
-        B b = new B<Sun1>();
-    }
 }

--- a/test/langtools/tools/javac/generics/inference/5081782/Neg.java
+++ b/test/langtools/tools/javac/generics/inference/5081782/Neg.java
@@ -8,7 +8,7 @@
 
 public class Neg {
     static void m() {}
-    public static void main(String... args) {
+    public static void meth() {
         Neg.<Can,I,write,a,little,story,here>m();
     }
 }

--- a/test/langtools/tools/javac/generics/odersky/BadTest.java
+++ b/test/langtools/tools/javac/generics/odersky/BadTest.java
@@ -15,7 +15,7 @@ class BadTest {
         static <A> Cell<A> makeCell(A x) { return new Cell<A>(x); }
         static <A> A id(A x) { return x; }
 
-        public static void main(String[] args) {
+        public static void meth() {
             List<Cell<String>> as = nil().prepend(makeCell(null));
             List<Cell<String>> bs = cons(makeCell(null), nil());
             List<String> xs = id(nil());

--- a/test/langtools/tools/javac/generics/odersky/BadTest3.java
+++ b/test/langtools/tools/javac/generics/odersky/BadTest3.java
@@ -27,7 +27,7 @@ class BadTest3 {
         static <A> Cell<A> makeCell(A x) { return new Cell<A>(x); }
         static <A> A id(A x) { return x; }
 
-        public static void main(String[] args) {
+        public static void meth() {
             List<String> xs = nil();
             f(null);
             f(nil());

--- a/test/langtools/tools/javac/generics/typeargs/Metharg1.java
+++ b/test/langtools/tools/javac/generics/typeargs/Metharg1.java
@@ -32,10 +32,4 @@ class T<X> {
     <K> void f(K k) {
         this.<Integer>f("");
     }
-
-    public static void main(String[] args) {
-        T<Integer> x = new <Object>T<Integer>();
-        T<Integer>.U<Float> y = x.new <Object>U<Float>();
-        x.<Object>f("");
-    }
 }

--- a/test/langtools/tools/javac/generics/typeargs/Metharg2.java
+++ b/test/langtools/tools/javac/generics/typeargs/Metharg2.java
@@ -33,7 +33,7 @@ class T<X> {
         this.<Object>f("");
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
         T<Integer> x = new <Object>T<Integer>();
         T<Integer>.U<Float> y = x.new <Object>U<Float>();
         x.<Integer>f("");

--- a/test/langtools/tools/javac/generics/typeargs/Newarg1.java
+++ b/test/langtools/tools/javac/generics/typeargs/Newarg1.java
@@ -14,7 +14,7 @@ class T<X> {
     <K> T(K x) {
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
         new <Integer>T<Float>("");
     }
 }

--- a/test/langtools/tools/javac/generics/typeargs/Newarg2.java
+++ b/test/langtools/tools/javac/generics/typeargs/Newarg2.java
@@ -15,7 +15,7 @@ class T {
         <B> U(B b) {}
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
         new T().new <Integer>U<Integer>("");
     }
 }

--- a/test/langtools/tools/javac/generics/typeargs/Superarg1.java
+++ b/test/langtools/tools/javac/generics/typeargs/Superarg1.java
@@ -32,10 +32,4 @@ class T<X> {
     <K> void f() {
         this.<Object>f();
     }
-
-    public static void main(String[] args) {
-        T<Integer> x = new <Object>T<Integer>("");
-        T<Integer>.U<Float> y = x.new <Object>U<Float>();
-        x.<Object>f();
-    }
 }

--- a/test/langtools/tools/javac/generics/typeargs/Superarg2.java
+++ b/test/langtools/tools/javac/generics/typeargs/Superarg2.java
@@ -32,10 +32,4 @@ class T<X> {
     <K> void f() {
         this.<Object>f();
     }
-
-    public static void main(String[] args) {
-        T<Integer> x = new <Object>T<Integer>();
-        T<Integer>.U<Float> y = x.new <Object>U<Float>("");
-        x.<Object>f();
-    }
 }

--- a/test/langtools/tools/javac/generics/typeargs/ThisArg.java
+++ b/test/langtools/tools/javac/generics/typeargs/ThisArg.java
@@ -32,10 +32,4 @@ class T<X> {
     <K> void f() {
         this.<Object>f();
     }
-
-    public static void main(String[] args) {
-        T<Integer> x = new <Object>T<Integer>();
-        T<Integer>.U<Float> y = x.new <Object>U<Float>("");
-        x.<Object>f();
-    }
 }

--- a/test/langtools/tools/javac/generics/wildcards/6437894/T6437894.java
+++ b/test/langtools/tools/javac/generics/wildcards/6437894/T6437894.java
@@ -10,7 +10,7 @@
  */
 
 public class T6437894 {
-    public static void main(String... args) {
+    public static void meth() {
         b.B m;
         a.A.X x = null;
         Long.parseLong(x.toString());

--- a/test/langtools/tools/javac/generics/wildcards/AssignmentDifferentTypes.java
+++ b/test/langtools/tools/javac/generics/wildcards/AssignmentDifferentTypes.java
@@ -7,7 +7,7 @@
 
 public class AssignmentDifferentTypes {
 
-    public static void main(String[] args) {
+    public static void meth() {
         Ref<Der> derexact = null;
         Ref<Base> baseexact = null;
         Ref<? extends Der> derext = null;

--- a/test/langtools/tools/javac/generics/wildcards/AssignmentSameType.java
+++ b/test/langtools/tools/javac/generics/wildcards/AssignmentSameType.java
@@ -7,7 +7,7 @@
 
 public class AssignmentSameType {
 
-    public static void main(String[] args) {
+    public static void meth() {
         Ref<B> exact = null;
         Ref<? extends B> ebound = null;
         Ref<? super B> sbound = null;

--- a/test/langtools/tools/javac/generics/wildcards/T6450290.java
+++ b/test/langtools/tools/javac/generics/wildcards/T6450290.java
@@ -14,7 +14,7 @@ public class T6450290 {
 
     static class A extends Box<A,A> {}
     static class B extends Box<B,B> {}
-    public static void main(String[] args) {
+    public static void meth() {
         Box<?,?> b = new Box<Box<A,A>,Box<A,A>>();
         b.value.same = new Box<B,B>(); //javac misses this bad assignment
     }

--- a/test/langtools/tools/javac/implicitThis/NewBeforeOuterConstructed2.java
+++ b/test/langtools/tools/javac/implicitThis/NewBeforeOuterConstructed2.java
@@ -24,9 +24,4 @@ public class NewBeforeOuterConstructed2 {
             System.out.println("ok");
         }
     }
-    public static void main(String[] args) {
-        NewBeforeOuterConstructed2 c = new NewBeforeOuterConstructed2(new Object());
-        Middle m = c.new Middle();
-        m.f();
-    }
 }

--- a/test/langtools/tools/javac/lambda/8071432/T8071432.java
+++ b/test/langtools/tools/javac/lambda/8071432/T8071432.java
@@ -41,7 +41,7 @@ class T8071432 {
         }
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
         Collection<Point> c = Arrays.asList(new Point(1.0, 0.1));
         System.out.println("------- 1 ---------------");
         System.out.println(c.stream().reduce(0.0,

--- a/test/langtools/tools/javac/lambda/LambdaConv10.java
+++ b/test/langtools/tools/javac/lambda/LambdaConv10.java
@@ -11,7 +11,7 @@ class LambdaConv10 {
 
     interface Method1<R, A1> { public R call( A1 a1 ); }
 
-    public static void main( final String... notUsed ) {
+    public static void meth() {
         Method1<Integer,Integer> m1 = (int i) -> 2 * i;
     }
 }

--- a/test/langtools/tools/javac/lambda/MethodReference20.java
+++ b/test/langtools/tools/javac/lambda/MethodReference20.java
@@ -17,7 +17,7 @@ class MethodReference20<X> {
 
     static void test(SAM<Integer> s) {   }
 
-    public static void main(String[] args) {
+    public static void meth() {
         SAM<Integer> s = MethodReference20<String>::new;
         test(MethodReference20<String>::new);
     }

--- a/test/langtools/tools/javac/lambda/MethodReference25.java
+++ b/test/langtools/tools/javac/lambda/MethodReference25.java
@@ -21,7 +21,7 @@ class MethodReference25 {
     static void call(int i, SAM1 s) { s.m(i);  }
     static void call(int i, SAM2 s) { s.m(i);  }
 
-    public static void main(String[] args) {
+    public static void meth() {
         call(1, MethodReference25::m); //ambiguous
     }
 }

--- a/test/langtools/tools/javac/lambda/MethodReference41.java
+++ b/test/langtools/tools/javac/lambda/MethodReference41.java
@@ -34,7 +34,7 @@ public class MethodReference41 {
     static void m4(SAM2 s) { }
     static void m4(SAM3 s) { }
 
-    public static void main(String[] args) {
+    public static void meth() {
         m1(Foo::new);
         m2(Foo::new);
         m3(Foo::new);

--- a/test/langtools/tools/javac/lambda/MethodReference42.java
+++ b/test/langtools/tools/javac/lambda/MethodReference42.java
@@ -34,7 +34,7 @@ public class MethodReference42 {
     static void m4(SAM2 s) { }
     static void m4(SAM3 s) { }
 
-    public static void main(String[] args) {
+    public static void meth() {
         m1(Foo::new);
         m2(Foo::new);
         m3(Foo::new);

--- a/test/langtools/tools/javac/lambda/MethodReference43.java
+++ b/test/langtools/tools/javac/lambda/MethodReference43.java
@@ -41,7 +41,7 @@ public class MethodReference43 {
     static void m5(SAM3 s) { }
     static void m5(SAM4 s) { }
 
-    public static void main(String[] args) {
+    public static void meth() {
         m1(Foo::new);
         m2(Foo::new);
         m3(Foo::new);

--- a/test/langtools/tools/javac/lambda/MethodReference44.java
+++ b/test/langtools/tools/javac/lambda/MethodReference44.java
@@ -36,7 +36,7 @@ public class MethodReference44 {
     static void g4(SAM2 s) { }
     static void g4(SAM3 s) { }
 
-    public static void main(String[] args) {
+    public static void meth() {
         g1(MethodReference44::m);
         g2(MethodReference44::m);
         g3(MethodReference44::m);

--- a/test/langtools/tools/javac/lambda/MethodReference46.java
+++ b/test/langtools/tools/javac/lambda/MethodReference46.java
@@ -36,7 +36,7 @@ public class MethodReference46 {
     static void g4(SAM2 s) { }
     static void g4(SAM3 s) { }
 
-    public static void main(String[] args) {
+    public static void meth() {
         g1(MethodReference46::m);
         g2(MethodReference46::m);
         g3(MethodReference46::m);

--- a/test/langtools/tools/javac/lambda/MethodReference47.java
+++ b/test/langtools/tools/javac/lambda/MethodReference47.java
@@ -25,7 +25,7 @@ public class MethodReference47 {
     static void g2(SAM1 s) { }
     static void g2(SAM2 s) { }
 
-    public static void main(String[] args) {
+    public static void meth() {
         g1(MethodReference47::m);
         g2(MethodReference47::m);
     }

--- a/test/langtools/tools/javac/lambda/MethodReference48.java
+++ b/test/langtools/tools/javac/lambda/MethodReference48.java
@@ -34,7 +34,7 @@ public class MethodReference48 {
     static void g4(SAM2 s) { } //ok
     static void g4(SAM3 s) { } //ok
 
-    public static void main(String[] args) {
+    public static void meth() {
         g1(Foo::m);
         g2(Foo::m);
         g3(Foo::m);

--- a/test/langtools/tools/javac/lambda/MethodReference60.java
+++ b/test/langtools/tools/javac/lambda/MethodReference60.java
@@ -22,7 +22,7 @@ public class MethodReference60 {
         X make(String s);
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
         BadArrayFactory1<int[]> factory1 = int[]::new; //param mismatch
         BadArrayFactory2<int[]> factory2 = int[]::new; //param mismatch
         BadArrayFactory3<int[]> factory3 = int[]::new; //param mismatch

--- a/test/langtools/tools/javac/lambda/MostSpecific04.java
+++ b/test/langtools/tools/javac/lambda/MostSpecific04.java
@@ -20,7 +20,7 @@ public class MostSpecific04 {
         void map(LongMapper<? super E> m) { }
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
         MyList<String> ls = new MyList<String>();
         ls.map(e->e.length()); //ambiguous - implicit
         ls.map((String e)->e.length()); //ok

--- a/test/langtools/tools/javac/lambda/MostSpecific05.java
+++ b/test/langtools/tools/javac/lambda/MostSpecific05.java
@@ -20,7 +20,7 @@ public class MostSpecific05 {
         void map(NumberConverter<? extends B> m) { }
     }
 
-    public static void main(String[] args) {
+    public static void meth() {
         MyMapper<Number, Double> mm = new MyMapper<Number, Double>();
         mm.map(e->1.0); //ambiguous - implicit
         mm.map((Object e)->1.0); //ok

--- a/test/langtools/tools/javac/lambda/funcInterfaces/LambdaTest2_neg1.java
+++ b/test/langtools/tools/javac/lambda/funcInterfaces/LambdaTest2_neg1.java
@@ -9,7 +9,7 @@
 
 public class LambdaTest2_neg1 {
 
-    public static void main(String[] args) {
+    public static void meth() {
         LambdaTest2_neg1 test = new LambdaTest2_neg1();
         //not convertible - QooRoo is not a SAM
         test.methodQooRoo((Integer i) -> { });

--- a/test/langtools/tools/javac/lambda/methodReference/MethodRefIntColonColonNewTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/MethodRefIntColonColonNewTest.java
@@ -13,7 +13,7 @@ public class MethodRefIntColonColonNewTest {
 
     static <T> SAM<T> infmethod(SAM<T> t) { return t; }
 
-    public static void main(String argv[]) {
+    public static void meth() {
         SAM<Object> s = infmethod(int::new);
         s.m();
     }

--- a/test/langtools/tools/javac/lambda/methodReference/MethodRefToInnerWithoutOuter.java
+++ b/test/langtools/tools/javac/lambda/methodReference/MethodRefToInnerWithoutOuter.java
@@ -17,7 +17,7 @@ class MethodRefToInnerBase {
     }
 }
 public class MethodRefToInnerWithoutOuter extends MethodRefToInnerBase {
-    public static void main(String[] args) {
+    public static void meth() {
         List<String> list = new ArrayList<>();
         list.stream().forEach(TestString::new);
     }

--- a/test/langtools/tools/javac/lambda/methodReferenceExecution/MethodReferenceTestVarHandle_neg.java
+++ b/test/langtools/tools/javac/lambda/methodReferenceExecution/MethodReferenceTestVarHandle_neg.java
@@ -13,7 +13,7 @@ public class MethodReferenceTestVarHandle_neg {
       int apply(int[] arr, int idx, int val);
   }
 
-  public static void main(String[] args) {
+  public static void meth() {
       VarHandle vh = MethodHandles.arrayElementVarHandle(int[].class);
 
       // Return type of Setter::apply does not match return type of VarHandle::set

--- a/test/langtools/tools/javac/lambda/typeInference/InferenceTest_neg1_2.java
+++ b/test/langtools/tools/javac/lambda/typeInference/InferenceTest_neg1_2.java
@@ -9,7 +9,7 @@
 
 public class InferenceTest_neg1_2 {
 
-    public static void main(String[] args) {
+    public static void meth() {
         InferenceTest_neg1_2 test = new InferenceTest_neg1_2();
         test.method(n -> null); //method 1-5 all match
         test.method(n -> "a"); //method 2, 4 match

--- a/test/langtools/tools/javac/limits/ArrayDims1.java
+++ b/test/langtools/tools/javac/limits/ArrayDims1.java
@@ -58,6 +58,4 @@ class ArrayDims1 {
         [][][][][][][][][][]
         [][][][][][][][][][]
         [][][][][] o; // 255 = limit (OK)
-    public static void main(String[] args) {
-    }
 }

--- a/test/langtools/tools/javac/limits/ArrayDims2.java
+++ b/test/langtools/tools/javac/limits/ArrayDims2.java
@@ -35,6 +35,4 @@ class ArrayDims2 {
         [][][][][][][][][][]
         [][][][][][][][][][]
         [][][][][][] o; // 256 = too many
-    public static void main(String[] args) {
-    }
 }

--- a/test/langtools/tools/javac/limits/ArrayDims3.java
+++ b/test/langtools/tools/javac/limits/ArrayDims3.java
@@ -58,6 +58,4 @@ class ArrayDims3 {
         [][][][][][][][][][]
         [][][][][][][][][][]
         [][][][][]; // 255 = limit (OK)
-    public static void main(String[] args) {
-    }
 }

--- a/test/langtools/tools/javac/limits/ArrayDims4.java
+++ b/test/langtools/tools/javac/limits/ArrayDims4.java
@@ -35,6 +35,4 @@ class ArrayDims4 {
         [][][][][][][][][][]
         [][][][][][][][][][]
         [][][][][][]; // 256 = too many
-    public static void main(String[] args) {
-    }
 }

--- a/test/langtools/tools/javac/limits/PoolSize2.java
+++ b/test/langtools/tools/javac/limits/PoolSize2.java
@@ -3331,6 +3331,4 @@ class PoolSize2 {
             ,32762.0,32763.0,32764.0,32765.0,32766.0,32767.0
         };
     }
-    public static void main(String args[]) {
-    System.out.println("Ok"); }
 }

--- a/test/langtools/tools/javac/limits/StringLength.java
+++ b/test/langtools/tools/javac/limits/StringLength.java
@@ -20,7 +20,4 @@ class StringLength {
 
     public static final String l65530 = l6e4 + l5e3 + l5e2 + l3e1;
     public static String X = l65530 + "abcdef"; // length 65536
-    public static void main(String[] args) {
-        System.out.println(X.length());
-    }
 }

--- a/test/langtools/tools/javac/nested/5009484/X.java
+++ b/test/langtools/tools/javac/nested/5009484/X.java
@@ -11,7 +11,7 @@ public class X<T> {
    X(T t) {
        this.t = t;
    }
-   public static void main(String[] args) {
+   public static void meth() {
        new X<String>("OUTER").bar();
    }
    void bar() {

--- a/test/langtools/tools/javac/overload/T5090220.java
+++ b/test/langtools/tools/javac/overload/T5090220.java
@@ -12,7 +12,7 @@ class T5090220 {
     static void foo(Integer i1, double d) {
         System.out.println("double");
     }
-    public static void main(String[] args) {
+    public static void meth() {
         foo(5, 5);
     }
 }

--- a/test/langtools/tools/javac/patterns/BindingsTest1Merging.java
+++ b/test/langtools/tools/javac/patterns/BindingsTest1Merging.java
@@ -7,7 +7,7 @@
 
 public class BindingsTest1Merging {
     public static boolean Ktrue() { return true; }
-    public static void main(String[] args) {
+    public static void meth() {
         Object o1 = "hello";
         Integer i = 42;
         Object o2 = i;

--- a/test/langtools/tools/javac/patterns/BindingsTest2.java
+++ b/test/langtools/tools/javac/patterns/BindingsTest2.java
@@ -6,7 +6,7 @@
  */
 public class BindingsTest2 {
     public static boolean Ktrue() { return true; }
-    public static void main(String[] args) {
+    public static void meth() {
         Object o1 = "hello";
         Integer in = 42;
         Object o2 = in;

--- a/test/langtools/tools/javac/patterns/CastConversionMatch.java
+++ b/test/langtools/tools/javac/patterns/CastConversionMatch.java
@@ -6,7 +6,7 @@
  */
 
 public class CastConversionMatch {
-    public static void main(String [] args) {
+    public static void meth() {
         Object o = 42;
         if (o instanceof int s) {
             System.out.println("Okay");

--- a/test/langtools/tools/javac/patterns/EnsureTypesOrderTest.java
+++ b/test/langtools/tools/javac/patterns/EnsureTypesOrderTest.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=EnsureTypesOrderTest.out -XDrawDiagnostics EnsureTypesOrderTest.java
  */
 public class EnsureTypesOrderTest {
-    public static void main(String [] args) {
+    public static void meth(String[] args) {
         if (args instanceof String s) {
             System.out.println("Broken");
         }

--- a/test/langtools/tools/javac/patterns/ImpossibleTypeTest.java
+++ b/test/langtools/tools/javac/patterns/ImpossibleTypeTest.java
@@ -6,7 +6,7 @@
  */
 public class ImpossibleTypeTest {
 
-    public static void main(String[] args) {
+    public static void meth() {
 
         int in = 42;
         Integer i = 42;

--- a/test/langtools/tools/javac/patterns/MatchBindingScopeTest.java
+++ b/test/langtools/tools/javac/patterns/MatchBindingScopeTest.java
@@ -11,7 +11,7 @@ public class MatchBindingScopeTest {
     static Object o1 = s;
     static Object o2 = i;
 
-    public static void main(String[] args) {
+    public static void meth() {
 
         if (o1 instanceof String j && j.length() == 5) { // OK
             System.out.println(j); // OK

--- a/test/langtools/tools/javac/patterns/NullsInPatterns.java
+++ b/test/langtools/tools/javac/patterns/NullsInPatterns.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class NullsInPatterns {
 
-    public static void main(String[] args) {
+    public static void meth() {
         if (null instanceof List t) {
             throw new AssertionError("broken");
         } else {

--- a/test/langtools/tools/javac/patterns/PatternVariablesAreNonFinal.java
+++ b/test/langtools/tools/javac/patterns/PatternVariablesAreNonFinal.java
@@ -5,7 +5,7 @@
  * @compile/fail/ref=PatternVariablesAreNonFinal.out -XDrawDiagnostics PatternVariablesAreNonFinal.java
  */
 public class PatternVariablesAreNonFinal {
-    public static void main(String[] args) {
+    public static void meth() {
         Object o = 32;
         if (o instanceof String s) {
             s = "hello again";

--- a/test/langtools/tools/javac/patterns/UncheckedWarningOnMatchesTest.java
+++ b/test/langtools/tools/javac/patterns/UncheckedWarningOnMatchesTest.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 
 public class UncheckedWarningOnMatchesTest {
 
-    public static void main(String [] args) {
+    public static void meth() {
 
         Object o = new ArrayList<UncheckedWarningOnMatchesTest>();
         if (o instanceof ArrayList<Integer> ai) {  // unchecked conversion

--- a/test/langtools/tools/javac/scope/6225935/Estatico4.java
+++ b/test/langtools/tools/javac/scope/6225935/Estatico4.java
@@ -12,7 +12,7 @@ import static javax.swing.JLabel.*;
 
 public class Estatico4 {
 
-  public static void main(String[] s) {
+  public static void meth() {
     System.out.println(CENTER);
   }
 

--- a/test/langtools/tools/javac/staticImport/ImportPrivate.java
+++ b/test/langtools/tools/javac/staticImport/ImportPrivate.java
@@ -18,7 +18,7 @@ class A {
 }
 
 class MyTest {
-    public static void main(String argv[]) {
+    public static void meth() {
         m();
     }
 }

--- a/test/langtools/tools/javac/switchexpr/DefiniteAssignment2.java
+++ b/test/langtools/tools/javac/switchexpr/DefiniteAssignment2.java
@@ -6,7 +6,7 @@
  */
 public class DefiniteAssignment2 {
 
-    public static void main(String[] args) {
+    public static void meth() {
         int a = 0;
         boolean b = true;
         boolean t;

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitchUnreachable.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitchUnreachable.java
@@ -7,7 +7,7 @@
 
 public class ExpressionSwitchUnreachable {
 
-    public static void main(String[] args) {
+    public static void meth() {
         int z = 42;
         int i = switch (z) {
             case 0 -> {

--- a/test/langtools/tools/javac/switchextra/DefiniteAssignment2.java
+++ b/test/langtools/tools/javac/switchextra/DefiniteAssignment2.java
@@ -5,7 +5,7 @@
  */
 public class DefiniteAssignment2 {
 
-    public static void main(String[] args) {
+    public static void meth() {
         int a = 0;
         E e = E.A;
 

--- a/test/langtools/tools/javac/unicode/NonasciiDigit.java
+++ b/test/langtools/tools/javac/unicode/NonasciiDigit.java
@@ -7,7 +7,7 @@
  * @compile/fail/ref=NonasciiDigit.out -XDrawDiagnostics  NonasciiDigit.java
  */
 public class NonasciiDigit {
-    public static void main(String[] args) {
+    public static void meth() {
         // error: only ASCII allowed in constants
         int i1 = \uff11;
         int i2 = 1\uff11;

--- a/test/langtools/tools/javac/varargs/6313164/T7175433.java
+++ b/test/langtools/tools/javac/varargs/6313164/T7175433.java
@@ -19,7 +19,7 @@ class Bar {
 
 public class T7175433 {
 
-    public static void main(String[] args) {
+    public static void meth() {
         Bar b = new Bar();
         b.m(b.getFoo());
     }

--- a/test/langtools/tools/javac/varargs/Warn2.java
+++ b/test/langtools/tools/javac/varargs/Warn2.java
@@ -14,7 +14,7 @@ package varargs.warn2;
 class T {
     static void f(String fmt, Object... args) {}
 
-    public static void main(String[] args) {
+    public static void meth() {
         f("foo", null);
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

Clean except for one file that is not in 17 (added by JEP 405: Record Patterns.).
Will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8163229](https://bugs.openjdk.org/browse/JDK-8163229) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8163229](https://bugs.openjdk.org/browse/JDK-8163229): several regression tests have a main method that is never executed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2347/head:pull/2347` \
`$ git checkout pull/2347`

Update a local copy of the PR: \
`$ git checkout pull/2347` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2347`

View PR using the GUI difftool: \
`$ git pr show -t 2347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2347.diff">https://git.openjdk.org/jdk17u-dev/pull/2347.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2347#issuecomment-2025933433)