### PR TITLE
8325553: Parallel: Use per-marker cache for marking stats during Full GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -63,6 +63,8 @@ ParCompactionManager::ParCompactionManager() {
   _region_stack.initialize();
 
   reset_bitmap_query_cache();
+
+  _marking_stats_cache = NULL;
 }
 
 void ParCompactionManager::initialize(ParMarkBitMap* mbm) {

--- a/src/hotspot/share/gc/parallel/psCompactionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.hpp
@@ -105,7 +105,35 @@ class ParCompactionManager : public CHeapObj<mtGC> {
   // Do not implement an equivalent stack_pop.  Deal with the
   // marking stack and overflow stack directly.
 
- public:
+  // To collect per-region live-words in a worker local cache in order to
+  // reduce threads contention.
+  class MarkingStatsCache : public CHeapObj<mtGC> {
+    constexpr static size_t num_entries = 1024;
+    static_assert(is_power_of_2(num_entries), "inv");
+    static_assert(num_entries > 0, "inv");
+
+    constexpr static size_t entry_mask = num_entries - 1;
+
+    struct CacheEntry {
+      size_t region_id;
+      size_t live_words;
+    };
+
+    CacheEntry entries[num_entries] = {};
+
+    inline void push(size_t region_id, size_t live_words);
+
+  public:
+    inline void push(oop obj, size_t live_words);
+
+    inline void evict(size_t index);
+
+    inline void evict_all();
+  };
+
+  MarkingStatsCache* _marking_stats_cache;
+
+public:
   static const size_t InvalidShadow = ~0;
   static size_t  pop_shadow_region_mt_safe(PSParallelCompact::RegionData* region_ptr);
   static void    push_shadow_region_mt_safe(size_t shadow_region);
@@ -194,6 +222,10 @@ class ParCompactionManager : public CHeapObj<mtGC> {
       : _compaction_manager(cm), _terminator(terminator), _worker_id(worker_id) { }
     virtual void do_void();
   };
+
+  inline void create_marking_stats_cache();
+
+  inline void flush_and_destroy_marking_stats_cache();
 
   // Called after marking.
   static void verify_all_marking_stack_empty() NOT_DEBUG_RETURN;

--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -107,6 +107,8 @@ inline void ParCompactionManager::mark_and_push(T* p) {
     assert(ParallelScavengeHeap::heap()->is_in(obj), "should be in heap");
 
     if (mark_bitmap()->is_unmarked(obj) && PSParallelCompact::mark_obj(obj)) {
+      assert(_marking_stats_cache != nullptr, "inv");
+      _marking_stats_cache->push(obj, obj->size());
       push(obj);
     }
   }
@@ -174,6 +176,75 @@ inline void ParCompactionManager::follow_contents(oop obj) {
     PCIterateMarkAndPushClosure cl(this, PSParallelCompact::ref_processor());
     obj->oop_iterate(&cl);
   }
+}
+
+inline void ParCompactionManager::MarkingStatsCache::push(size_t region_id, size_t live_words) {
+  size_t index = (region_id & entry_mask);
+  if (entries[index].region_id == region_id) {
+    // Hit
+    entries[index].live_words += live_words;
+    return;
+  }
+  // Miss
+  if (entries[index].live_words != 0) {
+    evict(index);
+  }
+  entries[index].region_id = region_id;
+  entries[index].live_words = live_words;
+}
+
+inline void ParCompactionManager::MarkingStatsCache::push(oop obj, size_t live_words) {
+  ParallelCompactData& data = PSParallelCompact::summary_data();
+  const size_t region_size = ParallelCompactData::RegionSize;
+
+  HeapWord* addr = cast_from_oop<HeapWord*>(obj);
+  const size_t start_region_id = data.addr_to_region_idx(addr);
+  const size_t end_region_id = data.addr_to_region_idx(addr + live_words - 1);
+  if (start_region_id == end_region_id) {
+    // Completely inside this region
+    push(start_region_id, live_words);
+    return;
+  }
+
+  // First region
+  push(start_region_id, region_size - data.region_offset(addr));
+
+  // Middle regions; bypass cache
+  for (size_t i = start_region_id + 1; i < end_region_id; ++i) {
+    data.region(i)->set_partial_obj_size(region_size);
+    data.region(i)->set_partial_obj_addr(addr);
+  }
+
+  // Last region; bypass cache
+  const size_t end_offset = data.region_offset(addr + live_words - 1);
+  data.region(end_region_id)->set_partial_obj_size(end_offset + 1);
+  data.region(end_region_id)->set_partial_obj_addr(addr);
+}
+
+inline void ParCompactionManager::MarkingStatsCache::evict(size_t index) {
+  ParallelCompactData& data = PSParallelCompact::summary_data();
+  // flush to global data
+  data.region(entries[index].region_id)->add_live_obj(entries[index].live_words);
+}
+
+inline void ParCompactionManager::MarkingStatsCache::evict_all() {
+  for (size_t i = 0; i < num_entries; ++i) {
+    if (entries[i].live_words != 0) {
+      evict(i);
+      entries[i].live_words = 0;
+    }
+  }
+}
+
+inline void ParCompactionManager::create_marking_stats_cache() {
+  assert(_marking_stats_cache == nullptr, "precondition");
+  _marking_stats_cache = new MarkingStatsCache();
+}
+
+inline void ParCompactionManager::flush_and_destroy_marking_stats_cache() {
+  _marking_stats_cache->evict_all();
+  delete _marking_stats_cache;
+  _marking_stats_cache = nullptr;
 }
 
 #endif // SHARE_GC_PARALLEL_PSCOMPACTIONMANAGER_INLINE_HPP

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -1044,9 +1044,7 @@ class PSParallelCompact : AllStatic {
   static void post_compact();
 
   // Mark live objects
-  static void marking_phase(ParCompactionManager* cm,
-                            bool maximum_heap_compaction,
-                            ParallelOldTracer *gc_tracer);
+  static void marking_phase(ParallelOldTracer *gc_tracer);
 
   // Compute the dense prefix for the designated space.  This is an experimental
   // implementation currently not used in production.

--- a/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
@@ -99,7 +99,6 @@ inline void PSParallelCompact::check_new_location(HeapWord* old_addr, HeapWord* 
 inline bool PSParallelCompact::mark_obj(oop obj) {
   const int obj_size = obj->size();
   if (mark_bitmap()->mark_obj(obj, obj_size)) {
-    _summary_data.add_obj(obj, obj_size);
     return true;
   } else {
     return false;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8325553](https://bugs.openjdk.org/browse/JDK-8325553) needs maintainer approval

### Issue
 * [JDK-8325553](https://bugs.openjdk.org/browse/JDK-8325553): Parallel: Use per-marker cache for marking stats during Full GC (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2707/head:pull/2707` \
`$ git checkout pull/2707`

Update a local copy of the PR: \
`$ git checkout pull/2707` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2707`

View PR using the GUI difftool: \
`$ git pr show -t 2707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2707.diff">https://git.openjdk.org/jdk17u-dev/pull/2707.diff</a>

</details>
