### PR TITLE
8317360: Missing null checks in JfrCheckpointManager and JfrStringPool initialization routines

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -103,6 +103,9 @@ bool JfrCheckpointManager::initialize() {
   // preallocate buffer count to each of the epoch live lists
   for (size_t i = 0; i < global_buffer_prealloc_count * 2; ++i) {
     Buffer* const buffer = mspace_allocate(global_buffer_size, _global_mspace);
+    if (buffer == nullptr) {
+      return false;
+    }
     _global_mspace->add_to_live_list(buffer, i % 2 == 0);
   }
   assert(_global_mspace->free_list_is_empty(), "invariant");

--- a/src/hotspot/share/jfr/recorder/stringpool/jfrStringPool.cpp
+++ b/src/hotspot/share/jfr/recorder/stringpool/jfrStringPool.cpp
@@ -85,6 +85,9 @@ bool JfrStringPool::initialize() {
   // preallocate buffer count to each of the epoch live lists
   for (size_t i = 0; i < string_pool_cache_count * 2; ++i) {
     Buffer* const buffer = mspace_allocate(string_pool_buffer_size, _mspace);
+    if (buffer == nullptr) {
+      return false;
+    }
     _mspace->add_to_live_list(buffer, i % 2 == 0);
   }
   assert(_mspace->free_list_is_empty(), "invariant");


### PR DESCRIPTION
**Notes**

Backport of [JDK-8317360](https://bugs.openjdk.org/browse/JDK-8317360)

**Verification**

* jdk_jfr, Tier1 & Tier 2 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317360](https://bugs.openjdk.org/browse/JDK-8317360) needs maintainer approval

### Issue
 * [JDK-8317360](https://bugs.openjdk.org/browse/JDK-8317360): Missing null checks in JfrCheckpointManager and JfrStringPool initialization routines (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2601/head:pull/2601` \
`$ git checkout pull/2601`

Update a local copy of the PR: \
`$ git checkout pull/2601` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2601`

View PR using the GUI difftool: \
`$ git pr show -t 2601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2601.diff">https://git.openjdk.org/jdk17u-dev/pull/2601.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2601#issuecomment-2176082375)