### PR TITLE
8297695: Fix typos in test/langtools files

### DIFF
--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
@@ -730,7 +730,7 @@ public abstract class JavadocTester {
 
     /**
      * Shows the heading structure for each of the specified files.
-     * The structure is is printed in plain text to the main output stream.
+     * The structure is printed in plain text to the main output stream.
      * No errors are reported (unless there is a problem reading a file)
      * but missing headings are noted within the output.
      *

--- a/test/langtools/tools/javac/VersionOpt.java
+++ b/test/langtools/tools/javac/VersionOpt.java
@@ -46,7 +46,7 @@ public class VersionOpt {
         // As such, it is only effective in testing the "standard" compiler,
         // and not any development version being tested via --patch-modules.
         // Check the version of the compiler being used, and let the test pass
-        // automatically if is is a development version.
+        // automatically if it is a development version.
         Class<?> javacClass = com.sun.tools.javac.Main.class;
         URL location = javacClass.getProtectionDomain().getCodeSource().getLocation();
         if (!location.toString().equals("jrt:/jdk.compiler")) {

--- a/test/langtools/tools/javac/annotations/typeAnnotations/classfile/CombinationsTargetTest2.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/classfile/CombinationsTargetTest2.java
@@ -42,7 +42,7 @@ public class CombinationsTargetTest2 extends ClassfileTestHelper {
 
     // Base test case template descriptions;true==annotations in code attribute.
     enum srce  {
-        src1("(repeating) type annotations on on field in method body",true),
+        src1("(repeating) type annotations on field in method body",true),
         src2("(repeating) type annotations on type parameters, bounds and  type arguments", true),
         src3("(repeating) type annotations on type parameters of class, method return value in method", true),
         src4("(repeating) type annotations on field in anonymous class", false),

--- a/test/langtools/tools/javac/diags/ArgTypeCompilerFactory.java
+++ b/test/langtools/tools/javac/diags/ArgTypeCompilerFactory.java
@@ -43,7 +43,7 @@ import javax.lang.model.SourceVersion;
 /**
  * Compiler factory for instances of Example.Compiler that use custom
  * DiagnosticFormatter and Messages objects to track the types of args
- * when when localizing diagnostics.
+ * when localizing diagnostics.
  * The compiler objects only support "output" mode, not "check" mode.
  */
 class ArgTypeCompilerFactory implements Example.Compiler.Factory {

--- a/test/langtools/tools/javac/lambda/VoidCompatibility.java
+++ b/test/langtools/tools/javac/lambda/VoidCompatibility.java
@@ -2,7 +2,7 @@
  * @test /nodynamiccopyright/
  * @bug 8003280
  * @summary Add lambda tests
- *  check that that void compatibility affects overloading as expected
+ *  check that void compatibility affects overloading as expected
  * @compile VoidCompatibility.java
  */
 class VoidCompatibility {

--- a/test/langtools/tools/javac/processing/filer/TestFilerConstraints.java
+++ b/test/langtools/tools/javac/processing/filer/TestFilerConstraints.java
@@ -168,7 +168,7 @@ public class TestFilerConstraints extends JavacTestingAbstractProcessor {
     }
 
     /**
-     * Test that the single expected expected type, name, is the root
+     * Test that the single expected type, name, is the root
      * element.
      */
     private void testExpectedType(RoundEnvironment roundEnv, String name) {

--- a/test/langtools/tools/javac/scope/DupUnsharedTest.java
+++ b/test/langtools/tools/javac/scope/DupUnsharedTest.java
@@ -125,7 +125,7 @@ public class DupUnsharedTest {
     }
 
     /**
-     * This tests tests the following situation.
+     * This tests the following situation.
      * - consider empty Scope S1
      * - a Symbol with name 'A' is added into S1
      * - S1 is dupped into S2

--- a/test/langtools/tools/javac/tree/T8024415.java
+++ b/test/langtools/tools/javac/tree/T8024415.java
@@ -86,7 +86,7 @@ public class T8024415 {
     }
 
 
-    // The true-part of of a conditional expression is surrounded by ? and :
+    // The true-part of a conditional expression is surrounded by ? and :
     // and can thus always be parsed unambiguously without surrounding
     // parentheses.
     public void testPrecedence() throws IOException {

--- a/test/langtools/tools/javac/warnings/6594914/T6594914a.java
+++ b/test/langtools/tools/javac/warnings/6594914/T6594914a.java
@@ -1,7 +1,7 @@
 /**
  * @test /nodynamiccopyright/
  * @bug 6594914
- * @summary \\@SuppressWarnings("deprecation") does not not work for the type of a variable
+ * @summary \\@SuppressWarnings("deprecation") does not work for the type of a variable
  * @compile/ref=T6594914a.out -XDrawDiagnostics -Xlint:deprecation T6594914a.java
  */
 

--- a/test/langtools/tools/lib/builder/ClassBuilder.java
+++ b/test/langtools/tools/lib/builder/ClassBuilder.java
@@ -550,7 +550,7 @@ public class ClassBuilder extends AbstractBuilder {
         }
 
         /**
-         * Adds a parameter(s) to the method method builder.
+         * Adds a parameter(s) to the method builder.
          * @param params a pair consisting of type and parameter name.
          * @return this method builder.
          */
@@ -560,7 +560,7 @@ public class ClassBuilder extends AbstractBuilder {
         }
 
         /**
-         * Adds a parameter to the method method builder.
+         * Adds a parameter to the method builder.
          * @param type the type of parameter.
          * @param name the parameter name.
          * @return this method builder.


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

Resolved JavadocTester because of extra line at end of file.
Will mark clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297695](https://bugs.openjdk.org/browse/JDK-8297695) needs maintainer approval

### Issue
 * [JDK-8297695](https://bugs.openjdk.org/browse/JDK-8297695): Fix typos in test/langtools files (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2383/head:pull/2383` \
`$ git checkout pull/2383`

Update a local copy of the PR: \
`$ git checkout pull/2383` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2383`

View PR using the GUI difftool: \
`$ git pr show -t 2383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2383.diff">https://git.openjdk.org/jdk17u-dev/pull/2383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2383#issuecomment-2045829292)