### PR TITLE
8284874: Add comment to ProcessHandle/OnExitTest to describe zombie problem

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/OnExitTest.java
+++ b/test/jdk/java/lang/ProcessHandle/OnExitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,24 @@ public class OnExitTest extends ProcessUtil {
      */
     @Test
     public static void test2() {
+
+        // Please note (JDK-8284282):
+        //
+        // On Unix, this test relies on the ability of the system to adopt orphaned processes and
+        // reap them in a timely fashion. In other words, the ability to prevent orphans from becoming
+        // zombies.
+        //
+        // Therefore, on misconfigured or broken systems, this test may fail. These failures will manifest
+        // as timeouts. The failures depend on timing: they may not happen at all, be intermittent or
+        // constant.
+        //
+        // That will rarely be a problem on bare-metal systems but may be more common when running in
+        // Docker. Misconfigured Docker instances may run with an initial process unable to reap. One
+        // infamous example would be running jtreg tests inside a Docker via Jenkins CI.
+        //
+        // This is quite difficult - and inefficient - to fix inside this test, and rather easy to
+        // avoid. For a detailed analysis, as well as proposed workarounds, please see JDK-8284282.
+        //
         ProcessHandle procHandle = null;
         try {
             ConcurrentHashMap<ProcessHandle, ProcessHandle> processes = new ConcurrentHashMap<>();


### PR DESCRIPTION
I am backporting this to simplify follow-up backports. Comment only, harmless.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8284874](https://bugs.openjdk.org/browse/JDK-8284874) needs maintainer approval

### Issue
 * [JDK-8284874](https://bugs.openjdk.org/browse/JDK-8284874): Add comment to ProcessHandle/OnExitTest to describe zombie problem (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2906/head:pull/2906` \
`$ git checkout pull/2906`

Update a local copy of the PR: \
`$ git checkout pull/2906` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2906`

View PR using the GUI difftool: \
`$ git pr show -t 2906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2906.diff">https://git.openjdk.org/jdk17u-dev/pull/2906.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2906#issuecomment-2367724962)