### PR TITLE
8331411: Shenandoah: Reconsider spinning duration in ShenandoahLock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -44,7 +44,7 @@ void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
 template<bool ALLOW_BLOCK>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
   assert(!ALLOW_BLOCK || java_thread != nullptr, "Must have a Java thread when allowing block.");
-  // Spin this much on multi-processor, but only on multi-processor systems.
+  // Spin this much, but only on multi-processor systems.
   int ctr = os::is_MP() ? 0xFF : 0;
   // Apply TTAS to avoid more expensive CAS calls if the lock is still held by other thread.
   while (Atomic::load(&_state) == locked ||

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -32,40 +32,49 @@
 #include "runtime/os.inline.hpp"
 #include "runtime/thread.hpp"
 
-// These are inline variants of Thread::SpinAcquire with optional blocking in VM.
-
-class ShenandoahNoBlockOp : public StackObj {
-public:
-  ShenandoahNoBlockOp(JavaThread* java_thread) {
-    assert(java_thread == NULL, "Should not pass anything");
-  }
-};
-
 void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
   Thread* thread = Thread::current();
   if (allow_block_for_safepoint && thread->is_Java_thread()) {
-    contended_lock_internal<ThreadBlockInVM>(thread->as_Java_thread());
+    contended_lock_internal<true>(JavaThread::cast(thread));
   } else {
-    contended_lock_internal<ShenandoahNoBlockOp>(NULL);
+    contended_lock_internal<false>(nullptr);
   }
 }
 
-template<typename BlockOp>
+template<bool ALLOW_BLOCK>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
-  int ctr = 0;
-  int yields = 0;
+  assert(!ALLOW_BLOCK || java_thread != nullptr, "Must have a Java thread when allowing block.");
+  // Spin this much on multi-processor, but only on multi-processor systems.
+  int ctr = os::is_MP() ? 0xFF : 0;
+  // Apply TTAS to avoid more expensive CAS calls if the lock is still held by other thread.
   while (Atomic::load(&_state) == locked ||
          Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
-    if ((++ctr & 0xFFF) == 0) {
-      BlockOp block(java_thread);
-      if (yields > 5) {
-        os::naked_short_sleep(1);
+    if (ctr > 0 && !SafepointSynchronize::is_synchronizing()) {
+      // Lightly contended, spin a little if no safepoint is pending.
+      SpinPause();
+      ctr--;
+    } else if (ALLOW_BLOCK) {
+      ThreadBlockInVM block(java_thread);
+      if (SafepointSynchronize::is_synchronizing()) {
+        // If safepoint is pending, we want to block and allow safepoint to proceed.
+        // Normally, TBIVM above would block us in its destructor.
+        //
+        // But that blocking only happens when TBIVM knows the thread poll is armed.
+        // There is a window between announcing a safepoint and arming the thread poll
+        // during which trying to continuously enter TBIVM is counter-productive.
+        // Under high contention, we may end up going in circles thousands of times.
+        // To avoid it, we wait here until local poll is armed and then proceed
+        // to TBVIM exit for blocking. We do not SpinPause, but yield to let
+        // VM thread to arm the poll sooner.
+        while (SafepointSynchronize::is_synchronizing() &&
+               !SafepointMechanism::local_poll_armed(java_thread)) {
+          os::naked_yield();
+        }
       } else {
         os::naked_yield();
-        yields++;
       }
     } else {
-      SpinPause();
+      os::naked_yield();
     }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -35,7 +35,7 @@
 void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
   Thread* thread = Thread::current();
   if (allow_block_for_safepoint && thread->is_Java_thread()) {
-    contended_lock_internal<true>(JavaThread::cast(thread));
+    contended_lock_internal<true>(thread->as_Java_thread());
   } else {
     contended_lock_internal<false>(nullptr);
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.hpp
@@ -37,20 +37,22 @@ private:
   shenandoah_padding(0);
   volatile LockState _state;
   shenandoah_padding(1);
-  volatile Thread* _owner;
+  Thread* volatile _owner;
   shenandoah_padding(2);
 
-  template<typename BlockOp>
+  template<bool ALLOW_BLOCK>
   void contended_lock_internal(JavaThread* java_thread);
-
 public:
   ShenandoahLock() : _state(unlocked), _owner(NULL) {};
 
   void lock(bool allow_block_for_safepoint) {
     assert(Atomic::load(&_owner) != Thread::current(), "reentrant locking attempt, would deadlock");
 
-    // Try to lock fast, or dive into contended lock handling.
-    if (Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
+    if ((allow_block_for_safepoint && SafepointSynchronize::is_synchronizing()) ||
+        (Atomic::cmpxchg(&_state, unlocked, locked) != unlocked)) {
+      // 1. Java thread, and there is a pending safepoint. Dive into contended locking
+      //    immediately without trying anything else, and block.
+      // 2. Fast lock fails, dive into contended lock handling.
       contended_lock(allow_block_for_safepoint);
     }
 


### PR DESCRIPTION
Hi, 
    This PR is a Backport of [[JDK-8331411](https://bugs.openjdk.org/browse/JDK-8331411)]: Reconsider spinning duration in ShenandoahLock. The original commit was authored by Xiaolong Peng on 26 June 2024 and was reviewed by[Aleksey Shipilëv](https://github.com/shipilev), [Kelvin Nilsen](https://github.com/kdnilsen), and [William Kemper](https://github.com/earthling-amzn), it had already been backported to jdk21.
    
   It was not a clean merge, there were some conflicts and API change which have been resolved and tested. Meanwhile, given there were conflicts to resolve, I also updated the invalid comments which was fixed in JDK-8335904.
   
   This is the third PR of the series of improvements we are proposing to backport to jdk17 to solve the contention issue in ShenandoahLock, we have observed  the lock contention is causing real problems in some of our products.

   Here is the series of improvements for ShenandoahLock I'm going to backport to JDK17:

| Bug         | Title                                          | PR         |
| ----------- | ---------------------------------------------- |------------|
| [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587) | ShenandoahLock should allow blocking in VM     | [2797](https://github.com/openjdk/jdk17u-dev/pull/2797)     |
| [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405) | Optimize ShenandoahLock with TTAS              | [2845](https://github.com/openjdk/jdk17u-dev/pull/2845) |
| [JDK-8331411](https://bugs.openjdk.org/browse/JDK-8331411) | Reconsider spinning duration in ShenandoahLock |  [2868](https://github.com/openjdk/jdk17u-dev/pull/2868)  |
| [JDK-8335904](https://bugs.openjdk.org/browse/JDK-8335904) | Fix invalid comment in ShenandoahLock          |  [2868](https://github.com/openjdk/jdk17u-dev/pull/2868)   |

### Additional test
- [x] MacOS AArch64 server fastdebug, hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8335904](https://bugs.openjdk.org/browse/JDK-8335904) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8331411](https://bugs.openjdk.org/browse/JDK-8331411) needs maintainer approval

### Issues
 * [JDK-8331411](https://bugs.openjdk.org/browse/JDK-8331411): Shenandoah: Reconsider spinning duration in ShenandoahLock (**Enhancement** - P4 - Approved)
 * [JDK-8335904](https://bugs.openjdk.org/browse/JDK-8335904): Fix invalid comment in ShenandoahLock (**Bug** - P5 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2868/head:pull/2868` \
`$ git checkout pull/2868`

Update a local copy of the PR: \
`$ git checkout pull/2868` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2868`

View PR using the GUI difftool: \
`$ git pr show -t 2868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2868.diff">https://git.openjdk.org/jdk17u-dev/pull/2868.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2868#issuecomment-2346363490)