### PR TITLE
8309756: Occasional crashes with pipewire screen capture on Wayland

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -89,8 +89,10 @@ static void doCleanup() {
         struct ScreenProps *screenProps = &screenSpace.screens[i];
         if (screenProps->data) {
             if (screenProps->data->stream) {
+                fp_pw_thread_loop_lock(pw.loop);
                 fp_pw_stream_disconnect(screenProps->data->stream);
                 fp_pw_stream_destroy(screenProps->data->stream);
+                fp_pw_thread_loop_unlock(pw.loop);
                 screenProps->data->stream = NULL;
             }
             free(screenProps->data);
@@ -892,8 +894,10 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl
             screenProps->captureData = NULL;
             screenProps->shouldCapture = FALSE;
 
+            fp_pw_thread_loop_lock(pw.loop);
             fp_pw_stream_set_active(screenProps->data->stream, FALSE);
             fp_pw_stream_disconnect(screenProps->data->stream);
+            fp_pw_thread_loop_unlock(pw.loop);
         }
     }
     doCleanup();


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309756](https://bugs.openjdk.org/browse/JDK-8309756) needs maintainer approval

### Issue
 * [JDK-8309756](https://bugs.openjdk.org/browse/JDK-8309756): Occasional crashes with pipewire screen capture on Wayland (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2712/head:pull/2712` \
`$ git checkout pull/2712`

Update a local copy of the PR: \
`$ git checkout pull/2712` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2712`

View PR using the GUI difftool: \
`$ git pr show -t 2712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2712.diff">https://git.openjdk.org/jdk17u-dev/pull/2712.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2712#issuecomment-2225480726)