### PR TITLE
8308891: TestCDSVMCrash.java needs @requires vm.cds

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -24,6 +24,7 @@
 /*
  * @test TestCDSVMCrash
  * @summary Verify that an exception is thrown when the VM crashes during executeAndLog
+ * @requires vm.cds
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestCDSVMCrash


### PR DESCRIPTION
Backport of [JDK-8308891](https://bugs.openjdk.org/browse/JDK-8308891)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - `TestCDSVMCrash.java`: Test results: passed: 1
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies Passed on `2024-08-17`
  - Automated jtreg test: `jtreg_hotspot_tier1`, Started at `2024-08-16 20:49:01+01:00`
  - runtime/cds/TestCDSVMCrash.java: SUCCESSFUL GitHub 📊 - [20:52:31.382 -> 2,093 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8308891](https://bugs.openjdk.org/browse/JDK-8308891) needs maintainer approval

### Issue
 * [JDK-8308891](https://bugs.openjdk.org/browse/JDK-8308891): TestCDSVMCrash.java needs @<!---->requires vm.cds (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2809/head:pull/2809` \
`$ git checkout pull/2809`

Update a local copy of the PR: \
`$ git checkout pull/2809` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2809`

View PR using the GUI difftool: \
`$ git pr show -t 2809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2809.diff">https://git.openjdk.org/jdk17u-dev/pull/2809.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2809#issuecomment-2292419419)