### PR TITLE
7026262: HttpServer: improve handling of finished HTTP exchanges

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedOutputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ChunkedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package sun.net.httpserver;
 
 import java.io.*;
 import java.net.*;
+import java.util.Objects;
+
 import com.sun.net.httpserver.*;
 import com.sun.net.httpserver.spi.*;
 
@@ -77,6 +79,10 @@ class ChunkedOutputStream extends FilterOutputStream
     }
 
     public void write (byte[]b, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return;
+        }
         if (closed) {
             throw new StreamClosedException ();
         }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ExchangeImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ExchangeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -282,9 +282,7 @@ class ExchangeImpl {
         sentHeaders = true;
         logger.log(Level.TRACE, "Sent headers: noContentToSend=" + noContentToSend);
         if (noContentToSend) {
-            WriteFinishedEvent e = new WriteFinishedEvent (this);
-            server.addEvent (e);
-            closed = true;
+            close();
         }
         server.logReply (rCode, req.requestLine(), null);
     }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/FixedLengthOutputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/FixedLengthOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package sun.net.httpserver;
 
 import java.io.*;
 import java.net.*;
+import java.util.Objects;
+
 import com.sun.net.httpserver.*;
 import com.sun.net.httpserver.spi.*;
 
@@ -41,7 +43,6 @@ import com.sun.net.httpserver.spi.*;
 class FixedLengthOutputStream extends FilterOutputStream
 {
     private long remaining;
-    private boolean eof = false;
     private boolean closed = false;
     ExchangeImpl t;
 
@@ -58,8 +59,7 @@ class FixedLengthOutputStream extends FilterOutputStream
         if (closed) {
             throw new IOException ("stream closed");
         }
-        eof = (remaining == 0);
-        if (eof) {
+        if (remaining == 0) {
             throw new StreamClosedException();
         }
         out.write(b);
@@ -67,12 +67,12 @@ class FixedLengthOutputStream extends FilterOutputStream
     }
 
     public void write (byte[]b, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return;
+        }
         if (closed) {
             throw new IOException ("stream closed");
-        }
-        eof = (remaining == 0);
-        if (eof) {
-            throw new StreamClosedException();
         }
         if (len > remaining) {
             // stream is still open, caller can retry
@@ -92,7 +92,6 @@ class FixedLengthOutputStream extends FilterOutputStream
             throw new IOException ("insufficient bytes written to stream");
         }
         flush();
-        eof = true;
         LeftOverInputStream is = t.getOriginalInputStream();
         if (!is.isClosed()) {
             try {

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/ServerImpl.java
@@ -696,7 +696,14 @@ class ServerImpl {
                     return;
                 }
                 String uriStr = requestLine.substring (start, space);
-                URI uri = new URI (uriStr);
+                URI uri;
+                try {
+                    uri = new URI (uriStr);
+                } catch (URISyntaxException e3) {
+                    reject(Code.HTTP_BAD_REQUEST,
+                            requestLine, "URISyntaxException thrown");
+                    return;
+                }
                 start = space+1;
                 String version = requestLine.substring (start);
                 Headers headers = req.headers();
@@ -732,7 +739,13 @@ class ServerImpl {
                 } else {
                     headerValue = headers.getFirst("Content-Length");
                     if (headerValue != null) {
-                        clen = Long.parseLong(headerValue);
+                        try {
+                            clen = Long.parseLong(headerValue);
+                        } catch (NumberFormatException e2) {
+                            reject(Code.HTTP_BAD_REQUEST,
+                                    requestLine, "NumberFormatException thrown");
+                            return;
+                        }
                         if (clen < 0) {
                             reject(Code.HTTP_BAD_REQUEST, requestLine,
                                     "Illegal Content-Length value");
@@ -818,20 +831,11 @@ class ServerImpl {
                     uc.doFilter (new HttpExchangeImpl (tx));
                 }
 
-            } catch (IOException e1) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (1)", e1);
-                closeConnection(connection);
-            } catch (NumberFormatException e2) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (2)", e2);
-                reject (Code.HTTP_BAD_REQUEST,
-                        requestLine, "NumberFormatException thrown");
-            } catch (URISyntaxException e3) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (3)", e3);
-                reject (Code.HTTP_BAD_REQUEST,
-                        requestLine, "URISyntaxException thrown");
-            } catch (Exception e4) {
-                logger.log (Level.TRACE, "ServerImpl.Exchange (4)", e4);
-                closeConnection(connection);
+            } catch (Exception e) {
+                logger.log (Level.TRACE, "ServerImpl.Exchange", e);
+                if (tx == null || !tx.writefinished) {
+                    closeConnection(connection);
+                }
             } catch (Throwable t) {
                 logger.log(Level.TRACE, "ServerImpl.Exchange (5)", t);
                 throw t;
@@ -856,9 +860,8 @@ class ServerImpl {
             rejected = true;
             logReply (code, requestStr, message);
             sendReply (
-                code, false, "<h1>"+code+Code.msg(code)+"</h1>"+message
+                code, true, "<h1>"+code+Code.msg(code)+"</h1>"+message
             );
-            closeConnection(connection);
         }
 
         void sendReply (

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/UndefLengthOutputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/UndefLengthOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package sun.net.httpserver;
 
 import java.io.*;
 import java.net.*;
+import java.util.Objects;
+
 import com.sun.net.httpserver.*;
 import com.sun.net.httpserver.spi.*;
 
@@ -55,6 +57,10 @@ class UndefLengthOutputStream extends FilterOutputStream
     }
 
     public void write (byte[]b, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return;
+        }
         if (closed) {
             throw new IOException ("stream closed");
         }

--- a/test/jdk/com/sun/net/httpserver/bugs/ExceptionKeepAlive.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/ExceptionKeepAlive.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8219083
+ * @summary Exceptions thrown from HttpHandler.handle should not close connection
+ *          if response is completed
+ * @library /test/lib
+ * @run junit ExceptionKeepAlive
+ */
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExceptionKeepAlive
+{
+
+    public static final Logger LOGGER = Logger.getLogger("com.sun.net.httpserver");
+
+    @Test
+    void test() throws IOException, InterruptedException {
+        HttpServer httpServer = startHttpServer();
+        int port = httpServer.getAddress().getPort();
+        try {
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .path("/firstCall")
+                .toURLUnchecked();
+            HttpURLConnection uc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
+            int responseCode = uc.getResponseCode();
+            assertEquals(200, responseCode, "First request should succeed");
+
+            URL url2 = URIBuilder.newBuilder()
+                    .scheme("http")
+                    .loopback()
+                    .port(port)
+                    .path("/secondCall")
+                    .toURLUnchecked();
+            HttpURLConnection uc2 = (HttpURLConnection)url2.openConnection(Proxy.NO_PROXY);
+            responseCode = uc2.getResponseCode();
+            assertEquals(200, responseCode, "Second request should reuse connection");
+        } finally {
+            httpServer.stop(0);
+        }
+    }
+
+    /**
+     * Http Server
+     */
+    HttpServer startHttpServer() throws IOException {
+        Handler outHandler = new StreamHandler(System.out,
+                                 new SimpleFormatter());
+        outHandler.setLevel(Level.FINEST);
+        LOGGER.setLevel(Level.FINEST);
+        LOGGER.addHandler(outHandler);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
+        httpServer.createContext("/", new MyHandler());
+        httpServer.start();
+        return httpServer;
+    }
+
+    class MyHandler implements HttpHandler {
+
+        volatile int port1;
+        @Override
+        public void handle(HttpExchange t) throws IOException {
+            String path = t.getRequestURI().getPath();
+            if (path.equals("/firstCall")) {
+                port1 = t.getRemoteAddress().getPort();
+                System.out.println("First connection on client port = " + port1);
+
+                // send response
+                t.sendResponseHeaders(200, -1);
+                // response is completed now; throw exception
+                throw new NumberFormatException();
+                // the connection should still be reusable
+            } else if (path.equals("/secondCall")) {
+                int port2 = t.getRemoteAddress().getPort();
+                System.out.println("Second connection on client port = " + port2);
+
+                if (port1 == port2) {
+                    t.sendResponseHeaders(200, -1);
+                } else {
+                    t.sendResponseHeaders(500, -1);
+                }
+            }
+            t.close();
+        }
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/bugs/ZeroLengthOutputStream.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/ZeroLengthOutputStream.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8219083
+ * @summary HttpExchange.getResponseBody write and close should not throw
+ *          even when response length is zero
+ * @library /test/lib
+ * @run junit ZeroLengthOutputStream
+ */
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ZeroLengthOutputStream
+{
+
+    public static final Logger LOGGER = Logger.getLogger("com.sun.net.httpserver");
+    public volatile boolean closed;
+    public CountDownLatch cdl = new CountDownLatch(1);
+
+    @Test
+    void test() throws IOException, InterruptedException {
+        HttpServer httpServer = startHttpServer();
+        int port = httpServer.getAddress().getPort();
+        try {
+            URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .path("/flis/")
+                .toURLUnchecked();
+            HttpURLConnection uc = (HttpURLConnection)url.openConnection(Proxy.NO_PROXY);
+            uc.getResponseCode();
+            cdl.await();
+            assertTrue(closed, "OutputStream close did not complete");
+        } finally {
+            httpServer.stop(0);
+        }
+    }
+
+    /**
+     * Http Server
+     */
+    HttpServer startHttpServer() throws IOException {
+        Handler outHandler = new StreamHandler(System.out,
+                                 new SimpleFormatter());
+        outHandler.setLevel(Level.FINEST);
+        LOGGER.setLevel(Level.FINEST);
+        LOGGER.addHandler(outHandler);
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(loopback, 0), 0);
+        httpServer.createContext("/flis/", new MyHandler());
+        httpServer.start();
+        return httpServer;
+    }
+
+    class MyHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange t) throws IOException {
+            try {
+                OutputStream os = t.getResponseBody();
+                t.sendResponseHeaders(200, -1);
+                os.write(new byte[0]);
+                os.close();
+                System.out.println("Output stream closed");
+                closed = true;
+            } finally {
+                cdl.countDown();
+            }
+        }
+    }
+}

--- a/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
+++ b/test/jdk/sun/net/www/http/KeepAliveCache/B5045306.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,7 +170,7 @@ class SimpleHttpTransactionHandler implements HttpHandler
         try {
             String path = trans.getRequestURI().getPath();
             if (path.equals("/firstCall")) {
-                port1 = trans.getLocalAddress().getPort();
+                port1 = trans.getRemoteAddress().getPort();
                 System.out.println("First connection on client port = " + port1);
 
                 byte[] responseBody = new byte[RESPONSE_DATA_LENGTH];
@@ -181,7 +181,7 @@ class SimpleHttpTransactionHandler implements HttpHandler
                     pw.print(responseBody);
                 }
             } else if (path.equals("/secondCall")) {
-                int port2 = trans.getLocalAddress().getPort();
+                int port2 = trans.getRemoteAddress().getPort();
                 System.out.println("Second connection on client port = " + port2);
 
                 if (port1 != port2)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-7026262](https://bugs.openjdk.org/browse/JDK-7026262), commit [a5ffa079](https://github.com/openjdk/jdk21u-dev/commit/a5ffa079a0d6107be652bc026f5c91b7dcd791f8) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by Daniel Jeliński on 27 Mar 2023 and was reviewed by Daniel Fuchs and Michael McMahon.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-7026262](https://bugs.openjdk.org/browse/JDK-7026262) needs maintainer approval

### Issue
 * [JDK-7026262](https://bugs.openjdk.org/browse/JDK-7026262): HttpServer: improve handling of finished HTTP exchanges (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2782/head:pull/2782` \
`$ git checkout pull/2782`

Update a local copy of the PR: \
`$ git checkout pull/2782` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2782`

View PR using the GUI difftool: \
`$ git pr show -t 2782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2782.diff">https://git.openjdk.org/jdk17u-dev/pull/2782.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2782#issuecomment-2266367259)