### PR TITLE
8279337: The MToolkit is still referenced in a few places

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -454,7 +454,7 @@ public final class LWCToolkit extends LWToolkit {
         desktopProperties.put("awt.multiClickInterval", getMultiClickTime());
 
         // These DnD properties must be set, otherwise Swing ends up spewing NPEs
-        // all over the place. The values came straight off of MToolkit.
+        // all over the place. The values came straight off of XToolkit.
         desktopProperties.put("DnD.Autoscroll.initialDelay", Integer.valueOf(50));
         desktopProperties.put("DnD.Autoscroll.interval", Integer.valueOf(50));
         desktopProperties.put("DnD.Autoscroll.cursorHysteresis", Integer.valueOf(5));

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,7 +205,7 @@ public abstract class SunToolkit extends Toolkit
      * access to Xlib, OpenGL, etc.  However, these methods are implemented
      * in SunToolkit so that they can be called from shared code (e.g.
      * from the OGL pipeline) or from the X11 pipeline regardless of whether
-     * XToolkit or MToolkit is currently in use.  There are native macros
+     * XToolkit is currently in use.  There are native macros
      * (such as AWT_LOCK) defined in awt.h, so if the implementation of these
      * methods is changed, make sure it is compatible with the native macros.
      *

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
                 System.loadLibrary("awt");
 
                 /*
-                 * Note: The MToolkit object depends on the static initializer
+                 * Note: The XToolkit object depends on the static initializer
                  * of X11GraphicsEnvironment to initialize the connection to
                  * the X11 server.
                  */

--- a/src/java.desktop/unix/classes/sun/java2d/opengl/GLXGraphicsConfig.java
+++ b/src/java.desktop/unix/classes/sun/java2d/opengl/GLXGraphicsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -216,7 +216,7 @@ public final class GLXGraphicsConfig
     }
 
     /**
-     * The following methods are invoked from MToolkit or XToolkit.java and
+     * The following methods are invoked from XToolkit.java and
      * X11ComponentPeer.java rather than having the X11-dependent
      * implementations hardcoded in those classes.  This way the appropriate
      * actions are taken based on the peer's GraphicsConfig, whether it is

--- a/src/java.desktop/unix/native/common/awt/awt.h
+++ b/src/java.desktop/unix/native/common/awt/awt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ typedef char Boolean;
 #endif /* !HEADLESS && !MACOSX */
 
 
-/* The JVM instance: defined in awt_MToolkit.c */
+/* The JVM instance: defined in awt_LoadLibrary.c */
 extern JavaVM *jvm;
 
 extern jclass tkClass;

--- a/test/jdk/java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java
+++ b/test/jdk/java/awt/Choice/ChoiceKeyEventReaction/ChoiceKeyEventReaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,7 +131,7 @@ public class ChoiceKeyEventReaction
 
         if (toolkit.equals("sun.awt.X11.XToolkit") &&
                 keyTypedOnTextField) {
-            throw new RuntimeException("Test failed. (XToolkit/MToolkit). KeyEvent was addressed to TextField.");
+            throw new RuntimeException("Test failed. (XToolkit). KeyEvent was addressed to TextField.");
         }
 
         System.out.println("Test passed. Unfocusable Choice doesn't react on keys.");

