### PR TITLE
8315406: [REDO] serviceability/jdwp/AllModulesCommandTest.java ignores VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,12 +70,6 @@ public class AllModulesCommandTest implements DebuggeeLauncher.Listener {
         // The debuggee has completed sending all the info
         // We can start the JDWP session
         jdwpLatch.countDown();
-    }
-
-    @Override
-    public void onDebuggeeError(String message) {
-        System.err.println("Debuggee error: '" + message + "'");
-        System.exit(1);
     }
 
     private void doJdwp() throws Exception {

--- a/test/hotspot/jtreg/serviceability/jdwp/StreamHandler.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/StreamHandler.java
@@ -37,10 +37,9 @@ public class StreamHandler implements Runnable {
     public interface Listener {
         /**
          * Called when a line has been read from the process output stream
-         * @param handler this StreamHandler
          * @param s the line
          */
-        void onStringRead(StreamHandler handler, String s);
+        void onStringRead(String s);
     }
 
     private final ExecutorService executor;
@@ -71,7 +70,7 @@ public class StreamHandler implements Runnable {
             BufferedReader br = new BufferedReader(new InputStreamReader(is));
             String line;
             while ((line = br.readLine()) != null) {
-                listener.onStringRead(this, line);
+                listener.onStringRead(line);
             }
         } catch (Exception x) {
             throw new RuntimeException(x);


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315406](https://bugs.openjdk.org/browse/JDK-8315406) needs maintainer approval

### Issue
 * [JDK-8315406](https://bugs.openjdk.org/browse/JDK-8315406): [REDO] serviceability/jdwp/AllModulesCommandTest.java ignores VM flags (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2873/head:pull/2873` \
`$ git checkout pull/2873`

Update a local copy of the PR: \
`$ git checkout pull/2873` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2873`

View PR using the GUI difftool: \
`$ git pr show -t 2873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2873.diff">https://git.openjdk.org/jdk17u-dev/pull/2873.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2873#issuecomment-2349205272)