### PR TITLE
8334418: Update IANA Language Subtag Registry to Version 2024-06-14

### DIFF
--- a/make/data/lsrdata/language-subtag-registry.txt
+++ b/make/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2024-05-16
+File-Date: 2024-06-14
 %%
 Type: language
 Subtag: aa
@@ -48009,7 +48009,9 @@ Type: variant
 Subtag: laukika
 Description: Classical Sanskrit
 Added: 2010-07-28
+Deprecated: 2024-06-08
 Prefix: sa
+Comments: Preferred tag is cls
 %%
 Type: variant
 Subtag: lemosin
@@ -48385,9 +48387,11 @@ Type: variant
 Subtag: vaidika
 Description: Vedic Sanskrit
 Added: 2010-07-28
+Deprecated: 2024-06-08
 Prefix: sa
 Comments: The most ancient dialect of Sanskrit used in verse and prose
   composed until about the 4th century B.C.E.
+Comments: Preferred tag is vsn
 %%
 Type: variant
 Subtag: valbadia

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8025703 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702 8318322
- *      8327631 8332424
+ *      8327631 8332424 8334418
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2024-05-16) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2024-06-14) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334418](https://bugs.openjdk.org/browse/JDK-8334418) needs maintainer approval

### Issue
 * [JDK-8334418](https://bugs.openjdk.org/browse/JDK-8334418): Update IANA Language Subtag Registry to Version 2024-06-14 (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2728/head:pull/2728` \
`$ git checkout pull/2728`

Update a local copy of the PR: \
`$ git checkout pull/2728` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2728`

View PR using the GUI difftool: \
`$ git pr show -t 2728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2728.diff">https://git.openjdk.org/jdk17u-dev/pull/2728.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2728#issuecomment-2239231321)