### PR TITLE
8288976: classfile parser 'wrong name' error message has the names the wrong way around

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -5803,8 +5803,8 @@ void ClassFileParser::parse_stream(const ClassFileStream* const stream,
         Exceptions::fthrow(THREAD_AND_LOCATION,
                            vmSymbols::java_lang_NoClassDefFoundError(),
                            "%s (wrong name: %s)",
-                           class_name_in_cp->as_C_string(),
-                           _class_name->as_C_string()
+                           _class_name->as_C_string(),
+                           class_name_in_cp->as_C_string()
                            );
         return;
       } else {

--- a/test/hotspot/jtreg/runtime/classFileParserBug/Bad_NCDFE_Msg.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/Bad_NCDFE_Msg.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288976
+ * @library /test/lib
+ * @summary Check that the right message is displayed for NoClassDefFoundError exception.
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @compile C.java
+ * @run driver Bad_NCDFE_Msg
+ */
+
+import java.io.File;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class Bad_NCDFE_Msg {
+
+    public static void main(String args[]) throws Throwable {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            "-cp", System.getProperty("test.classes") + File.separator + "pkg", "C");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldContain("java.lang.NoClassDefFoundError: C (wrong name: pkg/C");
+        output.shouldHaveExitValue(1);
+    }
+}

--- a/test/hotspot/jtreg/runtime/classFileParserBug/C.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/C.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// class used by test Bad_NCDFE_Msg.java.
+package pkg;
+public class C { }


### PR DESCRIPTION
This was introcuded in 15 with in "8238358: Implementation of JEP 371: Hidden Classes"
I think it is good to have error messages consistent over the releases, especially for
new features where we can still reach all releases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8288976](https://bugs.openjdk.org/browse/JDK-8288976) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8288976: classfile parser 'wrong name' error message has the names the wrong way around`

### Issue
 * [JDK-8288976](https://bugs.openjdk.org/browse/JDK-8288976): classfile parser 'wrong name' error message has the names the wrong way around (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2925/head:pull/2925` \
`$ git checkout pull/2925`

Update a local copy of the PR: \
`$ git checkout pull/2925` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2925`

View PR using the GUI difftool: \
`$ git pr show -t 2925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2925.diff">https://git.openjdk.org/jdk17u-dev/pull/2925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2925#issuecomment-2385523568)