### PR TITLE
8299378: sprintf is deprecated in Xcode 14

### DIFF
--- a/test/hotspot/gtest/logging/test_logDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorators.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "jvm.h"
 #include "logging/logDecorators.hpp"
+#include "runtime/os.hpp"
 #include "unittest.hpp"
 
 static LogDecorators::Decorator decorator_array[] = {

--- a/test/hotspot/gtest/logging/test_logDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorators.cpp
@@ -173,7 +173,7 @@ TEST(LogDecorators, combine_with) {
 
   // Select first and third decorator for dec1
   char input[64];
-  sprintf(input, "%s,%s", decorator_name_array[0], decorator_name_array[3]);
+  os::snprintf_checked(input, sizeof(input), "%s,%s", decorator_name_array[0], decorator_name_array[3]);
   dec1.parse(input);
   EXPECT_TRUE(dec1.is_decorator(decorator_array[0]));
   EXPECT_TRUE(dec1.is_decorator(decorator_array[3]));

--- a/test/hotspot/gtest/logging/test_logMessageTest.cpp
+++ b/test/hotspot/gtest/logging/test_logMessageTest.cpp
@@ -146,11 +146,12 @@ TEST_VM_F(LogMessageTest, long_message) {
   char* data = NEW_C_HEAP_ARRAY(char, size, mtLogging);
 
   // fill buffer with start_marker...some data...end_marker
-  sprintf(data, "%s", start_marker);
+  os::snprintf_checked(data, size, "%s", start_marker);
   for (size_t i = strlen(start_marker); i < size; i++) {
     data[i] = '0' + (i % 10);
   }
-  sprintf(data + size - strlen(end_marker) - 1, "%s", end_marker);
+  size_t remaining_size = strlen(end_marker) + 1;
+  os::snprintf_checked(data + size - remaining_size, remaining_size, "%s", end_marker);
 
   msg.trace("%s", data); // Adds a newline, making the message exactly 10K in length.
   _log.write(msg);


### PR DESCRIPTION
Backport applies cleanly except for the missing `test/hotspot/gtest/utilities/test_unsigned5.cpp` in JDK17u.

I had to manually add the `runtime/os.hpp` import which was added as part of https://github.com/openjdk/jdk/commit/df6cf1e41d0fc2dd5f5c094f66c7c8969cf5548d

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378) needs maintainer approval

### Issue
 * [JDK-8299378](https://bugs.openjdk.org/browse/JDK-8299378): sprintf is deprecated in Xcode 14 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2661/head:pull/2661` \
`$ git checkout pull/2661`

Update a local copy of the PR: \
`$ git checkout pull/2661` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2661`

View PR using the GUI difftool: \
`$ git pr show -t 2661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2661.diff">https://git.openjdk.org/jdk17u-dev/pull/2661.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2661#issuecomment-2208783463)