### PR TITLE
8261433: Better pkcs11 performance for libpkcs11:C_EncryptInit/libpkcs11:C_DecryptInit

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -475,9 +475,8 @@ final class P11AEADCipher extends CipherSpi {
             }
 
             if (type == Transformation.AES_GCM) {
-                CK_VERSION cryptokiVersion = token.p11.getVersion();
-                boolean useNormativeMechFirst = cryptokiVersion.major > 2 ||
-                    (cryptokiVersion.major == 2  && cryptokiVersion.minor >= 40);
+                // JDK-8255409 allows using useNormativeMechFirst dependent on token.p11.getVersion();
+                boolean useNormativeMechFirst = false;
                 if (encrypt) {
                     token.p11.C_GCMEncryptInitWithRetry(session.id(), mechWithParams,
                         p11KeyID, useNormativeMechFirst);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11AEADCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -473,12 +473,26 @@ final class P11AEADCipher extends CipherSpi {
             if (session == null) {
                 session = token.getOpSession();
             }
-            if (encrypt) {
-                token.p11.C_EncryptInit(session.id(), mechWithParams,
-                    p11KeyID);
+
+            if (type == Transformation.AES_GCM) {
+                CK_VERSION cryptokiVersion = token.p11.getVersion();
+                boolean useNormativeMechFirst = cryptokiVersion.major > 2 ||
+                    (cryptokiVersion.major == 2  && cryptokiVersion.minor >= 40);
+                if (encrypt) {
+                    token.p11.C_GCMEncryptInitWithRetry(session.id(), mechWithParams,
+                        p11KeyID, useNormativeMechFirst);
+                } else {
+                    token.p11.C_GCMDecryptInitWithRetry(session.id(), mechWithParams,
+                        p11KeyID, useNormativeMechFirst);
+                }
             } else {
-                token.p11.C_DecryptInit(session.id(), mechWithParams,
-                    p11KeyID);
+                if (encrypt) {
+                    token.p11.C_EncryptInit(session.id(), mechWithParams,
+                        p11KeyID);
+                } else {
+                    token.p11.C_DecryptInit(session.id(), mechWithParams,
+                        p11KeyID);
+                }
             }
         } catch (PKCS11Exception e) {
             p11Key.releaseKeyID();

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -730,6 +730,24 @@ public class PKCS11 {
     public native void C_EncryptInit(long hSession, CK_MECHANISM pMechanism,
             long hKey) throws PKCS11Exception;
 
+    /**
+     * C_GCMEncryptInitWithRetry initializes a GCM encryption operation and retry
+     * with alternative param structure for max compatibility.
+     * (Encryption and decryption)
+     *
+     * @param hSession the session's handle
+     *         (PKCS#11 param: CK_SESSION_HANDLE hSession)
+     * @param pMechanism the encryption mechanism
+     *         (PKCS#11 param: CK_MECHANISM_PTR pMechanism)
+     * @param hKey the handle of the encryption key
+     *         (PKCS#11 param: CK_OBJECT_HANDLE hKey)
+     * @param useNormativeVerFirst whether to use normative version of GCM parameter first
+     * @exception PKCS11Exception If function returns other value than CKR_OK.
+     * @preconditions
+     * @postconditions
+     */
+    public native void C_GCMEncryptInitWithRetry(long hSession, CK_MECHANISM pMechanism,
+            long hKey, boolean useNormativeVerFirst) throws PKCS11Exception;
 
     /**
      * C_Encrypt encrypts single-part data.
@@ -825,6 +843,24 @@ public class PKCS11 {
     public native void C_DecryptInit(long hSession, CK_MECHANISM pMechanism,
             long hKey) throws PKCS11Exception;
 
+    /**
+     * C_GCMDecryptInitWithRetry initializes a GCM decryption operation
+     * with alternative param structure for max compatibility.
+     * (Encryption and decryption)
+     *
+     * @param hSession the session's handle
+     *         (PKCS#11 param: CK_SESSION_HANDLE hSession)
+     * @param pMechanism the decryption mechanism
+     *         (PKCS#11 param: CK_MECHANISM_PTR pMechanism)
+     * @param hKey the handle of the decryption key
+     *         (PKCS#11 param: CK_OBJECT_HANDLE hKey)
+     * @param useNormativeVerFirst whether to use normative version of GCM parameter first
+     * @exception PKCS11Exception If function returns other value than CKR_OK.
+     * @preconditions
+     * @postconditions
+     */
+    public native void C_GCMDecryptInitWithRetry(long hSession, CK_MECHANISM pMechanism,
+            long hKey, boolean useNormativeVerFirst) throws PKCS11Exception;
 
     /**
      * C_Decrypt decrypts encrypted data in a single part.

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -1014,18 +1014,19 @@ cleanup:
 }
 
 /*
- * converts the Java CK_GCM_PARAMS object to a CK_GCM_PARAMS_NO_IVBITS pointer
- * Note: Need to try NSS definition first to avoid SIGSEGV.
+ * converts the Java CK_GCM_PARAMS object to a CK_GCM_PARAMS pointer
+ * Note: Early NSS versions crash w/ CK_GCM_PARAMS and need to use
+ * CK_GCM_PARAMS_NO_IVBITS to avoid SIGSEGV.
  *
  * @param env - used to call JNI funktions to get the Java classes and objects
  * @param jParam - the Java CK_GCM_PARAMS object to convert
  * @param pLength - length of the allocated memory of the returned pointer
- * @return pointer to the new CK_GCM_PARAMS_NO_IVBITS structure
+ * @return pointer to the new CK_GCM_PARAMS structure
  */
-CK_GCM_PARAMS_NO_IVBITS_PTR
+CK_GCM_PARAMS_PTR
 jGCMParamsToCKGCMParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
 {
-    CK_GCM_PARAMS_NO_IVBITS_PTR ckParamPtr;
+    CK_GCM_PARAMS_PTR ckParamPtr;
     jclass jGcmParamsClass;
     jfieldID fieldID;
     jobject jIv, jAad;
@@ -1053,8 +1054,8 @@ jGCMParamsToCKGCMParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     if (fieldID == NULL) { return NULL; }
     jTagLen = (*env)->GetLongField(env, jParam, fieldID);
 
-    // allocate memory for CK_GCM_PARAMS_NO_IVBITS pointer
-    ckParamPtr = calloc(1, sizeof(CK_GCM_PARAMS_NO_IVBITS));
+    // allocate memory for CK_GCM_PARAMS pointer
+    ckParamPtr = calloc(1, sizeof(CK_GCM_PARAMS));
     if (ckParamPtr == NULL) {
         throwOutOfMemoryError(env, 0);
         return NULL;
@@ -1065,6 +1066,8 @@ jGCMParamsToCKGCMParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     if ((*env)->ExceptionCheck(env)) {
         goto cleanup;
     }
+    // adjust since the value is in bits
+    ckParamPtr->ulIvBits = ckParamPtr->ulIvLen << 3;
 
     jByteArrayToCKByteArray(env, jAad, &(ckParamPtr->pAAD), &(ckParamPtr->ulAADLen));
     if ((*env)->ExceptionCheck(env)) {
@@ -1074,9 +1077,9 @@ jGCMParamsToCKGCMParamPtr(JNIEnv *env, jobject jParam, CK_ULONG *pLength)
     ckParamPtr->ulTagBits = jLongToCKULong(jTagLen);
 
     if (pLength != NULL) {
-        *pLength = sizeof(CK_GCM_PARAMS_NO_IVBITS);
+        *pLength = sizeof(CK_GCM_PARAMS);
     }
-    TRACE1("Created inner GCM_PARAMS PTR w/o ulIvBits %p\n", ckParamPtr);
+    TRACE1("Created inner GCM_PARAMS PTR %p\n", ckParamPtr);
     return ckParamPtr;
 cleanup:
     free(ckParamPtr->pIv);

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_crypt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_crypt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -72,7 +72,6 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1EncryptInit
 {
     CK_SESSION_HANDLE ckSessionHandle;
     CK_MECHANISM_PTR ckpMechanism = NULL;
-    CK_MECHANISM_PTR ckpTemp;
     CK_OBJECT_HANDLE ckKeyHandle;
     CK_RV rv;
 
@@ -90,20 +89,60 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1EncryptInit
     rv = (*ckpFunctions->C_EncryptInit)(ckSessionHandle, ckpMechanism,
                                         ckKeyHandle);
 
-    if (ckpMechanism->mechanism == CKM_AES_GCM) {
-        if (rv == CKR_ARGUMENTS_BAD || rv == CKR_MECHANISM_PARAM_INVALID) {
-            // retry with CKM_GCM_PARAMS structure in pkcs11t.h
-            TRACE0("DEBUG C_EncryptInit: retry with CK_GCM_PARAMS\n");
-            ckpTemp = updateGCMParams(env, ckpMechanism);
-            if (ckpTemp != NULL) { // only re-call if conversion succeeds
-                ckpMechanism = ckpTemp;
-                rv = (*ckpFunctions->C_EncryptInit)(ckSessionHandle, ckpMechanism,
-                        ckKeyHandle);
-            }
+    TRACE1("DEBUG C_EncryptInit: freed pMech = %p\n", ckpMechanism);
+    freeCKMechanismPtr(ckpMechanism);
+    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
+
+    TRACE0("FINISHED\n");
+}
+
+/*
+ * Class:     sun_security_pkcs11_wrapper_PKCS11
+ * Method:    C_GCMEncryptInitWithRetry
+ * Signature: (JLsun/security/pkcs11/wrapper/CK_MECHANISM;JZ)V
+ * Parametermapping:                    *PKCS11*
+ * @param   jlong jSessionHandle        CK_SESSION_HANDLE hSession
+ * @param   jobject jMechanism          CK_MECHANISM_PTR pMechanism
+ * @param   jlong jKeyHandle            CK_OBJECT_HANDLE hKey
+ * @param   jboolean useNormVerFirst    CK_BBOOL retry (only retry if the first
+ *                                      init uses the non-normative version)
+ */
+JNIEXPORT void JNICALL
+Java_sun_security_pkcs11_wrapper_PKCS11_C_1GCMEncryptInitWithRetry
+(JNIEnv *env, jobject obj, jlong jSessionHandle,
+ jobject jMechanism, jlong jKeyHandle, jboolean useNormVerFirst)
+{
+    CK_SESSION_HANDLE ckSessionHandle;
+    CK_MECHANISM_PTR ckpMechanism = NULL;
+    CK_OBJECT_HANDLE ckKeyHandle;
+    CK_BBOOL retry = FALSE;
+    CK_RV rv = 1;
+
+    CK_FUNCTION_LIST_PTR ckpFunctions = getFunctionList(env, obj);
+    if (ckpFunctions == NULL) { return; }
+
+    ckSessionHandle = jLongToCKULong(jSessionHandle);
+    ckKeyHandle = jLongToCKULong(jKeyHandle);
+    ckpMechanism = jMechanismToCKMechanismPtr(env, jMechanism);
+
+    if ((*env)->ExceptionCheck(env)) { return; }
+
+    // if !useNormVerFirst, then update 'ckpMechanism' in place w/
+    // non-normative GCM params.
+    retry = (!useNormVerFirst && updateGCMParams(env, ckpMechanism) != NULL);
+
+    rv = (*ckpFunctions->C_EncryptInit)(ckSessionHandle, ckpMechanism, ckKeyHandle);
+
+    if (rv == CKR_ARGUMENTS_BAD || rv == CKR_MECHANISM_PARAM_INVALID) {
+        // retry and update 'ckpMechanism' in place w/ normative GCM params.
+        if (retry && updateGCMParams(env, ckpMechanism) != NULL) {
+            TRACE0("DEBUG retry C_EncryptInit\n");
+            rv = (*ckpFunctions->C_EncryptInit)(ckSessionHandle,
+                ckpMechanism, ckKeyHandle);
         }
     }
 
-    TRACE1("DEBUG C_EncryptInit: freed pMech = %p\n", ckpMechanism);
+    TRACE1("DEBUG C_GCMEncryptInitWithRetry: freed pMech = %p\n", ckpMechanism);
     freeCKMechanismPtr(ckpMechanism);
     if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
 
@@ -312,7 +351,6 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1DecryptInit
 {
     CK_SESSION_HANDLE ckSessionHandle;
     CK_MECHANISM_PTR ckpMechanism = NULL;
-    CK_MECHANISM_PTR ckpTemp;
     CK_OBJECT_HANDLE ckKeyHandle;
     CK_RV rv;
 
@@ -330,20 +368,61 @@ Java_sun_security_pkcs11_wrapper_PKCS11_C_1DecryptInit
     rv = (*ckpFunctions->C_DecryptInit)(ckSessionHandle, ckpMechanism,
                                         ckKeyHandle);
 
-    if (ckpMechanism->mechanism == CKM_AES_GCM) {
-        if (rv == CKR_ARGUMENTS_BAD || rv == CKR_MECHANISM_PARAM_INVALID) {
-            // retry with CKM_GCM_PARAMS structure in pkcs11t.h
-            TRACE0("DEBUG C_DecryptInit: retry with CK_GCM_PARAMS\n");
-            ckpTemp = updateGCMParams(env, ckpMechanism);
-            if (ckpTemp != NULL) { // only re-call if conversion succeeds
-                ckpMechanism = ckpTemp;
-                rv = (*ckpFunctions->C_DecryptInit)(ckSessionHandle, ckpMechanism,
-                        ckKeyHandle);
-            }
+    TRACE1("DEBUG C_DecryptInit: freed pMech = %p\n", ckpMechanism);
+    freeCKMechanismPtr(ckpMechanism);
+    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
+
+    TRACE0("FINISHED\n");
+}
+
+/*
+ * Class:     sun_security_pkcs11_wrapper_PKCS11
+ * Method:    C_GCMDecryptInitWithRetry
+ * Signature: (JLsun/security/pkcs11/wrapper/CK_MECHANISM;JZ)V
+ * Parametermapping:                    *PKCS11*
+ * @param   jlong jSessionHandle        CK_SESSION_HANDLE hSession
+ * @param   jobject jMechanism          CK_MECHANISM_PTR pMechanism
+ * @param   jlong jKeyHandle            CK_OBJECT_HANDLE hKey
+ * @param   jboolean useNormVerFirst    CK_BBOOL retry (only retry if the first
+ *                                      init uses the non-normative version)
+ */
+JNIEXPORT void JNICALL
+Java_sun_security_pkcs11_wrapper_PKCS11_C_1GCMDecryptInitWithRetry
+(JNIEnv *env, jobject obj, jlong jSessionHandle,
+ jobject jMechanism, jlong jKeyHandle, jboolean useNormVerFirst)
+{
+    CK_SESSION_HANDLE ckSessionHandle;
+    CK_MECHANISM_PTR ckpMechanism = NULL;
+    CK_OBJECT_HANDLE ckKeyHandle;
+    CK_BBOOL retry = FALSE;
+    CK_RV rv = 1;
+
+    CK_FUNCTION_LIST_PTR ckpFunctions = getFunctionList(env, obj);
+    if (ckpFunctions == NULL) { return; }
+
+    ckSessionHandle = jLongToCKULong(jSessionHandle);
+    ckKeyHandle = jLongToCKULong(jKeyHandle);
+    ckpMechanism = jMechanismToCKMechanismPtr(env, jMechanism);
+
+    if ((*env)->ExceptionCheck(env)) { return; }
+
+    // if !useNormVerFirst, then update 'ckpMechanism' in place w/
+    // non-normative GCM params.
+    retry = (!useNormVerFirst && updateGCMParams(env, ckpMechanism) != NULL);
+
+    rv = (*ckpFunctions->C_DecryptInit)(ckSessionHandle, ckpMechanism,
+        ckKeyHandle);
+
+    if (rv == CKR_ARGUMENTS_BAD || rv == CKR_MECHANISM_PARAM_INVALID) {
+        // retry and update 'ckpMechanism' in place w/ normative GCM params.
+        if (retry && updateGCMParams(env, ckpMechanism) != NULL) {
+            TRACE0("DEBUG retry C_DecryptInit with normative CK_GCM_PARAMS\n");
+            rv = (*ckpFunctions->C_DecryptInit)(ckSessionHandle, ckpMechanism,
+                ckKeyHandle);
         }
     }
 
-    TRACE1("DEBUG C_DecryptInit: freed pMech = %p\n", ckpMechanism);
+    TRACE1("DEBUG C_GCMDecryptInitWithRetry: freed pMech = %p\n", ckpMechanism);
     freeCKMechanismPtr(ckpMechanism);
     if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -329,14 +329,14 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
              tmp = mechPtr->pParameter;
              switch (mechPtr->mechanism) {
                  case CKM_AES_GCM:
-                     if (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS_NO_IVBITS)) {
-                         TRACE0("[ GCM_PARAMS w/o ulIvBits ]\n");
-                         free(((CK_GCM_PARAMS_NO_IVBITS*)tmp)->pIv);
-                         free(((CK_GCM_PARAMS_NO_IVBITS*)tmp)->pAAD);
-                     } else if (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS)) {
+                     if (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS)) {
                          TRACE0("[ GCM_PARAMS ]\n");
                          free(((CK_GCM_PARAMS*)tmp)->pIv);
                          free(((CK_GCM_PARAMS*)tmp)->pAAD);
+                     } else if (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS_NO_IVBITS)) {
+                         TRACE0("[ GCM_PARAMS w/o ulIvBits ]\n");
+                         free(((CK_GCM_PARAMS_NO_IVBITS*)tmp)->pIv);
+                         free(((CK_GCM_PARAMS_NO_IVBITS*)tmp)->pAAD);
                      }
                      break;
                  case CKM_AES_CCM:
@@ -432,43 +432,54 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
      }
 }
 
-/* This function replaces the CK_GCM_PARAMS_NO_IVBITS structure associated
- * with the specified CK_MECHANISM structure with CK_GCM_PARAMS
- * structure.
+/* This function updates the specified CK_MECHANISM structure
+ * and its GCM parameter structure switching between CK_GCM_PARAMS and
+ * CK_GCM_PARAMS_NO_IVBITS.
  *
  * @param mechPtr pointer to the CK_MECHANISM structure containing
- * the to-be-converted CK_GCM_PARAMS_NO_IVBITS structure.
+ * the to-be-converted CK_GCM_PARAMS / CK_GCM_PARAMS_NO_IVBITS structure.
  * @return pointer to the CK_MECHANISM structure containing the
- * converted CK_GCM_PARAMS structure or NULL if no conversion took place.
+ * converted structure or NULL if no conversion is done.
  */
 CK_MECHANISM_PTR updateGCMParams(JNIEnv *env, CK_MECHANISM_PTR mechPtr) {
-    CK_GCM_PARAMS* pGcmParams2 = NULL;
-    CK_GCM_PARAMS_NO_IVBITS* pParams = NULL;
-    if ((mechPtr->mechanism == CKM_AES_GCM) &&
-            (mechPtr->pParameter != NULL_PTR) &&
-            (mechPtr->ulParameterLen == sizeof(CK_GCM_PARAMS_NO_IVBITS))) {
-        pGcmParams2 = calloc(1, sizeof(CK_GCM_PARAMS));
-        if (pGcmParams2 == NULL) {
-            throwOutOfMemoryError(env, 0);
-            return NULL;
+    CK_GCM_PARAMS_PTR pParams;
+    CK_GCM_PARAMS_NO_IVBITS_PTR pParamsNoIvBits;
+    CK_ULONG paramLen;
+
+    if (mechPtr != NULL) {
+        paramLen = mechPtr->ulParameterLen;
+        if (paramLen == sizeof(CK_GCM_PARAMS)) {
+            // CK_GCM_PARAMS => CK_GCM_PARAMS_NO_IVBITS
+            pParams = (CK_GCM_PARAMS*) mechPtr->pParameter;
+            pParamsNoIvBits = calloc(1, sizeof(CK_GCM_PARAMS_NO_IVBITS));
+            pParamsNoIvBits->pIv = pParams->pIv;
+            pParamsNoIvBits->ulIvLen = pParams->ulIvLen;
+            pParamsNoIvBits->pAAD = pParams->pAAD;
+            pParamsNoIvBits->ulAADLen = pParams->ulAADLen;
+            pParamsNoIvBits->ulTagBits = pParams->ulTagBits;
+            mechPtr->pParameter = pParamsNoIvBits;
+            mechPtr->ulParameterLen = sizeof(CK_GCM_PARAMS_NO_IVBITS);
+            free(pParams);
+            TRACE0("DEBUG update CK_GCM_PARAMS to CK_GCM_PARAMS_NO_IVBITS\n");
+            return mechPtr;
+        } else if (paramLen == sizeof(CK_GCM_PARAMS_NO_IVBITS)) {
+            // CK_GCM_PARAMS_NO_IVBITS => CK_GCM_PARAMS
+            pParamsNoIvBits = (CK_GCM_PARAMS_NO_IVBITS*) mechPtr->pParameter;
+            pParams = calloc(1, sizeof(CK_GCM_PARAMS));
+            pParams->pIv = pParamsNoIvBits->pIv;
+            pParams->ulIvLen = pParamsNoIvBits->ulIvLen;
+            pParams->ulIvBits = pParamsNoIvBits->ulIvLen << 3;
+            pParams->pAAD = pParamsNoIvBits->pAAD;
+            pParams->ulAADLen = pParamsNoIvBits->ulAADLen;
+            pParams->ulTagBits = pParamsNoIvBits->ulTagBits;
+            mechPtr->pParameter = pParams;
+            mechPtr->ulParameterLen = sizeof(CK_GCM_PARAMS);
+            free(pParamsNoIvBits);
+            TRACE0("DEBUG update CK_GCM_PARAMS_NO_IVBITS to CK_GCM_PARAMS\n");
+            return mechPtr;
         }
-        pParams = (CK_GCM_PARAMS_NO_IVBITS*) mechPtr->pParameter;
-        pGcmParams2->pIv = pParams->pIv;
-        pGcmParams2->ulIvLen = pParams->ulIvLen;
-        pGcmParams2->ulIvBits = (pGcmParams2->ulIvLen << 3);
-        pGcmParams2->pAAD = pParams->pAAD;
-        pGcmParams2->ulAADLen = pParams->ulAADLen;
-        pGcmParams2->ulTagBits = pParams->ulTagBits;
-        TRACE1("DEBUG updateGCMParams: pMech %p\n", mechPtr);
-        TRACE2("\t=> GCM param w/o ulIvBits %p => GCM param %p\n", pParams,
-                pGcmParams2);
-        free(pParams);
-        mechPtr->pParameter = pGcmParams2;
-        mechPtr->ulParameterLen = sizeof(CK_GCM_PARAMS);
-        return mechPtr;
-    } else {
-        TRACE0("DEBUG updateGCMParams: no conversion done\n");
     }
+    TRACE0("DEBUG updateGCMParams: no conversion done\n");
     return NULL;
 }
 


### PR DESCRIPTION
Backport of [JDK-8261433](https://bugs.openjdk.org/browse/JDK-8261433). p11_util.c needed some manual integration. The rest applies cleanly except Copyright year update. I had to disable `useNormativeMechFirst` because [JDK-8255409](https://bugs.openjdk.org/browse/JDK-8255409) is not in 17u (see 2nd commit). "test/jdk/sun/security/pkcs11" tests have passed. Please review!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8261433](https://bugs.openjdk.org/browse/JDK-8261433) needs maintainer approval

### Issue
 * [JDK-8261433](https://bugs.openjdk.org/browse/JDK-8261433): Better pkcs11 performance for libpkcs11:C_EncryptInit/libpkcs11:C_DecryptInit (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2560/head:pull/2560` \
`$ git checkout pull/2560`

Update a local copy of the PR: \
`$ git checkout pull/2560` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2560`

View PR using the GUI difftool: \
`$ git pr show -t 2560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2560.diff">https://git.openjdk.org/jdk17u-dev/pull/2560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2560#issuecomment-2158692306)