### PR TITLE
8305081: Remove finalize() from test/hotspot/jtreg/compiler/runtime/Test8168712

### DIFF
--- a/test/hotspot/jtreg/compiler/runtime/Test8168712.java
+++ b/test/hotspot/jtreg/compiler/runtime/Test8168712.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,20 +48,31 @@
  */
 package compiler.runtime;
 
+import java.lang.ref.Cleaner;
 import java.util.*;
 
 public class Test8168712 {
     static HashSet<Test8168712> m = new HashSet<>();
+
+    // One cleaner thread for cleaning all the instances. Otherwise, we get OOME.
+    static Cleaner cleaner = Cleaner.create();
+
+    public Test8168712() {
+        cleaner.register(this, () -> cleanup());
+    }
+
     public static void main(String args[]) {
         int i = 0;
         while (i++<15000) {
             test();
         }
     }
+
     static Test8168712 test() {
         return new Test8168712();
     }
-    protected void finalize() {
+
+    public void cleanup() {
         m.add(this);
     }
 }


### PR DESCRIPTION
Backport of [JDK-8305081](https://bugs.openjdk.org/browse/JDK-8305081)

Testing
- Local: Test passed on MacOS 14.5
  - `Test8168712.java`: Test results: passed: 2
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies passed on `2024-06-20`
  - `jtreg_hotspot_tier1`
    - compiler/runtime/Test8168712.java#with-dtrace: `SKIPPED` [Filter: Composite Filter - Filtered out by a composite filter.] GitHub 📊 - [0 msec]
    - compiler/runtime/Test8168712.java#without-dtrace: `SUCCESSFUL` GitHub 📊⏲ - [860 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8305081](https://bugs.openjdk.org/browse/JDK-8305081) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305081](https://bugs.openjdk.org/browse/JDK-8305081): Remove finalize() from test/hotspot/jtreg/compiler/runtime/Test8168712 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2585/head:pull/2585` \
`$ git checkout pull/2585`

Update a local copy of the PR: \
`$ git checkout pull/2585` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2585`

View PR using the GUI difftool: \
`$ git pr show -t 2585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2585.diff">https://git.openjdk.org/jdk17u-dev/pull/2585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2585#issuecomment-2167198372)