### PR TITLE
8273774: CDSPluginTest should only expect classes_nocoops.jsa exists on supported 64-bit platforms

### DIFF
--- a/test/jdk/tools/jlink/plugins/CDSPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CDSPluginTest.java
@@ -29,6 +29,8 @@ import jdk.test.lib.process.*;
 
 import tests.Helper;
 
+import jtreg.SkippedException;
+
 /* @test
  * @bug 8264322
  * @summary Test the --generate-cds-archive plugin
@@ -48,6 +50,9 @@ import tests.Helper;
 public class CDSPluginTest {
 
     public static void main(String[] args) throws Throwable {
+
+        if (!Platform.isDefaultCDSArchiveSupported())
+            throw new SkippedException("not a supported platform");
 
         Helper helper = Helper.newHelper();
         if (helper == null) {
@@ -69,8 +74,14 @@ public class CDSPluginTest {
             subDir = "lib" + sep;
         }
         subDir += "server" + sep;
-        helper.checkImage(image, module, null, null,
-                          new String[] { subDir + "classes.jsa", subDir + "classes_nocoops.jsa" });
+
+        if (Platform.isAArch64() || Platform.isX64()) {
+            helper.checkImage(image, module, null, null,
+                      new String[] { subDir + "classes.jsa", subDir + "classes_nocoops.jsa" });
+        } else {
+            helper.checkImage(image, module, null, null,
+                      new String[] { subDir + "classes.jsa" });
+        }
 
        // Simulate different platforms between current runtime and target image.
        if (Platform.isLinux()) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8273774](https://bugs.openjdk.org/browse/JDK-8273774) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273774](https://bugs.openjdk.org/browse/JDK-8273774): CDSPluginTest should only expect classes_nocoops.jsa exists on supported 64-bit platforms (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2440/head:pull/2440` \
`$ git checkout pull/2440`

Update a local copy of the PR: \
`$ git checkout pull/2440` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2440`

View PR using the GUI difftool: \
`$ git pr show -t 2440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2440.diff">https://git.openjdk.org/jdk17u-dev/pull/2440.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2440#issuecomment-2082098766)