### PR TITLE
8307850: update for deprecated sprintf for jdk.jdi

### DIFF
--- a/src/jdk.jdi/share/native/libdt_shmem/SharedMemoryTransport.c
+++ b/src/jdk.jdi/share/native/libdt_shmem/SharedMemoryTransport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,9 +64,9 @@ throwShmemException(JNIEnv *env, char *message, jint errorCode)
     char buf[255];
 
     if (shmemBase_getlasterror(msg, sizeof(msg)) == SYS_OK) {
-        sprintf(buf, "%s: %s\n", message, msg);
+        snprintf(buf, sizeof(buf), "%s: %s\n", message, msg);
     } else {
-        sprintf(buf, "%s, error code = %d", message, errorCode);
+        snprintf(buf, sizeof(buf), "%s, error code = %d", message, errorCode);
     }
     throwException(env, "java/io/IOException", buf);
 }

--- a/src/jdk.jdi/share/native/libdt_shmem/shmemBase.c
+++ b/src/jdk.jdi/share/native/libdt_shmem/shmemBase.c
@@ -244,7 +244,7 @@ createWithGeneratedName(char *prefix, char *nameBuffer, CreateFunc func, void *a
         strcpy(nameBuffer, prefix);
         if (i > 0) {
             char buf[10];
-            sprintf(buf, ".%d", i+1);
+            snprintf(buf, sizeof(buf), ".%d", i+1);
             strcat(nameBuffer, buf);
         }
         error = func(nameBuffer, arg);
@@ -433,14 +433,14 @@ createStream(char *name, Stream *stream)
     jint error;
     char objectName[MAX_IPC_NAME];
 
-    sprintf(objectName, "%s.mutex", name);
+    snprintf(objectName, sizeof(objectName), "%s.mutex", name);
     error = createWithGeneratedName(objectName, stream->shared->mutexName,
                                     createMutex, &stream->mutex);
     if (error != SYS_OK) {
         return error;
     }
 
-    sprintf(objectName, "%s.hasData", name);
+    snprintf(objectName, sizeof(objectName), "%s.hasData", name);
     error = createWithGeneratedName(objectName, stream->shared->hasDataEventName,
                                     createEvent, &stream->hasData);
     if (error != SYS_OK) {
@@ -448,7 +448,7 @@ createStream(char *name, Stream *stream)
         return error;
     }
 
-    sprintf(objectName, "%s.hasSpace", name);
+    snprintf(objectName, sizeof(objectName), "%s.hasSpace", name);
     error = createWithGeneratedName(objectName, stream->shared->hasSpaceEventName,
                                     createEvent, &stream->hasSpace);
     if (error != SYS_OK) {
@@ -571,7 +571,7 @@ openConnection(SharedMemoryTransport *transport, jlong otherPID,
         return SYS_NOMEM;
     }
 
-    sprintf(connection->name, "%s.%" PRId64, transport->name, sysProcessGetID());
+    snprintf(connection->name, sizeof(connection->name), "%s.%" PRId64, transport->name, sysProcessGetID());
     error = sysSharedMemOpen(connection->name, &connection->sharedMemory,
                              &connection->shared);
     if (error != SYS_OK) {
@@ -639,7 +639,7 @@ createConnection(SharedMemoryTransport *transport, jlong otherPID,
         return SYS_NOMEM;
     }
 
-    sprintf(connection->name, "%s.%" PRId64, transport->name, otherPID);
+    snprintf(connection->name, sizeof(connection->name), "%s.%" PRId64, transport->name, otherPID);
     error = sysSharedMemCreate(connection->name, sizeof(SharedMemory),
                                &connection->sharedMemory, &connection->shared);
     if (error != SYS_OK) {
@@ -738,7 +738,7 @@ openTransport(const char *address, SharedMemoryTransport **transportPtr)
 
     if (strlen(address) >= MAX_IPC_PREFIX) {
         char buf[128];
-        sprintf(buf, "Error: address strings longer than %d characters are invalid\n", MAX_IPC_PREFIX);
+        snprintf(buf, sizeof(buf), "Error: address strings longer than %d characters are invalid\n", MAX_IPC_PREFIX);
         setLastErrorMsg(buf);
         closeTransport(transport);
         return SYS_ERR;
@@ -802,7 +802,7 @@ createTransport(const char *address, SharedMemoryTransport **transportPtr)
     } else {
         if (strlen(address) >= MAX_IPC_PREFIX) {
             char buf[128];
-            sprintf(buf, "Error: address strings longer than %d characters are invalid\n", MAX_IPC_PREFIX);
+            snprintf(buf, sizeof(buf), "Error: address strings longer than %d characters are invalid\n", MAX_IPC_PREFIX);
             setLastErrorMsg(buf);
             closeTransport(transport);
             return SYS_ERR;
@@ -820,7 +820,7 @@ createTransport(const char *address, SharedMemoryTransport **transportPtr)
     memset(transport->shared, 0, sizeof(SharedListener));
     transport->shared->acceptingPID = sysProcessGetID();
 
-    sprintf(objectName, "%s.mutex", transport->name);
+    snprintf(objectName, sizeof(objectName), "%s.mutex", transport->name);
     error = createWithGeneratedName(objectName, transport->shared->mutexName,
                                     createMutex, &transport->mutex);
     if (error != SYS_OK) {
@@ -828,7 +828,7 @@ createTransport(const char *address, SharedMemoryTransport **transportPtr)
         return error;
     }
 
-    sprintf(objectName, "%s.accept", transport->name);
+    snprintf(objectName, sizeof(objectName), "%s.accept", transport->name);
     error = createWithGeneratedName(objectName, transport->shared->acceptEventName,
                                     createEvent, &transport->acceptEvent);
     if (error != SYS_OK) {
@@ -836,7 +836,7 @@ createTransport(const char *address, SharedMemoryTransport **transportPtr)
         return error;
     }
 
-    sprintf(objectName, "%s.attach", transport->name);
+    snprintf(objectName, sizeof(objectName), "%s.attach", transport->name);
     error = createWithGeneratedName(objectName, transport->shared->attachEventName,
                                     createEvent, &transport->attachEvent);
     if (error != SYS_OK) {
@@ -1263,7 +1263,7 @@ exitTransportWithError(char *message, char *fileName,
     jint error;
     char buffer[500];
 
-    sprintf(buffer, "Shared Memory Transport \"%s\" (%s), line %d: %s\n",
+    snprintf(buffer, sizeof(buffer), "Shared Memory Transport \"%s\" (%s), line %d: %s\n",
             fileName, date, lineNumber, message);
     error = (*jvm)->GetEnv(jvm, (void **)&env, JNI_VERSION_1_2);
     if (error != JNI_OK) {


### PR DESCRIPTION
Backport applies cleanly except for a slight difference in `src/jdk.jdi/share/native/libdt_shmem/shmemBase.c` due to https://github.com/openjdk/jdk/commit/b4ab5fe1daf22a543e1bd973bcd34322360054b4 being JDK20+

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307850](https://bugs.openjdk.org/browse/JDK-8307850) needs maintainer approval

### Issue
 * [JDK-8307850](https://bugs.openjdk.org/browse/JDK-8307850): update for deprecated sprintf for jdk.jdi (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2685/head:pull/2685` \
`$ git checkout pull/2685`

Update a local copy of the PR: \
`$ git checkout pull/2685` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2685`

View PR using the GUI difftool: \
`$ git pr show -t 2685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2685.diff">https://git.openjdk.org/jdk17u-dev/pull/2685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2685#issuecomment-2211737669)