### PR TITLE
8310201: Reduce verbose locale output in -XshowSettings launcher option

### DIFF
--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -167,7 +167,7 @@ public final class LauncherHelper {
                 printProperties();
                 break;
             case "locale":
-                printLocale();
+                printLocale(false);
                 break;
             case "security":
                 var opt = opts.length > 2 ? opts[2].trim() : "all";
@@ -181,7 +181,7 @@ public final class LauncherHelper {
             default:
                 printVmSettings(initialHeapSize, maxHeapSize, stackSize);
                 printProperties();
-                printLocale();
+                printLocale(true);
                 SecuritySettings.printSecuritySummarySettings(ostream);
                 if (System.getProperty("os.name").contains("Linux")) {
                     printSystemMetrics();
@@ -277,9 +277,15 @@ public final class LauncherHelper {
     /*
      * prints the locale subopt/section
      */
-    private static void printLocale() {
+    private static void printLocale(boolean summaryMode) {
         Locale locale = Locale.getDefault();
-        ostream.println(LOCALE_SETTINGS);
+        if (!summaryMode) {
+            ostream.println(LOCALE_SETTINGS);
+        } else {
+            ostream.println("Locale settings summary:");
+            ostream.println(INDENT + "Use \"-XshowSettings:locale\" " +
+                    "option for verbose locale settings options");
+        }
         ostream.println(INDENT + "default locale = " +
                 locale.getDisplayName());
         ostream.println(INDENT + "default display locale = " +
@@ -288,7 +294,9 @@ public final class LauncherHelper {
                 Locale.getDefault(Category.FORMAT).getDisplayName());
         ostream.println(INDENT + "tzdata version = " +
                 ZoneInfoFile.getVersion());
-        printLocales();
+        if (!summaryMode) {
+            printLocales();
+        }
         ostream.println();
     }
 

--- a/test/jdk/tools/launcher/Settings.java
+++ b/test/jdk/tools/launcher/Settings.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 /*
  * @test
- * @bug 6994753 7123582 8305950 8281658
+ * @bug 6994753 7123582 8305950 8281658 8310201
  * @summary tests -XshowSettings options
  * @modules jdk.compiler
  *          jdk.zipfs
@@ -67,6 +67,9 @@ public class Settings extends TestHelper {
     private static final String VM_SETTINGS = "VM settings:";
     private static final String PROP_SETTINGS = "Property settings:";
     private static final String LOCALE_SETTINGS = "Locale settings:";
+    private static final String LOCALE_SUMMARY_SETTINGS =
+                "Locale settings summary:";
+    private static final String AVAILABLE_LOCALES = "available locales";
     private static final String SEC_PROPS_SETTINGS = "Security properties:";
     private static final String SEC_SUMMARY_PROPS_SETTINGS =
                 "Security settings summary:";
@@ -81,7 +84,9 @@ public class Settings extends TestHelper {
     static void containsAllOptions(TestResult tr) {
         checkContains(tr, VM_SETTINGS);
         checkContains(tr, PROP_SETTINGS);
-        checkContains(tr, LOCALE_SETTINGS);
+        checkNotContains(tr, LOCALE_SETTINGS);
+        checkNotContains(tr, AVAILABLE_LOCALES);
+        checkContains(tr, LOCALE_SUMMARY_SETTINGS);
         // no verbose security settings unless "security" used
         checkNotContains(tr, SEC_PROPS_SETTINGS);
         checkContains(tr, SEC_SUMMARY_PROPS_SETTINGS);
@@ -153,6 +158,8 @@ public class Settings extends TestHelper {
         checkNotContains(tr, VM_SETTINGS);
         checkNotContains(tr, PROP_SETTINGS);
         checkContains(tr, LOCALE_SETTINGS);
+        checkContains(tr, AVAILABLE_LOCALES);
+        checkNotContains(tr, LOCALE_SUMMARY_SETTINGS);
         checkContains(tr, TZDATA_SETTINGS);
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8310201](https://bugs.openjdk.org/browse/JDK-8310201) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8331491](https://bugs.openjdk.org/browse/JDK-8331491) to be approved

### Issues
 * [JDK-8310201](https://bugs.openjdk.org/browse/JDK-8310201): Reduce verbose locale output in -XshowSettings launcher option (**Bug** - P3 - Approved)
 * [JDK-8331491](https://bugs.openjdk.org/browse/JDK-8331491): Reduce verbose locale output in -XshowSettings launcher option (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2509/head:pull/2509` \
`$ git checkout pull/2509`

Update a local copy of the PR: \
`$ git checkout pull/2509` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2509`

View PR using the GUI difftool: \
`$ git pr show -t 2509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2509.diff">https://git.openjdk.org/jdk17u-dev/pull/2509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2509#issuecomment-2138973217)