### PR TITLE
8273541: Cleaner Thread creates with normal priority instead of MAX_PRIORITY - 2

### DIFF
--- a/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/ref/CleanerImpl.java
@@ -214,7 +214,7 @@ public final class CleanerImpl implements Runnable {
 
         public Thread newThread(Runnable r) {
             return InnocuousThread.newThread("Cleaner-" + cleanerThreadNumber.getAndIncrement(),
-                r, Thread.MIN_PRIORITY - 2);
+                r, Thread.MAX_PRIORITY - 2);
         }
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8273541](https://bugs.openjdk.org/browse/JDK-8273541) needs maintainer approval

### Issue
 * [JDK-8273541](https://bugs.openjdk.org/browse/JDK-8273541): Cleaner Thread creates with normal priority instead of MAX_PRIORITY - 2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2701/head:pull/2701` \
`$ git checkout pull/2701`

Update a local copy of the PR: \
`$ git checkout pull/2701` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2701`

View PR using the GUI difftool: \
`$ git pr show -t 2701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2701.diff">https://git.openjdk.org/jdk17u-dev/pull/2701.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2701#issuecomment-2221374716)