### PR TITLE
8331063: Some HttpClient tests don't report leaks

### DIFF
--- a/test/jdk/java/net/httpclient/ProxySelectorTest.java
+++ b/test/jdk/java/net/httpclient/ProxySelectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,15 +377,18 @@ public class ProxySelectorTest implements HttpServerAdapters {
         client = null;
         Thread.sleep(100);
         AssertionError fail = TRACKER.check(500);
-
-        proxy.stop();
-        authproxy.stop();
-        httpTestServer.stop();
-        proxyHttpTestServer.stop();
-        authProxyHttpTestServer.stop();
-        httpsTestServer.stop();
-        http2TestServer.stop();
-        https2TestServer.stop();
+        try {
+            proxy.stop();
+            authproxy.stop();
+            httpTestServer.stop();
+            proxyHttpTestServer.stop();
+            authProxyHttpTestServer.stop();
+            httpsTestServer.stop();
+            http2TestServer.stop();
+            https2TestServer.stop();
+        } finally {
+            if (fail != null) throw fail;
+        }
     }
 
     class TestProxySelector extends ProxySelector {


### PR DESCRIPTION
Backport of [JDK-8331063](https://bugs.openjdk.org/browse/JDK-8331063)

Testing
- Local: Test passed on `MacOS 14.5`
  - `ForbiddenHeadTest.java`: Test results: passed: 1
  - `ProxySelectorTest.java`: Test results: passed: 1
- Pipeline: 
- Testing Machine: SAP nightlies passed on `2024-06-20`
  - `jtreg_jdk_tier2`
    - java/net/httpclient/ForbiddenHeadTest.java: SUCCESSFUL GitHub 📊⏲ - [9,389 msec]
    - java/net/httpclient/ProxySelectorTest.java: SUCCESSFUL GitHub 📊⏲ - [11,357 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331063](https://bugs.openjdk.org/browse/JDK-8331063) needs maintainer approval

### Issue
 * [JDK-8331063](https://bugs.openjdk.org/browse/JDK-8331063): Some HttpClient tests don't report leaks (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2612/head:pull/2612` \
`$ git checkout pull/2612`

Update a local copy of the PR: \
`$ git checkout pull/2612` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2612`

View PR using the GUI difftool: \
`$ git pr show -t 2612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2612.diff">https://git.openjdk.org/jdk17u-dev/pull/2612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2612#issuecomment-2177857728)