### PR TITLE
8284291: sun/security/krb5/auto/Renew.java fails intermittently on Windows 11

### DIFF
--- a/test/jdk/sun/security/krb5/auto/Renew.java
+++ b/test/jdk/sun/security/krb5/auto/Renew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,10 @@ public class Renew {
         Date d1 = c.s().getPrivateCredentials(KerberosTicket.class).iterator().next().getAuthTime();
 
         // 6s is longer than half of 10s
-        Thread.sleep(6000);
+        Date expiring = new Date(d1.getTime() + 6000);
+        while (new Date().before(expiring)) {
+            Thread.sleep(500);
+        }
 
         // The second login uses the cache
         c = Context.fromJAAS("second");


### PR DESCRIPTION
Backport of [JDK-8284291](https://bugs.openjdk.org/browse/JDK-8284291)

Testing
- Local: Test passed on `MacOS 14.6.1` on Apple M1 Max
  - Passed: `sun/security/krb5/auto/Renew.java`
- Pipeline: 
- Testing Machine:

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8284291](https://bugs.openjdk.org/browse/JDK-8284291) needs maintainer approval

### Issue
 * [JDK-8284291](https://bugs.openjdk.org/browse/JDK-8284291): sun/security/krb5/auto/Renew.java fails intermittently on Windows 11 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2836/head:pull/2836` \
`$ git checkout pull/2836`

Update a local copy of the PR: \
`$ git checkout pull/2836` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2836`

View PR using the GUI difftool: \
`$ git pr show -t 2836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2836.diff">https://git.openjdk.org/jdk17u-dev/pull/2836.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2836#issuecomment-2318631518)