### PR TITLE
8329823: RISC-V: Need to sync CPU features with related JVM flags

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -55,6 +55,10 @@ class VM_Version : public Abstract_VM_Version {
       _enabled = true;
       _value = value;
     }
+    void disable_feature() {
+      _enabled = false;
+      _value = -1;
+    }
     const char* const pretty()   { return _pretty; }
     const uint64_t feature_bit() { return _feature_bit; }
     const bool feature_string()  { return _feature_string; }
@@ -63,16 +67,21 @@ class VM_Version : public Abstract_VM_Version {
     virtual void update_flag() = 0;
   };
 
-  #define UPDATE_DEFAULT(flag)        \
-  void update_flag() {                \
-      assert(enabled(), "Must be.");  \
-      if (FLAG_IS_DEFAULT(flag)) {    \
-        FLAG_SET_DEFAULT(flag, true); \
-      }                               \
-  }                                   \
+  #define UPDATE_DEFAULT(flag)             \
+  void update_flag() {                     \
+      assert(enabled(), "Must be.");       \
+      if (FLAG_IS_DEFAULT(flag)) {         \
+        FLAG_SET_DEFAULT(flag, true);      \
+      } else {                             \
+        /* Sync CPU features with flags */ \
+        if (!flag) {                       \
+          disable_feature();               \
+        }                                  \
+      }                                    \
+  }                                        \
 
-  #define NO_UPDATE_DEFAULT           \
-  void update_flag() {}               \
+  #define NO_UPDATE_DEFAULT                \
+  void update_flag() {}                    \
 
   // Frozen standard extensions
   // I RV64I

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -115,6 +115,15 @@ void VM_Version::setup_cpu_available_features() {
   int i = 0;
   while (_feature_list[i] != nullptr) {
     if (_feature_list[i]->enabled()) {
+      // Change flag default
+      _feature_list[i]->update_flag();
+
+      // Feature will be disabled by update_flag() if flag
+      // is set to false by the user on the command line.
+      if (!_feature_list[i]->enabled()) {
+        continue;
+      }
+
       log_debug(os, cpu)("Enabled RV64 feature \"%s\" (%ld)",
              _feature_list[i]->pretty(),
              _feature_list[i]->value());
@@ -139,8 +148,6 @@ void VM_Version::setup_cpu_available_features() {
       if (_feature_list[i]->feature_bit() != 0) {
         _features |= _feature_list[i]->feature_bit();
       }
-      // Change flag default
-      _feature_list[i]->update_flag();
     }
     i++;
   }


### PR DESCRIPTION
Hi, The same issue also exists in the  jdk17u-dev. I would like to backport [8329823](https://bugs.openjdk.org/browse/JDK-8329823) to jdk17u-dev. With this backport,  We synchronize these features with related JVM flags so that "features" string can reflect actual usable CPU features. This is a risc-v specific change. Backport is clean, risk is low.

### Testing

- [x]  Run tier1 tests on SOPHON SG2042 (release)

Results without specifying any jvm flags(After applying this patch)
```
----------System.out:(4/135)----------
WB.getCPUFeatures(): "rv64 i m a f d c"
CPUInfo.getAdditionalCPUInfo(): ""
CPUInfo.getFeatures(): [rv64, i, m, a, f, d, c]
TEST PASSED
```

Results with specifying -XX:-UseRVC (After applying this patch)
```
----------System.out:(4/130)----------
WB.getCPUFeatures(): "rv64 i m a f d"
CPUInfo.getAdditionalCPUInfo(): ""
CPUInfo.getFeatures(): [rv64, i, m, a, f, d]
TEST PASSED
```
Results with specifying -XX:+UseRVC (After applying this patch)
```
----------System.out:(4/135)----------
WB.getCPUFeatures(): "rv64 i m a f d c"
CPUInfo.getAdditionalCPUInfo(): ""
CPUInfo.getFeatures(): [rv64, i, m, a, f, d, c]
TEST PASSED
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329823](https://bugs.openjdk.org/browse/JDK-8329823) needs maintainer approval

### Issue
 * [JDK-8329823](https://bugs.openjdk.org/browse/JDK-8329823): RISC-V: Need to sync CPU features with related JVM flags (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2385/head:pull/2385` \
`$ git checkout pull/2385`

Update a local copy of the PR: \
`$ git checkout pull/2385` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2385`

View PR using the GUI difftool: \
`$ git pr show -t 2385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2385.diff">https://git.openjdk.org/jdk17u-dev/pull/2385.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2385#issuecomment-2047150187)