### PR TITLE
8298381: Improve handling of session tickets for multiple SSLContexts

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,9 +71,6 @@ public abstract class SSLContextImpl extends SSLContextSpi {
     private volatile StatusResponseManager statusResponseManager;
 
     private final ReentrantLock contextLock = new ReentrantLock();
-    final HashMap<Integer,
-            SessionTicketExtension.StatelessKey> keyHashMap = new HashMap<>();
-
 
     SSLContextImpl() {
         ephemeralKeyManager = new EphemeralKeyManager();

--- a/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSessionContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,11 @@ package sun.security.ssl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
 
@@ -69,6 +73,11 @@ final class SSLSessionContextImpl implements SSLSessionContext {
     private int cacheLimit;             // the max cache size
     private int timeout;                // timeout in seconds
 
+    // The current session ticket encryption key ID (only used in server context)
+    private int currentKeyID;
+    // Session ticket encryption keys and IDs map (only used in server context)
+    private final Map<Integer, SessionTicketExtension.StatelessKey> keyHashMap;
+
     // Default setting for stateless session resumption support (RFC 5077)
     private boolean statelessSession = true;
 
@@ -80,6 +89,14 @@ final class SSLSessionContextImpl implements SSLSessionContext {
         // use soft reference
         sessionCache = Cache.newSoftMemoryCache(cacheLimit, timeout);
         sessionHostPortCache = Cache.newSoftMemoryCache(cacheLimit, timeout);
+        if (server) {
+            keyHashMap = new ConcurrentHashMap<>();
+            // Should be "randomly generated" according to RFC 5077,
+            // but doesn't necessarily has to be a true random number.
+            currentKeyID = new Random(System.nanoTime()).nextInt();
+        } else {
+            keyHashMap = Map.of();
+        }
     }
 
     // Stateless sessions when available, but there is a cache
@@ -168,6 +185,51 @@ final class SSLSessionContextImpl implements SSLSessionContext {
     @Override
     public int getSessionCacheSize() {
         return cacheLimit;
+    }
+
+    private void cleanupStatelessKeys() {
+        Iterator<Map.Entry<Integer, SessionTicketExtension.StatelessKey>> it =
+            keyHashMap.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Integer, SessionTicketExtension.StatelessKey> entry = it.next();
+            SessionTicketExtension.StatelessKey k = entry.getValue();
+            if (k.isInvalid(this)) {
+                it.remove();
+                try {
+                    k.key.destroy();
+                } catch (Exception e) {
+                    // Suppress
+                }
+            }
+        }
+    }
+
+    // Package-private, used only from SessionTicketExtension.KeyState::getCurrentKey.
+    SessionTicketExtension.StatelessKey getKey(HandshakeContext hc) {
+        SessionTicketExtension.StatelessKey ssk = keyHashMap.get(currentKeyID);
+        if (ssk != null && !ssk.isExpired()) {
+            return ssk;
+        }
+        synchronized (this) {
+            // If the current key is no longer expired, it was already
+            // updated by a concurrent request, and we can return.
+            ssk = keyHashMap.get(currentKeyID);
+            if (ssk != null && !ssk.isExpired()) {
+                return ssk;
+            }
+            int newID = currentKeyID + 1;
+            ssk = new SessionTicketExtension.StatelessKey(hc, newID);
+            keyHashMap.put(Integer.valueOf(newID), ssk);
+            currentKeyID = newID;
+        }
+        // Check for and delete invalid keys every time we create a new stateless key.
+        cleanupStatelessKeys();
+        return ssk;
+    }
+
+    // Package-private, used only from SessionTicketExtension.KeyState::getKey.
+    SessionTicketExtension.StatelessKey getKey(int id) {
+        return keyHashMap.get(id);
     }
 
     // package-private method, used ONLY by ServerHandshaker

--- a/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SessionTicketExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.net.ssl.SSLProtocolException;
+import javax.net.ssl.SSLSessionContext;
 
 import static sun.security.ssl.SSLExtension.CH_SESSION_TICKET;
 import static sun.security.ssl.SSLExtension.SH_SESSION_TICKET;
@@ -76,7 +77,6 @@ final class SessionTicketExtension {
     // Time in milliseconds until key is changed for encrypting session state
     private static final int TIMEOUT_DEFAULT = 3600 * 1000;
     private static final int keyTimeout;
-    private static int currentKeyID = new SecureRandom().nextInt();
     private static final int KEYLEN = 256;
 
     static {
@@ -117,7 +117,8 @@ final class SessionTicketExtension {
         final SecretKey key;
         final int num;
 
-        StatelessKey(HandshakeContext hc, int newNum) {
+        // package-private, used only by SSLContextImpl
+        StatelessKey(HandshakeContext hc, int num) {
             SecretKey k = null;
             try {
                 KeyGenerator kg = KeyGenerator.getInstance("AES");
@@ -128,8 +129,7 @@ final class SessionTicketExtension {
             }
             key = k;
             timeout = System.currentTimeMillis() + keyTimeout;
-            num = newNum;
-            hc.sslContext.keyHashMap.put(Integer.valueOf(num), this);
+            this.num = num;
         }
 
         // Check if key needs to be changed
@@ -138,7 +138,8 @@ final class SessionTicketExtension {
         }
 
         // Check if this key is ready for deletion.
-        boolean isInvalid(long sessionTimeout) {
+        boolean isInvalid(SSLSessionContext sslSessionContext) {
+            int sessionTimeout = sslSessionContext.getSessionTimeout() * 1000;
             return ((System.currentTimeMillis()) > (timeout + sessionTimeout));
         }
     }
@@ -147,9 +148,11 @@ final class SessionTicketExtension {
 
         // Get a key with a specific key number
         static StatelessKey getKey(HandshakeContext hc, int num)  {
-            StatelessKey ssk = hc.sslContext.keyHashMap.get(num);
+            SSLSessionContextImpl serverCache =
+                (SSLSessionContextImpl)hc.sslContext.engineGetServerSessionContext();
+            StatelessKey ssk = serverCache.getKey(num);
 
-            if (ssk == null || ssk.isInvalid(getSessionTimeout(hc))) {
+            if (ssk == null || ssk.isInvalid(serverCache)) {
                 return null;
             }
             return ssk;
@@ -157,69 +160,9 @@ final class SessionTicketExtension {
 
         // Get the current valid key, this will generate a new key if needed
         static StatelessKey getCurrentKey(HandshakeContext hc) {
-            StatelessKey ssk = hc.sslContext.keyHashMap.get(currentKeyID);
-
-            if (ssk != null && !ssk.isExpired()) {
-                return ssk;
-            }
-            return nextKey(hc);
-        }
-
-        // This method locks when the first getCurrentKey() finds it to be too
-        // old and create a new key to replace the current key.  After the new
-        // key established, the lock can be released so following
-        // operations will start using the new key.
-        // The first operation will take a longer code path by generating the
-        // next key and cleaning up old keys.
-        private static StatelessKey nextKey(HandshakeContext hc) {
-            StatelessKey ssk;
-
-            synchronized (hc.sslContext.keyHashMap) {
-                // If the current key is no longer expired, it was already
-                // updated by a previous operation and we can return.
-                ssk = hc.sslContext.keyHashMap.get(currentKeyID);
-                if (ssk != null && !ssk.isExpired()) {
-                    return ssk;
-                }
-                int newNum;
-                if (currentKeyID == Integer.MAX_VALUE) {
-                    newNum = 0;
-                } else {
-                    newNum = currentKeyID + 1;
-                }
-                // Get new key
-                ssk = new StatelessKey(hc, newNum);
-                currentKeyID = newNum;
-                // Release lock since the new key is ready to be used.
-            }
-
-            // Clean up any old keys, then return the current key
-            cleanup(hc);
-            return ssk;
-        }
-
-        // Deletes any invalid SessionStateKeys.
-        static void cleanup(HandshakeContext hc) {
-            int sessionTimeout = getSessionTimeout(hc);
-
-            StatelessKey ks;
-            for (Object o : hc.sslContext.keyHashMap.keySet().toArray()) {
-                Integer i = (Integer)o;
-                ks = hc.sslContext.keyHashMap.get(i);
-                if (ks.isInvalid(sessionTimeout)) {
-                    try {
-                        ks.key.destroy();
-                    } catch (Exception e) {
-                        // Suppress
-                    }
-                    hc.sslContext.keyHashMap.remove(i);
-                }
-            }
-        }
-
-        static int getSessionTimeout(HandshakeContext hc) {
-            return hc.sslContext.engineGetServerSessionContext().
-                    getSessionTimeout() * 1000;
+            SSLSessionContextImpl serverCache =
+                (SSLSessionContextImpl)hc.sslContext.engineGetServerSessionContext();
+            return serverCache.getKey(hc);
         }
     }
 


### PR DESCRIPTION
I would like to propose a backport of [JDK-8298381](https://bugs.openjdk.org/browse/JDK-8298381) commit https://github.com/openjdk/jdk/commit/debe5879aa7118a114ff6fcf8d15951757ae70a8 that landed in JDK 21 to jdk17u. This change significantly improves TLS handshaking latency and throughput for services that utilize multiple `SSLContext`. As an example, Apache Kafka running on JDK 17 with significant numbers of clients may see over 40% of CPU utilization due to `SessionTicketExtension$KeyState.cleanup(HandshakeContext)`.

@simonis or others, would you be willing to sponsor this change to JDK 17u and create a corresponding JIRA ticket?

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8298381](https://bugs.openjdk.org/browse/JDK-8298381) needs maintainer approval

### Issue
 * [JDK-8298381](https://bugs.openjdk.org/browse/JDK-8298381): Improve handling of session tickets for multiple SSLContexts (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2750/head:pull/2750` \
`$ git checkout pull/2750`

Update a local copy of the PR: \
`$ git checkout pull/2750` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2750`

View PR using the GUI difftool: \
`$ git pr show -t 2750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2750.diff">https://git.openjdk.org/jdk17u-dev/pull/2750.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2750#issuecomment-2256577087)