### PR TITLE
8279164: Disable TLS_ECDH_* cipher suites

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -737,7 +737,8 @@ jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024, \
 #   jdk.tls.disabledAlgorithms=MD5, SSLv3, DSA, RSA keySize < 2048, \
 #       rsa_pkcs1_sha1, secp224r1
 jdk.tls.disabledAlgorithms=SSLv3, TLSv1, TLSv1.1, DTLSv1.0, RC4, DES, \
-    MD5withRSA, DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL
+    MD5withRSA, DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    ECDH
 
 #
 # Legacy algorithms for Secure Socket Layer/Transport Layer Security (SSL/TLS)

--- a/test/jdk/javax/net/ssl/DTLS/CipherSuite.java
+++ b/test/jdk/javax/net/ssl/DTLS/CipherSuite.java
@@ -43,10 +43,10 @@
  * @run main/othervm CipherSuite TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
  * @run main/othervm CipherSuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
  * @run main/othervm CipherSuite TLS_RSA_WITH_AES_128_GCM_SHA256
- * @run main/othervm CipherSuite TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+ * @run main/othervm CipherSuite TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256 re-enable
  * @run main/othervm CipherSuite TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
  * @run main/othervm CipherSuite TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
- * @run main/othervm CipherSuite TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+ * @run main/othervm CipherSuite TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256 re-enable
  */
 
 import javax.net.ssl.SSLEngine;

--- a/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8076221 8211883
+ * @bug 8076221 8211883 8279164
  * @summary Check if weak cipher suites are disabled
  * @modules jdk.crypto.ec
  * @run main/othervm DisabledAlgorithms default
