### PR TITLE
8328540: test javax/swing/JSplitPane/4885629/bug4885629.java fails on windows hidpi

### DIFF
--- a/test/jdk/javax/swing/JSplitPane/4885629/bug4885629.java
+++ b/test/jdk/javax/swing/JSplitPane/4885629/bug4885629.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,9 +104,9 @@ public class bug4885629 {
 
                     SwingUtilities.convertPointToScreen(p, sp);
 
-                    for (int i = 0; i < rect.width; i++) {
+                    for (int i = 1; i < rect.width - 1; i++) {
                         if (!BGCOLOR.equals(robot.getPixelColor(p.x + i, p.y + rect.height - 1))) {
-                            throw new Error("The divider's area has incorrect color.");
+                            throw new Error("The divider's area has incorrect color. i=" + i);
                         }
                     }
                 }


### PR DESCRIPTION
I backport this for parity with 17.0.11-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328540](https://bugs.openjdk.org/browse/JDK-8328540) needs maintainer approval

### Issue
 * [JDK-8328540](https://bugs.openjdk.org/browse/JDK-8328540): test javax/swing/JSplitPane/4885629/bug4885629.java fails on windows hidpi (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2404/head:pull/2404` \
`$ git checkout pull/2404`

Update a local copy of the PR: \
`$ git checkout pull/2404` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2404`

View PR using the GUI difftool: \
`$ git pr show -t 2404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2404.diff">https://git.openjdk.org/jdk17u-dev/pull/2404.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2404#issuecomment-2051134046)