### PR TITLE
8307648: java/net/httpclient/ExpectContinueTest.java timed out

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,6 +135,7 @@ class Stream<T> extends ExchangeImpl<T> {
     private volatile boolean remotelyClosed;
     private volatile boolean closed;
     private volatile boolean endStreamSent;
+    private volatile boolean finalResponseCodeReceived;
     // Indicates the first reason that was invoked when sending a ResetFrame
     // to the server. A streamState of 0 indicates that no reset was sent.
     // (see markStream(int code)
@@ -464,30 +465,44 @@ class Stream<T> extends ExchangeImpl<T> {
 
     protected void handleResponse() throws IOException {
         HttpHeaders responseHeaders = responseHeadersBuilder.build();
-        responseCode = (int)responseHeaders
-                .firstValueAsLong(":status")
-                .orElseThrow(() -> new IOException("no statuscode in response"));
 
-        response = new Response(
-                request, exchange, responseHeaders, connection(),
-                responseCode, HttpClient.Version.HTTP_2);
+        if (!finalResponseCodeReceived) {
+            responseCode = (int) responseHeaders
+                    .firstValueAsLong(":status")
+                    .orElseThrow(() -> new IOException("no statuscode in response"));
+            // If informational code, response is partially complete
+            if (responseCode < 100 || responseCode > 199)
+                this.finalResponseCodeReceived = true;
+
+            response = new Response(
+                    request, exchange, responseHeaders, connection(),
+                    responseCode, HttpClient.Version.HTTP_2);
 
         /* TODO: review if needs to be removed
            the value is not used, but in case `content-length` doesn't parse as
            long, there will be NumberFormatException. If left as is, make sure
            code up the stack handles NFE correctly. */
-        responseHeaders.firstValueAsLong("content-length");
+            responseHeaders.firstValueAsLong("content-length");
 
-        if (Log.headers()) {
-            StringBuilder sb = new StringBuilder("RESPONSE HEADERS:\n");
-            Log.dumpHeaders(sb, "    ", responseHeaders);
-            Log.logHeaders(sb.toString());
+            if (Log.headers()) {
+                StringBuilder sb = new StringBuilder("RESPONSE HEADERS:\n");
+                Log.dumpHeaders(sb, "    ", responseHeaders);
+                Log.logHeaders(sb.toString());
+            }
+
+            // this will clear the response headers
+            rspHeadersConsumer.reset();
+
+            completeResponse(response);
+        } else {
+            if (Log.headers()) {
+                StringBuilder sb = new StringBuilder("TRAILING HEADERS:\n");
+                Log.dumpHeaders(sb, "    ", responseHeaders);
+                Log.logHeaders(sb.toString());
+            }
+            rspHeadersConsumer.reset();
         }
 
-        // this will clear the response headers
-        rspHeadersConsumer.reset();
-
-        completeResponse(response);
     }
 
     void incoming_reset(ResetFrame frame) {
@@ -1303,6 +1318,7 @@ class Stream<T> extends ExchangeImpl<T> {
         CompletableFuture<HttpResponse<T>> responseCF;
         final HttpRequestImpl pushReq;
         HttpResponse.BodyHandler<T> pushHandler;
+        private volatile boolean finalPushResponseCodeReceived;
 
         PushedStream(PushGroup<T> pushGroup,
                      Http2Connection connection,
@@ -1399,35 +1415,48 @@ class Stream<T> extends ExchangeImpl<T> {
         @Override
         protected void handleResponse() {
             HttpHeaders responseHeaders = responseHeadersBuilder.build();
-            responseCode = (int)responseHeaders
-                .firstValueAsLong(":status")
-                .orElse(-1);
 
-            if (responseCode == -1) {
-                completeResponseExceptionally(new IOException("No status code"));
+            if (!finalPushResponseCodeReceived) {
+                responseCode = (int)responseHeaders
+                    .firstValueAsLong(":status")
+                    .orElse(-1);
+
+                if (responseCode == -1) {
+                    completeResponseExceptionally(new IOException("No status code"));
+                }
+
+                this.finalPushResponseCodeReceived = true;
+
+                this.response = new Response(
+                        pushReq, exchange, responseHeaders, connection(),
+                        responseCode, HttpClient.Version.HTTP_2);
+
+                /* TODO: review if needs to be removed
+                   the value is not used, but in case `content-length` doesn't parse
+                   as long, there will be NumberFormatException. If left as is, make
+                   sure code up the stack handles NFE correctly. */
+                responseHeaders.firstValueAsLong("content-length");
+
+                if (Log.headers()) {
+                    StringBuilder sb = new StringBuilder("RESPONSE HEADERS");
+                    sb.append(" (streamid=").append(streamid).append("):\n");
+                    Log.dumpHeaders(sb, "    ", responseHeaders);
+                    Log.logHeaders(sb.toString());
+                }
+
+                rspHeadersConsumer.reset();
+
+                // different implementations for normal streams and pushed streams
+                completeResponse(response);
+            } else {
+                if (Log.headers()) {
+                    StringBuilder sb = new StringBuilder("TRAILING HEADERS");
+                    sb.append(" (streamid=").append(streamid).append("):\n");
+                    Log.dumpHeaders(sb, "    ", responseHeaders);
+                    Log.logHeaders(sb.toString());
+                }
+                rspHeadersConsumer.reset();
             }
-
-            this.response = new Response(
-                pushReq, exchange, responseHeaders, connection(),
-                responseCode, HttpClient.Version.HTTP_2);
-
-            /* TODO: review if needs to be removed
-               the value is not used, but in case `content-length` doesn't parse
-               as long, there will be NumberFormatException. If left as is, make
-               sure code up the stack handles NFE correctly. */
-            responseHeaders.firstValueAsLong("content-length");
-
-            if (Log.headers()) {
-                StringBuilder sb = new StringBuilder("RESPONSE HEADERS");
-                sb.append(" (streamid=").append(streamid).append("):\n");
-                Log.dumpHeaders(sb, "    ", responseHeaders);
-                Log.logHeaders(sb.toString());
-            }
-
-            rspHeadersConsumer.reset();
-
-            // different implementations for normal streams and pushed streams
-            completeResponse(response);
         }
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -433,7 +433,7 @@ class Stream<T> extends ExchangeImpl<T> {
             HeaderFrame hframe = (HeaderFrame) frame;
             if (hframe.endHeaders()) {
                 Log.logTrace("handling response (streamid={0})", streamid);
-                handleResponse();
+                handleResponse(hframe);
             }
             if (hframe.getFlag(HeaderFrame.END_STREAM)) {
                 if (debug.on()) debug.log("handling END_STREAM: %d", streamid);
@@ -463,7 +463,7 @@ class Stream<T> extends ExchangeImpl<T> {
         return rspHeadersConsumer;
     }
 
-    protected void handleResponse() throws IOException {
+    protected void handleResponse(HeaderFrame hf) throws IOException {
         HttpHeaders responseHeaders = responseHeadersBuilder.build();
 
         if (!finalResponseCodeReceived) {
@@ -471,8 +471,20 @@ class Stream<T> extends ExchangeImpl<T> {
                     .firstValueAsLong(":status")
                     .orElseThrow(() -> new IOException("no statuscode in response"));
             // If informational code, response is partially complete
-            if (responseCode < 100 || responseCode > 199)
+            if (responseCode < 100 || responseCode > 199) {
                 this.finalResponseCodeReceived = true;
+            } else if (hf.getFlag(HeaderFrame.END_STREAM)) {
+                // see RFC 9113 section 8.1:
+                // A HEADERS frame with the END_STREAM flag set that carries an
+                // informational status code is malformed
+                String msg = ("Stream %s PROTOCOL_ERROR: " +
+                        "HEADERS frame with status %s has END_STREAM flag set")
+                        .formatted(streamid, responseCode);
+                if (debug.on()) {
+                    debug.log(msg);
+                }
+                cancelImpl(new IOException(msg), ResetFrame.PROTOCOL_ERROR);
+            }
 
             response = new Response(
                     request, exchange, responseHeaders, connection(),
@@ -514,7 +526,7 @@ class Stream<T> extends ExchangeImpl<T> {
         } else {
             Flow.Subscriber<?> subscriber =
                     responseSubscriber == null ? pendingResponseSubscriber : responseSubscriber;
-            if (response == null && subscriber == null) {
+            if ((response == null || !finalResponseCodeReceived) && subscriber == null) {
                 // we haven't receive the headers yet, and won't receive any!
                 // handle reset now.
                 handleReset(frame, subscriber);
@@ -884,6 +896,10 @@ class Stream<T> extends ExchangeImpl<T> {
         private void onNextImpl(ByteBuffer item) {
             // Got some more request body bytes to send.
             if (requestBodyCF.isDone()) {
+                if (debug.on()) {
+                    debug.log("RequestSubscriber: requestBodyCf is done: " +
+                            "cancelling subscription");
+                }
                 // stream already cancelled, probably in timeout
                 sendScheduler.stop();
                 subscription.cancel();
@@ -1413,7 +1429,7 @@ class Stream<T> extends ExchangeImpl<T> {
 
         // create and return the PushResponseImpl
         @Override
-        protected void handleResponse() {
+        protected void handleResponse(HeaderFrame hf) {
             HttpHeaders responseHeaders = responseHeadersBuilder.build();
 
             if (!finalPushResponseCodeReceived) {

--- a/test/jdk/java/net/httpclient/http2/TrailingHeadersTest.java
+++ b/test/jdk/java/net/httpclient/http2/TrailingHeadersTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ @test
+ * @summary Trailing headers should be ignored by the client when using HTTP/2
+ *          and not affect the rest of the exchange.
+ * @bug 8296410
+ * @library /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.http2.Http2TestServer
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=all TrailingHeadersTest
+ */
+
+import jdk.httpclient.test.lib.http2.OutgoingPushPromise;
+import jdk.internal.net.http.common.HttpHeadersBuilder;
+import jdk.internal.net.http.frame.DataFrame;
+import jdk.internal.net.http.frame.HeaderFrame;
+import jdk.internal.net.http.frame.HeadersFrame;
+import org.testng.TestException;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.net.ssl.SSLSession;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.function.BiPredicate;
+
+import jdk.httpclient.test.lib.http2.Http2TestServer;
+import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
+import jdk.httpclient.test.lib.http2.Http2TestExchangeImpl;
+import jdk.httpclient.test.lib.http2.Http2TestExchange;
+import jdk.httpclient.test.lib.http2.Http2Handler;
+import jdk.httpclient.test.lib.http2.BodyOutputStream;
+
+import static java.net.http.HttpClient.Version.HTTP_2;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+
+public class TrailingHeadersTest {
+
+    Http2TestServer http2TestServer;
+    URI trailingURI, trailng1xxURI, trailingPushPromiseURI, warmupURI;
+    static PrintStream testLog = System.err;
+
+    // Set up simple client-side push promise handler
+    ConcurrentMap<HttpRequest, CompletableFuture<HttpResponse<String>>> pushPromiseMap = new ConcurrentHashMap<>();
+
+    @BeforeMethod
+    public void beforeMethod() {
+        pushPromiseMap = new ConcurrentHashMap<>();
+    }
+
+    @BeforeTest
+    public void setup() throws Exception {
+        Properties props = new Properties();
+        // For triggering trailing headers to send after Push Promise Response headers are sent
+        props.setProperty("sendTrailingHeadersAfterPushPromise", "1");
+
+        http2TestServer = new Http2TestServer("Test_Server",
+                                              false,
+                                              0,
+                                              null,
+                                              0,
+                                              props,
+                                       null);
+        http2TestServer.setExchangeSupplier(TrailingHeadersExchange::new);
+        http2TestServer.addHandler(new ResponseTrailersHandler(), "/ResponseTrailingHeaders");
+        http2TestServer.addHandler(new InformationalTrailersHandler(), "/InfoRespTrailingHeaders");
+        http2TestServer.addHandler(new PushPromiseTrailersHandler(), "/PushPromiseTrailingHeaders");
+        http2TestServer.addHandler(new WarmupHandler(), "/WarmupHandler");
+
+        http2TestServer.start();
+
+        trailingURI = URI.create("http://" + http2TestServer.serverAuthority() + "/ResponseTrailingHeaders");
+        trailng1xxURI = URI.create("http://" + http2TestServer.serverAuthority() + "/InfoRespTrailingHeaders");
+        trailingPushPromiseURI = URI.create("http://" + http2TestServer.serverAuthority() + "/PushPromiseTrailingHeaders");
+
+        // Used to ensure HTTP/2 upgrade takes place
+        warmupURI = URI.create("http://" + http2TestServer.serverAuthority() + "/WarmupHandler");
+    }
+
+    @AfterTest
+    public void teardown() {
+        http2TestServer.stop();
+    }
+
+    @Test(dataProvider = "httpRequests")
+    public void testTrailingHeaders(String description, HttpRequest hRequest, HttpResponse.PushPromiseHandler<String> pph) {
+        testLog.println("testTrailingHeaders(): " + description);
+        HttpClient httpClient = HttpClient.newBuilder().build();
+        performWarmupRequest(httpClient);
+        CompletableFuture<HttpResponse<String>> cf = httpClient.sendAsync(hRequest, BodyHandlers.ofString(UTF_8), pph);
+
+        testLog.println("testTrailingHeaders(): Performing request: " + hRequest);
+        HttpResponse<String> resp = cf.join();
+
+        assertEquals(resp.statusCode(), 200, "Status code of response should be 200");
+
+        // Verify Push Promise was successful if necessary
+        if (pph != null)
+            verifyPushPromise();
+
+        testLog.println("testTrailingHeaders(): Request successfully completed");
+    }
+
+    private void verifyPushPromise()  {
+        assertEquals(pushPromiseMap.size(), 1, "Push Promise should not be greater than 1");
+        // This will only iterate once
+        for (HttpRequest r : pushPromiseMap.keySet()) {
+            CompletableFuture<HttpResponse<String>> serverPushResp = pushPromiseMap.get(r);
+            // Get the push promise HttpResponse result if present
+            HttpResponse<String> resp = serverPushResp.join();
+            assertEquals(resp.body(), "Sample_Push_Data", "Unexpected Push Promise response body");
+            assertEquals(resp.statusCode(), 200, "Status code of Push Promise response should be 200");
+        }
+    }
+
+    private void performWarmupRequest(HttpClient httpClient) {
+        HttpRequest warmupReq = HttpRequest.newBuilder(warmupURI).version(HTTP_2)
+                .GET()
+                .build();
+        httpClient.sendAsync(warmupReq, BodyHandlers.discarding()).join();
+    }
+
+    @DataProvider(name = "httpRequests")
+    public Object[][] uris() {
+        HttpResponse.PushPromiseHandler<String> pph = (initial, pushRequest, acceptor) -> {
+            HttpResponse.BodyHandler<String> s = HttpResponse.BodyHandlers.ofString(UTF_8);
+            pushPromiseMap.put(pushRequest, acceptor.apply(s));
+        };
+
+        HttpRequest httpGetTrailing = HttpRequest.newBuilder(trailingURI).version(HTTP_2)
+                .GET()
+                .build();
+
+        HttpRequest httpPost1xxTrailing = HttpRequest.newBuilder(trailng1xxURI).version(HTTP_2)
+                .POST(HttpRequest.BodyPublishers.ofString("Test Post"))
+                .expectContinue(true)
+                .build();
+
+        HttpRequest httpGetPushPromiseTrailing = HttpRequest.newBuilder(trailingPushPromiseURI).version(HTTP_2)
+                .GET()
+                .build();
+
+        return new Object[][] {
+                { "Test GET with Trailing Headers", httpGetTrailing, null },
+                { "Test POST with 1xx response & Trailing Headers", httpPost1xxTrailing, null },
+                { "Test Push Promise with Trailing Headers", httpGetPushPromiseTrailing, pph }
+        };
+    }
+
+    static class TrailingHeadersExchange extends Http2TestExchangeImpl {
+
+        byte[] resp = "Sample_Data".getBytes(StandardCharsets.UTF_8);
+
+
+        TrailingHeadersExchange(int streamid, String method, HttpHeaders reqheaders, HttpHeadersBuilder rspheadersBuilder,
+                                 URI uri, InputStream is, SSLSession sslSession, BodyOutputStream os,
+                                 Http2TestServerConnection conn, boolean pushAllowed) {
+            super(streamid, method, reqheaders, rspheadersBuilder, uri, is, sslSession, os, conn, pushAllowed);
+        }
+
+        public void sendResponseThenTrailers() throws IOException {
+            /*
+            HttpHeadersBuilder hb = this.conn.createNewHeadersBuilder();
+            hb.setHeader("x-sample", "val");
+            HeaderFrame headerFrame = new HeadersFrame(this.streamid, 0, this.conn.encodeHeaders(hb.build()));
+            */
+            // TODO: see if there is a safe way to encode headers without interrupting connection thread
+            HeaderFrame headerFrame = new HeadersFrame(this.streamid, 0, List.of());
+            headerFrame.setFlag(HeaderFrame.END_HEADERS);
+            headerFrame.setFlag(HeaderFrame.END_STREAM);
+
+            this.sendResponseHeaders(200, resp.length);
+            DataFrame dataFrame = new DataFrame(this.streamid, 0, ByteBuffer.wrap(resp));
+            this.conn.addToOutputQ(dataFrame);
+            this.conn.addToOutputQ(headerFrame);
+        }
+
+        @Override
+        public void serverPush(URI uri, HttpHeaders headers, InputStream content) {
+            HttpHeadersBuilder headersBuilder = new HttpHeadersBuilder();
+            headersBuilder.setHeader(":method", "GET");
+            headersBuilder.setHeader(":scheme", uri.getScheme());
+            headersBuilder.setHeader(":authority", uri.getAuthority());
+            headersBuilder.setHeader(":path", uri.getPath());
+            for (Map.Entry<String,List<String>> entry : headers.map().entrySet()) {
+                for (String value : entry.getValue())
+                    headersBuilder.addHeader(entry.getKey(), value);
+            }
+            HttpHeaders combinedHeaders = headersBuilder.build();
+            OutgoingPushPromise pp = new OutgoingPushPromise(streamid, uri, combinedHeaders, content);
+            pp.setFlag(HeaderFrame.END_HEADERS);
+
+            try {
+                this.conn.addToOutputQ(pp);
+            } catch (IOException ex) {
+                testLog.println("serverPush(): pushPromise exception: " + ex);
+            }
+        }
+    }
+
+    static class WarmupHandler implements Http2Handler {
+
+        @Override
+        public void handle(Http2TestExchange exchange) throws IOException {
+            exchange.sendResponseHeaders(200, 0);
+        }
+    }
+
+    static class ResponseTrailersHandler implements Http2Handler {
+
+        @Override
+        public void handle(Http2TestExchange exchange) throws IOException {
+            if (exchange.getProtocol().equals("HTTP/2")) {
+                if (exchange instanceof TrailingHeadersExchange trailingHeadersExchange) {
+                    trailingHeadersExchange.sendResponseThenTrailers();
+                }
+            } else {
+                testLog.println("ResponseTrailersHandler: Incorrect protocol version");
+                exchange.sendResponseHeaders(400, 0);
+            }
+        }
+    }
+
+    static class InformationalTrailersHandler implements Http2Handler {
+
+        @Override
+        public void handle(Http2TestExchange exchange) throws IOException {
+            if (exchange.getProtocol().equals("HTTP/2")) {
+                if (exchange instanceof TrailingHeadersExchange trailingHeadersExchange) {
+                    testLog.println(this.getClass().getCanonicalName() + ": Sending status 100");
+                    trailingHeadersExchange.sendResponseHeaders(100, 0);
+
+                    try (InputStream is = exchange.getRequestBody()) {
+                        is.readAllBytes();
+                        trailingHeadersExchange.sendResponseThenTrailers();
+                    }
+                }
+            } else {
+                testLog.println("InformationalTrailersHandler: Incorrect protocol version");
+                exchange.sendResponseHeaders(400, 0);
+            }
+        }
+    }
+
+    static class PushPromiseTrailersHandler implements Http2Handler {
+
+        @Override
+        public void handle(Http2TestExchange exchange) throws IOException {
+            if (exchange.getProtocol().equals("HTTP/2")) {
+                if (exchange instanceof TrailingHeadersExchange trailingHeadersExchange) {
+                    try (InputStream is = exchange.getRequestBody()) {
+                        is.readAllBytes();
+                    }
+
+                    if (exchange.serverPushAllowed()) {
+                        pushPromise(trailingHeadersExchange);
+                    }
+
+                    try (OutputStream os = trailingHeadersExchange.getResponseBody()) {
+                        byte[] bytes = "Sample_Data".getBytes(UTF_8);
+                        trailingHeadersExchange.sendResponseHeaders(200, bytes.length);
+                        os.write(bytes);
+                    }
+                }
+            }
+        }
+
+        static final BiPredicate<String,String> ACCEPT_ALL = (x, y) -> true;
+
+        private void pushPromise(Http2TestExchange exchange) {
+            URI requestURI = exchange.getRequestURI();
+            URI uri = requestURI.resolve("/promise");
+            InputStream is = new ByteArrayInputStream("Sample_Push_Data".getBytes(UTF_8));
+            Map<String, List<String>> map = new HashMap<>();
+            map.put("x-promise", List.of("promise-header"));
+            HttpHeaders headers = HttpHeaders.of(map, ACCEPT_ALL);
+            exchange.serverPush(uri, headers, is);
+            testLog.println("PushPromiseTrailersHandler: Push Promise complete");
+        }
+    }
+}

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/BodyOutputStream.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/BodyOutputStream.java
@@ -130,10 +130,14 @@ public class BodyOutputStream extends OutputStream {
             closed = true;
         }
         try {
-            send(EMPTY_BARRAY, 0, 0, DataFrame.END_STREAM);
+            sendEndStream();
         } catch (IOException ex) {
             System.err.println("TestServer: OutputStream.close exception: " + ex);
             ex.printStackTrace();
         }
+    }
+
+    protected void sendEndStream() throws IOException {
+        send(EMPTY_BARRAY, 0, 0, DataFrame.END_STREAM);
     }
 }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
@@ -131,6 +131,9 @@ public class Http2TestExchangeImpl implements Http2TestExchange {
 
     @Override
     public void sendResponseHeaders(int rCode, long responseLength) throws IOException {
+        // Do not set Content-Length for 100, and do not set END_STREAM
+        if (rCode == 100) responseLength = 0;
+
         this.responseLength = responseLength;
         if (responseLength !=0 && rCode != 204 && !isHeadRequest()) {
                 long clen = responseLength > 0 ? responseLength : 0;

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -192,7 +192,7 @@ public class Http2TestServer implements AutoCloseable {
         this.secure = secure;
         this.exec = exec == null ? getDefaultExecutor() : exec;
         this.handlers = Collections.synchronizedMap(new HashMap<>());
-        this.properties = properties;
+        this.properties = properties == null ? new Properties() : properties;
         this.connections = new HashMap<>();
     }
 

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -924,13 +924,25 @@ public class Http2TestServerConnection {
         final BodyOutputStream oo = new BodyOutputStream(
                 promisedStreamid,
                 clientSettings.getParameter(
-                        SettingsFrame.INITIAL_WINDOW_SIZE), this);
+                        SettingsFrame.INITIAL_WINDOW_SIZE), this) {
+
+            @Override
+            protected void sendEndStream() throws IOException {
+                if (properties.getProperty("sendTrailingHeadersAfterPushPromise", "0").equals("1")) {
+                    conn.outputQ.put(getTrailingHeadersFrame(promisedStreamid, List.of()));
+                } else {
+                    super.sendEndStream();
+                }
+            }
+        };
+
         outStreams.put(promisedStreamid, oo);
         oo.goodToGo();
         exec.submit(() -> {
             try {
                 ResponseHeaders oh = getPushResponse(promisedStreamid);
                 outputQ.put(oh);
+
                 ii.transferTo(oo);
             } catch (Throwable ex) {
                 System.err.printf("TestServer: pushing response error: %s\n",
@@ -941,6 +953,11 @@ public class Http2TestServerConnection {
             }
         });
 
+    }
+
+    private HeadersFrame getTrailingHeadersFrame(int promisedStreamid, List<ByteBuffer> headerBlocks) {
+        // TODO: see if there is a safe way to encode headers without interrupting connection thread
+        return new HeadersFrame(promisedStreamid, (HeaderFrame.END_HEADERS | HeaderFrame.END_STREAM), headerBlocks);
     }
 
     // returns a minimal response with status 200


### PR DESCRIPTION
The backport is not clean.

JDK17 does not have JDK-8293786. As a result, the debug log is not merged into Stream::incoming_reset method. These changes could be skipped because they are not required for this functionality

Also, ExpectContinueTest test was added in JDK21 as part of JDK-8286171. Not backported to JDK17. The changes for this test are skipped

All java/net/httpclient JTREG tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8307648](https://bugs.openjdk.org/browse/JDK-8307648) needs maintainer approval

### Issue
 * [JDK-8307648](https://bugs.openjdk.org/browse/JDK-8307648): java/net/httpclient/ExpectContinueTest.java timed out (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2799/head:pull/2799` \
`$ git checkout pull/2799`

Update a local copy of the PR: \
`$ git checkout pull/2799` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2799`

View PR using the GUI difftool: \
`$ git pr show -t 2799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2799.diff">https://git.openjdk.org/jdk17u-dev/pull/2799.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2799#issuecomment-2287259293)