### PR TITLE
8342496: C2/Shenandoah: SEGV in compiled code when running jcstress

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -1048,6 +1048,7 @@ void ShenandoahBarrierC2Support::fix_ctrl(Node* barrier, Node* region, const Mem
     Node* u = ctrl->fast_out(i);
     if (u->_idx < last &&
         u != barrier &&
+        !u->depends_only_on_test() && // preserve dependency on test
         !uses_to_ignore.member(u) &&
         (u->in(0) != ctrl || (!u->is_Region() && !u->is_Phi())) &&
         (ctrl->Opcode() != Op_CatchProj || u->Opcode() != Op_CreateEx)) {

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8342496
+ * @summary C2/Shenandoah: SEGV in compiled code when running jcstress
+ * @requires vm.flavor == "server"
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:+StressGCM
+ *                   -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 -XX:StressSeed=270847015 TestLoadBypassesNullCheck
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:+StressGCM
+ *                   -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 TestLoadBypassesNullCheck
+ *
+ */
+
+public class TestLoadBypassesNullCheck {
+    private static A fieldA = new A();
+    private static Object fieldO = new Object();
+    private static volatile int volatileField;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test1();
+        }
+        fieldA = null;
+        try {
+            test1();
+        } catch (NullPointerException npe) {
+        }
+    }
+
+    private static boolean test1() {
+        for (int i = 0; i < 1000; i++) {
+            volatileField = 42;
+            A a = fieldA;
+            Object o = a.fieldO;
+            if (o == fieldO) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static class A {
+        public Object fieldO;
+    }
+}


### PR DESCRIPTION
Clean backport JDK-8342496

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342496](https://bugs.openjdk.org/browse/JDK-8342496) needs maintainer approval

### Issue
 * [JDK-8342496](https://bugs.openjdk.org/browse/JDK-8342496): C2/Shenandoah: SEGV in compiled code when running jcstress (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3006/head:pull/3006` \
`$ git checkout pull/3006`

Update a local copy of the PR: \
`$ git checkout pull/3006` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3006`

View PR using the GUI difftool: \
`$ git pr show -t 3006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3006.diff">https://git.openjdk.org/jdk17u-dev/pull/3006.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3006#issuecomment-2438376310)