### PR TITLE
8325579: Inconsistent behavior in com.sun.jndi.ldap.Connection::createSocket

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,17 +120,15 @@ import javax.security.sasl.SaslException;
 public final class Connection implements Runnable {
 
     private static final boolean debug = false;
-    private static final int dump = 0; // > 0 r, > 1 rw
-
 
     private final Thread worker;    // Initialized in constructor
 
-    private boolean v3 = true;       // Set in setV3()
+    private boolean v3 = true;     // Set in setV3()
 
     public final String host;  // used by LdapClient for generating exception messages
-                         // used by StartTlsResponse when creating an SSL socket
+                               // used by StartTlsResponse when creating an SSL socket
     public final int port;     // used by LdapClient for generating exception messages
-                         // used by StartTlsResponse when creating an SSL socket
+                               // used by StartTlsResponse when creating an SSL socket
 
     private boolean bound = false;   // Set in setBound()
 
@@ -319,30 +317,37 @@ public final class Connection implements Runnable {
     }
 
     private Socket createConnectionSocket(String host, int port, SocketFactory factory,
-                                          int connectTimeout) throws Exception {
+                                          int connectTimeout) throws IOException {
         Socket socket = null;
 
+        // if timeout is supplied, try to use unconnected socket for connecting with timeout
         if (connectTimeout > 0) {
-            // create unconnected socket and then connect it if timeout
-            // is supplied
-            InetSocketAddress endpoint =
-                    createInetSocketAddress(host, port);
-            // unconnected socket
-            socket = factory.createSocket();
-            // connect socket with a timeout
-            socket.connect(endpoint, connectTimeout);
             if (debug) {
-                System.err.println("Connection: creating socket with " +
-                        "a connect timeout");
+                System.err.println("Connection: creating socket with a connect timeout");
+            }
+            try {
+                // unconnected socket
+                socket = factory.createSocket();
+            } catch (IOException e) {
+                // unconnected socket is likely not supported by the SocketFactory
+                if (debug) {
+                    System.err.println("Connection: unconnected socket not supported by SocketFactory");
+                }
+            }
+            if (socket != null) {
+                InetSocketAddress endpoint = createInetSocketAddress(host, port);
+                // connect socket with a timeout
+                socket.connect(endpoint, connectTimeout);
             }
         }
+
+        // either no timeout was supplied or unconnected socket did not work
         if (socket == null) {
             // create connected socket
-            socket = factory.createSocket(host, port);
             if (debug) {
-                System.err.println("Connection: creating connected socket with" +
-                        " no connect timeout");
+                System.err.println("Connection: creating connected socket with no connect timeout");
             }
+            socket = factory.createSocket(host, port);
         }
         return socket;
     }
@@ -351,7 +356,7 @@ public final class Connection implements Runnable {
     // the SSL handshake following socket connection as part of the timeout.
     // So explicitly set a socket read timeout, trigger the SSL handshake,
     // then reset the timeout.
-    private void initialSSLHandshake(SSLSocket sslSocket , int connectTimeout) throws Exception {
+    private void initialSSLHandshake(SSLSocket sslSocket, int connectTimeout) throws Exception {
 
             if (!IS_HOSTNAME_VERIFICATION_DISABLED) {
                 SSLParameters param = sslSocket.getSSLParameters();

--- a/src/java.naming/share/classes/module-info.java
+++ b/src/java.naming/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,21 +36,33 @@
  * The following implementation specific environment properties are supported by the
  * default LDAP Naming Service Provider implementation in the JDK:
  * <ul>
+ *     <li>{@code java.naming.ldap.factory.socket}:
+ *         <br>The value of this environment property specifies the fully
+ *         qualified class name of the socket factory used by the LDAP provider.
+ *         This class must implement the {@link javax.net.SocketFactory} abstract class
+ *         and provide an implementation of the static "getDefault()" method that
+ *         returns an instance of the socket factory. By default the environment
+ *         property is not set.
+ *     </li>
  *     <li>{@code com.sun.jndi.ldap.connect.timeout}:
- *         <br>The value of this property is the string representation
- *         of an integer representing the connection timeout in
- *         milliseconds. If the LDAP provider cannot establish a
- *         connection within that period, it aborts the connection attempt.
+ *         <br>The value of this environment property is the string representation
+ *         of an integer specifying the connection timeout in milliseconds.
+ *         If the LDAP provider cannot establish a connection within that period,
+ *         it aborts the connection attempt.
  *         The integer should be greater than zero. An integer less than
  *         or equal to zero means to use the network protocol's (i.e., TCP's)
  *         timeout value.
  *         <br> If this property is not specified, the default is to wait
  *         for the connection to be established or until the underlying
  *         network times out.
+ *         <br> If a custom socket factory is provided via environment property
+ *         {@code java.naming.ldap.factory.socket} and unconnected sockets
+ *         are not supported, the specified timeout is ignored
+ *         and the provider behaves as if no connection timeout was set.
  *     </li>
  *     <li>{@code com.sun.jndi.ldap.read.timeout}:
  *         <br>The value of this property is the string representation
- *         of an integer representing the read timeout in milliseconds
+ *         of an integer specifying the read timeout in milliseconds
  *         for LDAP operations. If the LDAP provider cannot get a LDAP
  *         response within that period, it aborts the read attempt. The
  *         integer should be greater than zero. An integer less than or


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fbb424f9](https://github.com/openjdk/jdk21u-dev/commit/fbb424f95d73e99c7a533ed5dae8fbb6d13dc93b) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by Christoph Langer on 11 Apr 2024 and had no reviewers.

Applies clean except for the copyright years in module-info.java. Will mark clean, hence.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325579](https://bugs.openjdk.org/browse/JDK-8325579) needs maintainer approval
- [x] Change requires CSR request [JDK-8326482](https://bugs.openjdk.org/browse/JDK-8326482) to be approved

### Issues
 * [JDK-8325579](https://bugs.openjdk.org/browse/JDK-8325579): Inconsistent behavior in com.sun.jndi.ldap.Connection::createSocket (**Bug** - P3 - Approved)
 * [JDK-8326482](https://bugs.openjdk.org/browse/JDK-8326482): Inconsistent behavior in com.sun.jndi.ldap.Connection::createSocket (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2396/head:pull/2396` \
`$ git checkout pull/2396`

Update a local copy of the PR: \
`$ git checkout pull/2396` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2396`

View PR using the GUI difftool: \
`$ git pr show -t 2396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2396.diff">https://git.openjdk.org/jdk17u-dev/pull/2396.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2396#issuecomment-2050017615)