### PR TITLE
8316387: Exclude more failing multicast tests on AIX after JDK-8315651

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -591,7 +591,7 @@ java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc6
 java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
 java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
 java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc64
-java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-all,aix-ppc64
+java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083,8308807 windows-all,aix-ppc64
 java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 java/net/MulticastSocket/Test.java                              7145658 macosx-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -581,6 +581,12 @@ javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 g
 
 # jdk_net
 
+java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
+java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
+
+java/net/MulticastSocket/Test.java                              7145658 macosx-all
+
+
 java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
 java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64
 
@@ -588,13 +594,10 @@ java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc6
 java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
 java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc64
 java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc64
-java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
 java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
 java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc64
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
-java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
-java/net/MulticastSocket/Test.java                              7145658 macosx-all
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
@@ -603,14 +606,11 @@ java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc6
 # jdk_nio
 
 
-
+java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
-
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
-java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
-
 java/nio/file/Files/probeContentType/Basic.java                 8320943 windows-all
 
 ############################################################################

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -581,16 +581,13 @@ javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 g
 
 # jdk_net
 
-java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
-java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
-
-java/net/MulticastSocket/Test.java                              7145658 macosx-all
-
-java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-all
-java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
 java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64
 
+java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
+java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
+java/net/MulticastSocket/Test.java                              7145658 macosx-all
+java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-all,aix-ppc64
 java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
 java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
 java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc64
@@ -600,16 +597,18 @@ java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc6
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 
-
+java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 ############################################################################
 
 # jdk_nio
 
-java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
-java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
+java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
+
+java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
+
 java/nio/file/Files/probeContentType/Basic.java                 8320943 windows-all
 
 ############################################################################

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -588,19 +588,21 @@ java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc6
 java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
 java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc64
 java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc64
-java/net/MulticastSocket/NoLoopbackPackets.java                 7122846,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
 java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
 java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc64
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
-java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
-java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/Test.java                              7145658 macosx-all
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
 ############################################################################
 
 # jdk_nio
+
+
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -586,7 +586,7 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-a
 
 java/net/MulticastSocket/Test.java                              7145658 macosx-all
 
-
+java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-all
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
 java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -584,18 +584,17 @@ javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 g
 java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
 java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64
 
-java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
-java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
-java/net/MulticastSocket/Test.java                              7145658 macosx-all
-java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-all,aix-ppc64
 java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
 java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
 java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc64
 java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc64
+java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
 java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
 java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc64
-java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
+java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-all,aix-ppc64
+java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
+java/net/MulticastSocket/Test.java                              7145658 macosx-all
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 ############################################################################

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -587,6 +587,7 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-a
 java/net/MulticastSocket/Test.java                              7145658 macosx-all
 
 
+java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
 java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64
 
@@ -599,12 +600,10 @@ java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc6
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 
-java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
 ############################################################################
 
 # jdk_nio
-
 
 java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -581,25 +581,34 @@ javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 g
 
 # jdk_net
 
-java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
-java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
+java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
+java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64
 
-java/net/MulticastSocket/Test.java                              7145658 macosx-all
-
-java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083 windows-all
+java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
+java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
+java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc64
+java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc64
+java/net/MulticastSocket/NoLoopbackPackets.java                 7122846,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
+java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc64
+java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
+java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
+java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
-
 
 ############################################################################
 
 # jdk_nio
 
-java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
-
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64
+java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
+java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
+
 java/nio/file/Files/probeContentType/Basic.java                 8320943 windows-all
 
 ############################################################################


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c86bad51](https://github.com/openjdk/jdk21u/commit/c86bad51a88b867de3cd0b1a50bf544c2111755f) from the [openjdk/jdk21u](https://git.openjdk.org/jdk21u) repository.

The commit being backported was authored by Christoph Langer on 21 Sep 2023 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8316387](https://bugs.openjdk.org/browse/JDK-8316387) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316387](https://bugs.openjdk.org/browse/JDK-8316387): Exclude more failing multicast tests on AIX after JDK-8315651 (**Sub-task** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) 🔄 Re-review required (review applies to [d3b7e56d](https://git.openjdk.org/jdk17u-dev/pull/2619/files/d3b7e56dadf18f347f549a0a681ebbdb183eb651))
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2619/head:pull/2619` \
`$ git checkout pull/2619`

Update a local copy of the PR: \
`$ git checkout pull/2619` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2619`

View PR using the GUI difftool: \
`$ git pr show -t 2619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2619.diff">https://git.openjdk.org/jdk17u-dev/pull/2619.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2619#issuecomment-2180885851)