### PR TITLE
Backport 7f0ad513c30359816ac840f821ca0a22d723a642

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/action/ActionHelper.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/action/ActionHelper.java
@@ -164,7 +164,7 @@ public class ActionHelper {
         Stopwatch stopwatch = new Stopwatch();
         stopwatch.start();
 
-        log.printf("%s%n[%tF %<tT] %s timeout=%s%n%1$s%n", line, new Date(), pb.command(), params.timeout);
+        log.printf("%s%n[%tF %<tT] %s timeout=%s in %s%n%1$s%n", line, new Date(), pb.command(), params.timeout, pb.directory());
 
         Process process;
         KillerTask killer;


### PR DESCRIPTION
Clean backport of [JDK-8332898](https://bugs.openjdk.org/browse/JDK-8332898).