### PR TITLE
8306634: Open source AWT Event related tests

### DIFF
--- a/test/jdk/java/awt/Component/RepaintTest.java
+++ b/test/jdk/java/awt/Component/RepaintTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Point;
+import java.awt.Robot;
+
+/*
+ * @test
+ * @bug 4189198
+ * @key headful
+ * @summary updateClient should post a PaintEvent
+ */
+
+public class RepaintTest {
+    private static volatile Frame frame;
+    private static volatile Label label;
+    private static volatile Point frameLoc;
+
+    private static final int FRAME_DIM = 100;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("Repaint Tester");
+                frame.setSize(FRAME_DIM, FRAME_DIM);
+                label = new Label("Hi");
+                frame.add(label);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                label.setBackground(Color.GREEN);
+                label.repaint();
+                frameLoc = frame.getLocationOnScreen();
+            });
+            robot.waitForIdle();
+            robot.delay(500);
+
+            Color expectedColor = robot.getPixelColor(frameLoc.x + FRAME_DIM / 2,
+                                                      frameLoc.y + FRAME_DIM / 2);
+            if (!Color.GREEN.equals(expectedColor)) {
+                throw new RuntimeException("Test Failed! \n" +
+                        "PaintEvent was not triggered: ");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                   frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/java/awt/event/MouseEvent/MouseEventAbsoluteCoordsTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseEventAbsoluteCoordsTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+/*
+ * @test
+ * @bug 4992908
+ * @key headful
+ * @summary Need way to get location of MouseEvent in screen coordinates
+ */
+
+// The test consists of several parts:
+// 1. create MouseEvent with new Ctor and checking get(X|Y)OnScreen(),
+// getLocationOnScreen(), get(X|Y), getPoint().
+// 2. create MouseEvent with old Ctor and checking get(X|Y)OnScreen(),
+// getLocationOnScreen(),  get(X|Y), getPoint() .
+
+public class MouseEventAbsoluteCoordsTest implements MouseListener {
+    private static Frame frame;
+    private static Robot robot;
+
+    private static Point mousePositionOnScreen = new Point(200, 200);
+    private static final Point mousePosition = new Point(100, 100);
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+
+            MouseEventAbsoluteCoordsTest cordsTest =
+                    new MouseEventAbsoluteCoordsTest();
+            cordsTest.createTestUI();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void createTestUI() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            frame = new Frame("MouseEvent Test Frame");
+            frame.setSize(200, 200);
+            frame.setLocation(300, 400);
+            frame.addMouseListener(this);
+            frame.setVisible(true);
+        });
+
+        robot.waitForIdle();
+        robot.delay(1000);
+
+        // use new MouseEvent's Ctor with user-defined absolute
+        // coordinates
+        System.out.println("Stage MOUSE_PRESSED");
+        postMouseEventNewCtor(MouseEvent.MOUSE_PRESSED);
+
+        System.out.println("Stage MOUSE_RELEASED");
+        postMouseEventNewCtor(MouseEvent.MOUSE_RELEASED);
+
+        System.out.println("Stage MOUSE_CLICKED");
+        postMouseEventNewCtor(MouseEvent.MOUSE_CLICKED);
+
+        // call syncLocation to get correct on-screen frame position
+        syncLocationToWindowManager();
+
+        // now we gonna use old MouseEvent's Ctor thus absolute
+        // position calculates as frame's location + relative coords
+        // of the event.
+        EventQueue.invokeAndWait(() -> mousePositionOnScreen = new Point(
+                frame.getLocationOnScreen().x + mousePosition.x,
+                frame.getLocationOnScreen().y + mousePosition.y));
+
+        System.out.println("Stage MOUSE_PRESSED");
+        postMouseEventOldCtor(MouseEvent.MOUSE_PRESSED);
+
+        System.out.println("Stage MOUSE_RELEASED");
+        postMouseEventOldCtor(MouseEvent.MOUSE_RELEASED);
+
+        System.out.println("Stage MOUSE_CLICKED");
+        postMouseEventOldCtor(MouseEvent.MOUSE_CLICKED);
+    }
+
+    private static void syncLocationToWindowManager() {
+        Toolkit.getDefaultToolkit().sync();
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void mousePressed(MouseEvent e) {
+        checkEventAbsolutePosition(e, "MousePressed OK");
+    };
+
+    @Override
+    public void mouseExited(MouseEvent e) {
+        System.out.println("mouse exited");
+    };
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        checkEventAbsolutePosition(e, "MousePressed OK");
+    };
+
+    @Override
+    public void mouseEntered(MouseEvent e) {
+        System.out.println("mouse entered");
+    };
+
+    @Override
+    public void mouseClicked(MouseEvent e) {
+        checkEventAbsolutePosition(e, "MousePressed OK");
+    };
+
+    public void postMouseEventNewCtor(int MouseEventType) {
+        MouseEvent mouseEvt = new MouseEvent(frame,
+                                       MouseEventType,
+                                       System.currentTimeMillis(),
+                                       MouseEvent.BUTTON1_DOWN_MASK,
+                                       mousePosition.x, mousePosition.y,
+                                       mousePositionOnScreen.x,
+                                       mousePositionOnScreen.y,
+                                       1,
+                                       false,
+                                       MouseEvent.NOBUTTON
+                                       );
+        frame.dispatchEvent(mouseEvt);
+    }
+
+    public void postMouseEventOldCtor(int MouseEventType) {
+        MouseEvent oldMouseEvt = new MouseEvent(frame,
+                                          MouseEventType,
+                                          System.currentTimeMillis(),
+                                          MouseEvent.BUTTON1_DOWN_MASK,
+                                          mousePosition.x, mousePosition.y,
+                                          1,
+                                          false,
+                                          MouseEvent.NOBUTTON
+                                          );
+        frame.dispatchEvent(oldMouseEvt);
+    }
+
+    public void checkEventAbsolutePosition(MouseEvent evt, String message) {
+        if (evt.getXOnScreen() != mousePositionOnScreen.x ||
+            evt.getYOnScreen() != mousePositionOnScreen.y ||
+            !evt.getLocationOnScreen().equals( mousePositionOnScreen)) {
+                System.out.println("evt.location = "+evt.getLocationOnScreen());
+                System.out.println("mouse.location = "+mousePositionOnScreen);
+                throw new RuntimeException("get(X|Y)OnScreen() or getPointOnScreen() work incorrectly");
+        }
+
+        if (evt.getX() != mousePosition.x ||
+            evt.getY() != mousePosition.y ||
+            !evt.getPoint().equals( mousePosition)) {
+            throw new RuntimeException("get(X|Y)() or getPoint() work incorrectly");
+        }
+        System.out.println(message);
+    }
+}

