### PR TITLE
8292948: JEditorPane ignores font-size styles in external linked css-file

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2823,17 +2823,18 @@ public class StyleSheet extends StyleContext {
         }
 
         Object doGetAttribute(Object key) {
-            if (key == CSS.Attribute.FONT_SIZE && !isDefined(key)) {
+            Object retValue = super.getAttribute(key);
+            if (retValue != null) {
+                return retValue;
+            }
+
+            if (key == CSS.Attribute.FONT_SIZE) {
                 // CSS.FontSize represents a specified value and we need
                 // to inherit a computed value so don't resolve percentage
                 // value from parent.
                 return fontSizeInherit();
             }
 
-            Object retValue = super.getAttribute(key);
-            if (retValue != null) {
-                return retValue;
-            }
             // didn't find it... try parent if it's a css attribute
             // that is inherited.
             if (key instanceof CSS.Attribute) {

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.css
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.css
@@ -1,0 +1,14 @@
+.base {
+  font: 16px sans-serif;
+  font-size: 16;
+}
+
+.bigger {
+  font-weight: bold;
+  font-size: 150%;
+}
+
+.smaller {
+  font-style: italic;
+  font-size: 75%;
+}

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.html
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>JDK-8292948: JEditorPane ignores font-size styles in external linked css-file</title>
+  <link rel="stylesheet" href="TestExternalCSSFontSize.css" type="text/css">
+</head>
+<body>
+
+<div class="base">
+
+  <p class="bigger">Bigger text (24)</p>
+
+  <p>Normal size text (16)</p>
+
+  <p class="smaller">Smaller text (12)</p>
+
+</div>
+
+</body>
+</html>

--- a/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/TestExternalCSSFontSize.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.GlyphView;
+import javax.swing.text.View;
+
+/*
+ * @test
+ * @bug 8292948
+ * @summary Tests font-size declarations from an external style sheet.
+ * @run main TestExternalCSSFontSize
+ */
+public class TestExternalCSSFontSize {
+
+    private static final int[] expectedFontSizes = { 24, 16, 12 };
+
+    private volatile JEditorPane editor;
+
+    private volatile CountDownLatch loadLatch;
+
+    TestExternalCSSFontSize() {}
+
+    void setUp() {
+        String fileName = getClass().getName().replace('.', '/') + ".html";
+        URL htmlFile = getClass().getClassLoader().getResource(fileName);
+        if (htmlFile == null) {
+            throw new IllegalStateException("Resource not found: " + fileName);
+        }
+
+        loadLatch = new CountDownLatch(1);
+        editor = new JEditorPane();
+        editor.setContentType("text/html");
+        editor.addPropertyChangeListener("page", evt -> {
+            System.out.append("Loaded: ").println(evt.getNewValue());
+            loadLatch.countDown();
+        });
+        try {
+            editor.setPage(htmlFile);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    void verify() {
+        editor.setSize(editor.getPreferredSize()); // Do lay out text
+
+        scanFontSizes(editor.getUI().getRootView(editor), 0);
+    }
+
+    private int scanFontSizes(View view, int branchIndex) {
+        int currentIndex = branchIndex;
+        for (int i = 0; i < view.getViewCount(); i++) {
+            View child = view.getView(i);
+            if (child instanceof GlyphView) {
+                if (child.getElement()
+                        .getAttributes().getAttribute("CR") == Boolean.TRUE) {
+                    continue;
+                }
+                assertFontSize((GlyphView) child, currentIndex++);
+            } else {
+                currentIndex = scanFontSizes(child, currentIndex);
+            }
+        }
+        return currentIndex;
+    }
+
+    private void assertFontSize(GlyphView child, int index) {
+        printSource(child);
+        if (index >= expectedFontSizes.length) {
+            throw new AssertionError("Unexpected text run #"
+                    + index + " (>= " + expectedFontSizes.length + ")");
+        }
+
+        int actualFontSize = child.getFont().getSize();
+        if (actualFontSize != expectedFontSizes[index]) {
+            throw new AssertionError("Font size expected ["
+                    + expectedFontSizes[index] + "] but found [" + actualFontSize +"]");
+        }
+    }
+
+    private void printSource(View textRun) {
+        try {
+            editor.getEditorKit().write(System.out,
+                    editor.getDocument(), textRun.getStartOffset(),
+                    textRun.getEndOffset() - textRun.getStartOffset());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    void run() throws Throwable {
+        SwingUtilities.invokeAndWait(this::setUp);
+        if (loadLatch.await(5, TimeUnit.SECONDS)) {
+            SwingUtilities.invokeAndWait(this::verify);
+        } else {
+            throw new IllegalStateException("Page loading timed out");
+        }
+    }
+
+    public static void main(String[] args) throws Throwable {
+        TestExternalCSSFontSize test = new TestExternalCSSFontSize();
+        boolean success = false;
+        try {
+            test.run();
+            success = true;
+        } finally {
+            if (!success || hasOpt(args, "-capture")) {
+                if (test.editor == null) {
+                    System.err.println("Can't save image (test.editor is null)");
+                } else {
+                    String suffix = success ? "-success" : "-failure";
+                    SwingUtilities.invokeAndWait(() -> test.captureImage(suffix));
+                }
+            }
+        }
+    }
+
+    private static boolean hasOpt(String[] args, String opt) {
+        return Arrays.asList(args).contains(opt);
+    }
+
+    private void captureImage(String suffix) {
+        try {
+            BufferedImage capture =
+                    new BufferedImage(editor.getWidth(), editor.getHeight(),
+                                      BufferedImage.TYPE_INT_ARGB);
+            Graphics g = capture.getGraphics();
+            editor.paint(g);
+            g.dispose();
+
+            ImageIO.write(capture, "png",
+                    new File(getClass().getSimpleName() + suffix + ".png"));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
Clean backport of [JDK-8292948](https://bugs.openjdk.org/browse/JDK-8292948). The included test fails without the fix and passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8292948](https://bugs.openjdk.org/browse/JDK-8292948) needs maintainer approval

### Issue
 * [JDK-8292948](https://bugs.openjdk.org/browse/JDK-8292948): JEditorPane ignores font-size styles in external linked css-file (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2545/head:pull/2545` \
`$ git checkout pull/2545`

Update a local copy of the PR: \
`$ git checkout pull/2545` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2545`

View PR using the GUI difftool: \
`$ git pr show -t 2545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2545.diff">https://git.openjdk.org/jdk17u-dev/pull/2545.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2545#issuecomment-2152728581)