### PR TITLE
8339931: Update problem list for WindowUpdateFocusabilityTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -460,7 +460,7 @@ java/awt/image/VolatileImage/CustomCompositeTest.java 8199002 windows-all,linux-
 java/awt/image/VolatileImage/GradientPaints.java 8199003 linux-all
 java/awt/JAWT/JAWT.sh 8197798 windows-all,linux-all
 java/awt/Debug/DumpOnKey/DumpOnKey.java 8202667 windows-all
-java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 8202926 linux-all
+java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.java 8339929 linux-all
 java/awt/datatransfer/ConstructFlavoredObjectTest/ConstructFlavoredObjectTest.java 8202860 linux-all
 java/awt/FileDialog/FilenameFilterTest/FilenameFilterTest.java 8202882 linux-all
 java/awt/Focus/NonFocusableBlockedOwnerTest/NonFocusableBlockedOwnerTest.java 7124275 macosx-all


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

No commit available, but obvious to "implement".
Also adding 8202926, as this includes the backport of that change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339931](https://bugs.openjdk.org/browse/JDK-8339931) needs maintainer approval
- [x] [JDK-8202926](https://bugs.openjdk.org/browse/JDK-8202926) needs maintainer approval

### Issues
 * [JDK-8339931](https://bugs.openjdk.org/browse/JDK-8339931): Update problem list for WindowUpdateFocusabilityTest.java (**Sub-task** - P4 - Approved)
 * [JDK-8202926](https://bugs.openjdk.org/browse/JDK-8202926): Test java/awt/Focus/WindowUpdateFocusabilityTest/WindowUpdateFocusabilityTest.html fails (**Bug** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3022/head:pull/3022` \
`$ git checkout pull/3022`

Update a local copy of the PR: \
`$ git checkout pull/3022` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3022`

View PR using the GUI difftool: \
`$ git pr show -t 3022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3022.diff">https://git.openjdk.org/jdk17u-dev/pull/3022.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3022#issuecomment-2451666299)
</details>