--- a/test/jdk/java/awt/event/OtherEvents/UndecoratedShrink.java
+++ b/test/jdk/java/awt/event/OtherEvents/UndecoratedShrink.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Robot;
+
+/*
+ * @test
+ * @bug 4418155
+ * @key headful
+ * @summary Checks Undecorated Frame repaints when shrinking
+ */
+
+public class UndecoratedShrink extends Frame {
+    private static boolean passed = false;
+    private static UndecoratedShrink frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                frame = new UndecoratedShrink();
+                frame.setUndecorated(true);
+                frame.setSize(100, 100);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> {
+                frame.setSize(50, 50);
+                frame.repaint();
+            });
+            robot.waitForIdle();
+            robot.delay(500);
+
+            if (!passed) {
+                throw new RuntimeException("Test Fails." +
+                        " Frame does not get repainted");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        passed = true;
+    }
+}

--- a/test/jdk/javax/swing/JInternalFrame/bug4212562.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug4212562.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JInternalFrame;
+
+/*
+ * @test
+ * @bug 4212562
+ * @summary To check if StackOverflow occurs if foreground is set to null.
+ */
+
+public class bug4212562 {
+    public static void main(String[] args) {
+        try {
+            JInternalFrame jif = new JInternalFrame();
+            jif.getContentPane().setForeground(null);
+            jif.getForeground();
+        } catch (Exception e) {
+            throw new RuntimeException("Following exception occurred" +
+                    " when getForeground() was called", e);
+        }
+    }
+}

