### PR TITLE
8319574: Exec/process tests should be marked as flagless

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @summary Basic tests for Process and Environment Variable code
  * @modules java.base/java.lang:open
  * @requires !vm.musl
+ * @requires vm.flagless
  * @library /test/lib
  * @run main/othervm/native/timeout=300 -Djava.security.manager=allow Basic
  * @run main/othervm/native/timeout=300 -Djava.security.manager=allow -Djdk.lang.Process.launchMechanism=fork Basic

--- a/test/jdk/java/lang/ProcessBuilder/InheritIOTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/InheritIOTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8023130 8166026
  * @summary Unit test for java.lang.ProcessBuilder inheritance of standard output and standard error streams
+ * @requires vm.flagless
  * @library /test/lib
  * @build jdk.test.lib.process.*
  * @run testng InheritIOTest

--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
@@ -27,6 +27,7 @@
  * @bug 8307990
  * @requires (os.family == "linux") | (os.family == "aix") | (os.family == "mac")
  * @requires vm.debug
+ * @requires vm.flagless
  * @library /test/lib
  * @run main/othervm/timeout=300 JspawnhelperProtocol
  */

--- a/test/jdk/java/lang/ProcessBuilder/ReaderWriterTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/ReaderWriterTest.java
@@ -49,6 +49,7 @@ import jtreg.SkippedException;
 
 /*
  * @test
+ * @requires vm.flagless
  * @library /test/lib
  * @build jdk.test.lib.process.ProcessTools jdk.test.lib.hexdump.HexPrinter
  * @run testng ReaderWriterTest

--- a/test/jdk/java/lang/ProcessBuilder/SkipTest.java
+++ b/test/jdk/java/lang/ProcessBuilder/SkipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8155808
+ * @requires vm.flagless
  * @run main SkipTest
  * @summary verify skip method of Process Input Stream
  */

--- a/test/jdk/java/lang/ProcessHandle/OnExitTest.java
+++ b/test/jdk/java/lang/ProcessHandle/OnExitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import org.testng.TestNG;
 
 /*
  * @test
+ * @requires vm.flagless
  * @library /test/lib
  * @modules jdk.management
  * @build jdk.test.lib.Utils

--- a/test/jdk/java/lang/ProcessHandle/TreeTest.java
+++ b/test/jdk/java/lang/ProcessHandle/TreeTest.java
@@ -44,6 +44,7 @@ import org.testng.annotations.Test;
 
 /*
  * @test
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          jdk.management

--- a/test/jdk/java/lang/RuntimeTests/exec/ArgWithSpaceAndFinalBackslash.java
+++ b/test/jdk/java/lang/RuntimeTests/exec/ArgWithSpaceAndFinalBackslash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @bug 4794652
  * @summary Ensure that a command argument that contains a space and a final
  *          backslash is handled correctly
+ * @requires vm.flagless
  */
 
 import java.io.*;

--- a/test/jdk/java/lang/RuntimeTests/exec/Duped.java
+++ b/test/jdk/java/lang/RuntimeTests/exec/Duped.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
    @bug 4180429
    @summary Lossage in dup2 if System.in is closed.
+   @requires vm.flagless
    @run main/othervm Duped
  */
 

--- a/test/jdk/java/lang/RuntimeTests/exec/ExecWithLotsOfArgs.java
+++ b/test/jdk/java/lang/RuntimeTests/exec/ExecWithLotsOfArgs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
    @bug 4033560
    @summary 4033560 limited args of exec to 198 on Solaris. We check
             that we can actually exec more args than that.
+   @requires vm.flagless
    @author Anand Palaniswamy
    @run main/othervm ExecWithLotsOfArgs
 */

--- a/test/jdk/java/lang/RuntimeTests/exec/ExitValue.java
+++ b/test/jdk/java/lang/RuntimeTests/exec/ExitValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 4680945 4873419
  * @summary Check process exit code
+ * @requires vm.flagless
  * @author kladko, Martin Buchholz
  */
 

--- a/test/jdk/java/lang/RuntimeTests/exec/SetCwd.java
+++ b/test/jdk/java/lang/RuntimeTests/exec/SetCwd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Basic functional test for
  *          Runtime.exec(String[] command, String[] env, File path) and
  *          Runtime.exec(String command, String[] env, File path).
- *
+ * @requires vm.flagless
  * @library /test/lib
  * @run testng/othervm SetCwd
  */


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

Omitted test/jdk/java/lang/ProcessBuilder/ProcessStartLoggingTest.java. That came
with "8303392: Runtime.exec and ProcessBuilder.start should use System logger" 
which is not a candidate for backport.

Omitted test/jdk/java/lang/RuntimeTests/RuntimeExitLogTest.java. That came
with "8301627: System.exit and Runtime.exit debug logging"
which is not a candidate for backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319574](https://bugs.openjdk.org/browse/JDK-8319574) needs maintainer approval

### Issue
 * [JDK-8319574](https://bugs.openjdk.org/browse/JDK-8319574): Exec/process tests should be marked as flagless (**Sub-task** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2907/head:pull/2907` \
`$ git checkout pull/2907`

Update a local copy of the PR: \
`$ git checkout pull/2907` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2907`

View PR using the GUI difftool: \
`$ git pr show -t 2907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2907.diff">https://git.openjdk.org/jdk17u-dev/pull/2907.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2907#issuecomment-2367752048)