### PR TITLE
8276763: java/nio/channels/SocketChannel/AdaptorStreams.java fails with "SocketTimeoutException: Read timed out"

### DIFF
--- a/test/jdk/java/nio/channels/SocketChannel/AdaptorStreams.java
+++ b/test/jdk/java/nio/channels/SocketChannel/AdaptorStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,7 +158,7 @@ public class AdaptorStreams {
         withConnection((sc, peer) -> {
             peer.getOutputStream().write(99);
             Socket s = sc.socket();
-            s.setSoTimeout(1000);
+            s.setSoTimeout(60_000);
             int n = s.getInputStream().read();
             assertEquals(n, 99);
         });
@@ -171,7 +171,7 @@ public class AdaptorStreams {
         withConnection((sc, peer) -> {
             scheduleWrite(peer.getOutputStream(), 99, 1000);
             Socket s = sc.socket();
-            s.setSoTimeout(5000);
+            s.setSoTimeout(60_000);
             int n = s.getInputStream().read();
             assertEquals(n, 99);
         });
@@ -183,7 +183,7 @@ public class AdaptorStreams {
     public void testTimedRead3() throws Exception {
         withConnection((sc, peer) -> {
             Socket s = sc.socket();
-            s.setSoTimeout(1000);
+            s.setSoTimeout(500);
             InputStream in = s.getInputStream();
             expectThrows(SocketTimeoutException.class, () -> in.read());
         });
@@ -196,7 +196,7 @@ public class AdaptorStreams {
         withConnection((sc, peer) -> {
             scheduleClose(sc, 2000);
             Socket s = sc.socket();
-            s.setSoTimeout(60*1000);
+            s.setSoTimeout(60_000);
             InputStream in = s.getInputStream();
             expectThrows(IOException.class, () -> in.read());
         });
@@ -210,7 +210,7 @@ public class AdaptorStreams {
             Socket s = sc.socket();
             Thread.currentThread().interrupt();
             try {
-                s.setSoTimeout(60*1000);
+                s.setSoTimeout(60_000);
                 InputStream in = s.getInputStream();
                 expectThrows(IOException.class, () -> in.read());
             } finally {
@@ -228,7 +228,7 @@ public class AdaptorStreams {
             Future<?> interrupter = scheduleInterrupt(Thread.currentThread(), 2000);
             Socket s = sc.socket();
             try {
-                s.setSoTimeout(60*1000);
+                s.setSoTimeout(60_000);
                 InputStream in = s.getInputStream();
                 expectThrows(IOException.class, () -> in.read());
                 assertTrue(s.isClosed());
@@ -396,7 +396,7 @@ public class AdaptorStreams {
 
             // test read when bytes are available
             peer.getOutputStream().write(99);
-            s.setSoTimeout(60*1000);
+            s.setSoTimeout(60_000);
             int n = s.getInputStream().read();
             assertEquals(n, 99);
         });
@@ -421,7 +421,7 @@ public class AdaptorStreams {
 
             // test read blocking until bytes are available
             scheduleWrite(peer.getOutputStream(), 99, 500);
-            s.setSoTimeout(60*1000);
+            s.setSoTimeout(60_000);
             int n = s.getInputStream().read();
             assertEquals(n, 99);
         });
@@ -436,7 +436,7 @@ public class AdaptorStreams {
 
             // block thread in read
             execute(() -> {
-                s.setSoTimeout(60*1000);
+                s.setSoTimeout(60_000);
                 s.getInputStream().read();
             });
             Thread.sleep(100); // give reader time to block


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8276763](https://bugs.openjdk.org/browse/JDK-8276763) needs maintainer approval

### Issue
 * [JDK-8276763](https://bugs.openjdk.org/browse/JDK-8276763): java/nio/channels/SocketChannel/AdaptorStreams.java fails with "SocketTimeoutException: Read timed out" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2853/head:pull/2853` \
`$ git checkout pull/2853`

Update a local copy of the PR: \
`$ git checkout pull/2853` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2853`

View PR using the GUI difftool: \
`$ git pr show -t 2853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2853.diff">https://git.openjdk.org/jdk17u-dev/pull/2853.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2853#issuecomment-2333991348)