### PR TITLE
8324808: Manual printer tests have no Pass/Fail buttons, instructions close set 3

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PageDlgPrnButton.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDlgPrnButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,209 +21,93 @@
  * questions.
  */
 
-/**
- * @test
- * @bug 4956397
- * @key printer
- * @run main/manual PageDlgPrnButton
- */
-
-import java.awt.print.PrinterJob;
-import java.awt.print.PageFormat;
-import java.awt.print.Printable;
-import java.awt.print.PrinterException;
-
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.* ;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
 
-public class PageDlgPrnButton implements Printable
-{
-    public static void main ( String args[] ) {
+import jtreg.SkippedException;
 
-        String[] instructions =
-           {"For non-windows OS, this test PASSes.",
-            "You must have at least 2 printers available to perform this test.",
-            "This test brings up a native Windows page dialog.",
-            "Click on the Printer... button and change the selected printer. ",
-            "Test passes if the printout comes from the new selected printer.",
-         };
+/*
+ * @test
+ * @bug 4956397
+ * @key printer
+ * @requires os.family=="windows"
+ * @library /test/lib /java/awt/regtesthelpers
+ * @build PassFailJFrame jtreg.SkippedException
+ * @run main/manual PageDlgPrnButton
+ */
+public class PageDlgPrnButton implements Printable {
+    private static final String INSTRUCTIONS =
+            "This test brings up a native Windows page dialog.\n" +
+            "Click on the Printer... button and change the selected printer. \n" +
+            "Test passes if the printout comes from the new selected printer.";
 
-         Sysout.createDialog( );
-         Sysout.printInstructions( instructions );
-
-        PageDlgPrnButton pdpb = new PageDlgPrnButton() ;
-    }
-
-    public PageDlgPrnButton()
-    {
-        try
-        {
-            pageDialogExample();
+    public static void main(String[] args) throws Exception {
+        final int serviceCount = PrinterJob.lookupPrintServices().length;
+        if (serviceCount == 0) {
+            throw new RuntimeException("Printer not configured or available.");
         }
-        catch(Exception e)
-        {e.printStackTrace(System.err);}
-    }
+        if (serviceCount < 2) {
+            throw new SkippedException("The test requires at least 2 printers.");
+        }
 
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
+
+        pageDialogExample();
+        passFailJFrame.awaitAndCheck();
+    }
 
     // This example just displays the page dialog - you cannot change
     // the printer (press the "Printer..." button and choose one if you like).
-    public void pageDialogExample() throws PrinterException
-    {
+    public static void pageDialogExample() throws PrinterException {
         PrinterJob job = PrinterJob.getPrinterJob();
         PageFormat originalPageFormat = job.defaultPage();
         PageFormat pageFormat = job.pageDialog(originalPageFormat);
 
-        if(originalPageFormat == pageFormat) return;
-
-        job.setPrintable(this,pageFormat);
-        job.print();
+        job.setPrintable(new PageDlgPrnButton(), pageFormat);
+        if (job.printDialog()) {
+            job.print();
+        }
     }
 
-
-
-    public int print(Graphics g, PageFormat pageFormat, int pageIndex)
-    {
+    @Override
+    public int print(Graphics g, PageFormat pageFormat, int pageIndex) {
         final int boxWidth = 100;
         final int boxHeight = 100;
-        final Rectangle rect = new Rectangle(0,0,boxWidth,boxHeight);
+        final Rectangle rect = new Rectangle(0, 0, boxWidth, boxHeight);
         final double pageH = pageFormat.getImageableHeight();
         final double pageW = pageFormat.getImageableWidth();
+        final Graphics2D g2d = (Graphics2D) g;
 
-        if (pageIndex > 0) return (NO_SUCH_PAGE);
-
-        final Graphics2D g2d = (Graphics2D)g;
+        if (pageIndex > 0) {
+            return NO_SUCH_PAGE;
+        }
 
         // Move the (x,y) origin to account for the left-hand and top margins
         g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
 
         // Draw the page bounding box
-        g2d.drawRect(0,0,(int)pageW,(int)pageH);
+        g2d.drawRect(0, 0, (int) pageW, (int) pageH);
 
         // Select the smaller scaling factor so that the figure
         // fits on the page in both dimensions
-        final double scale = Math.min( (pageW/boxWidth), (pageH/boxHeight) );
+        final double scale = Math.min((pageW / boxWidth), (pageH / boxHeight));
 
-        if(scale < 1.0) g2d.scale(scale, scale);
+        if (scale < 1.0) {
+            g2d.scale(scale, scale);
+        }
 
         // Paint the scaled component on the printer
         g2d.fillRect(rect.x, rect.y, rect.width, rect.height);
 
-        return(PAGE_EXISTS);
+        return PAGE_EXISTS;
     }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintCompoundString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintCompoundString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,226 +21,87 @@
  * questions.
  */
 
-/**
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JOptionPane;
+
+/*
  * @test
  * @bug 4396835
  * @summary Compound font string not printing.
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual PrintCompoundString
  */
+public class PrintCompoundString implements Printable {
+    private static final String STR = "Test string compound printing \u2203\u2200\u2211";
 
+    private static final String INSTRUCTIONS =
+            "This test should print following text\n\n" +
+            STR +"\n\n" +
+            "If an exception is thrown, or the page doesn't print properly\n" +
+            "then the test fails";
 
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import java.text.*;
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-public class PrintCompoundString extends Frame implements ActionListener {
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .splitUI(PrintCompoundString::createTestUI)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 
- private TextCanvas c;
-
- public static void main(String args[]) {
-
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test should print a page which contains the same",
-         "text message as in the test window on the screen",
-         "You should also monitor the command line to see if any exceptions",
-         "were thrown",
-         "If an exception is thrown, or the page doesn't print properly",
-         "then the test fails",
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-    PrintCompoundString f = new PrintCompoundString();
-    f.show();
- }
-
- public PrintCompoundString() {
-    super("JDK 1.2 drawString Printing");
-
-    c = new TextCanvas();
-    add("Center", c);
-
-    Button printButton = new Button("Print");
-    printButton.addActionListener(this);
-    add("South", printButton);
-
-    addWindowListener(new WindowAdapter() {
-       public void windowClosing(WindowEvent e) {
-             System.exit(0);
+    private static JComponent createTestUI() {
+        JButton b = new JButton("Print");
+        b.addActionListener((ae) -> {
+            try {
+                PrinterJob job = PrinterJob.getPrinterJob();
+                job.setPrintable(new PrintCompoundString());
+                if (job.printDialog()) {
+                    job.print();
+                }
+            } catch (PrinterException ex) {
+                ex.printStackTrace();
+                String msg = "PrinterException: " + ex.getMessage();
+                JOptionPane.showMessageDialog(b, msg, "Error occurred",
+                        JOptionPane.ERROR_MESSAGE);
+                PassFailJFrame.forceFail(msg);
             }
-    });
+        });
 
-    pack();
- }
+        Box main = Box.createHorizontalBox();
+        main.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        main.add(Box.createHorizontalGlue());
+        main.add(b);
+        main.add(Box.createHorizontalGlue());
+        return main;
+    }
 
- public void actionPerformed(ActionEvent e) {
-
-   PrinterJob pj = PrinterJob.getPrinterJob();
-
-   if (pj != null && pj.printDialog()) {
-
-       pj.setPrintable(c);
-       try {
-            pj.print();
-      } catch (PrinterException pe) {
-      } finally {
-         System.err.println("PRINT RETURNED");
-      }
-   }
- }
-
- class TextCanvas extends Panel implements Printable {
-
-    String nullStr = null;
-    String emptyStr = new String();
-    AttributedString nullAttStr = null;
-    AttributedString emptyAttStr = new AttributedString(emptyStr);
-    AttributedCharacterIterator nullIterator = null;
-    AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
-
+    @Override
     public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
+        if (pgIndex > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-      if (pgIndex > 0)
-         return Printable.NO_SUCH_PAGE;
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+        g2d.drawString(STR, 20, 40);
 
-      Graphics2D g2d = (Graphics2D)g;
-      g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-
-      paint(g);
-
-      return Printable.PAGE_EXISTS;
+        return Printable.PAGE_EXISTS;
     }
-
-    public void paint(Graphics g1) {
-        Graphics2D g = (Graphics2D)g1;
-
-          String str = "Test string compound printing \u2203\u2200\u2211";
-          g.drawString(str, 20, 40);
-
-    }
-
-     public Dimension getPreferredSize() {
-        return new Dimension(450, 250);
-    }
- }
-
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,276 +21,152 @@
  * questions.
  */
 
-/**
- * @test %I %W
+import java.awt.BorderLayout;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+/*
+ * @test
  * @bug 4298489
  * @summary Confirm that output is same as screen.
  * @key printer
+ * @requires os.family=="windows"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual PrintImage
  */
-import java.awt.*;
-import java.awt.print.*;
-import java.awt.event.*;
-
 public class PrintImage extends Frame implements ActionListener {
+    private final PrintImageCanvas printImageCanvas = new PrintImageCanvas();
+    private final MenuItem print1Menu = new MenuItem("PrintTest1");
+    private final MenuItem print2Menu = new MenuItem("PrintTest2");
+    private static final String INSTRUCTIONS =
+            "Select PrintTest1 in the File menu.\n" +
+            "Print Dialog will appear.\n" +
+            "Click OK to start the first print job.\n" +
+            "\n" +
+            "Select PrintTest2 in the File menu.\n" +
+            "Page Setup Dialog will appear.\n" +
+            "Click OK.\n" +
+            "Print Dialog will appear.\n" +
+            "Click OK to start the second print job.\n" +
+            "\n" +
+            "The text in the printouts for PrintTest1 and PrintTest2 should be\n" +
+            "same as that on the screen.\n" +
+            "Press Pass if they are, otherwise press Fail.";
 
-        private PrintImageCanvas                printImageCanvas;
-
-        private MenuItem        print1Menu = new MenuItem("PrintTest1");
-        private MenuItem        print2Menu = new MenuItem("PrintTest2");
-        private MenuItem        exitMenu = new MenuItem("Exit");
-
-        public static void main(String[] argv) {
-        String[] instructions =
-           { "You must have a printer available to perform this test,",
-             "prefererably Canon LaserShot A309GII.",
-             "Printing must be done in Win 98 Japanese 2nd Edition.",
-             "",
-             "Passing test : Output of text image for PrintTest1 and PrintTest2 should be same as that on the screen.",
-           };
-
-        Sysout.createDialog( );
-         Sysout.printInstructions( instructions );
-
-                new PrintImage();
+    public static void main(String[] argv) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
         }
 
-        public PrintImage() {
-                super("PrintImage");
-                initPrintImage();
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .testUI(PrintImage::new)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public PrintImage() {
+        super("PrintImage");
+        initPrintImage();
+    }
+
+    public void initPrintImage() {
+        initMenu();
+        setLayout(new BorderLayout());
+        add(printImageCanvas, BorderLayout.CENTER);
+        setSize(500, 300);
+    }
+
+    private void initMenu() {
+        MenuBar mb = new MenuBar();
+        Menu me = new Menu("File");
+        me.add(print1Menu);
+        me.add(print2Menu);
+        mb.add(me);
+        setMenuBar(mb);
+
+        print1Menu.addActionListener(this);
+        print2Menu.addActionListener(this);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        Object target = e.getSource();
+        if (target.equals(print1Menu)) {
+            printMain1();
+        } else if (target.equals(print2Menu)) {
+            printMain2();
         }
+    }
 
-        public void initPrintImage() {
+    private void printMain1() {
+        PrinterJob printerJob = PrinterJob.getPrinterJob();
+        PageFormat pageFormat = printerJob.defaultPage();
 
-                printImageCanvas = new PrintImageCanvas(this);
+        printerJob.setPrintable(printImageCanvas, pageFormat);
 
-                initMenu();
-
-                addWindowListener(new WindowAdapter() {
-                        public void windowClosing(WindowEvent ev) {
-                                dispose();
-                        }
-                        public void windowClosed(WindowEvent ev) {
-                                System.exit(0);
-                        }
-                });
-
-                setLayout(new BorderLayout());
-                add(printImageCanvas, BorderLayout.CENTER);
-                pack();
-
-                setSize(500,500);
-                setVisible(true);
+        if (printerJob.printDialog()) {
+            try {
+                printerJob.print();
+            } catch (PrinterException e) {
+                PassFailJFrame.forceFail("Print Failed");
+                e.printStackTrace();
+            }
+        } else {
+            printerJob.cancel();
         }
+    }
 
-        private void initMenu() {
-                MenuBar         mb = new MenuBar();
-                Menu            me = new Menu("File");
-                me.add(print1Menu);
-                me.add(print2Menu);
-                me.add("-");
-                me.add(exitMenu);
-                mb.add(me);
-                this.setMenuBar(mb);
+    private void printMain2() {
+        PrinterJob printerJob = PrinterJob.getPrinterJob();
+        PageFormat pageFormat = printerJob.pageDialog(printerJob.defaultPage());
 
-                print1Menu.addActionListener(this);
-                print2Menu.addActionListener(this);
-                exitMenu.addActionListener(this);
+        printerJob.setPrintable(printImageCanvas, pageFormat);
+
+        if (printerJob.printDialog()) {
+            try {
+                printerJob.print();
+            } catch (PrinterException e) {
+                PassFailJFrame.forceFail("Print Failed");
+                e.printStackTrace();
+            }
+        } else {
+            printerJob.cancel();
         }
+    }
 
-        public void actionPerformed(ActionEvent e) {
-                Object target = e.getSource();
-                if( target.equals(print1Menu) ) {
-                        printMain1();
-                }
-                else if( target.equals(print2Menu) ) {
-                        printMain2();
-                }
-                else if( target.equals(exitMenu) ) {
-                        dispose();
-                }
-        }
-
-        private void printMain1(){
-
-                PrinterJob printerJob = PrinterJob.getPrinterJob();
-                PageFormat pageFormat = printerJob.defaultPage();
-
-                printerJob.setPrintable((Printable)printImageCanvas, pageFormat);
-
-                if(printerJob.printDialog()){
-                        try {
-                                printerJob.print();
-                        }
-                        catch(PrinterException p){
-                        }
-                }
-                else
-                        printerJob.cancel();
-        }
-
-        private void printMain2(){
-
-                PrinterJob printerJob = PrinterJob.getPrinterJob();
-                PageFormat pageFormat = printerJob.pageDialog(printerJob.defaultPage());
-
-                printerJob.setPrintable((Printable)printImageCanvas, pageFormat);
-
-                if(printerJob.printDialog()){
-                        try {
-                                printerJob.print();
-                        }
-                        catch(PrinterException p){
-                        }
-                }
-                else
-                        printerJob.cancel();
-        }
-
-}
-
-class PrintImageCanvas extends Canvas implements Printable {
-
-        private PrintImage pdsFrame;
-
-        public PrintImageCanvas(PrintImage pds) {
-                pdsFrame = pds;
-        }
-
+    private static class PrintImageCanvas extends Canvas implements Printable {
+        @Override
         public void paint(Graphics g) {
-                Font drawFont = new Font("MS Mincho",Font.ITALIC,50);
-                g.setFont(drawFont);
-                g.drawString("PrintSample!",100,150);
+            Font drawFont = new Font("MS Mincho", Font.ITALIC, 50);
+            g.setFont(drawFont);
+            g.setColor(new Color(0, 0, 0, 200));
+            g.drawString("PrintSample!", 100, 150);
         }
 
+        @Override
         public int print(Graphics g, PageFormat pf, int pi)
                 throws PrinterException {
-
-                if(pi>=1)
-                        return NO_SUCH_PAGE;
-                else{
-                        Graphics2D g2 = (Graphics2D)g;
-                        g.setColor(new Color(0,0,0,200));
-
-                        Font drawFont = new Font("MS Mincho",Font.ITALIC,50);
-                        g.setFont(drawFont);
-                        g.drawString("PrintSample!",100,150);
-                        return PAGE_EXISTS;
-                }
+            if (pi > 0) {
+                return NO_SUCH_PAGE;
+            }
+            paint(g);
+            return PAGE_EXISTS;
         }
+    }
 }
 
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,308 +21,164 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+
+import javax.swing.JOptionPane;
+
+/*
  * @test
  * @bug 4223328
  * @summary Printer graphics must behave the same as screen graphics
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual PrintNullString
  */
+public class PrintNullString extends Frame {
+    private static final String INSTRUCTIONS =
+            "This test should print a page which contains the same\n" +
+            "text messages as in the test window on the screen.\n" +
+            "\n" +
+            "The messages should contain only 'OK' and 'expected' messages.\n" +
+            "Press Pass if it's the case; otherwise press Fail.\n" +
+            "\n" +
+            "If the page fails to print, but there were no exceptions\n" +
+            "then the problem is likely elsewhere (i.e. your printer)";
 
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import java.text.*;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .testUI(PrintNullString::new)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 
-public class PrintNullString extends Frame implements ActionListener {
+    public PrintNullString() {
+        super("PrintNullString");
 
- private TextCanvas c;
+        TextCanvas c = new TextCanvas();
+        add("Center", c);
 
- public static void main(String args[]) {
-
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test should print a page which contains the same",
-         "text messages as in the test window on the screen",
-         "The messages should contain only 'OK' and 'expected' messages",
-         "There should be no FAILURE messages.",
-         "You should also monitor the command line to see if any exceptions",
-         "were thrown",
-         "If the page fails to print, but there were no exceptions",
-         "then the problem is likely elsewhere (ie your printer)"
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-    PrintNullString f = new PrintNullString();
-    f.show();
- }
-
- public PrintNullString() {
-    super("JDK 1.2 drawString Printing");
-
-    c = new TextCanvas();
-    add("Center", c);
-
-    Button printButton = new Button("Print");
-    printButton.addActionListener(this);
-    add("South", printButton);
-
-    addWindowListener(new WindowAdapter() {
-       public void windowClosing(WindowEvent e) {
-             System.exit(0);
+        Button b = new Button("Print");
+        add("South", b);
+        b.addActionListener(e -> {
+            PrinterJob pj = PrinterJob.getPrinterJob();
+            if (pj.printDialog()) {
+                pj.setPrintable(c);
+                try {
+                    pj.print();
+                } catch (PrinterException ex) {
+                    ex.printStackTrace();
+                    String msg = "PrinterException: " + ex.getMessage();
+                    JOptionPane.showMessageDialog(b, msg, "Error occurred",
+                            JOptionPane.ERROR_MESSAGE);
+                    PassFailJFrame.forceFail(msg);
+                }
             }
-    });
-
-    pack();
- }
-
- public void actionPerformed(ActionEvent e) {
-
-   PrinterJob pj = PrinterJob.getPrinterJob();
-
-   if (pj != null && pj.printDialog()) {
-
-       pj.setPrintable(c);
-       try {
-            pj.print();
-      } catch (PrinterException pe) {
-      } finally {
-         System.err.println("PRINT RETURNED");
-      }
-   }
- }
-
- class TextCanvas extends Panel implements Printable {
-
-    String nullStr = null;
-    String emptyStr = new String();
-    AttributedString nullAttStr = null;
-    AttributedString emptyAttStr = new AttributedString(emptyStr);
-    AttributedCharacterIterator nullIterator = null;
-    AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
-
-    public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-
-      if (pgIndex > 0)
-         return Printable.NO_SUCH_PAGE;
-
-      Graphics2D g2d = (Graphics2D)g;
-      g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-
-      paint(g);
-
-      return Printable.PAGE_EXISTS;
+        });
+        pack();
     }
 
-    public void paint(Graphics g1) {
-        Graphics2D g = (Graphics2D)g1;
+    private static class TextCanvas extends Panel implements Printable {
+        private final String nullStr = null;
+        private final String emptyStr = "";
+        private final AttributedString emptyAttStr = new AttributedString(emptyStr);
+        private final AttributedCharacterIterator nullIterator = null;
+        private final AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
 
-        // API 1: null & empty drawString(String, int, int);
-        try {
-             g.drawString(nullStr, 20, 40);
-             g.drawString("FAILURE: No NPE for null String, int", 20, 40);
-        } catch (NullPointerException e) {
-          g.drawString("caught expected NPE for null String, int", 20, 40);
-        }/* catch (Exception e) {
-          g.drawString("FAILURE: unexpected exception for null String, int",
-                        20, 40);
-        }*/
+        @Override
+        public void paint(Graphics g) {
+            Graphics2D g2d = (Graphics2D) g;
+            paint(g2d);
+        }
 
-        //try {
-             g.drawString(emptyStr, 20, 60);
-             g.drawString("OK for empty String, int", 20, 60);
-        /*} catch (Exception e) {
-          g.drawString("FAILURE: unexpected exception for empty String, int",
-                        20, 60);
-        }*/
+        @Override
+        public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
+            if (pgIndex > 0) {
+                return NO_SUCH_PAGE;
+            }
 
+            Graphics2D g2d = (Graphics2D) g;
+            g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+            paint(g2d);
 
-        // API 2: null & empty drawString(String, float, float);
-        try {
-             g.drawString(nullStr, 20.0f, 80.0f);
-             g.drawString("FAILURE: No NPE for null String, float", 20, 80);
-        } catch (NullPointerException e) {
-          g.drawString("caught expected NPE for null String, float", 20, 80);
-        } /*catch (Exception e) {
-          g.drawString("FAILURE: unexpected exception for null String, float",
-                        20, 80);
-        }*/
-        //try {
-             g.drawString(emptyStr, 20.0f, 100.0f);
-             g.drawString("OK for empty String, float", 20.0f, 100.f);
-        /* } catch (Exception e) {
-          g.drawString("FAILURE: unexpected exception for empty String, float",
-                        20, 100);
-        }*/
+            return PAGE_EXISTS;
+        }
 
-        // API 3: null & empty drawString(Iterator, int, int);
-        try {
-             g.drawString(nullIterator, 20, 120);
-             g.drawString("FAILURE: No NPE for null iterator, float", 20, 120);
-        } catch (NullPointerException e) {
-          g.drawString("caught expected NPE for null iterator, int", 20, 120);
-        } /*catch (Exception e) {
-          g.drawString("FAILURE: unexpected exception for null iterator, int",
-                       20, 120);
-        } */
-        try {
-             g.drawString(emptyIterator, 20, 140);
-             g.drawString("FAILURE: No IAE for empty iterator, int",
-                           20, 140);
-        } catch (IllegalArgumentException e) {
-          g.drawString("caught expected IAE for empty iterator, int",
-                        20, 140);
-        } /*catch (Exception e) {
-          g.drawString("FAILURE: unexpected exception for empty iterator, int",
-                       20, 140);
-        } */
+        private void paint(Graphics2D g2d) {
+            // API 1: null & empty drawString(String, int, int);
+            try {
+                g2d.drawString(nullStr, 20, 40);
+                g2d.drawString("FAILURE: No NPE for null String, int", 20, 40);
+            } catch (NullPointerException e) {
+                g2d.drawString("caught expected NPE for null String, int", 20, 40);
+            }
 
+            g2d.drawString(emptyStr, 20, 60);
+            g2d.drawString("OK for empty String, int", 20, 60);
 
-        // API 4: null & empty drawString(Iterator, float, int);
-        try {
-             g.drawString(nullIterator, 20.0f, 160.0f);
-             g.drawString("FAILURE: No NPE for null iterator, float", 20, 160);
-        } catch (NullPointerException e) {
-          g.drawString("caught expected NPE for null iterator, float", 20, 160);
-        } /*catch (Exception e) {
-          g.drawString("FAILURE: unexpected exception for null iterator, float",
-                        20, 160);
-        } */
+            // API 2: null & empty drawString(String, float, float);
+            try {
+                g2d.drawString(nullStr, 20.0f, 80.0f);
+                g2d.drawString("FAILURE: No NPE for null String, float", 20, 80);
+            } catch (NullPointerException e) {
+                g2d.drawString("caught expected NPE for null String, float", 20, 80);
+            }
 
-        try {
-             g.drawString(emptyIterator, 20, 180);
-             g.drawString("FAILURE: No IAE for empty iterator, float",
-                           20, 180);
-        } catch (IllegalArgumentException e) {
-          g.drawString("caught expected IAE for empty iterator, float",
-                        20, 180);
-        } /*catch (Exception e) {
-          g.drawString("FAILURE: unexpected exception for empty iterator, float",
-                       20, 180);
-        } */
+            g2d.drawString(emptyStr, 20.0f, 100.0f);
+            g2d.drawString("OK for empty String, float", 20.0f, 100.f);
+
+            // API 3: null & empty drawString(Iterator, int, int);
+            try {
+                g2d.drawString(nullIterator, 20, 120);
+                g2d.drawString("FAILURE: No NPE for null iterator, float", 20, 120);
+            } catch (NullPointerException e) {
+                g2d.drawString("caught expected NPE for null iterator, int", 20, 120);
+            }
+
+            try {
+                g2d.drawString(emptyIterator, 20, 140);
+                g2d.drawString("FAILURE: No IAE for empty iterator, int", 20, 140);
+            } catch (IllegalArgumentException e) {
+                g2d.drawString("caught expected IAE for empty iterator, int", 20, 140);
+            }
+
+            // API 4: null & empty drawString(Iterator, float, int);
+            try {
+                g2d.drawString(nullIterator, 20.0f, 160.0f);
+                g2d.drawString("FAILURE: No NPE for null iterator, float", 20, 160);
+            } catch (NullPointerException e) {
+                g2d.drawString("caught expected NPE for null iterator, float", 20, 160);
+            }
+
+            try {
+                g2d.drawString(emptyIterator, 20, 180);
+                g2d.drawString("FAILURE: No IAE for empty iterator, float", 20, 180);
+            } catch (IllegalArgumentException e) {
+                g2d.drawString("caught expected IAE for empty iterator, float", 20, 180);
+            }
+        }
+
+        @Override
+        public Dimension getPreferredSize() {
+            return new Dimension(450, 250);
+        }
     }
-
-     public Dimension getPreferredSize() {
-        return new Dimension(450, 250);
-    }
- }
-
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324808](https://bugs.openjdk.org/browse/JDK-8324808) needs maintainer approval

### Issue
 * [JDK-8324808](https://bugs.openjdk.org/browse/JDK-8324808): Manual printer tests have no Pass/Fail buttons, instructions close set 3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2887/head:pull/2887` \
`$ git checkout pull/2887`

Update a local copy of the PR: \
`$ git checkout pull/2887` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2887`

View PR using the GUI difftool: \
`$ git pr show -t 2887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2887.diff">https://git.openjdk.org/jdk17u-dev/pull/2887.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2887#issuecomment-2357653670)