### PR TITLE
8295343: sun/security/pkcs11 tests fail on Linux RHEL 8.6 and newer

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -237,10 +237,10 @@ TEST FAILURE</code></pre>
 <pre><code>$ export LANG=&quot;en_US&quot; &amp;&amp; make test TEST=...
 $ make test JTREG=&quot;VM_OPTIONS=-Duser.language=en -Duser.country=US&quot; TEST=...</code></pre>
 <h3 id="pkcs11-tests">PKCS11 Tests</h3>
-<p>It is highly recommended to use the latest NSS version when running PKCS11 tests. Improper NSS version may lead to unexpected failures which are hard to diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail on Ubuntu 18.04 with the default NSS version in the system. To run these tests correctly, the system property <code>test.nss.lib.paths</code> is required on Ubuntu 18.04 to specify the alternative NSS lib directories.</p>
+<p>It is highly recommended to use the latest NSS version when running PKCS11 tests. Improper NSS version may lead to unexpected failures which are hard to diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail on Ubuntu 18.04 with the default NSS version in the system. To run these tests correctly, the system property <<code>jdk.test.lib.artifacts.&lt;NAME&gt;</code> is required on Ubuntu 18.04 to specify the alternative NSS lib directories.The<code>&lt;NAME&gt;</code> component should be replaced with the name element of the appropriate <code>@Artifact</code> class. (See<code>test/jdk/sun/security/pkcs11/PKCS11Test.java</code>)</p>
 <p>For example:</p>
 <pre><code>$ make test TEST=&quot;jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java&quot; \
-    JTREG=&quot;JAVA_OPTIONS=-Dtest.nss.lib.paths=/path/to/your/latest/NSS-libs&quot;</code></pre>
+    JTREG=&quot;JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/NSS-libs&quot;</code></pre>
 <p>For more notes about the PKCS11 tests, please refer to test/jdk/sun/security/pkcs11/README.</p>
 <h3 id="client-ui-tests">Client UI Tests</h3>
 <h4 id="system-key-shortcuts">System key shortcuts</h4>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -536,14 +536,16 @@ It is highly recommended to use the latest NSS version when running PKCS11
 tests. Improper NSS version may lead to unexpected failures which are hard to
 diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail
 on Ubuntu 18.04 with the default NSS version in the system. To run these tests
-correctly, the system property `test.nss.lib.paths` is required on Ubuntu 18.04
-to specify the alternative NSS lib directories.
+correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on
+Ubuntu 18.04 to specify the alternative NSS lib directory. The `<NAME>`
+component should be replaced with the name element of the appropriate
+`@Artifact` class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 For example:
 
 ```
 $ make test TEST="jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java" \
-    JTREG="JAVA_OPTIONS=-Dtest.nss.lib.paths=/path/to/your/latest/NSS-libs"
+    JTREG="JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/NSS-libs"
 ```
 
 For more notes about the PKCS11 tests, please refer to

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -654,12 +654,6 @@ sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 gene
 sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 
