### PR TITLE
8301279: update for deprecated sprintf for management components

### DIFF
--- a/src/java.management/share/native/libmanagement/VMManagementImpl.c
+++ b/src/java.management/share/native/libmanagement/VMManagementImpl.c
@@ -44,7 +44,7 @@ Java_sun_management_VMManagementImpl_getVersion0
     // for internal use
     unsigned int micro = (unsigned int) jmm_version & 0xFF;
 
-    sprintf(buf, "%d.%d", major, minor);
+    snprintf(buf, sizeof(buf), "%d.%d", major, minor);
     version_string = (*env)->NewStringUTF(env, buf);
     return version_string;
 }

--- a/src/java.management/share/native/libmanagement/management.c
+++ b/src/java.management/share/native/libmanagement/management.c
@@ -57,6 +57,6 @@ JNIEXPORT jint JNICALL
 void throw_internal_error(JNIEnv* env, const char* msg) {
     char errmsg[128];
 
-    sprintf(errmsg, "errno: %d error: %s\n", errno, msg);
+    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
     JNU_ThrowInternalError(env, errmsg);
 }

--- a/src/jdk.management/share/native/libmanagement_ext/management_ext.c
+++ b/src/jdk.management/share/native/libmanagement_ext/management_ext.c
@@ -57,6 +57,6 @@ JNIEXPORT jint JNICALL
 void throw_internal_error(JNIEnv* env, const char* msg) {
     char errmsg[128];
 
-    sprintf(errmsg, "errno: %d error: %s\n", errno, msg);
+    snprintf(errmsg, sizeof(errmsg), "errno: %d error: %s\n", errno, msg);
     JNU_ThrowInternalError(env, errmsg);
 }


### PR DESCRIPTION
Backport applies cleanly, required to upgrade the GH actions runners to macos-13/Xcode 14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8301279](https://bugs.openjdk.org/browse/JDK-8301279) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301279](https://bugs.openjdk.org/browse/JDK-8301279): update for deprecated sprintf for management components (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2664/head:pull/2664` \
`$ git checkout pull/2664`

Update a local copy of the PR: \
`$ git checkout pull/2664` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2664`

View PR using the GUI difftool: \
`$ git pr show -t 2664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2664.diff">https://git.openjdk.org/jdk17u-dev/pull/2664.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2664#issuecomment-2210347687)