### PR TITLE
8309409: Update HttpInputStreamTest and BodyProcessorInputStreamTest to use hg.openjdk.org

### DIFF
--- a/test/jdk/java/net/httpclient/BodyProcessorInputStreamTest.java
+++ b/test/jdk/java/net/httpclient/BodyProcessorInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ public class BodyProcessorInputStreamTest {
     public static void main(String[] args) throws Exception {
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest
-            .newBuilder(new URI("http://hg.openjdk.java.net/jdk9/sandbox/jdk/shortlog/http-client-branch/"))
+            .newBuilder(new URI("https://hg.openjdk.org/jdk9/sandbox/jdk/shortlog/http-client-branch/"))
             .GET()
             .build();
 

--- a/test/jdk/java/net/httpclient/HttpInputStreamTest.java
+++ b/test/jdk/java/net/httpclient/HttpInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,7 +286,7 @@ public class HttpInputStreamTest {
     public static void main(String[] args) throws Exception {
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest
-            .newBuilder(new URI("http://hg.openjdk.java.net/jdk9/sandbox/jdk/shortlog/http-client-branch/"))
+            .newBuilder(new URI("https://hg.openjdk.org/jdk9/sandbox/jdk/shortlog/http-client-branch/"))
             .GET()
             .build();
 


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309409](https://bugs.openjdk.org/browse/JDK-8309409) needs maintainer approval

### Issue
 * [JDK-8309409](https://bugs.openjdk.org/browse/JDK-8309409): Update HttpInputStreamTest and BodyProcessorInputStreamTest to use hg.openjdk.org (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2387/head:pull/2387` \
`$ git checkout pull/2387`

Update a local copy of the PR: \
`$ git checkout pull/2387` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2387`

View PR using the GUI difftool: \
`$ git pr show -t 2387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2387.diff">https://git.openjdk.org/jdk17u-dev/pull/2387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2387#issuecomment-2047403704)