### PR TITLE
7124313: [macosx] Swing Popups should overlap taskbar

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -697,7 +697,6 @@ javax/swing/JTree/4633594/JTreeFocusTest.java 8173125 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
 javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8320944 windows-all
-javax/swing/JPopupMenu/6580930/bug6580930.java 7124313 macosx-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all

--- a/test/jdk/javax/swing/JPopupMenu/6580930/bug6580930.java
+++ b/test/jdk/javax/swing/JPopupMenu/6580930/bug6580930.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,17 +24,26 @@
  * @test
  * @key headful
  * @bug 6580930 7184956
+ * @requires (os.family != "mac")
  * @summary Swing Popups should overlap taskbar
- * @author Alexander Potochkin
  * @library /lib/client
  * @build ExtendedRobot
  * @run main bug6580930
  */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Insets;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
 
 public class bug6580930 {
     private static ExtendedRobot robot;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [532a6ec7](https://github.com/openjdk/jdk/commit/532a6ec7e3a048624b380b38b4611533a7caae18) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 7 Jul 2022 and was reviewed by Sergey Bylokhov and Dmitry Markov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-7124313](https://bugs.openjdk.org/browse/JDK-7124313) needs maintainer approval

### Issue
 * [JDK-7124313](https://bugs.openjdk.org/browse/JDK-7124313): [macosx] Swing Popups should overlap taskbar (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2562/head:pull/2562` \
`$ git checkout pull/2562`

Update a local copy of the PR: \
`$ git checkout pull/2562` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2562`

View PR using the GUI difftool: \
`$ git pr show -t 2562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2562.diff">https://git.openjdk.org/jdk17u-dev/pull/2562.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2562#issuecomment-2159336607)