### PR TITLE
8269770: nsk tests should start IOPipe channel before launch debuggee - Debugee.prepareDebugee

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/Accessible/isPackagePrivate/accipp001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,24 +109,8 @@ public class accipp001 extends Log {
         logHandler      = new Log(out, argsHandler);
         Binder binder   = new Binder(argsHandler, logHandler);
 
-
-        if (argsHandler.verbose()) {
-            debugee = binder.bindToDebugee(debugeeName + " -vbs");
-        } else {
-            debugee = binder.bindToDebugee(debugeeName);
-        }
-
-        IOPipe pipe     = new IOPipe(debugee);
-
-
-        debugee.redirectStderr(out);
-        debugee.resume();
-
-        String line = pipe.readln();
-        if (!line.equals("ready")) {
-            logHandler.complain("# Cannot recognize debugee's signal: " + line);
-            return 2;
-        };
+        debugee = Debugee.prepareDebugee(argsHandler, logHandler,
+                debugeeName + (argsHandler.verbose() ? " -vbs" : ""));
 
 //        ReferenceType classes[] = debugee.classes();
 //        for (int i=0; i<classes.length; i++) {
@@ -165,10 +149,8 @@ public class accipp001 extends Log {
             return 2;
         };
 
-        pipe.println("quit");
-        debugee.waitFor();
-
-        int status = debugee.getStatus();
+        debugee.sendSignal("quit");
+        int status = debugee.endDebugee();
         if (status != 95) {
             logHandler.complain("Debugee's exit status=" + status);
             return 2;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -110,12 +110,16 @@ abstract public class DebugeeProcess extends FinalizableObject {
 
     // --------------------------------------------------- //
 
-    /** Created and return new IOPipe channel to the debugee VM. */
+    /** Create and return new IOPipe channel to the debuggee VM.
+     * The channel should be created before debuggee starts execution,
+     * i.e. the method assumes debuggee is started, but suspended before
+     * its main class is loaded.
+     */
     public IOPipe createIOPipe() {
         if (pipe != null) {
             throw new TestBug("IOPipe channel is already created");
         }
-        pipe = new IOPipe(this);
+        pipe = IOPipe.startDebuggerPipe(binder);
         return pipe;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/IOPipe.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/IOPipe.java
@@ -84,7 +84,7 @@ public class IOPipe extends SocketIOPipe {
     /**
      * Creates and starts listening <code>IOPipe</code> at debugger side.
      */
-    public static IOPipe startDebuggerPipe(Binder binder) {
+    public static IOPipe startDebuggerPipe(DebugeeBinder binder) {
         IOPipe ioPipe = new IOPipe(binder.getLog(),
                 binder.getArgumentHandler().getDebugeeHost(),
                 binder.getArgumentHandler().getPipePortNumber(),
@@ -94,7 +94,6 @@ public class IOPipe extends SocketIOPipe {
         ioPipe.startListening();
         return ioPipe;
     }
-
 
     protected void connect() {
         super.connect();


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8269770](https://bugs.openjdk.org/browse/JDK-8269770) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8269770: nsk tests should start IOPipe channel before launch debuggee - Debugee.prepareDebugee`

### Issue
 * [JDK-8269770](https://bugs.openjdk.org/browse/JDK-8269770): nsk tests should start IOPipe channel before launch debuggee - Debugee.prepareDebugee (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2850/head:pull/2850` \
`$ git checkout pull/2850`

Update a local copy of the PR: \
`$ git checkout pull/2850` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2850`

View PR using the GUI difftool: \
`$ git pr show -t 2850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2850.diff">https://git.openjdk.org/jdk17u-dev/pull/2850.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2850#issuecomment-2333758036)