### PR TITLE
8295087: Manual Test to Automated Test Conversion

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -653,7 +653,6 @@ com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-
 javax/security/auth/kerberos/KerberosHashEqualsTest.java        8039280 generic-all
 javax/security/auth/kerberos/KerberosTixDateTest.java           8039280 generic-all
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
-sun/security/provider/PolicyParser/ExtDirsChange.java           8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183 linux-ppc64le

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -572,9 +572,6 @@ jdk_core_manual_no_input_security = \
     com/sun/security/sasl/gsskerb/ConfSecurityLayer.java \
     com/sun/security/sasl/gsskerb/NoSecurityLayer.java \
     sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java \
-    sun/security/provider/PolicyParser/ExtDirs.java \
-    sun/security/provider/PolicyParser/ExtDirsChange.java \
-    sun/security/provider/PolicyParser/ExtDirsDefaultPolicy.java \
     sun/security/provider/PolicyParser/PrincipalExpansionError.java \
     sun/security/smartcardio/TestChannel.java \
     sun/security/smartcardio/TestConnect.java \

--- a/test/jdk/java/security/Policy/Root/Root.java
+++ b/test/jdk/java/security/Policy/Root/Root.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,27 +22,46 @@
  */
 
 /*
- *
+ * @test
  * @bug 4619757
  * @summary User Policy Setting is not recognized on Netscape 6
  *          when invoked as root.
- * @run main/manual Root
+ * @library /test/lib
+ * @run testng/othervm Root
  */
 
