### PR TITLE
8325587: Shenandoah: ShenandoahLock should allow blocking in VM

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -894,7 +894,11 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
 }
 
 HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req, bool& in_new_region) {
-  ShenandoahHeapLocker locker(lock());
+  // If we are dealing with mutator allocation, then we may need to block for safepoint.
+  // We cannot block for safepoint for GC allocations, because there is a high chance
+  // we are already running at safepoint or from stack watermark machinery, and we cannot
+  // block again.
+  ShenandoahHeapLocker locker(lock(), req.is_mutator_alloc());
   return _free_set->allocate(req, in_new_region);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -37,7 +37,7 @@
 class ShenandoahNoBlockOp : public StackObj {
 public:
   ShenandoahNoBlockOp(JavaThread* java_thread) {
-    assert(java_thread == nullptr, "Should not pass anything");
+    assert(java_thread == NULL, "Should not pass anything");
   }
 };
 
@@ -46,7 +46,7 @@ void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
   if (allow_block_for_safepoint && thread->is_Java_thread()) {
     contended_lock_internal<ThreadBlockInVM>(static_cast<JavaThread*>(thread));
   } else {
-    contended_lock_internal<ShenandoahNoBlockOp>(nullptr);
+    contended_lock_internal<ShenandoahNoBlockOp>(NULL);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -28,8 +28,46 @@
 
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/os.inline.hpp"
 #include "runtime/thread.hpp"
+
+// These are inline variants of Thread::SpinAcquire with optional blocking in VM.
+
+class ShenandoahNoBlockOp : public StackObj {
+public:
+  ShenandoahNoBlockOp(JavaThread* java_thread) {
+    assert(java_thread == nullptr, "Should not pass anything");
+  }
+};
+
+void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
+  Thread* thread = Thread::current();
+  if (allow_block_for_safepoint && thread->is_Java_thread()) {
+    contended_lock_internal<ThreadBlockInVM>(static_cast<JavaThread*>(thread));
+  } else {
+    contended_lock_internal<ShenandoahNoBlockOp>(nullptr);
+  }
+}
+
+template<typename BlockOp>
+void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
+  int ctr = 0;
+  int yields = 0;
+  while (Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
+    if ((++ctr & 0xFFF) == 0) {
+      BlockOp block(java_thread);
+      if (yields > 5) {
+        os::naked_short_sleep(1);
+      } else {
+        os::naked_yield();
+        yields++;
+      }
+    } else {
+      SpinPause();
+    }
+  }
+}
 
 ShenandoahSimpleLock::ShenandoahSimpleLock() {
   assert(os::mutex_init_done(), "Too early!");

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -44,7 +44,7 @@ public:
 void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
   Thread* thread = Thread::current();
   if (allow_block_for_safepoint && thread->is_Java_thread()) {
-    contended_lock_internal<ThreadBlockInVM>(static_cast<JavaThread*>(thread));
+    contended_lock_internal<ThreadBlockInVM>(thread->as_Java_thread());
   } else {
     contended_lock_internal<ShenandoahNoBlockOp>(NULL);
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
@@ -35,33 +35,38 @@ private:
   enum LockState { unlocked = 0, locked = 1 };
 
   shenandoah_padding(0);
-  volatile int _state;
+  volatile LockState _state;
   shenandoah_padding(1);
   volatile Thread* _owner;
   shenandoah_padding(2);
 
+  template<typename BlockOp>
+  void contended_lock_internal(JavaThread* java_thread);
+
 public:
   ShenandoahLock() : _state(unlocked), _owner(NULL) {};
 
-  void lock() {
-#ifdef ASSERT
-    assert(_owner != Thread::current(), "reentrant locking attempt, would deadlock");
-#endif
-    Thread::SpinAcquire(&_state, "Shenandoah Heap Lock");
-#ifdef ASSERT
-    assert(_state == locked, "must be locked");
-    assert(_owner == NULL, "must not be owned");
-    _owner = Thread::current();
-#endif
+  void lock(bool allow_block_for_safepoint) {
+    assert(Atomic::load(&_owner) != Thread::current(), "reentrant locking attempt, would deadlock");
+
+    // Try to lock fast, or dive into contended lock handling.
+    if (Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
+      contended_lock(allow_block_for_safepoint);
+    }
+
+    assert(Atomic::load(&_state) == locked, "must be locked");
+    assert(Atomic::load(&_owner) == NULL, "must not be owned");
+    DEBUG_ONLY(Atomic::store(&_owner, Thread::current());)
   }
 
   void unlock() {
-#ifdef ASSERT
-    assert (_owner == Thread::current(), "sanity");
-    _owner = NULL;
-#endif
-    Thread::SpinRelease(&_state);
+    assert(Atomic::load(&_owner) == Thread::current(), "sanity");
+    DEBUG_ONLY(Atomic::store(&_owner, (Thread*)NULL);)
+    OrderAccess::fence();
+    Atomic::store(&_state, unlocked);
   }
+
+  void contended_lock(bool allow_block_for_safepoint);
 
   bool owned_by_self() {
 #ifdef ASSERT
@@ -77,9 +82,9 @@ class ShenandoahLocker : public StackObj {
 private:
   ShenandoahLock* const _lock;
 public:
-  ShenandoahLocker(ShenandoahLock* lock) : _lock(lock) {
+  ShenandoahLocker(ShenandoahLock* lock, bool allow_block_for_safepoint = false) : _lock(lock) {
     if (_lock != NULL) {
-      _lock->lock();
+      _lock->lock(allow_block_for_safepoint);
     }
   }
 


### PR DESCRIPTION
Hi, 
    This PR is a Backport of [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587): Shenandoah: ShenandoahLock should allow blocking in VM, the original commit was authored by Aleksey Shipilev on 21 Feb 2024 and was reviewed by Robbin Ehn and Roman Kennke, and already backported to jdk21.
     It is not a clean backport for JDK17 due to code style change(NULL -> nullptr) and thread header file and API changes.   
    This is the first backport of a series of improvements for ShenandoahLock to improve contention issue which we I have seem in our customer's production load running with JDK17, here are the series of improvements I'm going to backport to JDK17:

| Bug         | Title                                          |
| ----------- | ---------------------------------------------- |
| [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587) | ShenandoahLock should allow blocking in VM     |
| [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405) | Optimize ShenandoahLock with TTAS              |
| [JDK-8331411](https://bugs.openjdk.org/browse/JDK-8331411) | Reconsider spinning duration in ShenandoahLock |
| [JDK-8335904](https://bugs.openjdk.org/browse/JDK-8335904) | Fix invalid comment in ShenandoahLock          |


Best,
Xiaolong. 


Additional tests:
- [x] hotspot_gc_shenandoah
- [x] Linux x86_64 server fastdebug, all passes with -XX:+UseShenandoahGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587) needs maintainer approval

### Issue
 * [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587): Shenandoah: ShenandoahLock should allow blocking in VM (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) Review applies to [9696c8a2](https://git.openjdk.org/jdk17u-dev/pull/2797/files/9696c8a20e25da6c0a252088a35fb52a4cb1595f)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2797/head:pull/2797` \
`$ git checkout pull/2797`

Update a local copy of the PR: \
`$ git checkout pull/2797` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2797`

View PR using the GUI difftool: \
`$ git pr show -t 2797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2797.diff">https://git.openjdk.org/jdk17u-dev/pull/2797.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2797#issuecomment-2286750674)