### PR TITLE
8294691: dynamicArchive/RelativePath.java is running other test case

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RelativePath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RelativePath.java
@@ -39,7 +39,7 @@ import java.io.File;
 public class RelativePath extends DynamicArchiveTestBase {
 
     public static void main(String[] args) throws Exception {
-        runTest(AppendClasspath::testDefaultBase);
+        runTest(RelativePath::testDefaultBase);
     }
 
     static void testDefaultBase() throws Exception {
@@ -54,6 +54,16 @@ public class RelativePath extends DynamicArchiveTestBase {
         int idx = appJar.lastIndexOf(File.separator);
         String jarName = appJar.substring(idx + 1);
         String jarDir = appJar.substring(0, idx);
+
+        // Create CDS Archive
+        dump(topArchiveName, "-Xlog:cds",
+            "-Xlog:cds+dynamic=debug",
+            "-cp", appJar + File.pathSeparator + appJar2,
+            "HelloMore")
+            .assertNormalExit(output-> {
+                    output.shouldContain("Written dynamic archive 0x");
+            });
+
         // relative path starting with "."
         runWithRelativePath(null, topArchiveName, jarDir,
             "-Xlog:class+load",


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8294691](https://bugs.openjdk.org/browse/JDK-8294691) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294691](https://bugs.openjdk.org/browse/JDK-8294691): dynamicArchive/RelativePath.java is running other test case (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2649/head:pull/2649` \
`$ git checkout pull/2649`

Update a local copy of the PR: \
`$ git checkout pull/2649` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2649`

View PR using the GUI difftool: \
`$ git pr show -t 2649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2649.diff">https://git.openjdk.org/jdk17u-dev/pull/2649.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2649#issuecomment-2202380986)