### PR TITLE
8335775: Remove extraneous 's' in comment of rawmonitor.cpp test file

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp
@@ -1,5 +1,4 @@
 /*
-s
  * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
A trivial backport to fix a typo (an errant 's') in test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp introduced by [JDK-8299635](https://bugs.openjdk.org/browse/JDK-8299635). This is a clean backport from 21u. The original from 24 did not apply cleanly to 21u as it doesn't have [JDK-8324681](https://bugs.openjdk.org/browse/JDK-8324681) which bumped the copyright header to 2024 (which probably should have been bumped to 2023 in 8299635!)

This was spotted by George Adams (@gdams) when backporting 8299635 to 17u, where it is now needed to support builds on newer versions of Mac OS. It's a trivial fix it makes sense to clean up everywhere.

The original commit being backported was authored by Severin Gehwolf on 5 Jul 2024 and was reviewed by George Adams and Thomas Stuefe. It has been backported to 21u & 23.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335775](https://bugs.openjdk.org/browse/JDK-8335775) needs maintainer approval

### Issue
 * [JDK-8335775](https://bugs.openjdk.org/browse/JDK-8335775): Remove extraneous 's' in comment of rawmonitor.cpp test file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2702/head:pull/2702` \
`$ git checkout pull/2702`

Update a local copy of the PR: \
`$ git checkout pull/2702` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2702`

View PR using the GUI difftool: \
`$ git pr show -t 2702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2702.diff">https://git.openjdk.org/jdk17u-dev/pull/2702.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2702#issuecomment-2221824706)