### PR TITLE
8325754: Dead AbstractQueuedSynchronizer$ConditionNodes survive minor garbage collections

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -1080,13 +1080,18 @@ public abstract class AbstractQueuedLongSynchronizer
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null)
                     lastWaiter = null;
+                else
+                    first.nextWaiter = null; // GC assistance
+
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
                     enqueue(first);
                     if (!all)
                         break;
                 }
+
                 first = next;
             }
         }

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -1448,13 +1448,18 @@ public abstract class AbstractQueuedSynchronizer
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null)
                     lastWaiter = null;
+                else
+                    first.nextWaiter = null; // GC assistance
+
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
                     enqueue(first);
                     if (!all)
                         break;
                 }
+
                 first = next;
             }
         }


### PR DESCRIPTION
**Notes**
Backport of [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754).

Unlink 'ConditionNode' before they are transferred to the sync queue as G1 seems to be able to collect “dead” ConditionNode instances during minor collections only if no formerly alive ConditionNode instances were promoted to the old generation and died there, which often cannot be avoided since e.g. on application startup many objects are promoted to the old generation after a few collections.

**Verification**

* jdk_util, Tier 1 & Tier 2 tests passed.
* Ran G1LoiteringConditionNodes.java (sample code from bug description) and verified that YG GC time is not increasing after full GC.

_Before PR_

```
dev-dsk-neethp-jdk-2c-ad54955c % /home/neethp/Development/jdk17u-dev/build/linux-x86_64-server-release/images/jdk/bin/java -Xms2048m -Xmx2048m -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=20 '-Xlog:gc*,gc+age*=trace' -cp . G1LoiteringConditionNodes | grep -E 'Pause.*ms'
[0.960s][info ][gc          ] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 102M->1M(2048M) 5.290ms
[2.485s][info ][gc          ] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 149M->1M(2048M) 2.288ms
[6.805s][info ][gc          ] GC(2) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.393ms
[11.165s][info ][gc          ] GC(3) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.603ms
[15.544s][info ][gc          ] GC(4) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.462ms
[19.955s][info ][gc          ] GC(5) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.382ms
[24.369s][info ][gc          ] GC(6) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.246ms
[28.790s][info ][gc          ] GC(7) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.443ms
[33.211s][info ][gc          ] GC(8) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.331ms
[37.639s][info ][gc          ] GC(9) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.319ms
[42.066s][info ][gc          ] GC(10) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.629ms
[46.515s][info ][gc          ] GC(11) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.334ms
[50.957s][info ][gc          ] GC(12) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.280ms
[55.382s][info ][gc          ] GC(13) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.413ms
[59.830s][info ][gc          ] GC(14) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.061ms
[60.055s][info ][gc             ] GC(15) Pause Full (System.gc()) 26M->1M(2048M) 10.780ms
[64.482s][info ][gc             ] GC(16) Pause Young (Normal) (G1 Evacuation Pause) 410M->2M(2048M) 3.663ms
[68.893s][info ][gc             ] GC(17) Pause Young (Normal) (G1 Evacuation Pause) 410M->2M(2048M) 4.008ms
[73.297s][info ][gc             ] GC(18) Pause Young (Normal) (G1 Evacuation Pause) 409M->3M(2048M) 4.131ms
[77.699s][info ][gc             ] GC(19) Pause Young (Normal) (G1 Evacuation Pause) 410M->3M(2048M) 4.188ms
[82.106s][info ][gc             ] GC(20) Pause Young (Normal) (G1 Evacuation Pause) 410M->3M(2048M) 5.016ms
[86.509s][info ][gc             ] GC(21) Pause Young (Normal) (G1 Evacuation Pause) 409M->4M(2048M) 4.563ms
[90.907s][info ][gc             ] GC(22) Pause Young (Normal) (G1 Evacuation Pause) 410M->4M(2048M) 4.976ms
[95.292s][info ][gc             ] GC(23) Pause Young (Normal) (G1 Evacuation Pause) 409M->5M(2048M) 5.171ms
[99.671s][info ][gc             ] GC(24) Pause Young (Normal) (G1 Evacuation Pause) 410M->5M(2048M) 5.279ms
[104.050s][info ][gc             ] GC(25) Pause Young (Normal) (G1 Evacuation Pause) 410M->6M(2048M) 5.496ms
[108.418s][info ][gc             ] GC(26) Pause Young (Normal) (G1 Evacuation Pause) 410M->6M(2048M) 6.194ms
[112.784s][info ][gc             ] GC(27) Pause Young (Normal) (G1 Evacuation Pause) 410M->6M(2048M) 5.887ms
[117.147s][info ][gc             ] GC(28) Pause Young (Normal) (G1 Evacuation Pause) 409M->7M(2048M) 5.952ms
[121.505s][info ][gc             ] GC(29) Pause Young (Normal) (G1 Evacuation Pause) 410M->7M(2048M) 6.124ms
[125.846s][info ][gc             ] GC(30) Pause Young (Normal) (G1 Evacuation Pause) 409M->8M(2048M) 6.195ms
[130.192s][info ][gc             ] GC(31) Pause Young (Normal) (G1 Evacuation Pause) 410M->8M(2048M) 7.301ms
```


