### PR TITLE
8313256: Exclude failing multicast tests on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -564,9 +564,10 @@ com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java  8030957 aix-all
 
 java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-all
 
-sun/management/jdp/JdpDefaultsTest.java                         8241865 linux-aarch64,macosx-all
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-all
-sun/management/jdp/JdpSpecificAddressTest.java                  8241865 macosx-all
+sun/management/jdp/JdpDefaultsTest.java                         8241865,8308807 linux-aarch64,macosx-all,aix-ppc64
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865,8308807 macosx-all,aix-ppc64
+sun/management/jdp/JdpSpecificAddressTest.java                  8241865,8308807 macosx-all,aix-ppc64
+sun/management/jdp/JdpOffTest.java                              8308807 aix-ppc64
 
 ############################################################################
 
@@ -608,6 +609,8 @@ java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
 java/nio/file/Files/probeContentType/Basic.java                 8320943 windows-all
+
+java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -588,15 +588,18 @@ java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc6
 java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
 java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc64
 java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc64
-java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
+java/net/MulticastSocket/NoLoopbackPackets.java                 7122846,8308807 macosx-all,aix-ppc64
 java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
 java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc64
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8219083,8308807 windows-all,aix-ppc64
-java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
+java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 macosx-all,aix-ppc64
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
-java/net/MulticastSocket/Test.java                              7145658 macosx-all
+java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
+java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
+java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
+
 ############################################################################
 
 # jdk_nio


### PR DESCRIPTION
Backport of [JDK-8313256](https://bugs.openjdk.org/browse/JDK-8313256)
- This PR contains two commit
- `commit 1` is generated by git apply command, which is `clean`
- `commit 2` is the manual merge of the `test/jdk/ProblemList.txt.rej` file

Contents of `test/jdk/ProblemList.txt.rej`

```diff
@@ -586,13 +587,16 @@
 
 # jdk_net
 
-java/net/MulticastSocket/NoLoopbackPackets.java                 7122846 macosx-all
-java/net/MulticastSocket/SetLoopbackMode.java                   7122846 macosx-all
+java/net/MulticastSocket/NoLoopbackPackets.java                 7122846,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 macosx-all,aix-ppc64
 
-java/net/MulticastSocket/Test.java                              7145658 macosx-all
+java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
+java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
+java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
+
 ############################################################################
 
 # jdk_nio
```

Testing
- Local: Not applicable (`aix-ppc64`)
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies Passed on `2024-08-07`
  - Automated jtreg test: jtreg_jdk_tier3, Started at 2024-08-06 22:04:38+01:00
    - sun/management/jdp/JdpDefaultsTest.java: `SKIPPED` [Filter: jtregExcludeListFilter - Test has been excluded by an exclude list] GitHub 📊 - [0 msec]
    - sun/management/jdp/JdpJmxRemoteDynamicPortTest.java: `SKIPPED` [Filter: jtregExcludeListFilter - Test has been excluded by an exclude list] GitHub 📊 - [0 msec]
    - sun/management/jdp/JdpSpecificAddressTest.java: `SKIPPED` [Filter: jtregExcludeListFilter - Test has been excluded by an exclude list] GitHub 📊 - [0 msec]
    - sun/management/jdp/JdpOffTest.java: SUCCESSFUL GitHub 📊 - [22:20:33.777 -> 12,159 msec]
  - Automated jtreg test: jtreg_jdk_tier2, Started at 2024-08-06 21:10:46+01:00
    - java/net/MulticastSocket/NoLoopbackPackets.java: SKIPPED[Filter: jtregExcludeListFilter - Test has been excluded by an exclude list] GitHub 📊 - [0 msec]
    - java/net/MulticastSocket/SetLoopbackMode.java: SKIPPED[Filter: jtregExcludeListFilter - Test has been excluded by an exclude list] GitHub 📊 - [0 msec]
    - java/net/MulticastSocket/Test.java: SKIPPED[Filter: jtregExcludeListFilter - Test has been excluded by an exclude list] GitHub 📊 - [0 msec]
    - java/net/MulticastSocket/B6427403.java: SUCCESSFUL GitHub 📊 - [21:22:00.602 -> 156 msec]
    - java/net/MulticastSocket/SetOutgoingIf.java: SUCCESSFUL GitHub 📊 - [21:22:08.500 -> 273 msec]
    - java/nio/channels/DatagramChannel/AfterDisconnect.java: SUCCESSFUL GitHub 📊 - [21:23:10.918 -> 9,012 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313256](https://bugs.openjdk.org/browse/JDK-8313256) needs maintainer approval

### Issue
 * [JDK-8313256](https://bugs.openjdk.org/browse/JDK-8313256): Exclude failing multicast tests on AIX (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2780/head:pull/2780` \
`$ git checkout pull/2780`

Update a local copy of the PR: \
`$ git checkout pull/2780` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2780`

View PR using the GUI difftool: \
`$ git pr show -t 2780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2780.diff">https://git.openjdk.org/jdk17u-dev/pull/2780.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2780#issuecomment-2266330033)