### PR TITLE
8332903: ubsan: opto/output.cpp:1002:18: runtime error: load of value 171, which is not a valid value for type 'bool'

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3510,6 +3510,7 @@ encode %{
     call->_in_rms            = _in_rms;
     call->_nesting           = _nesting;
     call->_override_symbolic_info = _override_symbolic_info;
+    call->_arg_escape        = _arg_escape;
 
     // New call needs all inputs of old call.
     // Req...


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332903](https://bugs.openjdk.org/browse/JDK-8332903) needs maintainer approval

### Issue
 * [JDK-8332903](https://bugs.openjdk.org/browse/JDK-8332903): ubsan: opto/output.cpp:1002:18: runtime error: load of value 171, which is not a valid value for type 'bool' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2805/head:pull/2805` \
`$ git checkout pull/2805`

Update a local copy of the PR: \
`$ git checkout pull/2805` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2805`

View PR using the GUI difftool: \
`$ git pr show -t 2805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2805.diff">https://git.openjdk.org/jdk17u-dev/pull/2805.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2805#issuecomment-2288551537)