### PR TITLE
8296709: WARNING: JNI call made without checking exceptions

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -277,12 +277,12 @@ util_initialize(JNIEnv *env)
             localAgentProperties =
                 JNI_FUNC_PTR(env,CallStaticObjectMethod)
                             (env, localVMSupportClass, getAgentProperties);
-            saveGlobalRef(env, localAgentProperties, &(gdata->agent_properties));
             if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
                 JNI_FUNC_PTR(env,ExceptionClear)(env);
                 EXIT_ERROR(AGENT_ERROR_INTERNAL,
                     "Exception occurred calling VMSupport.getAgentProperties");
             }
+            saveGlobalRef(env, localAgentProperties, &(gdata->agent_properties));
         }
 
     } END_WITH_LOCAL_REFS(env);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -763,6 +763,11 @@ tools/jlink/plugins/CompressorPluginTest.java                   8247407 generic-
 
 ############################################################################
 
+# core_svc
+tools/launcher/TestXcheckJNIWarnings.java#jdwp-agent   8296936 generic-all
+
+############################################################################
+
 # jdk_jdi
 
 com/sun/jdi/RepStep.java                                        8043571 generic-all

--- a/test/jdk/tools/launcher/TestXcheckJNIWarnings.java
+++ b/test/jdk/tools/launcher/TestXcheckJNIWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,21 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * @test
+ * @test id=noagent
  * @bug 8187442
  * @summary Launching app shouldn't produce any jni warnings.
  * @modules jdk.compiler
  *          jdk.zipfs
- * @compile TestXcheckJNIWarnings.java
  * @run main TestXcheckJNIWarnings
+ */
+
+/**
+ * @test id=jdwp-agent
+ * @bug 8187442
+ * @summary Launching app with jdwp agent shouldn't produce any jni warnings.
+ * @modules jdk.compiler
+ *          jdk.zipfs
+ * @run main TestXcheckJNIWarnings -agentlib:jdwp=transport=dt_socket,server=y,suspend=n
  */
 public final class TestXcheckJNIWarnings extends TestHelper {
 
@@ -46,8 +54,14 @@ public final class TestXcheckJNIWarnings extends TestHelper {
     public static void main(String... args) throws IOException {
         File testJarFile = new File("test.jar");
         createJarFile(testJarFile);
-        TestResult tr = doExec(javaCmd, "-jar", "-Xcheck:jni",
-                               testJarFile.getName());
+
+        TestResult tr;
+        if (args.length > 0) {
+            tr = doExec(javaCmd, "-jar", "-Xcheck:jni", args[0], testJarFile.getName());
+        } else {
+            tr = doExec(javaCmd, "-jar", "-Xcheck:jni", testJarFile.getName());
+        }
+
         if (!tr.isOK()) {
             System.out.println(tr);
             throw new RuntimeException("test returned non-positive value");


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

I don't see why this is not clean, I generated it with the backport command...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296709](https://bugs.openjdk.org/browse/JDK-8296709) needs maintainer approval

### Issue
 * [JDK-8296709](https://bugs.openjdk.org/browse/JDK-8296709): WARNING: JNI call made without checking exceptions (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2983/head:pull/2983` \
`$ git checkout pull/2983`

Update a local copy of the PR: \
`$ git checkout pull/2983` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2983`

View PR using the GUI difftool: \
`$ git pr show -t 2983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2983.diff">https://git.openjdk.org/jdk17u-dev/pull/2983.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2983#issuecomment-2428867944)