### PR TITLE
8323801: <s> tag doesn't strikethrough the text

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,43 @@
 package javax.swing.text.html;
 
 import java.awt.font.TextAttribute;
-import java.util.*;
-import java.net.URL;
+import java.io.IOException;
+import java.io.StringReader;
 import java.net.MalformedURLException;
-import java.io.*;
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.text.*;
-import javax.swing.undo.*;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Stack;
+import java.util.Vector;
+
+import javax.swing.ButtonGroup;
+import javax.swing.DefaultButtonModel;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListModel;
+import javax.swing.JToggleButton;
+import javax.swing.ListSelectionModel;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.UndoableEditEvent;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultEditorKit;
+import javax.swing.text.DefaultStyledDocument;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.ElementIterator;
+import javax.swing.text.GapContent;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.PlainDocument;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.undo.UndoableEdit;
+
 import sun.swing.SwingUtilities2;
+
 import static sun.swing.SwingUtilities2.IMPLIED_CR;
 
 /**
@@ -2475,7 +2503,7 @@ public class HTMLDocument extends DefaultStyledDocument {
             tagMap.put(HTML.Tag.SMALL, ca);
             tagMap.put(HTML.Tag.SPAN, ca);
             tagMap.put(HTML.Tag.STRIKE, conv);
-            tagMap.put(HTML.Tag.S, ca);
+            tagMap.put(HTML.Tag.S, conv);
             tagMap.put(HTML.Tag.STRONG, ca);
             tagMap.put(HTML.Tag.STYLE, new StyleAction());
             tagMap.put(HTML.Tag.SUB, conv);
@@ -3449,7 +3477,7 @@ public class HTMLDocument extends DefaultStyledDocument {
                     String value = "underline";
                     value = (v != null) ? value + "," + v.toString() : value;
                     sheet.addCSSAttribute(charAttr, CSS.Attribute.TEXT_DECORATION, value);
-                } else if (t == HTML.Tag.STRIKE) {
+                } else if (t == HTML.Tag.STRIKE || t == HTML.Tag.S) {
                     Object v = charAttr.getAttribute(CSS.Attribute.TEXT_DECORATION);
                     String value = "line-through";
                     value = (v != null) ? value + "," + v.toString() : value;

--- a/test/jdk/javax/swing/text/html/HTMLDocument/HTMLUnderlineStrike.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/HTMLUnderlineStrike.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.StringReader;
+
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Element;
+import javax.swing.text.html.CSS;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+
+/*
+ * @test
+ * @bug 8323801
+ * @summary Tests that '<u><s>' produce underlined and struck-through text
+ */
+public final class HTMLUnderlineStrike {
+    private static final String HTML = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>Strike-through text</title>
+            </head>
+            <body>
+            <p><u><s>struck?</s></u></p>
+            <p><span style='text-decoration: underline'><s>struck?</s></span></p>
+
+            <p><u><strike>struck?</strike></u></p>
+            <p><span style='text-decoration: underline'><strike>struck?</strike></span></p>
+            </body>
+            </html>
+            """;
+
+    public static void main(String[] args) throws Exception {
+        HTMLEditorKit kit = new HTMLEditorKit();
+        HTMLDocument doc = new HTMLDocument();
+
+        try (StringReader reader = new StringReader(HTML)) {
+            kit.read(reader, doc, 0);
+        }
+
+        StringBuilder errors = new StringBuilder();
+
+        Element root = doc.getDefaultRootElement();
+        Element body = root.getElement(1);
+        for (int i = 0; i < body.getElementCount(); i++) {
+            Element p = body.getElement(i);
+            Element content = p.getElement(0);
+            AttributeSet attr = content.getAttributes();
+            Object decoration = attr.getAttribute(CSS.Attribute.TEXT_DECORATION);
+            String strDecoration = decoration.toString();
+            System.out.println(i + ": " + decoration);
+            if (!strDecoration.contains("line-through")
+                || !strDecoration.contains("underline")) {
+                errors.append("<p>[")
+                      .append(i)
+                      .append("], ");
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            errors.delete(errors.length() - 2, errors.length());
+            throw new RuntimeException(errors + " must have both "
+                                       + "'line-through' and 'underline' in "
+                                       + "'text-decoration'");
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8323801](https://bugs.openjdk.org/browse/JDK-8323801). Clean except Copyright year change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8323801](https://bugs.openjdk.org/browse/JDK-8323801) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323801](https://bugs.openjdk.org/browse/JDK-8323801): &lt;s&gt; tag doesn't strikethrough the text (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2541/head:pull/2541` \
`$ git checkout pull/2541`

Update a local copy of the PR: \
`$ git checkout pull/2541` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2541`

View PR using the GUI difftool: \
`$ git pr show -t 2541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2541.diff">https://git.openjdk.org/jdk17u-dev/pull/2541.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2541#issuecomment-2150290976)