### PR TITLE
8338748: [17u,21u] Test Disconnect.java compile error: cannot find symbol after JDK-8299813

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -52,7 +52,7 @@ public class Disconnect {
         if (IPSupport.hasIPv4()) {
             // test with IPv4 only
             try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET)) {
-                InetAddress lo4 = InetAddress.ofLiteral("127.0.0.1");
+                InetAddress lo4 = InetAddress.getByName("127.0.0.1");
                 System.out.println("Testing with INET family and " + lo4);
                 test(dc, lo4);
                 test(dc, lo4);
@@ -62,7 +62,7 @@ public class Disconnect {
         if (IPSupport.hasIPv6()) {
             // test with IPv6 only
             try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET6)) {
-                InetAddress lo6 = InetAddress.ofLiteral("::1");
+                InetAddress lo6 = InetAddress.getByName("::1");
                 System.out.println("Testing with INET6 family and " + lo6);
                 test(dc, lo6);
                 test(dc, lo6);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ad5656f7](https://github.com/openjdk/jdk21u-dev/commit/ad5656f7fa53e7d380dbadc204501c3c7f2e822a) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by SendaoYan on 10 Sep 2024 and was reviewed by Severin Gehwolf.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8338748](https://bugs.openjdk.org/browse/JDK-8338748) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338748](https://bugs.openjdk.org/browse/JDK-8338748): [17u,21u] Test Disconnect.java compile error: cannot find symbol after JDK-8299813 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2861/head:pull/2861` \
`$ git checkout pull/2861`

Update a local copy of the PR: \
`$ git checkout pull/2861` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2861`

View PR using the GUI difftool: \
`$ git pr show -t 2861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2861.diff">https://git.openjdk.org/jdk17u-dev/pull/2861.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2861#issuecomment-2340020271)