### PR TITLE
8308801: update for deprecated sprintf for libnet in java.base

### DIFF
--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1271,7 +1271,7 @@ static netif *enumIPv6Interfaces(JNIEnv *env, int sock, netif *ifs) {
             char addr6[40];
             struct sockaddr_in6 addr;
 
-            sprintf(addr6, "%s:%s:%s:%s:%s:%s:%s:%s",
+            snprintf(addr6, sizeof(addr6), "%s:%s:%s:%s:%s:%s:%s:%s",
                     addr6p[0], addr6p[1], addr6p[2], addr6p[3],
                     addr6p[4], addr6p[5], addr6p[6], addr6p[7]);
 

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,7 +221,7 @@ void NET_ThrowUnknownHostExceptionWithGaiError(JNIEnv *env,
     buf = (char *) malloc(size);
     if (buf) {
         jstring s;
-        sprintf(buf, format, hostname, error_string);
+        snprintf(buf, size, format, hostname, error_string);
         s = JNU_NewStringPlatform(env, buf);
         if (s != NULL) {
             jobject x = JNU_NewObjectByName(env,

--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ NET_ThrowNew(JNIEnv *env, int errorNum, char *msg)
     if (excP == NULL) {
         excP = "SocketException";
     }
-    sprintf(exc, "%s%s", JNU_JAVANETPKG, excP);
+    snprintf(exc, sizeof(exc), "%s%s", JNU_JAVANETPKG, excP);
     JNU_ThrowByName(env, exc, fullMsg);
 }
 


### PR DESCRIPTION
Backport applies cleanly, required to upgrade the GH actions runners to macos-13/Xcode 14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8308801](https://bugs.openjdk.org/browse/JDK-8308801) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308801](https://bugs.openjdk.org/browse/JDK-8308801): update for deprecated sprintf for libnet in java.base (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2682/head:pull/2682` \
`$ git checkout pull/2682`

Update a local copy of the PR: \
`$ git checkout pull/2682` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2682`

View PR using the GUI difftool: \
`$ git pr show -t 2682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2682.diff">https://git.openjdk.org/jdk17u-dev/pull/2682.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2682#issuecomment-2211736320)