### PR TITLE
8286311: remove boilerplate from use of runTests

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/5093723/T5093723.java
+++ b/test/langtools/jdk/javadoc/doclet/5093723/T5093723.java
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class T5093723 extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        T5093723 tester = new T5093723();
+        var tester = new T5093723();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/AccessAsciiArt/AccessAsciiArt.java
+++ b/test/langtools/jdk/javadoc/doclet/AccessAsciiArt/AccessAsciiArt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class AccessAsciiArt extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        AccessAsciiArt tester = new AccessAsciiArt();
+        var tester = new AccessAsciiArt();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/AccessH1/AccessH1.java
+++ b/test/langtools/jdk/javadoc/doclet/AccessH1/AccessH1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class AccessH1 extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        AccessH1 tester = new AccessH1();
+        var tester = new AccessH1();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/AccessSkipNav/AccessSkipNav.java
+++ b/test/langtools/jdk/javadoc/doclet/AccessSkipNav/AccessSkipNav.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class AccessSkipNav extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        AccessSkipNav tester = new AccessSkipNav();
+        var tester = new AccessSkipNav();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/AccessSummary/AccessSummary.java
+++ b/test/langtools/jdk/javadoc/doclet/AccessSummary/AccessSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class AccessSummary extends JavadocTester {
      * @throws Exception if the test fails
      */
     public static void main(String... args) throws Exception {
-        AccessSummary tester = new AccessSummary();
+        var tester = new AccessSummary();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/AuthorDD/AuthorDD.java
+++ b/test/langtools/jdk/javadoc/doclet/AuthorDD/AuthorDD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class AuthorDD extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        AuthorDD tester = new AuthorDD();
+        var tester = new AuthorDD();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/DocRootSlash/DocRootSlash.java
+++ b/test/langtools/jdk/javadoc/doclet/DocRootSlash/DocRootSlash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import javadoc.tester.JavadocTester;
 public class DocRootSlash extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        DocRootSlash tester = new DocRootSlash();
+        var tester = new DocRootSlash();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/InheritDocForUserTags/DocTest.java
+++ b/test/langtools/jdk/javadoc/doclet/InheritDocForUserTags/DocTest.java
@@ -42,7 +42,7 @@ import javadoc.tester.JavadocTester;
  */
 public class DocTest extends JavadocTester {
     public static void main(String... args) throws Exception {
-        DocTest tester = new DocTest();
+        var tester = new DocTest();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/JavascriptWinTitle/JavascriptWinTitle.java
+++ b/test/langtools/jdk/javadoc/doclet/JavascriptWinTitle/JavascriptWinTitle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class JavascriptWinTitle extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        JavascriptWinTitle tester = new JavascriptWinTitle();
+        var tester = new JavascriptWinTitle();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/MetaTag/MetaTag.java
+++ b/test/langtools/jdk/javadoc/doclet/MetaTag/MetaTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class MetaTag extends JavadocTester {
      * @throws Exception if the test fails
      */
     public static void main(String... args) throws Exception {
-        MetaTag tester = new MetaTag();
+        var tester = new MetaTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/T6735320/T6735320.java
+++ b/test/langtools/jdk/javadoc/doclet/T6735320/T6735320.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class T6735320 extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        T6735320 tester = new T6735320();
+        var tester = new T6735320();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/ValidHtml/ValidHtml.java
+++ b/test/langtools/jdk/javadoc/doclet/ValidHtml/ValidHtml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class ValidHtml extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        ValidHtml tester = new ValidHtml();
+        var tester = new ValidHtml();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/VersionNumber/VersionNumber.java
+++ b/test/langtools/jdk/javadoc/doclet/VersionNumber/VersionNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import javadoc.tester.JavadocTester;
 public class VersionNumber extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        VersionNumber tester = new VersionNumber();
+        var tester = new VersionNumber();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/WindowTitles/WindowTitles.java
+++ b/test/langtools/jdk/javadoc/doclet/WindowTitles/WindowTitles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class WindowTitles extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        WindowTitles tester = new WindowTitles();
+        var tester = new WindowTitles();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/constantValues/TestConstantValuesDriver.java
+++ b/test/langtools/jdk/javadoc/doclet/constantValues/TestConstantValuesDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import javadoc.tester.JavadocTester;
 public class TestConstantValuesDriver extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestConstantValuesDriver tester = new TestConstantValuesDriver();
+        var tester = new TestConstantValuesDriver();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/dupThrowsTags/TestDupThrowsTags.java
+++ b/test/langtools/jdk/javadoc/doclet/dupThrowsTags/TestDupThrowsTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import javadoc.tester.JavadocTester;
 public class TestDupThrowsTags extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDupThrowsTags tester = new TestDupThrowsTags();
+        var tester = new TestDupThrowsTags();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testAbsLinkPath/TestAbsLinkPath.java
+++ b/test/langtools/jdk/javadoc/doclet/testAbsLinkPath/TestAbsLinkPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestAbsLinkPath extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestAbsLinkPath tester = new TestAbsLinkPath();
+        var tester = new TestAbsLinkPath();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testAbstractMethod/TestAbstractMethod.java
+++ b/test/langtools/jdk/javadoc/doclet/testAbstractMethod/TestAbstractMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestAbstractMethod extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestAbstractMethod tester = new TestAbstractMethod();
+        var tester = new TestAbstractMethod();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testAnchorNames/TestAnchorNames.java
+++ b/test/langtools/jdk/javadoc/doclet/testAnchorNames/TestAnchorNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ public class TestAnchorNames extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestAnchorNames tester = new TestAnchorNames();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestAnchorNames();
+        tester.runTests();
     }
 
     public TestAnchorNames() {

--- a/test/langtools/jdk/javadoc/doclet/testAnnotationOptional/TestAnnotationOptional.java
+++ b/test/langtools/jdk/javadoc/doclet/testAnnotationOptional/TestAnnotationOptional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestAnnotationOptional extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestAnnotationOptional tester = new TestAnnotationOptional();
+        var tester = new TestAnnotationOptional();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testAnnotationTypes/TestAnnotationTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testAnnotationTypes/TestAnnotationTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestAnnotationTypes extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestAnnotationTypes tester = new TestAnnotationTypes();
+        var tester = new TestAnnotationTypes();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testAuthor/TestAuthor.java
+++ b/test/langtools/jdk/javadoc/doclet/testAuthor/TestAuthor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import toolbox.ToolBox;
 public class TestAuthor extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestAuthor tester = new TestAuthor();
+        var tester = new TestAuthor();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testAutoLoadTaglets/TestAutoLoadTaglets.java
+++ b/test/langtools/jdk/javadoc/doclet/testAutoLoadTaglets/TestAutoLoadTaglets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ public class TestAutoLoadTaglets extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestAutoLoadTaglets tester = new TestAutoLoadTaglets();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestAutoLoadTaglets();
+        tester.runTests();
     }
 
     TestAutoLoadTaglets() {

--- a/test/langtools/jdk/javadoc/doclet/testBackSlashInLink/TestBackSlashInLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testBackSlashInLink/TestBackSlashInLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestBackSlashInLink extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestBackSlashInLink tester = new TestBackSlashInLink();
+        var tester = new TestBackSlashInLink();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testBadHtml/TestBadHtml.java
+++ b/test/langtools/jdk/javadoc/doclet/testBadHtml/TestBadHtml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestBadHtml extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestBadHtml tester = new TestBadHtml();
+        var tester = new TestBadHtml();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testBadPackageFileInJar/TestBadPackageFileInJar.java
+++ b/test/langtools/jdk/javadoc/doclet/testBadPackageFileInJar/TestBadPackageFileInJar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class TestBadPackageFileInJar extends JavadocTester {
     final ToolBox tb = new ToolBox();
 
     public static void main(String... args) throws Exception {
-        TestBadPackageFileInJar tester = new TestBadPackageFileInJar();
+        var tester = new TestBadPackageFileInJar();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testBadSourceFile/TestBadSourceFile.java
+++ b/test/langtools/jdk/javadoc/doclet/testBadSourceFile/TestBadSourceFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class TestBadSourceFile extends JavadocTester {
      * @throws Exception if the test fails
      */
     public static void main(String... args) throws Exception {
-        TestBadSourceFile tester = new TestBadSourceFile();
+        var tester = new TestBadSourceFile();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testBaseClass/TestBaseClass.java
+++ b/test/langtools/jdk/javadoc/doclet/testBaseClass/TestBaseClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestBaseClass extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestBaseClass tester = new TestBaseClass();
+        var tester = new TestBaseClass();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testBimodalTaglets/TestBimodalTaglets.java
+++ b/test/langtools/jdk/javadoc/doclet/testBimodalTaglets/TestBimodalTaglets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ import toolbox.ToolBox;
 
 public class TestBimodalTaglets extends JavadocTester implements Taglet {
     public static void main(String... args) throws Exception {
-        new TestBimodalTaglets().runTests(m -> new Object[] { Path.of(m.getName()) });
+        new TestBimodalTaglets().runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testBreakIterator/TestBreakIterator.java
+++ b/test/langtools/jdk/javadoc/doclet/testBreakIterator/TestBreakIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestBreakIterator extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestBreakIterator tester = new TestBreakIterator();
+        var tester = new TestBreakIterator();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testCRLineSeparator/TestCRLineSeparator.java
+++ b/test/langtools/jdk/javadoc/doclet/testCRLineSeparator/TestCRLineSeparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestCRLineSeparator extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestCRLineSeparator tester = new TestCRLineSeparator();
+        var tester = new TestCRLineSeparator();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testCharset/TestCharset.java
+++ b/test/langtools/jdk/javadoc/doclet/testCharset/TestCharset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestCharset extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestCharset tester = new TestCharset();
+        var tester = new TestCharset();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testCharsetDocencodingOptions/TestCharsetDocencodingOptions.java
+++ b/test/langtools/jdk/javadoc/doclet/testCharsetDocencodingOptions/TestCharsetDocencodingOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestCharsetDocencodingOptions extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestCharsetDocencodingOptions tester = new TestCharsetDocencodingOptions();
+        var tester = new TestCharsetDocencodingOptions();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testClassCrossReferences/TestClassCrossReferences.java
+++ b/test/langtools/jdk/javadoc/doclet/testClassCrossReferences/TestClassCrossReferences.java
@@ -39,7 +39,7 @@ public class TestClassCrossReferences extends JavadocTester {
     static final String uri = "http://docs.oracle.com/javase/8/docs/api/";
 
     public static void main(String... args) throws Exception {
-        TestClassCrossReferences tester = new TestClassCrossReferences();
+        var tester = new TestClassCrossReferences();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testClassLinks/TestClassLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testClassLinks/TestClassLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestClassLinks extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestClassLinks tester = new TestClassLinks();
+        var tester = new TestClassLinks();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testClassTree/TestClassTree.java
+++ b/test/langtools/jdk/javadoc/doclet/testClassTree/TestClassTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestClassTree extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestClassTree tester = new TestClassTree();
+        var tester = new TestClassTree();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testCmndLineClass/TestCmndLineClass.java
+++ b/test/langtools/jdk/javadoc/doclet/testCmndLineClass/TestCmndLineClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestCmndLineClass extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestCmndLineClass tester = new TestCmndLineClass();
+        var tester = new TestCmndLineClass();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testCompletionFailure/TestCompletionFailure.java
+++ b/test/langtools/jdk/javadoc/doclet/testCompletionFailure/TestCompletionFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestCompletionFailure extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestCompletionFailure tester = new TestCompletionFailure();
+        var tester = new TestCompletionFailure();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testConditionalPages/TestConditionalPages.java
+++ b/test/langtools/jdk/javadoc/doclet/testConditionalPages/TestConditionalPages.java
@@ -44,8 +44,8 @@ import toolbox.ToolBox;
 public class TestConditionalPages extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestConditionalPages tester = new TestConditionalPages();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestConditionalPages();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testConstantValuesPage/TestConstantValuesPage.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstantValuesPage/TestConstantValuesPage.java
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestConstantValuesPage extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestConstantValuesPage tester = new TestConstantValuesPage();
+        var tester = new TestConstantValuesPage();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testConstructorIndent/TestConstructorIndent.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstructorIndent/TestConstructorIndent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestConstructorIndent extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestConstructorIndent tester = new TestConstructorIndent();
+        var tester = new TestConstructorIndent();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testConstructors/TestConstructors.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstructors/TestConstructors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestConstructors extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestConstructors tester = new TestConstructors();
+        var tester = new TestConstructors();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestCopyFiles extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestCopyFiles tester = new TestCopyFiles();
+        var tester = new TestCopyFiles();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
+++ b/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestDeprecatedDocs extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDeprecatedDocs tester = new TestDeprecatedDocs();
+        var tester = new TestDeprecatedDocs();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testDiagsLineCaret/TestDiagsLineCaret.java
+++ b/test/langtools/jdk/javadoc/doclet/testDiagsLineCaret/TestDiagsLineCaret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import toolbox.ToolBox;
 public class TestDiagsLineCaret extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDiagsLineCaret tester = new TestDiagsLineCaret();
+        var tester = new TestDiagsLineCaret();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testDocEncoding/TestDocEncoding.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocEncoding/TestDocEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import javadoc.tester.JavadocTester;
 public class TestDocEncoding extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDocEncoding tester = new TestDocEncoding();
+        var tester = new TestDocEncoding();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testDocErrorReporter/TestDocErrorReporter.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocErrorReporter/TestDocErrorReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class TestDocErrorReporter extends JavadocTester {
      * @throws Exception if the test fails
      */
     public static void main(String... args) throws Exception {
-        TestDocErrorReporter tester = new TestDocErrorReporter();
+        var tester = new TestDocErrorReporter();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testDocFileDir/TestDocFileDir.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocFileDir/TestDocFileDir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import toolbox.ToolBox;
 public class TestDocFileDir extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDocFileDir tester = new TestDocFileDir();
+        var tester = new TestDocFileDir();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testDocFiles/TestDocFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocFiles/TestDocFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ import javadoc.tester.JavadocTester;
 public class TestDocFiles extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDocFiles tester = new TestDocFiles();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestDocFiles();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testDocLintOption/TestDocLintOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocLintOption/TestDocLintOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,9 +53,9 @@ import toolbox.ToolBox;
 public class TestDocLintOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDocLintOption tester = new TestDocLintOption();
+        var tester = new TestDocLintOption();
         tester.generateSrc();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testDocPaths/TestDocPaths.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocPaths/TestDocPaths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import toolbox.TestRunner;
 public class TestDocPaths extends TestRunner {
 
     public static void main(String... args) throws Exception {
-        TestDocPaths tester = new TestDocPaths();
+        var tester = new TestDocPaths();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testDocRootInlineTag/TestDocRootInlineTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocRootInlineTag/TestDocRootInlineTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestDocRootInlineTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDocRootInlineTag tester = new TestDocRootInlineTag();
+        var tester = new TestDocRootInlineTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testDocRootLink/TestDocRootLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocRootLink/TestDocRootLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import javadoc.tester.JavadocTester;
 public class TestDocRootLink extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestDocRootLink tester = new TestDocRootLink();
+        var tester = new TestDocRootLink();
 
         // The test files intentionally contain examples of links that should
         // or should not be affected by the -Xdocrootparent option, and the

--- a/test/langtools/jdk/javadoc/doclet/testDupParamWarn/TestDupParamWarn.java
+++ b/test/langtools/jdk/javadoc/doclet/testDupParamWarn/TestDupParamWarn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestDupParamWarn extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        JavadocTester tester = new TestDupParamWarn();
+        var tester = new TestDupParamWarn();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testEmptyClass/TestEmptyClass.java
+++ b/test/langtools/jdk/javadoc/doclet/testEmptyClass/TestEmptyClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestEmptyClass extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestEmptyClass tester = new TestEmptyClass();
+        var tester = new TestEmptyClass();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testEmptyInheritDoc/TestEmptyInheritDoc.java
+++ b/test/langtools/jdk/javadoc/doclet/testEmptyInheritDoc/TestEmptyInheritDoc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import toolbox.ToolBox;
 public class TestEmptyInheritDoc extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestEmptyInheritDoc tester = new TestEmptyInheritDoc();
+        var tester = new TestEmptyInheritDoc();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testEnclosingClass/TestEnclosingClass.java
+++ b/test/langtools/jdk/javadoc/doclet/testEnclosingClass/TestEnclosingClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestEnclosingClass extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestEnclosingClass tester = new TestEnclosingClass();
+        var tester = new TestEnclosingClass();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testEncoding/TestEncoding.java
+++ b/test/langtools/jdk/javadoc/doclet/testEncoding/TestEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestEncoding extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestEncoding tester = new TestEncoding();
+        var tester = new TestEncoding();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testEnumConstructor/TestEnumConstructor.java
+++ b/test/langtools/jdk/javadoc/doclet/testEnumConstructor/TestEnumConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ public class TestEnumConstructor extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestEnumConstructor tester = new TestEnumConstructor();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestEnumConstructor();
+        tester.runTests();
     }
 
     TestEnumConstructor() {

--- a/test/langtools/jdk/javadoc/doclet/testExceptionInheritance/TestExceptionInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testExceptionInheritance/TestExceptionInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ import toolbox.ToolBox;
 public class TestExceptionInheritance extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestExceptionInheritance tester = new TestExceptionInheritance();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestExceptionInheritance();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testExternalOverriddenMethod/TestExternalOverriddenMethod.java
+++ b/test/langtools/jdk/javadoc/doclet/testExternalOverriddenMethod/TestExternalOverriddenMethod.java
@@ -39,7 +39,7 @@ public class TestExternalOverriddenMethod extends JavadocTester {
     static final String uri = "http://java.sun.com/j2se/1.4.1/docs/api";
 
     public static void main(String... args) throws Exception {
-        TestExternalOverriddenMethod tester = new TestExternalOverriddenMethod();
+        var tester = new TestExternalOverriddenMethod();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testGeneratedBy/TestGeneratedBy.java
+++ b/test/langtools/jdk/javadoc/doclet/testGeneratedBy/TestGeneratedBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestGeneratedBy extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestGeneratedBy tester = new TestGeneratedBy();
+        var tester = new TestGeneratedBy();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testGeneratedClasses/TestGeneratedClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testGeneratedClasses/TestGeneratedClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ import toolbox.ToolBox;
 public class TestGeneratedClasses extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestGeneratedClasses tester = new TestGeneratedClasses();
-        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+        var tester = new TestGeneratedClasses();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testGenericMethodLinkTaglet/TestGenericMethodLinkTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testGenericMethodLinkTaglet/TestGenericMethodLinkTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,8 @@ public class TestGenericMethodLinkTaglet extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestGenericMethodLinkTaglet tester = new TestGenericMethodLinkTaglet();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestGenericMethodLinkTaglet();
+        tester.runTests();
     }
 
     TestGenericMethodLinkTaglet() {

--- a/test/langtools/jdk/javadoc/doclet/testGrandParentTypes/TestGrandParentTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testGrandParentTypes/TestGrandParentTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestGrandParentTypes extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestGrandParentTypes tester = new TestGrandParentTypes();
+        var tester = new TestGrandParentTypes();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testGroupName/TestGroupName.java
+++ b/test/langtools/jdk/javadoc/doclet/testGroupName/TestGroupName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ public class TestGroupName extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestGroupName tester = new TestGroupName();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestGroupName();
+        tester.runTests();
     }
 
     public TestGroupName() {

--- a/test/langtools/jdk/javadoc/doclet/testGroupOption/TestGroupOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testGroupOption/TestGroupOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestGroupOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestGroupOption tester = new TestGroupOption();
+        var tester = new TestGroupOption();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHeadTag/TestHeadTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHeadTag/TestHeadTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ public class TestHeadTag extends JavadocTester {
     final String version = System.getProperty("java.specification.version");
 
     public static void main(String... args) throws Exception {
-        TestHeadTag tester = new TestHeadTag();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestHeadTag();
+        tester.runTests();
     }
 
     TestHeadTag() {

--- a/test/langtools/jdk/javadoc/doclet/testHeadings/TestHeadings.java
+++ b/test/langtools/jdk/javadoc/doclet/testHeadings/TestHeadings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestHeadings extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHeadings tester = new TestHeadings();
+        var tester = new TestHeadings();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHelpFile/TestHelpFile.java
+++ b/test/langtools/jdk/javadoc/doclet/testHelpFile/TestHelpFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ public class TestHelpFile extends JavadocTester {
     public static final int ZERO = 0;
 
     public static void main(String... args) throws Exception {
-        TestHelpFile tester = new TestHelpFile();
+        var tester = new TestHelpFile();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHelpOption/TestHelpOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testHelpOption/TestHelpOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestHelpOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHelpOption tester = new TestHelpOption();
+        var tester = new TestHelpOption();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHelpPage/TestHelpPage.java
+++ b/test/langtools/jdk/javadoc/doclet/testHelpPage/TestHelpPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 public class TestHelpPage extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHelpPage tester = new TestHelpPage();
+        var tester = new TestHelpPage();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHiddenMembers/TestHiddenMembers.java
+++ b/test/langtools/jdk/javadoc/doclet/testHiddenMembers/TestHiddenMembers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class TestHiddenMembers extends JavadocTester {
         };
 
     public static void main(String... args) throws Exception {
-        TestHiddenMembers tester = new TestHiddenMembers();
+        var tester = new TestHiddenMembers();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHiddenTag/TestHiddenTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHiddenTag/TestHiddenTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestHiddenTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHiddenTag tester = new TestHiddenTag();
+        var tester = new TestHiddenTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHref/TestHref.java
+++ b/test/langtools/jdk/javadoc/doclet/testHref/TestHref.java
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestHref extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHref tester = new TestHref();
+        var tester = new TestHref();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHrefInDocComment/TestHrefInDocComment.java
+++ b/test/langtools/jdk/javadoc/doclet/testHrefInDocComment/TestHrefInDocComment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestHrefInDocComment extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHrefInDocComment tester = new TestHrefInDocComment();
+        var tester = new TestHrefInDocComment();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtml4Removal/TestHtml4Removal.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtml4Removal/TestHtml4Removal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class TestHtml4Removal extends JavadocTester {
         Files.write(testFile,
                 List.of("/** Comment. */", "public class C { }"));
 
-        TestHtml4Removal tester = new TestHtml4Removal();
+        var tester = new TestHtml4Removal();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlComments/TestHtmlComments.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlComments/TestHtmlComments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestHtmlComments extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHtmlComments tester = new TestHtmlComments();
+        var tester = new TestHtmlComments();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
@@ -41,7 +41,7 @@ import javadoc.tester.JavadocTester;
 public class TestHtmlDefinitionListTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHtmlDefinitionListTag tester = new TestHtmlDefinitionListTag();
+        var tester = new TestHtmlDefinitionListTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDocument/TestHtmlDocument.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDocument/TestHtmlDocument.java
@@ -48,7 +48,7 @@ public class TestHtmlDocument extends JavadocTester {
 
     // Entry point
     public static void main(String... args) throws Exception {
-        TestHtmlDocument tester = new TestHtmlDocument();
+        var tester = new TestHtmlDocument();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlLandmarkRegions/TestHtmlLandmarkRegions.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlLandmarkRegions/TestHtmlLandmarkRegions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,8 +51,8 @@ public class TestHtmlLandmarkRegions extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestHtmlLandmarkRegions tester = new TestHtmlLandmarkRegions();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestHtmlLandmarkRegions();
+        tester.runTests();
     }
 
     TestHtmlLandmarkRegions() {

--- a/test/langtools/jdk/javadoc/doclet/testHtmlStrongTag/TestHtmlStrongTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlStrongTag/TestHtmlStrongTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestHtmlStrongTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHtmlStrongTag tester = new TestHtmlStrongTag();
+        var tester = new TestHtmlStrongTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableStyles/TestHtmlTableStyles.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableStyles/TestHtmlTableStyles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestHtmlTableStyles extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHtmlTableStyles tester = new TestHtmlTableStyles();
+        var tester = new TestHtmlTableStyles();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTableTags/TestHtmlTableTags.java
@@ -42,7 +42,7 @@ public class TestHtmlTableTags extends JavadocTester {
 
 
     public static void main(String... args) throws Exception {
-        TestHtmlTableTags tester = new TestHtmlTableTags();
+        var tester = new TestHtmlTableTags();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlTag/TestHtmlTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlTag/TestHtmlTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestHtmlTag extends JavadocTester {
     private static final String defaultLanguage = Locale.getDefault().getLanguage();
     public static void main(String... args) throws Exception {
-        TestHtmlTag tester = new TestHtmlTag();
+        var tester = new TestHtmlTag();
         tester.runTests();
     }
     @Test

--- a/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestHtmlVersion extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestHtmlVersion tester = new TestHtmlVersion();
+        var tester = new TestHtmlVersion();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
+++ b/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ import javadoc.tester.JavadocTester;
 public class TestIOException extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestIOException tester = new TestIOException();
+        var tester = new TestIOException();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIncluded/TestIncluded.java
+++ b/test/langtools/jdk/javadoc/doclet/testIncluded/TestIncluded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestIncluded extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestIncluded tester = new TestIncluded();
+        var tester = new TestIncluded();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIndentation/TestIndentation.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndentation/TestIndentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestIndentation extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestIndentation tester = new TestIndentation();
+        var tester = new TestIndentation();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIndex/TestIndex.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndex/TestIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestIndex extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestIndex tester = new TestIndex();
+        var tester = new TestIndex();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIndexFiles/TestIndexFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexFiles/TestIndexFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestIndexFiles extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestIndexFiles tester = new TestIndexFiles();
+        var tester = new TestIndexFiles();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIndexInDocFiles/TestIndexInDocFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInDocFiles/TestIndexInDocFiles.java
@@ -45,8 +45,8 @@ public class TestIndexInDocFiles extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestIndexInDocFiles tester = new TestIndexInDocFiles();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestIndexInDocFiles();
+        tester.runTests();
     }
 
     TestIndexInDocFiles() {

--- a/test/langtools/jdk/javadoc/doclet/testIndexInPackageFiles/TestIndexInPackageFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexInPackageFiles/TestIndexInPackageFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import toolbox.ToolBox;
 public class TestIndexInPackageFiles extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestIndexInPackageFiles  tester = new TestIndexInPackageFiles ();
+        var tester = new TestIndexInPackageFiles ();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIndexTaglet/TestIndexTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexTaglet/TestIndexTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,8 @@ public class TestIndexTaglet extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestIndexTaglet tester = new TestIndexTaglet();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestIndexTaglet();
+        tester.runTests();
     }
 
     TestIndexTaglet() {

--- a/test/langtools/jdk/javadoc/doclet/testIndexWithModules/TestIndexWithModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexWithModules/TestIndexWithModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ public class TestIndexWithModules extends JavadocTester {
     private final Path src;
 
     public static void main(String... args) throws Exception {
-        TestIndexWithModules tester = new TestIndexWithModules();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestIndexWithModules();
+        tester.runTests();
     }
 
     TestIndexWithModules() throws Exception{

--- a/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
+++ b/test/langtools/jdk/javadoc/doclet/testInherited/TestInherited.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ import toolbox.ToolBox;
 public class TestInherited extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestInherited tester = new TestInherited();
-        tester.runTests(m -> new Object[] { Path.of(m.getName())});
+        var tester = new TestInherited();
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testInlineLinkLabel/TestInlineLinkLabel.java
+++ b/test/langtools/jdk/javadoc/doclet/testInlineLinkLabel/TestInlineLinkLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestInlineLinkLabel extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestInlineLinkLabel tester = new TestInlineLinkLabel();
+        var tester = new TestInlineLinkLabel();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -54,7 +54,7 @@ import javadoc.tester.JavadocTester;
 public class TestInterface extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestInterface tester = new TestInterface();
+        var tester = new TestInterface();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestFxProperties.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestFxProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import javadoc.tester.JavadocTester;
 public class TestFxProperties extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestFxProperties tester = new TestFxProperties();
+        var tester = new TestFxProperties();
         if (!tester.sanity()) {
             return;
         }

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import javadoc.tester.JavadocTester;
 public class TestJavaFX extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestJavaFX tester = new TestJavaFX();
+        var tester = new TestJavaFX();
         tester.setAutomaticCheckAccessibility(false);
         tester.setAutomaticCheckLinks(false);
         tester.runTests();

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFxMode.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFxMode.java
@@ -43,9 +43,9 @@ public class TestJavaFxMode extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestJavaFxMode tester = new TestJavaFxMode();
+        var tester = new TestJavaFxMode();
         if (tester.sanity()) {
-            tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+            tester.runTests();
         }
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testJavaPackage/TestJavaPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaPackage/TestJavaPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import javadoc.tester.JavadocTester;
 
 public class TestJavaPackage extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestJavaPackage tester = new TestJavaPackage();
+        var tester = new TestJavaPackage();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testJavascript/TestJavascript.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavascript/TestJavascript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestJavascript extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestJavascript tester = new TestJavascript();
+        var tester = new TestJavascript();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLeadingSpaces/LeadingSpaces.java
+++ b/test/langtools/jdk/javadoc/doclet/testLeadingSpaces/LeadingSpaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class LeadingSpaces extends JavadocTester {
      * @throws Exception if the test fails
      */
     public static void main(String... args) throws Exception {
-        LeadingSpaces tester = new LeadingSpaces();
+        var tester = new LeadingSpaces();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLegacyTaglet/TestLegacyTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testLegacyTaglet/TestLegacyTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestLegacyTaglet extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestLegacyTaglet tester = new TestLegacyTaglet();
+        var tester = new TestLegacyTaglet();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLegalNotices/TestLegalNotices.java
+++ b/test/langtools/jdk/javadoc/doclet/testLegalNotices/TestLegalNotices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ import toolbox.ToolBox;
 
 public class TestLegalNotices extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestLegalNotices tester = new TestLegalNotices();
-        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+        var tester = new TestLegalNotices();
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestBadLinkOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestBadLinkOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestBadLinkOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestBadLinkOption tester = new TestBadLinkOption();
+        var tester = new TestBadLinkOption();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOption.java
@@ -43,7 +43,7 @@ public class TestLinkOption extends JavadocTester {
      * @param args the array of command line arguments.
      */
     public static void main(String... args) throws Exception {
-        TestLinkOption tester = new TestLinkOption();
+        var tester = new TestLinkOption();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOptionWithAutomaticModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOptionWithAutomaticModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,8 @@ import javadoc.tester.JavadocTester;
 public class TestLinkOptionWithAutomaticModule extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestLinkOptionWithAutomaticModule tester = new TestLinkOptionWithAutomaticModule();
-        tester.runTests(m -> new Object[]{ Path.of(m.getName()) });
+        var tester = new TestLinkOptionWithAutomaticModule();
+        tester.runTests();
     }
 
     final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOptionWithModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOptionWithModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,8 +51,8 @@ public class TestLinkOptionWithModule extends JavadocTester {
     private final Path moduleSrc, packageSrc;
 
     public static void main(String... args) throws Exception {
-        TestLinkOptionWithModule tester = new TestLinkOptionWithModule();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestLinkOptionWithModule();
+        tester.runTests();
     }
 
     TestLinkOptionWithModule() throws Exception {

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestNewLineInLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestNewLineInLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestNewLineInLink extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNewLineInLink tester = new TestNewLineInLink();
+        var tester = new TestNewLineInLink();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestOptionOrder.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestOptionOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,8 +52,8 @@ public class TestOptionOrder extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestOptionOrder tester = new TestOptionOrder();
-        tester.runTests(m -> new Object[] { Path.of(m.getName())} );
+        var tester = new TestOptionOrder();
+        tester.runTests();
     }
 
     TestOptionOrder() throws Exception {

--- a/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkOption/TestRedirectLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public class TestRedirectLinks extends JavadocTester {
         if (Platform.isSlowDebugBuild()) {
             throw new SkippedException("Test is unstable with slowdebug bits");
         }
-        TestRedirectLinks tester = new TestRedirectLinks();
+        var tester = new TestRedirectLinks();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLinkPlatform/TestLinkPlatform.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkPlatform/TestLinkPlatform.java
@@ -67,8 +67,8 @@ public class TestLinkPlatform extends JavadocTester {
      * @param args the array of command line arguments.
      */
     public static void main(String... args) throws Exception {
-        TestLinkPlatform tester = new TestLinkPlatform();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestLinkPlatform();
+        tester.runTests();
     }
 
     final ToolBox tb;

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestLinkTaglet extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestLinkTaglet tester = new TestLinkTaglet();
+        var tester = new TestLinkTaglet();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletWithModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletWithModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ public class TestLinkTagletWithModule extends JavadocTester {
     private final Path src;
 
     public static void main(String... args) throws Exception {
-        TestLinkTagletWithModule tester = new TestLinkTagletWithModule();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestLinkTagletWithModule();
+        tester.runTests();
     }
 
     TestLinkTagletWithModule() throws Exception {

--- a/test/langtools/jdk/javadoc/doclet/testLinkToSerialForm/TestLinkToSerialForm.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkToSerialForm/TestLinkToSerialForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestLinkToSerialForm extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestLinkToSerialForm tester = new TestLinkToSerialForm();
+        var tester = new TestLinkToSerialForm();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testLinksWithNoDeprecatedOption/TestLinksWithNoDeprecatedOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinksWithNoDeprecatedOption/TestLinksWithNoDeprecatedOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ public class TestLinksWithNoDeprecatedOption extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestLinksWithNoDeprecatedOption tester = new TestLinksWithNoDeprecatedOption();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestLinksWithNoDeprecatedOption();
+        tester.runTests();
     }
 
     TestLinksWithNoDeprecatedOption() {

--- a/test/langtools/jdk/javadoc/doclet/testLists/TestLists.java
+++ b/test/langtools/jdk/javadoc/doclet/testLists/TestLists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ import toolbox.ToolBox;
 public class TestLists extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestLists tester = new TestLists();
-        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+        var tester = new TestLists();
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testLiteralCodeInPre/TestLiteralCodeInPre.java
+++ b/test/langtools/jdk/javadoc/doclet/testLiteralCodeInPre/TestLiteralCodeInPre.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestLiteralCodeInPre extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestLiteralCodeInPre tester = new TestLiteralCodeInPre();
+        var tester = new TestLiteralCodeInPre();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestMemberInheritance extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestMemberInheritance tester = new TestMemberInheritance();
+        var tester = new TestMemberInheritance();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberSummary/TestMemberSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestMemberSummary extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestMemberSummary tester = new TestMemberSummary();
+        var tester = new TestMemberSummary();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testMetadata/TestMetadata.java
+++ b/test/langtools/jdk/javadoc/doclet/testMetadata/TestMetadata.java
@@ -53,7 +53,7 @@ import javadoc.tester.JavadocTester;
 
 public class TestMetadata extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestMetadata tester = new TestMetadata();
+        var tester = new TestMetadata();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testMethodId/TestMethodId.java
+++ b/test/langtools/jdk/javadoc/doclet/testMethodId/TestMethodId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ import toolbox.ToolBox;
 public class TestMethodId extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestMethodId tester = new TestMethodId();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestMethodId();
+        tester.runTests();
     }
 
     private ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testMethodSignature/TestMethodSignature.java
+++ b/test/langtools/jdk/javadoc/doclet/testMethodSignature/TestMethodSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestMethodSignature extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestMethodSignature tester = new TestMethodSignature();
+        var tester = new TestMethodSignature();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testMethodTypes/TestMethodTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testMethodTypes/TestMethodTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestMethodTypes extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestMethodTypes tester = new TestMethodTypes();
+        var tester = new TestMethodTypes();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testMissingComment/TestMissingComment.java
+++ b/test/langtools/jdk/javadoc/doclet/testMissingComment/TestMissingComment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ import toolbox.ToolBox;
 
 public class TestMissingComment extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestMissingComment tester = new TestMissingComment();
-        tester.runTests(m -> new Object[] { Path.of(m.getName() )});
+        var tester = new TestMissingComment();
+        tester.runTests();
     }
 
     private ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testMissingType/TestMissingType.java
+++ b/test/langtools/jdk/javadoc/doclet/testMissingType/TestMissingType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestMissingType extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestMissingType tester = new TestMissingType();
+        var tester = new TestMissingType();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testModifierEx/TestModifierEx.java
+++ b/test/langtools/jdk/javadoc/doclet/testModifierEx/TestModifierEx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import javadoc.tester.JavadocTester;
 public class TestModifierEx extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestModifierEx tester = new TestModifierEx();
+        var tester = new TestModifierEx();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testModuleDirs/TestModuleDirs.java
+++ b/test/langtools/jdk/javadoc/doclet/testModuleDirs/TestModuleDirs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ public class TestModuleDirs extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestModuleDirs tester = new TestModuleDirs();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestModuleDirs();
+        tester.runTests();
     }
 
     public TestModuleDirs() {

--- a/test/langtools/jdk/javadoc/doclet/testModuleSpecificStylesheet/TestModuleSpecificStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testModuleSpecificStylesheet/TestModuleSpecificStylesheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,8 +49,8 @@ public class TestModuleSpecificStylesheet extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestModuleSpecificStylesheet tester = new TestModuleSpecificStylesheet();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestModuleSpecificStylesheet();
+        tester.runTests();
     }
 
     TestModuleSpecificStylesheet() {

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestEmptyModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestEmptyModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,8 @@ public class TestEmptyModule extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestEmptyModule tester = new TestEmptyModule();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestEmptyModule();
+        tester.runTests();
     }
 
     public TestEmptyModule() {

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestIndirectExportsOpens.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestIndirectExportsOpens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,8 @@ public class TestIndirectExportsOpens extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestIndirectExportsOpens tester = new TestIndirectExportsOpens();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestIndirectExportsOpens();
+        tester.runTests();
     }
 
     public TestIndirectExportsOpens() {

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModulePackages.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModulePackages.java
@@ -47,8 +47,8 @@ public class TestModulePackages extends JavadocTester {
     enum ColKind { EXPORTED_TO, OPENED_TO };
 
     public static void main(String... args) throws Exception {
-        TestModulePackages tester = new TestModulePackages();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestModulePackages();
+        tester.runTests();
     }
 
     private final ToolBox tb;

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModuleServices.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModuleServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,8 @@ public class TestModuleServices extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestModuleServices tester = new TestModuleServices();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestModuleServices();
+        tester.runTests();
     }
 
     public TestModuleServices() {

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModuleServicesLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModuleServicesLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,8 @@ public class TestModuleServicesLink extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestModuleServicesLink  tester = new TestModuleServicesLink ();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestModuleServicesLink ();
+        tester.runTests();
     }
 
     public TestModuleServicesLink () {

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestModules extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestModules tester = new TestModules();
+        var tester = new TestModules();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testNavigation/TestModuleNavigation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNavigation/TestModuleNavigation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,8 @@ public class TestModuleNavigation extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestModuleNavigation  tester = new TestModuleNavigation ();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestModuleNavigation ();
+        tester.runTests();
     }
 
     public TestModuleNavigation () {

--- a/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ public class TestNavigation extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestNavigation tester = new TestNavigation();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestNavigation();
+        tester.runTests();
     }
 
     public TestNavigation() {

--- a/test/langtools/jdk/javadoc/doclet/testNestedClasses/TestNestedClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testNestedClasses/TestNestedClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ import toolbox.ToolBox;
 
 public class TestNestedClasses extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestNestedClasses tester = new TestNestedClasses();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestNestedClasses();
+        tester.runTests();
         tester.runLater();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testNestedGenerics/TestNestedGenerics.java
+++ b/test/langtools/jdk/javadoc/doclet/testNestedGenerics/TestNestedGenerics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestNestedGenerics extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNestedGenerics tester = new TestNestedGenerics();
+        var tester = new TestNestedGenerics();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testNestedInlineTags/TestNestedIndexTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testNestedInlineTags/TestNestedIndexTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ import static javadoc.tester.JavadocTester.Output.OUT;
 public class TestNestedIndexTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNestedIndexTag tester = new TestNestedIndexTag();
-        tester.runTests(m -> new Object[] { Path.of(m.getName())});
+        var tester = new TestNestedIndexTag();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testNestedInlineTags/TestNestedLinkTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testNestedInlineTags/TestNestedLinkTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ import toolbox.ToolBox;
 public class TestNestedLinkTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNestedLinkTag tester = new TestNestedLinkTag();
-        tester.runTests(m -> new Object[] { Path.of(m.getName())});
+        var tester = new TestNestedLinkTag();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testNestedInlineTags/TestNestedReturnTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testNestedInlineTags/TestNestedReturnTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ import toolbox.ToolBox;
 public class TestNestedReturnTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNestedReturnTag tester = new TestNestedReturnTag();
-        tester.runTests(m -> new Object[] { Path.of(m.getName())});
+        var tester = new TestNestedReturnTag();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testNestedInlineTags/TestNestedSummaryTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testNestedInlineTags/TestNestedSummaryTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ import toolbox.ToolBox;
 public class TestNestedSummaryTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNestedSummaryTag tester = new TestNestedSummaryTag();
-        tester.runTests(m -> new Object[] { Path.of(m.getName())});
+        var tester = new TestNestedSummaryTag();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
+++ b/test/langtools/jdk/javadoc/doclet/testNewLanguageFeatures/TestNewLanguageFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestNewLanguageFeatures extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNewLanguageFeatures tester = new TestNewLanguageFeatures();
+        var tester = new TestNewLanguageFeatures();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testNoFrames/TestNoFrames.java
+++ b/test/langtools/jdk/javadoc/doclet/testNoFrames/TestNoFrames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestNoFrames extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNoFrames tester = new TestNoFrames();
+        var tester = new TestNoFrames();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testNoPackagesFile/TestNoPackagesFile.java
+++ b/test/langtools/jdk/javadoc/doclet/testNoPackagesFile/TestNoPackagesFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestNoPackagesFile extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNoPackagesFile tester = new TestNoPackagesFile();
+        var tester = new TestNoPackagesFile();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testNonInlineHtmlTagRemoval/TestNonInlineHtmlTagRemoval.java
+++ b/test/langtools/jdk/javadoc/doclet/testNonInlineHtmlTagRemoval/TestNonInlineHtmlTagRemoval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestNonInlineHtmlTagRemoval extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNonInlineHtmlTagRemoval tester = new TestNonInlineHtmlTagRemoval();
+        var tester = new TestNonInlineHtmlTagRemoval();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testNotifications/TestNotifications.java
+++ b/test/langtools/jdk/javadoc/doclet/testNotifications/TestNotifications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestNotifications extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestNotifications tester = new TestNotifications();
+        var tester = new TestNotifications();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOptions/TestOptions.java
+++ b/test/langtools/jdk/javadoc/doclet/testOptions/TestOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestOptions extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestOptions tester = new TestOptions();
+        var tester = new TestOptions();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOrdering/TestOrdering.java
+++ b/test/langtools/jdk/javadoc/doclet/testOrdering/TestOrdering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import javadoc.tester.JavadocTester;
 public class TestOrdering extends JavadocTester {
 
     public static void main(String[] args) throws Exception {
-        TestOrdering tester = new TestOrdering();
+        var tester = new TestOrdering();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestBadOverride.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestBadOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class TestBadOverride extends JavadocTester {
      * @param args the array of command line arguments.
      */
     public static void main(String... args) throws Exception {
-        TestBadOverride tester = new TestBadOverride();
+        var tester = new TestBadOverride();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestMultiInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestMultiInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestMultiInheritance extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestMultiInheritance tester = new TestMultiInheritance();
+        var tester = new TestMultiInheritance();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenDeprecatedMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenDeprecatedMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestOverriddenDeprecatedMethods extends JavadocTester {
 
     public static void main(String args[]) throws Exception {
-        TestOverriddenDeprecatedMethods tester = new TestOverriddenDeprecatedMethods();
+        var tester = new TestOverriddenDeprecatedMethods();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenMethodDocCopy.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenMethodDocCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class TestOverriddenMethodDocCopy extends JavadocTester {
      * @param args the array of command line arguments.
      */
     public static void main(String... args) throws Exception {
-        TestOverriddenMethodDocCopy tester = new TestOverriddenMethodDocCopy();
+        var tester = new TestOverriddenMethodDocCopy();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenPrivateMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenPrivateMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestOverriddenPrivateMethods extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestOverriddenPrivateMethods tester = new TestOverriddenPrivateMethods();
+        var tester = new TestOverriddenPrivateMethods();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenPrivateMethodsWithPackageFlag.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenPrivateMethodsWithPackageFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestOverriddenPrivateMethodsWithPackageFlag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestOverriddenPrivateMethodsWithPackageFlag tester = new TestOverriddenPrivateMethodsWithPackageFlag();
+        var tester = new TestOverriddenPrivateMethodsWithPackageFlag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenPrivateMethodsWithPrivateFlag.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverriddenPrivateMethodsWithPrivateFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestOverriddenPrivateMethodsWithPrivateFlag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestOverriddenPrivateMethodsWithPrivateFlag tester = new TestOverriddenPrivateMethodsWithPrivateFlag();
+        var tester = new TestOverriddenPrivateMethodsWithPrivateFlag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverriddenMethods/TestOverrideMethods.java
@@ -35,7 +35,7 @@ import javadoc.tester.JavadocTester;
 
 public class TestOverrideMethods  extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestOverrideMethods tester = new TestOverrideMethods();
+        var tester = new TestOverrideMethods();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
+++ b/test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestOverview extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestOverview tester = new TestOverview();
+        var tester = new TestOverview();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestPackageAnnotation extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestPackageAnnotation tester = new TestPackageAnnotation();
+        var tester = new TestPackageAnnotation();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPackageDeprecation/TestPackageDeprecation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageDeprecation/TestPackageDeprecation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestPackageDeprecation extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestPackageDeprecation tester = new TestPackageDeprecation();
+        var tester = new TestPackageDeprecation();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPackageDescription/TestPackageDescription.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageDescription/TestPackageDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestPackageDescription extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestPackageDescription tester = new TestPackageDescription();
+        var tester = new TestPackageDescription();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPackageHtml/TestPackageHtml.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageHtml/TestPackageHtml.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import javadoc.tester.JavadocTester;
 
 public class TestPackageHtml extends JavadocTester {
     public static void main(String... args) throws Exception  {
-        TestPackageHtml tester = new TestPackageHtml();
+        var tester = new TestPackageHtml();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPackagePage/TestPackagePage.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackagePage/TestPackagePage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestPackagePage extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestPackagePage tester = new TestPackagePage();
+        var tester = new TestPackagePage();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPackageSpecificStylesheet/TestPackageSpecificStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageSpecificStylesheet/TestPackageSpecificStylesheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ public class TestPackageSpecificStylesheet extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestPackageSpecificStylesheet tester = new TestPackageSpecificStylesheet();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestPackageSpecificStylesheet();
+        tester.runTests();
     }
 
     TestPackageSpecificStylesheet() {

--- a/test/langtools/jdk/javadoc/doclet/testPackageSummary/TestPackageSummary.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageSummary/TestPackageSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestPackageSummary extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestPackageSummary tester = new TestPackageSummary();
+        var tester = new TestPackageSummary();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testParamTaglet/TestParamTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testParamTaglet/TestParamTaglet.java
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestParamTaglet extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestParamTaglet tester = new TestParamTaglet();
+        var tester = new TestParamTaglet();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -40,7 +40,7 @@ import javadoc.tester.JavadocTester;
 public class TestPreview extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestPreview tester = new TestPreview();
+        var tester = new TestPreview();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testPrivateClasses/TestPrivateClasses.java
@@ -46,7 +46,7 @@ import javadoc.tester.JavadocTester;
 public class TestPrivateClasses extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestPrivateClasses tester = new TestPrivateClasses();
+        var tester = new TestPrivateClasses();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
+++ b/test/langtools/jdk/javadoc/doclet/testProperty/TestProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestProperty extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestProperty tester = new TestProperty();
+        var tester = new TestProperty();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testRecordLinks/TestRecordLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordLinks/TestRecordLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,8 @@ import toolbox.ToolBox;
 
 public class TestRecordLinks  extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestRecordLinks tester = new TestRecordLinks();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestRecordLinks();
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
@@ -45,8 +45,8 @@ import toolbox.ToolBox;
 
 public class TestRecordTypes extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestRecordTypes tester = new TestRecordTypes();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestRecordTypes();
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testRecurseSubPackages/TestRecurseSubPackages.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecurseSubPackages/TestRecurseSubPackages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestRecurseSubPackages extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestRecurseSubPackages tester = new TestRecurseSubPackages();
+        var tester = new TestRecurseSubPackages();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java
+++ b/test/langtools/jdk/javadoc/doclet/testRelatedPackages/TestRelatedPackages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,8 @@ public class TestRelatedPackages extends JavadocTester {
     ToolBox tb = new ToolBox();
 
     public static void main(String... args) throws Exception {
-        TestRelatedPackages tester = new TestRelatedPackages();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestRelatedPackages();
+        tester.runTests();
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/doclet/testRelativeLinks/TestRelativeLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testRelativeLinks/TestRelativeLinks.java
@@ -44,7 +44,7 @@ import javadoc.tester.JavadocTester;
 public class TestRelativeLinks extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestRelativeLinks tester = new TestRelativeLinks();
+        var tester = new TestRelativeLinks();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testRelativeLinks/TestRelativeModuleLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testRelativeLinks/TestRelativeModuleLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,8 @@ public class TestRelativeModuleLinks extends JavadocTester {
 
     public final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestRelativeModuleLinks tester = new TestRelativeModuleLinks();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestRelativeModuleLinks();
+        tester.runTests();
     }
 
     public TestRelativeModuleLinks() {

--- a/test/langtools/jdk/javadoc/doclet/testRepeatedAnnotations/TestRepeatedAnnotations.java
+++ b/test/langtools/jdk/javadoc/doclet/testRepeatedAnnotations/TestRepeatedAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestRepeatedAnnotations extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestRepeatedAnnotations tester = new TestRepeatedAnnotations();
+        var tester = new TestRepeatedAnnotations();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testReporterStreams/TestReporterStreams.java
+++ b/test/langtools/jdk/javadoc/doclet/testReporterStreams/TestReporterStreams.java
@@ -1,5 +1,5 @@
 /*
-  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+  * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
   * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
   *
   * This code is free software; you can redistribute it and/or modify it
@@ -59,8 +59,8 @@ import toolbox.ToolBox;
 public class TestReporterStreams extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestReporterStreams tester = new TestReporterStreams();
-        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+        var tester = new TestReporterStreams();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
@@ -40,8 +40,8 @@ import toolbox.ToolBox;
 public class TestReturnTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestReturnTag tester = new TestReturnTag();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestReturnTag();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testSealedTypes/TestSealedTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testSealedTypes/TestSealedTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ import toolbox.ToolBox;
 public class TestSealedTypes extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSealedTypes tester = new TestSealedTypes();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestSealedTypes();
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -45,7 +45,7 @@ import javadoc.tester.JavadocTester;
 public class TestSearch extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSearch tester = new TestSearch();
+        var tester = new TestSearch();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearchScript/TestSearchScript.java
@@ -55,7 +55,7 @@ import jtreg.SkippedException;
 public class TestSearchScript extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSearchScript tester = new TestSearchScript();
+        var tester = new TestSearchScript();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestSeeTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSeeTag tester = new TestSeeTag();
+        var tester = new TestSeeTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTagWithModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTagWithModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ public class TestSeeTagWithModule extends JavadocTester {
     private final Path src;
 
     public static void main(String... args) throws Exception {
-        TestSeeTagWithModule tester = new TestSeeTagWithModule();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestSeeTagWithModule();
+        tester.runTests();
     }
 
     TestSeeTagWithModule() throws Exception {

--- a/test/langtools/jdk/javadoc/doclet/testSerialMissing/TestSerialMissing.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerialMissing/TestSerialMissing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ import toolbox.ToolBox;
 
 public class TestSerialMissing extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestSerialMissing tester = new TestSerialMissing();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) } );
+        var tester = new TestSerialMissing();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testSerialTag/TestSerialTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerialTag/TestSerialTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,8 @@ import javadoc.tester.JavadocTester;
 
 public class TestSerialTag extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestSerialTag tester = new TestSerialTag();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestSerialTag();
+        tester.runTests();
     }
 
     private final ToolBox tb;

--- a/test/langtools/jdk/javadoc/doclet/testSerialVersionUID/TestSerialVersionUID.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerialVersionUID/TestSerialVersionUID.java
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestSerialVersionUID extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSerialVersionUID tester = new TestSerialVersionUID();
+        var tester = new TestSerialVersionUID();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedForm/TestSerializedForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import javadoc.tester.JavadocTester;
 
 public class TestSerializedForm extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestSerializedForm tester = new TestSerializedForm();
+        var tester = new TestSerializedForm();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormDeprecationInfo/TestSerializedFormDeprecationInfo.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormDeprecationInfo/TestSerializedFormDeprecationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestSerializedFormDeprecationInfo extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSerializedFormDeprecationInfo tester = new TestSerializedFormDeprecationInfo();
+        var tester = new TestSerializedFormDeprecationInfo();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormWithClassFile/TestSerializedFormWithClassFile.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormWithClassFile/TestSerializedFormWithClassFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ public class TestSerializedFormWithClassFile extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestSerializedFormWithClassFile tester = new TestSerializedFormWithClassFile();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestSerializedFormWithClassFile();
+        tester.runTests();
     }
 
     TestSerializedFormWithClassFile() {

--- a/test/langtools/jdk/javadoc/doclet/testSerializedFormWithSee/TestSerializedFormWithSee.java
+++ b/test/langtools/jdk/javadoc/doclet/testSerializedFormWithSee/TestSerializedFormWithSee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,8 +51,8 @@ import javadoc.tester.JavadocTester;
 public class TestSerializedFormWithSee extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSerializedFormWithSee tester = new TestSerializedFormWithSee();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestSerializedFormWithSee();
+        tester.runTests();
     }
 
     private final ToolBox tb;

--- a/test/langtools/jdk/javadoc/doclet/testSimpleTag/TestSimpleTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSimpleTag/TestSimpleTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestSimpleTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSimpleTag tester = new TestSimpleTag();
+        var tester = new TestSimpleTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSimpleTagExclude/TestSimpleTagExclude.java
+++ b/test/langtools/jdk/javadoc/doclet/testSimpleTagExclude/TestSimpleTagExclude.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestSimpleTagExclude extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSimpleTagExclude tester = new TestSimpleTagExclude();
+        var tester = new TestSimpleTagExclude();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSimpleTagInherit/TestSimpleTagInherit.java
+++ b/test/langtools/jdk/javadoc/doclet/testSimpleTagInherit/TestSimpleTagInherit.java
@@ -46,7 +46,7 @@ public class TestSimpleTagInherit extends JavadocTester {
     };
 
     public static void main(String... args) throws Exception {
-        TestSimpleTagInherit tester = new TestSimpleTagInherit();
+        var tester = new TestSimpleTagInherit();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSinceTag/TestSinceTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSinceTag/TestSinceTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestSinceTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSinceTag tester = new TestSinceTag();
+        var tester = new TestSinceTag();
         tester.runTests();
         tester.printSummary();
     }

--- a/test/langtools/jdk/javadoc/doclet/testSingleQuotedLink/TestSingleQuotedLink.java
+++ b/test/langtools/jdk/javadoc/doclet/testSingleQuotedLink/TestSingleQuotedLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import javadoc.tester.JavadocTester;
 public class TestSingleQuotedLink extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSingleQuotedLink tester = new TestSingleQuotedLink();
+        var tester = new TestSingleQuotedLink();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSingletonLists/TestSingletonLists.java
+++ b/test/langtools/jdk/javadoc/doclet/testSingletonLists/TestSingletonLists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ import toolbox.ToolBox;
 
 public class TestSingletonLists extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestSingletonLists tester = new TestSingletonLists();
+        var tester = new TestSingletonLists();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSourceTab/TestSourceTab.java
+++ b/test/langtools/jdk/javadoc/doclet/testSourceTab/TestSourceTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestSourceTab extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSourceTab tester = new TestSourceTab();
+        var tester = new TestSourceTab();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -49,8 +49,8 @@ import toolbox.ToolBox;
 public class TestStylesheet extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestStylesheet tester = new TestStylesheet();
-        tester.runTests(m -> new Object[] { Path.of(m.getName())});
+        var tester = new TestStylesheet();
+        tester.runTests();
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/doclet/testStylesheetOverwrite/TestStylesheetOverwrite.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheetOverwrite/TestStylesheetOverwrite.java
@@ -1,4 +1,4 @@
-/* * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+/* * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ public class TestStylesheetOverwrite extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestStylesheetOverwrite tester = new TestStylesheetOverwrite();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestStylesheetOverwrite();
+        tester.runTests();
     }
 
     TestStylesheetOverwrite() {

--- a/test/langtools/jdk/javadoc/doclet/testSubTitle/TestSubTitle.java
+++ b/test/langtools/jdk/javadoc/doclet/testSubTitle/TestSubTitle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestSubTitle extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSubTitle tester = new TestSubTitle();
+        var tester = new TestSubTitle();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSummaryHeading/TestSummaryHeading.java
+++ b/test/langtools/jdk/javadoc/doclet/testSummaryHeading/TestSummaryHeading.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestSummaryHeading extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSummaryHeading tester = new TestSummaryHeading();
+        var tester = new TestSummaryHeading();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSummaryTag/TestSummaryTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSummaryTag/TestSummaryTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestSummaryTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSummaryTag tester = new TestSummaryTag();
+        var tester = new TestSummaryTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSuperclassInSerialForm/TestSuperClassInSerialForm.java
+++ b/test/langtools/jdk/javadoc/doclet/testSuperclassInSerialForm/TestSuperClassInSerialForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestSuperClassInSerialForm extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSuperClassInSerialForm tester = new TestSuperClassInSerialForm();
+        var tester = new TestSuperClassInSerialForm();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSupplementary/TestSupplementary.java
+++ b/test/langtools/jdk/javadoc/doclet/testSupplementary/TestSupplementary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class TestSupplementary extends JavadocTester {
     public static void main(String... args) throws Exception {
         Locale saveLocale = Locale.getDefault();
         try {
-            TestSupplementary tester = new TestSupplementary();
+            var tester = new TestSupplementary();
             tester.runTests();
         } finally {
             Locale.setDefault(saveLocale);

--- a/test/langtools/jdk/javadoc/doclet/testSystemPropertyPage/TestSystemPropertyPage.java
+++ b/test/langtools/jdk/javadoc/doclet/testSystemPropertyPage/TestSystemPropertyPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ public class TestSystemPropertyPage extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestSystemPropertyPage tester = new TestSystemPropertyPage();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestSystemPropertyPage();
+        tester.runTests();
     }
 
     TestSystemPropertyPage() {

--- a/test/langtools/jdk/javadoc/doclet/testSystemPropertyTaglet/TestSystemPropertyTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testSystemPropertyTaglet/TestSystemPropertyTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,8 @@ public class TestSystemPropertyTaglet extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestSystemPropertyTaglet tester = new TestSystemPropertyTaglet();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestSystemPropertyTaglet();
+        tester.runTests();
     }
 
     TestSystemPropertyTaglet() {

--- a/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
@@ -40,7 +40,7 @@ public class TestTagMisuse extends JavadocTester {
      * @throws Exception if the test fails
      */
     public static void main(String... args) throws Exception {
-        TestTagMisuse tester = new TestTagMisuse();
+        var tester = new TestTagMisuse();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagOrder/TestTagOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,8 @@ import toolbox.ToolBox;
  */
 public class TestTagOrder extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestTagOrder tester = new TestTagOrder();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new TestTagOrder();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testTagOutput/TestTagOutput.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagOutput/TestTagOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestTagOutput extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestTagOutput tester = new TestTagOutput();
+        var tester = new TestTagOutput();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testTaglets/TestTaglets.java
+++ b/test/langtools/jdk/javadoc/doclet/testTaglets/TestTaglets.java
@@ -50,7 +50,7 @@ import toolbox.ToolBox;
 public class TestTaglets extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestTaglets tester = new TestTaglets();
+        var tester = new TestTaglets();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testTerminology/TestTerminology.java
+++ b/test/langtools/jdk/javadoc/doclet/testTerminology/TestTerminology.java
@@ -40,8 +40,8 @@ import toolbox.ToolBox;
 
 public class TestTerminology extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestTerminology tester = new TestTerminology();
-        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+        var tester = new TestTerminology();
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
@@ -42,8 +42,8 @@
  public class TestThrows extends JavadocTester {
 
      public static void main(String... args) throws Exception {
-         TestThrows tester = new TestThrows();
-         tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+         var tester = new TestThrows();
+         tester.runTests();
      }
 
      private final ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/doclet/testThrowsHead/TestThrowsHead.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsHead/TestThrowsHead.java
@@ -38,7 +38,7 @@ import javadoc.tester.JavadocTester;
 public class TestThrowsHead extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestThrowsHead tester = new TestThrowsHead();
+        var tester = new TestThrowsHead();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testThrowsTag/TestThrowsTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsTag/TestThrowsTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestThrowsTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestThrowsTag tester = new TestThrowsTag();
+        var tester = new TestThrowsTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testTitleInHref/TestTitleInHref.java
+++ b/test/langtools/jdk/javadoc/doclet/testTitleInHref/TestTitleInHref.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestTitleInHref extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestTitleInHref tester = new TestTitleInHref();
+        var tester = new TestTitleInHref();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testTopOption/TestTopOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testTopOption/TestTopOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestTopOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestTopOption tester = new TestTopOption();
+        var tester = new TestTopOption();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestTypeAnnotations extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestTypeAnnotations tester = new TestTypeAnnotations();
+        var tester = new TestTypeAnnotations();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testTypeParams/TestTypeParameters.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeParams/TestTypeParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import javadoc.tester.JavadocTester;
 public class TestTypeParameters extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestTypeParameters tester = new TestTypeParameters();
+        var tester = new TestTypeParameters();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testTypeVariableLinks/TestTypeVariableLinks.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeVariableLinks/TestTypeVariableLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestTypeVariableLinks extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestTypeVariableLinks tester = new TestTypeVariableLinks();
+        var tester = new TestTypeVariableLinks();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import toolbox.ToolBox;
 public class TestUnicode extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestUnicode tester = new TestUnicode();
+        var tester = new TestUnicode();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestUnnamedPackage extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestUnnamedPackage tester = new TestUnnamedPackage();
+        var tester = new TestUnnamedPackage();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testUseOption/TestUseOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testUseOption/TestUseOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestUseOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestUseOption tester = new TestUseOption();
+        var tester = new TestUseOption();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testUserTaglet/TestUserTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testUserTaglet/TestUserTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestUserTaglet extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestUserTaglet tester = new TestUserTaglet();
+        var tester = new TestUserTaglet();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import javadoc.tester.JavadocTester;
 public class TestValueTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestValueTag tester = new TestValueTag();
+        var tester = new TestValueTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTagInModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTagInModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,8 @@ public class TestValueTagInModule extends JavadocTester {
     final ToolBox tb;
 
     public static void main(String... args) throws Exception {
-        TestValueTagInModule tester = new TestValueTagInModule();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new TestValueTagInModule();
+        tester.runTests();
     }
 
     TestValueTagInModule() {

--- a/test/langtools/jdk/javadoc/doclet/testVersionOption/TestVersionOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testVersionOption/TestVersionOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import javadoc.tester.JavadocTester;
 public class TestVersionOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestVersionOption tester = new TestVersionOption();
+        var tester = new TestVersionOption();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testVersionTag/TestVersionTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testVersionTag/TestVersionTag.java
@@ -41,7 +41,7 @@ import toolbox.ToolBox;
 public class TestVersionTag extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestVersionTag tester = new TestVersionTag();
+        var tester = new TestVersionTag();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testVisibleMembers/TestVisibleMembers.java
+++ b/test/langtools/jdk/javadoc/doclet/testVisibleMembers/TestVisibleMembers.java
@@ -49,8 +49,8 @@ public class TestVisibleMembers extends JavadocTester {
 
     final ToolBox tb;
     public static void main(String... args) throws Exception {
-        TestVisibleMembers tester = new TestVisibleMembers();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestVisibleMembers();
+        tester.runTests();
     }
 
     TestVisibleMembers() {

--- a/test/langtools/jdk/javadoc/doclet/testWarnBadParamNames/TestWarnBadParamNames.java
+++ b/test/langtools/jdk/javadoc/doclet/testWarnBadParamNames/TestWarnBadParamNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestWarnBadParamNames extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestWarnBadParamNames tester = new TestWarnBadParamNames();
+        var tester = new TestWarnBadParamNames();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testWarnings/TestWarnings.java
+++ b/test/langtools/jdk/javadoc/doclet/testWarnings/TestWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 
 public class TestWarnings extends JavadocTester {
     public static void main(String... args) throws Exception  {
-        TestWarnings tester = new TestWarnings();
+        var tester = new TestWarnings();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testXOption/TestXOption.java
+++ b/test/langtools/jdk/javadoc/doclet/testXOption/TestXOption.java
@@ -39,7 +39,7 @@ import javadoc.tester.JavadocTester;
 public class TestXOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestXOption tester = new TestXOption();
+        var tester = new TestXOption();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/typeAnnotations/smoke/TestSmoke.java
+++ b/test/langtools/jdk/javadoc/doclet/typeAnnotations/smoke/TestSmoke.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javadoc.tester.JavadocTester;
 public class TestSmoke extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestSmoke tester = new TestSmoke();
+        var tester = new TestSmoke();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
@@ -96,7 +96,7 @@ import java.util.stream.Stream;
  * <pre><code>
  *  public class MyTester extends JavadocTester {
  *      public static void main(String... args) throws Exception {
- *          MyTester tester = new MyTester();
+ *          var tester = new MyTester();
  *          tester.runTests();
  *      }
  *

--- a/test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTester.java
+++ b/test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTester.java
@@ -59,7 +59,7 @@ import toolbox.ToolBox;
  */
 public class TestJavadocTester extends JavadocTester {
     public static void main(String... args) throws Exception {
-        TestJavadocTester tester = new TestJavadocTester();
+        var tester = new TestJavadocTester();
         tester.setup().runTests();
     }
 

--- a/test/langtools/jdk/javadoc/tool/8224612/OptionsTest.java
+++ b/test/langtools/jdk/javadoc/tool/8224612/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ import java.util.function.Supplier;
 public class OptionsTest extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        new OptionsTest().runTests(m -> new Object[]{Paths.get(m.getName())});
+        new OptionsTest().runTests();
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/tool/8224613/OptionProcessingFailureTest.java
+++ b/test/langtools/jdk/javadoc/tool/8224613/OptionProcessingFailureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ public class OptionProcessingFailureTest extends JavadocTester {
     private final ToolBox tb = new ToolBox();
 
     public static void main(String... args) throws Exception {
-        new OptionProcessingFailureTest().runTests(m -> new Object[]{Paths.get(m.getName())});
+        new OptionProcessingFailureTest().runTests();
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/tool/CommandLineHelpTest.java
+++ b/test/langtools/jdk/javadoc/tool/CommandLineHelpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,8 @@ import javadoc.tester.JavadocTester;
 
 public class CommandLineHelpTest extends JavadocTester {
     public static void main(String... args) throws Exception {
-        CommandLineHelpTest tester = new CommandLineHelpTest();
-        tester.runTests(m -> new Object[] { Path.of(m.getName()) });
+        var tester = new CommandLineHelpTest();
+        tester.runTests();
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/tool/exceptionHandling/TestExceptionHandling.java
+++ b/test/langtools/jdk/javadoc/tool/exceptionHandling/TestExceptionHandling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class TestExceptionHandling extends TestRunner {
     final JavadocTask apiTask;
 
     public static void main(String... args) throws Exception {
-        TestExceptionHandling tester = new TestExceptionHandling();
+        var tester = new TestExceptionHandling();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/tool/removeOldDoclet/RemoveOldDoclet.java
+++ b/test/langtools/jdk/javadoc/tool/removeOldDoclet/RemoveOldDoclet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,8 @@ public class RemoveOldDoclet extends JavadocTester {
     static final String Doclet_CLASS_NAME = TestDoclet.class.getName();
 
     public static void main(String... args) throws Exception {
-        RemoveOldDoclet tester = new RemoveOldDoclet();
-        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+        var tester = new RemoveOldDoclet();
+        tester.runTests();
     }
 
     RemoveOldDoclet() {

--- a/test/langtools/jdk/javadoc/tool/reporter_generates_warnings/ReporterGeneratesWarningsInsteadOfNotes.java
+++ b/test/langtools/jdk/javadoc/tool/reporter_generates_warnings/ReporterGeneratesWarningsInsteadOfNotes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@ public class ReporterGeneratesWarningsInsteadOfNotes extends TestRunner {
     }
 
     public static void main(String... args) throws Exception {
-        ReporterGeneratesWarningsInsteadOfNotes tester = new ReporterGeneratesWarningsInsteadOfNotes();
+        var tester = new ReporterGeneratesWarningsInsteadOfNotes();
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/tool/testToolStreams/TestToolStreams.java
+++ b/test/langtools/jdk/javadoc/tool/testToolStreams/TestToolStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ import toolbox.ToolBox;
 public class TestToolStreams extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestToolStreams tester = new TestToolStreams();
-        tester.runTests(m -> new Object[]{Path.of(m.getName())});
+        var tester = new TestToolStreams();
+        tester.runTests();
     }
 
     ToolBox tb = new ToolBox();

--- a/test/langtools/jdk/javadoc/tool/testWErrorOption/TestWErrorOption.java
+++ b/test/langtools/jdk/javadoc/tool/testWErrorOption/TestWErrorOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ import toolbox.ToolBox;
 public class TestWErrorOption extends JavadocTester {
 
     public static void main(String... args) throws Exception {
-        TestWErrorOption tester = new TestWErrorOption();
-        tester.runTests(m -> new Object[] { Paths.get(m.getName()) });
+        var tester = new TestWErrorOption();
+        tester.runTests();
     }
 
     private final ToolBox tb = new ToolBox();


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

The patch needed some resolving. 

The only file with a trivial resolve in code is TestUnicode.java.

All other resolves are Copyright issues.
A row of files are not in 17. I did not research how they
apprear in 21, this seems too much effort for this rather
pointless change. 
Nevertheless this might make later backports easier for the 
files catched here, which is the majority.






File not in 17:
test/langtools/jdk/javadoc/doclet/testAutoHeaderId/TestAutoHeaderId.java

test/langtools/jdk/javadoc/doclet/testClassCrossReferences/TestClassCrossReferences.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/TestRegistrationErrors.java
test/langtools/jdk/javadoc/doclet/testDateOption/TestDateOption.java
test/langtools/jdk/javadoc/doclet/testDocTreeDiags/TestDocTreeDiags.java
test/langtools/jdk/javadoc/doclet/testDoclintDocletMessages/TestDocLintDocletMessages.java


test/langtools/jdk/javadoc/doclet/testExternalOverriddenMethod/TestExternalOverriddenMethod.java
test/langtools/jdk/javadoc/doclet/testHref/TestHref.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testInheritDocWithinInappropriateTag/TestInheritDocWithinInappropriateTag.java
test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXCombo.java
test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java

test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOption.java
test/langtools/jdk/javadoc/doclet/testLinkOption/TestLinkOptionWithModule.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkNotFound.java

test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTaglet.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkTagletPrimitive.java

test/langtools/jdk/javadoc/doclet/testModules/TestModuleServices.java
test/langtools/jdk/javadoc/doclet/testOverview/TestOverview.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testSeeLinkAnchor/TestSeeLinkAnchor.java

test/langtools/jdk/javadoc/doclet/testSerialVersionUID/TestSerialVersionUID.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testSerialWithLink/TestSerialWithLink.java
test/langtools/jdk/javadoc/doclet/testSnippetTag/TestLangProperties.java
test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetPathOption.java
test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java

test/langtools/jdk/javadoc/doclet/testSystemPropertyTaglet/TestSystemPropertyTaglet.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testTagInheritance/TestTagInheritance.java

test/langtools/jdk/javadoc/doclet/testThrows/TestThrows.java
test/langtools/jdk/javadoc/doclet/testThrowsHead/TestThrowsHead.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testThrowsInheritance/TestThrowsTagInheritance.java
test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMatching/TestExceptionTypeMatching.java
test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java

test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
Copyright and some code.

test/langtools/jdk/javadoc/doclet/testUnnamedPackage/TestUnnamedPackage.java
Copyright

File not in 17:
test/langtools/jdk/javadoc/doclet/testValueTag/TestValueFormats.java
test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTesterCrash.java
test/langtools/jdk/javadoc/testTFMBuilder/TestTFM

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286311](https://bugs.openjdk.org/browse/JDK-8286311) needs maintainer approval

### Issue
 * [JDK-8286311](https://bugs.openjdk.org/browse/JDK-8286311): remove boilerplate from use of runTests (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2384/head:pull/2384` \
`$ git checkout pull/2384`

Update a local copy of the PR: \
`$ git checkout pull/2384` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2384`

View PR using the GUI difftool: \
`$ git pr show -t 2384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2384.diff">https://git.openjdk.org/jdk17u-dev/pull/2384.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2384#issuecomment-2046750821)