### PR TITLE
8325621: Improve jspawnhelper version checks

### DIFF
--- a/make/modules/java.base/Launcher.gmk
+++ b/make/modules/java.base/Launcher.gmk
@@ -78,7 +78,8 @@ ifeq ($(call isTargetOs, macosx aix linux), true)
       NAME := jspawnhelper, \
       SRC := $(TOPDIR)/src/$(MODULE)/unix/native/jspawnhelper, \
       OPTIMIZATION := LOW, \
-      CFLAGS := $(CFLAGS_JDKEXE) -I$(TOPDIR)/src/$(MODULE)/unix/native/libjava, \
+      CFLAGS := $(CFLAGS_JDKEXE) $(VERSION_CFLAGS) \
+          -I$(TOPDIR)/src/$(MODULE)/unix/native/libjava, \
       EXTRA_OBJECT_FILES := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjava/childproc.o, \
       LDFLAGS := $(LDFLAGS_JDKEXE), \
       OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/modules_libs/$(MODULE), \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -92,6 +92,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     CFLAGS := $(CFLAGS_JDKLIB) \
         $(LIBJAVA_CFLAGS), \
     jdk_util.c_CFLAGS := $(VERSION_CFLAGS), \
+    ProcessImpl_md.c_CFLAGS := $(VERSION_CFLAGS), \
     EXTRA_HEADER_DIRS := libfdlibm, \
     WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc := unused-result unused-function, \

--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -28,6 +28,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -49,6 +50,10 @@ extern int errno;
 #define ERR_PIPE 2
 #define ERR_ARGS 3
 
