### PR TITLE
8332589: ubsan: unix/native/libjava/ProcessImpl_md.c:562:5: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -562,8 +562,17 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     }
     offset = copystrings(buf, 0, &c->argv[0]);
     offset = copystrings(buf, offset, &c->envv[0]);
-    memcpy(buf+offset, c->pdir, sp.dirlen);
-    offset += sp.dirlen;
+    if (c->pdir != NULL) {
+        if (sp.dirlen > 0) {
+            memcpy(buf+offset, c->pdir, sp.dirlen);
+            offset += sp.dirlen;
+        }
+    } else {
+        if (sp.dirlen > 0) {
+            free(buf);
+            return -1;
+        }
+    }
     offset = copystrings(buf, offset, parentPathv);
     assert(offset == bufsize);
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332589](https://bugs.openjdk.org/browse/JDK-8332589) needs maintainer approval

### Issue
 * [JDK-8332589](https://bugs.openjdk.org/browse/JDK-8332589): ubsan: unix/native/libjava/ProcessImpl_md.c:562:5: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2834/head:pull/2834` \
`$ git checkout pull/2834`

Update a local copy of the PR: \
`$ git checkout pull/2834` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2834`

View PR using the GUI difftool: \
`$ git pr show -t 2834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2834.diff">https://git.openjdk.org/jdk17u-dev/pull/2834.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2834#issuecomment-2317481804)