### PR TITLE
8336301: test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java leaves around a FIFO file upon test completion

### DIFF
--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -129,6 +129,7 @@ public class AsyncCloseAndInterrupt {
             return;
         }
         fifoFile = new File("x.fifo");
+        fifoFile.deleteOnExit();
         if (fifoFile.exists()) {
             if (!fifoFile.delete())
                 throw new IOException("Cannot delete existing fifo " + fifoFile);


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336301](https://bugs.openjdk.org/browse/JDK-8336301) needs maintainer approval

### Issue
 * [JDK-8336301](https://bugs.openjdk.org/browse/JDK-8336301): test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java leaves around a FIFO file upon test completion (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2757/head:pull/2757` \
`$ git checkout pull/2757`

Update a local copy of the PR: \
`$ git checkout pull/2757` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2757`

View PR using the GUI difftool: \
`$ git pr show -t 2757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2757.diff">https://git.openjdk.org/jdk17u-dev/pull/2757.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2757#issuecomment-2261835623)