### PR TITLE
8336240: Test com/sun/crypto/provider/Cipher/DES/PerformanceTest.java fails with java.lang.ArithmeticException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -662,7 +662,6 @@ sun/security/smartcardio/TestExclusive.java                     8039280 generic-
 sun/security/smartcardio/TestMultiplePresent.java               8039280 generic-all
 sun/security/smartcardio/TestPresent.java                       8039280 generic-all
 sun/security/smartcardio/TestTransmit.java                      8039280 generic-all
-com/sun/crypto/provider/Cipher/DES/PerformanceTest.java         8039280 generic-all
 com/sun/security/auth/callback/TextCallbackHandler/Password.java 8039280 generic-all
 com/sun/security/sasl/gsskerb/AuthOnly.java                     8039280 generic-all
 com/sun/security/sasl/gsskerb/ConfSecurityLayer.java            8039280 generic-all

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -568,7 +568,6 @@ jdk_core_manual_no_input = \
 
 jdk_security_manual_no_input = \
     :jdk_security_infra \
-    com/sun/crypto/provider/Cipher/DES/PerformanceTest.java \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementByte4.java \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementDirect4.java \
     com/sun/security/auth/callback/TextCallbackHandler/Password.java \

--- a/test/jdk/com/sun/crypto/provider/Cipher/DES/PerformanceTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/DES/PerformanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,8 @@
  * @bug 0000000
  * @summary This test checks performance of various ciphers.
  * @author Jan Luehe
- * @run main/manual PerformanceTest
  */
-import java.security.*;
 import java.security.spec.*;
-import java.io.*;
 import javax.crypto.*;
 import javax.crypto.spec.*;
 
@@ -178,14 +175,16 @@ public class PerformanceTest {
         long start, end;
         cipher.init(Cipher.ENCRYPT_MODE, cipherKey, params);
 
-        start = System.currentTimeMillis();
+        start = getTimeInMicroseconds();
         for (int i=0; i<count-1; i++) {
             cipher.update(data, 0, data.length);
         }
         cipher.doFinal(data, 0, data.length);
-        end = System.currentTimeMillis();
+        end = getTimeInMicroseconds();
 
-        int speed = (int)((data.length * count)/(end - start));
+        // To avoid dividing by zero in the rare case where end is equal to start
+        long executionTime = end != start ? end - start : 1L;
+        int speed = (int) ((data.length * count) / executionTime);
         sum += speed;
         col.append(speed);
     }
@@ -198,8 +197,12 @@ public class PerformanceTest {
         System.out.println
             ("=========================================================");
         System.out.println
-            ("Algorithm                      DataSize Rounds Kbytes/sec");
+            ("Algorithm                      DataSize Rounds Bytes/microsec");
 
+    }
+
+    private static long getTimeInMicroseconds() {
+        return System.nanoTime() / 1000;
     }
 
 }


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336240](https://bugs.openjdk.org/browse/JDK-8336240) needs maintainer approval

### Issue
 * [JDK-8336240](https://bugs.openjdk.org/browse/JDK-8336240): Test com/sun/crypto/provider/Cipher/DES/PerformanceTest.java fails with java.lang.ArithmeticException (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2986/head:pull/2986` \
`$ git checkout pull/2986`

Update a local copy of the PR: \
`$ git checkout pull/2986` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2986`

View PR using the GUI difftool: \
`$ git pr show -t 2986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2986.diff">https://git.openjdk.org/jdk17u-dev/pull/2986.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2986#issuecomment-2429324229)