### PR TITLE
8338380: Update TLSCommon/interop/AbstractServer to specify an interface to listen for connections

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/interop/AbstractServer.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/AbstractServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -52,10 +54,20 @@ public abstract class AbstractServer extends AbstractPeer implements Server {
 
     public static abstract class Builder extends AbstractPeer.Builder {
 
+        private InetAddress listenInterface = InetAddress.getLoopbackAddress();
         private int port;
 
         // Indicates if requires client authentication.
         private boolean clientAuth = true;
+
+        public InetAddress getListenInterface() {
+            return listenInterface;
+        }
+
+        public Builder setListenInterface(InetAddress listenInterface) {
+            this.listenInterface = listenInterface;
+            return this;
+        }
 
         public int getPort() {
             return port;

--- a/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/interop/JdkServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +54,8 @@ public class JdkServer extends AbstractServer {
         context = Utilities.createSSLContext(builder.getCertTuple());
         SSLServerSocketFactory serverFactory = context.getServerSocketFactory();
         serverSocket
-                = (SSLServerSocket) serverFactory.createServerSocket(builder.getPort());
+                = (SSLServerSocket) serverFactory.createServerSocket(builder.getPort(),
+                    0, builder.getListenInterface());
         configServerSocket(builder);
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8338380](https://bugs.openjdk.org/browse/JDK-8338380) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338380](https://bugs.openjdk.org/browse/JDK-8338380): Update TLSCommon/interop/AbstractServer to specify an interface to listen for connections (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2944/head:pull/2944` \
`$ git checkout pull/2944`

Update a local copy of the PR: \
`$ git checkout pull/2944` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2944`

View PR using the GUI difftool: \
`$ git pr show -t 2944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2944.diff">https://git.openjdk.org/jdk17u-dev/pull/2944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2944#issuecomment-2396429030)