### PR TITLE
8331164: createJMHBundle.sh download jars fail when url needed to be redirected

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -44,7 +44,7 @@ rm -f *
 fetchJar() {
   url="${MAVEN_MIRROR}/$1/$2/$3/$2-$3.jar"
   if command -v curl > /dev/null; then
-      curl -O --fail $url
+      curl -OL --fail $url
   elif command -v wget > /dev/null; then
       wget $url
   else


### PR DESCRIPTION
Hi,
  This is clean backport of JDK-8331164, to fixed download failure when the URL needed to be redirected.
  Only change devkit shell script, the risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8331164](https://bugs.openjdk.org/browse/JDK-8331164) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331164](https://bugs.openjdk.org/browse/JDK-8331164): createJMHBundle.sh download jars fail when url needed to be redirected (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2441/head:pull/2441` \
`$ git checkout pull/2441`

Update a local copy of the PR: \
`$ git checkout pull/2441` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2441`

View PR using the GUI difftool: \
`$ git pr show -t 2441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2441.diff">https://git.openjdk.org/jdk17u-dev/pull/2441.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2441#issuecomment-2083339925)