### PR TITLE
8336413: gtk headers : Fix typedef redeclaration of GMainContext and GdkPixbuf

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk2_interface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,13 +55,11 @@ typedef enum
 } GParamFlags;
 
 /* We define all structure pointers to be void* */
-typedef void GMainContext;
 typedef void GVfs;
 
 typedef void GdkColormap;
 typedef void GdkDrawable;
 typedef void GdkGC;
-typedef void GdkPixbuf;
 typedef void GdkPixmap;
 
 typedef void GtkFixed;

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,8 +180,6 @@ typedef enum _cairo_status {
 } cairo_status_t;
 
 /* We define all structure pointers to be void* */
-typedef void GdkPixbuf;
-typedef void GMainContext;
 typedef void GVfs;
 
 typedef void GdkColormap;


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336413](https://bugs.openjdk.org/browse/JDK-8336413) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8336413: gtk headers : Fix typedef redeclaration of GMainContext and GdkPixbuf`

### Issue
 * [JDK-8336413](https://bugs.openjdk.org/browse/JDK-8336413): gtk headers : Fix typedef redeclaration of GMainContext and GdkPixbuf (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2857/head:pull/2857` \
`$ git checkout pull/2857`

Update a local copy of the PR: \
`$ git checkout pull/2857` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2857`

View PR using the GUI difftool: \
`$ git pr show -t 2857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2857.diff">https://git.openjdk.org/jdk17u-dev/pull/2857.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2857#issuecomment-2337167781)