### PR TITLE
8335808: update for deprecated sprintf for jfrTypeSetUtils

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSetUtils.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSetUtils.cpp
@@ -207,7 +207,7 @@ static const char* create_hidden_klass_symbol(const InstanceKlass* ik, uintptr_t
   const oop mirror = ik->java_mirror_no_keepalive();
   assert(mirror != NULL, "invariant");
   char hash_buf[40];
-  sprintf(hash_buf, "/" UINTX_FORMAT, hash);
+  snprintf(hash_buf, sizeof(hash_buf), "/" UINTX_FORMAT, hash);
   const size_t hash_len = strlen(hash_buf);
   const size_t result_len = ik->name()->utf8_length();
   hidden_symbol = NEW_RESOURCE_ARRAY(char, result_len + hash_len + 1);


### PR DESCRIPTION
The occurrence of `sprintf` was removed in JDK18 as part of https://bugs.openjdk.org/browse/JDK-8266936. This patch simply converts it to `snprintf` to avoid build failures. 