-/*
- * Place Root.policy in the root home directory (/),
- * as /.java.policy and run as test as root user.
- */
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.*;
 
 public class Root {
-    public static void main(String[] args) {
+    private static final String SRC = System.getProperty("test.src");
+    private static final String ROOT = System.getProperty("user.home");
+    private static final Path SOURCE = Paths.get(SRC, "Root.policy");
+    private static final Path TARGET = Paths.get(ROOT, ".java.policy");
+
+    @BeforeTest
+    public void setup() throws IOException {
+        Files.copy(SOURCE, TARGET, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @AfterTest
+    public void cleanUp() throws IOException {
+        Files.delete(TARGET);
+    }
+
+    @Test
+    private void test() {
         Policy p = Policy.getPolicy();
-        if (p.implies(Root.class.getProtectionDomain(), new AllPermission())) {
-            System.out.println("Test succeeded");
-        } else {
-            throw new SecurityException("Test failed");
-        }
+        Assert.assertTrue(p.implies(Root.class.getProtectionDomain(),
+                new AllPermission()));
     }
 }

--- a/test/jdk/javax/crypto/CryptoPermissions/InconsistentEntries.java
+++ b/test/jdk/javax/crypto/CryptoPermissions/InconsistentEntries.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8286779
+ * @summary Test limited/default_local.policy containing inconsistent entries
+ * @library /test/lib
+ * @run testng/othervm InconsistentEntries
+ */
+
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import javax.crypto.*;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.Security;
+
+public class InconsistentEntries {
+
+    private static final String JDK_HOME = System.getProperty("test.jdk");
+    private static final String TEST_SRC = System.getProperty("test.src");
+    private static final Path POLICY_DIR = Paths.get(JDK_HOME, "conf", "security",
+            "policy", "testlimited");
+    private static final Path POLICY_FILE = Paths.get(TEST_SRC, "default_local.policy");
+
+    Path targetFile = null;
+
+    @BeforeTest
+    public void setUp() throws IOException {
+        if (!POLICY_DIR.toFile().exists()) {
+            Files.createDirectory(POLICY_DIR);
+        }
+
+        targetFile = POLICY_DIR.resolve(POLICY_FILE.getFileName());
+        Files.copy(POLICY_FILE, targetFile, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @AfterTest
+    public void cleanUp() throws IOException {
+        Files.delete(targetFile);
+    }
+
+    @Test
+    public void test() throws Exception {
+        String JAVA_HOME = System.getProperty("java.home");
+        String FS = System.getProperty("file.separator");
+        Path testlimited = Path.of(JAVA_HOME + FS + "conf" + FS + "security" +
+                FS + "policy" + FS + "testlimited");
+        if (!Files.exists(testlimited)) {
+            throw new RuntimeException(
+                    "custom policy subdirectory: testlimited does not exist");
+        }
+
+        File testpolicy = new File(JAVA_HOME + FS + "conf" + FS + "security" +
+                FS + "policy" + FS + "testlimited" + FS + "default_local.policy");
+        if (testpolicy.length() == 0) {
+            throw new RuntimeException(
+                    "policy: default_local.policy does not exist or is empty");
+        }
+
+        Security.setProperty("crypto.policy", "testlimited");
+
+        Assert.assertThrows(ExceptionInInitializerError.class,
+                () -> Cipher.getMaxAllowedKeyLength("AES"));
+    }
+}

--- a/test/jdk/javax/crypto/CryptoPermissions/default_local.policy
+++ b/test/jdk/javax/crypto/CryptoPermissions/default_local.policy
@@ -1,0 +1,4 @@
+grant {
+    permission javax.crypto.CryptoAllPermission;
+    permission javax.crypto.CryptoPermission "DES", 64;
+}

--- a/test/jdk/sun/security/provider/PolicyParser/ExtDirs.java
+++ b/test/jdk/sun/security/provider/PolicyParser/ExtDirs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,15 @@
  * @bug 4215035
  * @summary standard extensions path is hard-coded in default
  *      system policy file
- * @run main/manual ExtDirs
+ * @run main ExtDirs
  */
 
 /*
- * Run this test manually with:
- * java    -Djava.security.manager \
- *         -Djava.ext.dirs=./ExtDirsA:./ExtDirsB \
- *         -Djava.security.policy==./ExtDirs.policy \
- *         -Djava.security.debug=parser \
- *         ExtDirs
+ * @test
+ * @bug 4215035
+ * @summary standard extensions path is hard-coded in default
+ *      system policy file
+ * @run main/othervm/policy=ExtDirs.policy ExtDirs
  */
 
 public class ExtDirs {

--- a/test/jdk/sun/security/provider/PolicyParser/ExtDirs.policy
+++ b/test/jdk/sun/security/provider/PolicyParser/ExtDirs.policy
@@ -1,4 +1,4 @@
-grant codebase "${java.ext.dirs}" {
+grant codebase "file:${test.classes}" {
     permission java.util.PropertyPermission "user.name", "read";
     permission java.util.PropertyPermission "user.home", "read";
 };

--- a/test/jdk/sun/security/provider/PolicyParser/ExtDirs1.policy
+++ b/test/jdk/sun/security/provider/PolicyParser/ExtDirs1.policy
@@ -1,4 +1,4 @@
-grant codebase "file:${{java.ext.dirs}}/*" {
+grant codebase "file:${test.classes}" {
     permission java.util.PropertyPermission "user.name", "read";
     permission java.util.PropertyPermission "user.home", "read";
 };

--- a/test/jdk/sun/security/provider/PolicyParser/ExtDirs2.policy
+++ b/test/jdk/sun/security/provider/PolicyParser/ExtDirs2.policy
@@ -1,4 +1,4 @@
-grant codebase "file:${{java.ext.dirs}}" {
+grant codebase "file:${test.classes}/*" {
     permission java.util.PropertyPermission "user.name", "read";
     permission java.util.PropertyPermission "user.home", "read";
 };

--- a/test/jdk/sun/security/provider/PolicyParser/ExtDirs3.policy
+++ b/test/jdk/sun/security/provider/PolicyParser/ExtDirs3.policy
@@ -1,4 +1,4 @@
-grant codebase "${{java.ext.dirs}}" {
+grant codebase "file:${test.classes}/-" {
     permission java.util.PropertyPermission "user.name", "read";
     permission java.util.PropertyPermission "user.home", "read";
 };

--- a/test/jdk/sun/security/provider/PolicyParser/ExtDirsChange.java
+++ b/test/jdk/sun/security/provider/PolicyParser/ExtDirsChange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,30 +26,17 @@
  * @bug 4993819
  * @summary standard extensions path is hard-coded in default
  *      system policy file
- * @run main/manual ExtDirsChange
+ * @run main/othervm/policy=ExtDirsChange.policy ExtDirsChange
  */
 
-/*
- * Run this test manually with:
- * javac ExtDirChange
- * rm ExtDirsA*.class ExtDirsB*.class
- * java    -Djava.security.manager \
- *         -Dtest.src=. \
- *         -Djava.security.policy=ExtDirsChange.policy \
- *         -Djava.security.debug=parser \
- *         -cp ExtDirsA/a.jar:ExtDirsB/b.jar:. \
- *         ExtDirsChange
- */
-
-import java.io.File;
 import java.security.*;
 
 public class ExtDirsChange {
     public static void main(String args[]) throws Exception {
-        System.out.println("java.ext.dirs: " +
-            System.getProperty("java.ext.dirs"));
+        System.out.println("java.policy.dirs: " +
+                System.getProperty("java.policy.dirs"));
 
-        // Uses default security policy and java.ext.dirs
+        // Uses default security policy and java.policy.dirs
         try {
             ExtDirsA a = new ExtDirsA();
             a.go();
@@ -58,14 +45,14 @@ public class ExtDirsChange {
             System.out.println("Setup OK");
         }
 
-        // Change java.ext.dirs and refresh policy
+        // Change java.policy.dirs and refresh policy
         AccessController.doPrivileged(new PrivilegedAction() {
             public Object run() {
-                // Change java.ext.dirs
-                System.setProperty("java.ext.dirs",
-                    "ExtDirsA" + File.pathSeparator + "ExtDirsB");
-                System.out.println("java.ext.dirs: " +
-                    System.getProperty("java.ext.dirs"));
+                // Change java.policy.dirs
+                System.setProperty("java.policy.dirs",
+                        System.getProperty("test.classes"));
+                System.out.println("java.policy.dirs: " +
+                        System.getProperty("java.policy.dirs"));
                 return null;
             }
         });
@@ -79,7 +66,7 @@ public class ExtDirsChange {
             System.out.println("Setup before refresh OK");
         }
 
-        // Refresh policy using updated java.ext.dirs
+        // Refresh policy using updated java.policy.dirs
         AccessController.doPrivileged(new PrivilegedAction() {
             public Object run() {
                 Policy.getPolicy().refresh();
@@ -99,13 +86,13 @@ public class ExtDirsChange {
         }
 
         // Test with blank java.ext.dir
-        // Change java.ext.dirs and refresh policy
+        // Change java.policy.dirs and refresh policy
         AccessController.doPrivileged(new PrivilegedAction() {
             public Object run() {
-                // Change java.ext.dirs
-                System.setProperty("java.ext.dirs", " ");
-                System.out.println("java.ext.dirs: " +
-                    System.getProperty("java.ext.dirs"));
+                // Change java.policy.dirs
+                System.setProperty("java.policy.dirs", " ");
+                System.out.println("java.policy.dirs: " +
+                        System.getProperty("java.policy.dirs"));
                 Policy.getPolicy().refresh();
                 return null;
             }

--- a/test/jdk/sun/security/provider/PolicyParser/ExtDirsChange.policy
+++ b/test/jdk/sun/security/provider/PolicyParser/ExtDirsChange.policy
@@ -1,8 +1,16 @@
-grant codebase "file:${test.src}/*" {
-    permission java.security.AllPermission;
+grant {
+    permission java.util.PropertyPermission "test.classes", "read";
+    permission java.security.SecurityPermission "getPolicy";
+    permission java.security.SecurityPermission "setPolicy";
 };
 
-grant codebase "${java.ext.dirs}" {
+grant codebase "file:${test.classes}/*" {
+    permission java.util.PropertyPermission "java.policy.dirs", "read, write";
+    permission java.util.PropertyPermission "user.name", "write";
+    permission java.util.PropertyPermission "user.home", "write";
+};
+
+grant codebase "file:${java.policy.dirs}" {
     permission java.util.PropertyPermission "user.name", "read";
     permission java.util.PropertyPermission "user.home", "read";
 };

--- a/test/jdk/sun/security/provider/PolicyParser/ExtDirsDefaultPolicy.java
+++ b/test/jdk/sun/security/provider/PolicyParser/ExtDirsDefaultPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,25 +26,34 @@
  * @bug 4993819
  * @summary standard extensions path is hard-coded in default
  *      system policy file
- * @run main/manual ExtDirsDefaultPolicy
+ * @run main ExtDirsDefaultPolicy
  */
 
 /*
- * Run this test manually with:
- * java    -Djava.security.manager \
- *         -Djava.ext.dirs=./ExtDirsA:./ExtDirsB \
- *         -Djava.security.debug=parser \
- *         ExtDirsDefaultPolicy
+ * @test
+ * @bug 4993819
+ * @summary standard extensions path is hard-coded in default
+ *      system policy file
  *
- * To test other varients of the ${{java.ext.dirs}} protocol, remove
- * the grant statement for java.ext.dirs in $JAVA_HOME/lib/security/java.policy
- * and then run against the 3 different policy files.
+ * @run main/othervm/policy=ExtDirs1.policy ExtDirsDefaultPolicy
+ */
+
+/*
+ * @test
+ * @bug 4993819
+ * @summary standard extensions path is hard-coded in default
+ *      system policy file
  *
- * java    -Djava.security.manager \
- *         -Djava.ext.dirs=./ExtDirsA:./ExtDirsB \
- *         -Djava.security.debug=parser \
- *         -Djava.security.policy=ExtDirs{1,2,3}.policy \
- *         ExtDirsDefaultPolicy
+ * @run main/othervm/policy=ExtDirs2.policy ExtDirsDefaultPolicy
+ */
+
+/*
+ * @test
+ * @bug 4993819
+ * @summary standard extensions path is hard-coded in default
+ *      system policy file
+ *
+ * @run main/othervm/policy=ExtDirs3.policy ExtDirsDefaultPolicy
  */
 
 public class ExtDirsDefaultPolicy {


### PR DESCRIPTION
Backport of [JDK-8295087](https://bugs.openjdk.org/browse/JDK-8295087)
- This PR contains two commit
  - `Commit 1` is generated by git apply from original commit
  - `Commit 2` is adding the missing test case `InconsistentEntries.java`, which was originally added by [JDK-8286779](https://bugs.openjdk.org/browse/JDK-8286779)

Testing
- Local: Test passed on `MacOS 14.5` on Apple M1 Max
  - `ExtDirs.java`: Test results: passed: 2
  - `ExtDirsChange.java`: Test results: passed: 1
  - `ExtDirsDefaultPolicy.java`: Test results: passed: 4
  - `InconsistentEntries.java`: Test results: passed: 1
- Pipeline: 
  - Linux, Windows - Passed
  - MacOS - Skipped (`This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.`)
- Testing Machine: SAP nightlies Passed on `2024-08-07`
  - Automated jtreg test: jtreg_jdk_tier1, Started at 2024-08-06 20:35:20+01:00 
    - java/lang/ClassLoader/ExtDirs.java: SUCCESSFUL GitHub 📊 - [20:37:45.782 -> 568 msec]
  - Automated jtreg test: jtreg_jdk_tier2, Started at 2024-08-06 21:10:46+01:00
    - sun/security/provider/PolicyParser/ExtDirsChange.java: SUCCESSFUL GitHub 📊 - [21:41:01.101 -> 364 msec]
    - sun/security/provider/PolicyParser/ExtDirsDefaultPolicy.java#id0: SUCCESSFUL GitHub 📊 - [21:41:01.165 -> 39 msec]
    - sun/security/provider/PolicyParser/ExtDirsDefaultPolicy.java#id1: SUCCESSFUL GitHub 📊 - [21:41:01.204 -> 309 msec]
    - sun/security/provider/PolicyParser/ExtDirsDefaultPolicy.java#id2: SUCCESSFUL GitHub 📊 - [21:41:01.465 -> 309 msec]
    - sun/security/provider/PolicyParser/ExtDirsDefaultPolicy.java#id3: SUCCESSFUL GitHub 📊 - [21:41:01.513 -> 362 msec]
    - javax/crypto/CryptoPermissions/InconsistentEntries.java: SUCCESSFUL GitHub 📊 - [21:30:11.979 -> 4,379 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8295087](https://bugs.openjdk.org/browse/JDK-8295087) needs maintainer approval

### Issue
 * [JDK-8295087](https://bugs.openjdk.org/browse/JDK-8295087): Manual Test to Automated Test Conversion (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2774/head:pull/2774` \
`$ git checkout pull/2774`

Update a local copy of the PR: \
`$ git checkout pull/2774` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2774`

View PR using the GUI difftool: \
`$ git pr show -t 2774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2774.diff">https://git.openjdk.org/jdk17u-dev/pull/2774.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2774#issuecomment-2264431659)