### PR TITLE
8281944: JavaDoc throws java.lang.IllegalStateException: ERRONEOUS

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1015,6 +1015,10 @@ public class HtmlDocletWriter {
                         // @see reference label...
                         label = ref.subList(1, ref.size());
                     }
+                    case ERRONEOUS -> {
+                        return invalidTagOutput(resources.getText("doclet.tag.invalid_input", seeText),
+                                Optional.empty());
+                    }
                     default ->
                         throw new IllegalStateException(ref.get(0).getKind().toString());
                 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1016,8 +1016,11 @@ public class HtmlDocletWriter {
                         label = ref.subList(1, ref.size());
                     }
                     case ERRONEOUS -> {
-                        return invalidTagOutput(resources.getText("doclet.tag.invalid_input", seeText),
-                                Optional.empty());
+                        messages.warning(ch.getDocTreePath(see),
+                            "doclet.tag.invalid_input",
+                            "@" + tagName,
+                            seeText);
+                        return Text.of("invalid input: '" + seeText + "'");
                     }
                     default ->
                         throw new IllegalStateException(ref.get(0).getKind().toString());

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,19 @@
 
 /*
  * @test
- * @bug      8017191 8182765 8200432 8239804 8250766 8262992
+ * @bug      8017191 8182765 8200432 8239804 8250766 8262992 8281944
  * @summary  Javadoc is confused by at-link to imported classes outside of the set of generated packages
- * @library  ../../lib
+ * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
- * @build    javadoc.tester.*
+ * @build    toolbox.ToolBox javadoc.tester.*
  * @run main TestSeeTag
  */
 
 import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.io.IOException;
+import java.nio.file.Path;
 
 public class TestSeeTag extends JavadocTester {
 
@@ -104,5 +108,41 @@ public class TestSeeTag extends JavadocTester {
                     </ul>
                     </dd>
                     </dl>""");
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void testErroneous() throws IOException {
+        Path src = Path.of("erroneous", "src");
+        tb.writeJavaFiles(src, """
+                package erroneous;
+                /**
+                 * Comment.
+                 * @see <a href="
+                 */
+                public class C {
+                    private C() { }
+                }
+                """);
+
+        javadoc("-d", Path.of("erroneous", "api").toString(),
+                "-sourcepath", src.toString(),
+                "--no-platform-links",
+                "erroneous");
+        checkExit(Exit.ERROR);
+
+        checkOutput("erroneous/C.html", true,
+                """
+                    <dl class="notes">
+                    <dt>See Also:</dt>
+                    <dd>
+                    <ul class="see-list">
+                    <li><span class="invalid-tag">invalid input: '&lt;a href="'</span></li>
+                    </ul>
+                    </dd>
+                    </dl>
+                    """);
+
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSeeTag/TestSeeTag.java
@@ -138,7 +138,7 @@ public class TestSeeTag extends JavadocTester {
                     <dt>See Also:</dt>
                     <dd>
                     <ul class="see-list">
-                    <li><span class="invalid-tag">invalid input: '&lt;a href="'</span></li>
+                    <li>invalid input: '&lt;a href="'</li>
                     </ul>
                     </dd>
                     </dl>


### PR DESCRIPTION
Fixes a javadoc crash on incorrect `@see`. We have seen instances of this in our development pipelines. 

Unfortunately, javadoc code changed considerably in modern releases. The original patch, while simple, does not apply well to javadoc from JDK 17. The backports of javadoc improvements that would make this clean to JDK 17 are hairy. So instead I amended the patch to work on JDK 17, see https://github.com/openjdk/jdk17u-dev/commit/9249ee405fc0a8b4653a653c1150692b90319bd9.

Additional testing:
 - [x] New test fails without the patch, passes with it
 - [x] MacOS AArch64 server fastdebug, `jdk/javadoc` pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8281944](https://bugs.openjdk.org/browse/JDK-8281944) needs maintainer approval

### Issue
 * [JDK-8281944](https://bugs.openjdk.org/browse/JDK-8281944): JavaDoc throws java.lang.IllegalStateException: ERRONEOUS (**Bug** - P3 - Approved)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2546/head:pull/2546` \
`$ git checkout pull/2546`

Update a local copy of the PR: \
`$ git checkout pull/2546` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2546`

View PR using the GUI difftool: \
`$ git pr show -t 2546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2546.diff">https://git.openjdk.org/jdk17u-dev/pull/2546.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2546#issuecomment-2152858288)