### PR TITLE
8315988: Parallel: Make TestAggressiveHeap use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java
+++ b/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class TestAggressiveHeap {
         " *bool +UseParallelGC *= *true +\\{product\\} *\\{command line\\}";
 
     private static void testFlag() throws Exception {
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+        ProcessBuilder pb = GCArguments.createTestJvm(
             option, heapSizeOption, "-XX:+PrintFlagsFinal", "-version");
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315988](https://bugs.openjdk.org/browse/JDK-8315988) needs maintainer approval

### Issue
 * [JDK-8315988](https://bugs.openjdk.org/browse/JDK-8315988): Parallel: Make TestAggressiveHeap use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2875/head:pull/2875` \
`$ git checkout pull/2875`

Update a local copy of the PR: \
`$ git checkout pull/2875` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2875`

View PR using the GUI difftool: \
`$ git pr show -t 2875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2875.diff">https://git.openjdk.org/jdk17u-dev/pull/2875.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2875#issuecomment-2349666024)