### PR TITLE
8334057: JLinkReproducibleTest.java support receive test.tool.vm.opts

### DIFF
--- a/test/jdk/tools/jlink/JLinkReproducibleTest.java
+++ b/test/jdk/tools/jlink/JLinkReproducibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@ import jdk.test.lib.process.ProcessTools;
  * @run driver JLinkReproducibleTest
  */
 public class JLinkReproducibleTest {
+
+    private static final String TOOL_VM_OPTIONS = System.getProperty("test.tool.vm.opts", "");
+
     private static void run(List<String> cmd) throws Exception {
         var pb = new ProcessBuilder(cmd.toArray(new String[0]));
         var res = ProcessTools.executeProcess(pb);
@@ -46,6 +49,9 @@ public class JLinkReproducibleTest {
     private static void jlink(Path image, boolean with_default_trace_file) throws Exception {
         var cmd = new ArrayList<String>();
         cmd.add(JDKToolFinder.getJDKTool("jlink"));
+        if (!TOOL_VM_OPTIONS.isEmpty()) {
+            cmd.addAll(Arrays.asList(TOOL_VM_OPTIONS.split("\\s+", -1)));
+        }
         cmd.addAll(List.of(
             "--module-path", JMODS_DIR.toString() + File.pathSeparator + CLASS_DIR.toString(),
             "--add-modules", "main",


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334057](https://bugs.openjdk.org/browse/JDK-8334057) needs maintainer approval

### Issue
 * [JDK-8334057](https://bugs.openjdk.org/browse/JDK-8334057): JLinkReproducibleTest.java support receive test.tool.vm.opts (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3016/head:pull/3016` \
`$ git checkout pull/3016`

Update a local copy of the PR: \
`$ git checkout pull/3016` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3016`

View PR using the GUI difftool: \
`$ git pr show -t 3016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3016.diff">https://git.openjdk.org/jdk17u-dev/pull/3016.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3016#issuecomment-2447582702)
</details>
