### PR TITLE
Backport 72de24e59a80a38ea4ea6a8a3f966f555987ac86

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
@@ -77,6 +77,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.String.format;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -692,16 +694,13 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         // HTTP/1.1
         HttpTestHandler h1_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h1_chunkHandler = new HTTP_ChunkedHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(h1_fixedLengthHandler, "/http1/fixed");
         httpTestServer.addHandler(h1_chunkHandler, "/http1/chunk");
         httpURI_fixed = "http://" + httpTestServer.serverAuthority() + "/http1/fixed/x";
         httpURI_chunk = "http://" + httpTestServer.serverAuthority() + "/http1/chunk/x";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(h1_fixedLengthHandler, "/https1/fixed");
         httpsTestServer.addHandler(h1_chunkHandler, "/https1/chunk");
         httpsURI_fixed = "https://" + httpsTestServer.serverAuthority() + "/https1/fixed/x";
@@ -711,13 +710,13 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_ChunkedHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed/x";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk/x";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed/x";

--- a/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java
@@ -93,6 +93,7 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 import static java.lang.System.out;
 import static java.lang.System.err;
 import static java.lang.String.format;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -705,13 +706,13 @@ public abstract class AbstractThrowingPushPromises implements HttpServerAdapters
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_ChunkedHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed/x";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk/x";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed/x";

--- a/test/jdk/java/net/httpclient/AbstractThrowingSubscribers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingSubscribers.java
@@ -76,6 +76,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
 import static java.lang.String.format;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -683,16 +685,13 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         // HTTP/1.1
         HttpTestHandler h1_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h1_chunkHandler = new HTTP_ChunkedHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(h1_fixedLengthHandler, "/http1/fixed");
         httpTestServer.addHandler(h1_chunkHandler, "/http1/chunk");
         httpURI_fixed = "http://" + httpTestServer.serverAuthority() + "/http1/fixed/x";
         httpURI_chunk = "http://" + httpTestServer.serverAuthority() + "/http1/chunk/x";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(h1_fixedLengthHandler, "/https1/fixed");
         httpsTestServer.addHandler(h1_chunkHandler, "/https1/chunk");
         httpsURI_fixed = "https://" + httpsTestServer.serverAuthority() + "/https1/fixed/x";
@@ -702,13 +701,13 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_ChunkedHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed/x";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk/x";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed/x";

