### PR TITLE
8309303: jdk/internal/misc/VM/RuntimeArguments test ignores jdk/internal/vm/options

### DIFF
--- a/test/jdk/jdk/internal/misc/VM/RuntimeArguments.java
+++ b/test/jdk/jdk/internal/misc/VM/RuntimeArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,12 @@
  * @run testng RuntimeArguments
  */
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReader;
+import java.lang.module.ModuleReference;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -41,6 +47,30 @@ import static org.testng.Assert.*;
 
 public class RuntimeArguments {
     static final String TEST_CLASSES = System.getProperty("test.classes");
+    static final List<String> VM_OPTIONS = getInitialOptions();
+
+    /*
+     * Read jdk/internal/vm/options resource from the runtime image.
+     * If present, the runtime image was created with jlink --add-options and
+     * the java launcher launches the application as if
+     *   $ java @options <app>
+     * The VM options listed in the jdk/internal/vm/options resource file
+     * are passed to the VM.
+     */
+    static List<String> getInitialOptions() {
+        ModuleReference mref = ModuleFinder.ofSystem().find("java.base").orElseThrow();
+        try (ModuleReader reader = mref.open()) {
+            InputStream in = reader.open("jdk/internal/vm/options").orElse(null);
+            if (in != null) {
+                // support the simplest form for now: whitespace-separated
+                return List.of(new String(in.readAllBytes()).split("\s"));
+            } else {
+                return List.of();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 
     @DataProvider(name = "options")
     public Object[][] options() {
@@ -83,13 +113,15 @@ public class RuntimeArguments {
     @Test(dataProvider = "options")
     public void test(List<String> args, List<String> expected) throws Exception {
         // launch a test program
-        // $ java <runtime-arguments> -classpath <cpath> RuntimeArguments <expected>
-
+        // $ java <args> -classpath <cpath> RuntimeArguments <vm_options> <expected>
         Stream<String> options = Stream.concat(args.stream(),
             Stream.of("-classpath", TEST_CLASSES, "RuntimeArguments"));
 
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            Stream.concat(options, expected.stream())
+            // The runtime image may be created with jlink --add-options
+            // The initial VM options will be included in the result
+            // returned by VM.getRuntimeArguments()
+            Stream.concat(options, Stream.concat(VM_OPTIONS.stream(), expected.stream()))
                   .toArray(String[]::new)
         );
         ProcessTools.executeProcess(pb).shouldHaveExitValue(0);


### PR DESCRIPTION
I backport this to improve testing in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8309303](https://bugs.openjdk.org/browse/JDK-8309303) needs maintainer approval

### Issue
 * [JDK-8309303](https://bugs.openjdk.org/browse/JDK-8309303): jdk/internal/misc/VM/RuntimeArguments test ignores jdk/internal/vm/options (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2951/head:pull/2951` \
`$ git checkout pull/2951`

Update a local copy of the PR: \
`$ git checkout pull/2951` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2951`

View PR using the GUI difftool: \
`$ git pr show -t 2951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2951.diff">https://git.openjdk.org/jdk17u-dev/pull/2951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2951#issuecomment-2396850717)