_After this change_

```
dev-dsk-neethp-jdk-2c-ad54955c % /home/neethp/Development/jdk17u-dev/build/linux-x86_64-server-release/images/jdk/bin/java -Xms2048m -Xmx2048m -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=20 '-Xlog:gc*,gc+age*=trace' -cp . G1LoiteringConditionNodes | grep -E 'Pause.*ms'
[0.983s][info ][gc          ] GC(0) Pause Young (Normal) (G1 Evacuation Pause) 102M->1M(2048M) 4.400ms
[2.474s][info ][gc          ] GC(1) Pause Young (Normal) (G1 Evacuation Pause) 146M->1M(2048M) 2.198ms
[6.783s][info ][gc          ] GC(2) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.725ms
[11.169s][info ][gc          ] GC(3) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.613ms
[15.543s][info ][gc          ] GC(4) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.207ms
[19.941s][info ][gc          ] GC(5) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.155ms
[24.360s][info ][gc          ] GC(6) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.993ms
[28.789s][info ][gc          ] GC(7) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.168ms
[33.217s][info ][gc          ] GC(8) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.291ms
[37.644s][info ][gc          ] GC(9) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.463ms
[42.071s][info ][gc          ] GC(10) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.533ms
[46.514s][info ][gc          ] GC(11) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.097ms
[50.961s][info ][gc          ] GC(12) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.460ms
[55.381s][info ][gc          ] GC(13) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.409ms
[59.817s][info ][gc          ] GC(14) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.716ms
[60.082s][info ][gc             ] GC(15) Pause Full (System.gc()) 27M->1M(2048M) 9.750ms
[64.502s][info ][gc             ] GC(16) Pause Young (Normal) (G1 Evacuation Pause) 410M->1M(2048M) 1.855ms
[68.917s][info ][gc             ] GC(17) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.130ms
[73.325s][info ][gc             ] GC(18) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.897ms
[77.733s][info ][gc             ] GC(19) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.963ms
[82.135s][info ][gc             ] GC(20) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.986ms
[86.545s][info ][gc             ] GC(21) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.204ms
[90.946s][info ][gc             ] GC(22) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.737ms
[95.359s][info ][gc             ] GC(23) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.858ms
[99.757s][info ][gc             ] GC(24) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 2.115ms
[104.161s][info ][gc             ] GC(25) Pause Young (Normal) (G1 Evacuation Pause) 409M->1M(2048M) 1.915ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754): Dead AbstractQueuedSynchronizer$ConditionNodes survive minor garbage collections (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2599/head:pull/2599` \
`$ git checkout pull/2599`

Update a local copy of the PR: \
`$ git checkout pull/2599` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2599`

View PR using the GUI difftool: \
`$ git pr show -t 2599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2599.diff">https://git.openjdk.org/jdk17u-dev/pull/2599.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2599#issuecomment-2176188228)