### PR TITLE
8315936: Parallelize gc/stress/TestStressG1Humongous.java test

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
@@ -24,14 +24,41 @@
 package gc.stress;
 
 /*
- * @test TestStressG1Humongous
+ * @test
  * @key stress
  * @summary Stress G1 by humongous allocations in situation near OOM
  * @requires vm.gc.G1
  * @requires !vm.flightRecorder
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run driver/timeout=1300 gc.stress.TestStressG1Humongous
+ * @run driver/timeout=180 gc.stress.TestStressG1Humongous 4 3 1.1 120
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires !vm.flightRecorder
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=180 gc.stress.TestStressG1Humongous 16 5 2.1 120
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires !vm.flightRecorder
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=180 gc.stress.TestStressG1Humongous 32 4 0.6 120
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires !vm.flightRecorder
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=900 gc.stress.TestStressG1Humongous 1 7 0.6 600
  */
 
 import java.util.ArrayList;
@@ -48,17 +75,19 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestStressG1Humongous{
 
     public static void main(String[] args) throws Exception {
+        if (args.length != 4) {
+            throw new IllegalArgumentException("Test expects 4 arguments");
+        }
+
         // Limit heap size on 32-bit platforms
         int heapSize = Platform.is32bit() ? 512 : 1024;
-        // Heap size, region size, threads, humongous size, timeout
-        run(heapSize, 4, 3, 1.1, 120);
-        run(heapSize, 16, 5, 2.1, 120);
-        run(heapSize, 32, 4, 0.6, 120);
-        run(heapSize, 1, 7, 0.6, 600);
-    }
 
-    private static void run(int heapSize, int regionSize, int threads, double humongousSize, int timeout)
-            throws Exception {
+        // Region size, threads, humongous size, and timeout passed as @run arguments
+        int regionSize = Integer.parseInt(args[0]);
+        int threads = Integer.parseInt(args[1]);
+        double humongousSize = Double.parseDouble(args[2]);
+        int timeout = Integer.parseInt(args[3]);
+
         ArrayList<String> options = new ArrayList<>();
         Collections.addAll(options, Utils.getTestJavaOpts());
         Collections.addAll(options,


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315936](https://bugs.openjdk.org/browse/JDK-8315936) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315936](https://bugs.openjdk.org/browse/JDK-8315936): Parallelize gc/stress/TestStressG1Humongous.java test (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2801/head:pull/2801` \
`$ git checkout pull/2801`

Update a local copy of the PR: \
`$ git checkout pull/2801` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2801`

View PR using the GUI difftool: \
`$ git pr show -t 2801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2801.diff">https://git.openjdk.org/jdk17u-dev/pull/2801.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2801#issuecomment-2288414060)