### PR TITLE
8325384: sun/security/ssl/SSLSessionImpl/ResumptionUpdateBoundValues.java failing intermittently when main thread is a virtual thread

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumptionUpdateBoundValues.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumptionUpdateBoundValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  * @library /test/lib
  * @summary Test that a New Session Ticket will be generated when a
  * SSLSessionBindingListener is set (boundValues)
- * @key intermittent
  * @run main/othervm ResumptionUpdateBoundValues
  */
 
@@ -256,7 +255,7 @@ public class ResumptionUpdateBoundValues {
         Thread t;
         while ((t = threads.take()) != Thread.currentThread()) {
             System.out.printf("  joining: %s%n", t);
-            t.join(1000L);
+            t.join(4000L);
         }
         serverReady = false;
         System.gc();


### PR DESCRIPTION
Backport of [JDK-8325384](https://bugs.openjdk.org/browse/JDK-8325384)

Testing
- Local: Test passed on `MacOS 14.5`
  - `ResumptionUpdateBoundValues.java`: Test results: passed: 1
- Pipeline: 
- Testing Machine: SAP nightlies passed on `2024-06-20`
  - `jtreg_jdk_tier2`: sun/security/ssl/SSLSessionImpl/ResumptionUpdateBoundValues.java: SUCCESSFUL GitHub 📊⏲ - [5,172 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325384](https://bugs.openjdk.org/browse/JDK-8325384) needs maintainer approval

### Issue
 * [JDK-8325384](https://bugs.openjdk.org/browse/JDK-8325384): sun/security/ssl/SSLSessionImpl/ResumptionUpdateBoundValues.java failing intermittently when main thread is a virtual thread (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2610/head:pull/2610` \
`$ git checkout pull/2610`

Update a local copy of the PR: \
`$ git checkout pull/2610` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2610`

View PR using the GUI difftool: \
`$ git pr show -t 2610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2610.diff">https://git.openjdk.org/jdk17u-dev/pull/2610.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2610#issuecomment-2177759261)