### PR TITLE
8332248: (fc) java/nio/channels/FileChannel/BlockDeviceSize.java failed with RuntimeException

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -25,6 +25,7 @@
  * @bug 8054029
  * @requires (os.family == "linux")
  * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
+ * @library /test/lib
  */
 
 import java.io.RandomAccessFile;
@@ -36,6 +37,7 @@ import java.util.List;
 
 import static java.nio.file.StandardOpenOption.*;
 
+import jtreg.SkippedException;
 
 public class BlockDeviceSize {
     private static final List<String> BLK_FNAMES = List.of("/dev/sda1", "/dev/nvme0n1", "/dev/xvda1") ;
@@ -61,7 +63,7 @@ public class BlockDeviceSize {
                 System.err.println("File " + blkFname + " not found." +
                         " Skipping test");
             } catch (AccessDeniedException ade) {
-                throw new RuntimeException("Access to " + blkFname + " is denied."
+                throw new SkippedException("Access to " + blkFname + " is denied."
                         + " Run test as root.", ade);
 
             }


### PR DESCRIPTION
Backport of [JDK-8332248](https://bugs.openjdk.org/browse/JDK-8332248)

Testing
- Local: Test not executed on `MacOS 14.6.1` on Apple M1 Max, because `@requires (os.family == "linux")`
  - `BlockDeviceSize.java`: Test results: **no tests selected**
- Pipeline: All checks have passed
- Testing Machine: SAP nightlies SUCCESSFUL on `2024-08-23`
  - Automated jtreg test: `jtreg_jdk_tier2`, Started at `2024-08-23 19:44:34+01:00`
  - java/nio/channels/FileChannel/BlockDeviceSize.java: SUCCESSFUL GitHub 📊 - [19:56:22.058 -> 143 msec]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332248](https://bugs.openjdk.org/browse/JDK-8332248) needs maintainer approval

### Issue
 * [JDK-8332248](https://bugs.openjdk.org/browse/JDK-8332248): (fc) java/nio/channels/FileChannel/BlockDeviceSize.java failed with RuntimeException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2818/head:pull/2818` \
`$ git checkout pull/2818`

Update a local copy of the PR: \
`$ git checkout pull/2818` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2818`

View PR using the GUI difftool: \
`$ git pr show -t 2818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2818.diff">https://git.openjdk.org/jdk17u-dev/pull/2818.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2818#issuecomment-2303363329)