### PR TITLE
8299023: TestPLABResize.java and TestPLABPromotion.java are failing intermittently

### DIFF
--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8141278 8141141
  * @summary Test PLAB promotion
  * @requires vm.gc.G1
- * @requires !vm.flightRecorder
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  * @modules java.management

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABResize.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8141278 8141141
  * @summary Test for PLAB resizing
  * @requires vm.gc.G1
- * @requires !vm.flightRecorder
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  * @modules java.management


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8299023](https://bugs.openjdk.org/browse/JDK-8299023) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299023](https://bugs.openjdk.org/browse/JDK-8299023): TestPLABResize.java and TestPLABPromotion.java are failing intermittently (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2459/head:pull/2459` \
`$ git checkout pull/2459`

Update a local copy of the PR: \
`$ git checkout pull/2459` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2459`

View PR using the GUI difftool: \
`$ git pr show -t 2459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2459.diff">https://git.openjdk.org/jdk17u-dev/pull/2459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2459#issuecomment-2107111980)