### PR TITLE
8328110: Allow simultaneous use of PassFailJFrame with split UI and additional windows

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1331,14 +1331,6 @@ public final class PassFailJFrame {
                 position = Position.HORIZONTAL;
             }
 
-            if (panelCreator != null) {
-                if (splitUI && (testWindows != null || windowListCreator != null)) {
-                    // TODO Is it required? We can support both
-                    throw new IllegalStateException("Split UI is not allowed "
-                                                    + "with additional windows");
-                }
-            }
-
             if (positionWindows != null) {
                 if (testWindows == null && windowListCreator == null) {
                     throw new IllegalStateException("To position windows, "


### PR DESCRIPTION
Backport of [JDK-8328110](https://bugs.openjdk.org/browse/JDK-8328110)

Testing
- Local: Test passed
  - `PrintLatinCJKTest.java` (who calls `PassFailJFrame`): Test results: passed: 1
- Pipeline: 
- Testing Machine: Not Applicable - SAP nightlies skipped it because it is manual test
  - `jtreg_jdk_tier4`: java/awt/print/PrinterJob/PrintLatinCJKTest.java: SKIPPED[Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!printer)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328110](https://bugs.openjdk.org/browse/JDK-8328110) needs maintainer approval

### Issue
 * [JDK-8328110](https://bugs.openjdk.org/browse/JDK-8328110): Allow simultaneous use of PassFailJFrame with split UI and additional windows (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2611/head:pull/2611` \
`$ git checkout pull/2611`

Update a local copy of the PR: \
`$ git checkout pull/2611` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2611`

View PR using the GUI difftool: \
`$ git pr show -t 2611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2611.diff">https://git.openjdk.org/jdk17u-dev/pull/2611.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2611#issuecomment-2177839802)