### PR TITLE
8326006: Allow TEST_VM_FLAGLESS to set flagless mode

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -557,14 +557,15 @@ public class VMProps implements Callable<Map<String, String>> {
      * Checks if we are in <i>almost</i> out-of-box configuration, i.e. the flags
      * which JVM is started with don't affect its behavior "significantly".
      * {@code TEST_VM_FLAGLESS} enviroment variable can be used to force this
-     * method to return true and allow any flags.
+     * method to return true or false and allow or reject any flags.
      *
      * @return true if there are no JVM flags
      */
     private String isFlagless() {
         boolean result = true;
-        if (System.getenv("TEST_VM_FLAGLESS") != null) {
-            return "" + result;
+        String flagless = System.getenv("TEST_VM_FLAGLESS");
+        if (flagless != null) {
+            return "" + "true".equalsIgnoreCase(flagless);
         }
 
         List<String> allFlags = new ArrayList<String>();


### PR DESCRIPTION
Backport of [JDK-8326006](https://bugs.openjdk.org/browse/JDK-8326006)

Testing
- Local: Not Applicable.
- Pipeline: **All checks have passed**
- Testing Machine: SAP nightlies passed on `2024-04-17,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326006](https://bugs.openjdk.org/browse/JDK-8326006) needs maintainer approval

### Issue
 * [JDK-8326006](https://bugs.openjdk.org/browse/JDK-8326006): Allow TEST_VM_FLAGLESS to set flagless mode (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2410/head:pull/2410` \
`$ git checkout pull/2410`

Update a local copy of the PR: \
`$ git checkout pull/2410` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2410`

View PR using the GUI difftool: \
`$ git pr show -t 2410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2410.diff">https://git.openjdk.org/jdk17u-dev/pull/2410.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2410#issuecomment-2052443694)