### PR TITLE
8279878: java/awt/font/JNICheck/JNICheck.sh test fails on Ubuntu 21.10

### DIFF
--- a/test/jdk/java/awt/font/JNICheck/JNICheck.sh
+++ b/test/jdk/java/awt/font/JNICheck/JNICheck.sh
@@ -49,7 +49,7 @@ else
 fi
 
 $JAVA_HOME/bin/java ${TESTVMOPTS} \
-    -cp "${CP}" -Xcheck:jni JNICheck | grep -v SIG | grep -v Signal | grep -v CallStatic > "${CP}"/log.txt
+    -cp "${CP}" -Xcheck:jni JNICheck | grep -v SIG | grep -v Signal | grep -v Handler | grep -v jsig | grep -v CallStatic > "${CP}"/log.txt
 
 # any messages logged may indicate a failure.
 if [ -s "${CP}"/log.txt ]; then


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2f48a3f0](https://github.com/openjdk/jdk/commit/2f48a3f032dcfe159a7ab4a3d0afd0a0760d0a04) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Phil Race on 6 Feb 2022 and was reviewed by Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8279878](https://bugs.openjdk.org/browse/JDK-8279878) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279878](https://bugs.openjdk.org/browse/JDK-8279878): java/awt/font/JNICheck/JNICheck.sh test fails on Ubuntu 21.10 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2626/head:pull/2626` \
`$ git checkout pull/2626`

Update a local copy of the PR: \
`$ git checkout pull/2626` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2626`

View PR using the GUI difftool: \
`$ git pr show -t 2626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2626.diff">https://git.openjdk.org/jdk17u-dev/pull/2626.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2626#issuecomment-2184832326)