### PR TITLE
8318809: java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java shows intermittent failures on linux ppc64le and aarch64

### DIFF
--- a/test/jdk/java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java
+++ b/test/jdk/java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java
@@ -281,36 +281,6 @@ public class WhiteBox {
         assertInvariants(q);
     }
 
-    /**
-     * Actions that append an element, and are expected to
-     * leave at most one slack node at tail.
-     */
-    @DataProvider
-    public Object[][] addActions() {
-        return List.<Consumer<ConcurrentLinkedQueue>>of(
-            q -> q.add(1),
-            q -> q.offer(1))
-            .stream().map(x -> new Object[]{ x }).toArray(Object[][]::new);
-    }
-
-    @Test(dataProvider = "addActions")
-    public void addActionsOneNodeSlack(
-        Consumer<ConcurrentLinkedQueue> addAction) {
-        ConcurrentLinkedQueue q = new ConcurrentLinkedQueue();
-        int n = 1 + rnd.nextInt(5);
-        for (int i = 0; i < n; i++) {
-            boolean slack = next(tail(q)) != null;
-            addAction.accept(q);
-            if (slack)
-                assertNull(next(tail(q)));
-            else {
-                assertNotNull(next(tail(q)));
-                assertNull(next(next(tail(q))));
-            }
-            assertInvariants(q);
-        }
-    }
-
     byte[] serialBytes(Object o) {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
Backport of [JDK-8318809](https://bugs.openjdk.org/browse/JDK-8318809)

Testing
- Local: Test passed
  - `WhiteBox.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-04-28`
  - Automated jtreg test: jtreg_jdk_tier1
  - java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java: SUCCESSFUL GitHub 📊⏲ - [789 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318809](https://bugs.openjdk.org/browse/JDK-8318809) needs maintainer approval

### Issue
 * [JDK-8318809](https://bugs.openjdk.org/browse/JDK-8318809): java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java shows intermittent failures on linux ppc64le and aarch64 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2435/head:pull/2435` \
`$ git checkout pull/2435`

Update a local copy of the PR: \
`$ git checkout pull/2435` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2435`

View PR using the GUI difftool: \
`$ git pr show -t 2435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2435.diff">https://git.openjdk.org/jdk17u-dev/pull/2435.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2435#issuecomment-2080205252)