### PR TITLE
8272777: Clean up remaining AccessController warnings in test library

### DIFF
--- a/test/lib/jdk/test/lib/SA/SATestUtils.java
+++ b/test/lib/jdk/test/lib/SA/SATestUtils.java
@@ -159,6 +159,7 @@ public class SATestUtils {
      * if we are root, so return true.  Then return false for an expected denial
      * if "ptrace_scope" is 1, and true otherwise.
      */
+    @SuppressWarnings("removal")
     private static boolean canPtraceAttachLinux() throws IOException {
         // SELinux deny_ptrace:
         var deny_ptrace = Paths.get("/sys/fs/selinux/booleans/deny_ptrace");

--- a/test/lib/jdk/test/lib/net/IPSupport.java
+++ b/test/lib/jdk/test/lib/net/IPSupport.java
@@ -87,6 +87,7 @@ public class IPSupport {
         }
     }
 
+    @SuppressWarnings("removal")
     private static <T> T runPrivilegedAction(Callable<T> callable) {
         try {
             PrivilegedExceptionAction<T> pa = () -> callable.call();

--- a/test/lib/jdk/test/lib/net/SimpleSSLContext.java
+++ b/test/lib/jdk/test/lib/net/SimpleSSLContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ public class SimpleSSLContext {
         this(() -> "TLS");
     }
 
+    @SuppressWarnings("removal")
     private SimpleSSLContext(Supplier<String> protocols) throws IOException {
         try {
             final String proto = protocols.get();


### PR DESCRIPTION
Backport of [JDK-8272777](https://bugs.openjdk.org/browse/JDK-8272777)

Testing
- Local: Not Applicable
```
Error: Cannot determine test suite from test (is TEST.ROOT missing?): github.com/dev-8272777-17/test/lib/jdk/test/lib/SA/SATestUtils.java
Error: Cannot determine test suite from test (is TEST.ROOT missing?): github.com/dev-8272777-17/test/lib/jdk/test/lib/net/IPSupport.java
Error: Cannot determine test suite from test (is TEST.ROOT missing?): github.com/dev-8272777-17/test/lib/jdk/test/lib/net/SimpleSSLContext.java
```

- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-18,19,20`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8272777](https://bugs.openjdk.org/browse/JDK-8272777) needs maintainer approval

### Issue
 * [JDK-8272777](https://bugs.openjdk.org/browse/JDK-8272777): Clean up remaining AccessController warnings in test library (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2573/head:pull/2573` \
`$ git checkout pull/2573`

Update a local copy of the PR: \
`$ git checkout pull/2573` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2573`

View PR using the GUI difftool: \
`$ git pr show -t 2573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2573.diff">https://git.openjdk.org/jdk17u-dev/pull/2573.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2573#issuecomment-2163801639)