### PR TITLE
8333698: [17u] TestJstatdRmiPort fails after JDK-8333667

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -358,8 +358,11 @@ public final class JstatdTest {
         OutputAnalyzer output = jstatdThread.getOutput();
         List<String> stdout = output.asLinesWithoutVMWarnings();
         output.reportDiagnosticSummary();
-        assertEquals(stdout.size(), 1, "Output should contain one line");
-        assertTrue(stdout.get(0).startsWith("jstatd started"), "List should start with 'jstatd started'");
+        // These asserts are disabled until JDK-8272317 is backported:
+        // otherwise there are SM deprecation notices that fail them.
+        // assertEquals(stdout.size(), 1, "Output should contain one line");
+        // assertTrue(stdout.get(0).startsWith("jstatd started"), "List should start with 'jstatd started'");
+        output.shouldContain("jstatd started");
         assertNotEquals(output.getExitValue(), 0,
                 "jstatd process exited with unexpected exit code");
     }


### PR DESCRIPTION
Recent regression after [JDK-8233725](https://bugs.openjdk.org/browse/JDK-8233725) backport. The real fix is backporting [JDK-8272317](https://bugs.openjdk.org/browse/JDK-8272317), but it would take a while. Meanwhile, we can unbreak 17u-dev testing by rewriting the asserts a bit here.

Additional testing:
 - [x] MacOS AArch64 fastdebug, `sun/tools/jstatd` used to fail, now fully pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333698](https://bugs.openjdk.org/browse/JDK-8333698) needs maintainer approval

### Issue
 * [JDK-8333698](https://bugs.openjdk.org/browse/JDK-8333698): [17u] TestJstatdRmiPort fails after JDK-8333667 (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2543/head:pull/2543` \
`$ git checkout pull/2543`

Update a local copy of the PR: \
`$ git checkout pull/2543` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2543`

View PR using the GUI difftool: \
`$ git pr show -t 2543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2543.diff">https://git.openjdk.org/jdk17u-dev/pull/2543.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2543#issuecomment-2151903114)