### PR TITLE
8305874: Open source AWT Key, Text Event related tests

### DIFF
--- a/test/jdk/java/awt/event/KeyEvent/KeyTyped/DeleteKeyTyped.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTyped/DeleteKeyTyped.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
+/*
+ * @test
+ * @bug 4724007
+ * @key headful
+ * @summary Tests that KeyTyped events are fired for the Delete key
+ *          and that no extraneous characters are entered as a result.
+ */
+
+public class DeleteKeyTyped {
+    private static Frame frame;
+    private static TextField tf;
+
+    private static boolean deleteKeyTypedReceived = false;
+    private static final String ORIGINAL = "0123456789";
+    private static final String SUCCESS = "123456789";
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(100);
+
+            EventQueue.invokeAndWait(DeleteKeyTyped::createTestUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            // Move cursor to start of TextField
+            robot.keyPress(KeyEvent.VK_HOME);
+            robot.keyRelease(KeyEvent.VK_HOME);
+            robot.waitForIdle();
+            robot.delay(50);
+
+            // Press and release Delete
+            robot.keyPress(KeyEvent.VK_DELETE);
+            robot.keyRelease(KeyEvent.VK_DELETE);
+            robot.waitForIdle();
+            robot.delay(50);
+
+            EventQueue.invokeAndWait(DeleteKeyTyped::testDeleteKeyEvent);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createTestUI() {
+        frame = new Frame();
+        tf = new TextField(ORIGINAL, 20);
+        frame.add(tf);
+        frame.setSize(300, 100);
+        frame.setVisible(true);
+        tf.requestFocusInWindow();
+
+        tf.addKeyListener(new KeyListener() {
+            @Override
+            public void keyPressed(KeyEvent evt) {
+                printKey(evt);
+            }
+
+            @Override
+            public void keyTyped(KeyEvent evt) {
+                printKey(evt);
+                int keychar = evt.getKeyChar();
+                if (keychar == 127) { // Delete character is 127 or \u007F
+                    deleteKeyTypedReceived = true;
+                }
+            }
+
+            @Override
+            public void keyReleased(KeyEvent evt) {
+                printKey(evt);
+            }
+
+            private void printKey(KeyEvent evt) {
+                switch(evt.getID()) {
+                    case KeyEvent.KEY_TYPED:
+                    case KeyEvent.KEY_PRESSED:
+                    case KeyEvent.KEY_RELEASED:
+                        break;
+                    default:
+                        System.out.println("Other Event");
+                        return;
+                }
+
+                System.out.println("params= " + evt.paramString() + "  \n" +
+                        "KeyChar: " + evt.getKeyChar() + " = " + (int) evt.getKeyChar() +
+                        "   KeyCode: " + evt.getKeyCode() +
+                        "   Modifiers: " + evt.getModifiersEx());
+
+                if (evt.isActionKey()) {
+                    System.out.println("Action Key");
+                }
+
+                System.out.println("keyText= " + KeyEvent.getKeyText(evt.getKeyCode()) + "\n");
+            }
+        });
+    }
+
+    private static void testDeleteKeyEvent() {
+        if (deleteKeyTypedReceived) {
+            if (tf.getText().equals(SUCCESS)) {
+                System.out.println("Test PASSED");
+            } else {
+                System.out.println("Test FAILED: wrong string");
+                throw new RuntimeException("The test failed: wrong string:  " +
+                        tf.getText());
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/KeyTyped/EscapeKeyTyped.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyTyped/EscapeKeyTyped.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4734408
+ * @summary Tests that KeyTyped events are fired for the Escape key
+ *          and that no extraneous characters are entered as a result.
+ */
+
+public class EscapeKeyTyped {
+    private static Frame frame;
+    private static TextField tf;
+
+    private static final String ORIGINAL = "0123456789";
+    private static boolean escapeKeyTypedReceived = false;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(30);
+
+            EventQueue.invokeAndWait(EscapeKeyTyped::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            // Press and release Escape
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
+            robot.delay(20);
+
+            EventQueue.invokeAndWait(EscapeKeyTyped::testEscKeyEvent);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new Frame();
+        tf = new TextField(ORIGINAL, 20);
+        frame.add(tf);
+        frame.setSize(300, 100);
+        frame.setVisible(true);
+        tf.requestFocusInWindow();
+
+        tf.addKeyListener(new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+                printKey(e);
+            }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+                printKey(e);
+                int keychar = e.getKeyChar();
+                if (keychar == 27) { // Escape character is 27 or \u0021
+                    escapeKeyTypedReceived = true;
+                }
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) {
+                printKey(e);
+            }
+
+            private void printKey(KeyEvent evt) {
+                switch (evt.getID()) {
+                    case KeyEvent.KEY_TYPED:
+                    case KeyEvent.KEY_PRESSED:
+                    case KeyEvent.KEY_RELEASED:
+                        break;
+                    default:
+                        System.out.println("Other Event");
+                        return;
+                }
+
+                System.out.println("params= " + evt.paramString() + "  \n" +
+                        "KeyChar: " + evt.getKeyChar() + " = " + (int) evt.getKeyChar() +
+                        "   KeyCode: " + evt.getKeyCode() +
+                        "   Modifiers: " + evt.getModifiersEx());
+
+                if (evt.isActionKey()) {
+                    System.out.println("Action Key");
+                }
+
+                System.out.println("keyText= " + KeyEvent.getKeyText(evt.getKeyCode()) + "\n");
+            }
+        });
+    }
+
+    private static void testEscKeyEvent() {
+        if (escapeKeyTypedReceived) {
+            if (tf.getText().equals(ORIGINAL)) {
+                System.out.println("Test PASSED");
+            } else {
+                System.out.println("Test FAILED: wrong string");
+                throw new RuntimeException("The test failed: wrong string:  " +
+                        tf.getText());
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/ShiftF10Test.java
+++ b/test/jdk/java/awt/event/KeyEvent/ShiftF10Test.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4965227
+ * @requires (os.family == "linux")
+ * @summary tests that Shift+F10 during Window show doesn't cause deadlock- Linux only
+ */
+
+public class ShiftF10Test {
+    private static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(10);
+
+            EventQueue.invokeLater(() -> {
+                frame = new Frame("Deadlocking one");
+                frame.setSize(100, 100);
+                frame.setVisible(true);
+            });
+
+            for (int i = 0; i < 250; i++) {
+                robot.keyPress(KeyEvent.VK_SHIFT);
+                robot.keyPress(KeyEvent.VK_F10);
+                robot.keyRelease(KeyEvent.VK_F10);
+                robot.keyRelease(KeyEvent.VK_SHIFT);
+                robot.delay(10);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Test Failed due to following error: ", e);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/event/OtherEvents/ContainerEventChildTest.java
+++ b/test/jdk/java/awt/event/OtherEvents/ContainerEventChildTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.event.ContainerAdapter;
+import java.awt.event.ContainerEvent;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4028904
+ * @summary Tests whether System.out.println(ContainerEvent e)
+ *          yields incorrect display or not.
+ */
+
+public class ContainerEventChildTest {
+    private static Frame frame;
+    private static String com1, com2;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame();
+                Panel outerPanel = new Panel();
+                Panel innerPanel = new Panel();
+                Button b = new Button("Panel Button");
+
+                innerPanel.addContainerListener(new ContainerAdapter() {
+                    public void componentAdded(ContainerEvent e) {
+                        String str1 = e.toString();
+                        String str2 = (e.getChild()).toString();
+
+                        // extracting child values from ContainerEvent i.e., "e" and "e.getChild()"
+                        com1 = str1.substring(str1.indexOf("child") + 6, str1.indexOf("]"));
+                        com2 = str2.substring(str2.indexOf("[") + 1, str2.indexOf(","));
+
+                        System.out.println("e : " + com1);
+                        System.out.println("e.getChild() : " + com2);
+
+                        // comparing the child values between "e" and "e.getChild()"
+                        // if child value of "e" equals null and child values between
+                        // "e" and "e.getChild()" are not equal then throws exception
+                        if (com1.equals("null") && !(com1.equals(com2))) {
+                            System.out.println("unequal");
+                            throw new RuntimeException("Test Failed e.toString returns false value");
+                        } else {
+                            System.out.println("Test Passed - e and e.getChild() are same");
+                        }
+                    }
+                });
+                innerPanel.add(b);
+                outerPanel.add(innerPanel);
+                frame.add(outerPanel);
+                frame.setVisible(true);
+            });
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/event/TextEvent/InitialTextEventTest.java
+++ b/test/jdk/java/awt/event/TextEvent/InitialTextEventTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.IllegalComponentStateException;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.event.TextEvent;
+import java.awt.event.TextListener;
+
+/*
+ * @test
+ * @bug 4503516
+ * @key headful
+ * @summary TextEvent behaves differently across platforms, especially Solaris.
+ *          Following testcase is used to test whether an initial TextEvent
+ *          is triggered when a TextArea or TextField is initially added to UI.
+ */
+
+public class InitialTextEventTest implements TextListener {
+    private static Frame frame;
+    private static TextField textField;
+    private static TextArea textArea;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+
+            InitialTextEventTest textEventObj = new InitialTextEventTest();
+            EventQueue.invokeAndWait(textEventObj::createUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(textEventObj::testInitialTextEvent);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private void createUI() {
+        frame = new Frame();
+        frame.setTitle("Text Event Test");
+        frame.setLayout(new FlowLayout());
+
+        textField = new TextField("TextField");
+        textArea = new TextArea("TextArea", 5, 10);
+
+        textField.addTextListener(this);
+        textArea.addTextListener(this);
+
+        frame.add(textField);
+        frame.add(textArea);
+
+        frame.setBackground(Color.red);
+        frame.setSize(500,200);
+        frame.setVisible(true);
+    }
+
+    private void testInitialTextEvent() {
+        Point pt;
+        boolean drawn = false;
+        while (!drawn) {
+            try {
+                pt = textArea.getLocationOnScreen();
+                System.out.println("On-Screen Location on Text Area: " + pt);
+                pt = textField.getLocationOnScreen();
+                System.out.println("On-Screen Location on Text Field: " + pt);
+            } catch (IllegalComponentStateException icse) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException ignored) {}
+                continue;
+            }
+            drawn = true;
+        }
+    }
+
+    @Override
+    public void textValueChanged(TextEvent e) {
+        System.out.println("text event paramString: " + e.paramString());
+        System.out.println("text event changed on: " + e.getSource().getClass().getName());
+        throw new RuntimeException("InitialTextEventTest FAILED");
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8305874](https://bugs.openjdk.org/browse/JDK-8305874)

Testing
- Local: Test passed
  - `DeleteKeyTyped.java`: Test results: passed: 1
  - `EscapeKeyTyped.java`: Test results: passed: 1
  - `ShiftF10Test.java`: Test results: no tests selected
  - `ContainerEventChildTest.java`: Test results: passed: 1
  - `InitialTextEventTest.java`: Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8305874](https://bugs.openjdk.org/browse/JDK-8305874) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305874](https://bugs.openjdk.org/browse/JDK-8305874): Open source AWT Key, Text Event related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2400/head:pull/2400` \
`$ git checkout pull/2400`

Update a local copy of the PR: \
`$ git checkout pull/2400` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2400`

View PR using the GUI difftool: \
`$ git pr show -t 2400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2400.diff">https://git.openjdk.org/jdk17u-dev/pull/2400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2400#issuecomment-2050910631)