### PR TITLE
8303617: update for deprecated sprintf for jdk.jdwp.agent

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -220,11 +220,7 @@ handshake(int fd, jlong timeout) {
     if (strncmp(b, hello, received) != 0) {
         char msg[80+2*16];
         b[received] = '\0';
-        /*
-         * We should really use snprintf here but it's not available on Windows.
-         * We can't use jio_snprintf without linking the transport against the VM.
-         */
-        sprintf(msg, "handshake failed - received >%s< - expected >%s<", b, hello);
+        snprintf(msg, sizeof(msg), "handshake failed - received >%s< - expected >%s<", b, hello);
         setLastError(0, msg);
         return JDWPTRANSPORT_ERROR_IO_ERROR;
     }
@@ -690,7 +686,7 @@ static jdwpTransportError startListening(struct addrinfo *ai, int *socket, char*
         }
 
         portNum = getPort((struct sockaddr *)&addr);
-        sprintf(buf, "%d", portNum);
+        snprintf(buf, sizeof(buf), "%d", portNum);
         *actualAddress = (*callback->alloc)((int)strlen(buf) + 1);
         if (*actualAddress == NULL) {
             RETURN_ERROR(JDWPTRANSPORT_ERROR_OUT_OF_MEMORY, "out of memory");
@@ -858,7 +854,7 @@ socketTransport_accept(jdwpTransportEnv* env, jlong acceptTimeout, jlong handsha
                 int err2 = getnameinfo((struct sockaddr *)&clientAddr, clientAddrLen,
                                        addrStr, sizeof(addrStr), NULL, 0,
                                        NI_NUMERICHOST);
-                sprintf(ebuf, "ERROR: Peer not allowed to connect: %s\n",
+                snprintf(ebuf, sizeof(ebuf), "ERROR: Peer not allowed to connect: %s\n",
                         (err2 != 0) ? "<bad address>" : addrStr);
                 dbgsysSocketClose(socketFD);
                 socketFD = -1;

--- a/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libdt_socket/socket_md.c
@@ -402,7 +402,7 @@ dbgsysGetLastIOError(char *buf, jint size) {
     if (i < table_size) {
         strcpy(buf, winsock_errors[i].errString);
     } else {
-        sprintf(buf, "winsock error %d", error);
+        snprintf(buf, size, "winsock error %d", error);
     }
     return 0;
 }

--- a/src/jdk.jdwp.agent/windows/native/libjdwp/linker_md.c
+++ b/src/jdk.jdwp.agent/windows/native/libjdwp/linker_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,7 +119,7 @@ dbgsysBuildLibName(char *holder, int holderlen, const char *pname, const char *f
                 EXIT_ERROR(JVMTI_ERROR_INVALID_LOCATION, "One or more of the library paths supplied to jdwp, "
                                                          "likely by sun.boot.library.path, is too long.");
         }
-        sprintf(holder, "%s.dll", fname);
+        snprintf(holder, holderlen, "%s.dll", fname);
     } else {
       dll_build_name(holder, holderlen, pname, fname);
     }


### PR DESCRIPTION
Backport applies cleanly, required to upgrade the GH actions runners to macos-13/Xcode 14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8303617](https://bugs.openjdk.org/browse/JDK-8303617) needs maintainer approval

### Issue
 * [JDK-8303617](https://bugs.openjdk.org/browse/JDK-8303617): update for deprecated sprintf for jdk.jdwp.agent (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2666/head:pull/2666` \
`$ git checkout pull/2666`

Update a local copy of the PR: \
`$ git checkout pull/2666` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2666`

View PR using the GUI difftool: \
`$ git pr show -t 2666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2666.diff">https://git.openjdk.org/jdk17u-dev/pull/2666.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2666#issuecomment-2210354835)