### PR TITLE
8315576: compiler/codecache/CodeCacheFullCountTest.java fails after JDK-8314837

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -44,12 +44,20 @@ public class CodeCacheFullCountTest {
         }
     }
 
-    public static void wasteCodeCache()  throws Exception {
+    public static void wasteCodeCache() throws Throwable {
         URL url = CodeCacheFullCountTest.class.getProtectionDomain().getCodeSource().getLocation();
 
-        for (int i = 0; i < 500; i++) {
-            ClassLoader cl = new MyClassLoader(url);
-            refClass(cl.loadClass("SomeClass"));
+        try {
+            for (int i = 0; i < 500; i++) {
+                ClassLoader cl = new MyClassLoader(url);
+                refClass(cl.loadClass("SomeClass"));
+            }
+        } catch (Throwable t) {
+            // Expose the root cause of the Throwable instance.
+            while (t.getCause() != null) {
+                t = t.getCause();
+            }
+            throw t;
         }
     }
 
@@ -58,7 +66,7 @@ public class CodeCacheFullCountTest {
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         // Ignore adapter creation failures
-        if (oa.getExitValue() != 0 && !oa.getStderr().contains("Out of space in CodeCache for adapters")) {
+        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache for adapters")) {
             oa.reportDiagnosticSummary();
             throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
         }


### PR DESCRIPTION
Backport of [JDK-8315576](https://bugs.openjdk.org/browse/JDK-8315576)
- Changes on `CodeCacheFullCountTest.java` is `clean`
- Changes on `test/hotspot/jtreg/ProblemList-Xcomp.txt` has been ignored, because the line does not exist in `jdk17u-dev`
  - `test/hotspot/jtreg/ProblemList-Xcomp.txt.rej` contents

```diff
@@ -27,8 +27,6 @@
 #
 #############################################################################
 
-compiler/codecache/CodeCacheFullCountTest.java 8315576 generic-all
-
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64
```

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - `CodeCacheFullCountTest.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies SUCCESSFUL on `2024-08-17`
  - Automated jtreg test: `jtreg_hotspot_tier1`, Started at `2024-08-16 20:49:01+01:00`
  - compiler/codecache/CodeCacheFullCountTest.java: SUCCESSFUL GitHub 📊 - [20:49:52.546 -> 9,652 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315576](https://bugs.openjdk.org/browse/JDK-8315576) needs maintainer approval

### Issue
 * [JDK-8315576](https://bugs.openjdk.org/browse/JDK-8315576): compiler/codecache/CodeCacheFullCountTest.java fails after JDK-8314837 (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2808/head:pull/2808` \
`$ git checkout pull/2808`

Update a local copy of the PR: \
`$ git checkout pull/2808` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2808`

View PR using the GUI difftool: \
`$ git pr show -t 2808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2808.diff">https://git.openjdk.org/jdk17u-dev/pull/2808.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2808#issuecomment-2292347330)