### PR TITLE
8262895: [macos_aarch64] runtime/CompressedOops/CompressedClassPointers.java fails with 'Narrow klass base: 0x0000000000000000' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -27,6 +27,10 @@
  * @summary Testing address of compressed class pointer space as best as possible.
  * @requires vm.bits == 64 & !vm.graal.enabled
  * @requires vm.flagless
+ * @comment Testing compressed class pointers without compressed oops is not possible
+ *          on MacOS because the heap is given an arbitrary address that occasionally
+ *          collides with where we would ideally have placed the compressed class space.
+ * @requires os.family != "mac"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -326,19 +330,11 @@ public class CompressedClassPointers {
         heapBaseMinAddressTest();
         sharingTest();
 
-        if (!Platform.isOSX()) {
-            // Testing compressed class pointers without compressed oops.
-            // This is only possible if the platform supports it. Notably,
-            // on macOS, when compressed oops is disabled and the heap is
-            // given an arbitrary address, that address occasionally collides
-            // with where we would ideally have placed the compressed class
-            // space. Therefore, macOS is omitted for now.
-            smallHeapTestNoCoop();
-            smallHeapTestWith1GNoCoop();
-            largeHeapTestNoCoop();
-            largePagesTestNoCoop();
-            heapBaseMinAddressTestNoCoop();
-            sharingTestNoCoop();
-        }
+        smallHeapTestNoCoop();
+        smallHeapTestWith1GNoCoop();
+        largeHeapTestNoCoop();
+        largePagesTestNoCoop();
+        heapBaseMinAddressTestNoCoop();
+        sharingTestNoCoop();
     }
 }


### PR DESCRIPTION
Backport of [JDK-8262895](https://bugs.openjdk.org/browse/JDK-8262895)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - Passed: `runtime/CompressedOops/CompressedClassSpaceSize.java`
  - Passed: `runtime/CompressedOops/CompressedKlassPointerAndOops.java`
  - Passed: `runtime/CompressedOops/ObjectAlignment.java`
  - Passed: `runtime/CompressedOops/UseCompressedOops.java`
- Pipeline: 
- Testing Machine:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8262895](https://bugs.openjdk.org/browse/JDK-8262895) needs maintainer approval

### Issue
 * [JDK-8262895](https://bugs.openjdk.org/browse/JDK-8262895): [macos_aarch64] runtime/CompressedOops/CompressedClassPointers.java fails with 'Narrow klass base: 0x0000000000000000' missing from stdout/stderr (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2825/head:pull/2825` \
`$ git checkout pull/2825`

Update a local copy of the PR: \
`$ git checkout pull/2825` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2825`

View PR using the GUI difftool: \
`$ git pr show -t 2825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2825.diff">https://git.openjdk.org/jdk17u-dev/pull/2825.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2825#issuecomment-2311329464)