### PR TITLE
8255898: Test java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java fails on Mac OS

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -462,7 +462,7 @@ java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all
 java/awt/Debug/DumpOnKey/DumpOnKey.java 8202667 windows-all
 java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 8202926 linux-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
-java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882,8255898 linux-all,macosx-all
+java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java 7124275 macosx-all
 java/awt/Focus/TranserFocusToWindow/TranserFocusToWindow.java 6848810 macosx-all,linux-all
 java/awt/Component/NativeInLightShow/NativeInLightShow.java 8202932 linux-all

--- a/test/jdk/java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java
+++ b/test/jdk/java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java
@@ -28,7 +28,7 @@
   @summary namefilter is not called for file dialog on windows
   @library ../../regtesthelpers
   @build Util
-  @run main FilenameFilterTest
+  @run main/othervm FilenameFilterTest
 */
 
 import java.awt.*;


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8255898](https://bugs.openjdk.org/browse/JDK-8255898) needs maintainer approval

### Issue
 * [JDK-8255898](https://bugs.openjdk.org/browse/JDK-8255898): Test java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java fails on Mac OS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2696/head:pull/2696` \
`$ git checkout pull/2696`

Update a local copy of the PR: \
`$ git checkout pull/2696` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2696`

View PR using the GUI difftool: \
`$ git pr show -t 2696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2696.diff">https://git.openjdk.org/jdk17u-dev/pull/2696.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2696#issuecomment-2216710052)