### PR TITLE
8293862: javax/swing/JFileChooser/8046391/bug8046391.java failed with 'Cannot invoke "java.awt.Image.getWidth(java.awt.image.ImageObserver)" because "retVal" is null'

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -1137,6 +1137,14 @@ final class Win32ShellFolder2 extends ShellFolder {
     }
 
     /**
+     * The data is not available yet.
+     * @see
+     * <a href="https://learn.microsoft.com/en-us/windows/win32/com/com-error-codes-1">COM
+     * Error Codes</a>.
+     */
+    private static final long E_PENDING = 0x8000000AL;
+
+    /**
      * @return The icon image of specified size used to display this shell folder
      */
     public Image getIcon(int width, int height) {
@@ -1161,10 +1169,10 @@ final class Win32ShellFolder2 extends ShellFolder {
                             getRelativePIDL(), s, false);
 
                     // E_PENDING: loading can take time so get the default
-                    if (hIcon <= 0) {
+                    if (hIcon == E_PENDING || hIcon == 0) {
                         hIcon = extractIcon(getParentIShellFolder(),
                                 getRelativePIDL(), s, true);
-                        if (hIcon <= 0) {
+                        if (hIcon == 0) {
                             if (isDirectory()) {
                                 newIcon = getShell32Icon(FOLDER_ICON_ID, size);
                             } else {
@@ -1404,11 +1412,14 @@ final class Win32ShellFolder2 extends ShellFolder {
         final Map<Integer, Image> resolutionVariants = new HashMap<>();
 
         public MultiResolutionIconImage(int baseSize, Map<Integer, Image> resolutionVariants) {
+            assert !resolutionVariants.containsValue(null)
+                   : "There are null icons in the MRI variants map";
             this.baseSize = baseSize;
             this.resolutionVariants.putAll(resolutionVariants);
         }
 
         public MultiResolutionIconImage(int baseSize, Image image) {
+            assert image != null : "Null icon passed as the base image for MRI";
             this.baseSize = baseSize;
             this.resolutionVariants.put(baseSize, image);
         }

--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -974,7 +974,7 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_extractIcon
         return 0;
     }
 
-    HICON hIcon = NULL;
+    HICON hIcon;
 
     HRESULT hres;
     IExtractIconW* pIcon;
@@ -995,15 +995,21 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_extractIcon
                 iconSize = (16 << 16) + size;
             }
             hres = pIcon->Extract(szBuf, index, &hIcon, &hIconSmall, iconSize);
-            if (size < 24) {
-                fn_DestroyIcon((HICON)hIcon);
-                hIcon = hIconSmall;
+            if (SUCCEEDED(hres)) {
+                if (size < 24) {
+                    fn_DestroyIcon((HICON)hIcon);
+                    hIcon = hIconSmall;
+                } else {
+                    fn_DestroyIcon((HICON)hIconSmall);
+                }
             } else {
-                fn_DestroyIcon((HICON)hIconSmall);
+                hIcon = NULL;
             }
         } else if (hres == E_PENDING) {
             pIcon->Release();
-            return E_PENDING;
+            return (unsigned) E_PENDING;
+        } else {
+            hIcon = NULL;
         }
         pIcon->Release();
     }

--- a/test/jdk/javax/swing/JFileChooser/8046391/bug8046391.java
+++ b/test/jdk/javax/swing/JFileChooser/8046391/bug8046391.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8046391
+ * @bug 8046391 8293862
  * @requires (os.family == "windows")
  * @summary JFileChooser hangs if displayed in Windows L&F
  * @author Alexey Ivanov


### PR DESCRIPTION
Backport of [JDK-8293862](https://bugs.openjdk.org/browse/JDK-8293862)
- The changes on the file `test/jdk/ProblemList.txt` is not included because on `17` the lines are not there
- All other files are generated by git `patch` command so they are `clean`
- So this PR can be `considered as clean`

Testing
- Local test on Windows: 
  - `bug8046391.java`: Test results: passed: 1
```
Processor	12th Gen Intel(R) Core(TM) i7-12800H   2.40 GHz
Installed RAM	64.0 GB (63.7 GB usable)
System type	64-bit operating system, x64-based processor

Edition: Windows 11 Enterprise
Version: 23H2
Installed on: 5/10/2023
OS build: 22631.3155
Experience: Windows Feature Experience Pack 1000.22684.1000.0
```

- Pipeline: **All checks have passed**
- Testing Machine: Not Applicable: Skipped
  - `jtreg_jdk_tier4`: javax/swing/JFileChooser/8046391/bug8046391.java: `SKIPPED` [Filter: Composite Filter - Filtered out by a composite filter.] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8293862](https://bugs.openjdk.org/browse/JDK-8293862) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293862](https://bugs.openjdk.org/browse/JDK-8293862): javax/swing/JFileChooser/8046391/bug8046391.java failed with 'Cannot invoke "java.awt.Image.getWidth(java.awt.image.ImageObserver)" because "retVal" is null' (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2570/head:pull/2570` \
`$ git checkout pull/2570`

Update a local copy of the PR: \
`$ git checkout pull/2570` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2570`

View PR using the GUI difftool: \
`$ git pr show -t 2570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2570.diff">https://git.openjdk.org/jdk17u-dev/pull/2570.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2570#issuecomment-2162179501)