### PR TITLE
8272746: ZipFile can't open big file (NegativeArraySizeException)

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1660,6 +1660,9 @@ public class ZipFile implements ZipConstants, Closeable {
                     zerror("invalid END header (bad central directory offset)");
                 }
                 // read in the CEN and END
+                if (end.cenlen + ENDHDR >= Integer.MAX_VALUE) {
+                    zerror("invalid END header (central directory size too large)");
+                }
                 cen = this.cen = new byte[(int)(end.cenlen + ENDHDR)];
                 if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen + ENDHDR) {
                     zerror("read CEN tables failed");

--- a/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
+++ b/test/jdk/java/util/zip/ZipFile/TestTooManyEntries.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8272746
+ * @summary ZipFile can't open big file (NegativeArraySizeException)
+ * @requires (sun.arch.data.model == "64" & os.maxMemory > 8g)
+ * @run testng/manual/othervm -Xmx8g TestTooManyEntries
+ */
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+import java.util.UUID;
+
+import static org.testng.Assert.assertThrows;
+
+public class TestTooManyEntries {
+    // Number of directories in the zip file
+    private static final int DIR_COUNT = 25000;
+    // Number of entries per directory
+    private static final int ENTRIES_IN_DIR = 1000;
+
+    // Zip file to create for testing
+    private File hugeZipFile;
+
+    /**
+     * Create a zip file and add entries that exceed the CEN limit.
+     * @throws IOException if an error occurs creating the ZIP File
+     */
+    @BeforeTest
+    public void setup() throws IOException {
+        hugeZipFile = File.createTempFile("hugeZip", ".zip", new File("."));
+        hugeZipFile.deleteOnExit();
+        long startTime = System.currentTimeMillis();
+        try (ZipOutputStream zip = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(hugeZipFile)))) {
+            for (int dirN = 0; dirN < DIR_COUNT; dirN++) {
+                String dirName = UUID.randomUUID() + "/";
+                for (int fileN = 0; fileN < ENTRIES_IN_DIR; fileN++) {
+                    ZipEntry entry = new ZipEntry(dirName + UUID.randomUUID());
+                    zip.putNextEntry(entry);
+                    zip.closeEntry(); // all files are empty
+                }
+                if ((dirN + 1) % 1000 == 0) {
+                    System.out.printf("%s / %s of entries written, file size is %sMb (%ss)%n",
+                            (dirN + 1) * ENTRIES_IN_DIR, DIR_COUNT * ENTRIES_IN_DIR, hugeZipFile.length() / 1024 / 1024,
+                            (System.currentTimeMillis() - startTime) / 1000);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates that the ZipException is thrown when the ZipFile class
+     * is initialized with a zip file whose entries exceed the CEN limit.
+     */
+    @Test
+    public void test() {
+        assertThrows(ZipException.class, () -> new ZipFile(hugeZipFile));
+    }
+}


### PR DESCRIPTION
I would like to fix this issue in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8272746](https://bugs.openjdk.org/browse/JDK-8272746) needs maintainer approval

### Issue
 * [JDK-8272746](https://bugs.openjdk.org/browse/JDK-8272746): ZipFile can't open big file (NegativeArraySizeException) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2900/head:pull/2900` \
`$ git checkout pull/2900`

Update a local copy of the PR: \
`$ git checkout pull/2900` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2900`

View PR using the GUI difftool: \
`$ git pr show -t 2900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2900.diff">https://git.openjdk.org/jdk17u-dev/pull/2900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2900#issuecomment-2363392021)