### PR TITLE
8272317: jstatd has dependency on Security Manager which needs to be removed

### DIFF
--- a/make/modules/jdk.jstatd/Launcher.gmk
+++ b/make/modules/jdk.jstatd/Launcher.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jstatd/share/classes/sun/tools/jstatd/Jstatd.java
+++ b/src/jdk.jstatd/share/classes/sun/tools/jstatd/Jstatd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package sun.tools.jstatd;
 
+import java.io.ObjectInputFilter;
 import java.rmi.*;
 import java.rmi.server.*;
 import java.rmi.registry.Registry;
@@ -46,6 +47,8 @@ public class Jstatd {
     private static int port = -1;
     private static boolean startRegistry = true;
     private static RemoteHost remoteHost;
+
+    private static final String rmiFilterPattern = "sun.jvmstat.monitor.remote.RemoteVm;com.sun.proxy.jdk.proxy*;java.lang.reflect.Proxy;java.rmi.server.RemoteObjectInvocationHandler;java.rmi.server.RemoteObject;!*";
 
     private static void printUsage() {
         System.err.println("usage: jstatd [-nr] [-p port] [-r rmiport] [-n rminame]\n" +
@@ -72,7 +75,6 @@ public class Jstatd {
         }
     }
 
-    @SuppressWarnings({"removal","deprecation"}) // Use of RMISecurityManager
     public static void main(String[] args) {
         String rminame = null;
         int rmiPort = 0;
@@ -132,10 +134,6 @@ public class Jstatd {
             System.exit(1);
         }
 
-        if (System.getSecurityManager() == null) {
-            System.setSecurityManager(new RMISecurityManager());
-        }
-
         StringBuilder name = new StringBuilder();
 
         if (port >= 0) {
@@ -149,11 +147,10 @@ public class Jstatd {
         name.append("/").append(rminame);
 
         try {
-            // use 1.5.0 dynamically generated subs.
-            System.setProperty("java.rmi.server.ignoreSubClasses", "true");
             remoteHost = new RemoteHostImpl(rmiPort);
+            ObjectInputFilter filter = ObjectInputFilter.Config.createFilter(rmiFilterPattern);
             RemoteHost stub = (RemoteHost) UnicastRemoteObject.exportObject(
-                    remoteHost, rmiPort);
+                    remoteHost, rmiPort, filter);
             bind(name.toString(), stub);
             System.out.println("jstatd started (bound to " + name.toString() + ")");
             System.out.flush();

--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -43,7 +43,7 @@ import jdk.test.lib.thread.ProcessThread;
  * <pre>
  * {@code
  * // start jstatd process
- * jstatd -J-XX:+UsePerfData -J-Djava.security.policy=all.policy
+ * jstatd -J-XX:+UsePerfData
  *
  * // run jps and verify its output
  * jps -J-XX:+UsePerfData hostname
@@ -244,21 +244,17 @@ public final class JstatdTest {
     /**
      * Depending on test settings command line can look like:
      *
-     * jstatd -J-XX:+UsePerfData -J-Djava.security.policy=all.policy
-     * jstatd -J-XX:+UsePerfData -J-Djava.security.policy=all.policy -p port
-     * jstatd -J-XX:+UsePerfData -J-Djava.security.policy=all.policy -p port -r rmiport
-     * jstatd -J-XX:+UsePerfData -J-Djava.security.policy=all.policy -n serverName
-     * jstatd -J-XX:+UsePerfData -J-Djava.security.policy=all.policy -p port -n serverName
+     * jstatd -J-XX:+UsePerfData
+     * jstatd -J-XX:+UsePerfData -p port
+     * jstatd -J-XX:+UsePerfData -p port -r rmiport
+     * jstatd -J-XX:+UsePerfData -n serverName
+     * jstatd -J-XX:+UsePerfData -p port -n serverName
      */
     private String[] getJstatdCmd() throws Exception {
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jstatd");
         launcher.addVMArg("-XX:+UsePerfData");
         launcher.addVMArg("-Djava.security.manager=allow");
         String testSrc = System.getProperty("test.src");
-        File policy = new File(testSrc, "all.policy");
-        assertTrue(policy.exists() && policy.isFile(),
-                "Security policy " + policy.getAbsolutePath() + " does not exist or not a file");
-        launcher.addVMArg("-Djava.security.policy=" + policy.getAbsolutePath());
         if (port != null) {
             addToolArg(launcher,"-p", port);
         }

--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -354,11 +354,8 @@ public final class JstatdTest {
         OutputAnalyzer output = jstatdThread.getOutput();
         List<String> stdout = output.asLinesWithoutVMWarnings();
         output.reportDiagnosticSummary();
-        // These asserts are disabled until JDK-8272317 is backported:
-        // otherwise there are SM deprecation notices that fail them.
-        // assertEquals(stdout.size(), 1, "Output should contain one line");
-        // assertTrue(stdout.get(0).startsWith("jstatd started"), "List should start with 'jstatd started'");
-        output.shouldContain("jstatd started");
+        assertEquals(stdout.size(), 1, "Output should contain one line");
+        assertTrue(stdout.get(0).startsWith("jstatd started"), "List should start with 'jstatd started'");
         assertNotEquals(output.getExitValue(), 0,
                 "jstatd process exited with unexpected exit code");
     }

--- a/test/jdk/sun/tools/jstatd/all.policy
+++ b/test/jdk/sun/tools/jstatd/all.policy
@@ -1,3 +1,0 @@
-grant {
-   permission java.security.AllPermission;
-};


### PR DESCRIPTION
Semi-clean backport to resolve the jstatd dependency on SM. Current `jstatd` tests are also failing because some recently backported tests do not expect SM deprecation messages, see [JDK-8333698](https://bugs.openjdk.org/browse/JDK-8333698).

This also reverts 17u-specific test amendment, [JDK-8272317](https://bugs.openjdk.org/browse/JDK-8272317).

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `sun/tools/jstatd/` now pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8272317](https://bugs.openjdk.org/browse/JDK-8272317) needs maintainer approval
- [ ] Change requires CSR request [JDK-8333700](https://bugs.openjdk.org/browse/JDK-8333700) to be approved

### Issues
 * [JDK-8272317](https://bugs.openjdk.org/browse/JDK-8272317): jstatd has dependency on Security Manager which needs to be removed (**Enhancement** - P3)
 * [JDK-8333700](https://bugs.openjdk.org/browse/JDK-8333700): jstatd has dependency on Security Manager which needs to be removed (**CSR**)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [37201e3a](https://git.openjdk.org/jdk17u-dev/pull/2542/files/37201e3afaa765ca4086597513160dd6d256d98e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2542/head:pull/2542` \
`$ git checkout pull/2542`

Update a local copy of the PR: \
`$ git checkout pull/2542` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2542`

View PR using the GUI difftool: \
`$ git pr show -t 2542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2542.diff">https://git.openjdk.org/jdk17u-dev/pull/2542.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2542#issuecomment-2151857899)