### PR TITLE
8341635: [17u] runtime/ErrorHandling/ClassPathEnvVar test ignores external VM flags

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/ClassPathEnvVar.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ClassPathEnvVar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8271003
  * @summary CLASSPATH env variable setting should not be truncated in a hs err log.
+ * @requires vm.flagless
  * @requires vm.debug
  * @library /test/lib
  * @run driver ClassPathEnvVar


### PR DESCRIPTION
Hi,

this got lost due to the order of backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341635](https://bugs.openjdk.org/browse/JDK-8341635) needs maintainer approval

### Issue
 * [JDK-8341635](https://bugs.openjdk.org/browse/JDK-8341635): [17u] runtime/ErrorHandling/ClassPathEnvVar test ignores external VM flags (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2949/head:pull/2949` \
`$ git checkout pull/2949`

Update a local copy of the PR: \
`$ git checkout pull/2949` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2949`

View PR using the GUI difftool: \
`$ git pr show -t 2949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2949.diff">https://git.openjdk.org/jdk17u-dev/pull/2949.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2949#issuecomment-2396780504)