### PR TITLE
8303742: CompletableFuture.orTimeout leaks if the future completes exceptionally

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -2891,7 +2891,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
         final Future<?> f;
         Canceller(Future<?> f) { this.f = f; }
         public void accept(Object ignore, Throwable ex) {
-            if (ex == null && f != null && !f.isDone())
+            if (f != null && !f.isDone())
                 f.cancel(false);
         }
     }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -25,39 +25,59 @@
  * @test
  * @bug 8303742
  * @summary CompletableFuture.orTimeout can leak memory if completed exceptionally
+ * @modules java.base/java.util.concurrent:open
  * @run junit/othervm -Xmx128m CompletableFutureOrTimeoutExceptionallyTest
  */
 
 import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CompletableFutureOrTimeoutExceptionallyTest {
+    static final BlockingQueue<Runnable> delayerQueue;
+    static {
+        try {
+            var delayerClass = Class.forName("java.util.concurrent.CompletableFuture$Delayer",
+                                             true,
+                                             CompletableFuture.class.getClassLoader());
+            var delayerField = delayerClass.getDeclaredField("delayer");
+            delayerField.setAccessible(true);
+            delayerQueue = ((ScheduledThreadPoolExecutor)delayerField.get(null)).getQueue();
+        } catch (Throwable t) {
+            throw new ExceptionInInitializerError(t);
+        }
+    }
+
     /**
      * Test that orTimeout task is cancelled if the CompletableFuture is completed Exceptionally
      */
     @Test
-    void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() {
-        var count = 0L;
-        while (count++ < 2_000_000) {
-            new CompletableFuture<>()
-            .orTimeout(12, TimeUnit.HOURS)
-            .completeExceptionally(new RuntimeException("This is fine"));
-        }
+    void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() throws InterruptedException {
+        assertTrue(delayerQueue.peek() == null);
+        var future = new CompletableFuture<>().orTimeout(12, TimeUnit.HOURS);
+        assertTrue(delayerQueue.peek() != null);
+        future.completeExceptionally(new RuntimeException("This is fine"));
+        while (delayerQueue.peek() != null) {
+            Thread.sleep(100);
+        };
     }
 
     /**
      * Test that the completeOnTimeout task is cancelled if the CompletableFuture is completed Exceptionally
      */
     @Test
-    void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() {
-        var count = 0L;
-        while (count++ < 2_000_000) {
-            new CompletableFuture<>()
-            .completeOnTimeout(null, 12, TimeUnit.HOURS)
-            .completeExceptionally(new RuntimeException("This is fine"));
-        }
+    void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() throws InterruptedException {
+        assertTrue(delayerQueue.peek() == null);
+        var future = new CompletableFuture<>().completeOnTimeout(null, 12, TimeUnit.HOURS);
+        assertTrue(delayerQueue.peek() != null);
+        future.completeExceptionally(new RuntimeException("This is fine"));
+        while (delayerQueue.peek() != null) {
+            Thread.sleep(100);
+        };
     }
 }

--- a/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
+++ b/test/jdk/java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8303742
+ * @summary CompletableFuture.orTimeout can leak memory if completed exceptionally
+ * @run junit/othervm -Xmx128m CompletableFutureOrTimeoutExceptionallyTest
+ */
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class CompletableFutureOrTimeoutExceptionallyTest {
+    /**
+     * Test that orTimeout task is cancelled if the CompletableFuture is completed Exceptionally
+     */
+    @Test
+    void testOrTimeoutWithCompleteExceptionallyDoesNotLeak() {
+        var count = 0L;
+        while (count++ < 2_000_000) {
+            new CompletableFuture<>()
+            .orTimeout(12, TimeUnit.HOURS)
+            .completeExceptionally(new RuntimeException("This is fine"));
+        }
+    }
+
+    /**
+     * Test that the completeOnTimeout task is cancelled if the CompletableFuture is completed Exceptionally
+     */
+    @Test
+    void testCompleteOnTimeoutWithCompleteExceptionallyDoesNotLeak() {
+        var count = 0L;
+        while (count++ < 2_000_000) {
+            new CompletableFuture<>()
+            .completeOnTimeout(null, 12, TimeUnit.HOURS)
+            .completeExceptionally(new RuntimeException("This is fine"));
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of a patch to prevent `CompleteableFuture.orTimeout` from leaking when a `ScheduledFutureTask` exits exceptionally

Passes the included test as well as jtreg tier 1 locally on linux x86_64

Updated to include JDK-8304557, which is a follow up item to prevent the test from timing out, see @RealCLanger's comment below. That backport is also clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8303742](https://bugs.openjdk.org/browse/JDK-8303742) needs maintainer approval
- [x] [JDK-8304557](https://bugs.openjdk.org/browse/JDK-8304557) needs maintainer approval

### Issues
 * [JDK-8303742](https://bugs.openjdk.org/browse/JDK-8303742): CompletableFuture.orTimeout leaks if the future completes exceptionally (**Bug** - P4 - Approved)
 * [JDK-8304557](https://bugs.openjdk.org/browse/JDK-8304557): java/util/concurrent/CompletableFuture/CompletableFutureOrTimeoutExceptionallyTest.java times out (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3000/head:pull/3000` \
`$ git checkout pull/3000`

Update a local copy of the PR: \
`$ git checkout pull/3000` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3000`

View PR using the GUI difftool: \
`$ git pr show -t 3000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3000.diff">https://git.openjdk.org/jdk17u-dev/pull/3000.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3000#issuecomment-2433574837)
</details>
