### PR TITLE
8303527: update for deprecated sprintf for jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_proc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,7 +227,7 @@ static bool process_doesnt_exist(pid_t pid) {
   FILE *fp = NULL;
   const char state_string[] = "State:";
 
-  sprintf(fname, "/proc/%d/status", pid);
+  snprintf(fname, sizeof(fname), "/proc/%d/status", pid);
   fp = fopen(fname, "r");
   if (fp == NULL) {
     print_debug("can't open /proc/%d/status file\n", pid);
@@ -346,7 +346,7 @@ static bool read_lib_info(struct ps_prochandle* ph) {
   char buf[PATH_MAX];
   FILE *fp = NULL;
 
-  sprintf(fname, "/proc/%d/maps", ph->pid);
+  snprintf(fname, sizeof(fname), "/proc/%d/maps", ph->pid);
   fp = fopen(fname, "r");
   if (fp == NULL) {
     print_debug("can't open /proc/%d/maps file\n", ph->pid);

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -184,11 +184,12 @@ static void throwNewDebuggerException(JNIEnv* env, const char* errMsg) {
   do { \
     const HRESULT hr = (v); \
     if (hr != S_OK) { \
-      AutoArrayPtr<char> errmsg(new char[strlen(str) + 32]); \
+      size_t errmsg_size = strlen(str) + 32; \
+      AutoArrayPtr<char> errmsg(new char[errmsg_size]); \
       if (errmsg == nullptr) { \
         THROW_NEW_DEBUGGER_EXCEPTION_(str, retValue); \
       } else { \
-        sprintf(errmsg, "%s (hr: 0x%08X)", str, hr); \
+        snprintf(errmsg, errmsg_size, "%s (hr: 0x%08X)", str, hr); \
         THROW_NEW_DEBUGGER_EXCEPTION_(errmsg, retValue); \
       } \
     } \


### PR DESCRIPTION
Backport applies cleanly, required to upgrade the GH actions runners to macos-13/Xcode 14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8303527](https://bugs.openjdk.org/browse/JDK-8303527) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303527](https://bugs.openjdk.org/browse/JDK-8303527): update for deprecated sprintf for jdk.hotspot.agent (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2680/head:pull/2680` \
`$ git checkout pull/2680`

Update a local copy of the PR: \
`$ git checkout pull/2680` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2680`

View PR using the GUI difftool: \
`$ git pr show -t 2680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2680.diff">https://git.openjdk.org/jdk17u-dev/pull/2680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2680#issuecomment-2211735444)