### PR TITLE
8338286: GHA: Demote x86_32 to hotspot build only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ on:
       platforms:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
-        default: 'linux-x64, linux-x86, linux-x64-variants, linux-cross-compile, macos-x64, macos-aarch64, windows-x64, windows-aarch64'
+        default: 'linux-x64, linux-x86-hs, linux-x64-variants, linux-cross-compile, macos-x64, macos-aarch64, windows-x64, windows-aarch64'
       configure-arguments:
         description: 'Additional configure arguments'
         required: false
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
-      linux-x86: ${{ steps.include.outputs.linux-x86 }}
+      linux-x86-hs: ${{ steps.include.outputs.linux-x86-hs }}
       linux-x64-variants: ${{ steps.include.outputs.linux-x64-variants }}
       linux-cross-compile: ${{ steps.include.outputs.linux-cross-compile }}
       macos-x64: ${{ steps.include.outputs.macos-x64 }}
@@ -109,7 +109,7 @@ jobs:
           }
 
           echo "linux-x64=$(check_platform linux-x64 linux x64)" >> $GITHUB_OUTPUT
-          echo "linux-x86=$(check_platform linux-x86 linux x86)" >> $GITHUB_OUTPUT
+          echo "linux-x86-hs=$(check_platform linux-x86-hs linux x86)" >> $GITHUB_OUTPUT
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
           echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
@@ -132,12 +132,13 @@ jobs:
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-x64 == 'true'
 
-  build-linux-x86:
-    name: linux-x86
+  build-linux-x86-hs:
+    name: linux-x86-hs
     needs: select
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x86
+      make-target: 'hotspot'
       gcc-major-version: '10'
       gcc-package-suffix: '-multilib'
       apt-architecture: 'i386'
@@ -147,7 +148,7 @@ jobs:
       extra-conf-options: '--with-target-bits=32'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-x86 == 'true'
+    if: needs.select.outputs.linux-x86-hs == 'true'
 
   build-linux-x64-hs-nopch:
     name: linux-x64-hs-nopch
@@ -281,16 +282,6 @@ jobs:
       bootjdk-platform: linux-x64
       runs-on: ubuntu-22.04
 
-  test-linux-x86:
-    name: linux-x86
-    needs:
-      - build-linux-x86
-    uses: ./.github/workflows/test.yml
-    with:
-      platform: linux-x86
-      bootjdk-platform: linux-x64
-      runs-on: ubuntu-22.04
-
   test-macos-x64:
     name: macos-x64
     needs:
@@ -328,7 +319,7 @@ jobs:
     if: always()
     needs:
       - build-linux-x64
-      - build-linux-x86
+      - build-linux-x86-hs
       - build-linux-x64-hs-nopch
       - build-linux-x64-hs-zero
       - build-linux-x64-hs-minimal
@@ -339,7 +330,6 @@ jobs:
       - build-windows-x64
       - build-windows-aarch64
       - test-linux-x64
-      - test-linux-x86
       - test-macos-x64
       - test-windows-x64
 


### PR DESCRIPTION
This should make GHAs cleaner and more efficient for future backports.

This backport is a bit unclean: there was a minor conflict in `default` line, which does not include some platform builds that are present past JDK 17.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338286](https://bugs.openjdk.org/browse/JDK-8338286) needs maintainer approval

### Issue
 * [JDK-8338286](https://bugs.openjdk.org/browse/JDK-8338286): GHA: Demote x86_32 to hotspot build only (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2816/head:pull/2816` \
`$ git checkout pull/2816`

Update a local copy of the PR: \
`$ git checkout pull/2816` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2816`

View PR using the GUI difftool: \
`$ git pr show -t 2816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2816.diff">https://git.openjdk.org/jdk17u-dev/pull/2816.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2816#issuecomment-2298703104)