### PR TITLE
8170817: G1: Returning MinTLABSize from unsafe_max_tlab_alloc causes TLAB flapping

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -192,11 +192,14 @@ size_t G1Allocator::unsafe_max_tlab_alloc() {
   uint node_index = current_node_index();
   HeapRegion* hr = mutator_alloc_region(node_index)->get();
   size_t max_tlab = _g1h->max_tlab_size() * wordSize;
-  if (hr == NULL) {
+
+  if (hr == NULL || hr->free() < MinTLABSize) {
+    // The next TLAB allocation will most probably happen in a new region,
+    // therefore we can attempt to allocate the maximum allowed TLAB size.
     return max_tlab;
-  } else {
-    return clamp(hr->free(), MinTLABSize, max_tlab);
   }
+
+  return MIN2(hr->free(), max_tlab);
 }
 
 size_t G1Allocator::used_in_alloc_regions() {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [4c79e7d5](https://github.com/openjdk/jdk/commit/4c79e7d59caec01b4d2bdae2f7d25f1dd24ffbf6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ivan Walulya on 12 Oct 2023 and was reviewed by Thomas Schatzl and Albert Mingkun Yang.

Additional test:
- [x]  make test TEST=test/hotspot/jtreg/:tier2 CONF=linux-aarch64-server-fastdebug
There were two irrelevant failures, I have created bug for them https://bugs.openjdk.org/browse/JDK-8335127

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8170817](https://bugs.openjdk.org/browse/JDK-8170817) needs maintainer approval

### Issue
 * [JDK-8170817](https://bugs.openjdk.org/browse/JDK-8170817): G1: Returning MinTLABSize from unsafe_max_tlab_alloc causes TLAB flapping (**Enhancement** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2639/head:pull/2639` \
`$ git checkout pull/2639`

Update a local copy of the PR: \
`$ git checkout pull/2639` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2639`

View PR using the GUI difftool: \
`$ git pr show -t 2639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2639.diff">https://git.openjdk.org/jdk17u-dev/pull/2639.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2639#issuecomment-2190322006)