### PR TITLE
8271825: mark hotspot runtime/LoadClass tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/LoadClass/LoadClassNegative.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/LoadClassNegative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8020675
  * @summary make sure there is no fatal error if a class is loaded from an invalid jar file which is in the bootclasspath
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/LoadClass/LongBCP.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/LongBCP.java
@@ -26,6 +26,7 @@
  * @summary JVM should be able to handle full path (directory path plus
  *          class name) or directory path longer than MAX_PATH specified
  *          in -Xbootclasspath/a on windows.
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/LoadClass/TestResize.java
+++ b/test/hotspot/jtreg/runtime/LoadClass/TestResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8184765
  * @summary make sure the SystemDictionary gets resized when load factor is too high
  * @requires vm.debug
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
I backport this to improve testing in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271825](https://bugs.openjdk.org/browse/JDK-8271825) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8271825: mark hotspot runtime/LoadClass tests which ignore external VM flags`

### Issue
 * [JDK-8271825](https://bugs.openjdk.org/browse/JDK-8271825): mark hotspot runtime/LoadClass tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2934/head:pull/2934` \
`$ git checkout pull/2934`

Update a local copy of the PR: \
`$ git checkout pull/2934` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2934`

View PR using the GUI difftool: \
`$ git pr show -t 2934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2934.diff">https://git.openjdk.org/jdk17u-dev/pull/2934.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2934#issuecomment-2392058810)