### PR TITLE
Backport e649c563242a876a20007470c9412311ffa2a568

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jdk.test.lib.Platform;
  * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @requires vm.opt.CompressedClassSpaceSize == null & vm.opt.UseCompressedClassPointers == null
  * @run driver gc.arguments.TestCompressedClassFlags
  */
 public class TestCompressedClassFlags {
@@ -50,7 +51,7 @@ public class TestCompressedClassFlags {
     }
 
     private static OutputAnalyzer runJava(String ... args) throws Exception {
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(args);
+        ProcessBuilder pb = GCArguments.createTestJvm(args);
         return new OutputAnalyzer(pb.start());
     }
 }


### PR DESCRIPTION
I backport this to improve testing in17.