### PR TITLE
8179502: Enhance OCSP, CRL and Certificate Fetch Timeouts

### DIFF
--- a/src/java.base/share/classes/sun/security/action/GetPropertyAction.java
+++ b/src/java.base/share/classes/sun/security/action/GetPropertyAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,6 +159,68 @@ public class GetPropertyAction implements PrivilegedAction<String> {
                         }
                     }
             );
+        }
+    }
+
+    /**
+     * Convenience method for fetching System property values that are timeouts.
+     * Accepted timeout values may be purely numeric, a numeric value
+     * followed by "s" (both interpreted as seconds), or a numeric value
+     * followed by "ms" (interpreted as milliseconds).
+     *
+     * @param prop the name of the System property
+     * @param def a default value (in milliseconds)
+     * @param dbg a Debug object, if null no debug messages will be sent
+     *
+     * @return an integer value corresponding to the timeout value in the System
+     *      property in milliseconds.  If the property value is empty, negative,
+     *      or contains non-numeric characters (besides a trailing "s" or "ms")
+     *      then the default value will be returned.  If a negative value for
+     *      the "def" parameter is supplied, zero will be returned if the
+     *      property's value does not conform to the allowed syntax.
+     */
+    public static int privilegedGetTimeoutProp(String prop, int def, Debug dbg) {
+        if (def < 0) {
+            def = 0;
+        }
+
+        String rawPropVal = privilegedGetProperty(prop, "").trim();
+        if (rawPropVal.length() == 0) {
+            return def;
+        }
+
+        // Determine if "ms" or just "s" is on the end of the string.
+        // We may do a little surgery on the value so we'll retain
+        // the original value in rawPropVal for debug messages.
+        boolean isMillis = false;
+        String propVal = rawPropVal;
+        if (rawPropVal.toLowerCase().endsWith("ms")) {
+            propVal = rawPropVal.substring(0, rawPropVal.length() - 2);
+            isMillis = true;
+        } else if (rawPropVal.toLowerCase().endsWith("s")) {
+            propVal = rawPropVal.substring(0, rawPropVal.length() - 1);
+        }
+
+        // Next check to make sure the string is built only from digits
+        if (propVal.matches("^\\d+$")) {
+            try {
+                int timeout = Integer.parseInt(propVal);
+                return isMillis ? timeout : timeout * 1000;
+            } catch (NumberFormatException nfe) {
+                if (dbg != null) {
+                    dbg.println("Warning: Unexpected " + nfe +
+                            " for timeout value " + rawPropVal +
+                            ". Using default value of " + def + " msec.");
+                }
+                return def;
+            }
+        } else {
+            if (dbg != null) {
+                dbg.println("Warning: Incorrect syntax for timeout value " +
+                        rawPropVal + ". Using default value of " + def +
+                        " msec.");
+            }
+            return def;
         }
     }
 

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -85,7 +85,7 @@ public final class OCSP {
      * zero is interpreted as an infinite timeout.
      */
     private static final int READ_TIMEOUT = initializeTimeout(
-            "com.sun.security.ocsp.readtimeout", DEFAULT_READ_TIMEOUT);
+            "com.sun.security.ocsp.readtimeout", CONNECT_TIMEOUT);
 
     /**
      * Boolean value indicating whether OCSP client can use GET for OCSP

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSP.java
@@ -69,7 +69,6 @@ public final class OCSP {
     private static final Debug debug = Debug.getInstance("certpath");
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 15000;
-    private static final int DEFAULT_READ_TIMEOUT = 15000;
 
     /**
      * Integer value indicating the timeout length, in milliseconds, to be

--- a/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import sun.security.action.GetIntegerAction;
+
+import sun.security.action.GetPropertyAction;
 import sun.security.x509.AccessDescription;
 import sun.security.x509.GeneralNameInterface;
 import sun.security.x509.URIName;
@@ -127,8 +128,12 @@ class URICertStore extends CertStoreSpi {
     // allowed when downloading CRLs
     private static final int DEFAULT_CRL_READ_TIMEOUT = 15000;
 
+    // Default connect and read timeouts for CA certificate fetching (15 sec)
+    private static final int DEFAULT_CACERT_CONNECT_TIMEOUT = 15000;
+    private static final int DEFAULT_CACERT_READ_TIMEOUT = 15000;
+
     /**
-     * Integer value indicating the connect timeout, in seconds, to be
+     * Integer value indicating the connect timeout, in milliseconds, to be
      * used for the CRL download. A timeout of zero is interpreted as
      * an infinite timeout.
      */
@@ -137,7 +142,7 @@ class URICertStore extends CertStoreSpi {
                           DEFAULT_CRL_CONNECT_TIMEOUT);
 
     /**
-     * Integer value indicating the read timeout, in seconds, to be
+     * Integer value indicating the read timeout, in milliseconds, to be
      * used for the CRL download. A timeout of zero is interpreted as
      * an infinite timeout.
      */
