### PR TITLE
8333765: [17u] Six sun/tools/jstatd testcases fail after JDK-8233725

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -356,7 +356,7 @@ public final class JstatdTest {
 
         // Verify output from jstatd
         OutputAnalyzer output = jstatdThread.getOutput();
-        List<String> stdout = output.asLinesWithoutVMWarnings();
+        List<String> stdout = output.asLinesWithoutAnythingWarnings();
         output.reportDiagnosticSummary();
         assertEquals(stdout.size(), 1, "Output should contain one line");
         assertTrue(stdout.get(0).startsWith("jstatd started"), "List should start with 'jstatd started'");

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,8 @@ import java.util.regex.Pattern;
 public final class OutputAnalyzer {
 
     private static final String jvmwarningmsg = ".* VM warning:.*";
+
+    private static final String anythingwarningmsg = ".*WARNING:.*";
 
     private static final String deprecatedmsg = ".* VM warning:.* deprecated.*";
 
@@ -651,6 +653,18 @@ public final class OutputAnalyzer {
     public List<String> asLinesWithoutVMWarnings() {
         return Arrays.stream(getOutput().split("\\R"))
                      .filter(Pattern.compile(jvmwarningmsg).asPredicate().negate())
+                     .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the contents of the output buffer (stdout and stderr), without anything
+     * warning msgs, as list of strings. Output is split by newlines.
+     *
+     * @return Contents of the output buffer as list of strings
+     */
+    public List<String> asLinesWithoutAnythingWarnings() {
+        return Arrays.stream(getOutput().split("\\R"))
+                     .filter(Pattern.compile(anythingwarningmsg).asPredicate().negate())
                      .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Hi all,
  The below 6 sun/tools/jstatd testcases fail after [JDK-8233725](https://bugs.openjdk.org/browse/JDK-8233725):
```
sun/tools/jstatd/TestJstatdExternalRegistry.java
sun/tools/jstatd/TestJstatdPort.java
sun/tools/jstatd/TestJstatdPortAndServer.java
sun/tools/jstatd/TestJstatdRmiPort.java
sun/tools/jstatd/TestJstatdDefaults.java
sun/tools/jstatd/TestJstatdServer.java
```
  As descript in [JDK-8333765](https://bugs.openjdk.org/browse/JDK-8333765), the jdk17 has several additional `[Jstatd-Thread] WARNING:`, these warning messages can't deal with by `asLinesWithoutVMWarnings()`, so I add `asLinesWithoutAnythingWarnings()` to deal these warning messages. Only change the testcases, the risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8333765](https://bugs.openjdk.org/browse/JDK-8333765) needs maintainer approval

### Issue
 * [JDK-8333765](https://bugs.openjdk.org/browse/JDK-8333765): [17u] Six sun/tools/jstatd testcases fail after JDK-8233725 (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2548/head:pull/2548` \
`$ git checkout pull/2548`

Update a local copy of the PR: \
`$ git checkout pull/2548` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2548`

View PR using the GUI difftool: \
`$ git pr show -t 2548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2548.diff">https://git.openjdk.org/jdk17u-dev/pull/2548.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2548#issuecomment-2153958265)