@@ -60,9 +60,9 @@ public class DisabledAlgorithms {
             System.getProperty("test.src", "./") + "/" + pathToStores +
                 "/" + trustStoreFile;
 
-    // supported RC4, NULL, and anon cipher suites
-    // it does not contain KRB5 cipher suites because they need a KDC
-    private static final String[] rc4_null_anon_ciphersuites = new String[] {
+    // disabled 3DES, DES, RC4, NULL, anon, and ECDH cipher suites
+    private static final String[] disabled_ciphersuites
+        = new String[] {
         "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
         "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
         "SSL_RSA_WITH_RC4_128_SHA",
@@ -94,7 +94,20 @@ public class DisabledAlgorithms {
         "TLS_ECDH_anon_WITH_AES_128_CBC_SHA",
         "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
         "TLS_ECDH_anon_WITH_NULL_SHA",
-        "TLS_ECDH_anon_WITH_RC4_128_SHA"
+        "TLS_ECDH_anon_WITH_RC4_128_SHA",
+        "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA"
     };
 
     public static void main(String[] args) throws Exception {
@@ -113,9 +126,8 @@ public class DisabledAlgorithms {
                 System.out.println("jdk.tls.disabledAlgorithms = "
                         + Security.getProperty("jdk.tls.disabledAlgorithms"));
 
-                // check if RC4, NULL, and anon cipher suites
-                // can't be used by default
-                checkFailure(rc4_null_anon_ciphersuites);
+                // check that disabled cipher suites can't be used by default
+                checkFailure(disabled_ciphersuites);
                 break;
             case "empty":
                 // reset jdk.tls.disabledAlgorithms
@@ -123,9 +135,9 @@ public class DisabledAlgorithms {
                 System.out.println("jdk.tls.disabledAlgorithms = "
                         + Security.getProperty("jdk.tls.disabledAlgorithms"));
 
-                // check if RC4, NULL, and anon cipher suites can be used
-                // if jdk.tls.disabledAlgorithms is empty
-                checkSuccess(rc4_null_anon_ciphersuites);
+                // check that disabled cipher suites can be used if
+                // jdk.{tls,certpath}.disabledAlgorithms is empty
+                checkSuccess(disabled_ciphersuites);
                 break;
             default:
                 throw new RuntimeException("Wrong parameter: " + args[0]);
@@ -151,11 +163,12 @@ public class DisabledAlgorithms {
                     throw new RuntimeException("Expected SSLHandshakeException "
                             + "not thrown");
                 } catch (SSLHandshakeException e) {
-                    System.out.println("Expected exception on client side: "
+                    System.out.println("Got expected exception on client side: "
                             + e);
                 }
             }
 
+            server.stop();
             while (server.isRunning()) {
                 sleep();
             }
@@ -251,7 +264,6 @@ public class DisabledAlgorithms {
                 } catch (SSLHandshakeException e) {
                     System.out.println("Server: run: " + e);
                     sslError = true;
-                    stopped = true;
                 } catch (IOException e) {
                     if (!stopped) {
                         System.out.println("Server: run: unexpected exception: "

--- a/test/jdk/javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java
+++ b/test/jdk/javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4750141 4895631 8217579 8163326
+ * @bug 4750141 4895631 8217579 8163326 8279164
  * @summary Check enabled and supported ciphersuites are correct
  * @run main/othervm CheckCipherSuites default
  * @run main/othervm CheckCipherSuites limited
@@ -50,53 +50,37 @@ public class CheckCipherSuites {
         // Not suite B, but we want it to position the suite early
         "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
 
-        // AES_256(GCM) - ECDHE - forward screcy
+        // AES_256(GCM) - ECDHE - forward secrecy
         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
 
-        // AES_128(GCM) - ECDHE - forward screcy
+        // AES_128(GCM) - ECDHE - forward secrecy
         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(GCM) - DHE - forward screcy
+        // AES_256(GCM) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
         "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
 
-        // AES_128(GCM) - DHE - forward screcy
+        // AES_128(GCM) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(CBC) - ECDHE - forward screcy
+        // AES_256(CBC) - ECDHE - forward secrecy
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
 
-        // AES_256(CBC) - ECDHE - forward screcy
+        // AES_256(CBC) - ECDHE - forward secrecy
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
 
-        // AES_256(CBC) - DHE - forward screcy
+        // AES_256(CBC) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
 
-        // AES_128(CBC) - DHE - forward screcy
+        // AES_128(CBC) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-
-        // AES_256(GCM) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
-
-        // AES_128(GCM) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-
-        // AES_256(CBC) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-
-        // AES_128(CBC) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
 
         // AES_256(CBC) - ECDHE - using SHA
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
@@ -113,14 +97,6 @@ public class CheckCipherSuites {
         // AES_128(CBC) - DHE - using SHA
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-
-        // AES_256(CBC) - using SHA, not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-
-        // AES_128(CBC) - using SHA, not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
 
         // deprecated
         "TLS_RSA_WITH_AES_256_GCM_SHA384",
@@ -144,16 +120,10 @@ public class CheckCipherSuites {
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
         "TLS_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_RSA_WITH_AES_128_CBC_SHA",
@@ -175,53 +145,37 @@ public class CheckCipherSuites {
         // Not suite B, but we want it to position the suite early
         "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
 
-        // AES_256(GCM) - ECDHE - forward screcy
+        // AES_256(GCM) - ECDHE - forward secrecy
         "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
 
-        // AES_128(GCM) - ECDHE - forward screcy
+        // AES_128(GCM) - ECDHE - forward secrecy
         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(GCM) - DHE - forward screcy
+        // AES_256(GCM) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
         "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
         "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
 
-        // AES_128(GCM) - DHE - forward screcy
+        // AES_128(GCM) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
 
-        // AES_256(CBC) - ECDHE - forward screcy
+        // AES_256(CBC) - ECDHE - forward secrecy
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
         "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
 
-        // AES_256(CBC) - ECDHE - forward screcy
+        // AES_256(CBC) - ECDHE - forward secrecy
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
 
-        // AES_256(CBC) - DHE - forward screcy
+        // AES_256(CBC) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
 
-        // AES_128(CBC) - DHE - forward screcy
+        // AES_128(CBC) - DHE - forward secrecy
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-
-        // AES_256(GCM) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
-
-        // AES_128(GCM) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-
-        // AES_256(CBC) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-
-        // AES_128(CBC) - not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
 
         // AES_256(CBC) - ECDHE - using SHA
         "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
@@ -238,14 +192,6 @@ public class CheckCipherSuites {
         // AES_128(CBC) - DHE - using SHA
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-
-        // AES_256(CBC) - using SHA, not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-
-        // AES_128(CBC) - using SHA, not forward screcy
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
 
         // deprecated
         "TLS_RSA_WITH_AES_256_GCM_SHA384",
@@ -269,16 +215,10 @@ public class CheckCipherSuites {
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
         "TLS_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_RSA_WITH_AES_128_CBC_SHA256",
         "TLS_RSA_WITH_AES_128_CBC_SHA",


### PR DESCRIPTION
Backport of [JDK-8279164](https://bugs.openjdk.org/browse/JDK-8279164). The test changes in DisabledAlgorithms.java needed manual integration. The rest applies cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8279164](https://bugs.openjdk.org/browse/JDK-8279164) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8332812](https://bugs.openjdk.org/browse/JDK-8332812) to be approved

### Issues
 * [JDK-8279164](https://bugs.openjdk.org/browse/JDK-8279164): Disable TLS_ECDH_* cipher suites (**Enhancement** - P3 - Approved)
 * [JDK-8332812](https://bugs.openjdk.org/browse/JDK-8332812): Disable TLS_ECDH_* cipher suites (**CSR**)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2559/head:pull/2559` \
`$ git checkout pull/2559`

Update a local copy of the PR: \
`$ git checkout pull/2559` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2559`

View PR using the GUI difftool: \
`$ git pr show -t 2559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2559.diff">https://git.openjdk.org/jdk17u-dev/pull/2559.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2559#issuecomment-2157977695)