### PR TITLE
8330611: AES-CTR vector intrinsic may read out of bounds (x86_64, AVX-512)

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -5811,6 +5811,14 @@ void Assembler::xorw(Register dst, Register src) {
   emit_arith(0x33, 0xC0, dst, src);
 }
 
+void Assembler::xorw(Register dst, Address src) {
+  InstructionMark im(this);
+  emit_int8(0x66);
+  prefix(src, dst);
+  emit_int8(0x33);
+  emit_operand(dst, src, 0);
+}
+
 // AVX 3-operands scalar float-point arithmetic instructions
 
 void Assembler::vaddsd(XMMRegister dst, XMMRegister nds, Address src) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2116,6 +2116,7 @@ private:
   void xorb(Address dst, Register src);
   void xorb(Register dst, Address src);
   void xorw(Register dst, Register src);
+  void xorw(Register dst, Address src);
 
   void xorq(Register dst, Address src);
   void xorq(Address dst, int32_t imm32);


### PR DESCRIPTION
JDK-8330611: AES-CTR vector intrinsic may read out of bounds (x86_64, AVX-512)

Backporting 8a8d9288980513db459f7d6b36554b65844951ca from original JBS.

Backport was not clean due to renaming of a file.  Made changes in the old file consistent with the new file.

Tested release, fastdebug with tier1 and tier2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330611](https://bugs.openjdk.org/browse/JDK-8330611) needs maintainer approval

### Issue
 * [JDK-8330611](https://bugs.openjdk.org/browse/JDK-8330611): AES-CTR vector intrinsic may read out of bounds (x86_64, AVX-512) (**Bug** - P3 - Approved)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - no project role)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2634/head:pull/2634` \
`$ git checkout pull/2634`

Update a local copy of the PR: \
`$ git checkout pull/2634` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2634`

View PR using the GUI difftool: \
`$ git pr show -t 2634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2634.diff">https://git.openjdk.org/jdk17u-dev/pull/2634.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2634#issuecomment-2187449435)