### PR TITLE
8335449: runtime/cds/DeterministicDump.java fails with File content different at byte ...

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8241071
  * @summary The same JDK build should always generate the same archive file (no randomness).
- * @requires vm.cds
+ * @requires vm.cds & vm.flagless
  * @library /test/lib
  * @run driver DeterministicDump
  */


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335449](https://bugs.openjdk.org/browse/JDK-8335449) needs maintainer approval

### Issue
 * [JDK-8335449](https://bugs.openjdk.org/browse/JDK-8335449): runtime/cds/DeterministicDump.java fails with File content different at byte ... (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2897/head:pull/2897` \
`$ git checkout pull/2897`

Update a local copy of the PR: \
`$ git checkout pull/2897` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2897`

View PR using the GUI difftool: \
`$ git pr show -t 2897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2897.diff">https://git.openjdk.org/jdk17u-dev/pull/2897.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2897#issuecomment-2361144627)