@@ -146,21 +151,35 @@ class URICertStore extends CertStoreSpi {
                           DEFAULT_CRL_READ_TIMEOUT);
 
     /**
+     * Integer value indicating the connect timeout, in milliseconds, to be
+     * used for the CA certificate download. A timeout of zero is interpreted
+     * as an infinite timeout.
+     */
+    private static final int CACERT_CONNECT_TIMEOUT =
+            initializeTimeout("com.sun.security.cert.timeout",
+                    DEFAULT_CACERT_CONNECT_TIMEOUT);
+
+    /**
+     * Integer value indicating the read timeout, in milliseconds, to be
+     * used for the CA certificate download. A timeout of zero is interpreted
+     * as an infinite timeout.
+     */
+    private static final int CACERT_READ_TIMEOUT =
+            initializeTimeout("com.sun.security.cert.readtimeout",
+                    DEFAULT_CACERT_READ_TIMEOUT);
+
+    /**
      * Initialize the timeout length by getting the specified CRL timeout
      * system property. If the property has not been set, or if its
      * value is negative, set the timeout length to the specified default.
      */
     private static int initializeTimeout(String prop, int def) {
-        Integer tmp = GetIntegerAction.privilegedGetProperty(prop);
-        if (tmp == null || tmp < 0) {
-            return def;
-        }
+        int timeoutVal =
+                GetPropertyAction.privilegedGetTimeoutProp(prop, def, debug);
         if (debug != null) {
-            debug.println(prop + " set to " + tmp + " seconds");
+            debug.println(prop + " set to " + timeoutVal + " milliseconds");
         }
-        // Convert to milliseconds, as the system property will be
-        // specified in seconds
-        return tmp * 1000;
+        return timeoutVal;
     }
 
     /**
@@ -276,6 +295,8 @@ class URICertStore extends CertStoreSpi {
                 connection.setIfModifiedSince(lastModified);
             }
             long oldLastModified = lastModified;
+            connection.setConnectTimeout(CACERT_CONNECT_TIMEOUT);
+            connection.setReadTimeout(CACERT_READ_TIMEOUT);
             try (InputStream in = connection.getInputStream()) {
                 lastModified = connection.getLastModified();
                 if (oldLastModified != 0) {

--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+//
+// Security properties, once set, cannot revert to unset.  To avoid
+// conflicts with tests running in the same VM isolate this test by
+// running it in otherVM mode.
+//
+
+/**
+ * @test
+ * @bug 8179502
+ * @summary Enhance OCSP, CRL and Certificate Fetch Timeouts
+ * @modules java.base/sun.security.x509
+ *          java.base/sun.security.provider.certpath
+ *          java.base/sun.security.util
+ * @library ../../../../../java/security/testlibrary
+ * @build CertificateBuilder SimpleOCSPServer
+ * @run main/othervm OCSPTimeout 1000 true
+ * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=2
+ *      OCSPTimeout 1000 true
+ * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1
+ *      OCSPTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1s
+ *      OCSPTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1500ms
+ *      OCSPTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=2750ms
+ *      OCSPTimeout 2000 true
+ */
+
+import java.io.*;
+import java.math.BigInteger;
+import java.net.*;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.util.*;
+import java.security.cert.*;
+import java.util.concurrent.TimeUnit;
+
+import sun.security.testlibrary.SimpleOCSPServer;
+import sun.security.testlibrary.CertificateBuilder;
+
+import static java.security.cert.PKIXRevocationChecker.Option.*;
+
+public class OCSPTimeout {
+
+    static String passwd = "passphrase";
+    static String ROOT_ALIAS = "root";
+    static String EE_ALIAS = "endentity";
+
+    // Enable debugging for additional output
+    static final boolean debug = true;
+
+    // PKI components we will need for this test
+    static X509Certificate rootCert;        // The root CA certificate
+    static X509Certificate eeCert;          // The end entity certificate
+    static KeyStore rootKeystore;           // Root CA Keystore
+    static KeyStore eeKeystore;             // End Entity Keystore
+    static KeyStore trustStore;             // SSL Client trust store
+    static SimpleOCSPServer rootOcsp;       // Root CA OCSP Responder
+    static int rootOcspPort;                // Port number for root OCSP
+
+    public static void main(String args[]) throws Exception {
+        int ocspTimeout = 15000;
+        boolean expected = false;
+
+        createPKI();
+
+        if (args[0] != null) {
+            ocspTimeout = Integer.parseInt(args[0]);
+        }
+        rootOcsp.setDelay(ocspTimeout);
+
+        expected = (args[1] != null && Boolean.parseBoolean(args[1]));
+        log("Test case expects to " + (expected ? "pass" : "fail"));
+
+        // validate chain
+        CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
+        PKIXRevocationChecker prc =
+                (PKIXRevocationChecker) cpv.getRevocationChecker();
+        prc.setOptions(EnumSet.of(NO_FALLBACK, SOFT_FAIL));
+        PKIXParameters params =
+                new PKIXParameters(Set.of(new TrustAnchor(rootCert, null)));
+        params.addCertPathChecker(prc);
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        CertPath cp = cf.generateCertPath(List.of(eeCert));
+        cpv.validate(cp, params);
+
+        // unwrap soft fail exceptions and check for SocketTimeoutException
+        List<CertPathValidatorException> softExc = prc.getSoftFailExceptions();
+        if (expected) {
+            if (softExc.size() > 0) {
+                throw new RuntimeException("Expected to pass, found " +
+                        softExc.size() + " soft fail exceptions");
+            }
+        } else {
+            // If we expect to fail the validation then there should be a
+            // SocketTimeoutException
+            boolean found = false;
+            for (CertPathValidatorException softFail : softExc) {
+                log("CPVE: " + softFail);
+                Throwable cause = softFail.getCause();
+                log("Cause: " + cause);
+                while (cause != null) {
+                    if (cause instanceof SocketTimeoutException) {
+                        found = true;
+                        break;
+                    }
+                    cause = cause.getCause();
+                }
+                if (found) {
+                    break;
+                }
+            }
+
+            if (!found) {
+                throw new RuntimeException("SocketTimeoutException not thrown");
+            }
+        }
+    }
+
+    /**
+     * Creates the PKI components necessary for this test, including
+     * Root CA, Intermediate CA and SSL server certificates, the keystores
+     * for each entity, a client trust store, and starts the OCSP responders.
+     */
+    private static void createPKI() throws Exception {
+        CertificateBuilder cbld = new CertificateBuilder();
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+        keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyStore.Builder keyStoreBuilder =
+                KeyStore.Builder.newInstance("PKCS12", null,
+                        new KeyStore.PasswordProtection(passwd.toCharArray()));
+
+        // Generate Root and EE keys
+        KeyPair rootCaKP = keyGen.genKeyPair();
+        log("Generated Root CA KeyPair");
+        KeyPair eeKP = keyGen.genKeyPair();
+        log("Generated End Entity KeyPair");
+
+        // Set up the Root CA Cert
+        cbld.setSubjectName("CN=Root CA Cert, O=SomeCompany");
+        cbld.setPublicKey(rootCaKP.getPublic());
+        cbld.setSerialNumber(new BigInteger("1"));
+        // Make a 3 year validity starting from 60 days ago
+        long start = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+        long end = start + TimeUnit.DAYS.toMillis(1085);
+        cbld.setValidity(new Date(start), new Date(end));
+        addCommonExts(cbld, rootCaKP.getPublic(), rootCaKP.getPublic());
+        addCommonCAExts(cbld);
+        // Make our Root CA Cert!
+        rootCert = cbld.build(null, rootCaKP.getPrivate(),
+                "SHA256withECDSA");
+        log("Root CA Created:\n%s", certInfo(rootCert));
+
+        // Now build a keystore and add the keys and cert
+        rootKeystore = keyStoreBuilder.getKeyStore();
+        Certificate[] rootChain = {rootCert};
+        rootKeystore.setKeyEntry(ROOT_ALIAS, rootCaKP.getPrivate(),
+                passwd.toCharArray(), rootChain);
+
+        // Now fire up the OCSP responder
+        rootOcsp = new SimpleOCSPServer(rootKeystore, passwd, ROOT_ALIAS, null);
+        rootOcsp.enableLog(debug);
+        rootOcsp.setNextUpdateInterval(3600);
+        rootOcsp.setDisableContentLength(true);
+        rootOcsp.start();
+
+        // Wait 5 seconds for server ready
+        boolean readyStatus = rootOcsp.awaitServerReady(5, TimeUnit.SECONDS);
+        if (!readyStatus) {
+            throw new RuntimeException("Server not ready");
+        }
+
+        rootOcspPort = rootOcsp.getPort();
+        String rootRespURI = "http://localhost:" + rootOcspPort;
+        log("Root OCSP Responder URI is %s", rootRespURI);
+
+        // Now that we have the root keystore and OCSP responder we can
+        // create our end entity certificate
+        cbld.reset();
+        cbld.setSubjectName("CN=SSLCertificate, O=SomeCompany");
+        cbld.setPublicKey(eeKP.getPublic());
+        cbld.setSerialNumber(new BigInteger("4096"));
+        // Make a 1 year validity starting from 7 days ago
+        start = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(7);
+        end = start + TimeUnit.DAYS.toMillis(365);
+        cbld.setValidity(new Date(start), new Date(end));
+
+        // Add extensions
+        addCommonExts(cbld, eeKP.getPublic(), rootCaKP.getPublic());
+        boolean[] kuBits = {true, false, false, false, false, false,
+                false, false, false};
+        cbld.addKeyUsageExt(kuBits);
+        List<String> ekuOids = new ArrayList<>();
+        ekuOids.add("1.3.6.1.5.5.7.3.1");
+        ekuOids.add("1.3.6.1.5.5.7.3.2");
+        cbld.addExtendedKeyUsageExt(ekuOids);
+        cbld.addSubjectAltNameDNSExt(Collections.singletonList("localhost"));
+        cbld.addAIAExt(Collections.singletonList(rootRespURI));
+        // Make our End Entity Cert!
+        eeCert = cbld.build(rootCert, rootCaKP.getPrivate(),
+                "SHA256withECDSA");
+        log("SSL Certificate Created:\n%s", certInfo(eeCert));
+
+        // Provide end entity cert revocation info to the Root CA
+        // OCSP responder.
+        Map<BigInteger, SimpleOCSPServer.CertStatusInfo> revInfo =
+                new HashMap<>();
+        revInfo.put(eeCert.getSerialNumber(),
+                new SimpleOCSPServer.CertStatusInfo(
+                        SimpleOCSPServer.CertStatus.CERT_STATUS_GOOD));
+        rootOcsp.updateStatusDb(revInfo);
+
+        // Now build a keystore and add the keys, chain and root cert as a TA
+        eeKeystore = keyStoreBuilder.getKeyStore();
+        Certificate[] eeChain = {eeCert, rootCert};
+        eeKeystore.setKeyEntry(EE_ALIAS, eeKP.getPrivate(),
+                passwd.toCharArray(), eeChain);
+        eeKeystore.setCertificateEntry(ROOT_ALIAS, rootCert);
+
+        // And finally a Trust Store for the client
+        trustStore = keyStoreBuilder.getKeyStore();
+        trustStore.setCertificateEntry(ROOT_ALIAS, rootCert);
+    }
+
+    private static void addCommonExts(CertificateBuilder cbld,
+            PublicKey subjKey, PublicKey authKey) throws IOException {
+        cbld.addSubjectKeyIdExt(subjKey);
+        cbld.addAuthorityKeyIdExt(authKey);
+    }
+
+    private static void addCommonCAExts(CertificateBuilder cbld)
+            throws IOException {
+        cbld.addBasicConstraintsExt(true, true, -1);
+        // Set key usage bits for digitalSignature, keyCertSign and cRLSign
+        boolean[] kuBitSettings = {true, false, false, false, false, true,
+                true, false, false};
+        cbld.addKeyUsageExt(kuBitSettings);
+    }
+
+    /**
+     * Helper routine that dumps only a few cert fields rather than
+     * the whole toString() output.
+     *
+     * @param cert an X509Certificate to be displayed
+     *
+     * @return the String output of the issuer, subject and
+     * serial number
+     */
+    private static String certInfo(X509Certificate cert) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Issuer: ").append(cert.getIssuerX500Principal()).
+                append("\n");
+        sb.append("Subject: ").append(cert.getSubjectX500Principal()).
+                append("\n");
+        sb.append("Serial: ").append(cert.getSerialNumber()).append("\n");
+        return sb.toString();
+    }
+
+    /**
+     * Log a message on stdout
+     *
+     * @param format the format string for the log entry
+     * @param args zero or more arguments corresponding to the format string
+     */
+    private static void log(String format, Object ... args) {
+        System.out.format(format + "\n", args);
+    }
+}

