### PR TITLE
8337038: Test java/nio/file/attribute/BasicFileAttributeView/CreationTime.java shoud set as /native

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -27,7 +27,7 @@
  *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
- * @run main CreationTime
+ * @run main/native CreationTime
  */
 
 /* @test id=cwd
@@ -36,7 +36,7 @@
  *     scratch directory maybe at diff disk partition to /tmp on linux.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
- * @run main CreationTime .
+ * @run main/native CreationTime .
  */
 
 import java.nio.file.Path;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2c9f741d](https://github.com/openjdk/jdk21u-dev/commit/2c9f741d9ce27cd81e4ad9395a88af1b34a2ba77) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by SendaoYan on 30 Jul 2024 and was reviewed by Matthias Baesken.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337038](https://bugs.openjdk.org/browse/JDK-8337038) needs maintainer approval

### Issue
 * [JDK-8337038](https://bugs.openjdk.org/browse/JDK-8337038): Test java/nio/file/attribute/BasicFileAttributeView/CreationTime.java shoud set as /native (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2752/head:pull/2752` \
`$ git checkout pull/2752`

Update a local copy of the PR: \
`$ git checkout pull/2752` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2752`

View PR using the GUI difftool: \
`$ git pr show -t 2752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2752.diff">https://git.openjdk.org/jdk17u-dev/pull/2752.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2752#issuecomment-2259429692)