### PR TITLE
8328647: TestGarbageCollectorMXBean.java fails with C1-only and -Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/z/TestGarbageCollectorMXBean.java
+++ b/test/hotspot/jtreg/gc/z/TestGarbageCollectorMXBean.java
@@ -26,6 +26,7 @@
  * @requires vm.gc.Z
  * @summary Test ZGC garbage collector MXBean
  * @modules java.management
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:+UseZGC -Xms256M -Xmx512M -Xlog:gc TestGarbageCollectorMXBean 256 512
  * @run main/othervm -XX:+UseZGC -Xms512M -Xmx512M -Xlog:gc TestGarbageCollectorMXBean 512 512
  */


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328647](https://bugs.openjdk.org/browse/JDK-8328647) needs maintainer approval

### Issue
 * [JDK-8328647](https://bugs.openjdk.org/browse/JDK-8328647): TestGarbageCollectorMXBean.java fails with C1-only and -Xcomp (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2629/head:pull/2629` \
`$ git checkout pull/2629`

Update a local copy of the PR: \
`$ git checkout pull/2629` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2629`

View PR using the GUI difftool: \
`$ git pr show -t 2629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2629.diff">https://git.openjdk.org/jdk17u-dev/pull/2629.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2629#issuecomment-2186061369)