### PR TITLE
8303705: Field sleeper.started should be volatile JdbLockTestTarg.java

### DIFF
--- a/test/jdk/com/sun/jdi/JdbLockTest.java
+++ b/test/jdk/com/sun/jdi/JdbLockTest.java
@@ -56,7 +56,7 @@ class JdbLockTestTarg {
 }
 
 class sleeper extends Thread {
-    public static int started = 0;
+    public static volatile int started = 0;
     public void run() {
         started = 1;
         System.out.println("     sleeper starts sleeping");


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8303705](https://bugs.openjdk.org/browse/JDK-8303705) needs maintainer approval

### Issue
 * [JDK-8303705](https://bugs.openjdk.org/browse/JDK-8303705): Field sleeper.started should be volatile JdbLockTestTarg.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2867/head:pull/2867` \
`$ git checkout pull/2867`

Update a local copy of the PR: \
`$ git checkout pull/2867` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2867`

View PR using the GUI difftool: \
`$ git pr show -t 2867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2867.diff">https://git.openjdk.org/jdk17u-dev/pull/2867.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2867#issuecomment-2345824948)