### PR TITLE
8341997: Tests create files in src tree instead of scratch dir

### DIFF
--- a/test/jdk/java/io/FileInputStream/ReadXBytes.java
+++ b/test/jdk/java/io/FileInputStream/ReadXBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class ReadXBytes {
     private static final Random RND = RandomFactory.getRandom();
 
     public static void main(String args[]) throws IOException {
-        File dir = new File(System.getProperty("test.src", "."));
+        File dir = new File(".");
         dir.deleteOnExit();
 
         File empty = File.createTempFile("foo", "bar", dir);

--- a/test/jdk/java/nio/MappedByteBuffer/ForceException.java
+++ b/test/jdk/java/nio/MappedByteBuffer/ForceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class ForceException {
         int numberOfBlocks = 200;
         int fileLength = numberOfBlocks * blockSize;
 
-        File file = new File(System.getProperty("test.src", "."), "test.dat");
+        File file = new File(".", "test.dat");
         file.deleteOnExit();
         try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
             raf.setLength(fileLength);

--- a/test/jdk/java/nio/MappedByteBuffer/ForceViews.java
+++ b/test/jdk/java/nio/MappedByteBuffer/ForceViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class ForceViews {
 
     @BeforeTest(alwaysRun=true)
     public void openChannel() throws IOException {
-        Path file = Path.of(System.getProperty("test.src", "."), "junk");
+        Path file = Path.of(".", "junk");
         fc = FileChannel.open(file, CREATE_NEW, READ, WRITE, DELETE_ON_CLOSE);
         ByteBuffer buf = ByteBuffer.wrap(new byte[1024]);
         fc.write(buf);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b9cabbec](https://github.com/openjdk/jdk/commit/b9cabbecdac27ae8b93df88660a4a0f3f60e6828) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Brian Burkhalter on 15 Oct 2024 and was reviewed by Erik Joelsson and Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341997](https://bugs.openjdk.org/browse/JDK-8341997) needs maintainer approval

### Issue
 * [JDK-8341997](https://bugs.openjdk.org/browse/JDK-8341997): Tests create files in src tree instead of scratch dir (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2970/head:pull/2970` \
`$ git checkout pull/2970`

Update a local copy of the PR: \
`$ git checkout pull/2970` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2970`

View PR using the GUI difftool: \
`$ git pr show -t 2970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2970.diff">https://git.openjdk.org/jdk17u-dev/pull/2970.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2970#issuecomment-2419490037)