### PR TITLE
8307091: A few client tests intermittently throw ConcurrentModificationException

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -360,12 +360,15 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
                                 break;
                             }
                         }
-                        if (start >= 0 && end > start
-                            && newFileCache.subList(end, newSize).equals(fileCache.subList(start, oldSize))) {
-                            if (loadThread.isInterrupted()) {
-                                return null;
+
+                        if (start >= 0 && end > start) {
+                            List<File> listStart_OldSize = new Vector<>(fileCache.subList(start, oldSize));
+                            if (newFileCache.subList(end, newSize).equals(listStart_OldSize)) {
+                                if (loadThread.isInterrupted()) {
+                                    return null;
+                                }
+                                return new DoChangeContents(newFileCache.subList(start, end), start, null, 0, fid);
                             }
-                            return new DoChangeContents(newFileCache.subList(start, end), start, null, 0, fid);
                         }
                     } else if (newSize < oldSize) {
                         //see if interval is removed
@@ -378,12 +381,15 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
                                 break;
                             }
                         }
-                        if (start >= 0 && end > start
-                            && fileCache.subList(end, oldSize).equals(newFileCache.subList(start, newSize))) {
-                            if (loadThread.isInterrupted()) {
-                                return null;
+
+                        if (start >= 0 && end > start) {
+                            List<File> listEnd_OldSize = new Vector<>(fileCache.subList(end, oldSize));
+                            if (listEnd_OldSize.equals(newFileCache.subList(start, newSize))) {
+                                if (loadThread.isInterrupted()) {
+                                    return null;
+                                }
+                                return new DoChangeContents(null, 0, new Vector<>(fileCache.subList(start, end)), start, fid);
                             }
-                            return new DoChangeContents(null, 0, new Vector<>(fileCache.subList(start, end)), start, fid);
                         }
                     }
                     if (!fileCache.equals(newFileCache)) {


### PR DESCRIPTION
Clean backport of [JDK-8307091](https://bugs.openjdk.org/browse/JDK-8307091). This fix is superseded by [JDK-8323670](https://bugs.openjdk.org/browse/JDK-8323670), but required for that one to apply.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307091](https://bugs.openjdk.org/browse/JDK-8307091) needs maintainer approval

### Issue
 * [JDK-8307091](https://bugs.openjdk.org/browse/JDK-8307091): A few client tests intermittently throw ConcurrentModificationException (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2551/head:pull/2551` \
`$ git checkout pull/2551`

Update a local copy of the PR: \
`$ git checkout pull/2551` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2551`

View PR using the GUI difftool: \
`$ git pr show -t 2551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2551.diff">https://git.openjdk.org/jdk17u-dev/pull/2551.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2551#issuecomment-2154633810)