### PR TITLE
8309703: AIX build fails after JDK-8280982

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -49,6 +49,11 @@ static struct PwLoopData pw = {0};
 jclass tokenStorageClass = NULL;
 jmethodID storeTokenMethodID = NULL;
 
+#if defined(AIX) && defined(__open_xl_version__) && __open_xl_version__ >= 17
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
+
 inline void debug_screencast(
         const char *__restrict fmt,
         ...

--- a/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/raw.h
+++ b/src/java.desktop/unix/native/libpipewire/include/spa/param/audio/raw.h
@@ -11,8 +11,14 @@ extern "C" {
 
 #include <stdint.h>
 
-#if !defined(__FreeBSD__) && !defined(__MidnightBSD__)
+#if !defined(__FreeBSD__) && !defined(__MidnightBSD__) && !defined(AIX)
 #include <endian.h>
+#endif
+
+#if defined(AIX)
+#include <sys/machine.h>
+#define __BIG_ENDIAN      BIG_ENDIAN
+#define __BYTE_ORDER      BIG_ENDIAN
 #endif
 
 /**


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8309703](https://bugs.openjdk.org/browse/JDK-8309703) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309703](https://bugs.openjdk.org/browse/JDK-8309703): AIX build fails after JDK-8280982 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2704/head:pull/2704` \
`$ git checkout pull/2704`

Update a local copy of the PR: \
`$ git checkout pull/2704` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2704`

View PR using the GUI difftool: \
`$ git pr show -t 2704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2704.diff">https://git.openjdk.org/jdk17u-dev/pull/2704.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2704#issuecomment-2222287009)