### PR TITLE
8290126: Add a check in JavadocTester for "javadoc should not crash"

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/InheritDocForUserTags/DocTest.java
+++ b/test/langtools/jdk/javadoc/doclet/InheritDocForUserTags/DocTest.java
@@ -58,10 +58,6 @@ public class DocTest extends JavadocTester {
                 testSrc("DocTest.java")
         );
         checkExit(Exit.OK);
-
-        // javadoc does not report an exit code for an internal exception (!)
-        // so monitor stderr for stack dumps.
-        checkOutput(Output.STDERR, false, "at com.sun");
     }
 
     /**

--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
@@ -213,7 +213,7 @@ public abstract class JavadocTester {
         NONE(null) { @Override void check(Path dir) { } };
 
         /** The filter used to detect that files should <i>not</i> be present. */
-        DirectoryStream.Filter<Path> filter;
+        private final DirectoryStream.Filter<Path> filter;
 
         DirectoryCheck(DirectoryStream.Filter<Path> f) {
             filter = f;
@@ -245,6 +245,7 @@ public abstract class JavadocTester {
     private boolean automaticCheckAccessibility = true;
     private boolean automaticCheckLinks = true;
     private boolean automaticCheckUniqueOUT = true;
+    private boolean automaticCheckNoStacktrace = true;
     private boolean useStandardStreams = false;
 
     /** The current subtest number. Incremented when checking(...) is called. */
@@ -478,6 +479,11 @@ public abstract class JavadocTester {
             }
         });
 
+        if (automaticCheckNoStacktrace) {
+            // Any stacktrace will have javadoc near the bottom of the stack
+            checkOutput(Output.STDERR, false, "at jdk.javadoc/jdk.javadoc.internal.");
+        }
+
         if (exitCode == Exit.OK.code && Files.exists(outputDir)) {
             if (automaticCheckLinks) {
                 checkLinks();
@@ -521,6 +527,13 @@ public abstract class JavadocTester {
      */
     public void setAutomaticCheckUniqueOUT(boolean b) {
         automaticCheckUniqueOUT = b;
+    }
+
+    /**
+     * Sets whether or not to check for stacktraces.
+     */
+    public void setAutomaticCheckNoStacktrace(boolean b) {
+        automaticCheckNoStacktrace = b;
     }
 
     /**
@@ -1128,7 +1141,7 @@ public abstract class JavadocTester {
         public OutputChecker check(String... strings) {
             if (name == null) {
                 out.println("Skipping checks for:" + NL
-                        + List.of(strings).stream()
+                        + Stream.of(strings)
                         .map(s -> "    " + toShortString(s))
                         .collect(Collectors.joining(NL)));
                 return this;
@@ -1150,7 +1163,7 @@ public abstract class JavadocTester {
         public OutputChecker check(Pattern... patterns) {
             if (name == null) {
                 out.println("Skipping checks for:" + NL
-                        + List.of(patterns).stream()
+                        + Stream.of(patterns)
                         .map(p -> "    " + toShortString(p.pattern()))
                         .collect(Collectors.joining(NL)));
                 return this;

--- a/test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTester.java
+++ b/test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTester.java
@@ -63,7 +63,7 @@ public class TestJavadocTester extends JavadocTester {
         tester.setup().runTests();
     }
 
-    private final List<String> messages = new ArrayList<>();
+    protected final List<String> messages = new ArrayList<>();
     private int testErrors = 0;
 
     /**
@@ -158,7 +158,7 @@ public class TestJavadocTester extends JavadocTester {
 
     //-------------------------------------------------
 
-    private final ToolBox tb = new ToolBox();
+    protected final ToolBox tb = new ToolBox();
 
     TestJavadocTester setup() throws IOException {
         Path src = Path.of("src");


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

Omitted patch for test/langtools/jdk/javadoc/testTFMBuilder/TestTFMBuilder.java
which was added by " 8276892: Provide a way to emulate exceptional situations in FileManager when using JavadocTester" in 19.

Will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8290126](https://bugs.openjdk.org/browse/JDK-8290126) needs maintainer approval

### Issue
 * [JDK-8290126](https://bugs.openjdk.org/browse/JDK-8290126): Add a check in JavadocTester for "javadoc should not crash" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2369/head:pull/2369` \
`$ git checkout pull/2369`

Update a local copy of the PR: \
`$ git checkout pull/2369` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2369`

View PR using the GUI difftool: \
`$ git pr show -t 2369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2369.diff">https://git.openjdk.org/jdk17u-dev/pull/2369.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2369#issuecomment-2034744909)