### PR TITLE
8315071: Modify TrayIconScalingTest.java, PrintLatinCJKTest.java to use new PassFailJFrame's builder pattern usage

### DIFF
--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,15 @@ public class TrayIconScalingTest {
             System.out.println("SystemTray is not supported");
             return;
         }
-        PassFailJFrame passFailJFrame = new PassFailJFrame("TrayIcon " +
-                "Test Instructions", INSTRUCTIONS, 8, 25, 85);
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("TrayIcon Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(8)
+                .rows(25)
+                .columns(70)
+                .screenCapture()
+                .build();
+
         createAndShowGUI();
         // does not have a test window,
         // hence only the instruction frame is positioned

--- a/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintLatinCJKTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,8 +98,13 @@ public class PrintLatinCJKTest implements Printable {
     }
 
     public static void main(String[] args) throws InterruptedException, InvocationTargetException {
-        PassFailJFrame passFailJFrame = new PassFailJFrame("Test Instruction" +
-                "Frame", info, 10, 10, 45);
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("Test Instructions Frame")
+                .instructions(info)
+                .testTimeOut(10)
+                .rows(10)
+                .columns(45)
+                .build();
         showFrame();
         passFailJFrame.awaitAndCheck();
     }


### PR DESCRIPTION
Backport of [JDK-8315071](https://bugs.openjdk.org/browse/JDK-8315071)

Testing

- Local: Test passed on Windows machine (`(os.family == "windows")`)
  - `TrayIconScalingTest.java` Manual test passed
    -  `100% - 16, 125% - 20, 150% - 24, 175% - 28, 200% - 32` described in the test case - pass
    - and also we have tested the following cases
    - `225% - 36`
    - `250% - 40`
    - `300% - 48`
    - `350% - 48` - note. `350%` is also `48`, same as `300%`
  - `PrintLatinCJKTest.java` Manual test passed
    - Printer printed out the correct characters

```
Processor	12th Gen Intel(R) Core(TM) i7-12800H   2.40 GHz
Installed RAM	64.0 GB (63.7 GB usable)
System type	64-bit operating system, x64-based processor

Edition: Windows 11 Enterprise
Version: 23H2
Installed on: 5/10/2023
OS build: 22631.3155
Experience: Windows Feature Experience Pack 1000.22684.1000.0
```

- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315071](https://bugs.openjdk.org/browse/JDK-8315071) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315071](https://bugs.openjdk.org/browse/JDK-8315071): Modify TrayIconScalingTest.java, PrintLatinCJKTest.java to use new PassFailJFrame's builder pattern usage (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2403/head:pull/2403` \
`$ git checkout pull/2403`

Update a local copy of the PR: \
`$ git checkout pull/2403` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2403`

View PR using the GUI difftool: \
`$ git pr show -t 2403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2403.diff">https://git.openjdk.org/jdk17u-dev/pull/2403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2403#issuecomment-2051074920)