+#ifndef VERSION_STRING
+#error VERSION_STRING must be defined
+#endif
+
 void error (int fd, int err) {
     if (write (fd, &err, sizeof(err)) != sizeof(err)) {
         /* Not sure what to do here. I have no one to speak to. */
@@ -58,6 +63,7 @@ void error (int fd, int err) {
 }
 
 void shutItDown() {
+    fprintf(stdout, "jspawnhelper version %s\n", VERSION_STRING);
     fprintf(stdout, "This command is not for general use and should ");
     fprintf(stdout, "only be run as the result of a call to\n");
     fprintf(stdout, "ProcessBuilder.start() or Runtime.exec() in a java ");
@@ -143,19 +149,29 @@ int main(int argc, char *argv[]) {
     /* argv[1] contains the fd number to read all the child info */
     int r, fdinr, fdinw, fdout;
 
-    if (argc != 2) {
-        shutItDown();
-    }
-
 #ifdef DEBUG
     jtregSimulateCrash(0, 4);
 #endif
-    r = sscanf (argv[1], "%d:%d:%d", &fdinr, &fdinw, &fdout);
+
+    if (argc != 3) {
+        fprintf(stdout, "Incorrect number of arguments: %d\n", argc);
+        shutItDown();
+    }
+
+    if (strcmp(argv[1], VERSION_STRING) != 0) {
+        fprintf(stdout, "Incorrect Java version: %s\n", argv[1]);
+        shutItDown();
+    }
+
+    r = sscanf (argv[2], "%d:%d:%d", &fdinr, &fdinw, &fdout);
     if (r == 3 && fcntl(fdinr, F_GETFD) != -1 && fcntl(fdinw, F_GETFD) != -1) {
         fstat(fdinr, &buf);
-        if (!S_ISFIFO(buf.st_mode))
+        if (!S_ISFIFO(buf.st_mode)) {
+            fprintf(stdout, "Incorrect input pipe\n");
             shutItDown();
+        }
     } else {
+        fprintf(stdout, "Incorrect FD array data: %s\n", argv[2]);
         shutItDown();
     }
     // Close the writing end of the pipe we use for reading from the parent.

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -300,6 +300,10 @@ Java_java_lang_ProcessImpl_init(JNIEnv *env, jclass clazz)
 #define WTERMSIG(status) ((status)&0x7F)
 #endif
 
+#ifndef VERSION_STRING
+#error VERSION_STRING must be defined
+#endif
+
 static const char *
 getBytes(JNIEnv *env, jbyteArray arr)
 {
@@ -491,7 +495,7 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     jboolean isCopy;
     int i, offset, rval, bufsize, magic;
     char *buf, buf1[(3 * 11) + 3]; // "%d:%d:%d\0"
-    char *hlpargs[3];
+    char *hlpargs[4];
     SpawnInfo sp;
 
     /* need to tell helper which fd is for receiving the childstuff
@@ -500,11 +504,13 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     snprintf(buf1, sizeof(buf1), "%d:%d:%d", c->childenv[0], c->childenv[1], c->fail[1]);
     /* NULL-terminated argv array.
      * argv[0] contains path to jspawnhelper, to follow conventions.
-     * argv[1] contains the fd string as argument to jspawnhelper
+     * argv[1] contains the version string as argument to jspawnhelper
+     * argv[2] contains the fd string as argument to jspawnhelper
      */
     hlpargs[0] = (char*)helperpath;
-    hlpargs[1] = buf1;
-    hlpargs[2] = NULL;
+    hlpargs[1] = VERSION_STRING;
+    hlpargs[2] = buf1;
+    hlpargs[3] = NULL;
 
     /* Following items are sent down the pipe to the helper
      * after it is spawned.

--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
@@ -25,7 +25,7 @@
 
 /*
  * @test
- * @bug 8325567
+ * @bug 8325567 8325621
  * @requires (os.family == "linux") | (os.family == "aix") | (os.family == "mac")
  * @library /test/lib
  * @run driver JspawnhelperWarnings
@@ -47,11 +47,30 @@ public class JspawnhelperWarnings {
         OutputAnalyzer oa = new OutputAnalyzer(p);
         oa.shouldHaveExitValue(1);
         oa.shouldContain("This command is not for general use");
+        if (nArgs != 2) {
+            oa.shouldContain("Incorrect number of arguments");
+        } else {
+            oa.shouldContain("Incorrect Java version");
+        }
+    }
+
+    private static void testVersion() throws Exception {
+        String[] args = new String[3];
+        args[0] = Paths.get(System.getProperty("java.home"), "lib", "jspawnhelper").toString();
+        args[1] = "wrongVersion";
+        args[2] = "1:1:1";
+        Process p = ProcessTools.startProcess("jspawnhelper", new ProcessBuilder(args));
+        OutputAnalyzer oa = new OutputAnalyzer(p);
+        oa.shouldHaveExitValue(1);
+        oa.shouldContain("This command is not for general use");
+        oa.shouldContain("Incorrect Java version: wrongVersion");
     }
 
     public static void main(String[] args) throws Exception {
         for (int nArgs = 0; nArgs < 10; nArgs++) {
             tryWithNArgs(nArgs);
         }
+
+        testVersion();
     }
 }


### PR DESCRIPTION
Backport [JDK-8325621](https://bugs.openjdk.org/browse/JDK-8325621)

Clean backport to update jspawnhelper to check that JDK version and jspawnhelper version are the same. Updates test to include check for version. Updated test passes. Already backported to 21 and 22. Risk is low: touches the production code paths but only passes an additional argument to jspawnhelper.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325621](https://bugs.openjdk.org/browse/JDK-8325621) needs maintainer approval

### Issue
 * [JDK-8325621](https://bugs.openjdk.org/browse/JDK-8325621): Improve jspawnhelper version checks (**Enhancement** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2592/head:pull/2592` \
`$ git checkout pull/2592`

Update a local copy of the PR: \
`$ git checkout pull/2592` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2592`

View PR using the GUI difftool: \
`$ git pr show -t 2592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2592.diff">https://git.openjdk.org/jdk17u-dev/pull/2592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2592#issuecomment-2168961595)