### PR TITLE
8340308: PassFailJFrame: Make rows default to number of lines in instructions

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1105,11 +1105,45 @@ public final class PassFailJFrame {
             return this;
         }
 
+        /**
+         * Sets the number of rows for displaying the instruction text.
+         * The default value is the number of lines in the text plus 1:
+         * {@code ((int) instructions.lines().count() + 1)}.
+         *
+         * @param rows the number of rows for instruction text
+         * @return this builder
+         */
         public Builder rows(int rows) {
             this.rows = rows;
             return this;
         }
 
+        private int getDefaultRows() {
+            return (int) instructions.lines().count() + 1;
+        }
+
+        /**
+         * Adds a certain number of rows for displaying the instruction text.
+         *
+         * @param rowsAdd the number of rows to add to the number of rows
+         * @return this builder
+         * @see #rows
+         */
+        public Builder rowsAdd(int rowsAdd) {
+            if (rows == 0) {
+                rows = getDefaultRows();
+            }
+            rows += rowsAdd;
+
+            return this;
+        }
+
+        /**
+         * Sets the number of columns for displaying the instruction text.
+         *
+         * @param columns the number of columns for instruction text
+         * @return this builder
+         */
         public Builder columns(int columns) {
             this.columns = columns;
             return this;
@@ -1350,7 +1384,7 @@ public final class PassFailJFrame {
             }
 
             if (rows == 0) {
-                rows = ROWS;
+                rows = getDefaultRows();
             }
 
             if (columns == 0) {


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8340308](https://bugs.openjdk.org/browse/JDK-8340308) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340308](https://bugs.openjdk.org/browse/JDK-8340308): PassFailJFrame: Make rows default to number of lines in instructions (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2996/head:pull/2996` \
`$ git checkout pull/2996`

Update a local copy of the PR: \
`$ git checkout pull/2996` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2996`

View PR using the GUI difftool: \
`$ git pr show -t 2996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2996.diff">https://git.openjdk.org/jdk17u-dev/pull/2996.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2996#issuecomment-2432529764)