### PR TITLE
8286781: Replace the deprecated/obsolete gethostbyname and inet_addr calls

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -154,7 +154,7 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
   if test "x$OPENJDK_TARGET_OS" = xwindows; then
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS kernel32.lib user32.lib gdi32.lib winspool.lib \
         comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib powrprof.lib uuid.lib \
-        wsock32.lib winmm.lib version.lib psapi.lib"
+        ws2_32.lib winmm.lib version.lib psapi.lib"
   fi
 
   JDKLIB_LIBS="$BASIC_JDKLIB_LIBS"

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -800,10 +800,6 @@ int os::connect(int fd, struct sockaddr* him, socklen_t len) {
   RESTARTABLE_RETURN_INT(::connect(fd, him, len));
 }
 
-struct hostent* os::get_host_by_name(char* name) {
-  return ::gethostbyname(name);
-}
-
 void os::exit(int num) {
   ::exit(num);
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -5797,10 +5797,6 @@ static jint initSock() {
   return JNI_OK;
 }
 
-struct hostent* os::get_host_by_name(char* name) {
-  return (struct hostent*)gethostbyname(name);
-}
-
 int os::socket_close(int fd) {
   return ::closesocket(fd);
 }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -807,7 +807,6 @@ class os: AllStatic {
   static int send(int fd, char* buf, size_t nBytes, uint flags);
   static int raw_send(int fd, char* buf, size_t nBytes, uint flags);
   static int connect(int fd, struct sockaddr* him, socklen_t len);
-  static struct hostent* get_host_by_name(char* name);
 
   // Support for signals (see JVM_RaiseSignal, JVM_RegisterSignal)
   static void  initialize_jdk_signal_support(TRAPS);

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -1071,7 +1071,7 @@ bufferedStream::~bufferedStream() {
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #elif defined(_WINDOWS)
-#include <winsock2.h>
+#include <Ws2tcpip.h>
 #endif
 
 // Network access
@@ -1112,25 +1112,31 @@ void networkStream::close() {
   }
 }
 
-bool networkStream::connect(const char *ip, short port) {
+// host could be IP address, or a host name
+bool networkStream::connect(const char *host, short port) {
 
-  struct sockaddr_in server;
-  server.sin_family = AF_INET;
-  server.sin_port = htons(port);
+  char s_port[6]; // 5 digits max plus terminator
+  int ret = os::snprintf(s_port, sizeof(s_port), "%hu", (unsigned short) port);
+  assert(ret > 0, "snprintf failed: %d", ret);
 
-  server.sin_addr.s_addr = inet_addr(ip);
-  if (server.sin_addr.s_addr == (uint32_t)-1) {
-    struct hostent* host = os::get_host_by_name((char*)ip);
-    if (host != NULL) {
-      memcpy(&server.sin_addr, host->h_addr_list[0], host->h_length);
-    } else {
-      return false;
-    }
+  struct addrinfo* addr_info = nullptr;
+  struct addrinfo hints;
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;       // Allow IPv4 only
+  hints.ai_socktype = SOCK_STREAM; // TCP only
+
+  // getaddrinfo can resolve both an IP address and a host name
+  ret = getaddrinfo(host, s_port, &hints, &addr_info);
+  if (ret != 0) {
+    warning("networkStream::connect getaddrinfo for host %s and port %s failed: %s",
+            host, s_port, gai_strerror(ret));
+    return false;
   }
 
-
-  int result = os::connect(_socket, (struct sockaddr*)&server, sizeof(struct sockaddr_in));
-  return (result >= 0);
+  ret = os::connect(_socket, addr_info->ai_addr, (socklen_t)addr_info->ai_addrlen);
+  freeaddrinfo(addr_info);
+  return (ret >= 0);
 }
 
 #endif


### PR DESCRIPTION
I propose backporting the fix for `8286781` to `jdk17u`.

I tested the changes on `jdk17u-dev` `master`, on `Fedora 38` `x86-64`, `slowdebug` and `fastdebug` configurations.  The test was to run `IdealGraphVisualizer`, per `jdk17u-dev/src/utils/IdealGraphVisualizer/README.md`, then run, e.g.:

```
./build/linux-x86_64-server-fastdebug/jdk/bin/java -XX:+PrintIdealGraph -XX:PrintIdealGraphLevel=1 -classpath ~/source/hello-java Hello
```

I needed extra JVM arguments in `jdk17u-dev/src/utils/IdealGraphVisualizer/application/target/idealgraphvisualizer/bin/idealgraphvisualizer` to make the visualizer utility work on 17:

```
            --jdkhome '"$jdkhome"' \
            -J--add-opens=java.base/java.net=ALL-UNNAMED \
            -J--add-opens=java.base/java.security=ALL-UNNAMED \
            -J--add-opens=java.base/java.lang=ALL-UNNAMED \
            -J--add-opens=java.desktop/sun.awt=ALL-UNNAMED \
            -J--add-opens=java.desktop/javax.swing.plaf.synth=ALL-UNNAMED \
            -J--add-opens=java.desktop/javax.swing=ALL-UNNAMED \
            -J--add-exports=java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED \
            --clusters '"$clusters"' \
```

Networking between the test and the utility worked fine with the backport applied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286781](https://bugs.openjdk.org/browse/JDK-8286781) needs maintainer approval

### Issue
 * [JDK-8286781](https://bugs.openjdk.org/browse/JDK-8286781): Replace the deprecated/obsolete gethostbyname and inet_addr calls (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2487/head:pull/2487` \
`$ git checkout pull/2487`

Update a local copy of the PR: \
`$ git checkout pull/2487` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2487`

View PR using the GUI difftool: \
`$ git pr show -t 2487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2487.diff">https://git.openjdk.org/jdk17u-dev/pull/2487.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2487#issuecomment-2122948692)