### PR TITLE
8331466: Problemlist serviceability/dcmd/gc/RunFinalizationTest.java on generic-all

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -112,7 +112,7 @@ serviceability/sa/sadebugd/DebugdConnectTest.java 8239062,8270326 macosx-x64,mac
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
-serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
+serviceability/dcmd/gc/RunFinalizationTest.java 8227120 generic-all
 
 serviceability/sa/ClhsdbCDSCore.java  8294316,8267433 macosx-x64
 serviceability/sa/ClhsdbFindPC.java#id1  8294316,8267433 macosx-x64


### PR DESCRIPTION
Hi all,
This is backport of [JDK-8331466](https://bugs.openjdk.org/browse/JDK-8331466). This backport is not clean because the line number of 8227120 has changed from 115 to 137, and it's a previous problemlist for `aix-ppc64`. Only change the Problemlist.txt, the risk is low.

Thanks
sendao

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331466](https://bugs.openjdk.org/browse/JDK-8331466) needs maintainer approval

### Issue
 * [JDK-8331466](https://bugs.openjdk.org/browse/JDK-8331466): Problemlist serviceability/dcmd/gc/RunFinalizationTest.java on generic-all (**Sub-task** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2469/head:pull/2469` \
`$ git checkout pull/2469`

Update a local copy of the PR: \
`$ git checkout pull/2469` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2469`

View PR using the GUI difftool: \
`$ git pr show -t 2469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2469.diff">https://git.openjdk.org/jdk17u-dev/pull/2469.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2469#issuecomment-2109435936)