### PR TITLE
8314831: NMT tests ignore vm flags

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/CommandLineDetail.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class CommandLineDetail {
 
   public static void main(String args[]) throws Exception {
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = ProcessTools.createTestJvm(
       "-XX:NativeMemoryTracking=detail",
       "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/NMT/CommandLineEmptyArgument.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineEmptyArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  /*
  * @test
  * @summary Empty argument to NMT should result in an informative error message
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/NMT/CommandLineInvalidArgument.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineInvalidArgument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  /*
  * @test
  * @summary Invalid argument to NMT should result in an informative error message
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/NMT/CommandLineSummary.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class CommandLineSummary {
 
   public static void main(String args[]) throws Exception {
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = ProcessTools.createTestJvm(
       "-XX:NativeMemoryTracking=summary",
       "-version");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/NMT/CommandLineTurnOffNMT.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineTurnOffNMT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  /*
  * @test
  * @summary Turning off NMT should not result in an error
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/NMT/JcmdWithNMTDisabled.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdWithNMTDisabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Verify that jcmd correctly reports that NMT is not enabled
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/NMT/NMTInitializationTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/NMTInitializationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,7 +156,7 @@ public class NMTInitializationTest {
         }
         vmArgs.add("-version");
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(vmArgs);
+        ProcessBuilder pb = ProcessTools.createTestJvm(vmArgs);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         if (debug) {
             output.reportDiagnosticSummary();

--- a/test/hotspot/jtreg/runtime/NMT/NMTWithCDS.java
+++ b/test/hotspot/jtreg/runtime/NMT/NMTWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,14 +38,14 @@ public class NMTWithCDS {
 
   public static void main(String[] args) throws Exception {
     ProcessBuilder pb;
-    pb = ProcessTools.createJavaProcessBuilder(
+    pb = ProcessTools.createTestJvm(
         "-XX:+UnlockDiagnosticVMOptions", "-XX:SharedArchiveFile=./NMTWithCDS.jsa", "-Xshare:dump", "-Xlog:cds");
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     try {
       output.shouldContain("Loading classes to share");
       output.shouldHaveExitValue(0);
 
-      pb = ProcessTools.createJavaProcessBuilder(
+      pb = ProcessTools.createTestJvm(
         "-XX:+UnlockDiagnosticVMOptions", "-XX:NativeMemoryTracking=detail", "-XX:SharedArchiveFile=./NMTWithCDS.jsa", "-Xshare:on", "-version");
       output = new OutputAnalyzer(pb.start());
       output.shouldContain("sharing");

--- a/test/hotspot/jtreg/runtime/NMT/PrintNMTStatistics.java
+++ b/test/hotspot/jtreg/runtime/NMT/PrintNMTStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class PrintNMTStatistics {
 
     public static void main(String args[]) throws Exception {
 
-    ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb = ProcessTools.createTestJvm(
       "-XX:+UnlockDiagnosticVMOptions",
       "-XX:+PrintNMTStatistics",
       "-XX:NativeMemoryTracking=detail",
@@ -55,7 +55,7 @@ public class PrintNMTStatistics {
     // Make sure memory reserved for Module processing is recorded.
     output_detail.shouldContain(" Module (reserved=");
 
-    ProcessBuilder pb1 = ProcessTools.createJavaProcessBuilder(
+    ProcessBuilder pb1 = ProcessTools.createTestJvm(
       "-XX:+UnlockDiagnosticVMOptions",
       "-XX:+PrintNMTStatistics",
       "-XX:NativeMemoryTracking=summary",

--- a/test/hotspot/jtreg/runtime/NMT/PrintNMTStatisticsWithNMTDisabled.java
+++ b/test/hotspot/jtreg/runtime/NMT/PrintNMTStatisticsWithNMTDisabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  /*
  * @test
  * @summary Trying to enable PrintNMTStatistics should result in a warning
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

Clean except for one file omitted:
MallocLimitTest.java is not in 17, omitted. It was introduced by 
"8291878: NMT: Malloc limits" in jdk20, not a candidate for backport to 17

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314831](https://bugs.openjdk.org/browse/JDK-8314831) needs maintainer approval

### Issue
 * [JDK-8314831](https://bugs.openjdk.org/browse/JDK-8314831): NMT tests ignore vm flags (**Sub-task** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2874/head:pull/2874` \
`$ git checkout pull/2874`

Update a local copy of the PR: \
`$ git checkout pull/2874` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2874`

View PR using the GUI difftool: \
`$ git pr show -t 2874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2874.diff">https://git.openjdk.org/jdk17u-dev/pull/2874.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2874#issuecomment-2349223006)