### PR TITLE
8322858: compiler/c2/aarch64/TestFarJump.java fails on AArch64 due to unexpected PrintAssembly output

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestFarJump.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestFarJump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, BELLSOFT. All rights reserved.
+ * Copyright (c) 2024, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,10 +89,9 @@ public class TestFarJump {
             "-Xbatch",
             "-XX:+TieredCompilation",
             "-XX:+SegmentedCodeCache",
-            "-XX:CompileOnly=" + className + "::main",
             "-XX:ReservedCodeCacheSize=" + (bigCodeHeap ? "256M" : "200M"),
             "-XX:+UnlockDiagnosticVMOptions",
-            "-XX:+PrintAssembly",
+            "-XX:CompileCommand=option," + className + "::main,bool,PrintAssembly,true",
             className};
 
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(procArgs);


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322858](https://bugs.openjdk.org/browse/JDK-8322858) needs maintainer approval

### Issue
 * [JDK-8322858](https://bugs.openjdk.org/browse/JDK-8322858): compiler/c2/aarch64/TestFarJump.java fails on AArch64 due to unexpected PrintAssembly output (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2419/head:pull/2419` \
`$ git checkout pull/2419`

Update a local copy of the PR: \
`$ git checkout pull/2419` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2419`

View PR using the GUI difftool: \
`$ git pr show -t 2419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2419.diff">https://git.openjdk.org/jdk17u-dev/pull/2419.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2419#issuecomment-2066468877)