### PR TITLE
8328166: Epsilon: 'EpsilonHeap::allocate_work' misuses the parameter 'size' as size in bytes

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,14 +127,15 @@ HeapWord* EpsilonHeap::allocate_work(size_t size) {
       }
 
       // Expand and loop back if space is available
+      size_t size_in_bytes = size * HeapWordSize;
       size_t space_left = max_capacity() - capacity();
-      size_t want_space = MAX2(size, EpsilonMinHeapExpand);
+      size_t want_space = MAX2(size_in_bytes, EpsilonMinHeapExpand);
 
       if (want_space < space_left) {
         // Enough space to expand in bulk:
         bool expand = _virtual_space.expand_by(want_space);
         assert(expand, "Should be able to expand");
-      } else if (size < space_left) {
+      } else if (size_in_bytes < space_left) {
         // No space to expand in bulk, and this allocation is still possible,
         // take all the remaining space:
         bool expand = _virtual_space.expand_by(space_left);


### PR DESCRIPTION
Semi-clean backport to handle Epsilon corner case. The uncleanliness comes from copyright header updates, I accepted the version from incoming changeset. Will mark the backport clean.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `gc/epsilon`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328166](https://bugs.openjdk.org/browse/JDK-8328166) needs maintainer approval

### Issue
 * [JDK-8328166](https://bugs.openjdk.org/browse/JDK-8328166): Epsilon: 'EpsilonHeap::allocate_work' misuses the parameter 'size' as size in bytes (**Bug** - P2 - Approved)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2423/head:pull/2423` \
`$ git checkout pull/2423`

Update a local copy of the PR: \
`$ git checkout pull/2423` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2423`

View PR using the GUI difftool: \
`$ git pr show -t 2423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2423.diff">https://git.openjdk.org/jdk17u-dev/pull/2423.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2423#issuecomment-2068841838)