### PR TITLE
8282526: Default icon is not painted properly

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -25,7 +25,9 @@
 
 package sun.awt.shell;
 
+import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.RenderingHints;
 import java.awt.Toolkit;
 import java.awt.image.AbstractMultiResolutionImage;
 import java.awt.image.BufferedImage;
@@ -1430,7 +1432,7 @@ final class Win32ShellFolder2 extends ShellFolder {
         public Image getResolutionVariant(double width, double height) {
             int dist = 0;
             Image retVal = null;
-            // We only care about width since we don't support non-rectangular icons
+            // We only care about width since we don't support non-square icons
             int w = (int) width;
             int retindex = 0;
             for (Integer i : resolutionVariants.keySet()) {
@@ -1443,6 +1445,15 @@ final class Win32ShellFolder2 extends ShellFolder {
                         break;
                     }
                 }
+            }
+            if (retVal.getWidth(null) != w) {
+                BufferedImage newVariant = new BufferedImage(w, w, BufferedImage.TYPE_INT_ARGB);
+                Graphics2D g2d = newVariant.createGraphics();
+                g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+                g2d.drawImage(retVal, 0,0, w, w, null);
+                g2d.dispose();
+                resolutionVariants.put(w, newVariant);
+                retVal = newVariant;
             }
             return retVal;
         }

--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -987,10 +987,20 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_extractIcon
         UINT uFlags = getDefaultIcon ? GIL_DEFAULTICON : GIL_FORSHELL | GIL_ASYNC;
         hres = pIcon->GetIconLocation(uFlags, szBuf, MAX_PATH, &index, &flags);
         if (SUCCEEDED(hres)) {
+            UINT iconSize;
+            HICON hIconSmall;
             if (size < 24) {
-                size = 16;
+                iconSize = (size << 16) + 32;
+            } else {
+                iconSize = (16 << 16) + size;
             }
-            hres = pIcon->Extract(szBuf, index, &hIcon, NULL, size);
+            hres = pIcon->Extract(szBuf, index, &hIcon, &hIconSmall, iconSize);
+            if (size < 24) {
+                fn_DestroyIcon((HICON)hIcon);
+                hIcon = hIconSmall;
+            } else {
+                fn_DestroyIcon((HICON)hIconSmall);
+            }
         } else if (hres == E_PENDING) {
             pIcon->Release();
             return E_PENDING;

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.filechooser.FileSystemView;
+import java.awt.Image;
+import java.awt.image.MultiResolutionImage;
+import java.io.File;
+import java.io.IOException;
+
+/*
+ * @test
+ * @bug 8282526
+ * @summary Default icon is not painted properly
+ * @requires (os.family == "windows")
+ * @run main WindowsDefaultIconSizeTest
+ */
+
+public class WindowsDefaultIconSizeTest {
+    public static void main(String[] args) {
+        WindowsDefaultIconSizeTest test = new WindowsDefaultIconSizeTest();
+        test.test();
+    }
+
+    public void test() {
+        String sep = System.getProperty("file.separator");
+        String dir = System.getProperty("test.src", ".");
+        String filename = "test.not";
+
+        File testFile = new File(dir + sep + filename);
+        try {
+            if (!testFile.exists()) {
+                testFile.createNewFile();
+                testFile.deleteOnExit();
+            }
+            FileSystemView fsv = FileSystemView.getFileSystemView();
+            Icon icon = fsv.getSystemIcon(new File(dir + sep + filename));
+            if (icon instanceof ImageIcon) {
+                Image image = ((ImageIcon) icon).getImage();
+                if (image instanceof MultiResolutionImage) {
+                    Image variant = ((MultiResolutionImage) image).getResolutionVariant(16, 16);
+                    if (variant.getWidth(null) != 16) {
+                        throw new RuntimeException("Default file icon has size of " +
+                                variant.getWidth(null) + " instead of 16");
+                    }
+                }
+            }
+        } catch (IOException ioe) {
+            throw new RuntimeException("Unexpected error while creating the test file: " + ioe.getLocalizedMessage());
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8282526](https://bugs.openjdk.org/browse/JDK-8282526). The prerequisite [JDK-8320692](https://bugs.openjdk.org/browse/JDK-8320692) is already backported to 17.0.13. Applies almost cleanly (except Copyright year update).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8282526](https://bugs.openjdk.org/browse/JDK-8282526) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282526](https://bugs.openjdk.org/browse/JDK-8282526): Default icon is not painted properly (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2538/head:pull/2538` \
`$ git checkout pull/2538`

Update a local copy of the PR: \
`$ git checkout pull/2538` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2538`

View PR using the GUI difftool: \
`$ git pr show -t 2538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2538.diff">https://git.openjdk.org/jdk17u-dev/pull/2538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2538#issuecomment-2149985196)