### PR TITLE
8333716: Shenandoah: Check for disarmed method before taking the nmethod lock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -36,13 +36,19 @@
 #include "runtime/threadWXSetters.inline.hpp"
 
 bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
+  if (!is_armed(nm)) {
+    // Some other thread got here first and healed the oops
+    // and disarmed the nmethod. No need to continue.
+    return true;
+  }
+
   ShenandoahReentrantLock* lock = ShenandoahNMethod::lock_for_nmethod(nm);
   assert(lock != NULL, "Must be");
   ShenandoahReentrantLocker locker(lock);
 
   if (!is_armed(nm)) {
-    // Some other thread got here first and healed the oops
-    // and disarmed the nmethod.
+    // Some other thread managed to complete while we were
+    // waiting for lock. No need to continue.
     return true;
   }
 


### PR DESCRIPTION
**Notes**
JDK 17 backport for [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716).

We are spending significant time on acquiring the per-nmethod as all the
threads are in same nmethod.
Adding double-check lock by calling is_armed before lock acquisition.

**Verification**
1. hotspot_gc and  hotspot_gc_shenandoah tests

2. Benchmarking on [c6a.12xlarge](https://aws.amazon.com/ec2/instance-types/c6a/)
**Prior to this PR:**

```
dev-dsk-neethp-jdk-2c-ad54955c % jdk17u-dev/build/linux-x86_64-server-release/images/jdk/bin/java -Xmx1g -Xms1g -XX:+UseShenandoahGC -Xlog:gc ManyThreadsStacks.java 2>&1 | grep "marking roots"
[0.662s][info][gc] GC(0) Concurrent marking roots 86.390ms
[0.786s][info][gc] GC(1) Concurrent marking roots 100.924ms
[0.892s][info][gc] GC(2) Concurrent marking roots 86.194ms
[1.005s][info][gc] GC(3) Concurrent marking roots 91.148ms
[1.127s][info][gc] GC(4) Concurrent marking roots 105.993ms
[1.338s][info][gc] GC(5) Concurrent marking roots 105.688ms
[1.524s][info][gc] GC(6) Concurrent marking roots 100.296ms
[1.700s][info][gc] GC(7) Concurrent marking roots 100.837ms
[1.867s][info][gc] GC(8) Concurrent marking roots 86.750ms
[2.019s][info][gc] GC(9) Concurrent marking roots 90.834ms
[2.184s][info][gc] GC(10) Concurrent marking roots 95.014ms
[2.353s][info][gc] GC(11) Concurrent marking roots 96.484ms
[2.522s][info][gc] GC(12) Concurrent marking roots 99.743ms
[2.679s][info][gc] GC(13) Concurrent marking roots 91.842ms
[2.847s][info][gc] GC(14) Concurrent marking roots 101.321ms
[3.005s][info][gc] GC(15) Concurrent marking roots 89.214ms
[3.159s][info][gc] GC(16) Concurrent marking roots 90.958ms
[3.324s][info][gc] GC(17) Concurrent marking roots 92.622ms
```

**After:**

```
dev-dsk-neethp-jdk-2c-ad54955c % jdk17u-dev/build/linux-x86_64-server-release/images/jdk/bin/java -Xmx1g -Xms1g -XX:+UseShenandoahGC -Xlog:gc ManyThreadsStacks.java 2>&1 | grep "marking roots"  
[0.904s][info][gc] GC(0) Concurrent marking roots 6.698ms
[0.934s][info][gc] GC(1) Concurrent marking roots 6.004ms
[0.961s][info][gc] GC(2) Concurrent marking roots 5.089ms
[0.986s][info][gc] GC(3) Concurrent marking roots 5.134ms
[1.020s][info][gc] GC(4) Concurrent marking roots 4.797ms
[1.252s][info][gc] GC(5) Concurrent marking roots 5.856ms
[1.335s][info][gc] GC(6) Concurrent marking roots 4.467ms
[1.417s][info][gc] GC(7) Concurrent marking roots 4.963ms
[1.498s][info][gc] GC(8) Concurrent marking roots 5.005ms
[1.579s][info][gc] GC(9) Concurrent marking roots 5.354ms
[1.660s][info][gc] GC(10) Concurrent marking roots 5.297ms
[1.737s][info][gc] GC(11) Concurrent marking roots 5.166ms
[1.813s][info][gc] GC(12) Concurrent marking roots 4.784ms
[1.885s][info][gc] GC(13) Concurrent marking roots 5.444ms
[1.956s][info][gc] GC(14) Concurrent marking roots 4.261ms
[2.031s][info][gc] GC(15) Concurrent marking roots 4.438ms
[2.104s][info][gc] GC(16) Concurrent marking roots 4.127ms
[2.175s][info][gc] GC(17) Concurrent marking roots 4.536ms
[2.246s][info][gc] GC(18) Concurrent marking roots 4.811ms
[2.316s][info][gc] GC(19) Concurrent marking roots 4.457ms
[2.387s][info][gc] GC(20) Concurrent marking roots 4.320ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716) needs maintainer approval

### Issue
 * [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716): Shenandoah: Check for disarmed method before taking the nmethod lock (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2568/head:pull/2568` \
`$ git checkout pull/2568`

Update a local copy of the PR: \
`$ git checkout pull/2568` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2568`

View PR using the GUI difftool: \
`$ git pr show -t 2568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2568.diff">https://git.openjdk.org/jdk17u-dev/pull/2568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2568#issuecomment-2161446343)