### PR TITLE
8313873: java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  fails on AIX due to small default RCVBUF size and different IPv6 Header interpretation

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/SendReceiveMaxSize.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/SendReceiveMaxSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ import java.util.function.Predicate;
 import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardProtocolFamily.INET6;
 import static java.net.StandardSocketOptions.SO_SNDBUF;
+import static java.net.StandardSocketOptions.SO_RCVBUF;
 import static jdk.test.lib.net.IPSupport.hasIPv4;
 import static jdk.test.lib.net.IPSupport.hasIPv6;
 import static jdk.test.lib.net.IPSupport.preferIPv4Stack;
@@ -65,8 +66,6 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 public class SendReceiveMaxSize {
-    private final static int IPV4_SNDBUF = 65507;
-    private final static int IPV6_SNDBUF = 65527;
     private final static Class<IOException> IOE = IOException.class;
     private final static Random random = RandomFactory.getRandom();
 
@@ -91,12 +90,12 @@ public class SendReceiveMaxSize {
                     .orElse((Inet4Address) InetAddress.getByName("127.0.0.1"));
             testcases.add(new Object[]{
                     supplier(() -> DatagramChannel.open()),
-                    IPV4_SNDBUF,
+                    IPSupport.getMaxUDPSendBufSizeIPv4(),
                     IPv4Addr
             });
             testcases.add(new Object[]{
                     supplier(() -> DatagramChannel.open(INET)),
-                    IPV4_SNDBUF,
+                    IPSupport.getMaxUDPSendBufSizeIPv4(),
                     IPv4Addr
             });
         }
@@ -107,12 +106,12 @@ public class SendReceiveMaxSize {
                     .orElse((Inet6Address) InetAddress.getByName("::1"));
             testcases.add(new Object[]{
                     supplier(() -> DatagramChannel.open()),
-                    IPV6_SNDBUF,
+                    IPSupport.getMaxUDPSendBufSizeIPv6(),
                     IPv6Addr
             });
             testcases.add(new Object[]{
                     supplier(() -> DatagramChannel.open(INET6)),
-                    IPV6_SNDBUF,
+                    IPSupport.getMaxUDPSendBufSizeIPv6(),
                     IPv6Addr
             });
         }
@@ -134,6 +133,10 @@ public class SendReceiveMaxSize {
             throws IOException {
         try (var receiver = DatagramChannel.open()) {
             receiver.bind(new InetSocketAddress(host, 0));
+            assertTrue(receiver.getOption(SO_RCVBUF) >= capacity,
+                       receiver.getOption(SO_RCVBUF) +
+                       " for UDP receive buffer too small to hold capacity " +
+                       capacity);
             var port = receiver.socket().getLocalPort();
             var addr = new InetSocketAddress(host, port);
 

--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 package jdk.test.lib.net;
+
+import jdk.test.lib.Platform;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -47,6 +49,9 @@ public class IPSupport {
     private static final boolean hasIPv6;
     private static final boolean preferIPv4Stack;
     private static final boolean preferIPv6Addresses;
+    private static final int IPV4_SNDBUF = 65507;
+    private static final int IPV6_SNDBUF = 65527;
+    private static final int IPV6_SNDBUF_AIX = 65487;
 
     static {
         try {
@@ -121,7 +126,6 @@ public class IPSupport {
         return preferIPv6Addresses;
     }
 
-
     /**
      * Whether or not the current networking configuration is valid or not.
      *
@@ -164,4 +168,21 @@ public class IPSupport {
         out.println("preferIPv6Addresses: " + preferIPv6Addresses());
     }
 
+    /**
+     * Return current platform's maximum size for IPv4 UDP send buffer
+     */
+    public static final int getMaxUDPSendBufSizeIPv4() {
+        return IPV4_SNDBUF;
+    }
+
+    /**
+     * Return current platform's maximum size for IPv6 UDP send buffer
+     */
+    public static final int getMaxUDPSendBufSizeIPv6() {
+        if (Platform.isAix()) {
+            return IPV6_SNDBUF_AIX;
+        } else {
+            return IPV6_SNDBUF;
+        }
+    }
 }


### PR DESCRIPTION
Basically clean backport of [JDK-8313873](https://bugs.openjdk.org/browse/JDK-8313873).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8313873](https://bugs.openjdk.org/browse/JDK-8313873) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313873](https://bugs.openjdk.org/browse/JDK-8313873): java/nio/channels/DatagramChannel/SendReceiveMaxSize.java  fails on AIX due to small default RCVBUF size and different IPv6 Header interpretation (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2496/head:pull/2496` \
`$ git checkout pull/2496`

Update a local copy of the PR: \
`$ git checkout pull/2496` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2496`

View PR using the GUI difftool: \
`$ git pr show -t 2496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2496.diff">https://git.openjdk.org/jdk17u-dev/pull/2496.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2496#issuecomment-2133719363)