### PR TITLE
8340210: Add positionTestUI() to PassFailJFrame.Builder

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1143,6 +1143,29 @@ public final class PassFailJFrame {
         }
 
         /**
+         * Adds an implementation of {@link PositionWindows PositionWindows}
+         * which the framework will use to position multiple test UI windows.
+         *
+         * @param positionWindows an implementation of {@code PositionWindows}
+         *                        to position multiple test UI windows
+         * @return this builder
+         * @throws IllegalArgumentException if the {@code positionWindows}
+         *              parameter is {@code null}
+         * @throws IllegalStateException if the {@code positionWindows} field
+         *              is already set
+         */
+        public Builder positionTestUI(PositionWindows positionWindows) {
+            if (positionWindows == null) {
+                throw new IllegalArgumentException("positionWindows parameter can't be null");
+            }
+            if (this.positionWindows != null) {
+                throw new IllegalStateException("PositionWindows is already set");
+            }
+            this.positionWindows = positionWindows;
+            return this;
+        }
+
+        /**
          * Adds a {@code WindowListCreator} which the framework will use
          * to create a list of test UI windows.
          *


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8340210](https://bugs.openjdk.org/browse/JDK-8340210) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340210](https://bugs.openjdk.org/browse/JDK-8340210): Add positionTestUI() to PassFailJFrame.Builder (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2987/head:pull/2987` \
`$ git checkout pull/2987`

Update a local copy of the PR: \
`$ git checkout pull/2987` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2987`

View PR using the GUI difftool: \
`$ git pr show -t 2987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2987.diff">https://git.openjdk.org/jdk17u-dev/pull/2987.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2987#issuecomment-2429334265)