### PR TITLE
8302512: Update IANA Language Subtag Registry to Version 2023-02-14

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2022-08-08
+File-Date: 2023-02-14
 %%
 Type: language
 Subtag: aa
@@ -26378,6 +26378,7 @@ Type: language
 Subtag: nrf
 Description: Jèrriais
 Description: Guernésiais
+Description: Sercquiais
 Added: 2015-02-12
 %%
 Type: language
@@ -46011,6 +46012,11 @@ Type: region
 Subtag: CP
 Description: Clipperton Island
 Added: 2009-07-29
+%%
+Type: region
+Subtag: CQ
+Description: Sark
+Added: 2023-02-07
 %%
 Type: region
 Subtag: CR

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038
+ *      8258795 8267038 8287180 8302512
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2022-08-08) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-02-14) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

Clean except for different file location. Marked Clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8302512](https://bugs.openjdk.org/browse/JDK-8302512) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302512](https://bugs.openjdk.org/browse/JDK-8302512): Update IANA Language Subtag Registry to Version 2023-02-14 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2355/head:pull/2355` \
`$ git checkout pull/2355`

Update a local copy of the PR: \
`$ git checkout pull/2355` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2355`

View PR using the GUI difftool: \
`$ git pr show -t 2355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2355.diff">https://git.openjdk.org/jdk17u-dev/pull/2355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2355#issuecomment-2032108503)