### PR TITLE
8324841: PKCS11 tests still skip execution

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -720,8 +720,8 @@ public abstract class PKCS11Test {
                 (tp, attr) -> tp.getFileName().equals(libraryName))) {
 
             return files.findAny()
-                        .orElseThrow(() -> new SkippedException(
-                        "NSS library \"" + libraryName + "\" was not found in " + path));
+                        .orElseThrow(() ->
+                            new RuntimeException("NSS library \"" + libraryName + "\" was not found in " + path));
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324841](https://bugs.openjdk.org/browse/JDK-8324841) needs maintainer approval

### Issue
 * [JDK-8324841](https://bugs.openjdk.org/browse/JDK-8324841): PKCS11 tests still skip execution (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2919/head:pull/2919` \
`$ git checkout pull/2919`

Update a local copy of the PR: \
`$ git checkout pull/2919` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2919`

View PR using the GUI difftool: \
`$ git pr show -t 2919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2919.diff">https://git.openjdk.org/jdk17u-dev/pull/2919.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2919#issuecomment-2376113201)