--- a/test/jdk/java/net/httpclient/AggregateRequestBodyTest.java
+++ b/test/jdk/java/net/httpclient/AggregateRequestBodyTest.java
@@ -86,6 +86,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -817,25 +819,20 @@ public class AggregateRequestBodyTest implements HttpServerAdapters {
             throw new AssertionError("Unexpected null sslContext");
 
         HttpTestHandler handler = new HttpTestEchoHandler();
-        InetSocketAddress loopback = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        HttpServer http1 = HttpServer.create(loopback, 0);
-        http1TestServer = HttpTestServer.of(http1);
+        http1TestServer = HttpTestServer.create(HTTP_1_1);
         http1TestServer.addHandler(handler, "/http1/echo/");
         http1URI = "http://" + http1TestServer.serverAuthority() + "/http1/echo/x";
 
-        HttpsServer https1 = HttpsServer.create(loopback, 0);
-        https1.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        https1TestServer = HttpTestServer.of(https1);
+        https1TestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         https1TestServer.addHandler(handler, "/https1/echo/");
         https1URI = "https://" + https1TestServer.serverAuthority() + "/https1/echo/x";
 
         // HTTP/2
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(handler, "/http2/echo/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo/x";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(handler, "/https2/echo/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo/x";
 

--- a/test/jdk/java/net/httpclient/BasicRedirectTest.java
+++ b/test/jdk/java/net/httpclient/BasicRedirectTest.java
@@ -54,6 +54,8 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -209,21 +211,17 @@ public class BasicRedirectTest implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new BasicHttpRedirectHandler(), "/http1/same/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/same/redirect";
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new BasicHttpRedirectHandler(),"/https1/same/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/same/redirect";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new BasicHttpRedirectHandler(), "/http2/same/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/same/redirect";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new BasicHttpRedirectHandler(), "/https2/same/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/same/redirect";
 

--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -84,6 +84,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.arraycopy;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -547,25 +549,22 @@ public class CancelRequestTest implements HttpServerAdapters {
 
         // HTTP/1.1
         HttpTestHandler h1_chunkHandler = new HTTPSlowHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(h1_chunkHandler, "/http1/x/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/x/";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(h1_chunkHandler, "/https1/x/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/x/";
 
         // HTTP/2
         HttpTestHandler h2_chunkedHandler = new HTTPSlowHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/x/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/x/";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/x/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/x/";
 

--- a/test/jdk/java/net/httpclient/DependentActionsTest.java
+++ b/test/jdk/java/net/httpclient/DependentActionsTest.java
@@ -88,6 +88,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
 import static java.lang.String.format;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -580,16 +582,13 @@ public class DependentActionsTest implements HttpServerAdapters {
         // HTTP/1.1
         HttpTestHandler h1_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h1_chunkHandler = new HTTP_ChunkedHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(h1_fixedLengthHandler, "/http1/fixed");
         httpTestServer.addHandler(h1_chunkHandler, "/http1/chunk");
         httpURI_fixed = "http://" + httpTestServer.serverAuthority() + "/http1/fixed/x";
         httpURI_chunk = "http://" + httpTestServer.serverAuthority() + "/http1/chunk/x";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(h1_fixedLengthHandler, "/https1/fixed");
         httpsTestServer.addHandler(h1_chunkHandler, "/https1/chunk");
         httpsURI_fixed = "https://" + httpsTestServer.serverAuthority() + "/https1/fixed/x";
@@ -599,13 +598,13 @@ public class DependentActionsTest implements HttpServerAdapters {
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_ChunkedHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed/x";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk/x";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed/x";

--- a/test/jdk/java/net/httpclient/DependentPromiseActionsTest.java
+++ b/test/jdk/java/net/httpclient/DependentPromiseActionsTest.java
@@ -87,6 +87,7 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 import static java.lang.System.err;
 import static java.lang.System.out;
 import static java.lang.String.format;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -665,13 +666,13 @@ public class DependentPromiseActionsTest implements HttpServerAdapters {
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_ChunkedHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed/y";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk/y";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed/y";

--- a/test/jdk/java/net/httpclient/EncodedCharsInURI.java
+++ b/test/jdk/java/net/httpclient/EncodedCharsInURI.java
@@ -79,6 +79,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 import static java.lang.String.format;
 import static java.lang.System.in;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
@@ -260,16 +262,13 @@ public class EncodedCharsInURI implements HttpServerAdapters {
         // HTTP/1.1
         HttpTestHandler h1_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h1_chunkHandler = new HTTP_ChunkedHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(h1_fixedLengthHandler, "/http1/fixed");
         httpTestServer.addHandler(h1_chunkHandler, "/http1/chunk");
         httpURI_fixed = "http://" + httpTestServer.serverAuthority() + "/http1/fixed/x";
         httpURI_chunk = "http://" + httpTestServer.serverAuthority() + "/http1/chunk/x";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(h1_fixedLengthHandler, "/https1/fixed");
         httpsTestServer.addHandler(h1_chunkHandler, "/https1/chunk");
         httpsURI_fixed = "https://" + httpsTestServer.serverAuthority() + "/https1/fixed/x";
@@ -279,19 +278,20 @@ public class EncodedCharsInURI implements HttpServerAdapters {
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_ChunkedHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed/x";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk/x";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed/x";
         https2URI_chunk = "https://" + https2TestServer.serverAuthority() + "/https2/chunk/x";
 
         // DummyServer
+        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
         httpDummyServer = DummyServer.create(sa);
         httpsDummyServer = DummyServer.create(sa, sslContext);
         httpDummy = "http://" + httpDummyServer.serverAuthority() + "/http1/dummy/x";

--- a/test/jdk/java/net/httpclient/FilePublisher/FilePublisherPermsTest.java
+++ b/test/jdk/java/net/httpclient/FilePublisher/FilePublisherPermsTest.java
@@ -71,6 +71,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -310,29 +312,22 @@ public class FilePublisherPermsTest implements HttpServerAdapters {
         zipFsPath = zipFsFile(zipFs);
         defaultFsPath = defaultFsFile();
 
-        InetSocketAddress sa =
-                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpServerAdapters.HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(
                 new FilePublisherPermsTest.HttpEchoHandler(), "/http1/echo");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/echo";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpServerAdapters.HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(
                 new FilePublisherPermsTest.HttpEchoHandler(), "/https1/echo");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/echo";
 
-        http2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(
                 new FilePublisherPermsTest.HttpEchoHandler(), "/http2/echo");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo";
 
-        https2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(
                 new FilePublisherPermsTest.HttpEchoHandler(), "/https2/echo");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo";

--- a/test/jdk/java/net/httpclient/FilePublisher/FilePublisherTest.java
+++ b/test/jdk/java/net/httpclient/FilePublisher/FilePublisherTest.java
@@ -63,6 +63,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.testng.Assert.assertEquals;
 
 public class FilePublisherTest implements HttpServerAdapters {
@@ -199,23 +201,19 @@ public class FilePublisherTest implements HttpServerAdapters {
         InetSocketAddress sa =
                 new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 
-        httpTestServer = HttpServerAdapters.HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new HttpEchoHandler(), "/http1/echo");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/echo";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpServerAdapters.HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new HttpEchoHandler(), "/https1/echo");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/echo";
 
-        http2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new HttpEchoHandler(), "/http2/echo");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo";
 
-        https2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new HttpEchoHandler(), "/https2/echo");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo";
 

--- a/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
+++ b/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
@@ -80,6 +80,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.err;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -331,22 +333,18 @@ public class ForbiddenHeadTest implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new UnauthorizedHandler(), "/http1/");
         httpTestServer.addHandler(new UnauthorizedHandler(), "/http2/proxy/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1";
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new UnauthorizedHandler(),"/https1/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new UnauthorizedHandler(), "/http2/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new UnauthorizedHandler(), "/https2/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2";
 

--- a/test/jdk/java/net/httpclient/GZIPInputStreamTest.java
+++ b/test/jdk/java/net/httpclient/GZIPInputStreamTest.java
@@ -65,6 +65,8 @@ import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 
@@ -542,26 +544,23 @@ public class GZIPInputStreamTest implements HttpServerAdapters {
         HttpTestHandler gzipHandler  = new LoremIpsumGZIPHandler();
 
         // HTTP/1.1
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(plainHandler, "/http1/chunk/txt");
         httpTestServer.addHandler(gzipHandler,  "/http1/chunk/gz");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/chunk";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(plainHandler, "/https1/chunk/txt");
         httpsTestServer.addHandler(gzipHandler, "/https1/chunk/gz");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/chunk";
 
         // HTTP/2
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(plainHandler, "/http2/chunk/txt");
         http2TestServer.addHandler(gzipHandler, "/http2/chunk/gz");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/chunk";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(plainHandler, "/https2/chunk/txt");
         https2TestServer.addHandler(gzipHandler, "/https2/chunk/gz");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/chunk";

--- a/test/jdk/java/net/httpclient/HeadTest.java
+++ b/test/jdk/java/net/httpclient/HeadTest.java
@@ -76,6 +76,8 @@ import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.testng.Assert.assertEquals;
@@ -109,20 +111,20 @@ public class HeadTest implements HttpServerAdapters {
     @DataProvider(name = "positive")
     public Object[][] positive() {
         return new Object[][] {
-                { httpURI, "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_1_1  },
-                { httpsURI, "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_1_1  },
+                { httpURI, "GET", HTTP_NOT_MODIFIED, HTTP_1_1  },
+                { httpsURI, "GET", HTTP_NOT_MODIFIED, HTTP_1_1  },
                 { httpURI, "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
                 { httpsURI, "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
-                { httpURI, "HEAD", HTTP_OK, HttpClient.Version.HTTP_1_1  },
-                { httpsURI, "HEAD", HTTP_OK, HttpClient.Version.HTTP_1_1  },
+                { httpURI, "HEAD", HTTP_OK, HTTP_1_1  },
+                { httpsURI, "HEAD", HTTP_OK, HTTP_1_1  },
                 { httpURI, "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  },
                 { httpsURI, "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  },
-                { httpURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_1_1  },
-                { httpsURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_1_1  },
+                { httpURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HTTP_1_1  },
+                { httpsURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HTTP_1_1  },
                 { httpURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
                 { httpsURI + "transfer/", "GET", HTTP_NOT_MODIFIED, HttpClient.Version.HTTP_2  },
-                { httpURI + "transfer/", "HEAD", HTTP_OK, HttpClient.Version.HTTP_1_1  },
-                { httpsURI + "transfer/", "HEAD", HTTP_OK, HttpClient.Version.HTTP_1_1  },
+                { httpURI + "transfer/", "HEAD", HTTP_OK, HTTP_1_1  },
+                { httpsURI + "transfer/", "HEAD", HTTP_OK, HTTP_1_1  },
                 { httpURI + "transfer/", "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  },
                 { httpsURI + "transfer/", "HEAD", HTTP_OK, HttpClient.Version.HTTP_2  }
         };
@@ -170,19 +172,17 @@ public class HeadTest implements HttpServerAdapters {
 
         InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new HeadHandler(), "/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/";
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new HeadHandler(),"/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new HeadHandler(), "/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, 0));
+        https2TestServer = HttpTestServer.create(HTTP_2, SSLContext.getDefault());
         https2TestServer.addHandler(new HeadHandler(), "/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/";
 

--- a/test/jdk/java/net/httpclient/HttpRedirectTest.java
+++ b/test/jdk/java/net/httpclient/HttpRedirectTest.java
@@ -28,6 +28,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.testng.Assert.*;
 
 import javax.net.ssl.SSLContext;
@@ -163,9 +165,7 @@ public class HttpRedirectTest implements HttpServerAdapters {
             InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 
             // HTTP/1.1
-            HttpServer server1 = HttpServer.create(sa, 0);
-            server1.setExecutor(executor);
-            http1Server = HttpTestServer.of(server1);
+            http1Server = HttpTestServer.create(HTTP_1_1, null, executor);
             http1Server.addHandler(new HttpTestRedirectHandler("http", http1Server),
                     "/HttpRedirectTest/http1/");
             http1Server.start();
@@ -183,16 +183,14 @@ public class HttpRedirectTest implements HttpServerAdapters {
             https1URI = new URI("https://" + https1Server.serverAuthority() + "/HttpRedirectTest/https1/");
 
             // HTTP/2.0
-            http2Server = HttpTestServer.of(
-                    new Http2TestServer("localhost", false, 0));
+            http2Server = HttpTestServer.create(HTTP_2);
             http2Server.addHandler(new HttpTestRedirectHandler("http", http2Server),
                     "/HttpRedirectTest/http2/");
             http2Server.start();
             http2URI = new URI("http://" + http2Server.serverAuthority() + "/HttpRedirectTest/http2/");
 
             // HTTPS/2.0
-            https2Server = HttpTestServer.of(
-                    new Http2TestServer("localhost", true, 0));
+            https2Server = HttpTestServer.create(HTTP_2, SSLContext.getDefault());
             https2Server.addHandler(new HttpTestRedirectHandler("https", https2Server),
                     "/HttpRedirectTest/https2/");
             https2Server.start();

--- a/test/jdk/java/net/httpclient/HttpSlowServerTest.java
+++ b/test/jdk/java/net/httpclient/HttpSlowServerTest.java
@@ -52,6 +52,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 
 /**
  * @test
@@ -127,9 +129,7 @@ public class HttpSlowServerTest implements HttpServerAdapters {
             InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 
             // HTTP/1.1
-            HttpServer server1 = HttpServer.create(sa, 0);
-            server1.setExecutor(executor);
-            http1Server = HttpTestServer.of(server1);
+            http1Server = HttpTestServer.create(HTTP_1_1, null, executor);
             http1Server.addHandler(new HttpTestSlowHandler(), "/HttpSlowServerTest/http1/");
             http1Server.start();
             http1URI = new URI("http://" + http1Server.serverAuthority() + "/HttpSlowServerTest/http1/");
@@ -145,15 +145,13 @@ public class HttpSlowServerTest implements HttpServerAdapters {
             https1URI = new URI("https://" + https1Server.serverAuthority() + "/HttpSlowServerTest/https1/");
 
             // HTTP/2.0
-            http2Server = HttpTestServer.of(
-                    new Http2TestServer("localhost", false, 0));
+            http2Server = HttpTestServer.create(HTTP_2);
             http2Server.addHandler(new HttpTestSlowHandler(), "/HttpSlowServerTest/http2/");
             http2Server.start();
             http2URI = new URI("http://" + http2Server.serverAuthority() + "/HttpSlowServerTest/http2/");
 
             // HTTPS/2.0
-            https2Server = HttpTestServer.of(
-                    new Http2TestServer("localhost", true, 0));
+            https2Server = HttpTestServer.create(HTTP_2, SSLContext.getDefault());
             https2Server.addHandler(new HttpTestSlowHandler(), "/HttpSlowServerTest/https2/");
             https2Server.start();
             https2URI = new URI("https://" + https2Server.serverAuthority() + "/HttpSlowServerTest/https2/");

--- a/test/jdk/java/net/httpclient/HttpsTunnelTest.java
+++ b/test/jdk/java/net/httpclient/HttpsTunnelTest.java
@@ -42,6 +42,8 @@ import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 import static java.lang.String.format;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 
 /**
  * @test
@@ -102,15 +104,11 @@ public class HttpsTunnelTest implements HttpServerAdapters {
     }
 
     public static void main(String[] args) throws Exception {
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        HttpsServer server1 = HttpsServer.create(sa, 0);
-        server1.setHttpsConfigurator(new HttpsConfigurator(context));
         HttpTestServer http1Server =
-                HttpTestServer.of(server1);
+                HttpTestServer.create(HTTP_1_1, context);
         http1Server.addHandler(new HttpTestEchoHandler(), "/");
         http1Server.start();
-        HttpTestServer http2Server = HttpTestServer.of(
-                new Http2TestServer("localhost", true, 0));
+        HttpTestServer http2Server = HttpTestServer.create(HTTP_2, SSLContext.getDefault());
         http2Server.addHandler(new HttpTestEchoHandler(), "/");
         http2Server.start();
 
@@ -154,7 +152,7 @@ public class HttpsTunnelTest implements HttpServerAdapters {
             if (response.statusCode() != 200) {
                 throw new RuntimeException("Unexpected status code: " + response);
             }
-            if (response.version() != Version.HTTP_1_1) {
+            if (response.version() != HTTP_1_1) {
                 throw new RuntimeException("Unexpected protocol version: "
                         + response.version());
             }

--- a/test/jdk/java/net/httpclient/ISO_8859_1_Test.java
+++ b/test/jdk/java/net/httpclient/ISO_8859_1_Test.java
@@ -96,6 +96,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -412,23 +414,20 @@ public class ISO_8859_1_Test implements HttpServerAdapters {
         http1DummyServer = new DummyServer();
         http1Dummy = "http://" + http1DummyServer.serverAuthority() +"/http1/dummy/x";
 
-        HttpServer http1 = HttpServer.create(loopback, 0);
-        http1TestServer = HttpServerAdapters.HttpTestServer.of(http1);
+        http1TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1);
         http1TestServer.addHandler(handler, "/http1/server/");
         http1URI = "http://" + http1TestServer.serverAuthority() + "/http1/server/x";
 
-        HttpsServer https1 = HttpsServer.create(loopback, 0);
-        https1.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        https1TestServer = HttpServerAdapters.HttpTestServer.of(https1);
+        https1TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1, sslContext);
         https1TestServer.addHandler(handler, "/https1/server/");
         https1URI = "https://" + https1TestServer.serverAuthority() + "/https1/server/x";
 
         // HTTP/2
-        http2TestServer = HttpServerAdapters.HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(handler, "/http2/server/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/server/x";
 
-        https2TestServer = HttpServerAdapters.HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(handler, "/https2/server/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/server/x";
 

--- a/test/jdk/java/net/httpclient/InvalidInputStreamSubscriptionRequest.java
+++ b/test/jdk/java/net/httpclient/InvalidInputStreamSubscriptionRequest.java
@@ -74,6 +74,8 @@ import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 
@@ -228,7 +230,7 @@ public class InvalidInputStreamSubscriptionRequest implements HttpServerAdapters
                     String body = new String(is.readAllBytes(), UTF_8);
                     assertEquals(body, "");
                     if (uri.endsWith("/chunk")
-                            && response.version() == HttpClient.Version.HTTP_1_1) {
+                            && response.version() == HTTP_1_1) {
                         // with /fixed and 0 length
                         // there's no need for any call to request()
                         throw new RuntimeException("Expected IAE not thrown");
@@ -278,7 +280,7 @@ public class InvalidInputStreamSubscriptionRequest implements HttpServerAdapters
                 // Get the final result and compare it with the expected body
                 assertEquals(result.get(), "");
                 if (uri.endsWith("/chunk")
-                        && response.get().version() == HttpClient.Version.HTTP_1_1) {
+                        && response.get().version() == HTTP_1_1) {
                     // with /fixed and 0 length
                     // there's no need for any call to request()
                     throw new RuntimeException("Expected IAE not thrown");
@@ -446,16 +448,13 @@ public class InvalidInputStreamSubscriptionRequest implements HttpServerAdapters
         // HTTP/1.1
         HttpTestHandler h1_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h1_chunkHandler = new HTTP_VariableLengthHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler( h1_fixedLengthHandler, "/http1/fixed");
         httpTestServer.addHandler(h1_chunkHandler,"/http1/chunk");
         httpURI_fixed = "http://" + httpTestServer.serverAuthority() + "/http1/fixed";
         httpURI_chunk = "http://" + httpTestServer.serverAuthority() + "/http1/chunk";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(h1_fixedLengthHandler, "/https1/fixed");
         httpsTestServer.addHandler(h1_chunkHandler, "/https1/chunk");
         httpsURI_fixed = "https://" + httpsTestServer.serverAuthority() + "/https1/fixed";
@@ -465,13 +464,13 @@ public class InvalidInputStreamSubscriptionRequest implements HttpServerAdapters
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_VariableLengthHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed";

--- a/test/jdk/java/net/httpclient/InvalidSubscriptionRequest.java
+++ b/test/jdk/java/net/httpclient/InvalidSubscriptionRequest.java
@@ -72,6 +72,8 @@ import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 
@@ -176,7 +178,7 @@ public class InvalidSubscriptionRequest implements HttpServerAdapters {
                 String body = ofString.getBody().toCompletableFuture().get();
                 assertEquals(body, "");
                 if (uri.endsWith("/chunk")
-                        && response.version() == HttpClient.Version.HTTP_1_1) {
+                        && response.version() == HTTP_1_1) {
                     // with /fixed and 0 length
                     // there's no need for any call to request()
                     throw new RuntimeException("Expected IAE not thrown");
@@ -220,7 +222,7 @@ public class InvalidSubscriptionRequest implements HttpServerAdapters {
                 // Get the final result and compare it with the expected body
                 assertEquals(result.get(), "");
                 if (uri.endsWith("/chunk")
-                        && response.get().version() == HttpClient.Version.HTTP_1_1) {
+                        && response.get().version() == HTTP_1_1) {
                     // with /fixed and 0 length
                     // there's no need for any call to request()
                     throw new RuntimeException("Expected IAE not thrown");
@@ -379,16 +381,13 @@ public class InvalidSubscriptionRequest implements HttpServerAdapters {
         // HTTP/1.1
         HttpTestHandler h1_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h1_chunkHandler = new HTTP_VariableLengthHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler( h1_fixedLengthHandler, "/http1/fixed");
         httpTestServer.addHandler(h1_chunkHandler,"/http1/chunk");
         httpURI_fixed = "http://" + httpTestServer.serverAuthority() + "/http1/fixed";
         httpURI_chunk = "http://" + httpTestServer.serverAuthority() + "/http1/chunk";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(h1_fixedLengthHandler, "/https1/fixed");
         httpsTestServer.addHandler(h1_chunkHandler, "/https1/chunk");
         httpsURI_fixed = "https://" + httpsTestServer.serverAuthority() + "/https1/fixed";
@@ -398,13 +397,13 @@ public class InvalidSubscriptionRequest implements HttpServerAdapters {
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_VariableLengthHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed";

--- a/test/jdk/java/net/httpclient/LargeHandshakeTest.java
+++ b/test/jdk/java/net/httpclient/LargeHandshakeTest.java
@@ -62,6 +62,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 
 /**
  * @test
@@ -1000,9 +1002,7 @@ public class LargeHandshakeTest implements HttpServerAdapters {
             InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 
             // HTTP/1.1
-            HttpServer server1 = HttpServer.create(sa, 0);
-            server1.setExecutor(executor);
-            http1Server = HttpTestServer.of(server1);
+            http1Server = HttpTestServer.create(HTTP_1_1, null, executor);
             http1Server.addHandler(new HttpTestLargeHandler(), "/LargeHandshakeTest/http1/");
             http1Server.start();
             http1URI = new URI("http://" + http1Server.serverAuthority() + "/LargeHandshakeTest/http1/");
@@ -1018,15 +1018,13 @@ public class LargeHandshakeTest implements HttpServerAdapters {
             https1URI = new URI("https://" + https1Server.serverAuthority() + "/LargeHandshakeTest/https1/");
 
             // HTTP/2.0
-            http2Server = HttpTestServer.of(
-                    new Http2TestServer("localhost", false, 0));
+            http2Server = HttpTestServer.create(HTTP_2);
             http2Server.addHandler(new HttpTestLargeHandler(), "/LargeHandshakeTest/http2/");
             http2Server.start();
             http2URI = new URI("http://" + http2Server.serverAuthority() + "/LargeHandshakeTest/http2/");
 
             // HTTPS/2.0
-            https2Server = HttpTestServer.of(
-                    new Http2TestServer("localhost", true, 0));
+            https2Server = HttpTestServer.create(HTTP_2, SSLContext.getDefault());
             https2Server.addHandler(new HttpTestLargeHandler(), "/LargeHandshakeTest/https2/");
             https2Server.start();
             https2URI = new URI("https://" + https2Server.serverAuthority() + "/LargeHandshakeTest/https2/");

--- a/test/jdk/java/net/httpclient/LargeResponseTest.java
+++ b/test/jdk/java/net/httpclient/LargeResponseTest.java
@@ -52,6 +52,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 
 /**
  * @test
@@ -125,9 +127,7 @@ public class LargeResponseTest implements HttpServerAdapters {
             InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 
             // HTTP/1.1
-            HttpServer server1 = HttpServer.create(sa, 0);
-            server1.setExecutor(executor);
-            http1Server = HttpTestServer.of(server1);
+            http1Server = HttpTestServer.create(HTTP_1_1, null, executor);
             http1Server.addHandler(new HttpTestLargeHandler(), "/LargeResponseTest/http1/");
             http1Server.start();
             http1URI = new URI("http://" + http1Server.serverAuthority() + "/LargeResponseTest/http1/");
@@ -143,15 +143,13 @@ public class LargeResponseTest implements HttpServerAdapters {
             https1URI = new URI("https://" + https1Server.serverAuthority() + "/LargeResponseTest/https1/");
 
             // HTTP/2.0
-            http2Server = HttpTestServer.of(
-                    new Http2TestServer("localhost", false, 0));
+            http2Server = HttpTestServer.create(HTTP_2);
             http2Server.addHandler(new HttpTestLargeHandler(), "/LargeResponseTest/http2/");
             http2Server.start();
             http2URI = new URI("http://" + http2Server.serverAuthority() + "/LargeResponseTest/http2/");
 
             // HTTPS/2.0
-            https2Server = HttpTestServer.of(
-                    new Http2TestServer("localhost", true, 0));
+            https2Server = HttpTestServer.create(HTTP_2, SSLContext.getDefault());
             https2Server.addHandler(new HttpTestLargeHandler(), "/LargeResponseTest/https2/");
             https2Server.start();
             https2URI = new URI("https://" + https2Server.serverAuthority() + "/LargeResponseTest/https2/");

--- a/test/jdk/java/net/httpclient/LineBodyHandlerTest.java
+++ b/test/jdk/java/net/httpclient/LineBodyHandlerTest.java
@@ -65,6 +65,8 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_16;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
@@ -670,24 +672,21 @@ public class LineBodyHandlerTest implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0),
+        httpTestServer = HttpTestServer.create(HTTP_1_1, null,
                 executorFor("HTTP/1.1 Server Thread"));
         httpTestServer.addHandler(new HttpTestEchoHandler(), "/http1/echo");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/echo";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer,
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext,
                 executorFor("HTTPS/1.1 Server Thread"));
         httpsTestServer.addHandler(new HttpTestEchoHandler(),"/https1/echo");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/echo";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new HttpTestEchoHandler(), "/http2/echo");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new HttpTestEchoHandler(), "/https2/echo");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo";
 

--- a/test/jdk/java/net/httpclient/NonAsciiCharsInURI.java
+++ b/test/jdk/java/net/httpclient/NonAsciiCharsInURI.java
@@ -60,6 +60,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static java.lang.System.err;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static org.testng.Assert.assertEquals;
@@ -196,22 +198,19 @@ public class NonAsciiCharsInURI implements HttpServerAdapters {
             throw new AssertionError("Unexpected null sslContext");
 
         HttpTestHandler handler = new HttpUriStringHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(handler, "/http1");
         httpURI = "http://" + serverAuthority(httpTestServer) + "/http1";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(handler, "/https1");
         httpsURI = "https://" + serverAuthority(httpsTestServer) + "/https1";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(handler, "/http2");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(handler, "/https2");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2";
 

--- a/test/jdk/java/net/httpclient/PathSubscriber/BodyHandlerOfFileDownloadTest.java
+++ b/test/jdk/java/net/httpclient/PathSubscriber/BodyHandlerOfFileDownloadTest.java
@@ -77,6 +77,8 @@ import jdk.httpclient.test.lib.http2.OutgoingPushPromise;
 import jdk.httpclient.test.lib.http2.Queue;
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -197,26 +199,19 @@ public class BodyHandlerOfFileDownloadTest implements HttpServerAdapters {
         zipFs = newZipFs();
         zipFsPath = zipFsDir(zipFs);
 
-        InetSocketAddress sa =
-                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpServerAdapters.HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new HttpEchoHandler(), "/http1/echo");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/echo";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpServerAdapters.HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new HttpEchoHandler(), "/https1/echo");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/echo";
 
-        http2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new HttpEchoHandler(), "/http2/echo");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo";
 
-        https2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new HttpEchoHandler(), "/https2/echo");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo";
 

--- a/test/jdk/java/net/httpclient/PathSubscriber/BodyHandlerOfFileTest.java
+++ b/test/jdk/java/net/httpclient/PathSubscriber/BodyHandlerOfFileTest.java
@@ -74,6 +74,8 @@ import jdk.httpclient.test.lib.http2.OutgoingPushPromise;
 import jdk.httpclient.test.lib.http2.Queue;
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.testng.Assert.assertEquals;
 
 public class BodyHandlerOfFileTest implements HttpServerAdapters {
@@ -203,26 +205,19 @@ public class BodyHandlerOfFileTest implements HttpServerAdapters {
         zipFs = newZipFs();
         zipFsPath = zipFsFile(zipFs);
 
-        InetSocketAddress sa =
-                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpServerAdapters.HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new HttpEchoHandler(), "/http1/echo");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/echo";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpServerAdapters.HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new HttpEchoHandler(), "/https1/echo");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/echo";
 
-        http2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new HttpEchoHandler(), "/http2/echo");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo";
 
-        https2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new HttpEchoHandler(), "/https2/echo");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo";
 

--- a/test/jdk/java/net/httpclient/PathSubscriber/BodySubscriberOfFileTest.java
+++ b/test/jdk/java/net/httpclient/PathSubscriber/BodySubscriberOfFileTest.java
@@ -81,6 +81,8 @@ import jdk.httpclient.test.lib.http2.OutgoingPushPromise;
 import jdk.httpclient.test.lib.http2.Queue;
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static org.testng.Assert.assertEquals;
 
 public class BodySubscriberOfFileTest implements HttpServerAdapters {
@@ -240,26 +242,19 @@ public class BodySubscriberOfFileTest implements HttpServerAdapters {
         zipFs = newZipFs();
         zipFsPath = zipFsFile(zipFs);
 
-        InetSocketAddress sa =
-                new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpServerAdapters.HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new HttpEchoHandler(), "/http1/echo");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/echo";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpServerAdapters.HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpServerAdapters.HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new HttpEchoHandler(), "/https1/echo");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/echo";
 
-        http2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new HttpEchoHandler(), "/http2/echo");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/echo";
 
-        https2TestServer = HttpServerAdapters.HttpTestServer.of(
-                new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpServerAdapters.HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new HttpEchoHandler(), "/https2/echo");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/echo";
 

--- a/test/jdk/java/net/httpclient/ProxySelectorTest.java
+++ b/test/jdk/java/net/httpclient/ProxySelectorTest.java
@@ -79,6 +79,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.err;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 
@@ -209,13 +211,13 @@ public class ProxySelectorTest implements HttpServerAdapters {
     @DataProvider(name = "all")
     public Object[][] positive() {
         return new Object[][] {
-                { Schemes.HTTP,  HttpClient.Version.HTTP_1_1, httpURI,   true},
+                { Schemes.HTTP,  HTTP_1_1, httpURI,   true},
                 { Schemes.HTTP,  HttpClient.Version.HTTP_2,   http2URI,  true},
-                { Schemes.HTTPS, HttpClient.Version.HTTP_1_1, httpsURI,  true},
+                { Schemes.HTTPS, HTTP_1_1, httpsURI,  true},
                 { Schemes.HTTPS, HttpClient.Version.HTTP_2,   https2URI, true},
-                { Schemes.HTTP,  HttpClient.Version.HTTP_1_1, httpURI,   false},
+                { Schemes.HTTP,  HTTP_1_1, httpURI,   false},
                 { Schemes.HTTP,  HttpClient.Version.HTTP_2,   http2URI,  false},
-                { Schemes.HTTPS, HttpClient.Version.HTTP_1_1, httpsURI,  false},
+                { Schemes.HTTPS, HTTP_1_1, httpsURI,  false},
                 { Schemes.HTTPS, HttpClient.Version.HTTP_2,   https2URI, false},
         };
     }
@@ -322,30 +324,26 @@ public class ProxySelectorTest implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new PlainServerHandler("plain-server"), "/http1/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1";
-        proxyHttpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        proxyHttpTestServer = HttpTestServer.create(HTTP_1_1);
         proxyHttpTestServer.addHandler(new PlainServerHandler("proxy-server"), "/http1/proxy/");
         proxyHttpTestServer.addHandler(new PlainServerHandler("proxy-server"), "/http2/proxy/");
         proxyHttpURI = "http://" + httpTestServer.serverAuthority() + "/http1";
-        authProxyHttpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        authProxyHttpTestServer = HttpTestServer.create(HTTP_1_1);
         authProxyHttpTestServer.addHandler(new UnauthorizedHandler("auth-proxy-server"), "/http1/proxy/");
         authProxyHttpTestServer.addHandler(new UnauthorizedHandler("auth-proxy-server"), "/http2/proxy/");
         proxyHttpURI = "http://" + httpTestServer.serverAuthority() + "/http1";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new PlainServerHandler("https-server"),"/https1/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new PlainServerHandler("plain-server"), "/http2/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new PlainServerHandler("https-server"), "/https2/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2";
 

--- a/test/jdk/java/net/httpclient/RedirectMethodChange.java
+++ b/test/jdk/java/net/httpclient/RedirectMethodChange.java
@@ -51,6 +51,8 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.testng.Assert.assertEquals;
 
@@ -186,29 +188,25 @@ public class RedirectMethodChange implements HttpServerAdapters {
                 .sslContext(sslContext)
                 .build();
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         String targetURI = "http://" + httpTestServer.serverAuthority() + "/http1/redirect/rmt";
         RedirMethodChgeHandler handler = new RedirMethodChgeHandler(targetURI);
         httpTestServer.addHandler(handler, "/http1/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/test/rmt";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         targetURI = "https://" + httpsTestServer.serverAuthority() + "/https1/redirect/rmt";
         handler = new RedirMethodChgeHandler(targetURI);
         httpsTestServer.addHandler(handler,"/https1/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/test/rmt";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         targetURI = "http://" + http2TestServer.serverAuthority() + "/http2/redirect/rmt";
         handler = new RedirMethodChgeHandler(targetURI);
         http2TestServer.addHandler(handler, "/http2/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/test/rmt";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         targetURI = "https://" + https2TestServer.serverAuthority() + "/https2/redirect/rmt";
         handler = new RedirMethodChgeHandler(targetURI);
         https2TestServer.addHandler(handler, "/https2/");

--- a/test/jdk/java/net/httpclient/RedirectWithCookie.java
+++ b/test/jdk/java/net/httpclient/RedirectWithCookie.java
@@ -56,6 +56,8 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -148,21 +150,17 @@ public class RedirectWithCookie implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new CookieRedirectHandler(), "/http1/cookie/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/cookie/redirect";
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new CookieRedirectHandler(),"/https1/cookie/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/cookie/redirect";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new CookieRedirectHandler(), "/http2/cookie/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/cookie/redirect";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new CookieRedirectHandler(), "/https2/cookie/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/cookie/redirect";
 

--- a/test/jdk/java/net/httpclient/Response204V2Test.java
+++ b/test/jdk/java/net/httpclient/Response204V2Test.java
@@ -70,6 +70,7 @@ import org.testng.annotations.Test;
 import javax.net.ssl.SSLContext;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_2;
 
 public class Response204V2Test implements HttpServerAdapters {
 
@@ -270,11 +271,11 @@ public class Response204V2Test implements HttpServerAdapters {
         // HTTP/2
         HttpTestHandler handler204 = new Handler204();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(handler204, "/http2/test204/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/test204/x";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(handler204, "/https2/test204/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/test204/x";
 

--- a/test/jdk/java/net/httpclient/ResponsePublisher.java
+++ b/test/jdk/java/net/httpclient/ResponsePublisher.java
@@ -73,6 +73,8 @@ import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -399,16 +401,13 @@ public class ResponsePublisher implements HttpServerAdapters {
         // HTTP/1.1
         HttpTestHandler h1_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h1_chunkHandler = new HTTP_VariableLengthHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler( h1_fixedLengthHandler, "/http1/fixed");
         httpTestServer.addHandler(h1_chunkHandler,"/http1/chunk");
         httpURI_fixed = "http://" + httpTestServer.serverAuthority() + "/http1/fixed";
         httpURI_chunk = "http://" + httpTestServer.serverAuthority() + "/http1/chunk";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(h1_fixedLengthHandler, "/https1/fixed");
         httpsTestServer.addHandler(h1_chunkHandler, "/https1/chunk");
         httpsURI_fixed = "https://" + httpsTestServer.serverAuthority() + "/https1/fixed";
@@ -418,13 +417,13 @@ public class ResponsePublisher implements HttpServerAdapters {
         HttpTestHandler h2_fixedLengthHandler = new HTTP_FixedLengthHandler();
         HttpTestHandler h2_chunkedHandler = new HTTP_VariableLengthHandler();
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(h2_fixedLengthHandler, "/http2/fixed");
         http2TestServer.addHandler(h2_chunkedHandler, "/http2/chunk");
         http2URI_fixed = "http://" + http2TestServer.serverAuthority() + "/http2/fixed";
         http2URI_chunk = "http://" + http2TestServer.serverAuthority() + "/http2/chunk";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(h2_fixedLengthHandler, "/https2/fixed");
         https2TestServer.addHandler(h2_chunkedHandler, "/https2/chunk");
         https2URI_fixed = "https://" + https2TestServer.serverAuthority() + "/https2/fixed";

--- a/test/jdk/java/net/httpclient/RetryWithCookie.java
+++ b/test/jdk/java/net/httpclient/RetryWithCookie.java
@@ -67,6 +67,8 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -148,21 +150,17 @@ public class RetryWithCookie implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new CookieRetryHandler(), "/http1/cookie/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/cookie/retry";
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new CookieRetryHandler(),"/https1/cookie/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/cookie/retry";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new CookieRetryHandler(), "/http2/cookie/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/cookie/retry";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new CookieRetryHandler(), "/https2/cookie/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/cookie/retry";
 
@@ -208,7 +206,7 @@ public class RetryWithCookie implements HttpServerAdapters {
             String uuid = uuids.get(0);
             // retrying
             if (closedRequests.putIfAbsent(uuid, t.getRequestURI().toString()) == null) {
-                if (t.getExchangeVersion() == HttpClient.Version.HTTP_1_1) {
+                if (t.getExchangeVersion() == HTTP_1_1) {
                     // Throwing an exception here only causes a retry
                     // with HTTP_1_1 - where it forces the server to close
                     // the connection.

--- a/test/jdk/java/net/httpclient/SpecialHeadersTest.java
+++ b/test/jdk/java/net/httpclient/SpecialHeadersTest.java
@@ -89,6 +89,7 @@ import jdk.httpclient.test.lib.http2.Http2TestServer;
 import static java.lang.System.err;
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import org.testng.Assert;
@@ -520,22 +521,19 @@ public class SpecialHeadersTest implements HttpServerAdapters {
             throw new AssertionError("Unexpected null sslContext");
 
         HttpTestHandler handler = new HttpUriStringHandler();
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(handler, "/http1");
         httpURI = "http://" + serverAuthority(httpTestServer) + "/http1";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(handler, "/https1");
         httpsURI = "https://" + serverAuthority(httpsTestServer) + "/https1";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(handler, "/http2");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2";
 
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(handler, "/https2");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2";
 

--- a/test/jdk/java/net/httpclient/StreamCloseTest.java
+++ b/test/jdk/java/net/httpclient/StreamCloseTest.java
@@ -88,8 +88,7 @@ public class StreamCloseTest {
 
     @BeforeTest
     public void setup() throws Exception {
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-        httpTestServer = HttpServerAdapters.HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpServerAdapters.HttpTestServer.create(Version.HTTP_1_1);
         httpTestServer.addHandler(new HttpServerAdapters.HttpTestEchoHandler(), "/");
         URI uri = URI.create("http://" + httpTestServer.serverAuthority() + "/");
         httpTestServer.start();

--- a/test/jdk/java/net/httpclient/StreamingBody.java
+++ b/test/jdk/java/net/httpclient/StreamingBody.java
@@ -54,6 +54,8 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static org.testng.Assert.assertEquals;
@@ -116,22 +118,18 @@ public class StreamingBody implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new MessageHandler(), "/http1/streamingbody/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/streamingbody/w";
 
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new MessageHandler(),"/https1/streamingbody/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/streamingbody/x";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new MessageHandler(), "/http2/streamingbody/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/streamingbody/y";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new MessageHandler(), "/https2/streamingbody/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/streamingbody/z";
 

--- a/test/jdk/java/net/httpclient/UnauthorizedTest.java
+++ b/test/jdk/java/net/httpclient/UnauthorizedTest.java
@@ -63,6 +63,8 @@ import jdk.httpclient.test.lib.common.HttpServerAdapters;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -188,21 +190,17 @@ public class UnauthorizedTest implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new UnauthorizedHandler(), "/http1/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1";
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new UnauthorizedHandler(),"/https1/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new UnauthorizedHandler(), "/http2/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new UnauthorizedHandler(), "/https2/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2";
 

--- a/test/jdk/java/net/httpclient/UserCookieTest.java
+++ b/test/jdk/java/net/httpclient/UserCookieTest.java
@@ -78,6 +78,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static java.lang.System.out;
+import static java.net.http.HttpClient.Version.HTTP_1_1;
+import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 
@@ -111,14 +113,14 @@ public class UserCookieTest implements HttpServerAdapters {
     @DataProvider(name = "positive")
     public Object[][] positive() {
         return new Object[][] {
-                { httpURI, HttpClient.Version.HTTP_1_1  },
-                { httpsURI, HttpClient.Version.HTTP_1_1  },
-                { httpDummy, HttpClient.Version.HTTP_1_1 },
-                { httpsDummy, HttpClient.Version.HTTP_1_1 },
-                { httpURI, HttpClient.Version.HTTP_2  },
-                { httpsURI, HttpClient.Version.HTTP_2  },
-                { httpDummy, HttpClient.Version.HTTP_2 },
-                { httpsDummy, HttpClient.Version.HTTP_2 },
+                { httpURI, HTTP_1_1  },
+                { httpsURI, HTTP_1_1  },
+                { httpDummy, HTTP_1_1 },
+                { httpsDummy, HTTP_1_1 },
+                { httpURI, HTTP_2  },
+                { httpsURI, HTTP_2  },
+                { httpDummy, HTTP_2 },
+                { httpsDummy, HTTP_2 },
                 { http2URI, null  },
                 { https2URI, null },
         };
@@ -192,25 +194,21 @@ public class UserCookieTest implements HttpServerAdapters {
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
 
-        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-
-        httpTestServer = HttpTestServer.of(HttpServer.create(sa, 0));
+        httpTestServer = HttpTestServer.create(HTTP_1_1);
         httpTestServer.addHandler(new CookieValidationHandler(), "/http1/cookie/");
         httpURI = "http://" + httpTestServer.serverAuthority() + "/http1/cookie/retry";
-        HttpsServer httpsServer = HttpsServer.create(sa, 0);
-        httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
-        httpsTestServer = HttpTestServer.of(httpsServer);
+        httpsTestServer = HttpTestServer.create(HTTP_1_1, sslContext);
         httpsTestServer.addHandler(new CookieValidationHandler(),"/https1/cookie/");
         httpsURI = "https://" + httpsTestServer.serverAuthority() + "/https1/cookie/retry";
 
-        http2TestServer = HttpTestServer.of(new Http2TestServer("localhost", false, 0));
+        http2TestServer = HttpTestServer.create(HTTP_2);
         http2TestServer.addHandler(new CookieValidationHandler(), "/http2/cookie/");
         http2URI = "http://" + http2TestServer.serverAuthority() + "/http2/cookie/retry";
-        https2TestServer = HttpTestServer.of(new Http2TestServer("localhost", true, sslContext));
+        https2TestServer = HttpTestServer.create(HTTP_2, sslContext);
         https2TestServer.addHandler(new CookieValidationHandler(), "/https2/cookie/");
         https2URI = "https://" + https2TestServer.serverAuthority() + "/https2/cookie/retry";
 
-
+        InetSocketAddress sa = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
         // DummyServer
         httpDummyServer = DummyServer.create(sa);
         httpsDummyServer = DummyServer.create(sa, sslContext);
@@ -279,7 +277,7 @@ public class UserCookieTest implements HttpServerAdapters {
             String uuid = uuids.get(0);
             // retrying
             if (closedRequests.putIfAbsent(uuid, t.getRequestURI().toString()) == null) {
-                if (t.getExchangeVersion() == HttpClient.Version.HTTP_1_1) {
+                if (t.getExchangeVersion() == HTTP_1_1) {
                     // Throwing an exception here only causes a retry
                     // with HTTP_1_1 - where it forces the server to close
                     // the connection.
@@ -299,7 +297,7 @@ public class UserCookieTest implements HttpServerAdapters {
             HttpClient.Version version = t.getExchangeVersion();
             List<String> upgrade = t.getRequestHeaders().get("Upgrade");
             if (upgrade == null) upgrade = List.of();
-            boolean upgraded = version == HttpClient.Version.HTTP_2
+            boolean upgraded = version == HTTP_2
                     && upgrade.stream().anyMatch("h2c"::equalsIgnoreCase);
 
             // not retrying
@@ -307,7 +305,7 @@ public class UserCookieTest implements HttpServerAdapters {
             try (OutputStream os = t.getResponseBody()) {
                 List<String> cookie = t.getRequestHeaders().get("Cookie");
                 if (cookie != null) {
-                    if (version == HttpClient.Version.HTTP_1_1 || upgraded) {
+                    if (version == HTTP_1_1 || upgraded) {
                         if (cookie.size() == 1) {
                             cookie = List.of(cookie.get(0).split("; "));
                         } else if (cookie.size() > 1) {

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -28,6 +28,8 @@ import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
 import jdk.httpclient.test.lib.http2.Http2Handler;
 import jdk.httpclient.test.lib.http2.Http2TestExchange;
 import jdk.httpclient.test.lib.http2.Http2TestServer;
@@ -57,6 +59,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+
+import javax.net.ssl.SSLContext;
 
 /**
  * Defines an adaptation layers so that a test server handlers and filters
@@ -555,6 +559,90 @@ public interface HttpServerAdapters {
 
         public static HttpTestServer of(Http2TestServer server) {
             return new Http2TestServerImpl(server);
+        }
+
+        /**
+         * Creates a {@link HttpTestServer} which supports the {@code serverVersion}. The server
+         * will only be available on {@code http} protocol. {@code https} will not be supported
+         * by the returned server
+         *
+         * @param serverVersion The HTTP version of the server
+         * @return The newly created server
+         * @throws IllegalArgumentException if {@code serverVersion} is not supported by this method
+         * @throws IOException if any exception occurs during the server creation
+         */
+        public static HttpTestServer create(Version serverVersion) throws IOException {
+            Objects.requireNonNull(serverVersion);
+            return create(serverVersion, null);
+        }
+
+        /**
+         * Creates a {@link HttpTestServer} which supports the {@code serverVersion}. If the
+         * {@code sslContext} is null, then only {@code http} protocol will be supported by the
+         * server. Else, the server will be configured with the {@code sslContext} and will support
+         * {@code https} protocol.
+         *
+         * @param serverVersion The HTTP version of the server
+         * @param sslContext    The SSLContext to use. Can be null
+         * @return The newly created server
+         * @throws IllegalArgumentException if {@code serverVersion} is not supported by this method
+         * @throws IOException if any exception occurs during the server creation
+         */
+        public static HttpTestServer create(Version serverVersion, SSLContext sslContext)
+                throws IOException {
+            Objects.requireNonNull(serverVersion);
+            return create(serverVersion, sslContext, null);
+        }
+
+        /**
+         * Creates a {@link HttpTestServer} which supports the {@code serverVersion}. If the
+         * {@code sslContext} is null, then only {@code http} protocol will be supported by the
+         * server. Else, the server will be configured with the {@code sslContext} and will support
+         * {@code https} protocol.
+         *
+         * @param serverVersion The HTTP version of the server
+         * @param sslContext    The SSLContext to use. Can be null
+         * @param executor      The executor to be used by the server. Can be null
+         * @return The newly created server
+         * @throws IllegalArgumentException if {@code serverVersion} is not supported by this method
+         * @throws IOException if any exception occurs during the server creation
+         */
+        public static HttpTestServer create(Version serverVersion, SSLContext sslContext,
+                                            ExecutorService executor) throws IOException {
+            Objects.requireNonNull(serverVersion);
+            switch (serverVersion) {
+                case HTTP_2 -> {
+                    Http2TestServer underlying;
+                    try {
+                        underlying = sslContext == null
+                                ? new Http2TestServer("localhost", false, 0, executor, null) // HTTP
+                                : new Http2TestServer("localhost", true, 0, executor, sslContext); // HTTPS
+                    } catch (IOException ioe) {
+                        throw ioe;
+                    } catch (Exception e) {
+                        throw new IOException(e);
+                    }
+                    return HttpTestServer.of(underlying);
+                }
+                case HTTP_1_1 ->  {
+                    InetSocketAddress sa = new InetSocketAddress(
+                            InetAddress.getLoopbackAddress(), 0);
+                    HttpServer underlying;
+                    if (sslContext == null) {
+                        underlying = HttpServer.create(sa, 0); // HTTP
+                    } else {
+                        HttpsServer https = HttpsServer.create(sa, 0); // HTTPS
+                        https.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+                        underlying = https;
+                    }
+                    if (executor != null) {
+                        underlying.setExecutor(executor);
+                    }
+                    return HttpTestServer.of(underlying);
+                }
+                default -> throw new IllegalArgumentException("Unsupported HTTP version "
+                        + serverVersion);
+            }
         }
 
         private static class Http1TestServer extends  HttpTestServer {


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

test/jdk/java/net/httpclient/CancelRequestTest.java
test/jdk/java/net/httpclient/HeadTest.java
Resolved imports.

Omitted files:
test/jdk/java/net/httpclient/AsyncExecutorShutdown.java
test/jdk/java/net/httpclient/CancelStreamedBodyTest.java
test/jdk/java/net/httpclient/ExecutorShutdown.java
test/jdk/java/net/httpclient/ExpectContinueTest.java
test/jdk/java/net/httpclient/Response1xxTest.java
All these already had to be omitted in https://github.com/openjdk/jdk17u-dev/pull/2311,
they all came with new features or other changes that should
not be backported as prereq.
