### PR TITLE
8336342: Fix known X11 library locations in sysroot

### DIFF
--- a/make/autoconf/lib-x11.m4
+++ b/make/autoconf/lib-x11.m4
@@ -71,9 +71,9 @@ AC_DEFUN_ONCE([LIB_SETUP_X11],
           elif test -f "$SYSROOT/usr/lib/libX11.so"; then
             x_libraries="$SYSROOT/usr/lib"
           elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libX11.so"; then
-            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libX11.so"
+            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI"
           elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libX11.so"; then
-            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libX11.so"
+            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI"
           fi
         fi
       fi


### PR DESCRIPTION
Allows cleaner cross-builds without supplying `--x-libraries` for custom-generated sysroots, e.g. crosstool-ng ones. I have been running with this patch for 3+ weeks in 17u-dev builds, and there were no problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336342](https://bugs.openjdk.org/browse/JDK-8336342) needs maintainer approval

### Issue
 * [JDK-8336342](https://bugs.openjdk.org/browse/JDK-8336342): Fix known X11 library locations in sysroot (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2785/head:pull/2785` \
`$ git checkout pull/2785`

Update a local copy of the PR: \
`$ git checkout pull/2785` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2785`

View PR using the GUI difftool: \
`$ git pr show -t 2785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2785.diff">https://git.openjdk.org/jdk17u-dev/pull/2785.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2785#issuecomment-2269635568)