### PR TITLE
8340899: Remove wildcard bound in PositionWindows.positionTestWindows

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -551,7 +551,7 @@ public final class PassFailJFrame {
          * @param testWindows the list of test windows
          * @param instructionUI information about the instruction frame
          */
-        void positionTestWindows(List<? extends Window> testWindows,
+        void positionTestWindows(List<Window> testWindows,
                                  InstructionUI instructionUI);
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340899](https://bugs.openjdk.org/browse/JDK-8340899) needs maintainer approval

### Issue
 * [JDK-8340899](https://bugs.openjdk.org/browse/JDK-8340899): Remove wildcard bound in PositionWindows.positionTestWindows (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/2998/head:pull/2998` \
`$ git checkout pull/2998`

Update a local copy of the PR: \
`$ git checkout pull/2998` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/2998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2998`

View PR using the GUI difftool: \
`$ git pr show -t 2998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/2998.diff">https://git.openjdk.org/jdk17u-dev/pull/2998.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/2998#issuecomment-2432581381)