### PR TITLE
8294193: Files.createDirectories throws FileAlreadyExistsException for a symbolic link whose target is an existing directory

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -806,7 +806,7 @@ public final class Files {
         try {
             createDirectory(dir, attrs);
         } catch (FileAlreadyExistsException x) {
-            if (!isDirectory(dir, LinkOption.NOFOLLOW_LINKS))
+            if (!isDirectory(dir))
                 throw x;
         }
     }

--- a/test/jdk/java/nio/file/Files/CreateDirectories.java
+++ b/test/jdk/java/nio/file/Files/CreateDirectories.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.testng.Assert.*;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @bug 8032220 8293792
+ * @summary Test java.nio.file.Files.createDirectories method
+ * @library ..
+ * @run testng CreateDirectories
+ */
+public class CreateDirectories {
+
+    /**
+     * Test Files.createDirectories symbolic file with an existing directory.
+     */
+    @Test
+    public void testSymlinkDir() throws Exception {
+        // create a temp dir as the "root" in which we will run our tests.
+        final Path top = TestUtil.createTemporaryDirectory();
+        if (!TestUtil.supportsLinks(top)) {
+            System.out.println("Skipping tests since symbolic links isn't " +
+                    "supported under directory "+ top);
+            throw new SkipException("Symbolic links not supported");
+        }
+        System.out.println("Running tests under directory " + top.toAbsolutePath());
+        final Path fooDir = Files.createDirectory(top.resolve("foo"));
+        assertTrue(Files.isDirectory(fooDir),
+                fooDir + " was expected to be a directory but wasn't");
+
+        // now create a symlink to the "foo" dir
+        final Path symlink = Files.createSymbolicLink(top.resolve("symlinkToFoo"),
+                fooDir.toAbsolutePath());
+        assertTrue(Files.isSymbolicLink(symlink),
+                symlink + " was expected to be a symlink but wasn't");
+        assertTrue(Files.isDirectory(symlink),
+                symlink + " was expected to be a directory but wasn't");
+
+        // now create a directory under the symlink (which effectively creates a directory under
+        // "foo")
+        final Path barDir = Files.createDirectory(symlink.resolve("bar"));
+        assertTrue(Files.isDirectory(barDir),
+                barDir + " was expected to be a directory but wasn't");
+        // ultimately, we now have this directory structure:
+        // <root-dir>
+        //   |--- foo
+        //   |     |--- bar
+        //   |
+        //   |--- symlinkToFoo -> (links to) <absolute-path-to-root-dir>/foo
+
+
+        // now call Files.createDirectories on each of these existing directory/symlink paths
+        // and expect each one to succeed
+        Files.createDirectories(fooDir); // ./<root-dir>/foo
+        Files.createDirectories(symlink); // ./<root-dir>/symlinkToFoo
+        Files.createDirectories(barDir); // ./<root-dir>/symlinkToFoo/bar
+    }
+
+    /**
+     * Tests Files.createDirectories
+     */
+    @Test
+    public void testCreateDirectories() throws IOException {
+        final Path tmpdir = TestUtil.createTemporaryDirectory();
+        // a no-op
+        Files.createDirectories(tmpdir);
+
+        // create one directory
+        Path subdir = tmpdir.resolve("a");
+        Files.createDirectories(subdir);
+        assertTrue(Files.isDirectory(subdir), subdir + " was expected to be a directory," +
+                " but wasn't");
+
+        // create parents
+        subdir = subdir.resolve("b/c/d");
+        Files.createDirectories(subdir);
+        assertTrue(Files.isDirectory(subdir), subdir + " was expected to be a directory," +
+                " but wasn't");
+
+        // existing file is not a directory
+        Path file = Files.createFile(tmpdir.resolve("x"));
+        try {
+            Files.createDirectories(file);
+            throw new RuntimeException("failure expected");
+        } catch (FileAlreadyExistsException x) { }
+        try {
+            Files.createDirectories(file.resolve("y"));
+            throw new RuntimeException("failure expected");
+        } catch (IOException x) { }
+
+        // the root directory always exists
+        Path root = Path.of("/");
+        Files.createDirectories(root);
+        Files.createDirectories(root.toAbsolutePath());
+    }
+}

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -22,8 +22,8 @@
  */
 
 /* @test
- * @bug 4313887 6838333 8005566 8032220 8215467 8255576 8286160
- * @summary Unit test for miscellenous methods in java.nio.file.Files
+ * @bug 4313887 6838333 8005566 8215467 8255576 8286160
+ * @summary Unit test for miscellaneous methods in java.nio.file.Files
  * @library .. /test/lib
  * @build jdk.test.lib.Platform
  * @run main Misc
@@ -51,7 +51,6 @@ public class Misc {
     public static void main(String[] args) throws IOException {
         Path dir = TestUtil.createTemporaryDirectory();
         try {
-            testCreateDirectories(dir);
             testIsHidden(dir);
             testIsSameFile(dir);
             testFileTypeMethods(dir);
@@ -61,39 +60,6 @@ public class Misc {
         }
     }
 
-    /**
-     * Tests createDirectories
-     */
-    static void testCreateDirectories(Path tmpdir) throws IOException {
-        // a no-op
-        createDirectories(tmpdir);
-
-        // create one directory
-        Path subdir = tmpdir.resolve("a");
-        createDirectories(subdir);
-        assertTrue(exists(subdir));
-
-        // create parents
-        subdir = subdir.resolve("b/c/d");
-        createDirectories(subdir);
-        assertTrue(exists(subdir));
-
-        // existing file is not a directory
-        Path file = createFile(tmpdir.resolve("x"));
-        try {
-            createDirectories(file);
-            throw new RuntimeException("failure expected");
-        } catch (FileAlreadyExistsException x) { }
-        try {
-            createDirectories(file.resolve("y"));
-            throw new RuntimeException("failure expected");
-        } catch (IOException x) { }
-
-        // the root directory always exists
-        Path root = Path.of("/");
-        Files.createDirectories(root);
-        Files.createDirectories(root.toAbsolutePath());
-    }
 
     /**
      * Tests isHidden


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8294193](https://bugs.openjdk.org/browse/JDK-8294193) needs maintainer approval

### Issue
 * [JDK-8294193](https://bugs.openjdk.org/browse/JDK-8294193): Files.createDirectories throws FileAlreadyExistsException for a symbolic link whose target is an existing directory (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2870/head:pull/2870` \
`$ git checkout pull/2870`

Update a local copy of the PR: \
`$ git checkout pull/2870` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2870`

View PR using the GUI difftool: \
`$ git pr show -t 2870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2870.diff">https://git.openjdk.org/jdk17u-dev/pull/2870.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2870#issuecomment-2346661712)