### PR TITLE
8332724: x86 MacroAssembler may over-align code

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -3325,7 +3325,7 @@ void Assembler::negl(Address dst) {
   emit_operand(as_Register(3), dst);
 }
 
-void Assembler::nop(int i) {
+void Assembler::nop(uint i) {
 #ifdef ASSERT
   assert(i > 0, " ");
   // The fancy nops aren't currently recognized by debuggers making it a

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1644,7 +1644,7 @@ private:
   void negq(Address dst);
 #endif
 
-  void nop(int i = 1);
+  void nop(uint i = 1);
 
   void notl(Register dst);
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1175,20 +1175,20 @@ void MacroAssembler::addpd(XMMRegister dst, AddressLiteral src) {
 // Stub code is generated once and never copied.
 // NMethods can't use this because they get copied and we can't force alignment > 32 bytes.
 void MacroAssembler::align64() {
-  align(64, (unsigned long long) pc());
+  align(64, (uint)(uintptr_t)pc());
 }
 
 void MacroAssembler::align32() {
-  align(32, (unsigned long long) pc());
+  align(32, (uint)(uintptr_t)pc());
 }
 
-void MacroAssembler::align(int modulus) {
+void MacroAssembler::align(uint modulus) {
   // 8273459: Ensure alignment is possible with current segment alignment
-  assert(modulus <= CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
+  assert(modulus <= (uintx)CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
   align(modulus, offset());
 }
 
-void MacroAssembler::align(int modulus, int target) {
+void MacroAssembler::align(uint modulus, uint target) {
   if (target % modulus != 0) {
     nop(modulus - (target % modulus));
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -196,8 +196,8 @@ class MacroAssembler: public Assembler {
   // Alignment
   void align32();
   void align64();
-  void align(int modulus);
-  void align(int modulus, int target);
+  void align(uint modulus);
+  void align(uint modulus, uint target);
 
   // A 5 byte nop that is safe for patching (see patch_verified_entry)
   void fat_nop();


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8332724](https://bugs.openjdk.org/browse/JDK-8332724) needs maintainer approval

### Issue
 * [JDK-8332724](https://bugs.openjdk.org/browse/JDK-8332724): x86 MacroAssembler may over-align code (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2880/head:pull/2880` \
`$ git checkout pull/2880`

Update a local copy of the PR: \
`$ git checkout pull/2880` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2880`

View PR using the GUI difftool: \
`$ git pr show -t 2880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2880.diff">https://git.openjdk.org/jdk17u-dev/pull/2880.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2880#issuecomment-2349854984)