### PR TITLE
8327989: java/net/httpclient/ManyRequest.java should not use "localhost" in URIs

### DIFF
--- a/test/jdk/java/net/httpclient/ManyRequests.java
+++ b/test/jdk/java/net/httpclient/ManyRequests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,7 +176,7 @@ public class ManyRequests {
 
         URI baseURI = URIBuilder.newBuilder()
                 .scheme("https")
-                .host(InetAddress.getLoopbackAddress().getHostName())
+                .loopback()
                 .port(port)
                 .path("/foo/x").build();
         server.createContext("/foo", new TestEchoHandler());


### PR DESCRIPTION
Backport of [JDK-8327989](https://bugs.openjdk.org/browse/JDK-8327989)

Testing
- Local: Test passed
  - `ManyRequests.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-04-28`
  - Automated jtreg test: jtreg_jdk_tier2
  - java/net/httpclient/ManyRequests.java: SUCCESSFUL GitHub 📊⏲ - [43,417 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327989](https://bugs.openjdk.org/browse/JDK-8327989) needs maintainer approval

### Issue
 * [JDK-8327989](https://bugs.openjdk.org/browse/JDK-8327989): java/net/httpclient/ManyRequest.java should not use "localhost" in URIs (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2436/head:pull/2436` \
`$ git checkout pull/2436`

Update a local copy of the PR: \
`$ git checkout pull/2436` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2436`

View PR using the GUI difftool: \
`$ git pr show -t 2436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2436.diff">https://git.openjdk.org/jdk17u-dev/pull/2436.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2436#issuecomment-2080206950)