### PR TITLE
8331405: Shenandoah: Optimize ShenandoahLock with TTAS

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -54,7 +54,8 @@ template<typename BlockOp>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
   int ctr = 0;
   int yields = 0;
-  while (Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
+  while (Atomic::load(&_state) == locked ||
+         Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
     if ((++ctr & 0xFFF) == 0) {
       BlockOp block(java_thread);
       if (yields > 5) {


### PR DESCRIPTION
Hi, 
    This PR is a Backport of [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405): Shenandoah: Optimize ShenandoahLock with TTAS, the original commit was authored by Aleksey Shipilev on 2 May 2024 and was reviewed by Zhengyu Gu and Y. S. Ramakrishna, and it had already been backported to jdk21.
    It is a clean merge w/o any conflicts, overall risk should be very minimal given it is single line change to apply TTAS. 

   Here is the series of improvements for ShenandoahLock I'm going to backport to JDK17:

| Bug         | Title                                          | PR         |
| ----------- | ---------------------------------------------- |------------|
| [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587) | ShenandoahLock should allow blocking in VM     | [2797](https://github.com/openjdk/jdk17u-dev/pull/2797)     |
| [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405) | Optimize ShenandoahLock with TTAS              | [2845](https://github.com/openjdk/jdk17u-dev/pull/2845) |
| [JDK-8331411](https://bugs.openjdk.org/browse/JDK-8331411) | Reconsider spinning duration in ShenandoahLock |    |
| [JDK-8335904](https://bugs.openjdk.org/browse/JDK-8335904) | Fix invalid comment in ShenandoahLock          |     |

### Additional test
- [x] Linux AArch64 server fastdebug, hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405) needs maintainer approval

### Issue
 * [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405): Shenandoah: Optimize ShenandoahLock with TTAS (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2845/head:pull/2845` \
`$ git checkout pull/2845`

Update a local copy of the PR: \
`$ git checkout pull/2845` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2845`

View PR using the GUI difftool: \
`$ git pr show -t 2845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2845.diff">https://git.openjdk.org/jdk17u-dev/pull/2845.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2845#issuecomment-2326921712)