--- a/test/jdk/sun/security/x509/URICertStore/AIACertTimeout.java
+++ b/test/jdk/sun/security/x509/URICertStore/AIACertTimeout.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8179502
+ * @summary Enhance OCSP, CRL and Certificate Fetch Timeouts
+ * @modules java.base/sun.security.x509
+ *          java.base/sun.security.util
+ * @library /test/lib ../../../../java/security/testlibrary
+ * @build CertificateBuilder
+ * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
+ *      -Dcom.sun.security.cert.readtimeout=1 AIACertTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
+ *      -Dcom.sun.security.cert.readtimeout=1s AIACertTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
+ *      -Dcom.sun.security.cert.readtimeout=3 AIACertTimeout 2000 true
+ * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
+ *      -Dcom.sun.security.cert.readtimeout=1500ms AIACertTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.enableAIAcaIssuers=true
+ *      -Dcom.sun.security.cert.readtimeout=2750ms AIACertTimeout 2000 true
+ * @run main/othervm -Djava.security.debug=certpath
+ *      -Dcom.sun.security.enableAIAcaIssuers=false
+ *      -Dcom.sun.security.cert.readtimeout=20000ms AIACertTimeout 10000 false
+ */
+
+import com.sun.net.httpserver.*;
+import java.io.*;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.security.cert.*;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.*;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import sun.security.testlibrary.CertificateBuilder;
+
+import sun.security.x509.*;
+import sun.security.util.*;
+
+public class AIACertTimeout {
+
+    private static final boolean logging = true;
+
+    // PKI and server components we will need for this test
+    private static KeyPair          rootKp;     // Root CA keys
+    private static X509Certificate  rootCert;
+    private static KeyPair          intKp;      // Intermediate CA keys
+    private static X509Certificate  intCert;
+    private static KeyPair          eeKp;       // End-entity keys
+    private static X509Certificate  eeCert;
+
+    public static void main(String[] args) throws Exception {
+        int servTimeoutMsec = (args != null && args.length >= 1) ?
+                Integer.parseInt(args[0]) : -1;
+        boolean expectedPass = args != null && args.length >= 2 &&
+                Boolean.parseBoolean(args[1]);
+
+        createAuthorities();
+        CaCertHttpServer aiaServer = new CaCertHttpServer(intCert,
+                servTimeoutMsec);
+        try {
+            aiaServer.start();
+            createEE(aiaServer.getAddress());
+
+            X509CertSelector target = new X509CertSelector();
+            target.setCertificate(eeCert);
+            PKIXParameters params = new PKIXBuilderParameters(Set.of(
+                        new TrustAnchor(rootCert, null)), target);
+            params.setRevocationEnabled(false);
+
+            try {
+                CertPathBuilder cpb = CertPathBuilder.getInstance("PKIX");
+                CertPathBuilderResult result = cpb.build(params);
+                if (expectedPass) {
+                    int pathLen = result.getCertPath().getCertificates().size();
+                    if (pathLen != 2) {
+                        throw new RuntimeException("Expected 2 certificates " +
+                                "in certpath, got " + pathLen);
+                    }
+                } else {
+                    throw new RuntimeException("Missing expected CertPathBuilderException");
+                }
+            } catch (CertPathBuilderException cpve) {
+                if (!expectedPass) {
+                    log("Cert path building failed as expected: " + cpve);
+                } else {
+                    throw cpve;
+                }
+            }
+        } finally {
+            aiaServer.stop();
+        }
+    }
+
+    private static class CaCertHttpServer {
+
+        private final X509Certificate caCert;
+        private final HttpServer server;
+        private final int timeout;
+
+        public CaCertHttpServer(X509Certificate cert, int timeout)
+                throws IOException {
+            caCert = Objects.requireNonNull(cert, "Null CA cert disallowed");
+            server = HttpServer.create();
+            this.timeout = timeout;
+            if (timeout > 0) {
+                log("Created HttpServer with timeout of " + timeout + " msec.");
+            } else {
+                log("Created HttpServer with no timeout");
+            }
+        }
+
+        public void start() throws IOException {
+            server.bind(new InetSocketAddress("localhost", 0), 0);
+            server.createContext("/cacert", t -> {
+                try (InputStream is = t.getRequestBody()) {
+                    is.readAllBytes();
+                }
+                try {
+                    if (timeout > 0) {
+                        // Sleep in order to simulate network latency
+                        log("Server sleeping for " + timeout + " msec.");
+                        Thread.sleep(timeout);
+                    }
+
+                    byte[] derCert = caCert.getEncoded();
+                    t.getResponseHeaders().add("Content-Type",
+                            "application/pkix-cert");
+                    t.sendResponseHeaders(200, derCert.length);
+                    try (OutputStream os = t.getResponseBody()) {
+                        os.write(derCert);
+                    }
+                } catch (InterruptedException |
+                        CertificateEncodingException exc) {
+                    throw new IOException(exc);
+                }
+            });
+            server.setExecutor(null);
+            server.start();
+            log("Started HttpServer: Listening on " + server.getAddress());
+        }
+
+        public void stop() {
+            server.stop(0);
+        }
+
+        public InetSocketAddress getAddress() {
+            return server.getAddress();
+        }
+    }
+
+
+    /**
+     * Creates the CA PKI components necessary for this test.
+     */
+    private static void createAuthorities() throws Exception {
+        CertificateBuilder cbld = new CertificateBuilder();
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
+        keyGen.initialize(new ECGenParameterSpec("secp256r1"));
+
+        // Generate Root, IntCA, EE keys
+        rootKp = keyGen.genKeyPair();
+        log("Generated Root CA KeyPair");
+        intKp = keyGen.genKeyPair();
+        log("Generated Intermediate CA KeyPair");
+        eeKp = keyGen.genKeyPair();
+        log("Generated End Entity Cert KeyPair");
+
+        // Make a 3 year validity starting from 60 days ago
+        long start = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(60);
+        long end = start + TimeUnit.DAYS.toMillis(1085);
+
+        boolean[] kuBitSettings = {true, false, false, false, false, true,
+                true, false, false};
+
+        // Set up the Root CA Cert
+        cbld.setSubjectName("CN=Root CA Cert, O=SomeCompany").
+                setPublicKey(rootKp.getPublic()).
+                setSerialNumber(new BigInteger("1")).
+                setValidity(new Date(start), new Date(end)).
+                addSubjectKeyIdExt(rootKp.getPublic()).
+                addAuthorityKeyIdExt(rootKp.getPublic()).
+                addBasicConstraintsExt(true, true, -1).
+                addKeyUsageExt(kuBitSettings);
+
+        // Make our Root CA Cert!
+        rootCert = cbld.build(null, rootKp.getPrivate(), "SHA256withECDSA");
+        log("Root CA Created:\n" + certInfo(rootCert));
+
+        // Make a 2 year validity starting from 30 days ago
+        start = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(30);
+        end = start + TimeUnit.DAYS.toMillis(730);
+
+        // Now that we have the root keystore we can create our
+        // intermediate CA.
+        cbld.reset();
+        cbld.setSubjectName("CN=Intermediate CA Cert, O=SomeCompany").
+                setPublicKey(intKp.getPublic()).
+                setSerialNumber(new BigInteger("100")).
+                setValidity(new Date(start), new Date(end)).
+                addSubjectKeyIdExt(intKp.getPublic()).
+                addAuthorityKeyIdExt(rootKp.getPublic()).
+                addBasicConstraintsExt(true, true, -1).
+                addKeyUsageExt(kuBitSettings);
+
+        // Make our Intermediate CA Cert!
+        intCert = cbld.build(rootCert, rootKp.getPrivate(), "SHA256withECDSA");
+        log("Intermediate CA Created:\n" + certInfo(intCert));
+    }
+
+    /**
+     * Creates the end entity certificate from the previously generated
+     * intermediate CA cert.
+     *
+     * @param aiaAddr the address/port of the server that will hold the issuer
+     *                certificate. This will be used to create an AIA URI.
+     */
+    private static void createEE(InetSocketAddress aiaAddr) throws Exception {
+        // Make a 1 year validity starting from 7 days ago
+        long start = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(7);
+        long end = start + TimeUnit.DAYS.toMillis(365);
+        boolean[] kuBits = {true, false, false, false, false, false,
+                false, false, false};
+        List<String> ekuOids = List.of("1.3.6.1.5.5.7.3.1",
+                "1.3.6.1.5.5.7.3.2", "1.3.6.1.5.5.7.3.4");
+        String aiaUri = String.format("http://%s:%d/cacert",
+                aiaAddr.getHostName(), aiaAddr.getPort());
+
+        CertificateBuilder cbld = new CertificateBuilder();
+        cbld.setSubjectName("CN=Oscar T. Grouch, O=SomeCompany").
+                setPublicKey(eeKp.getPublic()).
+                setSerialNumber(new BigInteger("4096")).
+                setValidity(new Date(start), new Date(end)).
+                addSubjectKeyIdExt(eeKp.getPublic()).
+                addAuthorityKeyIdExt(intKp.getPublic()).
+                addKeyUsageExt(kuBits).addExtendedKeyUsageExt(ekuOids).
+                addAIAExt(List.of("CAISSUER|" + aiaUri));
+
+        // Build the cert
+        eeCert = cbld.build(intCert, intKp.getPrivate(), "SHA256withECDSA");
+        log("EE Certificate Created:\n" + certInfo(eeCert));
+    }
+
+    /**
+     * Helper routine that dumps only a few cert fields rather than
+     * the whole toString() output.
+     *
+     * @param cert an X509Certificate to be displayed
+     *
+     * @return the String output of the issuer, subject and
+     * serial number
+     */
+    private static String certInfo(X509Certificate cert) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Issuer: ").append(cert.getIssuerX500Principal()).
+                append("\n");
+        sb.append("Subject: ").append(cert.getSubjectX500Principal()).
+                append("\n");
+        sb.append("Serial: ").append(cert.getSerialNumber()).append("\n");
+        return sb.toString();
+    }
+
+    private static void log(String str) {
+        if (logging) {
+            System.out.println("[" + Thread.currentThread().getName() + "] " +
+                    str);
+        }
+    }
+}

