### PR TITLE
8329570: G1: Excessive is_obj_dead_cond calls in verification

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -493,8 +493,7 @@ public:
   }
 
   void set_containing_obj(oop obj) {
-    assert(!_g1h->is_obj_dead_cond(_containing_obj, _vo),
-           "Precondition");
+    assert(!_g1h->is_obj_dead_cond(obj, _vo), "Precondition");
     _containing_obj = obj;
   }
 

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -493,6 +493,8 @@ public:
   }
 
   void set_containing_obj(oop obj) {
+    assert(!_g1h->is_obj_dead_cond(_containing_obj, _vo),
+           "Precondition");
     _containing_obj = obj;
   }
 
@@ -519,8 +521,6 @@ public:
   template <class T>
   void do_oop_work(T* p) {
     assert(_containing_obj != NULL, "Precondition");
-    assert(!_g1h->is_obj_dead_cond(_containing_obj, _vo),
-      "Precondition");
     verify_liveness(p);
   }
 
@@ -577,8 +577,6 @@ public:
   template <class T>
   void do_oop_work(T* p) {
     assert(_containing_obj != NULL, "Precondition");
-    assert(!_g1h->is_obj_dead_cond(_containing_obj, _vo),
-      "Precondition");
     verify_remembered_set(p);
   }
 


### PR DESCRIPTION
Unclean backport to improve fastdebug build performance, which improves testing. The code shape in JDK 17 is different, I reapplied the hunks in places relevant to JDK 17.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329570](https://bugs.openjdk.org/browse/JDK-8329570) needs maintainer approval

### Issue
 * [JDK-8329570](https://bugs.openjdk.org/browse/JDK-8329570): G1: Excessive is_obj_dead_cond calls in verification (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2425/head:pull/2425` \
`$ git checkout pull/2425`

Update a local copy of the PR: \
`$ git checkout pull/2425` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2425`

View PR using the GUI difftool: \
`$ git pr show -t 2425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2425.diff">https://git.openjdk.org/jdk17u-dev/pull/2425.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2425#issuecomment-2071504118)