### PR TITLE
8326121: vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl failed with Full gc happened. Test was useless.

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/UnloadingTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/UnloadingTest.java
@@ -149,8 +149,6 @@ public class UnloadingTest extends GCTestBase {
     }
 
     private static void checkGCCounters() {
-//        System.out.println("WhiteBox.getWhiteBox().g1GetTotalCollections() = \t" + WhiteBox.getWhiteBox().g1GetTotalCollections());
-//        System.out.println("WhiteBox.getWhiteBox().g1GetTotalFullCollections() = \t" + WhiteBox.getWhiteBox().g1GetTotalFullCollections());
         GarbageCollectorMXBean oldGenBean = null;
         for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
             System.out.println("bean.getName() = \t\"" + bean.getName() + "\", bean.getCollectionCount() = \t" + bean.getCollectionCount());
@@ -158,9 +156,9 @@ public class UnloadingTest extends GCTestBase {
                 oldGenBean = bean;
             }
         }
-//        if (WhiteBox.getWhiteBox().g1GetTotalFullCollections() != 0 || (oldGenBean != null && oldGenBean.getCollectionCount() != 0)) {
+
         if (oldGenBean != null && oldGenBean.getCollectionCount() != 0) {
-            throw new RuntimeException("Full gc happened. Test was useless.");
+            throw new SkippedException("Full gc happened, skip the test.");
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/Tests.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/Tests.java
@@ -23,6 +23,8 @@
 
 package nsk.share.test;
 
+import jtreg.SkippedException;
+
 import nsk.share.log.*;
 import nsk.share.runner.*;
 import nsk.share.TestFailure;
@@ -82,6 +84,8 @@ public class Tests {
                                         ((Runnable) o).run();
                                 if (o instanceof TestExitCode)
                                         exitCode = ((TestExitCode) o).getExitCode();
+                        } catch (SkippedException se) {
+                                throw se;
                         } catch (RuntimeException t) {
                                 getLog().error(t);
                                 exitCode = 97;


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326121](https://bugs.openjdk.org/browse/JDK-8326121) needs maintainer approval

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8326121: vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl failed with Full gc happened. Test was useless.`

### Issue
 * [JDK-8326121](https://bugs.openjdk.org/browse/JDK-8326121): vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl failed with Full gc happened. Test was useless. (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2896/head:pull/2896` \
`$ git checkout pull/2896`

Update a local copy of the PR: \
`$ git checkout pull/2896` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2896`

View PR using the GUI difftool: \
`$ git pr show -t 2896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2896.diff">https://git.openjdk.org/jdk17u-dev/pull/2896.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2896#issuecomment-2361113005)