### PR TITLE
8313638: Add test for dump of resolved references

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1782,6 +1782,12 @@ WB_ENTRY(jint, WB_GetConstantPoolCacheLength(JNIEnv* env, jobject wb, jclass kla
   return cp->cache()->length();
 WB_END
 
+WB_ENTRY(jobjectArray, WB_GetResolvedReferences(JNIEnv* env, jobject wb, jclass klass))
+  InstanceKlass* ik = InstanceKlass::cast(java_lang_Class::as_Klass(JNIHandles::resolve(klass)));
+  objArrayOop resolved_refs= ik->constants()->resolved_references();
+  return (jobjectArray)JNIHandles::make_local(THREAD, resolved_refs);
+WB_END
+
 WB_ENTRY(jint, WB_ConstantPoolRemapInstructionOperandFromCache(JNIEnv* env, jobject wb, jclass klass, jint index))
   InstanceKlass* ik = InstanceKlass::cast(java_lang_Class::as_Klass(JNIHandles::resolve(klass)));
   ConstantPool* cp = ik->constants();
@@ -1911,18 +1917,6 @@ WB_END
 
 WB_ENTRY(jboolean, WB_AreSharedStringsIgnored(JNIEnv* env))
   return !HeapShared::closed_archive_heap_region_mapped();
-WB_END
-
-WB_ENTRY(jobject, WB_GetResolvedReferences(JNIEnv* env, jobject wb, jclass clazz))
-  Klass *k = java_lang_Class::as_Klass(JNIHandles::resolve_non_null(clazz));
-  if (k->is_instance_klass()) {
-    InstanceKlass *ik = InstanceKlass::cast(k);
-    ConstantPool *cp = ik->constants();
-    objArrayOop refs =  cp->resolved_references();
-    return (jobject)JNIHandles::make_local(THREAD, refs);
-  } else {
-    return NULL;
-  }
 WB_END
 
 WB_ENTRY(void, WB_LinkClass(JNIEnv* env, jobject wb, jclass clazz))
@@ -2553,6 +2547,7 @@ static JNINativeMethod methods[] = {
   {CC"getConstantPool0",   CC"(Ljava/lang/Class;)J",  (void*)&WB_GetConstantPool    },
   {CC"getConstantPoolCacheIndexTag0", CC"()I",  (void*)&WB_GetConstantPoolCacheIndexTag},
   {CC"getConstantPoolCacheLength0", CC"(Ljava/lang/Class;)I",  (void*)&WB_GetConstantPoolCacheLength},
+  {CC"getResolvedReferences0", CC"(Ljava/lang/Class;)[Ljava/lang/Object;", (void*)&WB_GetResolvedReferences},
   {CC"remapInstructionOperandFromCPCache0",
       CC"(Ljava/lang/Class;I)I",                      (void*)&WB_ConstantPoolRemapInstructionOperandFromCache},
   {CC"encodeConstantPoolIndyIndex0",
@@ -2578,7 +2573,6 @@ static JNINativeMethod methods[] = {
   {CC"isShared",           CC"(Ljava/lang/Object;)Z", (void*)&WB_IsShared },
   {CC"isSharedClass",      CC"(Ljava/lang/Class;)Z",  (void*)&WB_IsSharedClass },
   {CC"areSharedStringsIgnored",           CC"()Z",    (void*)&WB_AreSharedStringsIgnored },
-  {CC"getResolvedReferences", CC"(Ljava/lang/Class;)Ljava/lang/Object;", (void*)&WB_GetResolvedReferences},
   {CC"linkClass",          CC"(Ljava/lang/Class;)V",  (void*)&WB_LinkClass},
   {CC"areOpenArchiveHeapObjectsMapped",   CC"()Z",    (void*)&WB_AreOpenArchiveHeapObjectsMapped},
   {CC"isCDSIncluded",                     CC"()Z",    (void*)&WB_IsCDSIncluded },

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test ResolvedReferencesNotNullTest
+ * @bug 8313638
+ * @summary Testing resolved references array to ensure elements are non-null
+ * @requires vm.cds.write.archived.java.heap
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @build jdk.test.whitebox.WhiteBox ResolvedReferencesWb ResolvedReferencesTestApp
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run driver ResolvedReferencesNotNullTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.whitebox.WhiteBox;
+
+public class ResolvedReferencesNotNullTest {
+    public static void main(String[] args) throws Exception {
+        SharedStringsUtils.buildJarAndWhiteBox("ResolvedReferencesWb", "ResolvedReferencesTestApp");
+        String appJar = TestCommon.getTestJar(SharedStringsUtils.TEST_JAR_NAME_FULL);
+        String whiteboxParam = SharedStringsUtils.getWbParam();
+
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-cp",
+                                                                  appJar,
+                                                                  whiteboxParam,
+                                                                  "-XX:+UnlockDiagnosticVMOptions",
+                                                                  "-XX:+WhiteBoxAPI",
+                                                                  "ResolvedReferencesWb",
+                                                                  "false" // ResolvedReferencesTestApp is not archived
+                                                                  );
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
+
+        TestCommon.dump(appJar,
+                        TestCommon.list("ResolvedReferencesWb", "ResolvedReferencesTestApp"),
+                        TestCommon.concat("-XX:SharedArchiveFile=ResolvedRef.jsa",
+                                          "-XX:+UnlockDiagnosticVMOptions",
+                                          "-XX:+WhiteBoxAPI",
+                                          whiteboxParam));
+
+        // Since ResolvedReferencesTestApp is now archived, all of the strings should be in the resolved
+        // references array
+        TestCommon.run("-cp",
+                       appJar,
+                       whiteboxParam,
+                       "-XX:SharedArchiveFile=ResolvedRef.jsa",
+                       "-XX:+UnlockDiagnosticVMOptions",
+                       "-XX:+WhiteBoxAPI",
+                       "ResolvedReferencesWb",
+                       "true" // ResolvedReferencesTestApp is archived
+                       ).assertNormalExit();
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesTestApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesTestApp.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class ResolvedReferencesTestApp {
+    // These strings must be in the resolved references array
+    static String foo = "fooString";
+    static String bar = "barString";
+
+    // This method is never called so the string should not be added to the resolved references array
+    String qux() { return "quxString"; }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesWb.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesWb.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.whitebox.WhiteBox;
+
+public class ResolvedReferencesWb {
+    public static void main(String[] args) throws Exception {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+
+        if (args.length < 1) {
+            throw new RuntimeException("Test requires arg: [true|false]");
+        }
+
+        if (!args[0].equals("true") && !args[0].equals("false")) {
+            throw new RuntimeException("Invalid argument: Test requires arg: [true|false]");
+        }
+
+        ResolvedReferencesTestApp t = new ResolvedReferencesTestApp();
+        Object[] resolvedReferences = wb.getResolvedReferences(ResolvedReferencesTestApp.class);
+        boolean isArchived = (args[0].equals("true"));
+
+        if (resolvedReferences.length <= 0) {
+            throw new RuntimeException("Resolved reference should not be null");
+        }
+
+        boolean foundFoo = false;
+        boolean foundBar = false;
+        boolean foundQux = false;
+
+        for (Object o : resolvedReferences) {
+            if (o != null) {
+                foundFoo |= (o.equals("fooString"));
+                foundBar |= (o.equals("barString"));
+                foundQux |= (o.equals("quxString"));
+            }
+        }
+
+        if (isArchived) {
+            // CDS eagerly resolves all the string literals in the ConstantPool. At this point, all
+            // three strings should be in the resolvedReferences array.
+            if (!foundFoo || !foundBar || !foundQux) {
+                throwException(resolvedReferences, "Incorrect resolved references array, all strings should be present");
+            }
+        } else {
+            // If the class is not archived, the string literals in the ConstantPool are resolved
+            // on-demand. At this point, ResolvedReferencesTestApp::<clinit> has been executed
+            // so the two strings used there should be in the resolvedReferences array.
+            // ResolvedReferencesTestApp::qux() is not executed so "quxString"
+            // should not yet be resolved.
+            if (!foundFoo || !foundBar || foundQux) {
+                throwException(resolvedReferences, "Incorrect resolved references array, quxString should not be archived");
+            }
+        }
+    }
+
+    static void throwException(Object[] resolvedRefs, String errMsg) throws RuntimeException {
+        System.out.printf("Resolved References Array Length: %d\n", resolvedRefs.length);
+        for (Object o : resolvedRefs) {
+            System.out.println(o);
+        }
+        throw new RuntimeException(errMsg);
+    }
+}

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -138,6 +138,12 @@ public class WhiteBox {
     return getConstantPoolCacheLength0(aClass);
   }
 
+  private native Object[] getResolvedReferences0(Class<?> aClass);
+  public         Object[] getResolvedReferences(Class<?> aClass) {
+    Objects.requireNonNull(aClass);
+    return getResolvedReferences0(aClass);
+  }
+
   private native int remapInstructionOperandFromCPCache0(Class<?> aClass, int index);
   public         int remapInstructionOperandFromCPCache(Class<?> aClass, int index) {
     Objects.requireNonNull(aClass);
@@ -603,7 +609,6 @@ public class WhiteBox {
   public native boolean isJFRIncluded();
   public native boolean isDTraceIncluded();
   public native boolean canWriteJavaHeapArchive();
-  public native Object  getResolvedReferences(Class<?> c);
   public native void    linkClass(Class<?> c);
   public native boolean areOpenArchiveHeapObjectsMapped();
 


### PR DESCRIPTION
I had to resolve the Whitebox coding. The method added by the backported change already exists in 17.

Originally, WB_GetResolvedReferences was added by "https://bugs.openjdk.org/browse/JDK-8179302: Pre-resolve constant pool string entries and cache resolved_reference arrays in CDS archive" in 10 which did not directly use it, there were closed tests depending on it.  See "https://bugs.openjdk.org/browse/JDK-8188791: Move AppCDS from closed repo to open repo". It was removed in "https://bugs.openjdk.org/browse/JDK-8298048: Combine CDS archive heap into a single block" in 21 and added again by this change.

I resolved the code to use the version of this new change to reduce differences to 21.

The old Whitebox code is used in
runtime/cds/appcds/cacheObject/CheckCachedResolvedReferencesApp.java
runtime/cds/appcds/cacheObject/GCStressApp.java
All runtime/cds/appcds/cacheObject/ are still passing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313638](https://bugs.openjdk.org/browse/JDK-8313638) needs maintainer approval

### Issue
 * [JDK-8313638](https://bugs.openjdk.org/browse/JDK-8313638): Add test for dump of resolved references (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2924/head:pull/2924` \
`$ git checkout pull/2924`

Update a local copy of the PR: \
`$ git checkout pull/2924` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2924`

View PR using the GUI difftool: \
`$ git pr show -t 2924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2924.diff">https://git.openjdk.org/jdk17u-dev/pull/2924.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2924#issuecomment-2385128205)