### PR TITLE
8307848: update for deprecated sprintf for jdk.attach

### DIFF
--- a/src/jdk.attach/windows/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/windows/native/libattach/VirtualMachineImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -209,7 +209,7 @@ JNIEXPORT jlong JNICALL Java_sun_tools_attach_VirtualMachineImpl_openProcess
             } else {
                 char err_mesg[255];
                 /* include the last error in the default detail message */
-                sprintf(err_mesg, "OpenProcess(pid=%d) failed; LastError=0x%x",
+                snprintf(err_mesg, sizeof(err_mesg), "OpenProcess(pid=%d) failed; LastError=0x%x",
                     (int)pid, (int)GetLastError());
                 JNU_ThrowIOExceptionWithLastError(env, err_mesg);
             }
@@ -492,7 +492,7 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_enqueue
                         break;
                     default : {
                         char errmsg[128];
-                        sprintf(errmsg, "Remote thread failed for unknown reason (%d)", exitCode);
+                        snprintf(errmsg, sizeof(errmsg), "Remote thread failed for unknown reason (%d)", exitCode);
                         JNU_ThrowInternalError(env, errmsg);
                     }
                 }


### PR DESCRIPTION
Backport applies cleanly, required to upgrade the GH actions runners to macos-13/Xcode 14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8307848](https://bugs.openjdk.org/browse/JDK-8307848) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307848](https://bugs.openjdk.org/browse/JDK-8307848): update for deprecated sprintf for jdk.attach (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2683/head:pull/2683` \
`$ git checkout pull/2683`

Update a local copy of the PR: \
`$ git checkout pull/2683` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2683`

View PR using the GUI difftool: \
`$ git pr show -t 2683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2683.diff">https://git.openjdk.org/jdk17u-dev/pull/2683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2683#issuecomment-2211736672)