### PR TITLE
8280392: java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java failed with "RuntimeException: Test failed."

### DIFF
--- a/test/jdk/java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java
+++ b/test/jdk/java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,20 +21,29 @@
  * questions.
  */
 
-/*
-  @test
-  @key headful
-  @bug       6182359
-  @summary   Tests that Window having non-focusable owner can't be a focus owner.
-  @library   ../../regtesthelpers
-  @build     Util
-  @run       main NonfocusableOwnerTest
-*/
-
-import java.awt.*;
-import java.awt.event.*;
 import test.java.awt.regtesthelpers.Util;
 
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.AWTEventListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.WindowEvent;
+
+/*
+ ( @test
+ * @key headful
+ * @bug 6182359
+ * @summary Tests that Window having non-focusable owner can't be a focus owner.
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main NonfocusableOwnerTest
+ */
 public class NonfocusableOwnerTest {
     Robot robot = Util.createRobot();
     Frame frame;
@@ -55,7 +64,7 @@ public class NonfocusableOwnerTest {
                 }
             }, FocusEvent.FOCUS_EVENT_MASK | WindowEvent.WINDOW_FOCUS_EVENT_MASK | WindowEvent.WINDOW_EVENT_MASK);
 
-        frame = new Frame("Frame");
+        frame = new Frame("NonfocusableOwnerTest");
         frame.setName("Frame-owner");
         frame.setBounds(100, 0, 100, 100);
         dialog = new Dialog(frame, "Dialog");
@@ -92,9 +101,11 @@ public class NonfocusableOwnerTest {
 
         owner.setFocusableWindowState(false);
         owner.setVisible(true);
+        robot.waitForIdle();
 
         child.add(button);
         child.setVisible(true);
+        robot.waitForIdle();
 
         Util.waitTillShown(child);
 
@@ -111,12 +122,15 @@ public class NonfocusableOwnerTest {
 
         owner.setFocusableWindowState(false);
         owner.setVisible(true);
+        robot.waitForIdle();
 
         child1.setFocusableWindowState(true);
         child1.setVisible(true);
+        robot.waitForIdle();
 
         child2.add(button);
         child2.setVisible(true);
+        robot.waitForIdle();
 
         Util.waitTillShown(child2);
 
@@ -134,13 +148,16 @@ public class NonfocusableOwnerTest {
 
         owner.setFocusableWindowState(true);
         owner.setVisible(true);
+        robot.waitForIdle();
 
         child1.setFocusableWindowState(false);
         child1.setVisible(true);
+        robot.waitForIdle();
 
         child2.setFocusableWindowState(true);
         child2.add(button);
         child2.setVisible(true);
+        robot.waitForIdle();
 
         Util.waitTillShown(child2);
 


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.
java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64
not in problem.txt  make it clean

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8280392](https://bugs.openjdk.org/browse/JDK-8280392) needs maintainer approval

### Issue
 * [JDK-8280392](https://bugs.openjdk.org/browse/JDK-8280392): java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java failed with "RuntimeException: Test failed." (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2564/head:pull/2564` \
`$ git checkout pull/2564`

Update a local copy of the PR: \
`$ git checkout pull/2564` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2564`

View PR using the GUI difftool: \
`$ git pr show -t 2564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2564.diff">https://git.openjdk.org/jdk17u-dev/pull/2564.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2564#issuecomment-2159856127)