### PR TITLE
8331113: createJMHBundle.sh support configurable maven repo mirror

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 JMH_VERSION=1.37
 COMMONS_MATH3_VERSION=3.6.1
 JOPT_SIMPLE_VERSION=5.0.4
+MAVEN_MIRROR=${MAVEN_MIRROR:-https://repo.maven.apache.org/maven2}
 
 BUNDLE_NAME=jmh-$JMH_VERSION.tar.gz
 
@@ -41,7 +42,7 @@ cd $JAR_DIR
 rm -f *
 
 fetchJar() {
-  url="https://repo.maven.apache.org/maven2/$1/$2/$3/$2-$3.jar"
+  url="${MAVEN_MIRROR}/$1/$2/$3/$2-$3.jar"
   if command -v curl > /dev/null; then
       curl -O --fail $url
   elif command -v wget > /dev/null; then


### PR DESCRIPTION
Hi,
  Clean backport of JDK-8331113 for createJMHBundle.sh support configurable maven repo mirror.
  Only change devkit shell script, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331113](https://bugs.openjdk.org/browse/JDK-8331113) needs maintainer approval

### Issue
 * [JDK-8331113](https://bugs.openjdk.org/browse/JDK-8331113): createJMHBundle.sh support configurable maven repo mirror (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2428/head:pull/2428` \
`$ git checkout pull/2428`

Update a local copy of the PR: \
`$ git checkout pull/2428` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2428`

View PR using the GUI difftool: \
`$ git pr show -t 2428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2428.diff">https://git.openjdk.org/jdk17u-dev/pull/2428.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2428#issuecomment-2078485741)