### PR TITLE
8339470: [17u] More defensive fix for 8163921

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,7 +288,8 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
     }
 
     static final String httpVersion = "HTTP/1.1";
-    static final String acceptString = "*/*";
+    static final String acceptString =
+        "text/html, image/gif, image/jpeg, */*; q=0.2";
 
     // the following http request headers should NOT have their values
     // returned for security reasons.

--- a/test/jdk/sun/net/www/B8185898.java
+++ b/test/jdk/sun/net/www/B8185898.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8185898 8163921
+ * @bug 8185898 8163921 8339470
  * @modules java.base/sun.net.www
  * @library /test/lib
  * @run main/othervm B8185898

--- a/test/jdk/sun/net/www/B8185898.java
+++ b/test/jdk/sun/net/www/B8185898.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,32 +143,32 @@ public class B8185898 {
         // {{inputString1, expectedToString1, expectedPrint1}, {...}}
         String[][] strings = {
                 {"HTTP/1.1 200 OK\r\n"
-                        + "Accept: */*\r\n"
+                        + "Accept: text/html, image/gif, image/jpeg, */*; q=0.2\r\n"
                         + "Connection: keep-alive\r\n"
                         + "Host: 127.0.0.1:12345\r\n"
                         + "User-agent: Java/12\r\n\r\nfoooo",
                 "pairs: {null: HTTP/1.1 200 OK}"
-                        + "{Accept: */*}"
+                        + "{Accept: text/html, image/gif, image/jpeg, */*; q=0.2}"
                         + "{Connection: keep-alive}"
                         + "{Host: 127.0.0.1:12345}"
                         + "{User-agent: Java/12}",
-                "Accept: */*\r\n"
+                "Accept: text/html, image/gif, image/jpeg, */*; q=0.2\r\n"
                         + "Connection: keep-alive\r\n"
                         + "Host: 127.0.0.1:12345\r\n"
                         + "User-agent: Java/12\r\n\r\n"},
                 {"HTTP/1.1 200 OK\r\n"
-                        + "Accept: */*\r\n"
+                        + "Accept: text/html, image/gif, image/jpeg, */*; q=0.2\r\n"
                         + "Connection: keep-alive\r\n"
                         + "Host: 127.0.0.1:12345\r\n"
                         + "User-agent: Java/12\r\n"
                         + "X-Header:\r\n\r\n",
                 "pairs: {null: HTTP/1.1 200 OK}"
-                        + "{Accept: */*}"
+                        + "{Accept: text/html, image/gif, image/jpeg, */*; q=0.2}"
                         + "{Connection: keep-alive}"
                         + "{Host: 127.0.0.1:12345}"
                         + "{User-agent: Java/12}"
                         + "{X-Header: }",
-                "Accept: */*\r\n"
+                "Accept: text/html, image/gif, image/jpeg, */*; q=0.2\r\n"
                         + "Connection: keep-alive\r\n"
                         + "Host: 127.0.0.1:12345\r\n"
                         + "User-agent: Java/12\r\n"


### PR DESCRIPTION
This does not remove the header specifications, it just fixes the error.

Well, it removes * as type, but that is illegal and should be meant to match the same as */*.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339470](https://bugs.openjdk.org/browse/JDK-8339470) needs maintainer approval

### Issue
 * [JDK-8339470](https://bugs.openjdk.org/browse/JDK-8339470): [17u] More defensive fix for 8163921 (**Bug** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [151dfb6d](https://git.openjdk.org/jdk17u-dev/pull/2843/files/151dfb6d8d8078fb624f32a1af64a4774761aea5)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2843/head:pull/2843` \
`$ git checkout pull/2843`

Update a local copy of the PR: \
`$ git checkout pull/2843` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2843`

View PR using the GUI difftool: \
`$ git pr show -t 2843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2843.diff">https://git.openjdk.org/jdk17u-dev/pull/2843.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2843#issuecomment-2326157889)