### PR TITLE
8315652: RISC-V: Features string uses wrong separator for jtreg

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -108,7 +108,7 @@ void VM_Version::setup_cpu_available_features() {
   char buf[1024] = {};
   if (uarch != nullptr && strcmp(uarch, "") != 0) {
     // Use at max half the buffer.
-    snprintf(buf, sizeof(buf)/2, "%s,", uarch);
+    snprintf(buf, sizeof(buf)/2, "%s ", uarch);
   }
   os::free((void*) uarch);
   strcat(buf, "rv64");
@@ -122,13 +122,14 @@ void VM_Version::setup_cpu_available_features() {
       if (_feature_list[i]->feature_string()) {
         const char* tmp = _feature_list[i]->pretty();
         if (strlen(tmp) == 1) {
+          strcat(buf, " ");
           strcat(buf, tmp);
         } else {
           // Feature string is expected to be lower case.
           // Turn Zxxx into zxxx
           char prebuf[3] = {};
           assert(strlen(tmp) > 1, "Must be");
-          prebuf[0] = '_';
+          prebuf[0] = ' ';
           prebuf[1] = (char)tolower(tmp[0]);
           strcat(buf, prebuf);
           strcat(buf, &tmp[1]);


### PR DESCRIPTION
Hi, I would like to backport https://bugs.openjdk.org/browse/JDK-8315652 to jdk17u-dev. With this backport, features string looks more reasonable and it will be easier to match specific extensions e.g. vector. It will also be easier to backport jdk mainline test cases to jdk17u-dev in the future. RISC-V specific change, risk is low.

### Testing
- [x]  Run tier1 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315652](https://bugs.openjdk.org/browse/JDK-8315652) needs maintainer approval

### Issue
 * [JDK-8315652](https://bugs.openjdk.org/browse/JDK-8315652): RISC-V: Features string uses wrong separator for jtreg (**Bug** - P4 - Approved)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2377/head:pull/2377` \
`$ git checkout pull/2377`

Update a local copy of the PR: \
`$ git checkout pull/2377` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2377/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2377`

View PR using the GUI difftool: \
`$ git pr show -t 2377`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2377.diff">https://git.openjdk.org/jdk17u-dev/pull/2377.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2377#issuecomment-2041416656)