### PR TITLE
8310108: Skip ReplaceCriticalClassesForSubgraphs when EnableJVMCI is specified

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -58,6 +58,7 @@ requires.properties= \
     vm.gc.Epsilon \
     vm.gc.Z \
     vm.jvmci \
+    vm.jvmci.enabled \
     vm.emulatedClient \
     vm.cpu.features \
     vm.pageSize \

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
@@ -27,6 +27,7 @@
  * @summary Tests how CDS works when critical library classes are replaced with JVMTI ClassFileLoadHook
  * @library /test/lib
  * @requires vm.cds.write.archived.java.heap
+ * @requires !vm.jvmci.enabled
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
  * @run main/othervm/native ReplaceCriticalClassesForSubgraphs

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -68,6 +68,7 @@ requires.properties= \
     vm.hasSA \
     vm.hasJFR \
     vm.jvmci \
+    vm.jvmci.enabled \
     docker.support \
     release.implementor \
     jdk.containerized

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -99,6 +99,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.simpleArch", this::vmArch);
         map.put("vm.debug", this::vmDebug);
         map.put("vm.jvmci", this::vmJvmci);
+        map.put("vm.jvmci.enabled", this::vmJvmciEnabled);
         map.put("vm.emulatedClient", this::vmEmulatedClient);
         // vm.hasSA is "true" if the VM contains the serviceability agent
         // and jhsdb.
@@ -259,6 +260,20 @@ public class VMProps implements Callable<Map<String, String>> {
 
         return "true";
     }
+
+
+    /**
+     * @return true if JVMCI is enabled
+     */
+    protected String vmJvmciEnabled() {
+        // builds with jvmci have this flag
+        if ("false".equals(vmJvmci())) {
+            return "false";
+        }
+
+        return "" + Compiler.isJVMCIEnabled();
+    }
+
 
     /**
      * @return true if VM runs in emulated-client mode and false otherwise.


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8310108](https://bugs.openjdk.org/browse/JDK-8310108) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310108](https://bugs.openjdk.org/browse/JDK-8310108): Skip ReplaceCriticalClassesForSubgraphs when EnableJVMCI is specified (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2502/head:pull/2502` \
`$ git checkout pull/2502`

Update a local copy of the PR: \
`$ git checkout pull/2502` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2502`

View PR using the GUI difftool: \
`$ git pr show -t 2502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2502.diff">https://git.openjdk.org/jdk17u-dev/pull/2502.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2502#issuecomment-2134651811)