### PR TITLE
8265919: RunThese30M fails "assert((!(((((JfrTraceIdBits::load(value)) & ((1 << 4) << 8)) != 0))))) failed: invariant"

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -429,8 +429,6 @@ static void do_previous_epoch_artifact(JfrArtifactClosure* callback, T* value) {
   assert(value != NULL, "invariant");
   if (USED_PREVIOUS_EPOCH(value)) {
     callback->do_artifact(value);
-    assert(IS_NOT_SERIALIZED(value), "invariant");
-    return;
   }
   if (IS_SERIALIZED(value)) {
     CLEAR_SERIALIZED(value);


### PR DESCRIPTION
clean backport to remove assertion which asserts artifact is not serialized and assumes only `JfrRecorderThread` can perform serialization of artifacts marked during the window between rotate() and end_recording(), which is not true because a GC thread during class unloading process will serialize the class loaders associated with the unloaded classes. We should remove this assertion and let the code fall through and explicitly clear the serialize and transient meta bits.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8265919](https://bugs.openjdk.org/browse/JDK-8265919) needs maintainer approval

### Issue
 * [JDK-8265919](https://bugs.openjdk.org/browse/JDK-8265919): RunThese30M fails "assert((!(((((JfrTraceIdBits::load(value)) &amp; ((1 &lt;&lt; 4) &lt;&lt; 8)) != 0))))) failed: invariant" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2504/head:pull/2504` \
`$ git checkout pull/2504`

Update a local copy of the PR: \
`$ git checkout pull/2504` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2504`

View PR using the GUI difftool: \
`$ git pr show -t 2504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2504.diff">https://git.openjdk.org/jdk17u-dev/pull/2504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2504#issuecomment-2135513434)