### PR TITLE
8233725: ProcessTools.startProcess() has output issues when using an OutputAnalyzer at the same time

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -356,7 +356,10 @@ public final class JstatdTest {
 
         // Verify output from jstatd
         OutputAnalyzer output = jstatdThread.getOutput();
-        output.shouldBeEmptyIgnoreVMWarnings();
+        List<String> stdout = output.asLinesWithoutVMWarnings();
+        output.reportDiagnosticSummary();
+        assertEquals(stdout.size(), 1, "Output should contain one line");
+        assertTrue(stdout.get(0).startsWith("jstatd started"), "List should start with 'jstatd started'");
         assertNotEquals(output.getExitValue(), 0,
                 "jstatd process exited with unexpected exit code");
     }

--- a/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Unit test for ProcessTools.startProcess()
+ * @library /test/lib
+ * @compile ProcessToolsStartProcessTest.java
+ * @run main ProcessToolsStartProcessTest
+ */
+
+import java.util.function.Consumer;
+import java.io.File;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class ProcessToolsStartProcessTest {
+    static final int NUM_LINES = 50;
+    static String output = "";
+
+    private static Consumer<String> outputConsumer = s -> {
+        output += s + "\n";
+    };
+
+    static boolean testStartProcess(boolean withConsumer) throws Exception {
+        boolean success = true;
+        Process p;
+        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
+        launcher.addToolArg("-cp");
+        launcher.addToolArg(Utils.TEST_CLASSES);
+        launcher.addToolArg("ProcessToolsStartProcessTest");
+        launcher.addToolArg("test"); // This one argument triggers producing the output
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.command(launcher.getCommand());
+
+        System.out.println("DEBUG: Test with withConsumer=" + withConsumer);
+        System.out.println("DEBUG: about to start process.");
+        if (withConsumer) {
+            p = ProcessTools.startProcess("java", pb, outputConsumer);
+        } else {
+            p = ProcessTools.startProcess("java", pb);
+        }
+        OutputAnalyzer out = new OutputAnalyzer(p);
+
+        System.out.println("DEBUG: process started.");
+        p.waitFor();
+        if (p.exitValue() != 0) {
+            throw new RuntimeException("Bad exit value: " + p.exitValue());
+        }
+
+        if (withConsumer) {
+            int numLines = output.split("\n").length;
+            if (numLines != NUM_LINES ) {
+                System.out.print("FAILED: wrong number of lines in Consumer output\n");
+                success = false;
+            }
+            System.out.println("DEBUG: Consumer output: got " + numLines + " lines , expected "
+                               + NUM_LINES  + ". Output follow:");
+            System.out.print(output);
+            System.out.println("DEBUG: done with Consumer output.");
+        }
+
+        int numLinesOut = out.getStdout().split("\n").length;
+        if (numLinesOut != NUM_LINES) {
+            System.out.print("FAILED: wrong number of lines in OutputAnalyzer output\n");
+            success = false;
+        }
+        System.out.println("DEBUG: OutputAnalyzer output: got " + numLinesOut + " lines, expected "
+                           + NUM_LINES  + ". Output follows:");
+        System.out.print(out.getStdout());
+        System.out.println("DEBUG: done with OutputAnalyzer stdout.");
+
+        return success;
+    }
+
+    public static void main(String[] args) {
+        if (args.length > 0) {
+            for (int i = 0; i < NUM_LINES; i++) {
+                System.out.println("A line on stdout " + i);
+            }
+        } else {
+            try {
+                boolean test1Result = testStartProcess(false);
+                boolean test2Result = testStartProcess(true);
+                if (!test1Result || !test2Result) {
+                    throw new RuntimeException("One or more tests failed. See output for details.");
+                }
+            } catch (RuntimeException re) {
+                re.printStackTrace();
+                System.out.println("Test ERROR");
+                throw re;
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                System.out.println("Test ERROR");
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}

--- a/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
+++ b/test/lib-test/jdk/test/lib/process/ProcessToolsStartProcessTest.java
@@ -38,21 +38,21 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 public class ProcessToolsStartProcessTest {
-    static final int NUM_LINES = 50;
     static String output = "";
 
     private static Consumer<String> outputConsumer = s -> {
         output += s + "\n";
     };
 
-    static boolean testStartProcess(boolean withConsumer) throws Exception {
+    static boolean testStartProcess(int numOfLines, boolean withConsumer) throws Exception {
         boolean success = true;
+        output = "";
         Process p;
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
         launcher.addToolArg("-cp");
         launcher.addToolArg(Utils.TEST_CLASSES);
         launcher.addToolArg("ProcessToolsStartProcessTest");
-        launcher.addToolArg("test"); // This one argument triggers producing the output
+        launcher.addToolArg(Integer.toString(numOfLines));
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(launcher.getCommand());
 
@@ -73,49 +73,40 @@ public class ProcessToolsStartProcessTest {
 
         if (withConsumer) {
             int numLines = output.split("\n").length;
-            if (numLines != NUM_LINES ) {
+            if (numLines != numOfLines) {
                 System.out.print("FAILED: wrong number of lines in Consumer output\n");
                 success = false;
+                System.out.print(output);
             }
-            System.out.println("DEBUG: Consumer output: got " + numLines + " lines , expected "
-                               + NUM_LINES  + ". Output follow:");
-            System.out.print(output);
-            System.out.println("DEBUG: done with Consumer output.");
         }
 
         int numLinesOut = out.getStdout().split("\n").length;
-        if (numLinesOut != NUM_LINES) {
+        if (numLinesOut != numOfLines) {
             System.out.print("FAILED: wrong number of lines in OutputAnalyzer output\n");
+            System.out.print(out.getStdout());
             success = false;
         }
-        System.out.println("DEBUG: OutputAnalyzer output: got " + numLinesOut + " lines, expected "
-                           + NUM_LINES  + ". Output follows:");
-        System.out.print(out.getStdout());
-        System.out.println("DEBUG: done with OutputAnalyzer stdout.");
 
         return success;
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         if (args.length > 0) {
-            for (int i = 0; i < NUM_LINES; i++) {
-                System.out.println("A line on stdout " + i);
+            int iter = Integer.parseInt(args[0]);
+            for (int i = 0; i < iter; i++) {
+                System.out.println("A line on stdout: " + i + " " + ".".repeat(i));
             }
         } else {
-            try {
-                boolean test1Result = testStartProcess(false);
-                boolean test2Result = testStartProcess(true);
-                if (!test1Result || !test2Result) {
-                    throw new RuntimeException("One or more tests failed. See output for details.");
+            for (int i = 1; i < 5; i++) {
+                System.out.println("ITERATION " + i);
+                boolean test1Result = testStartProcess(i * 10 + i, false);
+                if (!test1Result) {
+                    throw new RuntimeException("First test (no consumer) failed. See output for details.");
                 }
-            } catch (RuntimeException re) {
-                re.printStackTrace();
-                System.out.println("Test ERROR");
-                throw re;
-            } catch (Exception ex) {
-                ex.printStackTrace();
-                System.out.println("Test ERROR");
-                throw new RuntimeException(ex);
+                boolean test2Result = testStartProcess(i * 10 + i, true);
+                if (!test2Result) {
+                    throw new RuntimeException("Second test (with consumer) failed. See output for details.");
+                }
             }
         }
     }

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -113,7 +114,7 @@ public final class ProcessTools {
             throws IOException {
         try {
             return startProcess(name, processBuilder, consumer, null, -1, TimeUnit.NANOSECONDS);
-        } catch (InterruptedException | TimeoutException e) {
+        } catch (InterruptedException | TimeoutException | CancellationException e) {
             // will never happen
             throw new RuntimeException(e);
         }
@@ -155,23 +156,38 @@ public final class ProcessTools {
         BufferOutputStream and BufferInputStream allow to re-use p.getInputStream() amd p.getOutputStream() of
         processes started with ProcessTools.startProcess(...).
         Implementation cashes ALL process output and allow to read it through InputStream.
+        The stream uses  Future<Void> task from StreamPumper.process() to check if output is complete.
      */
     private static class BufferOutputStream extends ByteArrayOutputStream {
         private int current = 0;
         final private Process p;
 
+        private Future<Void> task;
+
         public BufferOutputStream(Process p) {
             this.p = p;
         }
 
+        synchronized void setTask(Future<Void> task) {
+            this.task = task;
+        }
         synchronized int readNext() {
             if (current > count) {
                 throw new RuntimeException("Shouldn't ever happen.  start: "
                         + current + " count: " + count + " buffer: " + this);
             }
             while (current == count) {
-                if (!p.isAlive()) {
-                    return -1;
+                if (!p.isAlive() && (task != null)) {
+                    try {
+                        task.get(10, TimeUnit.MILLISECONDS);
+                        if (current == count) {
+                            return -1;
+                        }
+                    } catch (TimeoutException e) {
+                        // continue execution, so wait() give a chance to write
+                    } catch (InterruptedException | ExecutionException e) {
+                        return -1;
+                    }
                 }
                 try {
                     wait(1);
@@ -191,7 +207,7 @@ public final class ProcessTools {
             buffer = new BufferOutputStream(p);
         }
 
-        OutputStream getOutputStream() {
+        BufferOutputStream getOutputStream() {
             return buffer;
         }
 
@@ -239,6 +255,8 @@ public final class ProcessTools {
 
         stdout.addPump(new LineForwarder(name, System.out));
         stderr.addPump(new LineForwarder(name, System.err));
+
+
         BufferInputStream stdOut = new BufferInputStream(p);
         BufferInputStream stdErr = new BufferInputStream(p);
 
@@ -255,7 +273,6 @@ public final class ProcessTools {
             stdout.addPump(pump);
             stderr.addPump(pump);
         }
-
 
         CountDownLatch latch = new CountDownLatch(1);
         if (linePredicate != null) {
@@ -278,6 +295,9 @@ public final class ProcessTools {
         }
         final Future<Void> stdoutTask = stdout.process();
         final Future<Void> stderrTask = stderr.process();
+
+        stdOut.getOutputStream().setTask(stdoutTask);
+        stdErr.getOutputStream().setTask(stderrTask);
 
         try {
             if (timeout > -1) {


### PR DESCRIPTION
Clean backport to fix ProcessTools.startProcess() bug.

See original PR explanation [here](https://github.com/openjdk/jdk/pull/13594)

I need this backport to be merged to able to complete [this](https://github.com/openjdk/jdk17u-dev/pull/2339) backport request.

Additional testing: macos-x86_64-server-release tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8233725](https://bugs.openjdk.org/browse/JDK-8233725) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8306946](https://bugs.openjdk.org/browse/JDK-8306946) needs maintainer approval
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8233725](https://bugs.openjdk.org/browse/JDK-8233725): ProcessTools.startProcess() has output issues when using an OutputAnalyzer at the same time (**Bug** - P4 - Approved)
 * [JDK-8306946](https://bugs.openjdk.org/browse/JDK-8306946): jdk/test/lib/process/ProcessToolsStartProcessTest.java fails with "wrong number of lines in OutputAnalyzer output" (**Bug** - P3 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2456/head:pull/2456` \
`$ git checkout pull/2456`

Update a local copy of the PR: \
`$ git checkout pull/2456` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2456`

View PR using the GUI difftool: \
`$ git pr show -t 2456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2456.diff">https://git.openjdk.org/jdk17u-dev/pull/2456.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2456#issuecomment-2103015788)