### PR TITLE
8274505: Too weak variable type leads to unnecessary cast in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
@@ -289,12 +289,11 @@ public final class SoftSynthesizer implements AudioSynthesizer,
                     c.current_instrument = null;
                     c.current_director = null;
                 }
-            for (Instrument instrument : instruments) {
+            for (ModelInstrument instrument : instruments) {
                 String pat = patchToString(instrument.getPatch());
-                SoftInstrument softins
-                        = new SoftInstrument((ModelInstrument) instrument);
+                SoftInstrument softins = new SoftInstrument(instrument);
                 inslist.put(pat, softins);
-                loadedlist.put(pat, (ModelInstrument) instrument);
+                loadedlist.put(pat, instrument);
             }
         }
 

--- a/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
+++ b/src/java.desktop/share/classes/javax/swing/JFormattedTextField.java
@@ -868,11 +868,11 @@ public class JFormattedTextField extends JTextField {
             return new DefaultFormatterFactory(new DateFormatter());
         }
         if (type instanceof Number) {
-            AbstractFormatter displayFormatter = new NumberFormatter();
-            ((NumberFormatter)displayFormatter).setValueClass(type.getClass());
-            AbstractFormatter editFormatter = new NumberFormatter(
+            NumberFormatter displayFormatter = new NumberFormatter();
+            displayFormatter.setValueClass(type.getClass());
+            NumberFormatter editFormatter = new NumberFormatter(
                                   new DecimalFormat("#.#"));
-            ((NumberFormatter)editFormatter).setValueClass(type.getClass());
+            editFormatter.setValueClass(type.getClass());
 
             return new DefaultFormatterFactory(displayFormatter,
                                                displayFormatter,editFormatter);

--- a/src/java.desktop/share/classes/javax/swing/JRootPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JRootPane.java
@@ -24,18 +24,13 @@
  */
 package javax.swing;
 
-import java.applet.Applet;
 import java.awt.*;
-import java.awt.event.*;
 import java.beans.*;
 import java.security.AccessController;
 import javax.accessibility.*;
 import javax.swing.plaf.RootPaneUI;
-import java.util.Vector;
 import java.io.Serializable;
-import javax.swing.border.*;
 
-import sun.awt.AWTAccessor;
 import sun.security.action.GetBooleanAction;
 
 
@@ -511,10 +506,10 @@ public class JRootPane extends JComponent implements Accessible {
       * @return the default <code>glassPane</code>
       */
     protected Component createGlassPane() {
-        JComponent c = new JPanel();
+        JPanel c = new JPanel();
         c.setName(this.getName()+".glassPane");
         c.setVisible(false);
-        ((JPanel)c).setOpaque(false);
+        c.setOpaque(false);
         return c;
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -2033,7 +2033,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
         Enumeration<TreePath> toggledPaths = expandedState.keys();
         Vector<TreePath> elements = null;
         TreePath          path;
-        Object            value;
+        Boolean           value;
 
         if(toggledPaths != null) {
             while(toggledPaths.hasMoreElements()) {
@@ -2042,8 +2042,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
                 // Add the path if it is expanded, a descendant of parent,
                 // and it is visible (all parents expanded). This is rather
                 // expensive!
-                if(path != parent && value != null &&
-                   ((Boolean)value).booleanValue() &&
+                if (path != parent && value != null && value &&
                    parent.isDescendant(path) && isVisible(path)) {
                     if (elements == null) {
                         elements = new Vector<TreePath>();
@@ -2081,11 +2080,11 @@ public class JTree extends JComponent implements Scrollable, Accessible
 
         if(path == null)
             return false;
-        Object  value;
+        Boolean value;
 
         do{
             value = expandedState.get(path);
-            if(value == null || !((Boolean)value).booleanValue())
+            if (value == null || !value)
                 return false;
         } while( (path=path.getParentPath())!=null );
 
@@ -2109,7 +2108,7 @@ public class JTree extends JComponent implements Scrollable, Accessible
             if(path != null) {
                 Boolean value = expandedState.get(path);
 
-                return (value != null && value.booleanValue());
+                return (value != null && value);
             }
         }
         return false;
@@ -3729,9 +3728,9 @@ public class JTree extends JComponent implements Scrollable, Accessible
             }
             if(!state) {
                 // collapse last path.
-                Object          cValue = expandedState.get(path);
+                Boolean cValue = expandedState.get(path);
 
-                if(cValue != null && ((Boolean)cValue).booleanValue()) {
+                if (cValue != null && cValue) {
                     try {
                         fireTreeWillCollapse(path);
                     }
@@ -3753,9 +3752,9 @@ public class JTree extends JComponent implements Scrollable, Accessible
             }
             else {
                 // Expand last path.
-                Object          cValue = expandedState.get(path);
+                Boolean cValue = expandedState.get(path);
 
-                if(cValue == null || !((Boolean)cValue).booleanValue()) {
+                if (cValue == null || !cValue) {
                     try {
                         fireTreeWillExpand(path);
                     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1024,10 +1024,7 @@ class SynthParser extends DefaultHandler {
                                                        painter,
                                                        direction);
 
-        for (Object infoObject: painters) {
-            ParsedSynthStyle.PainterInfo info;
-            info = (ParsedSynthStyle.PainterInfo) infoObject;
-
+        for (ParsedSynthStyle.PainterInfo info: painters) {
             if (painterInfo.equalsPainter(info)) {
                 info.addPainter(painter);
                 return;

--- a/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/AccessibleHTML.java
@@ -317,14 +317,12 @@ class AccessibleHTML implements Accessible {
          */
         public AccessibleStateSet getAccessibleStateSet() {
             AccessibleStateSet states = new AccessibleStateSet();
-            Component comp = getTextComponent();
+            JTextComponent comp = getTextComponent();
 
             if (comp.isEnabled()) {
                 states.add(AccessibleState.ENABLED);
             }
-            if (comp instanceof JTextComponent &&
-                ((JTextComponent)comp).isEditable()) {
-
+            if (comp.isEditable()) {
                 states.add(AccessibleState.EDITABLE);
                 states.add(AccessibleState.FOCUSABLE);
             }
@@ -742,11 +740,9 @@ class AccessibleHTML implements Accessible {
          * @see AccessibleStateSet
          */
         public boolean isFocusTraversable() {
-            Component comp = getTextComponent();
-            if (comp instanceof JTextComponent) {
-                if (((JTextComponent)comp).isEditable()) {
-                    return true;
-                }
+            JTextComponent comp = getTextComponent();
+            if (comp != null && comp.isEditable()) {
+                return true;
             }
             return false;
         }
@@ -763,8 +759,8 @@ class AccessibleHTML implements Accessible {
                 return;
             }
 
-            Component comp = getTextComponent();
-            if (comp instanceof JTextComponent) {
+            JTextComponent comp = getTextComponent();
+            if (comp != null) {
 
                 comp.requestFocusInWindow();
 
@@ -772,7 +768,7 @@ class AccessibleHTML implements Accessible {
                     if (elementInfo.validateIfNecessary()) {
                         // set the caret position to the start of this component
                         Element elem = elementInfo.getElement();
-                        ((JTextComponent)comp).setCaretPosition(elem.getStartOffset());
+                        comp.setCaretPosition(elem.getStartOffset());
 
                         // fire a AccessibleState.FOCUSED property change event
                         AccessibleContext ac = editor.getAccessibleContext();

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -4225,7 +4225,7 @@ public class HTMLDocument extends DefaultStyledDocument {
                 try {
                     if (offset == 0 || !getText(offset - 1, 1).equals("\n")) {
                         // Need to insert a newline.
-                        AttributeSet newAttrs = null;
+                        SimpleAttributeSet newAttrs = null;
                         boolean joinP = true;
 
                         if (offset != 0) {
@@ -4259,9 +4259,8 @@ public class HTMLDocument extends DefaultStyledDocument {
                             // sure and set the name (otherwise it will be
                             // inherited).
                             newAttrs = new SimpleAttributeSet();
-                            ((SimpleAttributeSet)newAttrs).addAttribute
-                                              (StyleConstants.NameAttribute,
-                                               HTML.Tag.CONTENT);
+                            newAttrs.addAttribute(StyleConstants.NameAttribute,
+                                                  HTML.Tag.CONTENT);
                         }
                         ElementSpec es = new ElementSpec(newAttrs,
                                      ElementSpec.ContentType, NEWLINE, 0,

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -61,7 +61,6 @@ import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleAction;
 import javax.accessibility.AccessibleContext;
 import javax.swing.Action;
-import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JViewport;
 import javax.swing.SizeRequirements;
@@ -849,13 +848,12 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
                     Rectangle bounds;
                     TextUI ui = html.getUI();
                     try {
-                        Shape lBounds = ui.modelToView(html, offset,
+                        Rectangle lBounds = ui.modelToView(html, offset,
                                                    Position.Bias.Forward);
-                        Shape rBounds = ui.modelToView(html, offset + 1,
+                        Rectangle rBounds = ui.modelToView(html, offset + 1,
                                                    Position.Bias.Backward);
-                        bounds = lBounds.getBounds();
-                        bounds.add((rBounds instanceof Rectangle) ?
-                                    (Rectangle)rBounds : rBounds.getBounds());
+                        bounds = lBounds;
+                        bounds.add(rBounds);
                     } catch (BadLocationException ble) {
                         bounds = null;
                     }
@@ -886,18 +884,14 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
             if (e != null && offset > 0 && e.getStartOffset() == offset) {
                 try {
                     TextUI ui = editor.getUI();
-                    Shape s1 = ui.modelToView(editor, offset,
-                                              Position.Bias.Forward);
-                    if (s1 == null) {
+                    Rectangle r1 = ui.modelToView(editor, offset,
+                                                  Position.Bias.Forward);
+                    if (r1 == null) {
                         return false;
                     }
-                    Rectangle r1 = (s1 instanceof Rectangle) ? (Rectangle)s1 :
-                                    s1.getBounds();
-                    Shape s2 = ui.modelToView(editor, e.getEndOffset(),
-                                              Position.Bias.Backward);
-                    if (s2 != null) {
-                        Rectangle r2 = (s2 instanceof Rectangle) ? (Rectangle)s2 :
-                                    s2.getBounds();
+                    Rectangle r2 = ui.modelToView(editor, e.getEndOffset(),
+                                                  Position.Bias.Backward);
+                    if (r2 != null) {
                         r1.add(r2);
                     }
                     return r1.contains(x, y);
@@ -1522,9 +1516,9 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
                 //if parent == null unregister component listener
                 if (parent == null) {
                     if (cachedViewPort != null) {
-                        Object cachedObject;
+                        JViewport cachedObject;
                         if ((cachedObject = cachedViewPort.get()) != null) {
-                            ((JComponent)cachedObject).removeComponentListener(this);
+                            cachedObject.removeComponentListener(this);
                         }
                         cachedViewPort = null;
                     }

--- a/src/java.desktop/share/classes/javax/swing/text/rtf/RTFGenerator.java
+++ b/src/java.desktop/share/classes/javax/swing/text/rtf/RTFGenerator.java
@@ -27,7 +27,6 @@ package javax.swing.text.rtf;
 import java.lang.*;
 import java.util.*;
 import java.awt.Color;
-import java.awt.Font;
 import java.io.OutputStream;
 import java.io.IOException;
 
@@ -516,13 +515,13 @@ void updateSectionAttributes(MutableAttributeSet current,
 {
     if (emitStyleChanges) {
         Object oldStyle = current.getAttribute("sectionStyle");
-        Object newStyle = findStyleNumber(newAttributes, Constants.STSection);
+        Integer newStyle = findStyleNumber(newAttributes, Constants.STSection);
         if (oldStyle != newStyle) {
             if (oldStyle != null) {
                 resetSectionAttributes(current);
             }
             if (newStyle != null) {
-                writeControlWord("ds", ((Integer)newStyle).intValue());
+                writeControlWord("ds", newStyle);
                 current.addAttribute("sectionStyle", newStyle);
             } else {
                 current.removeAttribute("sectionStyle");
@@ -555,8 +554,8 @@ void updateParagraphAttributes(MutableAttributeSet current,
                                boolean emitStyleChanges)
     throws IOException
 {
-    Object parm;
-    Object oldStyle, newStyle;
+    Object oldStyle;
+    Integer newStyle;
 
     /* The only way to get rid of tabs or styles is with the \pard keyword,
        emitted by resetParagraphAttributes(). Ideally we should avoid
@@ -588,7 +587,7 @@ void updateParagraphAttributes(MutableAttributeSet current,
     }
 
     if (oldStyle != newStyle && newStyle != null) {
-        writeControlWord("s", ((Integer)newStyle).intValue());
+        writeControlWord("s", newStyle);
         current.addAttribute("paragraphStyle", newStyle);
     }
 
@@ -707,14 +706,14 @@ void updateCharacterAttributes(MutableAttributeSet current,
 
     if (updateStyleChanges) {
         Object oldStyle = current.getAttribute("characterStyle");
-        Object newStyle = findStyleNumber(newAttributes,
+        Integer newStyle = findStyleNumber(newAttributes,
                                           Constants.STCharacter);
         if (oldStyle != newStyle) {
             if (oldStyle != null) {
                 resetCharacterAttributes(current);
             }
             if (newStyle != null) {
-                writeControlWord("cs", ((Integer)newStyle).intValue());
+                writeControlWord("cs", newStyle.intValue());
                 current.addAttribute("characterStyle", newStyle);
             } else {
                 current.removeAttribute("characterStyle");

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1805,8 +1805,8 @@ public abstract class SunToolkit extends Toolkit
         if (useSystemAAFontSettings()) {
              Toolkit tk = Toolkit.getDefaultToolkit();
              if (tk instanceof SunToolkit) {
-                 Object map = ((SunToolkit)tk).getDesktopAAHints();
-                 return (RenderingHints)map;
+                 RenderingHints map = ((SunToolkit)tk).getDesktopAAHints();
+                 return map;
              } else { /* Headless Toolkit */
                  return null;
              }

--- a/src/java.desktop/share/classes/sun/java2d/Disposer.java
+++ b/src/java.desktop/share/classes/sun/java2d/Disposer.java
@@ -142,8 +142,8 @@ public class Disposer implements Runnable {
     public void run() {
         while (true) {
             try {
-                Object obj = queue.remove();
-                ((Reference)obj).clear();
+                Reference<?> obj = queue.remove();
+                obj.clear();
                 DisposerRecord rec = records.remove(obj);
                 rec.dispose();
                 obj = null;
@@ -200,7 +200,7 @@ public class Disposer implements Runnable {
         if (pollingQueue) {
             return;
         }
-        Object obj;
+        Reference<?> obj;
         pollingQueue = true;
         int freed = 0;
         int deferred = 0;
@@ -208,7 +208,7 @@ public class Disposer implements Runnable {
             while ( freed < 10000 && deferred < 100 &&
                     (obj = queue.poll()) != null ) {
                 freed++;
-                ((Reference)obj).clear();
+                obj.clear();
                 DisposerRecord rec = records.remove(obj);
                 if (rec instanceof PollDisposable) {
                     rec.dispose();


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8274505](https://bugs.openjdk.org/browse/JDK-8274505) needs maintainer approval

### Issue
 * [JDK-8274505](https://bugs.openjdk.org/browse/JDK-8274505): Too weak variable type leads to unnecessary cast in java.desktop (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2848/head:pull/2848` \
`$ git checkout pull/2848`

Update a local copy of the PR: \
`$ git checkout pull/2848` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2848`

View PR using the GUI difftool: \
`$ git pr show -t 2848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2848.diff">https://git.openjdk.org/jdk17u-dev/pull/2848.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2848#issuecomment-2331637540)