### PR TITLE
8329109: Threads::print_on() tries to print CPU time for terminated GC threads

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3828,14 +3828,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
   }
 
   PrintOnClosure cl(st);
-  cl.do_thread(VMThread::vm_thread());
-  Universe::heap()->gc_threads_do(&cl);
-  if (StringDedup::is_enabled()) {
-    StringDedup::threads_do(&cl);
-  }
-  cl.do_thread(WatcherThread::watcher_thread());
-  cl.do_thread(AsyncLogWriter::instance());
-
+  non_java_threads_do(&cl);
   st->flush();
 }
 


### PR DESCRIPTION
Backport of 8329109

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329109](https://bugs.openjdk.org/browse/JDK-8329109) needs maintainer approval

### Issue
 * [JDK-8329109](https://bugs.openjdk.org/browse/JDK-8329109): Threads::print_on() tries to print CPU time for terminated GC threads (**Bug** - P3 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2698/head:pull/2698` \
`$ git checkout pull/2698`

Update a local copy of the PR: \
`$ git checkout pull/2698` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2698`

View PR using the GUI difftool: \
`$ git pr show -t 2698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2698.diff">https://git.openjdk.org/jdk17u-dev/pull/2698.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2698#issuecomment-2217285525)