### PR TITLE
8332113: Update nsk.share.Log to be always verbose

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -80,15 +80,15 @@ public class Log extends FinalizableObject {
 
     /**
      * Is log-mode verbose?
-     * Default value is <code>false</code>.
+     * Always enabled.
      */
-    private boolean verbose = false;
+    private final boolean verbose = true;
 
     /**
      * Should log messages prefixed with timestamps?
-     * Default value is <code>false</code>.
+     * Always enabled.
      */
-    private boolean timestamp = false;
+    private final boolean timestamp = true;
 
     /**
      * Names for trace levels
@@ -212,7 +212,6 @@ public class Log extends FinalizableObject {
      */
     public Log(PrintStream stream, boolean verbose) {
         this(stream);
-        this.verbose = verbose;
     }
 
     /**
@@ -223,7 +222,6 @@ public class Log extends FinalizableObject {
     public Log(PrintStream stream, ArgumentParser argsParser) {
         this(stream, argsParser.verbose());
         traceLevel = argsParser.getTraceLevel();
-        timestamp = argsParser.isTimestamp();
     }
 
     /////////////////////////////////////////////////////////////////
@@ -267,10 +265,9 @@ public class Log extends FinalizableObject {
      * Enable or disable verbose mode for printing messages.
      */
     public void enableVerbose(boolean enable) {
-        if (!verbose) {
-            flushLogBuffer();
+        if (!enable) {
+            throw new RuntimeException("The non-verbose logging is not supported.");
         }
-        verbose = enable;
     }
 
     public int getTraceLevel() {
@@ -472,7 +469,6 @@ public class Log extends FinalizableObject {
     protected synchronized void logTo(PrintStream stream) {
         finalize(); // flush older log stream
         out = stream;
-        verbose = true;
     }
 
     /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332113](https://bugs.openjdk.org/browse/JDK-8332113) needs maintainer approval

### Issue
 * [JDK-8332113](https://bugs.openjdk.org/browse/JDK-8332113): Update nsk.share.Log to be always verbose (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2759/head:pull/2759` \
`$ git checkout pull/2759`

Update a local copy of the PR: \
`$ git checkout pull/2759` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2759`

View PR using the GUI difftool: \
`$ git pr show -t 2759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2759.diff">https://git.openjdk.org/jdk17u-dev/pull/2759.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2759#issuecomment-2261835760)