### PR TITLE
8279068: IGV: Update to work with JDK 16 and 17

### DIFF
--- a/src/utils/IdealGraphVisualizer/Bytecodes/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Bytecodes/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -124,6 +124,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/ControlFlow/pom.xml
+++ b/src/utils/IdealGraphVisualizer/ControlFlow/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -124,6 +124,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/Coordinator/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Coordinator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -149,6 +149,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/Data/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Data/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -93,6 +93,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/Difference/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Difference/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -94,6 +94,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/Filter/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Filter/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -96,7 +96,7 @@
                 <dependency>
                     <groupId>org.openjdk.nashorn</groupId>
                     <artifactId>nashorn-core</artifactId>
-                    <version>15.2</version>
+                    <version>15.3</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -133,6 +133,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/FilterWindow/pom.xml
+++ b/src/utils/IdealGraphVisualizer/FilterWindow/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -144,6 +144,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/Graal/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Graal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -94,6 +94,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/Graph/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Graph/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -95,6 +95,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/HierarchicalLayout/pom.xml
+++ b/src/utils/IdealGraphVisualizer/HierarchicalLayout/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -84,6 +84,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/Layout/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Layout/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -77,6 +77,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/NetworkConnection/pom.xml
+++ b/src/utils/IdealGraphVisualizer/NetworkConnection/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -99,6 +99,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/README.md
+++ b/src/utils/IdealGraphVisualizer/README.md
@@ -8,7 +8,7 @@ tool itself is fairly general with only a few modules that contain C2 specific
 elements.
 
 The tool is built on top of the NetBeans Platform, and requires a JDK version
-between 8 and 15 (the latest JDK supported by the current NetBeans Platform).
+between 11 and 17 (the JDKs supported by the current NetBeans Platform).
 
 # Building and Running
 

--- a/src/utils/IdealGraphVisualizer/SelectionCoordinator/pom.xml
+++ b/src/utils/IdealGraphVisualizer/SelectionCoordinator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -84,6 +84,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/pom.xml
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/pom.xml
@@ -90,6 +90,10 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/utils/IdealGraphVisualizer/Settings/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Settings/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -109,6 +109,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/Util/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Util/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -114,6 +114,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/View/pom.xml
+++ b/src/utils/IdealGraphVisualizer/View/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -184,6 +184,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/application/pom.xml
+++ b/src/utils/IdealGraphVisualizer/application/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -158,6 +158,9 @@
             <plugin>
                 <groupId>org.apache.netbeans.utilities</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
+                <configuration>
+                    <etcConfFile>src/main/resources/${brandingToken}.conf</etcConfFile>
+                </configuration>
             </plugin>
             <!-- Permits NbModuleSuite to be run in integration-test phase: -->
             <plugin>

--- a/src/utils/IdealGraphVisualizer/application/src/main/resources/idealgraphvisualizer.conf
+++ b/src/utils/IdealGraphVisualizer/application/src/main/resources/idealgraphvisualizer.conf
@@ -1,0 +1,24 @@
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+
+# Open/export modules still accessed by the NetBeans Platform.
+# All options must be passed in a single line for multi-platform support.
+default_options="-J--add-opens=java.base/java.net=ALL-UNNAMED -J--add-opens=java.desktop/javax.swing.plaf.synth=ALL-UNNAMED -J--add-opens=java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED -J--add-opens=java.desktop/javax.swing=ALL-UNNAMED -J--add-exports=java.desktop/sun.awt=ALL-UNNAMED"

--- a/src/utils/IdealGraphVisualizer/branding/pom.xml
+++ b/src/utils/IdealGraphVisualizer/branding/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -60,6 +60,10 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -64,6 +64,27 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${mvnjarplugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${mvnenforcerplugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-java</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireJavaVersion>
+                                      <version>[11,18)</version>
+                                      <message>IGV requires a JDK version between 11 and 17</message>
+                                    </requireJavaVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -90,11 +111,12 @@
         <module>View</module>
     </modules>
     <properties>
-        <netbeans.version>RELEASE123</netbeans.version>
+        <netbeans.version>RELEASE126</netbeans.version>
         <swinglayouts.version>1.0.2</swinglayouts.version>
         <nbmmvnplugin.version>4.3</nbmmvnplugin.version>
         <mvncompilerplugin.version>3.8.1</mvncompilerplugin.version>
         <mvnjarplugin.version>3.1.2</mvnjarplugin.version>
+        <mvnenforcerplugin.version>3.0.0</mvnenforcerplugin.version>
         <junit.version>4.13.2</junit.version>
         <brandingToken>idealgraphvisualizer</brandingToken>
     </properties>


### PR DESCRIPTION
I propose the following backport to `jdk17u-dev`:

```
8279068: IGV: Update to work with JDK 16 and 17

Reviewed-by: kvn, neliasso, chagedorn
Backport-of: 7bcca7692b62a37f70c757694f6acff0295371cc
```

This is a mostly-clean backport to 17.  I had to move and apply manually these two lines:

```
--- src/utils/IdealGraphVisualizer/pom.xml
+++ src/utils/IdealGraphVisualizer/pom.xml
@@ -110,11 +131,12 @@
         <module>View</module>
     </modules>
     <properties>
-        <netbeans.version>RELEASE123</netbeans.version>
+        <netbeans.version>RELEASE126</netbeans.version>
         <swinglayouts.version>1.0.2</swinglayouts.version>
         <nbmmvnplugin.version>4.6</nbmmvnplugin.version>
         <mvncompilerplugin.version>3.8.1</mvncompilerplugin.version>
         <mvnjarplugin.version>3.2.0</mvnjarplugin.version>
+        <mvnenforcerplugin.version>3.0.0</mvnenforcerplugin.version>
         <junit.version>4.13.2</junit.version>
         <batik.version>1.14</batik.version>
         <openpdf.version>1.3.26</openpdf.version>
```

With this backport `mvn install; sh igv.sh` works fine for me on `x86-64 Fedora 38`, `fastdebug` build, without needing to add JVM options to the `idealgraphviewer` wrapper script, which I needed to do  when testing #2487.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8279068](https://bugs.openjdk.org/browse/JDK-8279068) needs maintainer approval

### Issue
 * [JDK-8279068](https://bugs.openjdk.org/browse/JDK-8279068): IGV: Update to work with JDK 16 and 17 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2488/head:pull/2488` \
`$ git checkout pull/2488`

Update a local copy of the PR: \
`$ git checkout pull/2488` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2488`

View PR using the GUI difftool: \
`$ git pr show -t 2488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2488.diff">https://git.openjdk.org/jdk17u-dev/pull/2488.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2488#issuecomment-2125150373)