### PR TITLE
8318479: [jmh] the test security.CacheBench  failed for multiple threads run

### DIFF
--- a/test/micro/org/openjdk/bench/java/security/CacheBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CacheBench.java
@@ -44,9 +44,7 @@ import sun.security.util.Cache;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED", "-Xmx1g"})
-@Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 5, time = 1)
+@Fork(jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 public class CacheBench {
 
     @State(Scope.Benchmark)


### PR DESCRIPTION
Hi all,
  This is backport of [JDK-8318479](https://bugs.openjdk.org/browse/JDK-8318479) parity with 17.0.13-oracle, which remove the hardcoded maximum heap size, to avoid OOM fail with 100+ threads.
  It's not clean because of it has a prefixed bakport [JDK-8288568](https://github.com/openjdk/jdk17u-dev/pull/2499)
  Only change the jmh testcase, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8318479](https://bugs.openjdk.org/browse/JDK-8318479) needs maintainer approval

### Issue
 * [JDK-8318479](https://bugs.openjdk.org/browse/JDK-8318479): [jmh] the test security.CacheBench  failed for multiple threads run (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2500/head:pull/2500` \
`$ git checkout pull/2500`

Update a local copy of the PR: \
`$ git checkout pull/2500` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2500`

View PR using the GUI difftool: \
`$ git pr show -t 2500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2500.diff">https://git.openjdk.org/jdk17u-dev/pull/2500.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2500#issuecomment-2134302796)