### PR TITLE
8289182: NMT: MemTracker::baseline should return void

### DIFF
--- a/src/hotspot/share/services/memBaseline.cpp
+++ b/src/hotspot/share/services/memBaseline.cpp
@@ -145,11 +145,10 @@ class VirtualMemoryAllocationWalker : public VirtualMemoryWalker {
 };
 
 
-bool MemBaseline::baseline_summary() {
+void MemBaseline::baseline_summary() {
   MallocMemorySummary::snapshot(&_malloc_memory_snapshot);
   VirtualMemorySummary::snapshot(&_virtual_memory_snapshot);
   _metaspace_stats = MetaspaceUtils::get_combined_statistics();
-  return true;
 }
 
 bool MemBaseline::baseline_allocation_sites() {
@@ -186,15 +185,12 @@ bool MemBaseline::baseline_allocation_sites() {
   return true;
 }
 
-bool MemBaseline::baseline(bool summaryOnly) {
+void MemBaseline::baseline(bool summaryOnly) {
   reset();
 
   _instance_class_count = ClassLoaderDataGraph::num_instance_classes();
   _array_class_count = ClassLoaderDataGraph::num_array_classes();
-
-  if (!baseline_summary()) {
-    return false;
-  }
+  baseline_summary();
 
   _baseline_type = Summary_baselined;
 
@@ -205,7 +201,6 @@ bool MemBaseline::baseline(bool summaryOnly) {
     _baseline_type = Detail_baselined;
   }
 
-  return true;
 }
 
 int compare_allocation_site(const VirtualMemoryAllocationSite& s1,

--- a/src/hotspot/share/services/memBaseline.hpp
+++ b/src/hotspot/share/services/memBaseline.hpp
@@ -90,7 +90,7 @@ class MemBaseline {
     _baseline_type(Not_baselined) {
   }
 
-  bool baseline(bool summaryOnly = true);
+  void baseline(bool summaryOnly = true);
 
   BaselineType baseline_type() const { return _baseline_type; }
 
@@ -190,7 +190,7 @@ class MemBaseline {
 
  private:
   // Baseline summary information
-  bool baseline_summary();
+  void baseline_summary();
 
   // Baseline allocation sites (detail tracking only)
   bool baseline_allocation_sites();

--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -129,18 +129,17 @@ void MemTracker::final_report(outputStream* output) {
 void MemTracker::report(bool summary_only, outputStream* output, size_t scale) {
  assert(output != NULL, "No output stream");
   MemBaseline baseline;
-  if (baseline.baseline(summary_only)) {
-    if (summary_only) {
-      MemSummaryReporter rpt(baseline, output, scale);
-      rpt.report();
-    } else {
-      MemDetailReporter rpt(baseline, output, scale);
-      rpt.report();
-      output->print("Metaspace:");
-      // The basic metaspace report avoids any locking and should be safe to
-      // be called at any time.
-      MetaspaceUtils::print_basic_report(output, scale);
-    }
+  baseline.baseline(summary_only);
+  if (summary_only) {
+    MemSummaryReporter rpt(baseline, output, scale);
+    rpt.report();
+  } else {
+    MemDetailReporter rpt(baseline, output, scale);
+    rpt.report();
+    output->print("Metaspace:");
+    // The basic metaspace report avoids any locking and should be safe to
+    // be called at any time.
+    MetaspaceUtils::print_basic_report(output, scale);
   }
 }
 

--- a/src/hotspot/share/services/nmtDCmd.cpp
+++ b/src/hotspot/share/services/nmtDCmd.cpp
@@ -121,11 +121,8 @@ void NMTDCmd::execute(DCmdSource source, TRAPS) {
     report(false, scale_unit);
   } else if (_baseline.value()) {
     MemBaseline& baseline = MemTracker::get_baseline();
-    if (!baseline.baseline(MemTracker::tracking_level() != NMT_detail)) {
-      output()->print_cr("Baseline failed");
-    } else {
-      output()->print_cr("Baseline succeeded");
-    }
+    baseline.baseline(MemTracker::tracking_level() != NMT_detail);
+    output()->print_cr("Baseline taken");
   } else if (_summary_diff.value()) {
     MemBaseline& baseline = MemTracker::get_baseline();
     if (baseline.baseline_type() >= MemBaseline::Summary_baselined) {
@@ -157,14 +154,13 @@ void NMTDCmd::execute(DCmdSource source, TRAPS) {
 
 void NMTDCmd::report(bool summaryOnly, size_t scale_unit) {
   MemBaseline baseline;
-  if (baseline.baseline(summaryOnly)) {
-    if (summaryOnly) {
-      MemSummaryReporter rpt(baseline, output(), scale_unit);
-      rpt.report();
-    } else {
-      MemDetailReporter rpt(baseline, output(), scale_unit);
-      rpt.report();
-    }
+  baseline.baseline(summaryOnly);
+  if (summaryOnly) {
+    MemSummaryReporter rpt(baseline, output(), scale_unit);
+    rpt.report();
+  } else {
+    MemDetailReporter rpt(baseline, output(), scale_unit);
+    rpt.report();
   }
 }
 
@@ -176,14 +172,13 @@ void NMTDCmd::report_diff(bool summaryOnly, size_t scale_unit) {
     "Not a detail baseline");
 
   MemBaseline baseline;
-  if (baseline.baseline(summaryOnly)) {
-    if (summaryOnly) {
-      MemSummaryDiffReporter rpt(early_baseline, baseline, output(), scale_unit);
-      rpt.report_diff();
-    } else {
-      MemDetailDiffReporter rpt(early_baseline, baseline, output(), scale_unit);
-      rpt.report_diff();
-    }
+  baseline.baseline(summaryOnly);
+  if (summaryOnly) {
+    MemSummaryDiffReporter rpt(early_baseline, baseline, output(), scale_unit);
+    rpt.report_diff();
+  } else {
+    MemDetailDiffReporter rpt(early_baseline, baseline, output(), scale_unit);
+    rpt.report_diff();
   }
 }
 

--- a/test/hotspot/jtreg/runtime/NMT/JcmdBaselineDetail.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdBaselineDetail.java
@@ -47,6 +47,6 @@ public class JcmdBaselineDetail {
         pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "baseline=true"});
 
         output = new OutputAnalyzer(pb.start());
-        output.shouldContain("Baseline succeeded");
+        output.shouldContain("Baseline taken");
     }
 }

--- a/test/hotspot/jtreg/runtime/NMT/JcmdDetailDiff.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdDetailDiff.java
@@ -57,7 +57,7 @@ public class JcmdDetailDiff {
         pb.start().waitFor();
 
         output = new OutputAnalyzer(pb.start());
-        output.shouldContain("Baseline succeeded");
+        output.shouldContain("Baseline taken");
 
         addr = wb.NMTReserveMemory(reserveSize);
         pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "detail.diff", "scale=KB"});

--- a/test/hotspot/jtreg/runtime/NMT/JcmdSummaryDiff.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdSummaryDiff.java
@@ -57,7 +57,7 @@ public class JcmdSummaryDiff {
         pb.start().waitFor();
 
         output = new OutputAnalyzer(pb.start());
-        output.shouldContain("Baseline succeeded");
+        output.shouldContain("Baseline taken");
 
         addr = wb.NMTReserveMemory(reserveSize);
         pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "summary.diff", "scale=KB"});

--- a/test/hotspot/jtreg/runtime/NMT/MallocSiteTypeChange.java
+++ b/test/hotspot/jtreg/runtime/NMT/MallocSiteTypeChange.java
@@ -56,7 +56,7 @@ public class MallocSiteTypeChange {
 
         pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "baseline"});
         output = new OutputAnalyzer(pb.start());
-        output.shouldContain("Baseline succeeded");
+        output.shouldContain("Baseline taken");
 
         wb.NMTFree(addr);
         addr = wb.NMTMallocWithPseudoStackAndType(2 * 1024, pc, 8 /* mtInternal */ );


### PR DESCRIPTION
This backport does not introduce any new feature or bug fixing, but it removes dead code. Before the backport, MemTracker::baseline() always returned true. Now, it returns void and all the conditionals that depended on that result are simplified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8289182](https://bugs.openjdk.org/browse/JDK-8289182) needs maintainer approval

### Issue
 * [JDK-8289182](https://bugs.openjdk.org/browse/JDK-8289182): NMT: MemTracker::baseline should return void (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2415/head:pull/2415` \
`$ git checkout pull/2415`

Update a local copy of the PR: \
`$ git checkout pull/2415` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2415`

View PR using the GUI difftool: \
`$ git pr show -t 2415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2415.diff">https://git.openjdk.org/jdk17u-dev/pull/2415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2415#issuecomment-2059151947)