### PR TITLE
8269428: java/util/concurrent/ConcurrentHashMap/ToArray.java timed out

### DIFF
--- a/test/jdk/java/util/concurrent/ConcurrentHashMap/ToArray.java
+++ b/test/jdk/java/util/concurrent/ConcurrentHashMap/ToArray.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -46,7 +47,8 @@ public class ToArray {
     }
 
     static void executeTest() throws Throwable {
-        try (ExecutorService executor = Executors.newCachedThreadPool()) {
+        ExecutorService executor = Executors.newCachedThreadPool();
+        try {
             final ConcurrentHashMap<Integer, Integer> m = new ConcurrentHashMap<>();
             final ThreadLocalRandom rnd = ThreadLocalRandom.current();
             final int nCPU = Runtime.getRuntime().availableProcessors();
@@ -99,6 +101,8 @@ public class ToArray {
             // Wait for workers and foreman to complete
             workers.forEach(CompletableFuture<?>::join);
             foreman.join();
+        } finally {
+            executor.shutdown();
         }
     }
 }

--- a/test/jdk/java/util/concurrent/ConcurrentHashMap/ToArray.java
+++ b/test/jdk/java/util/concurrent/ConcurrentHashMap/ToArray.java
@@ -46,7 +46,7 @@ public class ToArray {
     }
 
     static void executeTest() throws Throwable {
-        try (var executor = Executors.newCachedThreadPool()) {
+        try (ExecutorService executor = Executors.newCachedThreadPool()) {
             final ConcurrentHashMap<Integer, Integer> m = new ConcurrentHashMap<>();
             final ThreadLocalRandom rnd = ThreadLocalRandom.current();
             final int nCPU = Runtime.getRuntime().availableProcessors();


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.
‘ try (var executor = Executors.newCachedThreadPool())’ is modified due to it's not supported in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8269428](https://bugs.openjdk.org/browse/JDK-8269428) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269428](https://bugs.openjdk.org/browse/JDK-8269428): java/util/concurrent/ConcurrentHashMap/ToArray.java timed out (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2577/head:pull/2577` \
`$ git checkout pull/2577`

Update a local copy of the PR: \
`$ git checkout pull/2577` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2577`

View PR using the GUI difftool: \
`$ git pr show -t 2577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2577.diff">https://git.openjdk.org/jdk17u-dev/pull/2577.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2577#issuecomment-2164836868)