### PR TITLE
8305819: LogConfigurationTest intermittently fails on AArch64

### DIFF
--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -124,17 +124,22 @@ void LogOutputList::add_output(LogOutput* output, LogLevelType level) {
        node->_next = node->_next->_next) {
   }
 
+  // To allow lock-free iteration of the output list the updates in the loops
+  // below require release semantics.
+  OrderAccess::release();
+
   // Update the _level_start index
   for (int l = LogLevel::Last; l >= level; l--) {
-    if (_level_start[l] == NULL || _level_start[l]->_level < level) {
-      _level_start[l] = node;
+    LogOutputNode* lnode = Atomic::load(&_level_start[l]);
+    if (lnode == nullptr || lnode->_level < level) {
+      Atomic::store(&_level_start[l], node);
     }
   }
 
   // Add the node the list
-  for (LogOutputNode* cur = _level_start[LogLevel::Last]; cur != NULL; cur = cur->_next) {
-    if (cur != node && cur->_next == node->_next) {
-      cur->_next = node;
+  for (LogOutputNode* cur = Atomic::load(&_level_start[LogLevel::Last]); cur != nullptr; cur = Atomic::load(&cur->_next)) {
+    if (cur != node && Atomic::load(&cur->_next) == node->_next) {
+      Atomic::store(&cur->_next, node);
       break;
     }
   }

--- a/src/hotspot/share/logging/logOutputList.hpp
+++ b/src/hotspot/share/logging/logOutputList.hpp
@@ -26,6 +26,7 @@
 
 #include "logging/logLevel.hpp"
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 class LogOutput;
@@ -48,11 +49,11 @@ class LogOutputList {
  private:
   struct LogOutputNode : public CHeapObj<mtLogging> {
     LogOutput*      _value;
-    LogOutputNode*  _next;
+    LogOutputNode* volatile _next;
     LogLevelType    _level;
   };
 
-  LogOutputNode*  _level_start[LogLevel::Count];
+  LogOutputNode* volatile _level_start[LogLevel::Count];
   volatile jint   _active_readers;
 
   LogOutputNode* find(const LogOutput* output) const;
@@ -124,7 +125,9 @@ class LogOutputList {
     }
 
     void operator++(int) {
-      _current = _current->_next;
+      // FIXME: memory_order_consume could be used here.
+      // Atomic access on the reading side for LogOutputList.
+      _current = Atomic::load_acquire(&_current->_next);
     }
 
     bool operator!=(const LogOutputNode *ref) const {
@@ -138,7 +141,9 @@ class LogOutputList {
 
   Iterator iterator(LogLevelType level = LogLevel::Last) {
     increase_readers();
-    return Iterator(this, _level_start[level]);
+    // FIXME: memory_order_consume could be used here.
+    // Atomic access on the reading side for LogOutputList.
+    return Iterator(this, Atomic::load_acquire(&_level_start[level]));
   }
 
   LogOutputNode* end() const {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [911cc7cb](https://github.com/openjdk/jdk/commit/911cc7cb07ed44b24b4c20977d7d6e475bd1b234) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.


It fixed a logging crash due to arm weak memory model.

The commit being backported was authored by gaogao-mem on 15 May 2023 and was reviewed by Andrew Haley, David Holmes and Xin Liu.

The conflicts only come from the difference of "NULL" and "nullptr".

Additional testing:
- [x] Verified the test case in original PR.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8305819](https://bugs.openjdk.org/browse/JDK-8305819) needs maintainer approval

### Issue
 * [JDK-8305819](https://bugs.openjdk.org/browse/JDK-8305819): LogConfigurationTest intermittently fails on AArch64 (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2460/head:pull/2460` \
`$ git checkout pull/2460`

Update a local copy of the PR: \
`$ git checkout pull/2460` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2460`

View PR using the GUI difftool: \
`$ git pr show -t 2460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2460.diff">https://git.openjdk.org/jdk17u-dev/pull/2460.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2460#issuecomment-2107208113)