### PR TITLE
8298596: vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java fails with "NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -234,11 +234,21 @@ public final class GarbageUtils {
                      long.class,
                      OOM_TYPE.class);
 
+         private static MethodHandle eat;
+
+         static {
+             try {
+                 eat = MethodHandles.lookup().findStatic(GarbageUtils.class, "eatMemoryImpl", mt);
+             } catch (Exception nsme) {
+                 // Can't run the test for some unexpected reason
+                 throw new RuntimeException(nsme);
+             }
+         }
+
+
          public static int eatMemory(ExecutionController stresser, GarbageProducer gp, long initialFactor, long minMemoryChunk, long factor, OOM_TYPE type) {
             try {
                // Using a methodhandle invoke of eatMemoryImpl to prevent inlining of it
-               MethodHandles.Lookup lookup = MethodHandles.lookup();
-               MethodHandle eat = lookup.findStatic(GarbageUtils.class, "eatMemoryImpl", mt);
                return (int) eat.invoke(stresser, gp, initialFactor, minMemoryChunk, factor, type);
             } catch (OutOfMemoryError e) {
                return numberOfOOMEs++;


### PR DESCRIPTION
Backport of [JDK-8298596](https://bugs.openjdk.org/browse/JDK-8298596)
- The change on file `test/hotspot/jtreg/vmTestbase/nsk/share/gc/gp/GarbageUtils.java` is `clean`
- The change on file `test/hotspot/jtreg/ProblemList-zgc.txt` has been **ignored**, because the line does not exist in `jdk17u-dev`

Testing
- Local: Test passed on `MacOS 14.5` on Apple M1 Max
  - `OneeFinalizerTest.java`: Test results: passed: 1
  - `PhantomReferenceEvilTest.java`: Test results: passed: 1
  - `PhantomReferenceTest.java`: Test results: passed: 1
  - `ReferencesGC.java`: Test results: passed: 1
  - `soft001.java`: Test results: passed: 1
  - `weak001.java`: Test results: passed: 1
  - `WeakReferenceGC.java`: Test results: passed: 1
- Pipeline: 
  - Linux, Windows - Passed
  - MacOS - Skipped (`This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.`)
- Testing Machine: SAP nightlies Passed on `2024-08-07`
  - Automated jtreg test: jtreg_notstresshotspot_tier4, Started at 2024-08-06 23:51:31+01:00
    - vmTestbase/gc/gctests/OneeFinalizerTest/OneeFinalizerTest.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!stress)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - vmTestbase/gc/gctests/PhantomReference/PhantomReferenceEvilTest/PhantomReferenceEvilTest.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!stress)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - vmTestbase/gc/gctests/PhantomReference/PhantomReferenceTest/PhantomReferenceTest.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!stress)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - vmTestbase/gc/gctests/ReferencesGC/ReferencesGC.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!stress)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - vmTestbase/gc/gctests/SoftReference/soft001/soft001.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!stress)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - vmTestbase/gc/gctests/WeakReference/weak001/weak001.java: `SKIPPED` [Filter: Keywords - Not matching the given keyword expression: `(((!headful)&(!stress)&(!intermittent))) & !manual & !ignore`] GitHub 📊 - [0 msec]
    - vmTestbase/gc/gctests/WeakReferenceGC/WeakReferenceGC.java: SUCCESSFUL GitHub 📊 - [23:56:56.422 -> 31,830 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8298596](https://bugs.openjdk.org/browse/JDK-8298596) needs maintainer approval

### Issue
 * [JDK-8298596](https://bugs.openjdk.org/browse/JDK-8298596): vmTestbase/nsk/sysdict/vm/stress/chain/chain008/chain008.java fails with "NoClassDefFoundError: Could not initialize class java.util.concurrent.ThreadLocalRandom" (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2778/head:pull/2778` \
`$ git checkout pull/2778`

Update a local copy of the PR: \
`$ git checkout pull/2778` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2778`

View PR using the GUI difftool: \
`$ git pr show -t 2778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2778.diff">https://git.openjdk.org/jdk17u-dev/pull/2778.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2778#issuecomment-2266253879)