### PR TITLE
8296190: TestMD5Intrinsics and TestMD5MultiBlockIntrinsics don't test the intrinsics

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/DigestSanityTestBase.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/DigestSanityTestBase.java
@@ -54,7 +54,7 @@ public class DigestSanityTestBase {
     private static final int MSG_SIZE = 1024;
     private static final int OFFSET = 0;
     private static final int ITERATIONS = 10000;
-    private static final int WARMUP_ITERATIONS = 1;
+    private static final int WARMUP_ITERATIONS = WHITE_BOX.getIntxVMFlag("Tier4InvocationThreshold").intValue() + 50;
     private static final String PROVIDER = "SUN";
 
     private final BooleanSupplier predicate;


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296190](https://bugs.openjdk.org/browse/JDK-8296190) needs maintainer approval

### Issue
 * [JDK-8296190](https://bugs.openjdk.org/browse/JDK-8296190): TestMD5Intrinsics and TestMD5MultiBlockIntrinsics don't test the intrinsics (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2357/head:pull/2357` \
`$ git checkout pull/2357`

Update a local copy of the PR: \
`$ git checkout pull/2357` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2357`

View PR using the GUI difftool: \
`$ git pr show -t 2357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2357.diff">https://git.openjdk.org/jdk17u-dev/pull/2357.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2357#issuecomment-2032201524)