### PR TITLE
8301200: Don't scale timeout stress with timeout factor

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/StressOptions.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/StressOptions.java
@@ -211,12 +211,12 @@ public class StressOptions {
     }
 
     /**
-     * Obtain execution time in seconds adjusted for TIMEOUT_FACTOR.
+     * Obtain execution time in seconds.
      *
      * @return time
      */
     public long getTime() {
-        return Utils.adjustTimeout(time);
+        return time;
     }
 
     /**


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301200](https://bugs.openjdk.org/browse/JDK-8301200) needs maintainer approval

### Issue
 * [JDK-8301200](https://bugs.openjdk.org/browse/JDK-8301200): Don't scale timeout stress with timeout factor (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2727/head:pull/2727` \
`$ git checkout pull/2727`

Update a local copy of the PR: \
`$ git checkout pull/2727` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2727`

View PR using the GUI difftool: \
`$ git pr show -t 2727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2727.diff">https://git.openjdk.org/jdk17u-dev/pull/2727.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2727#issuecomment-2238644590)