### PR TITLE
8293798: Fix test bugs due to incompatibility with -XX:+AlwaysIncrementalInline

### DIFF
--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -93,7 +93,7 @@ public class TestInliningProtectionDomain extends DumpReplayBase {
                                        "bar", inlineesReplay.get(0).isDisallowedByReplay()));
         } else {
             Asserts.assertTrue(compare(inlineesNormal.get(4), "compiler.ciReplay.InliningBar", "bar2", inlineesNormal.get(4).isNormalInline()));
-            Asserts.assertTrue(compare(inlineesReplay.get(4), "compiler.ciReplay.InliningBar", "bar2", inlineesReplay.get(4).isForcedByReplay()));
+            Asserts.assertTrue(compare(inlineesReplay.get(4), "compiler.ciReplay.InliningBar", "bar2", inlineesReplay.get(4).isForcedByReplay() || inlineesReplay.get(4).isForcedIncrementalInlineByReplay()));
         }
         remove(LOG_FILE_NORMAL);
         remove(LOG_FILE_REPLAY);

--- a/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/klass/CastNullCheckDroppingsTest.java
@@ -35,6 +35,7 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *                   -Xmixed -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:CompileThreshold=1000
+ *                   -XX:-AlwaysIncrementalInline
  *                   -XX:CompileCommand=exclude,compiler.intrinsics.klass.CastNullCheckDroppingsTest::runTest
  *                   compiler.intrinsics.klass.CastNullCheckDroppingsTest
  */


### PR DESCRIPTION
Backport of [JDK-8293798](https://bugs.openjdk.org/browse/JDK-8293798). Skipped Decompile.java which belongs to [JDK-8275908](https://bugs.openjdk.java.net/browse/JDK-8275908) which is not in 17.
[JDK-8254108](https://bugs.openjdk.org/browse/JDK-8254108) is not in 17, so there's not much left we can do for 17 atm. `isForcedIncrementalInlineByReplay()` is not available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8293798](https://bugs.openjdk.org/browse/JDK-8293798) needs maintainer approval

### Issue
 * [JDK-8293798](https://bugs.openjdk.org/browse/JDK-8293798): Fix test bugs due to incompatibility with -XX:+AlwaysIncrementalInline (**Bug** - P3)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2508/head:pull/2508` \
`$ git checkout pull/2508`

Update a local copy of the PR: \
`$ git checkout pull/2508` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2508`

View PR using the GUI difftool: \
`$ git pr show -t 2508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2508.diff">https://git.openjdk.org/jdk17u-dev/pull/2508.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2508#issuecomment-2137587443)