### PR TITLE
8337780: RISC-V: C2: Change C calling convention for sp to NS

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -84,8 +84,8 @@ reg_def R0      ( NS,  NS,  Op_RegI, 0,  x0->as_VMReg()         ); // zr
 reg_def R0_H    ( NS,  NS,  Op_RegI, 0,  x0->as_VMReg()->next() );
 reg_def R1      ( NS,  SOC, Op_RegI, 1,  x1->as_VMReg()         ); // ra
 reg_def R1_H    ( NS,  SOC, Op_RegI, 1,  x1->as_VMReg()->next() );
-reg_def R2      ( NS,  SOE, Op_RegI, 2,  x2->as_VMReg()         ); // sp
-reg_def R2_H    ( NS,  SOE, Op_RegI, 2,  x2->as_VMReg()->next() );
+reg_def R2      ( NS,  NS,  Op_RegI, 2,  x2->as_VMReg()         ); // sp
+reg_def R2_H    ( NS,  NS,  Op_RegI, 2,  x2->as_VMReg()->next() );
 reg_def R3      ( NS,  NS,  Op_RegI, 3,  x3->as_VMReg()         ); // gp
 reg_def R3_H    ( NS,  NS,  Op_RegI, 3,  x3->as_VMReg()->next() );
 reg_def R4      ( NS,  NS,  Op_RegI, 4,  x4->as_VMReg()         ); // tp


### PR DESCRIPTION
Clean backport of JDK-8337780 to reduce frame size by 16 bytes and improve performance for some C2 runtime stubs as we do not have to save sp on the method entry. Gtest & Tier1-3 tested on linux-riscv64 platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337780](https://bugs.openjdk.org/browse/JDK-8337780) needs maintainer approval

### Issue
 * [JDK-8337780](https://bugs.openjdk.org/browse/JDK-8337780): RISC-V: C2: Change C calling convention for sp to NS (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2823/head:pull/2823` \
`$ git checkout pull/2823`

Update a local copy of the PR: \
`$ git checkout pull/2823` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2823`

View PR using the GUI difftool: \
`$ git pr show -t 2823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2823.diff">https://git.openjdk.org/jdk17u-dev/pull/2823.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2823#issuecomment-2308627246)