### PR TITLE
8342578: GHA: RISC-V: Bootstrap using Debian snapshot is still failing

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -84,7 +84,7 @@ jobs:
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
-            debian-repository: https://snapshot.debian.org/archive/debian/20240228T034848Z/
+            debian-repository: https://httpredir.debian.org/debian/
             debian-version: sid
             tolerate-sysroot-errors: true
 
@@ -131,6 +131,7 @@ jobs:
         id: create-sysroot
         run: >
           sudo debootstrap
+          --no-merged-usr
           --arch=${{ matrix.debian-arch }}
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype-dev,libpng-dev
@@ -151,6 +152,9 @@ jobs:
           rm -rf sysroot/usr/{sbin,bin,share}
           rm -rf sysroot/usr/lib/{apt,gcc,udev,systemd}
           rm -rf sysroot/usr/libexec/gcc
+          # /{bin,sbin,lib}/ are not symbolic links to /usr/{bin,sbin,lib}/ when debootstrap with --no-merged-usr
+          rm -rf sysroot/{sbin,bin}
+          rm -rf sysroot/lib/{udev,systemd}
         if: steps.create-sysroot.outcome == 'success' && steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Remove broken sysroot'


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [239d84a8](https://github.com/openjdk/jdk/commit/239d84a82a1e6f4ebbd5c5abb320e39cfd5bc330) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fei Yang on 21 Oct 2024 and was reviewed by Aleksey Shipilev and Erik Joelsson.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342578](https://bugs.openjdk.org/browse/JDK-8342578) needs maintainer approval

### Issue
 * [JDK-8342578](https://bugs.openjdk.org/browse/JDK-8342578): GHA: RISC-V: Bootstrap using Debian snapshot is still failing (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3017/head:pull/3017` \
`$ git checkout pull/3017`

Update a local copy of the PR: \
`$ git checkout pull/3017` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3017`

View PR using the GUI difftool: \
`$ git pr show -t 3017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3017.diff">https://git.openjdk.org/jdk17u-dev/pull/3017.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3017#issuecomment-2448973889)
</details>
