### PR TITLE
8333824: Unused ClassValue in VarHandles

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -38,8 +38,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
 
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
@@ -49,13 +47,6 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 final class VarHandles {
-
-    static ClassValue<ConcurrentMap<Integer, MethodHandle>> ADDRESS_FACTORIES = new ClassValue<>() {
-        @Override
-        protected ConcurrentMap<Integer, MethodHandle> computeValue(Class<?> type) {
-            return new ConcurrentHashMap<>();
-        }
-    };
 
     static VarHandle makeFieldHandle(MemberName f, Class<?> refc, Class<?> type, boolean isWriteAllowedOnFinalFields) {
         if (!f.isStatic()) {


### PR DESCRIPTION
Backporting JDK-8333824: Unused ClassValue in VarHandles. Removes completely unused code. Likely a leftover. Ran GHA Sanity Checks and local Tier 1 and Tier 2 tests. Patch is almost clean: it does not remove an import used in JDK <=21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333824](https://bugs.openjdk.org/browse/JDK-8333824) needs maintainer approval

### Issue
 * [JDK-8333824](https://bugs.openjdk.org/browse/JDK-8333824): Unused ClassValue in VarHandles (**Bug** - P5 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2972/head:pull/2972` \
`$ git checkout pull/2972`

Update a local copy of the PR: \
`$ git checkout pull/2972` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2972`

View PR using the GUI difftool: \
`$ git pr show -t 2972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2972.diff">https://git.openjdk.org/jdk17u-dev/pull/2972.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2972#issuecomment-2420495785)