### PR TITLE
8313674: (fc) java/nio/channels/FileChannel/BlockDeviceSize.java should test for more block devices

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,40 +24,47 @@
 /* @test
  * @bug 8054029
  * @requires (os.family == "linux")
- * @summary Block devices should not report size=0 on Linux
+ * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
  */
 
 import java.io.RandomAccessFile;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.channels.FileChannel;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.NoSuchFileException;
+import java.util.List;
+
 import static java.nio.file.StandardOpenOption.*;
 
 
 public class BlockDeviceSize {
-    private static final String BLK_FNAME = "/dev/sda1";
-    private static final Path BLK_PATH = Paths.get(BLK_FNAME);
+    private static final List<String> BLK_FNAMES = List.of("/dev/sda1", "/dev/nvme0n1", "/dev/xvda1") ;
 
     public static void main(String[] args) throws Throwable {
-        try (FileChannel ch = FileChannel.open(BLK_PATH, READ);
-             RandomAccessFile file = new RandomAccessFile(BLK_FNAME, "r")) {
+        for (String blkFname: BLK_FNAMES) {
+            Path blkPath = Path.of(blkFname);
+            try (FileChannel ch = FileChannel.open(blkPath, READ);
+                 RandomAccessFile file = new RandomAccessFile(blkFname, "r")) {
 
-            long size1 = ch.size();
-            long size2 = file.length();
-            if (size1 != size2) {
-                throw new RuntimeException("size differs when retrieved" +
-                        " in different ways: " + size1 + " != " + size2);
+                long size1 = ch.size();
+                long size2 = file.length();
+                if (size1 != size2) {
+                    throw new RuntimeException("size differs when retrieved" +
+                            " in different ways: " + size1 + " != " + size2);
+                }
+                if (size1 <= 0) {
+                    throw new RuntimeException("size() for a block device size returns zero or a negative value");
+                }
+                System.out.println("OK");
+
+            } catch (NoSuchFileException nsfe) {
+                System.err.println("File " + blkFname + " not found." +
+                        " Skipping test");
+            } catch (AccessDeniedException ade) {
+                throw new RuntimeException("Access to " + blkFname + " is denied."
+                        + " Run test as root.", ade);
+
             }
-            System.out.println("OK");
-
-        } catch (NoSuchFileException nsfe) {
-            System.err.println("File " + BLK_FNAME + " not found." +
-                    " Skipping test");
-        } catch (AccessDeniedException ade) {
-            System.err.println("Access to " + BLK_FNAME + " is denied." +
-                    " Run test as root.");
         }
     }
 }


### PR DESCRIPTION
Backport of [JDK-8313674](https://bugs.openjdk.org/browse/JDK-8313674)
- Manually merged based original commit. Although `Unclean`, all code is in line with current latest code base.

Testing
- Local: `(os.family == "linux")`
  - `BlockDeviceSize.java`: Test results: passed: 1, on [WSL](https://ubuntu.com/desktop/wsl) based `Ubuntu Linux 22.04` 
  - see comments bellow by @Harry-Junhua-Huang 
- Pipeline
  - `Linux`, Windows - `Passed`
  - MacOS - skipped
- Testing Machine:  SAP nightlies skipped on `2024-08-07`
  - Automated jtreg test: jtreg_jdk_tier2, Started at 2024-08-06 21:10:46+01:00
  - java/nio/channels/FileChannel/BlockDeviceSize.java: `SKIPPED` [Filter: Composite Filter - Filtered out by a composite filter.] GitHub 📊 - [0 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313674](https://bugs.openjdk.org/browse/JDK-8313674) needs maintainer approval

### Issue
 * [JDK-8313674](https://bugs.openjdk.org/browse/JDK-8313674): (fc) java/nio/channels/FileChannel/BlockDeviceSize.java should test for more block devices (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2756/head:pull/2756` \
`$ git checkout pull/2756`

Update a local copy of the PR: \
`$ git checkout pull/2756` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2756`

View PR using the GUI difftool: \
`$ git pr show -t 2756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2756.diff">https://git.openjdk.org/jdk17u-dev/pull/2756.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2756#issuecomment-2261539914)