### PR TITLE
8331077: nroff man page update for jar tool

### DIFF
--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -196,7 +196,8 @@ Specifies the location of module dependence for generating the hash.
 .RE
 .TP
 .B \f[CB]\@\f[R]\f[I]file\f[R]
-Reads \f[CB]jar\f[R] options and file names from a text file.
+Reads \f[CB]jar\f[R] options and file names from a text file as if they
+were supplied on the command line
 .RS
 .RE
 .SH OPERATION MODIFIERS VALID ONLY IN CREATE, UPDATE, AND
@@ -339,8 +340,15 @@ class files from the file \f[CB]classes.list\f[R].
 To shorten or simplify the \f[CB]jar\f[R] command, you can specify
 arguments in a separate text file and pass it to the \f[CB]jar\f[R]
 command with the at sign (\f[CB]\@\f[R]) as a prefix.
+
+To shorten or simplify the \f[CB]jar\f[R] command, you can provide an arg
+file that lists the files to include in the JAR file and pass it to the
+\f[CB]jar\f[R] command with the at sign (\f[CB]\@\f[R]) as a prefix.
 .RS
 .PP
 \f[CB]jar\ \-\-create\ \-\-file\ my.jar\ \@classes.list\f[R]
 .RE
+.PP
+If one or more entries in the arg file cannot be found then the jar
+command fails without creating the JAR file.
 .RE


### PR DESCRIPTION
Backport of 8331077

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331077](https://bugs.openjdk.org/browse/JDK-8331077) needs maintainer approval

### Issue
 * [JDK-8331077](https://bugs.openjdk.org/browse/JDK-8331077): nroff man page update for jar tool (**Sub-task** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2748/head:pull/2748` \
`$ git checkout pull/2748`

Update a local copy of the PR: \
`$ git checkout pull/2748` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2748`

View PR using the GUI difftool: \
`$ git pr show -t 2748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2748.diff">https://git.openjdk.org/jdk17u-dev/pull/2748.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2748#issuecomment-2255788290)