### PR TITLE
8330156: RISC-V: Range check auipc + signed 12 imm instruction

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -650,7 +650,7 @@ void MacroAssembler::super_call_VM_leaf(address entry_point, Register arg_0, Reg
 
 void MacroAssembler::la(Register Rd, const address dest) {
   int64_t offset = dest - pc();
-  if (is_simm32(offset)) {
+  if (is_valid_32bit_offset(offset)) {
     auipc(Rd, (int32_t)offset + 0x800);  //0x800, Note:the 11th sign bit
     addi(Rd, Rd, ((int64_t)offset << 52) >> 52);
   } else {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8990864a](https://github.com/openjdk/jdk/commit/8990864a53fa04f44ecf8bff65a6dc9cdd67cb1c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Robbin Ehn on 19 Apr 2024 and was reviewed by Fei Yang, Hamlin Li and Antonios Printezis.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330156](https://bugs.openjdk.org/browse/JDK-8330156) needs maintainer approval

### Issue
 * [JDK-8330156](https://bugs.openjdk.org/browse/JDK-8330156): RISC-V: Range check auipc + signed 12 imm instruction (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2422/head:pull/2422` \
`$ git checkout pull/2422`

Update a local copy of the PR: \
`$ git checkout pull/2422` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2422`

View PR using the GUI difftool: \
`$ git pr show -t 2422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2422.diff">https://git.openjdk.org/jdk17u-dev/pull/2422.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2422#issuecomment-2068688565)