### PR TITLE
8317347: Parallel: Make TestInitialTenuringThreshold use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestInitialTenuringThreshold.java
+++ b/test/hotspot/jtreg/gc/arguments/TestInitialTenuringThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ package gc.arguments;
 /*
  * @test TestInitialTenuringThreshold
  * @bug 8014765
- * @requires vm.gc.Parallel
+ * @requires vm.gc.Parallel & vm.opt.InitialTenuringThreshold == null & vm.opt.MaxTenuringThreshold == null
  * @summary Tests argument processing for initial tenuring threshold
  * @library /test/lib
  * @library /
@@ -41,7 +41,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestInitialTenuringThreshold {
 
   public static void runWithThresholds(int initial, int max, boolean shouldfail) throws Exception {
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createTestJvm(
       "-XX:+UseParallelGC",
       "-XX:InitialTenuringThreshold=" + String.valueOf(initial),
       "-XX:MaxTenuringThreshold=" + String.valueOf(max),
@@ -58,8 +58,9 @@ public class TestInitialTenuringThreshold {
 
 
   public static void main(String args[]) throws Exception {
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createTestJvm(
       // some value below the default value of InitialTenuringThreshold of 7
+      "-XX:+UseParallelGC",
       "-XX:MaxTenuringThreshold=1",
       "-version"
       );


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317347](https://bugs.openjdk.org/browse/JDK-8317347) needs maintainer approval

### Issue
 * [JDK-8317347](https://bugs.openjdk.org/browse/JDK-8317347): Parallel: Make TestInitialTenuringThreshold use createTestJvm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2930/head:pull/2930` \
`$ git checkout pull/2930`

Update a local copy of the PR: \
`$ git checkout pull/2930` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2930`

View PR using the GUI difftool: \
`$ git pr show -t 2930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2930.diff">https://git.openjdk.org/jdk17u-dev/pull/2930.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2930#issuecomment-2391627628)