### PR TITLE
8318479: [jmh] the test security.CacheBench  failed for multiple threads run

### DIFF
--- a/test/micro/org/openjdk/bench/java/security/CacheBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CacheBench.java
@@ -44,7 +44,7 @@ import sun.security.util.Cache;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED", "-Xmx1g"})
+@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 public class CacheBench {


### PR DESCRIPTION
Hi all,
  This is backport of [JDK-8318479](https://bugs.openjdk.org/browse/JDK-8318479) parity with 17.0.13-oracle, which remove the hardcoded maximum heap size, to avoid OOM fail with 100+ threads.
  Only change the jmh testcase, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318479](https://bugs.openjdk.org/browse/JDK-8318479) needs maintainer approval

### Issue
 * [JDK-8318479](https://bugs.openjdk.org/browse/JDK-8318479): [jmh] the test security.CacheBench  failed for multiple threads run (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2506/head:pull/2506` \
`$ git checkout pull/2506`

Update a local copy of the PR: \
`$ git checkout pull/2506` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2506`

View PR using the GUI difftool: \
`$ git pr show -t 2506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2506.diff">https://git.openjdk.org/jdk17u-dev/pull/2506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2506#issuecomment-2137376035)