--- a/test/jdk/sun/awt/font/DoubleAntialiasTest.java
+++ b/test/jdk/sun/awt/font/DoubleAntialiasTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.Robot;
+
+import static java.awt.RenderingHints.KEY_ANTIALIASING;
+import static java.awt.RenderingHints.KEY_TEXT_ANTIALIASING;
+import static java.awt.RenderingHints.VALUE_ANTIALIAS_ON;
+import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON;
+
+/*
+ * @test
+ * @bug 4357180
+ * @key headful
+ * @summary When both KEY_ANTIALIASING and KEY_TEXT_ANTIALIASING hints
+ *          were turned on, java aborts with EXCEPTION_ACCESS_VIOLATION
+ *          at attempt to draw characters in Hebrew or Arabic.
+ *          This could happen immediately or after several draws,
+ *          depending on th locale and platform. This test draws
+ *          large number of characters that are among this range repeatedly.
+ */
+
+public class DoubleAntialiasTest extends Panel {
+    private static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame();
+                frame.setTitle("DoubleAntialiasTest");
+                frame.add(new DoubleAntialiasTest());
+                frame.pack();
+                frame.setSize(500, 500);
+                frame.setVisible(true);
+            });
+
+            robot.waitForIdle();
+            robot.delay(2000);
+        } catch (Exception e) {
+            throw new RuntimeException("Following exception occurred" +
+                    " when testing Antialiasing Rendering hints: ", e);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                 if (frame != null) {
+                     frame.dispose();
+                 }
+            });
+        }
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        Graphics2D g2 = (Graphics2D) g;
+        int y = 50;
+        for (int i = 0; i < 2; i++) {
+            int k = 5;
+            for (int j = 0x500; j < 0x700; j++) {
+                g2.setRenderingHint(KEY_TEXT_ANTIALIASING,
+                                    VALUE_TEXT_ANTIALIAS_ON);
+                g2.setRenderingHint(KEY_ANTIALIASING,
+                                    VALUE_ANTIALIAS_ON);
+                g2.drawString(String.valueOf((char) j), (5 + k), y);
+                k = k + 15;
+            }
+            k = 5;
+            y += 50;
+            for (int j = 0x700; j > 0x500; j--) {
+                g2.setRenderingHint(KEY_TEXT_ANTIALIASING,
+                                    VALUE_TEXT_ANTIALIAS_ON);
+                g2.setRenderingHint(KEY_ANTIALIASING,
+                                    VALUE_ANTIALIAS_ON);
+                g2.drawString(String.valueOf((char) j), (5 + k), y);
+                k = k + 15;
+            }
+            y += 50;
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8306634](https://bugs.openjdk.org/browse/JDK-8306634)

Testing
- Local: Test passed
  - `RepaintTest.java`: Test results: passed: 1
  - `MouseEventAbsoluteCoordsTest.java`: Test results: passed: 1
  - `UndecoratedShrink.java`: Test results: passed: 1
  - `bug4212562.java`: Test results: passed: 1
  - `DoubleAntialiasTest.java`: Test results: passed: 1
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8306634](https://bugs.openjdk.org/browse/JDK-8306634) needs maintainer approval

### Issue
 * [JDK-8306634](https://bugs.openjdk.org/browse/JDK-8306634): Open source AWT Event related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2402/head:pull/2402` \
`$ git checkout pull/2402`

Update a local copy of the PR: \
`$ git checkout pull/2402` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2402`

View PR using the GUI difftool: \
`$ git pr show -t 2402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2402.diff">https://git.openjdk.org/jdk17u-dev/pull/2402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2402#issuecomment-2051033846)