### PR TITLE
8319103: Popups that request focus are not shown on Linux with Wayland

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -564,6 +564,21 @@ public abstract class UNIXToolkit extends SunToolkit
                 @Override
                 public void windowLostFocus(WindowEvent e) {
                     Window window = e.getWindow();
+                    Window oppositeWindow = e.getOppositeWindow();
+
+                    // The focus can move between the window calling the popup,
+                    // and the popup window itself.
+                    // We only dismiss the popup in other cases.
+                    if (oppositeWindow != null) {
+                        if (window == oppositeWindow.getParent() ) {
+                            addWaylandWindowFocusListenerToWindow(oppositeWindow);
+                            return;
+                        }
+                        if (window.getParent() == oppositeWindow) {
+                            return;
+                        }
+                    }
+
                     window.removeWindowFocusListener(this);
 
                     // AWT
@@ -578,18 +593,22 @@ public abstract class UNIXToolkit extends SunToolkit
         }
     }
 
+    private static void addWaylandWindowFocusListenerToWindow(Window window) {
+        if (!Arrays
+                .asList(window.getWindowFocusListeners())
+                .contains(waylandWindowFocusListener)
+        ) {
+            window.addWindowFocusListener(waylandWindowFocusListener);
+        }
+    }
+
     @Override
     public void dismissPopupOnFocusLostIfNeeded(Window invoker) {
-        if (!isOnWayland()
-                || invoker == null
-                || Arrays
-                    .asList(invoker.getWindowFocusListeners())
-                    .contains(waylandWindowFocusListener)
-        ) {
+        if (!isOnWayland() || invoker == null) {
             return;
         }
 
-        invoker.addWindowFocusListener(waylandWindowFocusListener);
+        addWaylandWindowFocusListenerToWindow(invoker);
     }
 
     @Override
@@ -599,5 +618,8 @@ public abstract class UNIXToolkit extends SunToolkit
         }
 
         invoker.removeWindowFocusListener(waylandWindowFocusListener);
+        for (Window ownedWindow : invoker.getOwnedWindows()) {
+            ownedWindow.removeWindowFocusListener(waylandWindowFocusListener);
+        }
     }
 }

--- a/test/jdk/javax/swing/JPopupMenu/FocusablePopupDismissTest.java
+++ b/test/jdk/javax/swing/JPopupMenu/FocusablePopupDismissTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+  * @test
+  * @key headful
+  * @bug 8319103
+  * @requires (os.family == "linux")
+  * @library /java/awt/regtesthelpers
+  * @build PassFailJFrame
+  * @summary Tests if the focusable popup can be dismissed when the parent
+  *          window or the popup itself loses focus in Wayland.
+  * @run main/manual FocusablePopupDismissTest
+  */
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.JTextField;
+import java.awt.Window;
+import java.util.List;
+
+public class FocusablePopupDismissTest {
+    private static final String INSTRUCTIONS = """
+            A frame with a "Click me" button should appear next to the window
+            with this instruction.
+
+            Click on the "Click me" button.
+
+            If the JTextField popup with "Some text" is not showing on the screen,
+            click Fail.
+
+            The following steps require some focusable system window to be displayed
+            on the screen. This could be a system settings window, file manager, etc.
+
+            Click on the "Click me" button if the popup is not displayed
+            on the screen.
+
+            While the popup is displayed, click on some other window on the desktop.
+            If the popup has disappeared, click Pass, otherwise click Fail.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        if (System.getenv("WAYLAND_DISPLAY") == null) {
+            //test is valid only when running on Wayland.
+            return;
+        }
+
+        PassFailJFrame.builder()
+                .title("FocusablePopupDismissTest")
+                .instructions(INSTRUCTIONS)
+                .rows(20)
+                .columns(45)
+                .testUI(FocusablePopupDismissTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static List<Window> createTestUI() {
+        JFrame frame = new JFrame("FocusablePopupDismissTest");
+        JButton button = new JButton("Click me");
+        frame.add(button);
+
+        button.addActionListener(e -> {
+            JPopupMenu popupMenu = new JPopupMenu();
+            JTextField textField = new JTextField("Some text", 10);
+            popupMenu.add(textField);
+            popupMenu.show(button, 0, button.getHeight());
+        });
+        frame.pack();
+
+        return List.of(frame);
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8319103](https://bugs.openjdk.org/browse/JDK-8319103) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319103](https://bugs.openjdk.org/browse/JDK-8319103): Popups that request focus are not shown on Linux with Wayland (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2723/head:pull/2723` \
`$ git checkout pull/2723`

Update a local copy of the PR: \
`$ git checkout pull/2723` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2723`

View PR using the GUI difftool: \
`$ git pr show -t 2723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2723.diff">https://git.openjdk.org/jdk17u-dev/pull/2723.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2723#issuecomment-2233349666)