--- a/test/jdk/sun/security/x509/URICertStore/CRLReadTimeout.java
+++ b/test/jdk/sun/security/x509/URICertStore/CRLReadTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,55 +23,65 @@
 
 /*
  * @test
- * @bug 8191808
+ * @bug 8191808 8179502
  * @summary check that CRL download is interrupted if it takes too long
+ * @modules java.base/sun.security.x509
+ *          java.base/sun.security.util
  * @library /test/lib
- * @run main/othervm -Dcom.sun.security.crl.readtimeout=1 CRLReadTimeout
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=1 CRLReadTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=1s CRLReadTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=4 CRLReadTimeout 2000 true
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=1500ms CRLReadTimeout 2000 false
+ * @run main/othervm -Dcom.sun.security.crl.readtimeout=2750ms CRLReadTimeout 2000 true
  */
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.IOException;
+import java.io.*;
+import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
+import java.security.GeneralSecurityException;
 import java.security.KeyStore;
-import java.security.cert.CertificateFactory;
-import java.security.cert.CertPath;
-import java.security.cert.CertPathValidator;
-import java.security.cert.CertPathValidatorException;
-import java.security.cert.PKIXParameters;
-import java.security.cert.PKIXRevocationChecker;
-import static java.security.cert.PKIXRevocationChecker.Option.*;
-import java.security.cert.TrustAnchor;
-import java.security.cert.X509Certificate;
+import java.security.PrivateKey;
+import java.security.cert.*;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import com.sun.net.httpserver.HttpServer;
+import java.util.concurrent.TimeUnit;
 
