### PR TITLE
8328957: Update PKCS11Test.java to not use hardcoded path

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,9 +53,7 @@ import java.util.Properties;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jdk.test.lib.Platform;
 import jdk.test.lib.artifacts.Artifact;
@@ -256,19 +254,13 @@ public abstract class PKCS11Test {
 
     static Path getNSSLibPath(String library) throws Exception {
         String osid = getOsId();
-        String nssLibDir = fetchNssLib(osid);
-        if (nssLibDir == null) {
+        Path libraryName = Path.of(System.mapLibraryName(library));
+        Path nssLibPath = fetchNssLib(osid, libraryName);
+        if (nssLibPath == null) {
             throw new SkippedException("Warning: unsupported OS: " + osid
                     + ", please initialize NSS library location, skipping test");
         }
-
-        String libraryName = System.mapLibraryName(library);
-        Path libPath = Paths.get(nssLibDir).resolve(libraryName);
-        if (!Files.exists(libPath)) {
-            throw new SkippedException("NSS library \"" + libraryName + "\" was not found in " + nssLibDir);
-        }
-
-        return libPath;
+        return nssLibPath;
     }
 
     private static String getOsId() {
@@ -674,42 +666,42 @@ public abstract class PKCS11Test {
         return data;
     }
 
-    private static String fetchNssLib(String osId) {
+    private static Path fetchNssLib(String osId, Path libraryName) {
         switch (osId) {
             case "Windows-amd64-64":
-                return fetchNssLib(WINDOWS_X64.class);
+                return fetchNssLib(WINDOWS_X64.class, libraryName);
 
             case "MacOSX-x86_64-64":
-                return fetchNssLib(MACOSX_X64.class);
+                return fetchNssLib(MACOSX_X64.class, libraryName);
 
             case "MacOSX-aarch64-64":
-                return fetchNssLib(MACOSX_AARCH64.class);
+                return fetchNssLib(MACOSX_AARCH64.class, libraryName);
 
             case "Linux-amd64-64":
                 if (Platform.isOracleLinux7()) {
                     throw new SkippedException("Skipping Oracle Linux prior to v8");
                 } else {
-                    return fetchNssLib(LINUX_X64.class);
+                    return fetchNssLib(LINUX_X64.class, libraryName);
                 }
 
             case "Linux-aarch64-64":
                 if (Platform.isOracleLinux7()) {
                     throw new SkippedException("Skipping Oracle Linux prior to v8");
                 } else {
-                    return fetchNssLib(LINUX_AARCH64.class);
+                    return fetchNssLib(LINUX_AARCH64.class, libraryName);
                 }
             default:
                 return null;
         }
     }
 
-    private static String fetchNssLib(Class<?> clazz) {
-        String path = null;
+    private static Path fetchNssLib(Class<?> clazz, Path libraryName) {
+        Path path = null;
         try {
-            path = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue() + File.separator + "nss"
-                    + File.separator + "lib" + File.separator;
-        } catch (ArtifactResolverException e) {
+            Path p = ArtifactResolver.resolve(clazz).entrySet().stream()
+                    .findAny().get().getValue();
+            path = findNSSLibrary(p, libraryName);
+        } catch (ArtifactResolverException | IOException e) {
             Throwable cause = e.getCause();
             if (cause == null) {
                 System.out.println("Cannot resolve artifact, "
@@ -721,6 +713,16 @@ public abstract class PKCS11Test {
         }
         Policy.setPolicy(null); // Clear the policy created by JIB if any
         return path;
+    }
+
+    private static Path findNSSLibrary(Path path, Path libraryName) throws IOException {
+        try(Stream<Path> files = Files.find(path, 10,
+                (tp, attr) -> tp.getFileName().equals(libraryName))) {
+
+            return files.findAny()
+                        .orElseThrow(() -> new SkippedException(
+                        "NSS library \"" + libraryName + "\" was not found in " + path));
+        }
     }
 
     public abstract void main(Provider p) throws Exception;


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328957](https://bugs.openjdk.org/browse/JDK-8328957) needs maintainer approval

### Issue
 * [JDK-8328957](https://bugs.openjdk.org/browse/JDK-8328957): Update PKCS11Test.java to not use hardcoded path (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2894/head:pull/2894` \
`$ git checkout pull/2894`

Update a local copy of the PR: \
`$ git checkout pull/2894` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2894`

View PR using the GUI difftool: \
`$ git pr show -t 2894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2894.diff">https://git.openjdk.org/jdk17u-dev/pull/2894.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2894#issuecomment-2358663497)