### PR TITLE
Backport 7ca0ae94159ac0fd2df23ee1a1e8cf626ce31048

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -33,7 +33,8 @@
 # randomness:           test uses randomness, test cases differ from run to run
 # cgroups:              test uses cgroups
 # external-dep:         test requires external dependencies to work
-keys=stress headful intermittent randomness cgroups external-dep
+# flag-sensitive:       test is sensitive to certain flags and might fail when flags are passed using -vmoptions and -javaoptions
+keys=stress headful intermittent randomness cgroups flag-sensitive
 
 groups=TEST.groups TEST.quick-groups
 

--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,9 @@ package gc.arguments;
 /*
  * @test TestG1HeapSizeFlags
  * @bug 8006088
- * @requires vm.gc.G1
  * @summary Tests argument processing for initial and maximum heap size for the G1 collector
+ * @key flag-sensitive
+ * @requires vm.gc.G1 & vm.opt.x.Xmx == null & vm.opt.x.Xms == null & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,10 @@
 
 package gc.arguments;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.whitebox.WhiteBox;
@@ -115,7 +115,7 @@ class TestMaxHeapSizeTools {
   }
 
   private static void getNewOldSize(String gcflag, long[] values) throws Exception {
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(gcflag,
+    ProcessBuilder pb = GCArguments.createTestJvm(gcflag,
       "-XX:+PrintFlagsFinal", "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
@@ -208,7 +208,7 @@ class TestMaxHeapSizeTools {
     finalargs.add(classname);
     finalargs.addAll(Arrays.asList(arguments));
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(finalargs.toArray(String[]::new));
+    ProcessBuilder pb = GCArguments.createTestJvm(finalargs.toArray(String[]::new));
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
 
@@ -308,7 +308,7 @@ class TestMaxHeapSizeTools {
   }
 
   private static void expect(String[] flags, boolean hasWarning, boolean hasError, int errorcode) throws Exception {
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flags);
+    ProcessBuilder pb = GCArguments.createTestJvm(flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     shouldContainOrNot(output, hasWarning, "Warning");
     shouldContainOrNot(output, hasError, "Error");

--- a/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,8 @@ package gc.arguments;
  * @bug 8006088
  * @summary Tests argument processing for initial and maximum heap size for the
  * parallel collectors.
- * @requires vm.gc.Parallel
+ * @key flag-sensitive
+ * @requires vm.gc.Parallel & vm.opt.x.Xmx == null & vm.opt.x.Xms == null & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package gc.arguments;
  * @test TestSerialHeapSizeFlags
  * @bug 8006088
  * @summary Tests argument processing for initial and maximum heap size for the Serial collector
+ * @key flag-sensitive
+ * @requires vm.gc.Serial & vm.opt.x.Xmx == null & vm.opt.x.Xms == null & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -46,6 +46,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jdk.test.whitebox.code.Compiler;
 import jdk.test.whitebox.cpuinfo.CPUInfo;
@@ -79,6 +81,10 @@ public class VMProps implements Callable<Map<String, String>> {
                 value = ERROR_STATE + t;
             }
             map.put(key, value);
+        }
+
+        public void putAll(Map<String, String> map) {
+            map.entrySet().forEach(e -> put(e.getKey(), () -> e.getValue()));
         }
     }
 
@@ -126,6 +132,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("release.implementor", this::implementor);
         map.put("jdk.containerized", this::jdkContainerized);
         map.put("vm.flagless", this::isFlagless);
+	map.putAll(xOptFlags()); // -Xmx4g -> @requires vm.opt.x.Xmx == "4g" )
         vmGC(map); // vm.gc.X = true/false
         vmOptFinalFlags(map);
 
@@ -583,9 +590,7 @@ public class VMProps implements Callable<Map<String, String>> {
             return "" + "true".equalsIgnoreCase(flagless);
         }
 
-        List<String> allFlags = new ArrayList<String>();
-        Collections.addAll(allFlags, System.getProperty("test.vm.opts", "").trim().split("\\s+"));
-        Collections.addAll(allFlags, System.getProperty("test.java.opts", "").trim().split("\\s+"));
+        List<String> allFlags = allFlags().toList();
 
         // check -XX flags
         var ignoredXXFlags = Set.of(
@@ -630,6 +635,31 @@ public class VMProps implements Callable<Map<String, String>> {
                           .isEmpty();
 
         return "" + result;
+    }
+
+    private Stream<String> allFlags() {
+        return Stream.of((System.getProperty("test.vm.opts", "") + " " + System.getProperty("test.java.opts", "")).trim().split("\\s+"));
+    }
+
+    /**
+     * Parses extra options, options that start with -X excluding the
+     * bare -X option (as it is not considered an extra option).
+     * Ignores extra options not starting with -X
+     *
+     * This could be improved to handle extra options not starting
+     * with -X as well as "standard" options.
+     */
+    private Map<String, String> xOptFlags() {
+        return allFlags()
+            .filter(s -> s.startsWith("-X") && !s.startsWith("-XX:") && !s.equals("-X"))
+            .map(s -> s.replaceFirst("-", ""))
+            .map(flag -> flag.splitWithDelimiters("[:0123456789]", 2))
+            .collect(Collectors.toMap(a -> "vm.opt.x." + a[0],
+                                      a -> (a.length == 1)
+                                      ? "true" // -Xnoclassgc
+                                      : (a[1].equals(":")
+                                         ? a[2]            // ["-XshowSettings", ":", "system"]
+                                         : a[1] + a[2]))); // ["-Xmx", "4", "g"]
     }
 
     /**


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

