### PR TITLE
8316581: Improve performance of Symbol::print_value_on()

### DIFF
--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-
 #include "precompiled.hpp"
 #include "cds/metaspaceShared.hpp"
 #include "classfile/altHashing.hpp"
@@ -388,11 +387,9 @@ void Symbol::print() const { print_on(tty); }
 // The print_value functions are present in all builds, to support the
 // disassembler and error reporting.
 void Symbol::print_value_on(outputStream* st) const {
-  st->print("'");
-  for (int i = 0; i < utf8_length(); i++) {
-    st->print("%c", char_at(i));
-  }
-  st->print("'");
+  st->print_raw("'", 1);
+  st->print_raw((const char*)base(), utf8_length());
+  st->print_raw("'", 1);
 }
 
 void Symbol::print_value() const { print_value_on(tty); }


### PR DESCRIPTION
Clean backport to improve class unloading performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316581](https://bugs.openjdk.org/browse/JDK-8316581) needs maintainer approval

### Issue
 * [JDK-8316581](https://bugs.openjdk.org/browse/JDK-8316581): Improve performance of Symbol::print_value_on() (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2895/head:pull/2895` \
`$ git checkout pull/2895`

Update a local copy of the PR: \
`$ git checkout pull/2895` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2895`

View PR using the GUI difftool: \
`$ git pr show -t 2895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2895.diff">https://git.openjdk.org/jdk17u-dev/pull/2895.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2895#issuecomment-2360913711)