### PR TITLE
8336343: Add more known sysroot library locations for ALSA

### DIFF
--- a/make/autoconf/lib-alsa.m4
+++ b/make/autoconf/lib-alsa.m4
@@ -71,6 +71,25 @@ AC_DEFUN_ONCE([LIB_SETUP_ALSA],
       fi
     fi
     if test "x$ALSA_FOUND" = xno; then
+      # If we have sysroot set, and no explicit library location is set,
+      # look at known locations in sysroot.
+      if test "x$SYSROOT" != "x" && test "x${with_alsa_lib}" == x; then
+        if test -f "$SYSROOT/usr/lib64/libasound.so" && test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
+          ALSA_LIBS="-L$SYSROOT/usr/lib64 -lasound"
+          ALSA_FOUND=yes
+        elif test -f "$SYSROOT/usr/lib/libasound.so"; then
+          ALSA_LIBS="-L$SYSROOT/usr/lib -lasound"
+          ALSA_FOUND=yes
+        elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libasound.so"; then
+          ALSA_LIBS="-L$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI -lasound"
+          ALSA_FOUND=yes
+        elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libasound.so"; then
+          ALSA_LIBS="-L$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI -lasound"
+          ALSA_FOUND=yes
+        fi
+      fi
+    fi
+    if test "x$ALSA_FOUND" = xno; then
       AC_CHECK_HEADERS([alsa/asoundlib.h],
           [
             ALSA_FOUND=yes


### PR DESCRIPTION
Allows cleaner cross-builds without supplying `--with-alsa` for custom-generated sysroots, e.g. crosstool-ng ones. I have been running with this patch for 3+ weeks in 17u-dev builds, and there were no problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336343](https://bugs.openjdk.org/browse/JDK-8336343) needs maintainer approval

### Issue
 * [JDK-8336343](https://bugs.openjdk.org/browse/JDK-8336343): Add more known sysroot library locations for ALSA (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2786/head:pull/2786` \
`$ git checkout pull/2786`

Update a local copy of the PR: \
`$ git checkout pull/2786` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2786`

View PR using the GUI difftool: \
`$ git pr show -t 2786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2786.diff">https://git.openjdk.org/jdk17u-dev/pull/2786.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2786#issuecomment-2269646756)