### PR TITLE
8304375: jdk/jfr/api/consumer/filestream/TestOrdered.java failed with "Expected at least some events to be out of order! Reuse = false"

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
+++ b/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
@@ -66,6 +66,11 @@ public class TestOrdered {
                 e.printStackTrace();
                 throw new Error("Unexpected exception in barrier");
             }
+            Instant timestamp = Instant.now();
+            // Wait for clock to increment
+            while (Instant.now().equals(timestamp)) {
+                ;
+            }
             OrderedEvent e2 = new OrderedEvent();
             e2.commit();
         }
@@ -108,6 +113,7 @@ public class TestOrdered {
                 es.setOrdered(false);
                 es.onEvent(e -> {
                     Instant endTime = e.getEndTime();
+                    System.out.println("testSetOrderedFalse: endTime: " + endTime);
                     if (endTime.isBefore(timestamp.get())) {
                         unoreded.set(true);
                         es.close();


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [48702345](https://github.com/openjdk/jdk/commit/4870234552d2c63c786641493794a87654b98b7b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Erik Gahlin on 25 May 2023 and was reviewed by Markus Grönlund.

This the one of the several prefixed backports of JDK-8323196.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8304375](https://bugs.openjdk.org/browse/JDK-8304375) needs maintainer approval

### Issue
 * [JDK-8304375](https://bugs.openjdk.org/browse/JDK-8304375): jdk/jfr/api/consumer/filestream/TestOrdered.java failed with "Expected at least some events to be out of order! Reuse = false" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2796/head:pull/2796` \
`$ git checkout pull/2796`

Update a local copy of the PR: \
`$ git checkout pull/2796` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2796`

View PR using the GUI difftool: \
`$ git pr show -t 2796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2796.diff">https://git.openjdk.org/jdk17u-dev/pull/2796.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2796#issuecomment-2285269019)