### PR TITLE
8331885: C2: meet between unloaded and speculative types is not symmetric

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3720,24 +3720,24 @@ const TypeInstPtr *TypeInstPtr::xmeet_unloaded(const TypeInstPtr *tinst) const {
       //
       assert(loaded->ptr() != TypePtr::Null, "insanity check");
       //
-      if(      loaded->ptr() == TypePtr::TopPTR ) { return unloaded; }
+      if(      loaded->ptr() == TypePtr::TopPTR ) { return unloaded->with_speculative(speculative); }
       else if (loaded->ptr() == TypePtr::AnyNull) { return TypeInstPtr::make(ptr, unloaded->klass(), false, nullptr, off, instance_id, speculative, depth); }
-      else if (loaded->ptr() == TypePtr::BotPTR ) { return TypeInstPtr::BOTTOM; }
+      else if (loaded->ptr() == TypePtr::BotPTR ) { return TypeInstPtr::BOTTOM->with_speculative(speculative); }
       else if (loaded->ptr() == TypePtr::Constant || loaded->ptr() == TypePtr::NotNull) {
-        if (unloaded->ptr() == TypePtr::BotPTR  ) { return TypeInstPtr::BOTTOM;  }
-        else                                      { return TypeInstPtr::NOTNULL; }
+        if (unloaded->ptr() == TypePtr::BotPTR  ) { return TypeInstPtr::BOTTOM->with_speculative(speculative);  }
+        else                                      { return TypeInstPtr::NOTNULL->with_speculative(speculative); }
       }
-      else if( unloaded->ptr() == TypePtr::TopPTR )  { return unloaded; }
+      else if( unloaded->ptr() == TypePtr::TopPTR )  { return unloaded->with_speculative(speculative); }
 
-      return unloaded->cast_to_ptr_type(TypePtr::AnyNull)->is_instptr();
+      return unloaded->cast_to_ptr_type(TypePtr::AnyNull)->is_instptr()->with_speculative(speculative);
     }
 
     // Both are unloaded, not the same class, not Object
     // Or meet unloaded with a different loaded class, not java/lang/Object
     if( ptr != TypePtr::BotPTR ) {
-      return TypeInstPtr::NOTNULL;
+      return TypeInstPtr::NOTNULL->with_speculative(speculative);
     }
-    return TypeInstPtr::BOTTOM;
+    return TypeInstPtr::BOTTOM->with_speculative(speculative);
 }
 
 
@@ -4122,6 +4122,10 @@ const Type *TypeInstPtr::remove_speculative() const {
   assert(_inline_depth == InlineDepthTop || _inline_depth == InlineDepthBottom, "non speculative type shouldn't have inline depth");
   return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset,
               _instance_id, nullptr, _inline_depth);
+}
+
+const TypeInstPtr* TypeInstPtr::with_speculative(const TypePtr* speculative) const {
+  return make(_ptr, klass(), klass_is_exact(), const_oop(), _offset, _instance_id, speculative, _inline_depth);
 }
 
 const TypePtr *TypeInstPtr::with_inline_depth(int depth) const {

--- a/src/hotspot/share/opto/type.hpp
+++ b/src/hotspot/share/opto/type.hpp
@@ -1191,6 +1191,7 @@ class TypeInstPtr : public TypeOopPtr {
 
   // Speculative type helper methods.
   virtual const Type* remove_speculative() const;
+  const TypeInstPtr* with_speculative(const TypePtr* speculative) const;
   virtual const TypePtr* with_inline_depth(int depth) const;
   virtual const TypePtr* with_instance_id(int instance_id) const;
 

--- a/test/hotspot/jtreg/compiler/runtime/unloaded/TestMHUnloaded.java
+++ b/test/hotspot/jtreg/compiler/runtime/unloaded/TestMHUnloaded.java
@@ -31,9 +31,16 @@
  *
  * @compile TestMHUnloaded.java TestMHUnloadedHelper.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller compiler.runtime.unloaded.TestMHUnloadedHelper
+ *
  * @run main/othervm -Xbootclasspath/a:.
  *                   -Xbatch -XX:-TieredCompilation -XX:CompileCommand=exclude,*::test
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+PrintCompilation -XX:+PrintInlining
+ *                      compiler.runtime.unloaded.TestMHUnloaded
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *                   -Xbatch -XX:-TieredCompilation -XX:CompileCommand=exclude,*::test
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+PrintCompilation -XX:+PrintInlining
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
  *                      compiler.runtime.unloaded.TestMHUnloaded
  */
 


### PR DESCRIPTION
Backport of [JDK-8331885](https://bugs.openjdk.org/browse/JDK-8331885). Manual integration was needed. I had to omit `_interfaces` in `TypeInstPtr::with_speculative` because [JDK-8297933](https://bugs.openjdk.org/browse/JDK-8297933) is not in 17u. The context differs to some degree, but all modifications are integrated (each line). The test update applies cleanly. Please review!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331885](https://bugs.openjdk.org/browse/JDK-8331885) needs maintainer approval

### Issue
 * [JDK-8331885](https://bugs.openjdk.org/browse/JDK-8331885): C2: meet between unloaded and speculative types is not symmetric (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2554/head:pull/2554` \
`$ git checkout pull/2554`

Update a local copy of the PR: \
`$ git checkout pull/2554` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2554`

View PR using the GUI difftool: \
`$ git pr show -t 2554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2554.diff">https://git.openjdk.org/jdk17u-dev/pull/2554.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2554#issuecomment-2155145503)