### PR TITLE
8332936: Test vmTestbase/metaspace/gc/watermark_70_80/TestDescription.java fails with no GC's recorded

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_0_1/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_0_1/TestDescription.java
@@ -33,6 +33,7 @@
  * @requires vm.gc != null | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "G1" | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "Z"
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase /test/lib
  * @run main/othervm
  *      -Xmx1g

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_10_20/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_10_20/TestDescription.java
@@ -33,6 +33,7 @@
  * @requires vm.gc != null | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "G1" | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "Z"
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase /test/lib
  * @run main/othervm
  *      -Xmx1g

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_70_80/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_70_80/TestDescription.java
@@ -33,6 +33,7 @@
  * @requires vm.gc != null | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "G1" | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "Z"
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase /test/lib
  * @run main/othervm
  *      -Xmx1g

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_99_100/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_99_100/TestDescription.java
@@ -33,6 +33,7 @@
  * @requires vm.gc != null | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "G1" | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "Z"
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase /test/lib
  * @run main/othervm
  *      -Xmx1g


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332936](https://bugs.openjdk.org/browse/JDK-8332936) needs maintainer approval

### Issue
 * [JDK-8332936](https://bugs.openjdk.org/browse/JDK-8332936): Test vmTestbase/metaspace/gc/watermark_70_80/TestDescription.java fails with no GC's recorded (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2603/head:pull/2603` \
`$ git checkout pull/2603`

Update a local copy of the PR: \
`$ git checkout pull/2603` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2603/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2603`

View PR using the GUI difftool: \
`$ git pr show -t 2603`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2603.diff">https://git.openjdk.org/jdk17u-dev/pull/2603.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2603#issuecomment-2175454422)