### PR TITLE
8298249: Excessive memory allocation in CipherInputStream AEAD decryption

### DIFF
--- a/src/java.base/share/classes/javax/crypto/CipherInputStream.java
+++ b/src/java.base/share/classes/javax/crypto/CipherInputStream.java
@@ -105,11 +105,17 @@ public class CipherInputStream extends FilterInputStream {
      * operation, given the input length <code>inLen</code> (in bytes)
      * The ostart and ofinish indices are reset to 0.
      *
+     * If obuffer is null/zero-sized, do not allocate a new buffer.
+     * This reduces allocation for AEAD ciphers that never return data from update
+     *
      * @param inLen the input length (in bytes)
      */
     private void ensureCapacity(int inLen) {
+        if (obuffer == null || obuffer.length == 0) {
+            return;
+        }
         int minLen = cipher.getOutputSize(inLen);
-        if (obuffer == null || obuffer.length < minLen) {
+        if (obuffer.length < minLen) {
             obuffer = new byte[minLen];
         }
         ostart = 0;
@@ -142,7 +148,12 @@ public class CipherInputStream extends FilterInputStream {
             done = true;
             ensureCapacity(0);
             try {
-                ofinish = cipher.doFinal(obuffer, 0);
+                if (obuffer != null && obuffer.length > 0) {
+                    ofinish = cipher.doFinal(obuffer, 0);
+                } else {
+                    obuffer = cipher.doFinal();
+                    ofinish = obuffer.length;
+                }
             } catch (IllegalBlockSizeException | BadPaddingException
                     | ShortBufferException e) {
                 throw new IOException(e);
@@ -155,7 +166,14 @@ public class CipherInputStream extends FilterInputStream {
         }
         ensureCapacity(readin);
         try {
-            ofinish = cipher.update(ibuffer, 0, readin, obuffer, ostart);
+            // initial obuffer is assigned by update/doFinal;
+            // for AEAD ciphers, obuffer is always null or zero-length here
+            if (obuffer != null && obuffer.length > 0) {
+                ofinish = cipher.update(ibuffer, 0, readin, obuffer, ostart);
+            } else {
+                obuffer = cipher.update(ibuffer, 0, readin);
+                ofinish = (obuffer != null) ? obuffer.length : 0;
+            }
         } catch (IllegalStateException e) {
             throw e;
         } catch (ShortBufferException e) {
@@ -342,7 +360,11 @@ public class CipherInputStream extends FilterInputStream {
         if (!done) {
             ensureCapacity(0);
             try {
-                cipher.doFinal(obuffer, 0);
+                if (obuffer != null && obuffer.length > 0) {
+                    cipher.doFinal(obuffer, 0);
+                } else {
+                    cipher.doFinal();
+                }
             } catch (BadPaddingException | IllegalBlockSizeException
                     | ShortBufferException ex) {
                 // Catch exceptions as the rest of the stream is unused.

--- a/test/micro/org/openjdk/bench/javax/crypto/full/AESGCMCipherInputStream.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/AESGCMCipherInputStream.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.javax.crypto.full;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+/**
+ * This performance test runs AES/GCM encryption and decryption using CipherInputStream.
+ *
+ * This test rotates the IV and creates a new GCMParameterSpec for each encrypt
+ * benchmark operation
+ */
+
+public class AESGCMCipherInputStream extends CryptoBase {
+
+    @Param({"128"})
+    private int keyLength;
+
+    @Param({"16384", "1048576"})
+    private int dataSize;
+
+    byte[] encryptedData;
+    byte[] in;
+    ByteArrayOutputStream out;
+    private Cipher encryptCipher;
+    private Cipher decryptCipher;
+    SecretKeySpec ks;
+    GCMParameterSpec gcm_spec;
+    byte[] iv;
+
+    private static final int IV_BUFFER_SIZE = 32;
+    private static final int IV_MODULO = IV_BUFFER_SIZE - 16;
+    int iv_index = 0;
+
+    private int next_iv_index() {
+        int r = iv_index;
+        iv_index = (iv_index + 1) % IV_MODULO;
+        return r;
+    }
+
+    @Setup
+    public void setup() throws Exception {
+        setupProvider();
+
+        // Setup key material
+        byte[] keystring = fillSecureRandom(new byte[keyLength / 8]);
+        ks = new SecretKeySpec(keystring, "AES");
+        iv = fillSecureRandom(new byte[IV_BUFFER_SIZE]);
+        gcm_spec = new GCMParameterSpec(96, iv, next_iv_index(), 16);
+
+        // Setup Cipher classes
+        encryptCipher = makeCipher(prov, "AES/GCM/NoPadding");
+        encryptCipher.init(Cipher.ENCRYPT_MODE, ks, gcm_spec);
+        decryptCipher = makeCipher(prov, "AES/GCM/NoPadding");
+        decryptCipher.init(Cipher.DECRYPT_MODE, ks,
+            encryptCipher.getParameters().
+                getParameterSpec(GCMParameterSpec.class));
+
+        // Setup input/output buffers
+        in = fillRandom(new byte[dataSize]);
+        encryptedData = new byte[encryptCipher.getOutputSize(in.length)];
+        out = new ByteArrayOutputStream(encryptedData.length);
+        encryptCipher.doFinal(in, 0, in.length, encryptedData, 0);
+    }
+
+    @Benchmark
+    public byte[] encrypt() throws Exception {
+        out.reset();
+        gcm_spec = new GCMParameterSpec(96, iv, next_iv_index(), 16);
+        encryptCipher.init(Cipher.ENCRYPT_MODE, ks, gcm_spec);
+        ByteArrayInputStream fin = new ByteArrayInputStream(in);
+        InputStream cin = new CipherInputStream(fin, encryptCipher);
+
+        cin.transferTo(out);
+        return out.toByteArray();
+    }
+
+    @Benchmark
+    public byte[] decrypt() throws Exception {
+        out.reset();
+        decryptCipher.init(Cipher.DECRYPT_MODE, ks,
+                encryptCipher.getParameters().
+                        getParameterSpec(GCMParameterSpec.class));
+        ByteArrayInputStream fin = new ByteArrayInputStream(encryptedData);
+        InputStream cin = new CipherInputStream(fin, decryptCipher);
+
+        cin.transferTo(out);
+        return out.toByteArray();
+    }
+}


### PR DESCRIPTION
Improves `CipherInputStream` with `AES-GCM` significantly. This problem is seen in some of our services.

There is a related [JDK-8298865](https://bugs.openjdk.org/browse/JDK-8298865), which I would backport separately.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `jdk_security`
 - [ ] Linux x86_64 server fastdebug, `all`
 - [x] Ad-hoc benchmarks 

```
Benchmark                        (dataSize)  (keyLength)    Mode  Cnt       Score     Error  Units

# Before
AESGCMCipherInputStream.decrypt       16384          128   thrpt   40   35547.250 ± 154.108  ops/s
AESGCMCipherInputStream.decrypt     1048576          128   thrpt   40      17.297 ±   0.043  ops/s
AESGCMCipherInputStream.encrypt       16384          128   thrpt   40  150791.244 ± 656.878  ops/s
AESGCMCipherInputStream.encrypt     1048576          128   thrpt   40    2561.195 ±  27.701  ops/s

# After
AESGCMCipherInputStream.decrypt       16384          128   thrpt   40   65815.523 ± 156.983  ops/s
AESGCMCipherInputStream.decrypt     1048576          128   thrpt   40     786.680 ± 298.170  ops/s
AESGCMCipherInputStream.encrypt       16384          128   thrpt   40  149412.181 ± 431.304  ops/s
AESGCMCipherInputStream.encrypt     1048576          128   thrpt   40    2581.110 ±  23.931  ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8298249](https://bugs.openjdk.org/browse/JDK-8298249) needs maintainer approval

### Issue
 * [JDK-8298249](https://bugs.openjdk.org/browse/JDK-8298249): Excessive memory allocation in CipherInputStream AEAD decryption (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2393/head:pull/2393` \
`$ git checkout pull/2393`

Update a local copy of the PR: \
`$ git checkout pull/2393` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2393`

View PR using the GUI difftool: \
`$ git pr show -t 2393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2393.diff">https://git.openjdk.org/jdk17u-dev/pull/2393.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2393#issuecomment-2049858320)