### PR TITLE
8325862: set -XX:+ErrorFileToStderr when executing java in containers for some container related jtreg tests

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,9 @@ public class DockerRunOptions {
         this.command = javaCmd;
         this.classToRun = classToRun;
         this.addJavaOpts(javaOpts);
+        // always print hserr to stderr in the docker tests to avoid
+        // trouble accessing it after a crash in the container
+        this.addJavaOpts("-XX:+ErrorFileToStderr");
     }
 
     public DockerRunOptions addDockerOpts(String... opts) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8325862](https://bugs.openjdk.org/browse/JDK-8325862) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325862](https://bugs.openjdk.org/browse/JDK-8325862): set -XX:+ErrorFileToStderr when executing java in containers for some container related jtreg tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2365/head:pull/2365` \
`$ git checkout pull/2365`

Update a local copy of the PR: \
`$ git checkout pull/2365` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2365`

View PR using the GUI difftool: \
`$ git pr show -t 2365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2365.diff">https://git.openjdk.org/jdk17u-dev/pull/2365.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2365#issuecomment-2034503907)