### PR TITLE
8325616: JFR ZGC Allocation Stall events should record stack traces

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1051,7 +1051,7 @@
     <Field type="uint" name="newRatio" label="New Ratio" description="The size of the young generation relative to the tenured generation" />
   </Event>
 
-  <Event name="ZAllocationStall" category="Java Virtual Machine, GC, Detailed" label="ZGC Allocation Stall" description="Time spent waiting for memory to become available" thread="true">
+  <Event name="ZAllocationStall" category="Java Virtual Machine, GC, Detailed" label="ZGC Allocation Stall" description="Time spent waiting for memory to become available" thread="true" stackTrace="true">
     <Field type="ZPageTypeType" name="type" label="Type" />
     <Field type="ulong" contentType="bytes" name="size" label="Size" />
   </Event>

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -777,6 +777,7 @@
 
     <event name="jdk.ZAllocationStall">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -777,6 +777,7 @@
 
     <event name="jdk.ZAllocationStall">
       <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
       <setting name="threshold">0 ms</setting>
     </event>
 


### PR DESCRIPTION
Backport of JDK-8325616, conflict in a single hunk that wants to add `ZYoungGarbageCollection` and `ZOldGarbageCollection` to `metadata.xml`, which are unrelated and part of GenZGC.

#### Verification

1. Ran jdk_jfr and hotspot_gc tests. All tests passed.

  ```
  make test TEST=hotspot_gc TEST_VM_OPTS=-XX:+UseZGC
  make test TEST=jdk_jdr TEST_VM_OPTS=-XX:+UseZGC
  ```

2. `ZAllocationStall` event has stack trace entry in the jfr for a sample java program:

```
jdk.ZAllocationStall {
  startTime = 15:07:54.691
  duration = 4.48 ms
  type = "Large"
  size = 12.0 MB
  eventThread = "main" (javaThreadId = 1)
  stackTrace = [
    AllocRate.main(String[]) line: 16
  ]
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325616](https://bugs.openjdk.org/browse/JDK-8325616) needs maintainer approval

### Issue
 * [JDK-8325616](https://bugs.openjdk.org/browse/JDK-8325616): JFR ZGC Allocation Stall events should record stack traces (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2898/head:pull/2898` \
`$ git checkout pull/2898`

Update a local copy of the PR: \
`$ git checkout pull/2898` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2898`

View PR using the GUI difftool: \
`$ git pr show -t 2898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2898.diff">https://git.openjdk.org/jdk17u-dev/pull/2898.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2898#issuecomment-2361318062)