### PR TITLE
8314610: hotspot can't compile with the latest of gtest because of <iomanip>

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
+++ b/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 #include "utilities/vmassert_uninstall.hpp"
+#include <iomanip>
 #include <string.h>
 #include <sstream>
 #include "utilities/vmassert_reinstall.hpp"


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [febc34d](https://github.com/openjdk/jdk/commit/febc34dd285c3382716e068748d4a3b0c73d87ad) from the [openjdk/jdk](https://github.com/openjdk/jdk) repository.
Tier1 testing is successful.
Thanks!

JBS Issue: [JDK-8314610](https://bugs.openjdk.org/browse/JDK-8314610)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8314610](https://bugs.openjdk.org/browse/JDK-8314610) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8314610: hotspot can't compile with the latest of gtest because of <iomanip>`

### Issue
 * [JDK-8314610](https://bugs.openjdk.org/browse/JDK-8314610): hotspot can't compile with the latest of gtest because of &lt;iomanip&gt; (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2959/head:pull/2959` \
`$ git checkout pull/2959`

Update a local copy of the PR: \
`$ git checkout pull/2959` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2959`

View PR using the GUI difftool: \
`$ git pr show -t 2959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2959.diff">https://git.openjdk.org/jdk17u-dev/pull/2959.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2959#issuecomment-2429966037)
</details>
