### PR TITLE
8327136: javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java fails on libgraal

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
@@ -170,7 +170,7 @@ public class NotifReconnectDeadlockTest {
             }
         };
 
-    private static final long serverTimeout = 1000;
+    private static final long serverTimeout = 3000;
     private static final long listenerSleep = serverTimeout*6;
 
     private static String clientState = null;


### PR DESCRIPTION
Backport of [JDK-8327136](https://bugs.openjdk.org/browse/JDK-8327136)

Testing
- Local: Test passed on `MacOS 14.4.1`
  - `NotifReconnectDeadlockTest.java`: Test results: passed: 1
- Pipeline: 
- Testing Machine:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8327136](https://bugs.openjdk.org/browse/JDK-8327136) needs maintainer approval

### Issue
 * [JDK-8327136](https://bugs.openjdk.org/browse/JDK-8327136): javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java fails on libgraal (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2411/head:pull/2411` \
`$ git checkout pull/2411`

Update a local copy of the PR: \
`$ git checkout pull/2411` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2411`

View PR using the GUI difftool: \
`$ git pr show -t 2411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2411.diff">https://git.openjdk.org/jdk17u-dev/pull/2411.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2411#issuecomment-2052508802)