### PR TITLE
8313901: [TESTBUG] test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java fails with java.lang.VirtualMachineError

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,11 @@ public class CodeCacheFullCountTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
-        oa.shouldHaveExitValue(0);
+        // Ignore adapter creation failures
+        if (oa.getExitValue() != 0 && !oa.getStderr().contains("Out of space in CodeCache for adapters")) {
+            oa.reportDiagnosticSummary();
+            throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
+        }
         String stdout = oa.getStdout();
 
         Pattern pattern = Pattern.compile("full_count=(\\d)");


### PR DESCRIPTION
Backport of [JDK-8313901](https://bugs.openjdk.org/browse/JDK-8313901)

Testing
- Local: Test passed on `MacOS 14.5` on Apple M1 Max
  - `CodeCacheFullCountTest.java`: Test results: passed: 1
- Pipeline:
  - linux-x86,x64 macos-aarch64,x64 windows-aarch64,x64 - `Passed`
  - Other failed test case is not caused by current PR and has been fixed in master
- Testing Machine: SAP nightlies skipped on `2024-08-07`
  - Automated jtreg test: jtreg_hotspot_tier1, Started at 2024-08-06 20:18:52+01:00
  - `compiler/codecache/CodeCacheFullCountTest.java`: SUCCESSFUL GitHub 📊 - [20:19:40.191 -> 6,078 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313901](https://bugs.openjdk.org/browse/JDK-8313901) needs maintainer approval

### Issue
 * [JDK-8313901](https://bugs.openjdk.org/browse/JDK-8313901): [TESTBUG] test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java fails with java.lang.VirtualMachineError (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2769/head:pull/2769` \
`$ git checkout pull/2769`

Update a local copy of the PR: \
`$ git checkout pull/2769` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2769`

View PR using the GUI difftool: \
`$ git pr show -t 2769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2769.diff">https://git.openjdk.org/jdk17u-dev/pull/2769.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2769#issuecomment-2263988772)