+import static java.security.cert.PKIXRevocationChecker.Option.*;
+
+import com.sun.net.httpserver.HttpServer;
 import jdk.test.lib.SecurityTools;
 import jdk.test.lib.process.OutputAnalyzer;
+import sun.security.util.SignatureUtil;
+import sun.security.x509.*;
 
 public class CRLReadTimeout {
 
+    public static final String PASS = "changeit";
+    public static X509CRL crl;
+
     public static void main(String[] args) throws Exception {
 
-        String timeout = System.getProperty("com.sun.security.crl.readtimeout");
-        if (timeout == null) {
-            timeout = "15";
-        }
-        System.out.println("Testing timeout of " + timeout + " seconds");
+        int serverTimeout = (args != null && args[0] != null) ?
+                Integer.parseInt(args[0]) : 15000;
+        boolean expectedPass = args != null && args[1] != null &&
+                Boolean.parseBoolean(args[1]);
+        System.out.println("Server timeout is " + serverTimeout + " msec.");
+        System.out.println("Test is expected to " + (expectedPass ? "pass" : "fail"));
 
-        CrlHttpServer crlServer = new CrlHttpServer(Integer.parseInt(timeout));
+        CrlHttpServer crlServer = new CrlHttpServer(serverTimeout);
         try {
             crlServer.start();
-            testTimeout(crlServer.getPort());
+            testTimeout(crlServer.getPort(), expectedPass);
         } finally {
             crlServer.stop();
         }
     }
 
-    private static void testTimeout(int port) throws Exception {
+    private static void testTimeout(int port, boolean expectedPass)
+            throws Exception {
 
         // create certificate chain with two certs, root and end-entity
         keytool("-alias duke -dname CN=duke -genkey -keyalg RSA");
@@ -82,10 +92,10 @@ public class CRLReadTimeout {
                 + "-ext crl=uri:http://localhost:" + port + "/crl");
         keytool("-importcert -file duke.cert -alias duke");
 
-        KeyStore ks = KeyStore.getInstance(new File("ks"),
-                                           "changeit".toCharArray());
+        KeyStore ks = KeyStore.getInstance(new File("ks"), PASS.toCharArray());
         X509Certificate cert = (X509Certificate)ks.getCertificate("duke");
         X509Certificate root = (X509Certificate)ks.getCertificate("root");
+        crl = genCrl(ks, "root", PASS);
 
         // validate chain
         CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
@@ -100,28 +110,60 @@ public class CRLReadTimeout {
         cpv.validate(cp, params);
 
         // unwrap soft fail exceptions and check for SocketTimeoutException
-        boolean expected = false;
-        for (CertPathValidatorException softFail:prc.getSoftFailExceptions()) {
-            Throwable cause = softFail.getCause();
-            while (cause != null) {
-                if (cause instanceof SocketTimeoutException) {
-                    expected = true;
+        List<CertPathValidatorException> softExc = prc.getSoftFailExceptions();
+        if (expectedPass) {
+            if (softExc.size() > 0) {
+                throw new RuntimeException("Expected to pass, found " +
+                        softExc.size() + " soft fail exceptions");
+            }
+        } else {
+            boolean foundSockTOExc = false;
+            for (CertPathValidatorException softFail : softExc) {
+                Throwable cause = softFail.getCause();
+                while (cause != null) {
+                    if (cause instanceof SocketTimeoutException) {
+                        foundSockTOExc = true;
+                        break;
+                    }
+                    cause = cause.getCause();
+                }
+                if (foundSockTOExc) {
                     break;
                 }
-                cause = cause.getCause();
             }
-            if (expected) {
-                break;
+            if (!foundSockTOExc) {
+                throw new Exception("SocketTimeoutException not thrown");
             }
-        }
-        if (!expected) {
-            throw new Exception("SocketTimeoutException not thrown");
         }
     }
 
     private static OutputAnalyzer keytool(String cmd) throws Exception {
-        return SecurityTools.keytool("-storepass changeit "
-                + "-keystore ks " + cmd);
+        return SecurityTools.keytool("-storepass " + PASS +
+                " -keystore ks " + cmd);
+    }
+
+    private static X509CRL genCrl(KeyStore ks, String issAlias, String pass)
+            throws GeneralSecurityException, IOException {
+        // Create an empty CRL with a 1-day validity period.
+        X509Certificate issuerCert = (X509Certificate)ks.getCertificate(issAlias);
+        PrivateKey issuerKey = (PrivateKey)ks.getKey(issAlias, pass.toCharArray());
+
+        long curTime = System.currentTimeMillis();
+        Date thisUp = new Date(curTime - TimeUnit.SECONDS.toMillis(43200));
+        Date nextUp = new Date(curTime + TimeUnit.SECONDS.toMillis(43200));
+        CRLExtensions exts = new CRLExtensions();
+        var aki = new AuthorityKeyIdentifierExtension(new KeyIdentifier(
+                issuerCert.getPublicKey()), null, null);
+        var crlNum = new CRLNumberExtension(BigInteger.ONE);
+        exts.set(aki.getId(), aki);
+        exts.set(crlNum.getId(), crlNum);
+        X509CRLImpl crl = new X509CRLImpl(
+                new X500Name(issuerCert.getSubjectX500Principal().toString()),
+                thisUp, nextUp, null, exts);
+        crl.sign(issuerKey,
+                SignatureUtil.getDefaultSigAlgForKey(issuerKey));
+        System.out.println("ISSUED CRL:\n" + crl);
+        return crl;
     }
 
     private static class CrlHttpServer {
@@ -136,15 +178,23 @@ public class CRLReadTimeout {
 
         public void start() throws IOException {
             server.bind(new InetSocketAddress(0), 0);
-            server.createContext("/", t -> {
+            server.createContext("/crl", t -> {
                 try (InputStream is = t.getRequestBody()) {
                     is.readAllBytes();
                 }
                 try {
-                    // sleep for 2 seconds longer to force timeout
-                    Thread.sleep((timeout + 2)*1000);
-                } catch (InterruptedException ie) {
-                    throw new IOException(ie);
+                    // Sleep in order to simulate network latency
+                    Thread.sleep(timeout);
+
+                    byte[] derCrl = crl.getEncoded();
+                    t.getResponseHeaders().add("Content-Type",
+                            "application/pkix-crl");
+                    t.sendResponseHeaders(200, derCrl.length);
+                    try (OutputStream os = t.getResponseBody()) {
+                        os.write(derCrl);
+                    }
+                } catch (InterruptedException | CRLException exc) {
+                    throw new IOException(exc);
                 }
             });
             server.setExecutor(null);


### PR DESCRIPTION
Hello, I'd like to backport JDK-8179502 to JDK17u to improve the timeout adjustment for OCSP GET requests (which was missed in JDK-8179503).

The backport is almost clean except for the following:
- OCSP.java was merged manually because of JDK-8328638 and JDK-8329213 is already backported into 17u-dev
- copyright year in GetPropertyAction.java and URICertStore.java files are updated manually
- CRLReadTimeout.java test is updated manually because of the different notation of internal X509CRLImpl and CRLExtensions classes.

All new and related jtreg tests are passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8337407](https://bugs.openjdk.org/browse/JDK-8337407) to be approved
- [x] [JDK-8179502](https://bugs.openjdk.org/browse/JDK-8179502) needs maintainer approval

### Issues
 * [JDK-8179502](https://bugs.openjdk.org/browse/JDK-8179502): Enhance OCSP, CRL and Certificate Fetch Timeouts (**Enhancement** - P4 - Approved)
 * [JDK-8337407](https://bugs.openjdk.org/browse/JDK-8337407): Enhance OCSP, CRL and Certificate Fetch Timeouts (**CSR**)


### Reviewers
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2747/head:pull/2747` \
`$ git checkout pull/2747`

Update a local copy of the PR: \
`$ git checkout pull/2747` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2747`

View PR using the GUI difftool: \
`$ git pr show -t 2747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2747.diff">https://git.openjdk.org/jdk17u-dev/pull/2747.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2747#issuecomment-2254665502)
</details>
