### PR TITLE
8317831: compiler/codecache/CheckLargePages.java fails on OL 8.8 with unexpected memory string

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -67,6 +67,7 @@ compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
 
 compiler/onSpinWait/TestOnSpinWaitAArch64DefaultFlags.java 8277503 linux-aarch64
 
+compiler/codecache/CheckLargePages.java 8319795 linux-x64
 
 #############################################################################
 

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -62,7 +62,7 @@ public class CheckLargePages {
             out.shouldMatch("Code cache size too small for \\S* pages\\. Reverting to smaller page size \\((\\S*)\\)\\.");
             out.shouldHaveExitValue(0);
             // Parse page sizes to find next biggest page
-            String sizes = out.firstMatch("Usable page sizes:(.*)", 1);
+            String sizes = out.firstMatch("Usable page sizes:([^.]+)", 1);
             List<Long> sizeList = Arrays.stream(sizes.trim().split("\\s*,\\s*")).map(CheckLargePages::parseMemoryString).sorted().toList();
             final int smallerPageSizeIndex = sizeList.indexOf(largePageSize) - 1;
             Asserts.assertGreaterThanOrEqual(smallerPageSizeIndex, 0);


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

due to JDK-8318482 is not backported, so add 'compiler/codecache/CheckLargePages.java 8319795 linux-x64' in problemList.txt

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317831](https://bugs.openjdk.org/browse/JDK-8317831) needs maintainer approval

### Issue
 * [JDK-8317831](https://bugs.openjdk.org/browse/JDK-8317831): compiler/codecache/CheckLargePages.java fails on OL 8.8 with unexpected memory string (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2576/head:pull/2576` \
`$ git checkout pull/2576`

Update a local copy of the PR: \
`$ git checkout pull/2576` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2576`

View PR using the GUI difftool: \
`$ git pr show -t 2576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2576.diff">https://git.openjdk.org/jdk17u-dev/pull/2576.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2576#issuecomment-2164488159)