### PR TITLE
8328953: JEditorPane.read throws ChangedCharSetException

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -618,35 +618,37 @@ public class JEditorPane extends JTextComponent {
         String charset = (String) getClientProperty("charset");
         try(Reader r = (charset != null) ? new InputStreamReader(in, charset) :
                 new InputStreamReader(in)) {
-            kit.read(r, doc, 0);
-        } catch (BadLocationException e) {
-            throw new IOException(e.getMessage());
-        } catch (ChangedCharSetException changedCharSetException) {
-            String charSetSpec = changedCharSetException.getCharSetSpec();
-            if (changedCharSetException.keyEqualsCharSet()) {
-                putClientProperty("charset", charSetSpec);
-            } else {
-                setCharsetFromContentTypeParameters(charSetSpec);
-            }
             try {
-                in.reset();
-            } catch (IOException exception) {
-                //mark was invalidated
-                in.close();
-                URL url = (URL)doc.getProperty(Document.StreamDescriptionProperty);
-                if (url != null) {
-                    URLConnection conn = url.openConnection();
-                    in = conn.getInputStream();
+                kit.read(r, doc, 0);
+            } catch (BadLocationException e) {
+                throw new IOException(e.getMessage());
+            } catch (ChangedCharSetException changedCharSetException) {
+                String charSetSpec = changedCharSetException.getCharSetSpec();
+                if (changedCharSetException.keyEqualsCharSet()) {
+                    putClientProperty("charset", charSetSpec);
                 } else {
-                    //there is nothing we can do to recover stream
-                    throw changedCharSetException;
+                    setCharsetFromContentTypeParameters(charSetSpec);
                 }
+                try {
+                    in.reset();
+                } catch (IOException exception) {
+                    //mark was invalidated
+                    in.close();
+                    URL url = (URL)doc.getProperty(Document.StreamDescriptionProperty);
+                    if (url != null) {
+                        URLConnection conn = url.openConnection();
+                        in = conn.getInputStream();
+                    } else {
+                        //there is nothing we can do to recover stream
+                        throw changedCharSetException;
+                    }
+                }
+                try {
+                    doc.remove(0, doc.getLength());
+                } catch (BadLocationException e) {}
+                doc.putProperty("IgnoreCharsetDirective", Boolean.valueOf(true));
+                read(in, doc);
             }
-            try {
-                doc.remove(0, doc.getLength());
-            } catch (BadLocationException e) {}
-            doc.putProperty("IgnoreCharsetDirective", Boolean.valueOf(true));
-            read(in, doc);
         }
     }
 

--- a/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import javax.swing.JEditorPane;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+
+/*
+ * @test
+ * @bug 8328953
+ * @summary Verifies JEditorPane.read doesn't throw ChangedCharSetException
+            but handles it and reads HTML in the specified encoding
+ * @run main EditorPaneCharset
+ */
+
+public final class EditorPaneCharset {
+    private static final String CYRILLIC_TEXT =
+            "\u041F\u0440\u0438\u0432\u0435\u0442, \u043C\u0438\u0440!";
+    private static final String HTML_CYRILLIC =
+            "<html lang=\"ru\">\n" +
+            "<head>\n" +
+            "    <meta http-equiv=\"Content-Type\" " +
+            "          content=\"text/html; charset=windows-1251\">\n" +
+            "</head><body>\n" +
+            "<p>" + CYRILLIC_TEXT + "</p>\n" +
+            "</body></html>\n";
+
+    public static void main(String[] args) throws IOException, BadLocationException {
+        JEditorPane editorPane = new JEditorPane();
+        editorPane.setContentType("text/html");
+        Document document = editorPane.getDocument();
+
+        // Shouldn't throw ChangedCharSetException
+        editorPane.read(
+                new ByteArrayInputStream(
+                        HTML_CYRILLIC.getBytes(
+                                Charset.forName("windows-1251"))),
+                document);
+
+        Element root = document.getDefaultRootElement();
+        Element body = root.getElement(1);
+        Element p = body.getElement(0);
+        String pText = document.getText(p.getStartOffset(),
+                                        p.getEndOffset() - p.getStartOffset() - 1);
+        if (!CYRILLIC_TEXT.equals(pText)) {
+            throw new RuntimeException("Text doesn't match");
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8328953](https://bugs.openjdk.org/browse/JDK-8328953). Clean except Copyright year change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328953](https://bugs.openjdk.org/browse/JDK-8328953) needs maintainer approval

### Issue
 * [JDK-8328953](https://bugs.openjdk.org/browse/JDK-8328953): JEditorPane.read throws ChangedCharSetException (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2528/head:pull/2528` \
`$ git checkout pull/2528`

Update a local copy of the PR: \
`$ git checkout pull/2528` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2528`

View PR using the GUI difftool: \
`$ git pr show -t 2528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2528.diff">https://git.openjdk.org/jdk17u-dev/pull/2528.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2528#issuecomment-2146122603)