### PR TITLE
8280113: (dc) DatagramSocket.receive does not always throw when the channel is closed

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -547,7 +547,7 @@ class DatagramChannelImpl
                             n = receive(dst, connected);
                         }
                     }
-                    if (n >= 0) {
+                    if (n > 0 || (n == 0 && isOpen())) {
                         // sender address is in socket address buffer
                         sender = sourceSocketAddress();
                     }
@@ -668,7 +668,7 @@ class DatagramChannelImpl
                 park(Net.POLLIN);
                 n = receive(dst, connected);
             }
-            if (n >= 0) {
+            if (n > 0 || (n == 0 && isOpen())) {
                 // sender address is in socket address buffer
                 sender = sourceSocketAddress();
             }
@@ -705,7 +705,7 @@ class DatagramChannelImpl
                     park(Net.POLLIN, remainingNanos);
                     n = receive(dst, connected);
                 }
-                if (n >= 0) {
+                if (n > 0 || (n == 0 && isOpen())) {
                     // sender address is in socket address buffer
                     sender = sourceSocketAddress();
                 }


### PR DESCRIPTION
I omit the test from this change. 
The test heavily depends on features only available in 21. 
I tried to get it working in 20 because that has virtual threads, 
but there are more things missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8280113](https://bugs.openjdk.org/browse/JDK-8280113) needs maintainer approval

### Issue
 * [JDK-8280113](https://bugs.openjdk.org/browse/JDK-8280113): (dc) DatagramSocket.receive does not always throw when the channel is closed (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2445/head:pull/2445` \
`$ git checkout pull/2445`

Update a local copy of the PR: \
`$ git checkout pull/2445` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2445`

View PR using the GUI difftool: \
`$ git pr show -t 2445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2445.diff">https://git.openjdk.org/jdk17u-dev/pull/2445.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2445#issuecomment-2100065923)