### PR TITLE
8304962: sun/net/www/http/KeepAliveCache/B5045306.java: java.lang.RuntimeException: Failed: Initial Keep Alive Connection is not being reused

### DIFF
--- a/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
@@ -31,7 +31,7 @@
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
+import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -40,7 +40,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -176,9 +175,9 @@ class SimpleHttpTransactionHandler implements HttpHandler
                 byte[] responseBody = new byte[RESPONSE_DATA_LENGTH];
                 for (int i=0; i<responseBody.length; i++)
                     responseBody[i] = 0x41;
-                trans.sendResponseHeaders(200, 0);
-                try(PrintWriter pw = new PrintWriter(trans.getResponseBody(), false, Charset.forName("UTF-8"))) {
-                    pw.print(responseBody);
+                trans.sendResponseHeaders(200, responseBody.length);
+                try (OutputStream os = trans.getResponseBody()) {
+                    os.write(responseBody);
                 }
             } else if (path.equals("/secondCall")) {
                 int port2 = trans.getLocalAddress().getPort();
@@ -201,10 +200,10 @@ class SimpleHttpTransactionHandler implements HttpHandler
                     responseBody[i] = 0x41;
                 // override the Content-length header to be greater than the actual response body
                 trans.sendResponseHeaders(200, responseBody.length+1);
-                try(PrintWriter pw = new PrintWriter(trans.getResponseBody(), false, Charset.forName("UTF-8"))) {
-                    pw.print(responseBody);
-                }
+                OutputStream os = trans.getResponseBody();
+                os.write(responseBody);
                 // now close the socket
+                // closing the stream here would throw; close the exchange instead
                 trans.close();
             }
         } catch (Exception e) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8304962](https://bugs.openjdk.org/browse/JDK-8304962), commit [cddaf686](https://github.com/openjdk/jdk21u-dev/commit/cddaf686e16424e9543be50a48b1c02337e79cf1) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by Daniel Jeliński on 28 Mar 2023 and was reviewed by Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8304962](https://bugs.openjdk.org/browse/JDK-8304962) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304962](https://bugs.openjdk.org/browse/JDK-8304962): sun/net/www/http/KeepAliveCache/B5045306.java: java.lang.RuntimeException: Failed: Initial Keep Alive Connection is not being reused (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2781/head:pull/2781` \
`$ git checkout pull/2781`

Update a local copy of the PR: \
`$ git checkout pull/2781` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2781`

View PR using the GUI difftool: \
`$ git pr show -t 2781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2781.diff">https://git.openjdk.org/jdk17u-dev/pull/2781.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2781#issuecomment-2266362954)