### PR TITLE
8335709: C2: assert(!loop->is_member(get_loop(useblock))) failed: must be outside loop

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4807,7 +4807,8 @@ int PhaseIdealLoop::build_loop_tree_impl( Node *n, int pre_order ) {
 
     } else {                    // Else not a nested loop
       if( !_nodes[m->_idx] ) continue; // Dead code has no loop
-      l = get_loop(m);          // Get previously determined loop
+      IdealLoopTree* m_loop = get_loop(m);
+      l = m_loop;          // Get previously determined loop
       // If successor is header of a loop (nest), move up-loop till it
       // is a member of some outer enclosing loop.  Since there are no
       // shared headers (I've split them already) I only need to go up
@@ -4833,10 +4834,10 @@ int PhaseIdealLoop::build_loop_tree_impl( Node *n, int pre_order ) {
           // Insert the NeverBranch between 'm' and it's control user.
           NeverBranchNode *iff = new NeverBranchNode( m );
           _igvn.register_new_node_with_optimizer(iff);
-          set_loop(iff, l);
+          set_loop(iff, m_loop);
           Node *if_t = new CProjNode( iff, 0 );
           _igvn.register_new_node_with_optimizer(if_t);
-          set_loop(if_t, l);
+          set_loop(if_t, m_loop);
 
           Node* cfg = nullptr;       // Find the One True Control User of m
           for (DUIterator_Fast jmax, j = m->fast_outs(jmax); j < jmax; j++) {

--- a/test/hotspot/jtreg/compiler/loopopts/InfiniteLoopBadControlNeverBranch.java
+++ b/test/hotspot/jtreg/compiler/loopopts/InfiniteLoopBadControlNeverBranch.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8335709
+ * @summary C2: assert(!loop->is_member(get_loop(useblock))) failed: must be outside loop
+ * @library /test/lib
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,InfiniteLoopBadControlNeverBranch::* InfiniteLoopBadControlNeverBranch
+ *
+ */
+
+
+import jdk.test.lib.Utils;
+
+public class InfiniteLoopBadControlNeverBranch {
+    static int b;
+    static short c;
+
+    public static void main(String[] args) throws InterruptedException {
+        Thread thread = new Thread(() -> test());
+        thread.setDaemon(true);
+        thread.start();
+        Thread.sleep(Utils.adjustTimeout(4000));
+    }
+
+    static void test() {
+        int i = 0;
+        while (true) {
+            if (i > 1) {
+                b = 0;
+            }
+            c = (short) (b * 7);
+            i++;
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335709](https://bugs.openjdk.org/browse/JDK-8335709) needs maintainer approval

### Issue
 * [JDK-8335709](https://bugs.openjdk.org/browse/JDK-8335709): C2: assert(!loop-&gt;is_member(get_loop(useblock))) failed: must be outside loop (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2991/head:pull/2991` \
`$ git checkout pull/2991`

Update a local copy of the PR: \
`$ git checkout pull/2991` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2991`

View PR using the GUI difftool: \
`$ git pr show -t 2991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2991.diff">https://git.openjdk.org/jdk17u-dev/pull/2991.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2991#issuecomment-2432377811)