### PR TITLE
8328988: [macos14] Problem list LightweightEventTest.java which fails due to macOS bug described in JDK-8322653

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -182,7 +182,7 @@ java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java 6829264
 java/awt/datatransfer/DragImage/MultiResolutionDragImageTest.java 8080982 generic-all
 java/awt/datatransfer/SystemFlavorMap/AddFlavorTest.java 8079268 linux-all
 java/awt/Toolkit/RealSync/Test.java 6849383 linux-all
-java/awt/LightweightComponent/LightweightEventTest/LightweightEventTest.java 8159252 windows-all
+java/awt/LightweightComponent/LightweightEventTest/LightweightEventTest.java 8159252,8324782 windows-all,macosx-all
 java/awt/EventDispatchThread/HandleExceptionOnEDT/HandleExceptionOnEDT.java 8203047 macosx-all
 java/awt/EventDispatchThread/LoopRobustness/LoopRobustness.java 8073636 macosx-all
 java/awt/FullScreen/FullScreenInsets/FullScreenInsets.java 7019055,8266245 windows-all,linux-all,macosx-all


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

Resolved due to context. probably clean anywasy, else will mark as such.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328988](https://bugs.openjdk.org/browse/JDK-8328988) needs maintainer approval

### Issue
 * [JDK-8328988](https://bugs.openjdk.org/browse/JDK-8328988): [macos14] Problem list LightweightEventTest.java which fails due to macOS bug described in JDK-8322653 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2397/head:pull/2397` \
`$ git checkout pull/2397`

Update a local copy of the PR: \
`$ git checkout pull/2397` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2397`

View PR using the GUI difftool: \
`$ git pr show -t 2397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2397.diff">https://git.openjdk.org/jdk17u-dev/pull/2397.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2397#issuecomment-2050159760)