### PR TITLE
8319651: Several network tests ignore vm flags when start java process

### DIFF
--- a/test/jdk/java/net/InetAddress/ptr/Lookup.java
+++ b/test/jdk/java/net/InetAddress/ptr/Lookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,18 +41,15 @@
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class Lookup {
     private static final String HOST = "icann.org";
     private static final String SKIP = "SKIP";
-    private static final String CLASS_PATH = System.getProperty(
-            "test.class.path");
 
     public static void main(String args[]) throws IOException {
         String addr = null;
@@ -135,20 +132,16 @@ public class Lookup {
     }
 
     static String lookupWithIPv4Prefer() throws IOException {
-        String java = JDKToolFinder.getTestJDKTool("java");
         String testClz = Lookup.class.getName();
-        List<String> cmd = List.of(java, "-Djava.net.preferIPv4Stack=true",
-                "-cp", CLASS_PATH, testClz);
-        System.out.println("Executing: " + cmd);
-        return new OutputAnalyzer(new ProcessBuilder(cmd).start()).getOutput();
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-Djava.net.preferIPv4Stack=true", testClz);
+        return new OutputAnalyzer(pb.start()).getOutput();
     }
 
     static String reverseWithIPv4Prefer(String addr) throws IOException {
-        String java = JDKToolFinder.getTestJDKTool("java");
         String testClz = Lookup.class.getName();
-        List<String> cmd = List.of(java, "-Djava.net.preferIPv4Stack=true",
-                                   "-cp", CLASS_PATH, testClz, "reverse", addr);
-        System.out.println("Executing: " + cmd);
-        return new OutputAnalyzer(new ProcessBuilder(cmd).start()).getOutput();
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-Djava.net.preferIPv4Stack=true", testClz, "reverse", addr);
+        return new OutputAnalyzer(pb.start()).getOutput();
     }
 }

--- a/test/jdk/java/net/ServerSocket/AcceptCauseFileDescriptorLeak.java
+++ b/test/jdk/java/net/ServerSocket/AcceptCauseFileDescriptorLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,8 @@
  *          can cause fd leak.
  *          This test may fail intermittently if foreign processes will
  *          try to establish connection to the test server socket.
- * @requires (os.family != "windows")
+ * @requires os.family != "windows"
+ * @requires vm.flagless
  * @library /test/lib
  * @build jdk.test.lib.Utils
  *        jdk.test.lib.Asserts

--- a/test/jdk/java/net/ServerSocket/AcceptInheritHandle.java
+++ b/test/jdk/java/net/ServerSocket/AcceptInheritHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,12 @@ import java.net.*;
 import java.nio.channels.ServerSocketChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import jdk.test.lib.net.IPSupport;
+import jdk.test.lib.process.ProcessTools;
 
 public class AcceptInheritHandle {
 
@@ -95,16 +97,12 @@ public class AcceptInheritHandle {
         System.out.println("\nStarting test for " + ssp.name());
 
         List<String> commands = new ArrayList<>();
-        commands.add(JAVA);
-        for (String arg : jvmArgs)
-            commands.add(arg);
-        commands.add("-cp");
-        commands.add(CLASSPATH);
+        Collections.addAll(commands, jvmArgs);
         commands.add("AcceptInheritHandle");
         commands.add(ssp.name());
 
         System.out.println("Executing: "+ commands);
-        ProcessBuilder pb = new ProcessBuilder(commands);
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(commands);
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
         Process serverProcess = pb.start();
         DataInputStream dis = new DataInputStream(serverProcess.getInputStream());

--- a/test/jdk/java/net/URLClassLoader/getresourceasstream/TestDriver.java
+++ b/test/jdk/java/net/URLClassLoader/getresourceasstream/TestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@
  * @run main/othervm TestDriver
  */
 
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 
 import java.io.IOException;
@@ -53,33 +52,33 @@ public class TestDriver {
             throws Throwable {
 
         Path userDir = Paths.get(System.getProperty("user.dir"));
-        String java = JDKToolFinder.getTestJDKTool("java");
         String basename = userDir.getFileName().toString();
         setup(userDir);
         ProcessBuilder[] tests = new ProcessBuilder[]{
-                new ProcessBuilder(
-                        java, TEST_NAME, "./" + ARCHIVE_NAME
+                ProcessTools.createTestJavaProcessBuilder(
+                        TEST_NAME,
+                        "./" + ARCHIVE_NAME
                 ),
-                new ProcessBuilder(
-                        java, "-cp", ".",
+                ProcessTools.createTestJavaProcessBuilder(
+                        "-cp", ".",
                         "-Djava.security.policy=file:./policy",
                         "-Djava.security.manager",
                         TEST_NAME, "./" + ARCHIVE_NAME
                 ),
-                new ProcessBuilder(
-                        java, "-cp", ".",
+                ProcessTools.createTestJavaProcessBuilder(
+                        "-cp", ".",
                         "-Djava.security.policy=file:./policy",
                         "-Djava.security.manager",
                         TEST_NAME, "./" + ARCHIVE_NAME
                 ),
-                new ProcessBuilder(
-                        java, "-cp", "..",
+                ProcessTools.createTestJavaProcessBuilder(
+                        "-cp", "..",
                         "-Djava.security.policy=file:../policy",
                         "-Djava.security.manager",
                         TEST_NAME, "../" + ARCHIVE_NAME
                 ).directory(userDir.resolve("tmp").toFile()),
-                new ProcessBuilder(
-                        java, "-cp", basename,
+                ProcessTools.createTestJavaProcessBuilder(
+                        "-cp", basename,
                         "-Djava.security.policy=file:" + basename + "/policy",
                         "-Djava.security.manager",
                         TEST_NAME, basename + "/" + ARCHIVE_NAME

--- a/test/jdk/java/net/URLClassLoader/sealing/CheckSealedTest.java
+++ b/test/jdk/java/net/URLClassLoader/sealing/CheckSealedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,8 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static jdk.test.lib.process.ProcessTools.createTestJavaProcessBuilder;
+import static jdk.test.lib.process.ProcessTools.executeCommand;
 
 public class CheckSealedTest {
     private static final String ARCHIVE_NAME = "b.jar";
@@ -55,31 +57,30 @@ public class CheckSealedTest {
 
         String baseDir = System.getProperty("user.dir") + File.separator;
         String javac = JDKToolFinder.getTestJDKTool("javac");
-        String java = JDKToolFinder.getTestJDKTool("java");
 
         setup(baseDir);
         String srcDir = System.getProperty("test.src");
         String cp = srcDir + File.separator + "a" + File.pathSeparator
                 + srcDir + File.separator + "b.jar" + File.pathSeparator
                 + ".";
+
+        // Compile
+        ProcessTools.executeCommand(javac, "-cp", cp, "-d", ".",
+                srcDir + File.separator + TEST_NAME + ".java");
+
         List<String[]> allCMDs = List.of(
-                // Compile command
-                new String[]{
-                        javac, "-cp", cp, "-d", ".",
-                        srcDir + File.separator + TEST_NAME + ".java"
-                },
                 // Run test the first time
                 new String[]{
-                        java, "-cp", cp, TEST_NAME, "1"
+                        "-cp", cp, TEST_NAME, "1"
                 },
                 // Run test the second time
                 new String[]{
-                        java, "-cp", cp, TEST_NAME, "2"
+                        "-cp", cp, TEST_NAME, "2"
                 }
         );
 
         for (String[] cmd : allCMDs) {
-            ProcessTools.executeCommand(cmd)
+            executeCommand(createTestJavaProcessBuilder(cmd))
                         .outputTo(System.out)
                         .errorTo(System.out)
                         .shouldHaveExitValue(0);

--- a/test/jdk/java/net/URLConnection/6212146/TestDriver.java
+++ b/test/jdk/java/net/URLConnection/6212146/TestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary URLConnection.connect() fails on JAR Entry it creates
  * file handler leak
  * @library /test/lib
+ * @requires vm.flagless
  * @build jdk.test.lib.Utils
  *        jdk.test.lib.Asserts
  *        jdk.test.lib.JDKToolFinder

--- a/test/jdk/java/net/URLConnection/ContentHandlers/ContentHandlersTest.java
+++ b/test/jdk/java/net/URLConnection/ContentHandlers/ContentHandlersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -56,6 +58,7 @@ import static java.util.Collections.singletonMap;
 /*
  * @test
  * @bug 8064925
+ * @library /test/lib
  * @summary Basic test for ContentHandler. Ensures discovery paths for content
  *          handlers follow a particular order.
  */
@@ -268,14 +271,10 @@ public class ContentHandlersTest {
                                Collection<Path> classpath,
                                String classname, String... args) {
 
-        String java = getJDKTool("java");
-
-        List<String> commands = new ArrayList<>();
-        commands.add(java);
-        commands.addAll(properties.entrySet()
+        List<String> commands = properties.entrySet()
                 .stream()
                 .map(e -> "-D" + e.getKey() + "=" + e.getValue())
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList());
 
         String cp = classpath.stream()
                 .map(Path::toString)
@@ -285,7 +284,7 @@ public class ContentHandlersTest {
         commands.add(classname);
         commands.addAll(Arrays.asList(args));
 
-        return run(new ProcessBuilder(commands));
+        return run(ProcessTools.createTestJavaProcessBuilder(commands));
     }
 
     private static Result run(ProcessBuilder b) {

--- a/test/jdk/java/net/httpclient/security/Driver.java
+++ b/test/jdk/java/net/httpclient/security/Driver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * Driver for tests
@@ -126,12 +127,10 @@ public class Driver {
         String testClassPath = System.getProperty("test.class.path", "?");
         String testClasses = System.getProperty("test.classes", "?");
         String sep = System.getProperty("file.separator", "?");
-        String javaCmd = testJdk + sep + "bin" + sep + "java";
         int retval = 10; // 10 is special exit code denoting a bind error
                          // in which case, we retry
         while (retval == 10) {
             List<String> cmd = new ArrayList<>();
-            cmd.add(javaCmd);
             cmd.add("-ea");
             cmd.add("-esa");
             cmd.add("-Dtest.jdk=" + testJdk);
@@ -150,7 +149,7 @@ public class Driver {
             cmd.add("Security");
             cmd.add(testnum);
 
-            ProcessBuilder processBuilder = new ProcessBuilder(cmd)
+            ProcessBuilder processBuilder = ProcessTools.createTestJavaProcessBuilder(cmd)
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .redirectErrorStream(true);
 

--- a/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
+++ b/test/jdk/java/net/spi/URLStreamHandlerProvider/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,8 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
+
+import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.FileUtils;
 import jdk.test.lib.JDKToolFinder;
 import static java.lang.String.format;
@@ -234,12 +236,8 @@ public class Basic {
 
     static Result java(List<String> sysProps, Collection<Path> classpath,
                        String classname, String arg) {
-        String java = getJDKTool("java");
 
-        List<String> commands = new ArrayList<>();
-        commands.add(java);
-        for (String prop : sysProps)
-            commands.add(prop);
+        List<String> commands = new ArrayList<>(sysProps);
 
         String cp = classpath.stream()
                 .map(Path::toString)
@@ -249,7 +247,7 @@ public class Basic {
         commands.add(classname);
         commands.add(arg);
 
-        return run(new ProcessBuilder(commands));
+        return run(ProcessTools.createTestJavaProcessBuilder(commands));
     }
 
     static Result run(ProcessBuilder pb) {

--- a/test/jdk/javax/net/ssl/DTLS/DTLSWontNegotiateV10.java
+++ b/test/jdk/javax/net/ssl/DTLS/DTLSWontNegotiateV10.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,13 @@
  * questions.
  */
 
+import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.security.SecurityUtils;
 
 import javax.net.ssl.*;
 import java.io.IOException;
 import java.net.*;
 import java.nio.ByteBuffer;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -87,14 +87,13 @@ public class DTLSWontNegotiateV10 {
         Process clientProcess = null;
         try (DTLSServer server = new DTLSServer(protocol)) {
             List<String> command = List.of(
-                    Path.of(System.getProperty("java.home"), "bin", "java").toString(),
                     "DTLSWontNegotiateV10",
                     // if server is "DTLS" then the client should be v1.0 and vice versa
                     protocol.equals(DTLS) ? DTLSV_1_0 : DTLS,
                     Integer.toString(server.getListeningPortNumber())
             );
 
-            ProcessBuilder builder = new ProcessBuilder(command);
+            ProcessBuilder builder = ProcessTools.createTestJavaProcessBuilder(command);
             clientProcess = builder.inheritIO().start();
             server.run();
             System.out.println("Success: DTLSv1.0 connection was not established.");

--- a/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/DisabledAlgorithms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8076221 8211883 8279164
  * @summary Check if weak cipher suites are disabled
+ * @library /javax/net/ssl/templates
  * @modules jdk.crypto.ec
  * @run main/othervm DisabledAlgorithms default
  * @run main/othervm DisabledAlgorithms empty
@@ -35,7 +36,6 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
@@ -45,79 +45,78 @@ import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
+/*
+ * This test verifies that setEnabledProtocols() does not override the
+ * jdk.tls.disabledAlgorithms property. Both the client and server throw
+ * an exception when creating a handshake context.
+ *
+ * In the TLSWontNegotiateDisabledCipherAlgoos test, one side of the connection
+ * disables the cipher suites and the other side enables them and verifies
+ * that the handshake cannot complete successfully.
+ */
 public class DisabledAlgorithms {
 
-    private static final String pathToStores = "../etc";
-    private static final String keyStoreFile = "keystore";
-    private static final String trustStoreFile = "truststore";
-    private static final String passwd = "passphrase";
-
-    private static final String keyFilename =
-            System.getProperty("test.src", "./") + "/" + pathToStores +
-                "/" + keyStoreFile;
-
-    private static final String trustFilename =
-            System.getProperty("test.src", "./") + "/" + pathToStores +
-                "/" + trustStoreFile;
+    public static final SSLContextTemplate.Cert[] CERTIFICATES = {
+            SSLContextTemplate.Cert.EE_DSA_SHA1_1024,
+            SSLContextTemplate.Cert.EE_DSA_SHA224_1024,
+            SSLContextTemplate.Cert.EE_DSA_SHA256_1024,
+            SSLContextTemplate.Cert.CA_ECDSA_SECP256R1,
+            SSLContextTemplate.Cert.CA_RSA_2048
+    };
 
     // disabled RC4, NULL, anon, and ECDH cipher suites
-    private static final String[] disabled_ciphersuites
-        = new String[] {
-        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
-        "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-        "SSL_RSA_WITH_RC4_128_SHA",
-        "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
-        "TLS_ECDH_RSA_WITH_RC4_128_SHA",
-        "SSL_RSA_WITH_RC4_128_MD5",
-        "TLS_ECDH_anon_WITH_RC4_128_SHA",
-        "SSL_DH_anon_WITH_RC4_128_MD5",
-        "SSL_RSA_WITH_NULL_MD5",
-        "SSL_RSA_WITH_NULL_SHA",
-        "TLS_RSA_WITH_NULL_SHA256",
-        "TLS_ECDH_ECDSA_WITH_NULL_SHA",
-        "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
-        "TLS_ECDH_RSA_WITH_NULL_SHA",
-        "TLS_ECDHE_RSA_WITH_NULL_SHA",
-        "TLS_ECDH_anon_WITH_NULL_SHA",
-        "SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA",
-        "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",
-        "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA",
-        "SSL_DH_anon_WITH_DES_CBC_SHA",
-        "SSL_DH_anon_WITH_RC4_128_MD5",
-        "TLS_DH_anon_WITH_AES_128_CBC_SHA",
-        "TLS_DH_anon_WITH_AES_128_CBC_SHA256",
-        "TLS_DH_anon_WITH_AES_128_GCM_SHA256",
-        "TLS_DH_anon_WITH_AES_256_CBC_SHA",
-        "TLS_DH_anon_WITH_AES_256_CBC_SHA256",
-        "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA",
-        "TLS_ECDH_anon_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_anon_WITH_NULL_SHA",
-        "TLS_ECDH_anon_WITH_RC4_128_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
-        "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
-        "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
-        "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
-        "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA"
+    public static final String[] DISABLED_CIPHERSUITES
+            = new String[]{
+            "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+            "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+            "SSL_RSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_RSA_WITH_RC4_128_SHA",
+            "SSL_RSA_WITH_RC4_128_MD5",
+            "TLS_ECDH_anon_WITH_RC4_128_SHA",
+            "SSL_DH_anon_WITH_RC4_128_MD5",
+            "SSL_RSA_WITH_NULL_MD5",
+            "SSL_RSA_WITH_NULL_SHA",
+            "TLS_RSA_WITH_NULL_SHA256",
+            "TLS_ECDH_ECDSA_WITH_NULL_SHA",
+            "TLS_ECDHE_ECDSA_WITH_NULL_SHA",
+            "TLS_ECDH_RSA_WITH_NULL_SHA",
+            "TLS_ECDHE_RSA_WITH_NULL_SHA",
+            "TLS_ECDH_anon_WITH_NULL_SHA",
+            "SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA",
+            "SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",
+            "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA",
+            "SSL_DH_anon_WITH_DES_CBC_SHA",
+            "SSL_DH_anon_WITH_RC4_128_MD5",
+            "TLS_DH_anon_WITH_AES_128_CBC_SHA",
+            "TLS_DH_anon_WITH_AES_128_CBC_SHA256",
+            "TLS_DH_anon_WITH_AES_128_GCM_SHA256",
+            "TLS_DH_anon_WITH_AES_256_CBC_SHA",
+            "TLS_DH_anon_WITH_AES_256_CBC_SHA256",
+            "TLS_DH_anon_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDH_anon_WITH_AES_128_CBC_SHA",
+            "TLS_ECDH_anon_WITH_AES_256_CBC_SHA",
+            "TLS_ECDH_anon_WITH_NULL_SHA",
+            "TLS_ECDH_anon_WITH_RC4_128_SHA",
+            "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA"
     };
 
     public static void main(String[] args) throws Exception {
         if (args.length < 1) {
             throw new RuntimeException("No parameters specified");
         }
-
-        System.setProperty("javax.net.ssl.keyStore", keyFilename);
-        System.setProperty("javax.net.ssl.keyStorePassword", passwd);
-        System.setProperty("javax.net.ssl.trustStore", trustFilename);
-        System.setProperty("javax.net.ssl.trustStorePassword", passwd);
 
         switch (args[0]) {
             case "default":
@@ -126,7 +125,7 @@ public class DisabledAlgorithms {
                         + Security.getProperty("jdk.tls.disabledAlgorithms"));
 
                 // check that disabled cipher suites can't be used by default
-                checkFailure(disabled_ciphersuites);
+                checkFailure(DISABLED_CIPHERSUITES);
                 break;
             case "empty":
                 // reset jdk.tls.disabledAlgorithms
@@ -136,7 +135,7 @@ public class DisabledAlgorithms {
 
                 // check that disabled cipher suites can be used if
                 // jdk.{tls,certpath}.disabledAlgorithms is empty
-                checkSuccess(disabled_ciphersuites);
+                checkSuccess(DISABLED_CIPHERSUITES);
                 break;
             default:
                 throw new RuntimeException("Wrong parameter: " + args[0]);
@@ -149,7 +148,7 @@ public class DisabledAlgorithms {
      * Checks if that specified cipher suites cannot be used.
      */
     private static void checkFailure(String[] ciphersuites) throws Exception {
-        try (SSLServer server = SSLServer.init(ciphersuites)) {
+        try (SSLServer server = new SSLServer(ciphersuites)) {
             startNewThread(server);
             while (!server.isRunning()) {
                 sleep();
@@ -157,7 +156,7 @@ public class DisabledAlgorithms {
 
             int port = server.getPort();
             for (String ciphersuite : ciphersuites) {
-                try (SSLClient client = SSLClient.init(port, ciphersuite)) {
+                try (SSLClient client = new SSLClient(port, ciphersuite)) {
                     client.connect();
                     throw new RuntimeException("Expected SSLHandshakeException "
                             + "not thrown");
@@ -184,7 +183,7 @@ public class DisabledAlgorithms {
      * Checks if specified cipher suites can be used.
      */
     private static void checkSuccess(String[] ciphersuites) throws Exception {
-        try (SSLServer server = SSLServer.init(ciphersuites)) {
+        try (SSLServer server = new SSLServer(ciphersuites)) {
             startNewThread(server);
             while (!server.isRunning()) {
                 sleep();
@@ -192,7 +191,7 @@ public class DisabledAlgorithms {
 
             int port = server.getPort();
             for (String ciphersuite : ciphersuites) {
-                try (SSLClient client = SSLClient.init(port, ciphersuite)) {
+                try (SSLClient client = new SSLClient(port, ciphersuite)) {
                     client.connect();
                     String negotiated = client.getNegotiatedCipherSuite();
                     System.out.println("Negotiated cipher suite: "
@@ -231,7 +230,8 @@ public class DisabledAlgorithms {
         }
     }
 
-    static class SSLServer implements Runnable, AutoCloseable {
+    static class SSLServer extends SSLContextTemplate implements Runnable, AutoCloseable {
+
 
         private final SSLServerSocket ssocket;
         private volatile boolean stopped = false;
@@ -239,7 +239,19 @@ public class DisabledAlgorithms {
         private volatile boolean sslError = false;
         private volatile boolean otherError = false;
 
-        private SSLServer(SSLServerSocket ssocket) {
+        private SSLServer(String[] ciphersuites) throws Exception {
+            SSLContext context = createSSLContext(null,
+                    DisabledAlgorithms.CERTIFICATES, getServerContextParameters());
+            SSLServerSocketFactory ssf = context.getServerSocketFactory();
+            SSLServerSocket ssocket = (SSLServerSocket)
+                    ssf.createServerSocket(0);
+
+            if (ciphersuites != null) {
+                System.out.println("Server: enable cipher suites: "
+                        + java.util.Arrays.toString(ciphersuites));
+                ssocket.setEnabledCipherSuites(ciphersuites);
+            }
+
             this.ssocket = ssocket;
         }
 
@@ -273,8 +285,8 @@ public class DisabledAlgorithms {
                     } else {
                         System.out.println("Server: run: " + e);
                         System.out.println("The exception above occurred "
-                                    + "because socket was closed, "
-                                    + "please ignore it");
+                                + "because socket was closed, "
+                                + "please ignore it");
                     }
                 }
             }
@@ -319,29 +331,23 @@ public class DisabledAlgorithms {
         public void close() {
             stop();
         }
-
-        static SSLServer init(String[] ciphersuites)
-                throws IOException {
-            SSLServerSocketFactory ssf = (SSLServerSocketFactory)
-                    SSLServerSocketFactory.getDefault();
-            SSLServerSocket ssocket = (SSLServerSocket)
-                    ssf.createServerSocket(0);
-
-            if (ciphersuites != null) {
-                System.out.println("Server: enable cipher suites: "
-                        + java.util.Arrays.toString(ciphersuites));
-                ssocket.setEnabledCipherSuites(ciphersuites);
-            }
-
-            return new SSLServer(ssocket);
-        }
     }
 
-    static class SSLClient implements AutoCloseable {
+    static class SSLClient extends SSLContextTemplate implements AutoCloseable {
 
         private final SSLSocket socket;
 
-        private SSLClient(SSLSocket socket) {
+        private SSLClient(int port, String ciphersuite) throws Exception {
+            SSLContext context = createSSLContext(DisabledAlgorithms.CERTIFICATES,
+                    null, getClientContextParameters());
+            SSLSocketFactory ssf = context.getSocketFactory();
+            SSLSocket socket = (SSLSocket) ssf.createSocket("localhost", port);
+
+            if (ciphersuite != null) {
+                System.out.println("Client: enable cipher suite: "
+                        + ciphersuite);
+                socket.setEnabledCipherSuites(new String[]{ciphersuite});
+            }
             this.socket = socket;
         }
 
@@ -381,29 +387,5 @@ public class DisabledAlgorithms {
                 }
             }
         }
-
-        static SSLClient init(int port)
-                throws NoSuchAlgorithmException, IOException {
-            return init(port, null);
-        }
-
-        static SSLClient init(int port, String ciphersuite)
-                throws NoSuchAlgorithmException, IOException {
-            SSLContext context = SSLContext.getDefault();
-            SSLSocketFactory ssf = (SSLSocketFactory)
-                    context.getSocketFactory();
-            SSLSocket socket = (SSLSocket) ssf.createSocket("localhost", port);
-
-            if (ciphersuite != null) {
-                System.out.println("Client: enable cipher suite: "
-                        + ciphersuite);
-                socket.setEnabledCipherSuites(new String[] { ciphersuite });
-            }
-
-            return new SSLClient(socket);
-        }
-
     }
-
-
 }

--- a/test/jdk/javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +21,19 @@
  * questions.
  */
 
+import jdk.test.lib.process.ProcessTools;
+
 import javax.net.ssl.*;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.security.Security;
 import java.util.List;
 
 /*
  * @test id=Server
  * @bug 8301379
+ * @library /test/lib
  * @summary Verify that Java will not negotiate disabled cipher suites when the
  * other side of the connection requests them.
  *
@@ -42,6 +44,7 @@ import java.util.List;
 /*
  * @test id=Client
  * @bug 8301379
+ * @library /test/lib
  * @summary Verify that Java will not negotiate disabled cipher suites when the
  * other side of the connection requests them.
  *
@@ -61,13 +64,12 @@ public class TLSWontNegotiateDisabledCipherAlgos {
         if (args[0].equals("server")) {
             try (TLSServer server = new TLSServer(useDisabledAlgo)) {
                 List<String> command = List.of(
-                        Path.of(System.getProperty("java.home"), "bin", "java").toString(),
                         "TLSWontNegotiateDisabledCipherAlgos",
                         "client",
                         Boolean.toString(!useDisabledAlgo),
                         Integer.toString(server.getListeningPort())
                 );
-                ProcessBuilder builder = new ProcessBuilder(command);
+                ProcessBuilder builder = ProcessTools.createTestJavaProcessBuilder(command);
                 Process p = builder.inheritIO().start();
                 server.run();
                 p.destroy();

--- a/test/jdk/javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java
+++ b/test/jdk/javax/net/ssl/ciphersuites/TLSWontNegotiateDisabledCipherAlgos.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.Security;
+import java.util.List;
+
+/*
+ * @test id=Server
+ * @bug 8301379
+ * @summary Verify that Java will not negotiate disabled cipher suites when the
+ * other side of the connection requests them.
+ *
+ * @library /javax/net/ssl/templates
+ * @run main/othervm TLSWontNegotiateDisabledCipherAlgos server true
+ */
+
+/*
+ * @test id=Client
+ * @bug 8301379
+ * @summary Verify that Java will not negotiate disabled cipher suites when the
+ * other side of the connection requests them.
+ *
+ * @library /javax/net/ssl/templates
+ * @run main/othervm TLSWontNegotiateDisabledCipherAlgos server false
+ */
+
+
+public class TLSWontNegotiateDisabledCipherAlgos {
+
+    public static void main(String [] args) throws Exception {
+        boolean useDisabledAlgo = Boolean.parseBoolean(args[1]);
+        if (useDisabledAlgo) {
+            Security.setProperty("jdk.tls.disabledAlgorithms", "");
+        }
+
+        if (args[0].equals("server")) {
+            try (TLSServer server = new TLSServer(useDisabledAlgo)) {
+                List<String> command = List.of(
+                        Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                        "TLSWontNegotiateDisabledCipherAlgos",
+                        "client",
+                        Boolean.toString(!useDisabledAlgo),
+                        Integer.toString(server.getListeningPort())
+                );
+                ProcessBuilder builder = new ProcessBuilder(command);
+                Process p = builder.inheritIO().start();
+                server.run();
+                p.destroy();
+            }
+        } else if (args[0].equals("client")) {
+            try (TLSClient client = new TLSClient(Integer.parseInt(args[2]), useDisabledAlgo)) {
+                client.run();
+            }
+        }
+    }
+
+    private static class TLSClient extends SSLContextTemplate implements AutoCloseable {
+        private final SSLSocket socket;
+
+        public TLSClient(int portNumber, boolean useDisableAlgo) throws Exception {
+            SSLContext context = createClientSSLContext();
+            socket = (SSLSocket)context.getSocketFactory().createSocket("localhost", portNumber);
+            if (useDisableAlgo) {
+                socket.setEnabledCipherSuites(DisabledAlgorithms.DISABLED_CIPHERSUITES);
+            }
+        }
+
+        public void run() throws IOException {
+            try {
+                socket.getOutputStream().write("SECRET MESSAGE".getBytes(StandardCharsets.UTF_8));
+                throw new RuntimeException("SSL handshake completed successfully.");
+            } catch (SSLHandshakeException exc) {
+                if (!exc.getMessage().equals("Received fatal alert: handshake_failure")) {
+                    throw new RuntimeException("Expected handshake_failure message. Got: "
+                            + "\"" + exc.getMessage() + "\" message.", exc);
+                }
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            socket.close();
+        }
+    }
+
+    private static class TLSServer extends SSLContextTemplate implements AutoCloseable {
+        private SSLServerSocket serverSocket;
+
+        public TLSServer(boolean useDisableAlgo) throws Exception {
+            SSLContext ctx = createServerSSLContext();
+            serverSocket = (SSLServerSocket) ctx.getServerSocketFactory().createServerSocket(0);
+            if (useDisableAlgo) {
+                serverSocket.setEnabledCipherSuites(DisabledAlgorithms.DISABLED_CIPHERSUITES);
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            serverSocket.close();
+        }
+
+        public int getListeningPort() {
+            return serverSocket.getLocalPort();
+        }
+
+        public void run() throws IOException {
+            try (Socket clientSocket = serverSocket.accept()) {
+                try {
+                    byte[] bytes = clientSocket.getInputStream().readAllBytes();
+                    throw new RuntimeException("The expected SSLHandshakeException was not thrown.");
+                } catch (SSLHandshakeException exc) {
+                    if (!exc.getMessage().contains("no cipher suites in common")) {
+                        throw exc;
+                    } else {
+                        System.out.println("Success: The connection could not be negotiated (as expected.)");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/sun/net/www/protocol/jar/GetContentTypeTest.java
+++ b/test/jdk/sun/net/www/protocol/jar/GetContentTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,10 @@
  *        GetContentType GetContentTypeTest
  * @run main/othervm GetContentTypeTest
  * @summary Test JarURLConnection.getContentType would
- *          would return default "content/unknown"
+ *          return default "content/unknown"
  */
 
-import jdk.test.lib.JDKToolFinder;
+import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
@@ -49,9 +49,9 @@ public class GetContentTypeTest {
         Path resJar = Paths.get(System.getProperty("test.src"),
                 "resource.jar");
         Path classes = Paths.get(System.getProperty("test.classes"));
-        ProcessTools.executeCommand(
-                JDKToolFinder.getTestJDKTool("java"),
-                "-cp", resJar + File.pathSeparator + classes, "GetContentType")
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-cp", resJar + File.pathSeparator + classes, "GetContentType");
+        new OutputAnalyzer(pb.start())
                 .outputTo(System.out)
                 .errorTo(System.out)
                 .shouldHaveExitValue(0);

--- a/test/jdk/sun/net/www/protocol/jar/jarbug/TestDriver.java
+++ b/test/jdk/sun/net/www/protocol/jar/jarbug/TestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,7 @@ import java.nio.file.Paths;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.compiler.CompilerUtils;
+import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
 
@@ -81,14 +82,14 @@ public class TestDriver {
         CompilerUtils.compile(srcDir.resolve("src").resolve("test"), targetDir);
 
         // Run tests
-        String java = JDKToolFinder.getTestJDKTool("java");
         String cp = targetDir.toString() + File.pathSeparator + jarFile;
         String[] tests = new String[]{"TestBug4361044", "TestBug4523159"};
         for (String test : tests) {
-            ProcessTools.executeCommand(java, "-cp", cp, test)
-                        .outputTo(System.out)
-                        .errorTo(System.out)
-                        .shouldHaveExitValue(0);
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-cp", cp, test);
+            new OutputAnalyzer(pb.start())
+                    .outputTo(System.out)
+                    .errorTo(System.out)
+                    .shouldHaveExitValue(0);
         }
     }
 }

--- a/test/jdk/sun/net/www/protocol/jrt/OtherResourcesTest.java
+++ b/test/jdk/sun/net/www/protocol/jrt/OtherResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,8 @@
  * questions.
  */
 
-import jdk.test.lib.JDKToolFinder;
-import static jdk.test.lib.process.ProcessTools.executeCommand;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * @test
@@ -39,12 +39,13 @@ import static jdk.test.lib.process.ProcessTools.executeCommand;
 public class OtherResourcesTest {
     public static void main(String[] args) throws Throwable {
         String classes = System.getProperty("test.classes");
-        executeCommand(JDKToolFinder.getTestJDKTool("java"),
-                       "--limit-modules", "java.base",
-                       "-cp", classes, "OtherResources")
-                      .outputTo(System.out)
-                      .errorTo(System.out)
-                      .shouldHaveExitValue(0);
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "--limit-modules", "java.base",
+                "-cp", classes, "OtherResources");
+        new OutputAnalyzer(pb.start())
+                .outputTo(System.out)
+                .errorTo(System.out)
+                .shouldHaveExitValue(0);
     }
 }
 


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

Resolved two copyrights, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8319651](https://bugs.openjdk.org/browse/JDK-8319651) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319651](https://bugs.openjdk.org/browse/JDK-8319651): Several network tests ignore vm flags when start java process (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2985/head:pull/2985` \
`$ git checkout pull/2985`

Update a local copy of the PR: \
`$ git checkout pull/2985` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2985`

View PR using the GUI difftool: \
`$ git pr show -t 2985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2985.diff">https://git.openjdk.org/jdk17u-dev/pull/2985.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2985#issuecomment-2429178285)