-sun/security/tools/keytool/NssTest.java                         8295343 linux-all
-sun/security/pkcs11/Signature/TestRSAKeyLength.java             8295343 linux-all
-sun/security/pkcs11/rsa/TestSignatures.java                     8295343 linux-all
-sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-all
-sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all
-sun/security/pkcs11/KeyStore/Basic.java                         8295343 linux-all
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183 linux-ppc64le
 
 ############################################################################

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ import java.security.spec.ECGenParameterSpec;
 import java.security.spec.ECParameterSpec;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -257,30 +256,19 @@ public abstract class PKCS11Test {
 
     static Path getNSSLibPath(String library) throws Exception {
         String osid = getOsId();
-        String[] nssLibDirs = getNssLibPaths(osid);
-        if (nssLibDirs == null) {
-            System.out.println("Warning: unsupported OS: " + osid
+        String nssLibDir = fetchNssLib(osid);
+        if (nssLibDir == null) {
+            throw new SkippedException("Warning: unsupported OS: " + osid
                     + ", please initialize NSS library location, skipping test");
-            return null;
-        }
-        if (nssLibDirs.length == 0) {
-            System.out.println("Warning: NSS not supported on this platform, skipping test");
-            return null;
         }
 
-        Path nssLibPath = null;
-        for (String dir : nssLibDirs) {
-            Path libPath = Paths.get(dir).resolve(System.mapLibraryName(library));
-            if (Files.exists(libPath)) {
-                nssLibPath = libPath;
-                break;
-            }
+        String libraryName = System.mapLibraryName(library);
+        Path libPath = Paths.get(nssLibDir).resolve(libraryName);
+        if (!Files.exists(libPath)) {
+            throw new SkippedException("NSS library \"" + libraryName + "\" was not found in " + nssLibDir);
         }
-        if (nssLibPath == null) {
-            System.out.println("Warning: can't find NSS library on this machine, skipping test");
-            return null;
-        }
-        return nssLibPath;
+
+        return libPath;
     }
 
     private static String getOsId() {
@@ -602,71 +590,6 @@ public abstract class PKCS11Test {
         parameters.init(new ECGenParameterSpec(name));
 
         return parameters.getParameterSpec(ECParameterSpec.class);
-    }
-
-    // Location of the NSS libraries on each supported platform
-    private static Map<String, String[]> getOsMap() {
-        if (osMap != null) {
-            return osMap;
-        }
-
-        osMap = new HashMap<>();
-        osMap.put("Linux-i386-32", new String[]{
-                "/usr/lib/i386-linux-gnu/",
-                "/usr/lib32/",
-                "/usr/lib/"});
-        osMap.put("Linux-amd64-64", new String[]{
-                "/usr/lib/x86_64-linux-gnu/",
-                "/usr/lib/x86_64-linux-gnu/nss/",
-                "/usr/lib64/"});
-        osMap.put("Linux-ppc64-64", new String[]{"/usr/lib64/"});
-        osMap.put("Linux-ppc64le-64", new String[]{"/usr/lib64/"});
-        osMap.put("Linux-s390x-64", new String[]{"/usr/lib64/"});
-        osMap.put("Windows-x86-32", new String[]{});
-        osMap.put("Windows-amd64-64", new String[]{});
-        osMap.put("MacOSX-x86_64-64", new String[]{});
-        osMap.put("Linux-arm-32", new String[]{
-                "/usr/lib/arm-linux-gnueabi/nss/",
-                "/usr/lib/arm-linux-gnueabihf/nss/"});
-        osMap.put("Linux-aarch64-64", new String[] {
-                "/usr/lib/aarch64-linux-gnu/",
-                "/usr/lib/aarch64-linux-gnu/nss/",
-                "/usr/lib64/" });
-        return osMap;
-    }
-
-    private static String[] getNssLibPaths(String osId) {
-        String[] preferablePaths = getPreferableNssLibPaths(osId);
-        if (preferablePaths.length != 0) {
-            return preferablePaths;
-        } else {
-            return getOsMap().get(osId);
-        }
-    }
-
-    private static String[] getPreferableNssLibPaths(String osId) {
-        List<String> nssLibPaths = new ArrayList<>();
-
-        String customNssLibPaths = System.getProperty("test.nss.lib.paths");
-        if (customNssLibPaths == null) {
-            // If custom local NSS lib path is not provided,
-            // try to download NSS libs from artifactory
-            String path = fetchNssLib(osId);
-            if (path != null) {
-                nssLibPaths.add(path);
-            }
-        } else {
-            String[] paths = customNssLibPaths.split(",");
-            for (String path : paths) {
-                if (!path.endsWith(File.separator)) {
-                    nssLibPaths.add(path + File.separator);
-                } else {
-                    nssLibPaths.add(path);
-                }
-            }
-        }
-
-        return nssLibPaths.toArray(new String[0]);
     }
 
     public static String toString(byte[] b) {

--- a/test/jdk/sun/security/pkcs11/README
+++ b/test/jdk/sun/security/pkcs11/README
@@ -4,14 +4,15 @@ perform as a result of bugs or features in NSS or other pkcs11 libraries.
 - How to get NSS libraries?
 The libraries come from the following sources.
 
-1. Specified by system property test.nss.lib.paths
-System property test.nss.lib.paths can specify a set of absolute paths to
-the local NSS library directories. The paths are separated by comma.
+1. Specified by system property jdk.test.lib.artifacts.<NAME>
+The system property, jdk.test.lib.artifacts.<NAME>, can specify an absolute path
+to the local NSS library directory. The <NAME> component should be replaced with
+the name element of the appropriate @Artifact class.
+(See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 2. Pre-built NSS libraries from artifactory server
-If the value of system property test.nss.lib.paths is not set, the tests will try
-to download pre-built NSS libraries from artifactory server. Currently, the
-tests only looks for libraries for Windows and MacOSX platforms on artifactory.
+If the value of system property jdk.test.lib.artifacts.<NAME> is not set, the
+tests will try to download pre-built NSS libraries from artifactory server.
 Please note that JIB jar MUST be present in classpath when downloading the
 libraries.
 

--- a/test/jdk/sun/security/tools/keytool/NssTest.java
+++ b/test/jdk/sun/security/tools/keytool/NssTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,9 @@ public class NssTest {
 
         Path dbPath = srcPath.getParent().getParent()
                 .resolve("pkcs11").resolve("nss").resolve("db");
-        Files.copy(dbPath.resolve("cert8.db"), Paths.get("cert8.db"));
-        Files.copy(dbPath.resolve("key3.db"), Paths.get("key3.db"));
-        Files.copy(dbPath.resolve("secmod.db"), Paths.get("secmod.db"));
+        Path destDir = Path.of( "tmpdb");
+        Files.createDirectory(destDir);
+        Files.copy(dbPath.resolve("cert9.db"), destDir.resolve("cert9.db"));
+        Files.copy(dbPath.resolve("key4.db"), destDir.resolve("key4.db"));
     }
 }

--- a/test/jdk/sun/security/tools/keytool/p11-nss.txt
+++ b/test/jdk/sun/security/tools/keytool/p11-nss.txt
@@ -6,7 +6,7 @@ slot = 2
 
 library = ${nss.lib}
 
-nssArgs = "configdir='.' certPrefix='' keyPrefix='' secmod='secmod.db'"
+nssArgs = "configdir='sql:./tmpdb' certPrefix='' keyPrefix='' secmod='secmod.db'"
 
 #forceLogin = true
 


### PR DESCRIPTION
This PR contains a backport of
https://github.com/openjdk/jdk/commit/6ce0ebb858d3112f136e12d3ad595f805f6871a0
Patch is not clean, for the doc/testing.html and doc/testing.md were only some code style changes in previous commits.
for this test/jdk/ProblemList.txt, it updated problemlist in
https://github.com/openjdk/jdk/commit/8d2ad2b1ae37d2411649e35d4000b0fe873facdb
, but this time I just do remove action, and it does not conflict with the previous commit.
for this class test/jdk/sun/security/pkcs11/PKCS11Test.java was changed in
https://github.com/openjdk/jdk/commit/c2e77e2f17b624e750dea8fd51bbfde99596690e
, I ignored these commits, and the test has passed in my local.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8295343](https://bugs.openjdk.org/browse/JDK-8295343) needs maintainer approval

### Issue
 * [JDK-8295343](https://bugs.openjdk.org/browse/JDK-8295343): sun/security/pkcs11 tests fail on Linux RHEL 8.6 and newer (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2412/head:pull/2412` \
`$ git checkout pull/2412`

Update a local copy of the PR: \
`$ git checkout pull/2412` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2412`

View PR using the GUI difftool: \
`$ git pr show -t 2412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2412.diff">https://git.openjdk.org/jdk17u-dev/pull/2412.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2412#issuecomment-2058102030)