### PR TITLE
Backport ddbd7a78f191462695ecbeeef7fd6312e322b15a

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -512,6 +512,11 @@ java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-
 # This test fails on macOS 14
 java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
 
+# Wayland related
+
+java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8332158 linux-x64
+java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java 8280991 linux-x64
+
 ############################################################################
 
 # jdk_beans


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.