### PR TITLE
8309630: Clean up tests that reference deploy modules

### DIFF
--- a/test/jdk/java/lang/SecurityManager/CheckAccessClassInPackagePermissions.java
+++ b/test/jdk/java/lang/SecurityManager/CheckAccessClassInPackagePermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,9 +50,6 @@ import java.util.stream.Stream;
 
 public class CheckAccessClassInPackagePermissions {
 
-    private static final String[] deployModules = {
-        "jdk.javaws", "jdk.plugin", "jdk.plugin.server", "jdk.deploy" };
-
     public static void main(String[] args) throws Exception {
 
         // Get the modules in the boot layer loaded by the boot or platform
@@ -91,15 +88,8 @@ public class CheckAccessClassInPackagePermissions {
         // Check if each target module has the right permissions to access
         // its qualified exports
         Policy policy = Policy.getPolicy();
-        List<String> deployMods = Arrays.asList(deployModules);
         for (Map.Entry<String, List<String>> me : map.entrySet()) {
             String moduleName = me.getKey();
-
-            // skip deploy modules since they are granted permissions in
-            // deployment policy file
-            if (deployMods.contains(moduleName)) {
-                continue;
-            }
 
             // is this a module loaded by the platform loader?
             Optional<Module> module = bootLayer.findModule(moduleName);

--- a/test/jdk/tools/jimage/VerifyJimage.java
+++ b/test/jdk/tools/jimage/VerifyJimage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,18 +195,13 @@ public class VerifyJimage {
                     .replaceAll("\\.class$", "").replace('/', '.');
     }
 
-    private static Set<String> EXCLUDED_MODULES =
-        Set.of("javafx.deploy", "jdk.deploy", "jdk.plugin", "jdk.javaws",
-            // All JVMCI packages other than jdk.vm.ci.services are dynamically
-            // exported to jdk.internal.vm.compiler
-            "jdk.internal.vm.compiler"
-        );
+    // All JVMCI packages other than jdk.vm.ci.services are dynamically
+    // exported to jdk.internal.vm.compiler
+    private static Set<String> EXCLUDED_MODULES = Set.of("jdk.internal.vm.compiler");
 
     private boolean accept(String entry) {
         int index = entry.indexOf('/', 1);
         String mn = index > 1 ? entry.substring(1, index) : "";
-        // filter deployment modules
-
         if (mn.isEmpty() || EXCLUDED_MODULES.contains(mn)) {
             return false;
         }


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8309630](https://bugs.openjdk.org/browse/JDK-8309630) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309630](https://bugs.openjdk.org/browse/JDK-8309630): Clean up tests that reference deploy modules (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2361/head:pull/2361` \
`$ git checkout pull/2361`

Update a local copy of the PR: \
`$ git checkout pull/2361` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2361`

View PR using the GUI difftool: \
`$ git pr show -t 2361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2361.diff">https://git.openjdk.org/jdk17u-dev/pull/2361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2361#issuecomment-2032236025)