### PR TITLE
8271821: mark hotspot runtime/MinimalVM tests which ignore external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/MinimalVM/CDS.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/CDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver CDS

--- a/test/hotspot/jtreg/runtime/MinimalVM/CheckJNI.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/CheckJNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver CheckJNI

--- a/test/hotspot/jtreg/runtime/MinimalVM/Instrumentation.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/Instrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.instrument
  * @run driver Instrumentation

--- a/test/hotspot/jtreg/runtime/MinimalVM/JMX.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/JMX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @library /test/lib
  * @run main/othervm JMX
  */

--- a/test/hotspot/jtreg/runtime/MinimalVM/JVMTI.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/JVMTI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver JVMTI

--- a/test/hotspot/jtreg/runtime/MinimalVM/NMT.java
+++ b/test/hotspot/jtreg/runtime/MinimalVM/NMT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @requires vm.flavor == "minimal"
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver NMT


### PR DESCRIPTION
I backport this  to improve testing in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8271821](https://bugs.openjdk.org/browse/JDK-8271821) needs maintainer approval
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8271821: mark hotspot runtime/MinimalVM tests which ignore external VM flags`

### Issue
 * [JDK-8271821](https://bugs.openjdk.org/browse/JDK-8271821): mark hotspot runtime/MinimalVM tests which ignore external VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2935/head:pull/2935` \
`$ git checkout pull/2935`

Update a local copy of the PR: \
`$ git checkout pull/2935` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2935`

View PR using the GUI difftool: \
`$ git pr show -t 2935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2935.diff">https://git.openjdk.org/jdk17u-dev/pull/2935.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2935#issuecomment-2392087019)