### PR TITLE
8325203: System.exit(0) kills the launched 3rd party application

### DIFF
--- a/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
+++ b/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,7 +241,7 @@ void launchApp() {
         }
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInfo = { };
         jobInfo.BasicLimitInformation.LimitFlags =
-                                          JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK;
         if (!SetInformationJobObject(jobHandle.get(),
                 JobObjectExtendedLimitInformation, &jobInfo, sizeof(jobInfo))) {
             JP_THROW(SysError(tstrings::any() <<


### PR DESCRIPTION
Clean backport of [JDK-8325203](https://bugs.openjdk.org/browse/JDK-8325203) from JDK 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325203](https://bugs.openjdk.org/browse/JDK-8325203) needs maintainer approval

### Issue
 * [JDK-8325203](https://bugs.openjdk.org/browse/JDK-8325203): System.exit(0) kills the launched 3rd party application (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2505/head:pull/2505` \
`$ git checkout pull/2505`

Update a local copy of the PR: \
`$ git checkout pull/2505` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2505`

View PR using the GUI difftool: \
`$ git pr show -t 2505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2505.diff">https://git.openjdk.org/jdk17u-dev/pull/2505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2505#issuecomment-2136038069)