### PR TITLE
8306929: Avoid CleanClassLoaderDataMetaspaces safepoints when previous versions are shared

### DIFF
--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -186,7 +186,7 @@ void ClassLoaderDataGraph::walk_metadata_and_clean_metaspaces() {
   // on the stack or in the code cache, so we only have to repeat the full walk if
   // they were found at that time.
   // TODO: have redefinition clean old methods out of the code cache.  They still exist in some places.
-  bool walk_all_metadata = InstanceKlass::has_previous_versions_and_reset();
+  bool walk_all_metadata = InstanceKlass::should_clean_previous_versions_and_reset();
 
   MetadataOnStackMark md_on_stack(walk_all_metadata, /*redefinition_walk*/false);
   clean_deallocate_lists(walk_all_metadata);

--- a/src/hotspot/share/classfile/classLoaderDataGraph.inline.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.inline.hpp
@@ -73,7 +73,7 @@ bool ClassLoaderDataGraph::should_clean_metaspaces_and_reset() {
   // Only clean metaspaces after full GC.
   bool do_cleaning = _safepoint_cleanup_needed;
 #if INCLUDE_JVMTI
-  do_cleaning = do_cleaning && (_should_clean_deallocate_lists || InstanceKlass::has_previous_versions());
+  do_cleaning = do_cleaning && (_should_clean_deallocate_lists || InstanceKlass::should_clean_previous_versions());
 #else
   do_cleaning = do_cleaning && _should_clean_deallocate_lists;
 #endif

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3941,18 +3941,18 @@ void InstanceKlass::set_init_state(ClassState state) {
 // Globally, there is at least one previous version of a class to walk
 // during class unloading, which is saved because old methods in the class
 // are still running.   Otherwise the previous version list is cleaned up.
-bool InstanceKlass::_has_previous_versions = false;
+bool InstanceKlass::_should_clean_previous_versions = false;
 
 // Returns true if there are previous versions of a class for class
 // unloading only. Also resets the flag to false. purge_previous_version
 // will set the flag to true if there are any left, i.e., if there's any
 // work to do for next time. This is to avoid the expensive code cache
 // walk in CLDG::clean_deallocate_lists().
-bool InstanceKlass::has_previous_versions_and_reset() {
-  bool ret = _has_previous_versions;
-  log_trace(redefine, class, iklass, purge)("Class unloading: has_previous_versions = %s",
+bool InstanceKlass::should_clean_previous_versions_and_reset() {
+  bool ret = _should_clean_previous_versions;
+  log_trace(redefine, class, iklass, purge)("Class unloading: should_clean_previous_versions = %s",
      ret ? "true" : "false");
-  _has_previous_versions = false;
+  _should_clean_previous_versions = false;
   return ret;
 }
 
@@ -4027,12 +4027,17 @@ void InstanceKlass::purge_previous_version_list() {
       version++;
       continue;
     } else {
-      log_trace(redefine, class, iklass, purge)("previous version " INTPTR_FORMAT " is alive", p2i(pv_node));
       assert(pvcp->pool_holder() != NULL, "Constant pool with no holder");
       guarantee (!loader_data->is_unloading(), "unloaded classes can't be on the stack");
       live_count++;
-      // found a previous version for next time we do class unloading
-      _has_previous_versions = true;
+      if (pvcp->is_shared()) {
+        // Shared previous versions can never be removed so no cleaning is needed.
+        log_trace(redefine, class, iklass, purge)("previous version " PTR_FORMAT " is shared", p2i(pv_node));
+      } else {
+        // Previous version alive, set that clean is needed for next time.
+        _should_clean_previous_versions = true;
+        log_trace(redefine, class, iklass, purge)("previous version " PTR_FORMAT " is alive", p2i(pv_node));
+      }
     }
 
     // next previous version
@@ -4132,13 +4137,19 @@ void InstanceKlass::add_previous_version(InstanceKlass* scratch_class,
     return;
   }
 
-  // Add previous version if any methods are still running.
-  // Set has_previous_version flag for processing during class unloading.
-  _has_previous_versions = true;
-  log_trace(redefine, class, iklass, add) ("scratch class added; one of its methods is on_stack.");
+  // Add previous version if any methods are still running or if this is
+  // a shared class which should never be removed.
   assert(scratch_class->previous_versions() == NULL, "shouldn't have a previous version");
   scratch_class->link_previous_versions(previous_versions());
   link_previous_versions(scratch_class);
+  if (cp_ref->is_shared()) {
+    log_trace(redefine, class, iklass, add) ("scratch class added; class is shared");
+  } else {
+    //  We only set clean_previous_versions flag for processing during class
+    // unloading for non-shared classes.
+    _should_clean_previous_versions = true;
+    log_trace(redefine, class, iklass, add) ("scratch class added; one of its methods is on_stack.");
+  }
 } // end add_previous_version()
 
 #endif // INCLUDE_JVMTI

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -815,7 +815,7 @@ public:
   }
 
  private:
-  static bool  _has_previous_versions;
+  static bool  _should_clean_previous_versions;
  public:
   static void purge_previous_versions(InstanceKlass* ik) {
     if (ik->has_been_redefined()) {
@@ -823,8 +823,8 @@ public:
     }
   }
 
-  static bool has_previous_versions_and_reset();
-  static bool has_previous_versions() { return _has_previous_versions; }
+  static bool should_clean_previous_versions_and_reset();
+  static bool should_clean_previous_versions() { return _should_clean_previous_versions; }
 
   // JVMTI: Support for caching a class file before it is modified by an agent that can do retransformation
   void set_cached_class_file(JvmtiCachedClassFileData *data) {
@@ -844,7 +844,7 @@ public:
 #else // INCLUDE_JVMTI
 
   static void purge_previous_versions(InstanceKlass* ik) { return; };
-  static bool has_previous_versions_and_reset() { return false; }
+  static bool should_clean_previous_versions_and_reset() { return false; }
 
   void set_cached_class_file(JvmtiCachedClassFileData *data) {
     assert(data == NULL, "unexpected call with JVMTI disabled");

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefinePreviousVersions.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8165246 8010319
- * @summary Test has_previous_versions flag and processing during class unloading.
+ * @summary Test clean_previous_versions flag and processing during class unloading.
  * @requires vm.jvmti
  * @requires vm.opt.final.ClassUnloading
  * @requires vm.flagless
@@ -86,15 +86,15 @@ public class RedefinePreviousVersions {
                "-Xlog:redefine+class+iklass+add=trace,redefine+class+iklass+purge=trace",
                "RedefinePreviousVersions");
             new OutputAnalyzer(pb.start())
-              .shouldContain("Class unloading: has_previous_versions = false")
-              .shouldContain("Class unloading: has_previous_versions = true")
+              .shouldContain("Class unloading: should_clean_previous_versions = false")
+              .shouldContain("Class unloading: should_clean_previous_versions = true")
               .shouldHaveExitValue(0);
             return;
         }
 
         // Redefine a class and create some garbage
         // Since there are no methods running, the previous version is never added to the
-        // previous_version_list and the flag _has_previous_versions should stay false
+        // previous_version_list and the flag _should_clean_previous_versions should stay false
         RedefineClassHelper.redefineClass(RedefinePreviousVersions_B.class, newB);
 
         for (int i = 0; i < 10 ; i++) {
@@ -114,7 +114,7 @@ public class RedefinePreviousVersions {
         }
 
         // Since a method of newRunning is running, this class should be added to the previous_version_list
-        // of Running, and _has_previous_versions should return true at class unloading.
+        // of Running, and _should_clean_previous_versions should return true at class unloading.
         RedefineClassHelper.redefineClass(RedefinePreviousVersions_Running.class, newRunning);
 
         for (int i = 0; i < 10 ; i++) {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8306929
- * @summary Verify clean_previous_versions when run with JFR and CDS
+ * @summary Verify should_clean_previous_versions when run with JFR and CDS
  * @requires vm.jvmti
  * @requires vm.cds
  * @requires vm.hasJFR
@@ -69,19 +69,17 @@ public class RedefineSharedClassJFR {
 
             if (args[0].equals("xshare-off")) {
                 // First case is with -Xshare:off. In this case no classes are shared
-                // and we should be able to clean out the retransformed classes. Verify
-                // that the cleaning is done when the GC is triggered.
+                // and we should be able to clean out the retransformed classes. There
+                // is no guarantee that any classes will be in use, so just verify that
+                // no classes are added due to being shared.
                 List<String> offCommand = new ArrayList<>();
                 offCommand.add("-Xshare:off");
                 offCommand.addAll(baseCommand);
                 ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(offCommand);
                 new OutputAnalyzer(pb.start())
-                    .shouldContain(SHOULD_CLEAN_TRUE)
-                    .shouldNotContain(SHOULD_CLEAN_FALSE)
-                    // We expect at least one of the transformed classes to be in use, if
-                    // not the above check that should_clean_previous should be true will also
-                    // fail. This check is to show what is expected.
-                    .shouldContain(SCRATCH_CLASS_ADDED_ON_STACK)
+                    // We can't expect any of the transformed classes to be in use
+                    // so the only thing we can verify is that no scratch classes
+                    // are added because they are shared.
                     .shouldNotContain(SCRATCH_CLASS_ADDED_SHARED)
                     .shouldHaveExitValue(0);
                 return;

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8306929
+ * @summary Verify clean_previous_versions when run with JFR and CDS
+ * @requires vm.jvmti
+ * @requires vm.cds
+ * @requires vm.hasJFR
+ * @requires vm.opt.final.ClassUnloading
+ * @requires vm.flagless
+ * @library /test/lib
+ * @run driver RedefineSharedClassJFR xshare-off
+ * @run driver RedefineSharedClassJFR xshare-on
+ */
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import jtreg.SkippedException;
+
+public class RedefineSharedClassJFR {
+
+    private static final String SHOULD_CLEAN_TRUE = "Class unloading: should_clean_previous_versions = true";
+    private static final String SHOULD_CLEAN_FALSE = "Class unloading: should_clean_previous_versions = false";
+    private static final String SCRATCH_CLASS_ADDED_SHARED = "scratch class added; class is shared";
+    private static final String SCRATCH_CLASS_ADDED_ON_STACK = "scratch class added; one of its methods is on_stack.";
+
+    public static void main(String[] args) throws Exception {
+        // Skip test if default archive is supported.
+        if (!Platform.isDefaultCDSArchiveSupported()) {
+            throw new SkippedException("Supported platform");
+        }
+
+        // Test is run with JFR which will transform a number of classes. Depending
+        // on if the test is run with or without CDS the output will be different,
+        // due to the fact that shared classes can never be cleaned out after retranform.
+        if (args.length > 0) {
+            // When run with an argument the class is used as driver and should parse
+            // the output to verify it is correct given the command line.
+            List<String> baseCommand = List.of(
+                "-XX:StartFlightRecording",
+                "-Xlog:redefine+class+iklass+add=trace,redefine+class+iklass+purge=trace",
+                "RedefineSharedClassJFR");
+
+            if (args[0].equals("xshare-off")) {
+                // First case is with -Xshare:off. In this case no classes are shared
+                // and we should be able to clean out the retransformed classes. Verify
+                // that the cleaning is done when the GC is triggered.
+                List<String> offCommand = new ArrayList<>();
+                offCommand.add("-Xshare:off");
+                offCommand.addAll(baseCommand);
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(offCommand);
+                new OutputAnalyzer(pb.start())
+                    .shouldContain(SHOULD_CLEAN_TRUE)
+                    .shouldNotContain(SHOULD_CLEAN_FALSE)
+                    // We expect at least one of the transformed classes to be in use, if
+                    // not the above check that should_clean_previous should be true will also
+                    // fail. This check is to show what is expected.
+                    .shouldContain(SCRATCH_CLASS_ADDED_ON_STACK)
+                    .shouldNotContain(SCRATCH_CLASS_ADDED_SHARED)
+                    .shouldHaveExitValue(0);
+                return;
+            } else if (args[0].equals("xshare-on")) {
+                // With -Xshare:on, the shared classes can never be cleaned out. Check the
+                // logs to verify we don't try to clean when we know it is not needed.
+                List<String> onCommand = new ArrayList<>();
+                onCommand.add("-Xshare:on");
+                onCommand.addAll(baseCommand);
+                ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(onCommand);
+                new OutputAnalyzer(pb.start())
+                    .shouldContain(SHOULD_CLEAN_FALSE)
+                    .shouldNotContain(SHOULD_CLEAN_TRUE)
+                    .shouldContain(SCRATCH_CLASS_ADDED_SHARED)
+                    // If the below line occurs, then should_clean_previous_versions will be
+                    // true and the above shouldContain will trigger. This check is to
+                    // show the intention that we don't expect any non-shared transformed
+                    // classes to be in use.
+                    .shouldNotContain(SCRATCH_CLASS_ADDED_ON_STACK)
+                    .shouldHaveExitValue(0);
+                return;
+            }
+        }
+
+        // When run without any argument this class acts as test and we do a system GC
+        // to trigger cleaning and get the output we want to check.
+        System.gc();
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [408cec51](https://github.com/openjdk/jdk/commit/408cec516bb5fd82fb6dcddeee934ac0c5ecffaf) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Stefan Johansson on 4 May 2023 and was reviewed by Coleen Phillimore and Serguei Spitsyn.

It's clean except for the surrounding context changing between NULL and nullptr which was trivial to resolve. It comes with its own test, but I also confirmed that it fixes the reproducer shared on the issue.

Edit: This now also backports 8307448/https://github.com/openjdk/jdk/commit/29233e0a001adde71a3fa5d56292ccfba8409ea5 to fix the flaky test. 8307448 applied cleanly.

Testing - looks good, just 3 unrelated tests failing on my machine.

```
 JTREG_KEYWORDS="\!headful & \!external-dep & \!printer" make test TEST=all

   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/hotspot/jtreg:all                       6131  6131     0     0
>> jtreg:test/jdk:all                                 9140  9137     3     0 <<
   jtreg:test/langtools:all                           4251  4251     0     0
   jtreg:test/jaxp:all                                 467   467     0     0
   jtreg:test/lib-test:all                              30    30     0     0
   
build/AbsPathsInImage.java                                                                                         Failed. Execution failed: `main' threw exception: java.lang.Exception: Test failed
java/nio/channels/FileChannel/directio/DirectIOTest.java                                                           Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: DirectIO is not working properly with read. File still exists in cache!
jdk/internal/platform/docker/TestDockerMemoryMetrics.java                                                          Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Expected to get exit value of [0]
```

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307448](https://bugs.openjdk.org/browse/JDK-8307448) needs maintainer approval
- [x] [JDK-8306929](https://bugs.openjdk.org/browse/JDK-8306929) needs maintainer approval

### Issues
 * [JDK-8306929](https://bugs.openjdk.org/browse/JDK-8306929): Avoid CleanClassLoaderDataMetaspaces safepoints when previous versions are shared (**Enhancement** - P3 - Approved)
 * [JDK-8307448](https://bugs.openjdk.org/browse/JDK-8307448): Test RedefineSharedClassJFR fail due to wrong assumption (**Bug** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2776/head:pull/2776` \
`$ git checkout pull/2776`

Update a local copy of the PR: \
`$ git checkout pull/2776` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2776`

View PR using the GUI difftool: \
`$ git pr show -t 2776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2776.diff">https://git.openjdk.org/jdk17u-dev/pull/2776.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2776#issuecomment-2265404834)