### PR TITLE
8315651: Stop hiding AIX specific multicast socket errors via NetworkConfiguration (aix)

### DIFF
--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,17 +173,6 @@ public class NetworkConfiguration {
     private boolean supportsIp4Multicast(NetworkInterface nif) {
         try {
             if (!nif.supportsMulticast()) {
-                return false;
-            }
-
-            // On AIX there is a bug:
-            // When IPv6 is enabled on the system, the JDK opens sockets as AF_INET6.
-            // If there's an interface configured with IPv4 addresses only, it should
-            // be able to become the network interface for a multicast socket (that
-            // could be in both, IPv4 or IPv6 space). But both possible setsockopt
-            // calls for either IPV6_MULTICAST_IF or IP_MULTICAST_IF return
-            // EADDRNOTAVAIL. So we must skip such interfaces here.
-            if (Platform.isAix() && isIPv6Available() && !hasIp6Addresses(nif)) {
                 return false;
             }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e22eb06a](https://github.com/openjdk/jdk/commit/e22eb06a3b59f83eb38881f7e1aed1c18ee7e193) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Obermeier on 7 Sep 2023 and was reviewed by Alan Bateman, Martin Doerr and Christoph Langer.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315651](https://bugs.openjdk.org/browse/JDK-8315651) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315651](https://bugs.openjdk.org/browse/JDK-8315651): Stop hiding AIX specific multicast socket errors via NetworkConfiguration (aix) (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2617/head:pull/2617` \
`$ git checkout pull/2617`

Update a local copy of the PR: \
`$ git checkout pull/2617` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2617`

View PR using the GUI difftool: \
`$ git pr show -t 2617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2617.diff">https://git.openjdk.org/jdk17u-dev/pull/2617.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2617#issuecomment-2180179969)