### PR TITLE
8324668: JDWP process management needs more efficient file descriptor handling

### DIFF
--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,16 @@
  * questions.
  */
 
+#include <dirent.h>
+#include <errno.h>
 #include <stdlib.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #include <string.h>
 #include <ctype.h>
 #include "sys.h"
 #include "util.h"
+#include "error_messages.h"
 
 static char *skipWhitespace(char *p) {
     while ((*p != '\0') && isspace(*p)) {
@@ -42,6 +46,106 @@ static char *skipNonWhitespace(char *p) {
         p++;
     }
     return p;
+}
+
+#if defined(_AIX)
+  /* AIX does not understand '/proc/self' - it requires the real process ID */
+  #define FD_DIR aix_fd_dir
+  #define DIR DIR64
+  #define dirent dirent64
+  #define opendir opendir64
+  #define readdir readdir64
+  #define closedir closedir64
+#elif defined(_ALLBSD_SOURCE)
+  #define FD_DIR "/dev/fd"
+#else
+  #define FD_DIR "/proc/self/fd"
+#endif
+
+// Closes every file descriptor that is listed as a directory
+// entry in "/proc/self/fd" (or its equivalent). Standard
+// input/output/error file descriptors will not be closed
+// by this function. This function returns 0 on failure
+// and 1 on success.
+int
+closeDescriptors(void)
+{
+    DIR *dp;
+    struct dirent *dirp;
+    /* leave out standard input/output/error descriptors */
+    int from_fd = STDERR_FILENO + 1;
+
+    /* We're trying to close all file descriptors, but opendir() might
+     * itself be implemented using a file descriptor, and we certainly
+     * don't want to close that while it's in use.  We assume that if
+     * opendir() is implemented using a file descriptor, then it uses
+     * the lowest numbered file descriptor, just like open().  So
+     * before calling opendir(), we close a couple explicitly, so that
+     * opendir() can then use these lowest numbered closed file
+     * descriptors afresh.   */
+
+    close(from_fd);          /* for possible use by opendir() */
+    close(from_fd + 1);      /* another one for good luck */
+    from_fd += 2; /* leave out the 2 we just closed, which the opendir() may use */
+
+#if defined(_AIX)
+    /* set FD_DIR for AIX which does not understand '/proc/self' - it
+     * requires the real process ID */
+    char aix_fd_dir[32];     /* the pid has at most 19 digits */
+    snprintf(aix_fd_dir, 32, "/proc/%d/fd", getpid());
+#endif
+
+    if ((dp = opendir(FD_DIR)) == NULL) {
+        ERROR_MESSAGE(("failed to open dir %s while determining"
+                       " file descriptors to close for process %d",
+                       FD_DIR, getpid()));
+        return 0; // failure
+    }
+
+    while ((dirp = readdir(dp)) != NULL) {
+        if (!isdigit(dirp->d_name[0])) {
+            continue;
+        }
+        const long fd = strtol(dirp->d_name, NULL, 10);
+        if (fd <= INT_MAX && fd >= from_fd) {
+            (void)close((int)fd);
+        }
+    }
+
+    (void)closedir(dp);
+
+    return 1; // success
+}
+
+// Does necessary housekeeping of a forked child process
+// (like closing copied file descriptors) before
+// execing the child process. This function never returns.
+void
+forkedChildProcess(const char *file, char *const argv[])
+{
+    /* Close all file descriptors that have been copied over
+     * from the parent process due to fork(). */
+    if (closeDescriptors() == 0) { /* failed,  close the old way */
+        /* Find max allowed file descriptors for a process
+         * and assume all were opened for the parent process and
+         * copied over to this child process. We close them all. */
+        const rlim_t max_fd = sysconf(_SC_OPEN_MAX);
+        JDI_ASSERT(max_fd != (rlim_t)-1); // -1 represents error
+        /* close(), that we subsequently call, takes only int values */
+        JDI_ASSERT(max_fd <= INT_MAX);
+        /* leave out standard input/output/error file descriptors */
+        rlim_t i = STDERR_FILENO + 1;
+        ERROR_MESSAGE(("failed to close file descriptors of"
+                       " child process optimally, falling back to closing"
+                       " %d file descriptors sequentially", (max_fd - i + 1)));
+        for (; i < max_fd; i++) {
+            (void)close(i);
+        }
+    }
+
+    (void)execvp(file, argv); /* not expected to return */
+
+    exit(errno); /* errno will have been set by the failed execvp */
 }
 
 int
@@ -93,21 +197,11 @@ dbgsysExec(char *cmdLine)
     argv[i] = NULL;  /* NULL terminate */
 
     if ((pid = fork()) == 0) {
-        /* Child process */
-        int i;
-        long max_fd;
-
-        /* close everything */
-        max_fd = sysconf(_SC_OPEN_MAX);
-        /*LINTED*/
-        for (i = 3; i < (int)max_fd; i++) {
-            (void)close(i);
-        }
-
-        (void)execvp(argv[0], argv);
-
-        exit(-1);
+        // manage the child process
+        forkedChildProcess(argv[0], argv);
     }
+    // call to forkedChildProcess(...) will never return for a forked process
+    JDI_ASSERT(pid != 0);
     jvmtiDeallocate(args);
     jvmtiDeallocate(argv);
     if (pid == pid_err) {


### PR DESCRIPTION
The original patch applies almost cleanly except for copyright years

Additional testing: passed local test1-4 testing on macos-aarch64

It's needed as a prerequisite to fix JDK-8324577 (already backported to JDK 21)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324668](https://bugs.openjdk.org/browse/JDK-8324668) needs maintainer approval

### Issue
 * [JDK-8324668](https://bugs.openjdk.org/browse/JDK-8324668): JDWP process management needs more efficient file descriptor handling (**Enhancement** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2557/head:pull/2557` \
`$ git checkout pull/2557`

Update a local copy of the PR: \
`$ git checkout pull/2557` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2557`

View PR using the GUI difftool: \
`$ git pr show -t 2557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2557.diff">https://git.openjdk.org/jdk17u-dev/pull/2557.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2557#issuecomment-2157585104)