### PR TITLE
8302069: javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java update

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -571,8 +571,6 @@ sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-a
 
 javax/management/MBeanServer/OldMBeanServerTest.java            8030957 aix-all
 
-javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java 8042215 generic-all
-
 javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 generic-all
 
 ############################################################################

--- a/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,10 @@ public class NotifReconnectDeadlockTest {
         JMXServiceURL addr = server.getAddress();
         JMXConnector client = JMXConnectorFactory.connect(addr, env);
 
-        Thread.sleep(100); // let pass the first client open notif if there is
+        // Sleeping here was an attempt to avoid seeing an initial notification.
+        // This does not work, but does not matter.
+        // Thread.sleep(100);
+
         client.getMBeanServerConnection().addNotificationListener(oname,
                                                                   listener,
                                                                   null,
@@ -100,12 +103,13 @@ public class NotifReconnectDeadlockTest {
 
         synchronized(lock) {
             while(clientState == null && System.currentTimeMillis() < end) {
+                System.out.println("Calling sendNotifications");
                 mbs.invoke(oname, "sendNotifications",
                            new Object[] {new Notification("MyType", "", 0)},
                            new String[] {"javax.management.Notification"});
 
                 try {
-                    lock.wait(10);
+                    lock.wait(1000); // sleep as no point in constant notifications
                 } catch (Exception e) {}
             }
         }
@@ -143,10 +147,10 @@ public class NotifReconnectDeadlockTest {
     private final static NotificationListener listener = new NotificationListener() {
             public void handleNotification(Notification n, Object hb) {
 
-                // treat the client notif to know the end
+                System.out.println("handleNotification: " + n);
                 if (n instanceof JMXConnectionNotification) {
                     if (!JMXConnectionNotification.NOTIFS_LOST.equals(n.getType())) {
-
+                        // Expected: [type=jmx.remote.connection.opened][message=Reconnected to server]
                         clientState = n.getType();
                         System.out.println(
                            ">>> The client state has been changed to: "+clientState);
@@ -159,7 +163,7 @@ public class NotifReconnectDeadlockTest {
                     return;
                 }
 
-                System.out.println(">>> Do sleep to make reconnection.");
+                System.out.println(">>> sleeping in NotificationListener to force reconnection.");
                 synchronized(lock) {
                     try {
                         lock.wait(listenerSleep);
@@ -170,9 +174,11 @@ public class NotifReconnectDeadlockTest {
             }
         };
 
-    private static final long serverTimeout = 1000;
+    // serverTimeout increased to avoid occasional problems with initial connect.
+    // Not using Utils.adjustTimeout to avoid accidentally making it too long.
+    private static final long serverTimeout = 2000;
     private static final long listenerSleep = serverTimeout*6;
 
-    private static String clientState = null;
+    private volatile static String clientState = null;
     private static final int[] lock = new int[0];
 }


### PR DESCRIPTION
Backport of [JDK-8302069](https://bugs.openjdk.org/browse/JDK-8302069)

Testing
- Local: Test passed
  - `NotifReconnectDeadlockTest.java`: Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8302069](https://bugs.openjdk.org/browse/JDK-8302069) needs maintainer approval

### Issue
 * [JDK-8302069](https://bugs.openjdk.org/browse/JDK-8302069): javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java update (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2399/head:pull/2399` \
`$ git checkout pull/2399`

Update a local copy of the PR: \
`$ git checkout pull/2399` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2399`

View PR using the GUI difftool: \
`$ git pr show -t 2399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2399.diff">https://git.openjdk.org/jdk17u-dev/pull/2399.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2399#issuecomment-2050841826)