### PR TITLE
8334405: java/nio/channels/Selector/SelectWithConsumer.java#id0 failed in testWakeupDuringSelect

### DIFF
--- a/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
+++ b/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -308,11 +308,10 @@ public class SelectWithConsumer {
             Pipe.SinkChannel sink = p.sink();
             source.configureBlocking(false);
             source.register(sel, SelectionKey.OP_READ);
-            long start = System.currentTimeMillis();
+            long start = millisTime();
             int n = sel.select(k -> assertTrue(false), 1000L);
-            long duration = System.currentTimeMillis() - start;
+            expectDuration(start, 500, Long.MAX_VALUE);
             assertTrue(n == 0);
-            assertTrue(duration > 500, "select took " + duration + " ms");
         } finally {
             closePipe(p);
         }
@@ -332,11 +331,10 @@ public class SelectWithConsumer {
         // select(Consumer, timeout)
         try (Selector sel = Selector.open()) {
             sel.wakeup();
-            long start = System.currentTimeMillis();
+            long start = millisTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            long duration = System.currentTimeMillis() - start;
+            expectDuration(start, 0, 20_000);
             assertTrue(n == 0);
-            assertTrue(duration < 5000, "select took " + duration + " ms");
         }
     }
 
@@ -354,12 +352,10 @@ public class SelectWithConsumer {
         // select(Consumer, timeout)
         try (Selector sel = Selector.open()) {
             scheduleWakeup(sel, 1, SECONDS);
-            long start = System.currentTimeMillis();
+            long start = millisTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            long duration = System.currentTimeMillis() - start;
+            expectDuration(start, 0, 20_000);
             assertTrue(n == 0);
-            assertTrue(duration > 500 && duration < 10*1000,
-                    "select took " + duration + " ms");
         }
     }
 
@@ -381,11 +377,10 @@ public class SelectWithConsumer {
         // select(Consumer, timeout)
         try (Selector sel = Selector.open()) {
             Thread.currentThread().interrupt();
-            long start = System.currentTimeMillis();
+            long start = millisTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            long duration = System.currentTimeMillis() - start;
+            expectDuration(start, 0, 20_000);
             assertTrue(n == 0);
-            assertTrue(duration < 5000, "select took " + duration + " ms");
             assertTrue(Thread.currentThread().isInterrupted());
             assertTrue(sel.isOpen());
         } finally {
@@ -763,5 +758,33 @@ public class SelectWithConsumer {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Returns the current time in milliseconds.
+     */
+    private static long millisTime() {
+        long now = System.nanoTime();
+        return TimeUnit.MILLISECONDS.convert(now, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Check the duration of a task. The method will fail with an
+     * AssertionError if the millisecond duration does not satisfy:
+     *
+     *     duration >= min && duration <= max
+     *
+     * Note that the inequalities are not strict, i.e., are inclusive.
+     *
+     * @param start start time, in milliseconds
+     * @param min minimum expected duration, in milliseconds
+     * @param max maximum expected duration, in milliseconds
+     */
+    private static void expectDuration(long start, long min, long max) {
+        long duration = millisTime() - start;
+        assertTrue(duration >= min,
+                "Duration " + duration + "ms, expected >= " + min + "ms");
+        assertTrue(duration <= max,
+                "Duration " + duration + "ms, expected <= " + max + "ms");
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

Resolved Copyright. Probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334405](https://bugs.openjdk.org/browse/JDK-8334405) needs maintainer approval

### Issue
 * [JDK-8334405](https://bugs.openjdk.org/browse/JDK-8334405): java/nio/channels/Selector/SelectWithConsumer.java#id0 failed in testWakeupDuringSelect (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2916/head:pull/2916` \
`$ git checkout pull/2916`

Update a local copy of the PR: \
`$ git checkout pull/2916` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2916`

View PR using the GUI difftool: \
`$ git pr show -t 2916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2916.diff">https://git.openjdk.org/jdk17u-dev/pull/2916.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2916#issuecomment-2371482413)