### PR TITLE
8294726: Update URLs in minefield tests

### DIFF
--- a/test/langtools/tools/javac/Paths/ClassPath.java
+++ b/test/langtools/tools/javac/Paths/ClassPath.java
@@ -36,7 +36,7 @@
  * Converted from Class-Path.sh, originally written by Martin Buchholz.
  *
  * For the last version of the original, Class-Path.sh, see
- * https://github.com/openjdk/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/Class-Path.sh
+ * https://git.openjdk.org/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/Class-Path.sh
  *
  * This class primarily tests that the Class-Path attribute in jar files
  * is handled the same way by javac and java. It also has various tests

--- a/test/langtools/tools/javac/Paths/ClassPath2.java
+++ b/test/langtools/tools/javac/Paths/ClassPath2.java
@@ -34,7 +34,7 @@
  * Converted from Class-Path2.sh, originally written by Martin Buchholz.
  *
  * For the last version of the original, Class-Path2.sh, see
- * https://github.com/openjdk/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/Class-Path2.sh
+ * https://git.openjdk.org/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/Class-Path2.sh
  *
  * This class provides additional tests for the Class-Path attribute in jar
  * files, when the entries are not in the same directory.

--- a/test/langtools/tools/javac/Paths/Diagnostics.java
+++ b/test/langtools/tools/javac/Paths/Diagnostics.java
@@ -35,7 +35,7 @@
  * Converted from Diagnostics.sh, originally written by Martin Buchholz.
  *
  * For the last version of the original, Diagnostics.sh, see
- * https://github.com/openjdk/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/Diagnostics.sh
+ * https://git.openjdk.org/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/Diagnostics.sh
  *
  * This class primarily tests that javac generates warnings or errors
  * as appropriate for various input conditions.

--- a/test/langtools/tools/javac/Paths/Help.java
+++ b/test/langtools/tools/javac/Paths/Help.java
@@ -32,7 +32,7 @@
  * Converted from Help.sh, originally written by Martin Buchholz
  *
  * For the last version of the original, Help.sh, see
- * https://github.com/openjdk/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/Help.sh
+ * https://git.openjdk.org/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/Help.sh
  *
  * This class provides rudimentary tests of the javac command-line help.
  */

--- a/test/langtools/tools/javac/Paths/MineField.java
+++ b/test/langtools/tools/javac/Paths/MineField.java
@@ -35,7 +35,7 @@
  * Converted from MineField.sh, originally written by Martin Buchholz.
  *
  * For the last version of the original, MineField.sh, see
- * https://github.com/openjdk/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/MineField.sh
+ * https://git.openjdk.org/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/MineField.sh
  *
  * This class primarily tests that javac and the java launcher provide
  * equivalent handling of all path-related options, like {@code -classpath}.

--- a/test/langtools/tools/javac/Paths/WildcardMineField.java
+++ b/test/langtools/tools/javac/Paths/WildcardMineField.java
@@ -34,7 +34,7 @@
  * Converted from wcMineField.sh, originally written by Martin Buchholz.
  *
  * For the last version of the original, wcMineField.sh, see
- * https://github.com/openjdk/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/wcMineField.sh
+ * https://git.openjdk.org/jdk/blob/jdk-19%2B36/test/langtools/tools/javac/Paths/wcMineField.sh
  *
  * This class primarily tests support for "classpath wildcards", which is a feature
  * by which elements of a classpath option ending in {@code *} are expanded into


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8294726](https://bugs.openjdk.org/browse/JDK-8294726) needs maintainer approval

### Issue
 * [JDK-8294726](https://bugs.openjdk.org/browse/JDK-8294726): Update URLs in minefield tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2862/head:pull/2862` \
`$ git checkout pull/2862`

Update a local copy of the PR: \
`$ git checkout pull/2862` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2862`

View PR using the GUI difftool: \
`$ git pr show -t 2862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2862.diff">https://git.openjdk.org/jdk17u-dev/pull/2862.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2862#issuecomment-2340147592)