### PR TITLE
8319338: tools/jpackage/share/RuntimeImageTest.java fails with -XX:+UseZGC

### DIFF
--- a/test/jdk/tools/jpackage/share/RuntimeImageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageTest.java
@@ -47,7 +47,7 @@ import jdk.jpackage.test.Executor;
  * @build jdk.jpackage.test.*
  * @modules jdk.incubator.jpackage/jdk.incubator.jpackage.internal
  * @compile RuntimeImageTest.java
- * @run main/othervm/timeout=1400 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=1400 jdk.jpackage.test.Main
  *  --jpt-run=RuntimeImageTest
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.12-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319338](https://bugs.openjdk.org/browse/JDK-8319338) needs maintainer approval

### Issue
 * [JDK-8319338](https://bugs.openjdk.org/browse/JDK-8319338): tools/jpackage/share/RuntimeImageTest.java fails with -XX:+UseZGC (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2484/head:pull/2484` \
`$ git checkout pull/2484`

Update a local copy of the PR: \
`$ git checkout pull/2484` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2484`

View PR using the GUI difftool: \
`$ git pr show -t 2484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2484.diff">https://git.openjdk.org/jdk17u-dev/pull/2484.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2484#issuecomment-2121904828)