### PR TITLE
8332174: Remove 2 (unpaired) RLO Unicode characters in ff_Adlm.xml

### DIFF
--- a/make/data/cldr/common/main/ff_Adlm.xml
+++ b/make/data/cldr/common/main/ff_Adlm.xml
@@ -272,7 +272,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 			<territory type="BS">𞤄𞤢𞤸𞤢𞤥𞤢𞥄𞤧</territory>
 			<territory type="BT">𞤄𞤵𞥅𞤼𞤢𞥄𞤲</territory>
 			<territory type="BV">𞤅𞤵𞤪𞤭𞥅𞤪𞤫 𞤄𞤵𞥅𞤾𞤫𞥅</territory>
-			<territory type="BW">‮𞤄𞤮𞤼𞤧𞤵𞤱𞤢𞥄𞤲𞤢</territory>
+			<territory type="BW">𞤄𞤮𞤼𞤧𞤵𞤱𞤢𞥄𞤲𞤢</territory>
 			<territory type="BY">𞤄𞤫𞤤𞤢𞤪𞤵𞥅𞤧</territory>
 			<territory type="BZ">𞤄𞤫𞤤𞤭𞥅𞥁</territory>
 			<territory type="CA">𞤑𞤢𞤲𞤢𞤣𞤢𞥄</territory>
@@ -2245,7 +2245,7 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				<exemplarCity>𞤐𞤵𞥅𞤳</exemplarCity>
 			</zone>
 			<zone type="America/Scoresbysund">
-				<exemplarCity>‮𞤋𞤼𞥆𞤮𞤳𞤮𞤪𞤼𞤮𞥅𞤪𞤥𞤭𞥅𞤼</exemplarCity>
+				<exemplarCity>𞤋𞤼𞥆𞤮𞤳𞤮𞤪𞤼𞤮𞥅𞤪𞤥𞤭𞥅𞤼</exemplarCity>
 			</zone>
 			<zone type="America/Danmarkshavn">
 				<exemplarCity>𞤁𞤢𞥄𞤲𞤥𞤢𞤪𞤳𞥃𞤢𞥄𞤾𞤲</exemplarCity>


### PR DESCRIPTION
I would like to backport the fix for 8332174 from 21u to 17u.  Skara
was able to apply the patch without alteration:

```
$ git skara backport --from https://github.com/openjdk/jdk21u-dev d5363bc509d4996529420b453a99e982c843da1c
Fetching ...
Cherry picking ...
Performing inexact rename detection: 100% (7376712/7376712), done.
Auto-merging make/data/cldr/common/main/ff_Adlm.xml
Committing ...
Commit d5363bc509d4996529420b453a99e982c843da1c successfully backported as commit 859f60badb2c034ad6361fba1ab1ac128b828029
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8332174](https://bugs.openjdk.org/browse/JDK-8332174) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332174](https://bugs.openjdk.org/browse/JDK-8332174): Remove 2 (unpaired) RLO Unicode characters in ff_Adlm.xml (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2625/head:pull/2625` \
`$ git checkout pull/2625`

Update a local copy of the PR: \
`$ git checkout pull/2625` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2625`

View PR using the GUI difftool: \
`$ git pr show -t 2625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2625.diff">https://git.openjdk.org/jdk17u-dev/pull/2625.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2625#issuecomment-2182879632)