--- a/test/jdk/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
+++ b/test/jdk/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,11 +69,6 @@ public class ActualFocusedWindowBlockingTest {
     }
 
     public void start() {
-        if ("sun.awt.motif.MToolkit".equals(Toolkit.getDefaultToolkit().getClass().getName())) {
-            System.out.println("No testing on Motif. Test passed.");
-            return;
-        }
-
         System.out.println("\nTest started:\n");
 
         // Test 1.

--- a/test/jdk/java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java
+++ b/test/jdk/java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusSetVisibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,43 +293,39 @@ public class AutoRequestFocusSetVisibleTest {
         // 6. Show unblocking modal Dialog.
         ///////////////////////////////////
 
-        if ("sun.awt.motif.MToolkit".equals(toolkitClassName)) {
-            System.out.println("Stage 6 - Skiping.");
-        } else {
-            System.out.println("Stage 6 in progress...");
+        System.out.println("Stage 6 in progress...");
 
-            // ---
-            // Testing the bug of activating invisible modal Dialog (awt_Window::SetAndActivateModalBlocker).
-            // Having some window not excluded from modality, so that it would be blocked.
-            Frame f = new Frame("Aux. Frame");
-            f.setSize(100, 100);
-            setVisible(f, true);
-            // ---
+        // ---
+        // Testing the bug of activating invisible modal Dialog (awt_Window::SetAndActivateModalBlocker).
+        // Having some window not excluded from modality, so that it would be blocked.
+        Frame f = new Frame("Aux. Frame");
+        f.setSize(100, 100);
+        setVisible(f, true);
+        // ---
 
-            setVisible(focusedFrame, true);
+        setVisible(focusedFrame, true);
+        if (!focusOwner.hasFocus()) {
+            Util.clickOnComp(focusOwner, robot);
+            Util.waitForIdle(robot);
             if (!focusOwner.hasFocus()) {
-                Util.clickOnComp(focusOwner, robot);
-                Util.waitForIdle(robot);
-                if (!focusOwner.hasFocus()) {
-                    throw new Error("Test error: the frame couldn't be focused.");
-                }
+                throw new Error("Test error: the frame couldn't be focused.");
             }
-
-            dialog.setModal(true);
-            dialog.setAutoRequestFocus(false);
-            focusedFrame.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
-
-            TestHelper.invokeLaterAndWait(new Runnable() {
-                    public void run() {
-                        dialog.setVisible(true);
-                    }
-                }, robot);
-
-            if (dialog.isFocused()) {
-                throw new TestFailedException("the unblocking dialog shouldn't gain focus but it did!");
-            }
-            setVisible(dialog, false);
         }
+
+        dialog.setModal(true);
+        dialog.setAutoRequestFocus(false);
+        focusedFrame.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
+
+        TestHelper.invokeLaterAndWait(new Runnable() {
+                public void run() {
+                    dialog.setVisible(true);
+                }
+            }, robot);
+
+        if (dialog.isFocused()) {
+            throw new TestFailedException("the unblocking dialog shouldn't gain focus but it did!");
+        }
+        setVisible(dialog, false);
 
         System.out.println("Test passed.");
     }

--- a/test/jdk/java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java
+++ b/test/jdk/java/awt/Focus/AutoRequestFocusTest/AutoRequestFocusToFrontTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,26 +202,22 @@ public class AutoRequestFocusToFrontTest {
         //      Focused frame is excluded from modality.
         ////////////////////////////////////////////////
 
-        if (!"sun.awt.motif.MToolkit".equals(toolkitClassName)) {
-            recreateGUI();
-            auxFrame.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
+        recreateGUI();
+        auxFrame.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
 
-            Test.setWindows(modalDialog, modalDialog, new Window[] {modalDialog, frame3});
-            Test.test("Test stage 6.1 in progress", modalDlgButton);
-        }
+        Test.setWindows(modalDialog, modalDialog, new Window[] {modalDialog, frame3});
+        Test.test("Test stage 6.1 in progress", modalDlgButton);
 
 
         // 6.2. Owner Frame (with owned modal Dialog).
         //      Focused frame is excluded from modality.
         ////////////////////////////////////////////////
 
-        if (!"sun.awt.motif.MToolkit".equals(toolkitClassName)) {
-            recreateGUI();
-            auxFrame.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
+        recreateGUI();
+        auxFrame.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
 
-            Test.setWindows(frame3, modalDialog, new Window[] {modalDialog, frame3});
-            Test.test("Test stage 6.2 in progress", modalDlgButton, true);
-        }
+        Test.setWindows(frame3, modalDialog, new Window[] {modalDialog, frame3});
+        Test.test("Test stage 6.2 in progress", modalDlgButton, true);
 
         ///////////////////////////////////////////////////
         // 7. Calling setVisible(true) for the shown Frame.
@@ -422,4 +418,3 @@ class TestFailedException extends RuntimeException {
         super("Test failed: " + msg);
     }
 }
-

--- a/test/jdk/java/awt/Focus/ModalBlockedStealsFocusTest/ModalBlockedStealsFocusTest.java
+++ b/test/jdk/java/awt/Focus/ModalBlockedStealsFocusTest/ModalBlockedStealsFocusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,11 +47,6 @@ public class ModalBlockedStealsFocusTest {
     }
 
     public void start() {
-        if ("sun.awt.motif.MToolkit".equals(Toolkit.getDefaultToolkit().getClass().getName())) {
-            System.out.println("The test is not for MToolkit.");
-            return;
-        }
-
         dialog.setBounds(800, 0, 200, 100);
         frame.setBounds(800, 150, 200, 100);
 

--- a/test/jdk/java/awt/Focus/ModalExcludedWindowClickTest/ModalExcludedWindowClickTest.java
+++ b/test/jdk/java/awt/Focus/ModalExcludedWindowClickTest/ModalExcludedWindowClickTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,12 +57,6 @@ public class ModalExcludedWindowClickTest {
     }
 
     public void start() {
-
-        if ("sun.awt.motif.MToolkit".equals(Toolkit.getDefaultToolkit().getClass().getName())) {
-            System.out.println("No testing on MToolkit.");
-            return;
-        }
-
         button.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent e) {
                     actionPerformed = true;

--- a/test/jdk/java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java
+++ b/test/jdk/java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,12 +56,6 @@ public class NonFocusableBlockedOwnerTest {
     }
 
     public void start() {
-
-        if ("sun.awt.motif.MToolkit".equals(Toolkit.getDefaultToolkit().getClass().getName())) {
-            System.out.println("No testing on MToolkit.");
-            return;
-        }
-
         try {
             EventQueue.invokeLater(new Runnable() {
                 public void run() {

--- a/test/jdk/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
+++ b/test/jdk/java/awt/Focus/SimpleWindowActivationTest/SimpleWindowActivationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,12 +56,6 @@ public class SimpleWindowActivationTest {
     private static Robot robot;
 
     public static void main(String[] args) throws Exception {
-
-        if ("sun.awt.motif.MToolkit".equals(Toolkit.getDefaultToolkit().getClass().getName())) {
-            System.out.println("No testing on Motif. Test passed.");
-            return;
-        }
-
         robot = new Robot();
         robot.setAutoDelay(50);
 

--- a/test/jdk/java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java
+++ b/test/jdk/java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,11 +63,6 @@ public class WindowUpdateFocusabilityTest {
     }
 
     public void start() {
-        if ("sun.awt.motif.MToolkit".equals(Toolkit.getDefaultToolkit().getClass().getName())) {
-            System.out.println("No testing on Motif.");
-            return;
-        }
-
         test(new Frame("Frame owner"));
         Frame dialog_owner = new Frame("dialog's owner");
         test(new Dialog(dialog_owner));

--- a/test/jdk/java/awt/Mouse/MouseModifiersUnitTest/ExtraButtonDrag.java
+++ b/test/jdk/java/awt/Mouse/MouseModifiersUnitTest/ExtraButtonDrag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public class ExtraButtonDrag extends Frame {
                 //XToolkit: extra buttons should report MOVED events only
                 //WToolkit: extra buttons should report DRAGGED events only
                 if (i > 2){ //extra buttons only
-                    if (tk.equals("sun.awt.X11.XToolkit") || tk.equals("sun.awt.motif.MToolkit")) {
+                    if (tk.equals("sun.awt.X11.XToolkit")) {
                         if (!moved || dragged) {
                             throw new RuntimeException("Test failed."+ tk +" Button = " +(i+1) + " moved = "+moved +" : dragged = " +dragged);
                         }
@@ -152,4 +152,3 @@ public class ExtraButtonDrag extends Frame {
     }
 
 }
-

--- a/test/jdk/java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java
+++ b/test/jdk/java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class AcceptExtraMouseButtons extends Frame {
 
         //MouseInfo.getNumberOfButtons() reports two more buttons on XToolkit
         //as they reserved for wheel (both directions).
-        if (tk.equals("sun.awt.X11.XToolkit") || tk.equals("sun.awt.motif.MToolkit")) {
+        if (tk.equals("sun.awt.X11.XToolkit")) {
             buttonsNum = buttonsNum - 2;
         }
         System.out.println("Number Of Buttons = "+ buttonsNum);

--- a/test/jdk/java/awt/Window/GrabSequence/GrabSequence.java
+++ b/test/jdk/java/awt/Window/GrabSequence/GrabSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,11 +40,6 @@ public class GrabSequence
 {
     private static void init()
     {
-        String toolkit = Toolkit.getDefaultToolkit().getClass().getName();
-        if ( toolkit.equals("sun.awt.motif.MToolkit")){
-            System.out.println("This test is for XToolkit and WToolkit only. Now using " + toolkit + ". Automatically passed.");
-            return;
-        }
         Frame frame = new Frame("Frame");
         frame.setBackground(Color.green);
         frame.setForeground(Color.green);

--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -410,8 +410,7 @@ public final class Util {
     }
 
     /*
-     * The values directly map to the ones of
-     * sun.awt.X11.XWM & sun.awt.motif.MToolkit classes.
+     * The values directly map to the ones of sun.awt.X11.XWM class.
      */
     public final static int
         UNDETERMINED_WM = 1,
@@ -438,8 +437,6 @@ public final class Util {
         try {
             if ("sun.awt.X11.XToolkit".equals(Toolkit.getDefaultToolkit().getClass().getName())) {
                 clazz = Class.forName("sun.awt.X11.XWM");
-            } else if ("sun.awt.motif.MToolkit".equals(Toolkit.getDefaultToolkit().getClass().getName())) {
-                clazz = Class.forName("sun.awt.motif.MToolkit");
             }
         } catch (ClassNotFoundException cnfe) {
             cnfe.printStackTrace();
@@ -451,7 +448,6 @@ public final class Util {
         try {
             final Class _clazz = clazz;
             Method m_addExports = Class.forName("java.awt.Helper").getDeclaredMethod("addExports", String.class, java.lang.Module.class);
-            // No MToolkit anymore: nothing to do about it.
             // We may be called from non-X11 system, and this permission cannot be delegated to a test.
             m_addExports.invoke(null, "sun.awt.X11", Util.class.getModule());
             Method m_getWMID = (Method)AccessController.doPrivileged(new PrivilegedAction() {


### PR DESCRIPTION
Clean backport of [JDK-8279337](https://bugs.openjdk.java.net/browse/JDK-8279337).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8279337](https://bugs.openjdk.org/browse/JDK-8279337) needs maintainer approval

### Issue
 * [JDK-8279337](https://bugs.openjdk.org/browse/JDK-8279337): The MToolkit is still referenced in a few places (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2536/head:pull/2536` \
`$ git checkout pull/2536`

Update a local copy of the PR: \
`$ git checkout pull/2536` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2536`

View PR using the GUI difftool: \
`$ git pr show -t 2536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2536.diff">https://git.openjdk.org/jdk17u-dev/pull/2536.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2536#issuecomment-2149857083)