### PR TITLE
8314829: serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java ignores vm flags

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -32,6 +32,7 @@ vmTestbase/jit/escape/AdaptiveBlocking/AdaptiveBlocking001/AdaptiveBlocking001.j
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8220624   generic-all
 serviceability/sa/CDSJMapClstats.java                         8220624   generic-all
 serviceability/sa/ClhsdbJhisto.java                           8220624   generic-all
+serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java      8276539   generic-all
 
 serviceability/sa/ClhsdbCDSCore.java                          8268722   macosx-x64
 serviceability/sa/ClhsdbFindPC.java#id1                       8268722   macosx-x64

--- a/test/hotspot/jtreg/serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class JMapHProfLargeHeapTest {
     private static void testHProfFileFormat(String vmArgs, long heapSize,
             String expectedFormat) throws Exception, IOException,
             InterruptedException, FileNotFoundException {
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder procBuilder = ProcessTools.createTestJvm(
                 "--add-exports=java.management/sun.management=ALL-UNNAMED", vmArgs, "JMapHProfLargeHeapProc", String.valueOf(heapSize));
         procBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
         Process largeHeapProc = procBuilder.start();


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

Resolved ProblemList, probably clean

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314829](https://bugs.openjdk.org/browse/JDK-8314829) needs maintainer approval

### Issue
 * [JDK-8314829](https://bugs.openjdk.org/browse/JDK-8314829): serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java ignores vm flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2876/head:pull/2876` \
`$ git checkout pull/2876`

Update a local copy of the PR: \
`$ git checkout pull/2876` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2876`

View PR using the GUI difftool: \
`$ git pr show -t 2876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2876.diff">https://git.openjdk.org/jdk17u-dev/pull/2876.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2876#issuecomment-2349693235)