### PR TITLE
8328997: Remove unnecessary template parameter lists in GrowableArray

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -118,7 +118,7 @@ class GrowableArrayView : public GrowableArrayBase {
 protected:
   E* _data; // data array
 
-  GrowableArrayView<E>(E* data, int initial_max, int initial_len) :
+  GrowableArrayView(E* data, int initial_max, int initial_len) :
       GrowableArrayBase(initial_max, initial_len), _data(data) {}
 
   ~GrowableArrayView() {}
@@ -126,7 +126,7 @@ protected:
 public:
   const static GrowableArrayView EMPTY;
 
-  bool operator==(const GrowableArrayView<E>& rhs) const {
+  bool operator==(const GrowableArrayView& rhs) const {
     if (_len != rhs._len)
       return false;
     for (int i = 0; i < _len; i++) {
@@ -137,7 +137,7 @@ public:
     return true;
   }
 
-  bool operator!=(const GrowableArrayView<E>& rhs) const {
+  bool operator!=(const GrowableArrayView& rhs) const {
     return !(*this == rhs);
   }
 
@@ -467,7 +467,7 @@ public:
     return this->at(location);
   }
 
-  void swap(GrowableArrayWithAllocator<E, Derived>* other) {
+  void swap(GrowableArrayWithAllocator* other) {
     ::swap(this->_data, other->_data);
     ::swap(this->_len, other->_len);
     ::swap(this->_max, other->_max);
@@ -618,8 +618,8 @@ public:
 //  See: init_checks.
 
 template <typename E>
-class GrowableArray : public GrowableArrayWithAllocator<E, GrowableArray<E> > {
-  friend class GrowableArrayWithAllocator<E, GrowableArray<E> >;
+class GrowableArray : public GrowableArrayWithAllocator<E, GrowableArray<E>> {
+  friend class GrowableArrayWithAllocator<E, GrowableArray>;
   friend class GrowableArrayTest;
 
   static E* allocate(int max) {
@@ -669,7 +669,7 @@ class GrowableArray : public GrowableArrayWithAllocator<E, GrowableArray<E> > {
 
 public:
   GrowableArray(int initial_max = 2, MEMFLAGS memflags = mtNone) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
+      GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_max, memflags),
           initial_max),
       _metadata(memflags) {
@@ -677,7 +677,7 @@ public:
   }
 
   GrowableArray(int initial_max, int initial_len, const E& filler, MEMFLAGS memflags = mtNone) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
+      GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_max, memflags),
           initial_max, initial_len, filler),
       _metadata(memflags) {
@@ -685,7 +685,7 @@ public:
   }
 
   GrowableArray(Arena* arena, int initial_max, int initial_len, const E& filler) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
+      GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_max, arena),
           initial_max, initial_len, filler),
       _metadata(arena) {
@@ -766,15 +766,15 @@ class GrowableArrayIterator : public StackObj {
 
  public:
   GrowableArrayIterator() : _array(NULL), _position(0) { }
-  GrowableArrayIterator<E>& operator++() { ++_position; return *this; }
-  E operator*()                          { return _array->at(_position); }
+  GrowableArrayIterator& operator++() { ++_position; return *this; }
+  E operator*()                       { return _array->at(_position); }
 
-  bool operator==(const GrowableArrayIterator<E>& rhs)  {
+  bool operator==(const GrowableArrayIterator& rhs)  {
     assert(_array == rhs._array, "iterator belongs to different array");
     return _position == rhs._position;
   }
 
-  bool operator!=(const GrowableArrayIterator<E>& rhs)  {
+  bool operator!=(const GrowableArrayIterator& rhs)  {
     assert(_array == rhs._array, "iterator belongs to different array");
     return _position != rhs._position;
   }


### PR DESCRIPTION
It is needed to build OpenJDK-17 on Fedora 40 x86_64 (gcc-14.1.1-1.fc40.x86_64).
It needs all of [JDK-8328997](https://bugs.openjdk.org/browse/JDK-8328997) (this [backport](https://github.com/openjdk/jdk17u-dev/pull/2466)), [JDK-8331352](https://bugs.openjdk.org/browse/JDK-8331352) ([backport](https://github.com/openjdk/jdk17u-dev/pull/2467)) and [JDK-8324243](https://bugs.openjdk.org/browse/JDK-8324243) ([backport](https://github.com/openjdk/jdk17u-dev/pull/2468)).
Git cherry-pick was not clean but it was easy to apply.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8328997](https://bugs.openjdk.org/browse/JDK-8328997) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328997](https://bugs.openjdk.org/browse/JDK-8328997): Remove unnecessary template parameter lists in GrowableArray (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2466/head:pull/2466` \
`$ git checkout pull/2466`

Update a local copy of the PR: \
`$ git checkout pull/2466` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2466`

View PR using the GUI difftool: \
`$ git pr show -t 2466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2466.diff">https://git.openjdk.org/jdk17u-dev/pull/2466.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2466#issuecomment-2109303467)