### PR TITLE
8323584: AArch64: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe

### DIFF
--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -28,7 +28,6 @@
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "gc/shared/collectedHeap.hpp"
-#include "memory/resourceArea.hpp"
 #include "nativeInst_aarch64.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.hpp"
@@ -189,8 +188,6 @@ void NativeCall::set_destination_mt_safe(address dest, bool assert_lock) {
          CompiledICLocker::is_safe(addr_at(0)),
          "concurrent code patching");
 
-  ResourceMark rm;
-  int code_size = NativeInstruction::instruction_size;
   address addr_call = addr_at(0);
   bool reachable = Assembler::reachable_from_branch_at(addr_call, dest);
   assert(NativeCall::is_call_at(addr_call), "unexpected code at call site");


### PR DESCRIPTION
Backport of [JDK-8323584](https://bugs.openjdk.org/browse/JDK-8323584)

Created issue for the test bug: https://bugs.openjdk.org/browse/JDK-8335127

Test/verification:
- [x] Linux x86_64 AArch64 server fastdebug, tier1
- [x] Linux x86_64 AArch64 server fastdebug, tier2, there were two test failures but not seem to to be related
```
JavaTest Message: Test threw exception: java.lang.AssertionError: Option 'UseSHA3Intrinsics' is expected to have 'true' value
JavaTest Message: Test threw exception: java.lang.AssertionError: Option 'UseSHA512Intrinsics' is expected to have 'true' value
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323584](https://bugs.openjdk.org/browse/JDK-8323584) needs maintainer approval

### Issue
 * [JDK-8323584](https://bugs.openjdk.org/browse/JDK-8323584): AArch64: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2633/head:pull/2633` \
`$ git checkout pull/2633`

Update a local copy of the PR: \
`$ git checkout pull/2633` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2633`

View PR using the GUI difftool: \
`$ git pr show -t 2633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2633.diff">https://git.openjdk.org/jdk17u-dev/pull/2633.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2633#issuecomment-2190222825)