### PR TITLE
8295111: dpkg appears to have problems resolving symbolically linked native libraries

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/LinuxDebBundler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,6 +195,24 @@ public class LinuxDebBundler extends LinuxPackageBundler {
             Map<String, ? super Object> params,
             LibProvidersLookup libProvidersLookup) {
 
+        libProvidersLookup.setPackageLookup(file -> {
+            Path realPath = file.toRealPath();
+
+            try {
+                // Try the real path first as it works better on newer Ubuntu versions
+                return findProvidingPackages(realPath);
+            } catch (IOException ex) {
+                // Try the default path if differ
+                if (!realPath.toString().equals(file.toString())) {
+                    return findProvidingPackages(file);
+                } else {
+                    throw ex;
+                }
+            }
+        });
+    }
+
+    private static Stream<String> findProvidingPackages(Path file) throws IOException {
         //
         // `dpkg -S` command does glob pattern lookup. If not the absolute path
         // to the file is specified it might return mltiple package names.
@@ -237,32 +255,30 @@ public class LinuxDebBundler extends LinuxPackageBundler {
         // 4. Arch suffix should be stripped from accepted package names.
         //
 
-        libProvidersLookup.setPackageLookup(file -> {
-            Set<String> archPackages = new HashSet<>();
-            Set<String> otherPackages = new HashSet<>();
+        Set<String> archPackages = new HashSet<>();
+        Set<String> otherPackages = new HashSet<>();
 
-            Executor.of(TOOL_DPKG, "-S", file.toString())
-                    .saveOutput(true).executeExpectSuccess()
-                    .getOutput().forEach(line -> {
-                        Matcher matcher = PACKAGE_NAME_REGEX.matcher(line);
-                        if (matcher.find()) {
-                            String name = matcher.group(1);
-                            if (name.endsWith(":" + DEB_ARCH)) {
-                                // Strip arch suffix
-                                name = name.substring(0,
-                                        name.length() - (DEB_ARCH.length() + 1));
-                                archPackages.add(name);
-                            } else {
-                                otherPackages.add(name);
-                            }
+        Executor.of(TOOL_DPKG, "-S", file.toString())
+                .saveOutput(true).executeExpectSuccess()
+                .getOutput().forEach(line -> {
+                    Matcher matcher = PACKAGE_NAME_REGEX.matcher(line);
+                    if (matcher.find()) {
+                        String name = matcher.group(1);
+                        if (name.endsWith(":" + DEB_ARCH)) {
+                            // Strip arch suffix
+                            name = name.substring(0,
+                                    name.length() - (DEB_ARCH.length() + 1));
+                            archPackages.add(name);
+                        } else {
+                            otherPackages.add(name);
                         }
-                    });
+                    }
+                });
 
-            if (!archPackages.isEmpty()) {
-                return archPackages.stream();
-            }
-            return otherPackages.stream();
-        });
+        if (!archPackages.isEmpty()) {
+            return archPackages.stream();
+        }
+        return otherPackages.stream();
     }
 
     @Override


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [32946e18](https://github.com/openjdk/jdk/commit/32946e1882e9b22c983cbba3c6bda3cc7295946a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Alexey Semenyuk on 18 Apr 2024 and was reviewed by Alexander Matveev.

The backport had a conflict in the copyright header that was resolved manually. 

This change fixes an issue caused by usrmerge on Debian-based systems - dpkg -S does not return a package containing a symlinked shared library in /lib, e.g.
```
dpkg -S /lib/x86_64-linux-gnu/libmd.so.0
# dpkg-query: no path found matching pattern /lib/x86_64-linux-gnu/libmd.so.0
```
The fix calls toRealPath() to resolve an actual path to the file before dpkg call and falls back to the old behaviour if the dpkg call fails.

The change is tested by jpackage set of jtreg tests and should be low risk.

jpackage tests pass (Ubuntu 24.04):
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/tools/jpackage                        55    55     0     0   
==============================
TEST SUCCESS
```

Thanks!

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8295111](https://bugs.openjdk.org/browse/JDK-8295111) needs maintainer approval

### Issue
 * [JDK-8295111](https://bugs.openjdk.org/browse/JDK-8295111): dpkg appears to have problems resolving symbolically linked native libraries (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2501/head:pull/2501` \
`$ git checkout pull/2501`

Update a local copy of the PR: \
`$ git checkout pull/2501` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2501`

View PR using the GUI difftool: \
`$ git pr show -t 2501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2501.diff">https://git.openjdk.org/jdk17u-dev/pull/2501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2501#issuecomment-2136066212)