### PR TITLE
8296610: java/net/HttpURLConnection/SetAuthenticator/HTTPSetAuthenticatorTest.java failed with "BindException: Address already in use: connect"

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPSetAuthenticatorTest.java
+++ b/test/jdk/java/net/HttpURLConnection/SetAuthenticator/HTTPSetAuthenticatorTest.java
@@ -191,25 +191,25 @@ public class HTTPSetAuthenticatorTest extends HTTPTest {
         // Now tries with explicitly setting the default authenticator: it should
         // be invoked again.
         // Uncomment the code below when 8169068 is available.
-//        System.out.println("\nClient: Explicitly setting the default authenticator: "
-//            + toString(Authenticator.getDefault()));
-//        HTTPTestClient.connect(protocol, server, mode, Authenticator.getDefault());
-//        count = authOne.count.get();
-//        if (count != expectedIncrement) {
-//            throw new AssertionError("Authenticator #1 called " + count(count)
-//                + " expected it to be called " + expected(expectedIncrement));
-//        }
-//        count = authTwo.count.get();
-//        if (count != expectedIncrement) {
-//            throw new AssertionError("Authenticator #2 called " + count(count)
-//                + " expected it to be called " + expected(expectedIncrement));
-//        }
-//        count =  AUTHENTICATOR.count.get();
-//        if (count != defaultCount + 2 * expectedIncrement) {
-//            throw new AssertionError("Default Authenticator called " + count(count)
-//                + " expected it to be called "
-//                + expected(defaultCount + 2 * expectedIncrement));
-//        }
+        System.out.println("\nClient: Explicitly setting the default authenticator: "
+            + toString(Authenticator.getDefault()));
+        HTTPTestClient.connect(protocol, server, mode, Authenticator.getDefault());
+        count = authOne.count.get();
+        if (count != expectedIncrement) {
+            throw new AssertionError("Authenticator #1 called " + count(count)
+                + " expected it to be called " + expected(expectedIncrement));
+        }
+        count = authTwo.count.get();
+        if (count != expectedIncrement) {
+            throw new AssertionError("Authenticator #2 called " + count(count)
+                + " expected it to be called " + expected(expectedIncrement));
+        }
+        count =  AUTHENTICATOR.count.get();
+        if (count != defaultCount + 2 * expectedIncrement) {
+            throw new AssertionError("Default Authenticator called " + count(count)
+                + " expected it to be called "
+                + expected(defaultCount + 2 * expectedIncrement));
+        }
 
         // Now tries to set an authenticator on a connected connection.
         URL url = url(protocol,  server.getAddress(), "/");
@@ -238,16 +238,16 @@ public class HTTPSetAuthenticatorTest extends HTTPTest {
                         + ise);
             }
             // Uncomment the code below when 8169068 is available.
-//            try {
-//                conn.setAuthenticator(Authenticator.getDefault());
-//                throw new RuntimeException("Expected IllegalStateException"
-//                        + " trying to set an authenticator after connect"
-//                        + " not raised.");
-//            } catch (IllegalStateException ise) {
-//                System.out.println("Client: caught expected ISE"
-//                        + " trying to set an authenticator after connect: "
-//                        + ise);
-//            }
+            try {
+                conn.setAuthenticator(Authenticator.getDefault());
+                throw new RuntimeException("Expected IllegalStateException"
+                        + " trying to set an authenticator after connect"
+                        + " not raised.");
+            } catch (IllegalStateException ise) {
+                System.out.println("Client: caught expected ISE"
+                        + " trying to set an authenticator after connect: "
+                        + ise);
+            }
             try {
                 conn.setAuthenticator(null);
                 throw new RuntimeException("Expected"
@@ -279,7 +279,7 @@ public class HTTPSetAuthenticatorTest extends HTTPTest {
         // All good!
         // return the number of times the default authenticator is supposed
         // to have been called.
-        return scheme == HttpSchemeType.NONE ? 0 : 1 * EXPECTED_AUTH_CALLS_PER_TEST;
+        return scheme == HttpSchemeType.NONE ? 0 : 2 * EXPECTED_AUTH_CALLS_PER_TEST;
     }
 
     static String toString(Authenticator a) {


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296610](https://bugs.openjdk.org/browse/JDK-8296610) needs maintainer approval

### Issue
 * [JDK-8296610](https://bugs.openjdk.org/browse/JDK-8296610): java/net/HttpURLConnection/SetAuthenticator/HTTPSetAuthenticatorTest.java failed with "BindException: Address already in use: connect" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2348/head:pull/2348` \
`$ git checkout pull/2348`

Update a local copy of the PR: \
`$ git checkout pull/2348` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2348`

View PR using the GUI difftool: \
`$ git pr show -t 2348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2348.diff">https://git.openjdk.org/jdk17u-dev/pull/2348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2348#issuecomment-2025934540)