### PR TITLE
8295026: Remove unused fields in StyleSheet

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1821,8 +1821,6 @@ public class StyleSheet extends StyleContext {
     }
 
 
-    static final Border noBorder = new EmptyBorder(0,0,0,0);
-
     /**
      * Class to carry out some of the duties of
      * CSS formatting.  Implementations of this
@@ -2523,7 +2521,6 @@ public class StyleSheet extends StyleContext {
         private boolean checkedForStart;
         private int start;
         private CSS.Value type;
-        URL imageurl;
         private StyleSheet ss = null;
         Icon img = null;
         private int bulletgap = 5;
@@ -3226,8 +3223,6 @@ public class StyleSheet extends StyleContext {
 
 
     // ---- Variables ---------------------------------------------
-
-    static final int DEFAULT_FONT_SIZE = 3;
 
     private transient Object fontSizeInherit;
 


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8295026](https://bugs.openjdk.org/browse/JDK-8295026) needs maintainer approval

### Issue
 * [JDK-8295026](https://bugs.openjdk.org/browse/JDK-8295026): Remove unused fields in StyleSheet (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2363/head:pull/2363` \
`$ git checkout pull/2363`

Update a local copy of the PR: \
`$ git checkout pull/2363` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2363`

View PR using the GUI difftool: \
`$ git pr show -t 2363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2363.diff">https://git.openjdk.org/jdk17u-dev/pull/2363.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2363#issuecomment-2034483299)