### PR TITLE
8324580: SIGFPE on THP initialization on kernels < 4.10

### DIFF
--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -230,6 +230,19 @@ void THPSupport::print_on(outputStream* os) {
 StaticHugePageSupport HugePages::_static_hugepage_support;
 THPSupport HugePages::_thp_support;
 
+size_t HugePages::thp_pagesize_fallback() {
+    // Older kernels won't publish the THP page size. Fall back to default static huge page size,
+    // since that is likely to be the THP page size as well. Don't do it if the page size is considered
+    // too large to avoid large alignment waste. If static huge page size is unknown, use educated guess.
+    if (thp_pagesize() != 0) {
+        return thp_pagesize();
+    }
+    if (supports_static_hugepages()) {
+        return MIN2(default_static_hugepage_size(), 16 * M);
+    }
+    return 2 * M;
+}
+
 void HugePages::initialize() {
   _static_hugepage_support.scan_os();
   _thp_support.scan_os();

--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -107,6 +107,7 @@ public:
   static THPMode thp_mode()                     { return _thp_support.mode(); }
   static bool supports_thp()                    { return thp_mode() == THPMode::madvise || thp_mode() == THPMode::always; }
   static size_t thp_pagesize()                  { return _thp_support.pagesize(); }
+  static size_t thp_pagesize_fallback();
 
   static void initialize();
   static void print_on(outputStream* os);

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3872,8 +3872,12 @@ void os::large_page_init() {
     // In THP mode:
     // - os::large_page_size() is the *THP page size*
     // - os::pagesizes() has two members, the THP page size and the system page size
-    assert(HugePages::supports_thp() && HugePages::thp_pagesize() > 0, "Missing OS info");
     _large_page_size = HugePages::thp_pagesize();
+    if (_large_page_size == 0) {
+        log_info(pagesize) ("Cannot determine THP page size (kernel < 4.10 ?)");
+        _large_page_size = HugePages::thp_pagesize_fallback();
+        log_info(pagesize) ("Assuming THP page size to be: " EXACTFMT " (heuristics)", EXACTFMTARGS(_large_page_size));
+    }
     _page_sizes.add(_large_page_size);
     _page_sizes.add(os::vm_page_size());
 

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -84,6 +84,20 @@ class HugePageConfiguration {
         return _thpPageSize;
     }
 
+    // Returns the THP page size (if exposed by the kernel) or a guessed THP page size.
+    // Mimics HugePages::thp_pagesize_fallback() method in hotspot (must be kept in sync with it).
+    public long getThpPageSizeOrFallback() {
+        long pageSize = getThpPageSize();
+        if (pageSize != 0) {
+            return pageSize;
+        }
+        pageSize = getStaticDefaultHugePageSize();
+        if (pageSize != 0) {
+            return Math.min(pageSize, 16 * 1024 * 1024);
+        }
+        return 2 * 1024 * 1024;
+    }
+
     // Returns true if the THP support is enabled
     public boolean supportsTHP() {
         return _thpMode == THPMode.always || _thpMode == THPMode.madvise;

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -125,7 +125,8 @@ public class TestHugePageDecisionsAtVMStartup {
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=0");
             out.shouldContain("[info][pagesize] Large page support enabled");
         } else if (useLP && useTHP && configuration.supportsTHP()) {
-            String thpPageSizeString = buildSizeString(configuration.getThpPageSize());
+            long thpPageSize = configuration.getThpPageSizeOrFallback();
+            String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system
             // page size differs, but its always in KB).
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=1");


### PR DESCRIPTION
hi @tstuefe ,

This pull request contains a backport of commit [a231706a](https://git.openjdk.org/jdk/commit/a231706a06a86abb16d0040e8ca1b76a9741a0b2) from the [master](https://github.com/openjdk/jdk) repository.

The commit being backported was authored by Zdenek Zambersky on 15 Feb 2024.


When I tested jdk17-dev(3.10.0-1160.108.1.el7.x86_64 used by RHEL-7), it showed the same situation as jdk21-dev, so I Backported it .

Thanks！

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8324580](https://bugs.openjdk.org/browse/JDK-8324580) needs maintainer approval

### Issue
 * [JDK-8324580](https://bugs.openjdk.org/browse/JDK-8324580): SIGFPE on THP initialization on kernels &lt; 4.10 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2745/head:pull/2745` \
`$ git checkout pull/2745`

Update a local copy of the PR: \
`$ git checkout pull/2745` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2745`

View PR using the GUI difftool: \
`$ git pr show -t 2745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2745.diff">https://git.openjdk.org/jdk17u-dev/pull/2745.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2745#issuecomment-2251858558)