### PR TITLE
8319268: Build failure with GCC8.3.1 after 8313643

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -467,9 +467,10 @@ else
         array-bounds parentheses
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
+   # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
         maybe-uninitialized class-memaccess unused-result extra use-after-free noexcept-type \
-        expansion-to-defined dangling-reference
+        expansion-to-defined dangling-reference maybe-uninitialized
    HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
         tautological-constant-out-of-range-compare int-to-pointer-cast \
         undef missing-field-initializers range-loop-analysis \


### PR DESCRIPTION
It has been requested in https://github.com/openjdk/jdk17u-dev/pull/2468#discussion_r1601617775 but I do not have this problem reproducible.
I have tried devtoolset-8-gcc-8.3.1-3.2.el7.x86_64 (CentOS-7) and gcc-8.3.0.tar.xz (rebuilt from source).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8319268](https://bugs.openjdk.org/browse/JDK-8319268) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319268](https://bugs.openjdk.org/browse/JDK-8319268): Build failure with GCC8.3.1 after 8313643 (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2475/head:pull/2475` \
`$ git checkout pull/2475`

Update a local copy of the PR: \
`$ git checkout pull/2475` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2475`

View PR using the GUI difftool: \
`$ git pr show -t 2475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2475.diff">https://git.openjdk.org/jdk17u-dev/pull/2475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2475#issuecomment-2113815439)