### PR TITLE
8285497: Add system property for Java SE specification maintenance version

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -726,6 +726,9 @@ public final class System {
      *     <td>Java Runtime Environment specification version, whose value is
      *     the {@linkplain Runtime.Version#feature feature} element of the
      *     {@linkplain Runtime#version() runtime version}</td></tr>
+     * <tr><th scope="row">{@systemProperty java.specification.maintenance.version}</th>
+     *     <td>Java Runtime Environment specification maintenance version,
+     *     may be interpreted as a positive integer <em>(optional, see below)</em></td></tr>
      * <tr><th scope="row">{@systemProperty java.specification.vendor}</th>
      *     <td>Java Runtime Environment specification  vendor</td></tr>
      * <tr><th scope="row">{@systemProperty java.specification.name}</th>
@@ -764,6 +767,16 @@ public final class System {
      *     the user's settings. Setting this system property has no effect.</td></tr>
      * </tbody>
      * </table>
+     * <p>
+     * The {@code java.specification.maintenance.version} property is
+     * defined if the specification implemented by this runtime at the
+     * time of its construction had undergone a <a
+     * href="https://jcp.org/en/procedures/jcp2#3.6.4">maintenance
+     * release</a>. When defined, its value identifies that
+     * maintenance release. To indicate the first maintenance release
+     * this property will have the value {@code "1"}, to indicate the
+     * second maintenance release this property will have the value
+     * {@code "2"}, and so on.
      * <p>
      * Multiple paths in a system property value are separated by the path
      * separator character of the platform.

--- a/src/java.base/share/classes/java/lang/VersionProps.java.template
+++ b/src/java.base/share/classes/java/lang/VersionProps.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,6 +109,7 @@ class VersionProps {
         props.put("java.class.version", CLASSFILE_MAJOR_MINOR);
 
         props.put("java.specification.version", VERSION_SPECIFICATION);
+        props.put("java.specification.maintenance.version", "1");
         props.put("java.specification.name", "Java Platform API Specification");
         props.put("java.specification.vendor", "Oracle Corporation");
 

--- a/src/java.base/share/classes/sun/security/provider/PolicyFile.java
+++ b/src/java.base/share/classes/sun/security/provider/PolicyFile.java
@@ -615,6 +615,9 @@ public class PolicyFile extends java.security.Policy {
                                 ("java.specification.version",
                                     SecurityConstants.PROPERTY_READ_ACTION));
                 pe.add(new PropertyPermission
+                                ("java.specification.maintenance.version",
+                                    SecurityConstants.PROPERTY_READ_ACTION));
+                pe.add(new PropertyPermission
                                 ("java.specification.vendor",
                                     SecurityConstants.PROPERTY_READ_ACTION));
                 pe.add(new PropertyPermission

--- a/src/java.base/share/conf/security/java.policy
+++ b/src/java.base/share/conf/security/java.policy
@@ -30,6 +30,8 @@ grant {
     permission java.util.PropertyPermission "line.separator", "read";
     permission java.util.PropertyPermission
                    "java.specification.version", "read";
+    permission java.util.PropertyPermission
+                   "java.specification.maintenance.version", "read";
     permission java.util.PropertyPermission "java.specification.vendor", "read";
     permission java.util.PropertyPermission "java.specification.name", "read";
     permission java.util.PropertyPermission


### PR DESCRIPTION
Please review this PR which is a backport of https://github.com/openjdk/jdk17u-ri/commit/c2c9e7fb8c857e40bc43b4053c2633825d4fb68e
This change adds the `"java.specification.maintenance.version"` system property with a value of 1.
Associated GHA run: https://github.com/justin-curtis-lu/jdk17u-dev/actions/runs/9553139534

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8330418](https://bugs.openjdk.org/browse/JDK-8330418) to be approved
- [x] [JDK-8285497](https://bugs.openjdk.org/browse/JDK-8285497) needs maintainer approval

### Issues
 * [JDK-8285497](https://bugs.openjdk.org/browse/JDK-8285497): Add system property for Java SE specification maintenance version (**Enhancement** - P4 - Approved)
 * [JDK-8330418](https://bugs.openjdk.org/browse/JDK-8330418): Add system property for Java SE specification maintenance version (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2598/head:pull/2598` \
`$ git checkout pull/2598`

Update a local copy of the PR: \
`$ git checkout pull/2598` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2598`

View PR using the GUI difftool: \
`$ git pr show -t 2598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2598.diff">https://git.openjdk.org/jdk17u-dev/pull/2598.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2598#issuecomment-2174393513)