### PR TITLE
8320681: [macos] Test tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java timed out on macOS

### DIFF
--- a/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import jdk.jpackage.test.Annotations.Test;
  * @build MacAppStoreJLinkOptionsTest
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @requires (os.family == "mac")
- * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=MacAppStoreJLinkOptionsTest
  */
 public class MacAppStoreJLinkOptionsTest {


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320681](https://bugs.openjdk.org/browse/JDK-8320681) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320681](https://bugs.openjdk.org/browse/JDK-8320681): [macos] Test tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java timed out on macOS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2485/head:pull/2485` \
`$ git checkout pull/2485`

Update a local copy of the PR: \
`$ git checkout pull/2485` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2485`

View PR using the GUI difftool: \
`$ git pr show -t 2485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2485.diff">https://git.openjdk.org/jdk17u-dev/pull/2485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2485#issuecomment-2122005330)