### PR TITLE
8322008: Exclude some CDS tests from running with -Xshare:off

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -53,6 +53,13 @@ hotspot_gc = \
 hotspot_runtime = \
   runtime
 
+hotspot_runtime_non_cds_mode = \
+  runtime \
+  -runtime/cds/CheckSharingWithDefaultArchive.java \
+  -runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java \
+  -runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java \
+  -runtime/cds/appcds/jcmd
+
 hotspot_handshake = \
   runtime/handshake
 

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -56,8 +56,6 @@ hotspot_runtime = \
 hotspot_runtime_non_cds_mode = \
   runtime \
   -runtime/cds/CheckSharingWithDefaultArchive.java \
-  -runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java \
-  -runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java \
   -runtime/cds/appcds/jcmd
 
 hotspot_handshake = \


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.
remove
"  -runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java \
  -runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java \"
due to the tests not exist

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322008](https://bugs.openjdk.org/browse/JDK-8322008) needs maintainer approval

### Issue
 * [JDK-8322008](https://bugs.openjdk.org/browse/JDK-8322008): Exclude some CDS tests from running with -Xshare:off (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2511/head:pull/2511` \
`$ git checkout pull/2511`

Update a local copy of the PR: \
`$ git checkout pull/2511` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2511`

View PR using the GUI difftool: \
`$ git pr show -t 2511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2511.diff">https://git.openjdk.org/jdk17u-dev/pull/2511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2511#issuecomment-2141572647)