### PR TITLE
8328402: Implement pausing functionality for the PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -24,6 +24,7 @@
 import java.awt.AWTException;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
@@ -186,7 +187,7 @@ public final class PassFailJFrame {
 
     private static final CountDownLatch latch = new CountDownLatch(1);
 
-    private static TimeoutHandler timeoutHandler;
+    private static TimeoutHandlerPanel timeoutHandlerPanel;
 
     /**
      * The description of why the test fails.
@@ -423,10 +424,8 @@ public final class PassFailJFrame {
                                                        int rows, int columns,
                                                        boolean enableScreenCapture) {
         JPanel main = new JPanel(new BorderLayout());
-
-        JLabel testTimeoutLabel = new JLabel("", JLabel.CENTER);
-        timeoutHandler = new TimeoutHandler(testTimeoutLabel, testTimeOut);
-        main.add(testTimeoutLabel, BorderLayout.NORTH);
+        timeoutHandlerPanel = new TimeoutHandlerPanel(testTimeOut);
+        main.add(timeoutHandlerPanel, BorderLayout.NORTH);
 
         JTextComponent text = instructions.startsWith("<html>")
                               ? configureHTML(instructions, rows, columns)
@@ -438,13 +437,13 @@ public final class PassFailJFrame {
         JButton btnPass = new JButton("Pass");
         btnPass.addActionListener((e) -> {
             latch.countDown();
-            timeoutHandler.stop();
+            timeoutHandlerPanel.stop();
         });
 
         JButton btnFail = new JButton("Fail");
         btnFail.addActionListener((e) -> {
             requestFailureReason();
-            timeoutHandler.stop();
+            timeoutHandlerPanel.stop();
         });
 
         JPanel buttonsPanel = new JPanel();
@@ -602,17 +601,35 @@ public final class PassFailJFrame {
     }
 
 
-    private static final class TimeoutHandler implements ActionListener {
-        private final long endTime;
+    private static final class TimeoutHandlerPanel
+            extends JPanel
+            implements ActionListener {
+
+        private static final String PAUSE_BUTTON_LABEL = "Pause";
+        private static final String RESUME_BUTTON_LABEL = "Resume";
+
+        private long endTime;
+        private long pauseTimeLeft;
 
         private final Timer timer;
 
         private final JLabel label;
+        private final JButton button;
 
-        public TimeoutHandler(final JLabel label, final long testTimeOut) {
-            endTime = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(testTimeOut);
+        public TimeoutHandlerPanel(final long testTimeOut) {
+            endTime = System.currentTimeMillis()
+                    + TimeUnit.MINUTES.toMillis(testTimeOut);
 
-            this.label = label;
+            label =  new JLabel("", JLabel.CENTER);
+            button = new JButton(PAUSE_BUTTON_LABEL);
+
+            button.setFocusPainted(false);
+            button.setFont(new Font(Font.DIALOG, Font.BOLD, 10));
+            button.addActionListener(e -> pauseToggle());
+
+            setLayout(new BorderLayout());
+            add(label, BorderLayout.CENTER);
+            add(button, BorderLayout.EAST);
 
             timer = new Timer(1000, this);
             timer.start();
@@ -641,6 +658,22 @@ public final class PassFailJFrame {
             long seconds = (leftTime - hours * 3_600_000 - minutes * 60_000) / 1_000;
             label.setText(String.format("Test timeout: %02d:%02d:%02d",
                                         hours, minutes, seconds));
+        }
+
+
+        private void pauseToggle() {
+            if (timer.isRunning()) {
+                pauseTimeLeft = endTime - System.currentTimeMillis();
+                timer.stop();
+                label.setEnabled(false);
+                button.setText(RESUME_BUTTON_LABEL);
+            } else {
+                endTime = System.currentTimeMillis() + pauseTimeLeft;
+                updateTime(pauseTimeLeft);
+                timer.start();
+                label.setEnabled(true);
+                button.setText(PAUSE_BUTTON_LABEL);
+            }
         }
 
         public void stop() {


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8328402](https://bugs.openjdk.org/browse/JDK-8328402) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328402](https://bugs.openjdk.org/browse/JDK-8328402): Implement pausing functionality for the PassFailJFrame (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2980/head:pull/2980` \
`$ git checkout pull/2980`

Update a local copy of the PR: \
`$ git checkout pull/2980` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2980`

View PR using the GUI difftool: \
`$ git pr show -t 2980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2980.diff">https://git.openjdk.org/jdk17u-dev/pull/2980.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2980#issuecomment-2426909284)