### PR TITLE
8306031: Update IANA Language Subtag Registry to Version 2023-04-13

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2023-03-22
+File-Date: 2023-04-13
 %%
 Type: language
 Subtag: aa
@@ -42986,7 +42986,7 @@ Subtag: ajp
 Description: South Levantine Arabic
 Added: 2009-07-29
 Deprecated: 2023-03-17
-Preferred-Value: apc
+Preferred-Value: ajp
 Prefix: ar
 Macrolanguage: ar
 %%

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -262,7 +262,7 @@ public class EquivMapsGenerator {
         + "    static final Map<String, String[]> multiEquivsMap;\n"
         + "    static final Map<String, String> regionVariantEquivMap;\n\n"
         + "    static {\n"
-        + "        singleEquivMap = HashMap.newHashMap(";
+        + "        singleEquivMap = new HashMap<>(";
 
     private static final String footerText =
         "    }\n\n"
@@ -285,9 +285,9 @@ public class EquivMapsGenerator {
             writer.write(getOpenJDKCopyright());
             writer.write(headerText
                 + sortedLanguageMap1.size() + ");\n"
-                + "        multiEquivsMap = HashMap.newHashMap("
+                + "        multiEquivsMap = new HashMap<>("
                 + sortedLanguageMap2.size() + ");\n"
-                + "        regionVariantEquivMap = HashMap.newHashMap("
+                + "        regionVariantEquivMap = new HashMap<>("
                 + sortedRegionVariantMap.size() + ");\n\n"
                 + "        // This is an auto-generated file and should not be manually edited.\n"
                 + "        //   LSR Revision: " + LSRrevisionDate);

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
+import java.util.regex.Pattern;
 
 /**
  * This tool reads the IANA Language Subtag Registry data file downloaded from
@@ -138,10 +138,29 @@ public class EquivMapsGenerator {
             }
         } else { // language, extlang, legacy, and redundant
             if (!initialLanguageMap.containsKey(preferred)) {
-                sb = new StringBuilder(preferred);
-                sb.append(',');
-                sb.append(tag);
-                initialLanguageMap.put(preferred, sb);
+                // IANA update 4/13 introduced case where a preferred value
+                // can have a preferred value itself.
+                // eg: ar-ajp has pref ajp which has pref apc
+                boolean foundInOther = false;
+                Pattern pattern = Pattern.compile(","+preferred+"(,|$)");
+                // Check if current pref exists inside a value for another pref
+                List<StringBuilder> doublePrefs = initialLanguageMap
+                        .values()
+                        .stream()
+                        .filter(e -> pattern.matcher(e.toString()).find())
+                        .toList();
+                for (StringBuilder otherPrefVal : doublePrefs) {
+                    otherPrefVal.append(",");
+                    otherPrefVal.append(tag);
+                    foundInOther = true;
+                }
+                if (!foundInOther) {
+                    // does not exist in any other pref's values, so add as new entry
+                    sb = new StringBuilder(preferred);
+                    sb.append(',');
+                    sb.append(tag);
+                    initialLanguageMap.put(preferred, sb);
+                }
             } else {
                 sb = initialLanguageMap.get(preferred);
                 sb.append(',');
@@ -158,7 +177,7 @@ public class EquivMapsGenerator {
             // "yue" is defined both as extlang and redundant. Remove the dup.
             subtags = Arrays.stream(initialLanguageMap.get(preferred).toString().split(","))
                     .distinct()
-                    .collect(Collectors.toList())
+                    .toList()
                     .toArray(new String[0]);
 
             if (subtags.length == 2) {
@@ -243,7 +262,7 @@ public class EquivMapsGenerator {
         + "    static final Map<String, String[]> multiEquivsMap;\n"
         + "    static final Map<String, String> regionVariantEquivMap;\n\n"
         + "    static {\n"
-        + "        singleEquivMap = new HashMap<>(";
+        + "        singleEquivMap = HashMap.newHashMap(";
 
     private static final String footerText =
         "    }\n\n"
@@ -265,11 +284,11 @@ public class EquivMapsGenerator {
                 Paths.get(fileName))) {
             writer.write(getOpenJDKCopyright());
             writer.write(headerText
-                + (int)(sortedLanguageMap1.size() / 0.75f + 1) + ");\n"
-                + "        multiEquivsMap = new HashMap<>("
-                + (int)(sortedLanguageMap2.size() / 0.75f + 1) + ");\n"
-                + "        regionVariantEquivMap = new HashMap<>("
-                + (int)(sortedRegionVariantMap.size() / 0.75f + 1) + ");\n\n"
+                + sortedLanguageMap1.size() + ");\n"
+                + "        multiEquivsMap = HashMap.newHashMap("
+                + sortedLanguageMap2.size() + ");\n"
+                + "        regionVariantEquivMap = HashMap.newHashMap("
+                + sortedRegionVariantMap.size() + ");\n\n"
                 + "        // This is an auto-generated file and should not be manually edited.\n"
                 + "        //   LSR Revision: " + LSRrevisionDate);
             writer.newLine();

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038 8287180 8302512 8304761
+ *      8258795 8267038 8287180 8302512 8304761 8306031
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2023-03-22) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-04-13) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */
@@ -44,7 +44,7 @@ public class LanguageSubtagRegistryTest {
     static boolean err = false;
 
     private static final String ACCEPT_LANGUAGE =
-        "Accept-Language: aam, adp, aeb, ajs, aog, apc, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
+        "Accept-Language: aam, adp, aeb, ajs, aog, apc, ajp, aue, bcg, bic, bpp, cey, cbr, cnp, cqu, crr, csp, csx, dif, dmw, dsz, ehs, ema,"
         + " en-gb-oed, gti, iba, jks, kdz, kjh, kmb, koj, kru, ksp, kwq, kxe, kzk, lgs, lii, lmm, lsb, lsc, lsn, lsv, lsw, lvi, mtm,"
         + " ngv, nns, ola, oyb, pat, phr, plu, pnd, pub, rib, rnb, rsn, scv, snz, sqx, suj, szy, taj, tdg, tjj, tjp, tpn, tvx,"
         + " umi, uss, uth, ysm, zko, wkr;q=0.9, ar-hyw;q=0.8, yug;q=0.5, gfx;q=0.4";


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

Resolved Copyright and file location. 

I had to remove some modern Java constructs not supported by 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306031](https://bugs.openjdk.org/browse/JDK-8306031) needs maintainer approval

### Issue
 * [JDK-8306031](https://bugs.openjdk.org/browse/JDK-8306031): Update IANA Language Subtag Registry to Version 2023-04-13 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2364/head:pull/2364` \
`$ git checkout pull/2364`

Update a local copy of the PR: \
`$ git checkout pull/2364` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2364`

View PR using the GUI difftool: \
`$ git pr show -t 2364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2364.diff">https://git.openjdk.org/jdk17u-dev/pull/2364.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2364#issuecomment-2034487335)