### PR TITLE
8340632: ProblemList java/nio/channels/DatagramChannel/ for Macos

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -585,8 +585,8 @@ javax/management/remote/mandatory/connection/RMIConnector_NPETest.java 8267887 g
 
 # jdk_net
 
-java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
-java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64
+java/net/DatagramSocket/DatagramSocketExample.java              8144003,8308807 macosx-all,aix-ppc64
+java/net/DatagramSocket/DatagramSocketMulticasting.java         8144003,8308807 macosx-all,aix-ppc64
 
 java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
 java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
@@ -608,16 +608,17 @@ java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc6
 
 # jdk_nio
 
-java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8144003,8308807 macosx-all,aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
+java/nio/channels/DatagramChannel/BasicMulticastTests.java      8144003 macosx-all
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
+java/nio/channels/DatagramChannel/MulticastSendReceiveTests.java 8144003 macosx-all
+java/nio/channels/DatagramChannel/Promiscuous.java              8144003 macosx-all
 java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
 java/nio/file/Files/probeContentType/Basic.java                 8320943 windows-all
-
-java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
 
 ############################################################################
 


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.
It's a backport of my commit to 21.

backport command did not work, but clean local patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340632](https://bugs.openjdk.org/browse/JDK-8340632) needs maintainer approval

### Issue
 * [JDK-8340632](https://bugs.openjdk.org/browse/JDK-8340632): ProblemList java/nio/channels/DatagramChannel/ for Macos (**Sub-task** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2962/head:pull/2962` \
`$ git checkout pull/2962`

Update a local copy of the PR: \
`$ git checkout pull/2962` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2962`

View PR using the GUI difftool: \
`$ git pr show -t 2962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2962.diff">https://git.openjdk.org/jdk17u-dev/pull/2962.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2962#issuecomment-2411562361)