### PR TITLE
8341146: RISC-V: Unnecessary fences used for load-acquire in template interpreter

### DIFF
--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -265,7 +265,6 @@ void InterpreterMacroAssembler::get_cache_and_index_and_bytecode_at_bcp(Register
   la(bytecode, Address(cache,
                        ConstantPoolCache::base_offset() +
                        ConstantPoolCacheEntry::indices_offset()));
-  membar(MacroAssembler::AnyAny);
   lwu(bytecode, bytecode);
   membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
   const int shift_count = (1 + byte_no) * BitsPerByte;

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -317,7 +317,6 @@ void TemplateTable::ldc(bool wide)
   // get type
   __ addi(x13, x11, tags_offset);
   __ add(x13, x10, x13);
-  __ membar(MacroAssembler::AnyAny);
   __ lbu(x13, Address(x13, 0));
   __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
 
@@ -3491,7 +3490,6 @@ void TemplateTable::_new() {
   const int tags_offset = Array<u1>::base_offset_in_bytes();
   __ add(t0, x10, x13);
   __ la(t0, Address(t0, tags_offset));
-  __ membar(MacroAssembler::AnyAny);
   __ lbu(t0, t0);
   __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
   __ sub(t1, t0, (u1)JVM_CONSTANT_Class);
@@ -3638,7 +3636,6 @@ void TemplateTable::checkcast()
   // See if bytecode has already been quicked
   __ add(t0, x13, Array<u1>::base_offset_in_bytes());
   __ add(x11, t0, x9);
-  __ membar(MacroAssembler::AnyAny);
   __ lbu(x11, x11);
   __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
   __ sub(t0, x11, (u1)JVM_CONSTANT_Class);
@@ -3694,7 +3691,6 @@ void TemplateTable::instanceof() {
   // See if bytecode has already been quicked
   __ add(t0, x13, Array<u1>::base_offset_in_bytes());
   __ add(x11, t0, x9);
-  __ membar(MacroAssembler::AnyAny);
   __ lbu(x11, x11);
   __ membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
   __ sub(t0, x11, (u1)JVM_CONSTANT_Class);


### PR DESCRIPTION
Hi, The same issue also exists in the jdk17u. I would like to backport 8341146 to jdk17u-dev. becasue jdk17u-dev not have [JDK-8301997](https://bugs.openjdk.org/browse/JDK-8301997), so this backport is not clean. This is a risc-v specific change, risk is low. 

### Testing on SOPHON SG2042 (release) 
- [x] JCstress
- [x] Run tier1 tests
- [x] ~5% improvement on SPECJbb2005 score (-Xint -XX:+UseParallelGC)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341146](https://bugs.openjdk.org/browse/JDK-8341146) needs maintainer approval

### Issue
 * [JDK-8341146](https://bugs.openjdk.org/browse/JDK-8341146): RISC-V: Unnecessary fences used for load-acquire in template interpreter (**Enhancement** - P4 - Approved)


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - no project role)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2958/head:pull/2958` \
`$ git checkout pull/2958`

Update a local copy of the PR: \
`$ git checkout pull/2958` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2958`

View PR using the GUI difftool: \
`$ git pr show -t 2958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2958.diff">https://git.openjdk.org/jdk17u-dev/pull/2958.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2958#issuecomment-2406332454)