### PR TITLE
8280034: ProblemList jdk/jfr/api/consumer/recordingstream/TestOnEvent.java on linux-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -797,6 +797,7 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209    gener
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
+jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
 
 ############################################################################
 


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8280034](https://bugs.openjdk.org/browse/JDK-8280034) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280034](https://bugs.openjdk.org/browse/JDK-8280034): ProblemList jdk/jfr/api/consumer/recordingstream/TestOnEvent.java on linux-x64 (**Sub-task** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2738/head:pull/2738` \
`$ git checkout pull/2738`

Update a local copy of the PR: \
`$ git checkout pull/2738` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2738`

View PR using the GUI difftool: \
`$ git pr show -t 2738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2738.diff">https://git.openjdk.org/jdk17u-dev/pull/2738.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2738#issuecomment-2244403313)