### PR TITLE
8320665: update jdk_core at open/test/jdk/TEST.groups

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -608,3 +608,7 @@ jdk_containers_extended = \
     :jdk_io \
     :jdk_nio \
     :jdk_svc
+
+jdk_core_no_security = \
+   :jdk_core \
+   -:jdk_security


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320665](https://bugs.openjdk.org/browse/JDK-8320665) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8320665: update jdk_core at open/test/jdk/TEST.groups`

### Issue
 * [JDK-8320665](https://bugs.openjdk.org/browse/JDK-8320665): update jdk_core at open/test/jdk/TEST.groups (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2914/head:pull/2914` \
`$ git checkout pull/2914`

Update a local copy of the PR: \
`$ git checkout pull/2914` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2914`

View PR using the GUI difftool: \
`$ git pr show -t 2914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2914.diff">https://git.openjdk.org/jdk17u-dev/pull/2914.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2914#issuecomment-2370403097)