### PR TITLE
8338058: map_or_reserve_memory_aligned Windows enhance remap assertion

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3352,7 +3352,8 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
                                      os::attempt_reserve_memory_at(aligned_base, size);
   }
 
-  assert(aligned_base != NULL, "Did not manage to re-map after %d attempts?", max_attempts);
+  assert(aligned_base != nullptr,
+      "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
 
   return aligned_base;
 }


### PR DESCRIPTION
Backport of 8338058; NULL vs nullptr , also include follow up JDK-8338101

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8338101](https://bugs.openjdk.org/browse/JDK-8338101) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8338058](https://bugs.openjdk.org/browse/JDK-8338058) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8338101: remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058`

### Issues
 * [JDK-8338058](https://bugs.openjdk.org/browse/JDK-8338058): map_or_reserve_memory_aligned Windows enhance remap assertion (**Enhancement** - P4 - Approved)
 * [JDK-8338101](https://bugs.openjdk.org/browse/JDK-8338101): remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2903/head:pull/2903` \
`$ git checkout pull/2903`

Update a local copy of the PR: \
`$ git checkout pull/2903` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2903`

View PR using the GUI difftool: \
`$ git pr show -t 2903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2903.diff">https://git.openjdk.org/jdk17u-dev/pull/2903.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2903#issuecomment-2363676269)