### PR TITLE
8303830: update for deprecated sprintf for jdk.accessibility

### DIFF
--- a/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
+++ b/src/jdk.accessibility/windows/native/common/AccessBridgeDebug.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,7 +125,7 @@ char *printError(char *msg) {
         va_list argprt;
 
         va_start(argprt, msg);     // set up argptr
-        vsprintf(buf, msg, argprt);
+        vsnprintf(buf, sizeof(buf), msg, argprt);
 #ifdef SEND_TO_OUTPUT_DEBUG_STRING
         OutputDebugString(buf);
 #endif
@@ -153,7 +153,7 @@ char *printError(char *msg) {
         va_list argprt;
 
         va_start(argprt, msg);     // set up argptr
-        vsprintf(buf, msg, argprt);
+        vsnprintf(buf, sizeof(buf), msg, argprt);
 #ifdef SEND_TO_OUTPUT_DEBUG_STRING
         OutputDebugString(buf);
 #endif
@@ -181,8 +181,8 @@ char *printError(char *msg) {
         va_list argprt;
 
         va_start(argprt, msg);          // set up argptr
-        sprintf(charmsg, "%ls", msg);  // convert format string to multi-byte
-        vsprintf(buf, charmsg, argprt);
+        snprintf(charmsg, sizeof(charmsg), "%ls", msg);  // convert format string to multi-byte
+        vsnprintf(buf, sizeof(buf), charmsg, argprt);
 #ifdef SEND_TO_OUTPUT_DEBUG_STRING
         OutputDebugString(buf);
 #endif
@@ -211,8 +211,8 @@ char *printError(char *msg) {
         va_list argprt;
 
         va_start(argprt, msg);          // set up argptr
-        sprintf(charmsg, "%ls", msg);  // convert format string to multi-byte
-        vsprintf(buf, charmsg, argprt);
+        snprintf(charmsg, sizeof(charmsg), "%ls", msg);  // convert format string to multi-byte
+        vsnprintf(buf, sizeof(buf), charmsg, argprt);
 #ifdef SEND_TO_OUTPUT_DEBUG_STRING
         OutputDebugString(buf);
 #endif

--- a/src/jdk.accessibility/windows/native/jaccessinspector/jaccessinspector.cpp
+++ b/src/jdk.accessibility/windows/native/jaccessinspector/jaccessinspector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -609,7 +609,7 @@ void HandlePropertyChildChange( long vmID, PropertyChangeEvent event,
     char buffer[HUGE_BUFSIZE];
     char *bufOffset;
 
-    sprintf( buffer,
+    snprintf( buffer, sizeof(buffer),
              "Child property changed event:\r\n=======================\r\n\r\n" );
 
     if (oldChild != 0) {
@@ -647,7 +647,7 @@ void HandlePropertyActiveDescendentChange( long vmID, PropertyChangeEvent event,
                                            JOBJECT64 newActiveDescendent ) {
     char buffer[HUGE_BUFSIZE];
 
-    sprintf( buffer,
+    snprintf( buffer, sizeof(buffer),
              "ActiveDescendent property changed event:\r\n=======================\r\n\r\n" );
 
 #ifdef _notdef

--- a/src/jdk.accessibility/windows/native/jaccesswalker/jaccesswalker.cpp
+++ b/src/jdk.accessibility/windows/native/jaccesswalker/jaccesswalker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -542,7 +542,7 @@ void Jaccesswalker::addComponentNodes(long vmID, AccessibleContext context,
         }
     } else {
         char s[LINE_BUFSIZE];
-        sprintf( s,
+        snprintf( s, sizeof(s),
             "ERROR calling GetAccessibleContextInfo; vmID = %X, context = %p",
             vmID, (void*)context );
 

--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeEventHandler.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeEventHandler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,9 +161,9 @@ AccessBridgeEventHandler::firePropertyChange(long vmID,
                                              wchar_t *newName) {
     DEBUG_CODE(char debugBuf[255]);
 #ifdef ACCESSBRIDGE_ARCH_LEGACY // JOBJECT64 is jobject (32 bit pointer)
-    DEBUG_CODE(sprintf(debugBuf, "\r\nCalling firePropertyChange(%p, %p):\r\n", event, source));
+    DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "\r\nCalling firePropertyChange(%p, %p):\r\n", event, source));
 #else // JOBJECT64 is jlong (64 bit)
-    DEBUG_CODE(sprintf(debugBuf, "\r\nCalling firePropertyChange(%016I64X, %016I64X):\r\n", event, source));
+    DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "\r\nCalling firePropertyChange(%016I64X, %016I64X):\r\n", event, source));
 #endif
     DEBUG_CODE(AppendToCallInfo(debugBuf));
 
@@ -194,7 +194,7 @@ const char fireEventDebugString[] = "[INFO]: In AccessBridgeEventHandler::%s(%01
 #define FIRE_EVENT(method, FPprototype, eventFP) \
     void AccessBridgeEventHandler::method(long vmID, JOBJECT64 event, JOBJECT64 source) { \
         DEBUG_CODE(char debugBuf[255]); \
-        DEBUG_CODE(sprintf(debugBuf, fireEventDebugString, #method, event, source, vmID)); \
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), fireEventDebugString, #method, event, source, vmID)); \
         DEBUG_CODE(AppendToCallInfo(debugBuf)); \
         if (eventFP != (FPprototype) 0) { \
             eventFP(vmID, event, source); \
@@ -205,7 +205,7 @@ const char fireEventDebugString[] = "[INFO]: In AccessBridgeEventHandler::%s(%01
 
     void AccessBridgeEventHandler::fireJavaShutdown(long vmID) {
         DEBUG_CODE(char debugBuf[255]);
-        DEBUG_CODE(sprintf(debugBuf, "[INFO]: Calling fireJavaShutdown; vmID = %X\r\n", vmID));
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "[INFO]: Calling fireJavaShutdown; vmID = %X\r\n", vmID));
         DEBUG_CODE(AppendToCallInfo(debugBuf));
         if (javaShutdownFP != (AccessBridge_JavaShutdownFP) 0) {
             javaShutdownFP(vmID);
@@ -249,7 +249,7 @@ const char firePropertyChangeDebugString[] = "[INFO]: In AccessBridgeEventHandle
 #define FIRE_PROPERTY_CHANGE(method, FPprototype, eventFP) \
     void AccessBridgeEventHandler::method(long vmID, JOBJECT64 event, JOBJECT64 source) { \
         DEBUG_CODE(char debugBuf[255]); \
-        DEBUG_CODE(sprintf(debugBuf, firePropertyChangeDebugString, #method, event, source)); \
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), firePropertyChangeDebugString, #method, event, source)); \
         DEBUG_CODE(AppendToCallInfo(debugBuf)); \
         if (eventFP != (FPprototype) 0) { \
             eventFP(vmID, event, source); \
@@ -278,7 +278,7 @@ const char fireStringPropertyChangeDebugString[] = "[INFO]: In AccessBridgeEvent
     void AccessBridgeEventHandler::method(long vmID, JOBJECT64 event, JOBJECT64 source, \
                                           wchar_t *oldValue, wchar_t *newValue) { \
         DEBUG_CODE(char debugBuf[255]); \
-        DEBUG_CODE(sprintf(debugBuf, fireStringPropertyChangeDebugString, #method, event, source, oldValue, newValue)); \
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), fireStringPropertyChangeDebugString, #method, event, source, oldValue, newValue)); \
         DEBUG_CODE(AppendToCallInfo(debugBuf)); \
         if (eventFP != (FPprototype) 0) { \
             eventFP(vmID, event, source, oldValue, newValue); \
@@ -307,7 +307,7 @@ const char fireIntPropertyChangeDebugString[] = "[INFO]: In AccessBridgeEventHan
     void AccessBridgeEventHandler::method(long vmID, JOBJECT64 event, JOBJECT64 source,  \
                                           int oldValue, int newValue) { \
         DEBUG_CODE(char debugBuf[255]); \
-        DEBUG_CODE(sprintf(debugBuf, fireIntPropertyChangeDebugString, #method, event, source, oldValue, newValue)); \
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), fireIntPropertyChangeDebugString, #method, event, source, oldValue, newValue)); \
         DEBUG_CODE(AppendToCallInfo(debugBuf)); \
         if (eventFP != (FPprototype) 0) { \
             eventFP(vmID, event, source, oldValue, newValue); \
@@ -336,7 +336,7 @@ const char fireACPropertyChangeDebugString[] = "[INFO]: In AccessBridgeEventHand
     void AccessBridgeEventHandler::method(long vmID, JOBJECT64 event, JOBJECT64 source,  \
                                           JOBJECT64 oldValue, JOBJECT64 newValue) { \
         DEBUG_CODE(char debugBuf[255]); \
-        DEBUG_CODE(sprintf(debugBuf, fireACPropertyChangeDebugString, #method, event, source, oldValue, newValue)); \
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), fireACPropertyChangeDebugString, #method, event, source, oldValue, newValue)); \
         DEBUG_CODE(AppendToCallInfo(debugBuf)); \
         if (eventFP != (FPprototype) 0) { \
             eventFP(vmID, event, source, oldValue, newValue); \

--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeJavaVMInstance.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/AccessBridgeJavaVMInstance.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ AccessBridgeJavaVMInstance::AccessBridgeJavaVMInstance(HWND ourABWindow,
     nextJVMInstance = next;
     memoryMappedFileMapHandle = (HANDLE) 0;
     memoryMappedView = (char *) 0;
-    sprintf(memoryMappedFileName, "AccessBridge-%p-%p.mmf",
+    snprintf(memoryMappedFileName, sizeof(memoryMappedFileName), "AccessBridge-%p-%p.mmf",
             ourAccessBridgeWindow, javaAccessBridgeWindow);
 }
 
@@ -85,14 +85,14 @@ AccessBridgeJavaVMInstance::~AccessBridgeJavaVMInstance() {
     // if IPC memory mapped file view is valid, unmap it
     goingAway = TRUE;
     if (memoryMappedView != (char *) 0) {
-        DEBUG_CODE(sprintf(buffer, "  unmapping memoryMappedView; view = %p\r\n", memoryMappedView));
+        DEBUG_CODE(snprintf(buffer, sizeof(buffer), "  unmapping memoryMappedView; view = %p\r\n", memoryMappedView));
         DEBUG_CODE(AppendToCallInfo(buffer));
         UnmapViewOfFile(memoryMappedView);
         memoryMappedView = (char *) 0;
     }
     // if IPC memory mapped file handle map is open, close it
     if (memoryMappedFileMapHandle != (HANDLE) 0) {
-        DEBUG_CODE(sprintf(buffer, "  closing memoryMappedFileMapHandle; handle = %p\r\n", memoryMappedFileMapHandle));
+        DEBUG_CODE(snprintf(buffer, sizeof(buffer), "  closing memoryMappedFileMapHandle; handle = %p\r\n", memoryMappedFileMapHandle));
         DEBUG_CODE(AppendToCallInfo(buffer));
         CloseHandle(memoryMappedFileMapHandle);
         memoryMappedFileMapHandle = (HANDLE) 0;
@@ -131,11 +131,11 @@ AccessBridgeJavaVMInstance::initiateIPC() {
                                                   memoryMappedFileName);
     if (memoryMappedFileMapHandle == NULL) {
         errorCode = GetLastError();
-        DEBUG_CODE(sprintf(debugBuf, "  Failed to CreateFileMapping for %s, error: %X", memoryMappedFileName, errorCode));
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "  Failed to CreateFileMapping for %s, error: %X", memoryMappedFileName, errorCode));
         DEBUG_CODE(AppendToCallInfo(debugBuf));
         return errorCode;
     } else {
-        DEBUG_CODE(sprintf(debugBuf, "  CreateFileMapping worked - filename: %s\r\n", memoryMappedFileName));
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "  CreateFileMapping worked - filename: %s\r\n", memoryMappedFileName));
         DEBUG_CODE(AppendToCallInfo(debugBuf));
     }
 
@@ -144,11 +144,11 @@ AccessBridgeJavaVMInstance::initiateIPC() {
                                               0, 0, 0);
     if (memoryMappedView == NULL) {
         errorCode = GetLastError();
-        DEBUG_CODE(sprintf(debugBuf, "  Failed to MapViewOfFile for %s, error: %X", memoryMappedFileName, errorCode));
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "  Failed to MapViewOfFile for %s, error: %X", memoryMappedFileName, errorCode));
         DEBUG_CODE(AppendToCallInfo(debugBuf));
         return errorCode;
     } else {
-        DEBUG_CODE(sprintf(debugBuf, "  MapViewOfFile worked - view: %p\r\n", memoryMappedView));
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "  MapViewOfFile worked - view: %p\r\n", memoryMappedView));
         DEBUG_CODE(AppendToCallInfo(debugBuf));
     }
 
@@ -169,12 +169,12 @@ AccessBridgeJavaVMInstance::initiateIPC() {
 
     // look for the JavaDLL's answer to see if it could read the file
     if (strcmp(memoryMappedView, AB_MEMORY_MAPPED_FILE_OK_ANSWER) != 0) {
-        DEBUG_CODE(sprintf(debugBuf, "  JavaVM failed to deal with memory mapped file %s\r\n",
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "  JavaVM failed to deal with memory mapped file %s\r\n",
                       memoryMappedFileName));
         DEBUG_CODE(AppendToCallInfo(debugBuf));
         return -1;
     } else {
-        DEBUG_CODE(sprintf(debugBuf, "  Success!  JavaVM accpeted our file\r\n"));
+        DEBUG_CODE(snprintf(debugBuf, sizeof(debugBuf), "  Success!  JavaVM accpeted our file\r\n"));
         DEBUG_CODE(AppendToCallInfo(debugBuf));
     }
 
@@ -245,16 +245,16 @@ AccessBridgeJavaVMInstance::sendMemoryPackage(char *buffer, long bufsize) {
     BOOL retval = FALSE;
 
     DEBUG_CODE(char outputBuf[256]);
-    DEBUG_CODE(sprintf(outputBuf, "AccessBridgeJavaVMInstance::sendMemoryPackage(, %d)", bufsize));
+    DEBUG_CODE(snprintf(outputBuf, sizeof(outputBuf), "AccessBridgeJavaVMInstance::sendMemoryPackage(, %d)", bufsize));
     DEBUG_CODE(AppendToCallInfo(outputBuf));
 
     DEBUG_CODE(PackageType *type = (PackageType *) buffer);
     DEBUG_CODE(if (*type == cGetAccessibleTextRangePackage) {)
         DEBUG_CODE(AppendToCallInfo("  'buffer' contains:"));
         DEBUG_CODE(GetAccessibleTextRangePackage *pkg = (GetAccessibleTextRangePackage *) (buffer + sizeof(PackageType)));
-        DEBUG_CODE(sprintf(outputBuf, "    PackageType = %X", *type));
+        DEBUG_CODE(snprintf(outputBuf, sizeof(outputBuf), "    PackageType = %X", *type));
         DEBUG_CODE(AppendToCallInfo(outputBuf));
-        DEBUG_CODE(sprintf(outputBuf, "    GetAccessibleTextRange: start = %d, end = %d, rText = %ls",
+        DEBUG_CODE(snprintf(outputBuf, sizeof(outputBuf), "    GetAccessibleTextRange: start = %d, end = %d, rText = %ls",
             pkg->start, pkg->end, pkg->rText));
         DEBUG_CODE(AppendToCallInfo(outputBuf));
     DEBUG_CODE(})
@@ -269,7 +269,7 @@ AccessBridgeJavaVMInstance::sendMemoryPackage(char *buffer, long bufsize) {
             DEBUG_CODE(if (*type == cGetAccessibleTextItemsPackage) {)
                 DEBUG_CODE(AppendToCallInfo("  'memoryMappedView' now contains:"));
                 DEBUG_CODE(GetAccessibleTextItemsPackage *pkg = (GetAccessibleTextItemsPackage *) (buffer + sizeof(PackageType)));
-                DEBUG_CODE(sprintf(outputBuf, "    PackageType = %X", *type));
+                DEBUG_CODE(snprintf(outputBuf, sizeof(outputBuf), "    PackageType = %X", *type));
                 DEBUG_CODE(AppendToCallInfo(outputBuf));
             DEBUG_CODE(})
         }

--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,7 +160,7 @@ extern "C" {
         */
 
         char buf[1024];
-        sprintf(buf, "WinAccessBridge: %s", s);
+        snprintf(buf, sizeof(buf), "WinAccessBridge: %s", s);
         OutputDebugString(buf);
     }
 

--- a/src/jdk.accessibility/windows/native/toolscommon/AccessInfo.cpp
+++ b/src/jdk.accessibility/windows/native/toolscommon/AccessInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ char *getTimeAndDate() {
     if( newtime->tm_hour == 0 )        /*Set hour to 12 if midnight. */
         newtime->tm_hour = 12;
 
-    sprintf(datebuf, "%.19s %s\n", asctime( newtime ), am_pm );
+    snprintf(datebuf, sizeof(datebuf), "%.19s %s\n", asctime( newtime ), am_pm );
     return (char *)datebuf;
 }
 
@@ -67,7 +67,7 @@ void displayAndLog(HWND hDlg, int nIDDlgItem, FILE *logfile, char *msg, ...) {
     va_list argprt;
 
     va_start(argprt, msg);
-    vsprintf(tmpbuf, msg, argprt);
+    vsnprintf(tmpbuf, sizeof(tmpbuf), msg, argprt);
 
     SetDlgItemText(hDlg, nIDDlgItem, tmpbuf);
 
@@ -95,7 +95,7 @@ void logString(FILE *logfile, char *msg, ...) {
     va_list argprt;
 
     va_start(argprt, msg);
-    vsprintf(tmpbuf, msg, argprt);
+    vsnprintf(tmpbuf, sizeof(tmpbuf), msg, argprt);
 
     fprintf(logfile, tmpbuf);
     fprintf(logfile, "\n");
@@ -119,7 +119,7 @@ BOOL appendToBuffer(char *buf, size_t buflen, char *msg, ...) {
     va_list argprt;
 
     va_start(argprt, msg);
-    vsprintf(tmpbuf, msg, argprt);
+    vsnprintf(tmpbuf, sizeof(tmpbuf), msg, argprt);
 
     // verify there's enough space in the buffer
     size_t spaceRemaining = buflen - strlen(buf) - 1;


### PR DESCRIPTION
Backport applies cleanly, required to upgrade the GH actions runners to macos-13/Xcode 14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8303830](https://bugs.openjdk.org/browse/JDK-8303830) needs maintainer approval

### Issue
 * [JDK-8303830](https://bugs.openjdk.org/browse/JDK-8303830): update for deprecated sprintf for jdk.accessibility (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2684/head:pull/2684` \
`$ git checkout pull/2684`

Update a local copy of the PR: \
`$ git checkout pull/2684` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2684`

View PR using the GUI difftool: \
`$ git pr show -t 2684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2684.diff">https://git.openjdk.org/jdk17u-dev/pull/2684.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2684#issuecomment-2211736449)