### PR TITLE
8271836: runtime/ErrorHandling/ClassPathEnvVar.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/ClassPathEnvVar.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ClassPathEnvVar.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8271003
  * @summary CLASSPATH env variable setting should not be truncated in a hs err log.
+ * @requires vm.debug
  * @library /test/lib
  * @run driver ClassPathEnvVar
  */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [977b8c4e](https://github.com/openjdk/jdk/commit/977b8c4e16b02421de8bf78dc60a3866ce25fc1f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. This backport fix test failure of `Error: VM option 'ErrorHandlerTest' is develop and is available only in debug version of VM.`

The commit being backported was authored by Jie Fu on 4 Aug 2021 and was reviewed by Thomas Stuefe.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8271836](https://bugs.openjdk.org/browse/JDK-8271836) needs maintainer approval

### Issue
 * [JDK-8271836](https://bugs.openjdk.org/browse/JDK-8271836): runtime/ErrorHandling/ClassPathEnvVar.java fails with release VMs (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2942/head:pull/2942` \
`$ git checkout pull/2942`

Update a local copy of the PR: \
`$ git checkout pull/2942` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2942`

View PR using the GUI difftool: \
`$ git pr show -t 2942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2942.diff">https://git.openjdk.org/jdk17u-dev/pull/2942.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2942#issuecomment-2395654987)