### PR TITLE
8314824: Fix serviceability/jvmti/8036666/GetObjectLockCount.java to use vm flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/8036666/GetObjectLockCount.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/8036666/GetObjectLockCount.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 SAP SE. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,12 +57,14 @@ import com.sun.jdi.request.BreakpointRequest;
 import com.sun.jdi.request.ClassPrepareRequest;
 import com.sun.jdi.request.EventRequestManager;
 
+import jdk.test.lib.Utils;
 
 /*
  * @test GetObjectLockCount.java
  * @bug 8036666
  * @summary verify jvm returns correct lock recursion count
  * @requires vm.jvmti
+ * @library /test/lib
  * @run compile -g RecursiveObjectLock.java
  * @run main/othervm GetObjectLockCount
  * @author axel.siebenborn@sap.com
@@ -71,8 +74,6 @@ public class GetObjectLockCount {
 
     public static final String CLASS_NAME  = "RecursiveObjectLock";
     public static final String METHOD_NAME = "breakpoint1";
-    public static final String ARGUMENTS = "";
-
 
     /**
      * Find a com.sun.jdi.CommandLineLaunch connector
@@ -119,7 +120,7 @@ public class GetObjectLockCount {
         if (optionsArg == null) {
             throw new Error("Bad launching connector");
         }
-        optionsArg.setValue(ARGUMENTS);
+        optionsArg.setValue(String.join(" ", Utils.getTestJavaOpts()));
         return arguments;
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314824](https://bugs.openjdk.org/browse/JDK-8314824) needs maintainer approval

### Issue
 * [JDK-8314824](https://bugs.openjdk.org/browse/JDK-8314824): Fix serviceability/jvmti/8036666/GetObjectLockCount.java to use vm flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2872/head:pull/2872` \
`$ git checkout pull/2872`

Update a local copy of the PR: \
`$ git checkout pull/2872` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2872`

View PR using the GUI difftool: \
`$ git pr show -t 2872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2872.diff">https://git.openjdk.org/jdk17u-dev/pull/2872.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2872#issuecomment-2349201220)