### PR TITLE
8340812: LambdaForm customization via MethodHandle::updateForm is not thread safe

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1764,8 +1764,7 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
                 if (oldForm != newForm) {
                     assert (newForm.customized == null || newForm.customized == this);
                     newForm.prepare(); // as in MethodHandle.<init>
-                    UNSAFE.putReference(this, FORM_OFFSET, newForm);
-                    UNSAFE.fullFence();
+                    UNSAFE.putReferenceRelease(this, FORM_OFFSET, newForm); // properly publish newForm
                 }
             } finally {
                 updateInProgress = false;

--- a/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
+++ b/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+
+/**
+  * @test
+  * @bug 8340812
+  * @summary Verify that LambdaForm customization via MethodHandle::updateForm is thread safe.
+  * @run main TestLambdaFormCustomization
+  * @run main/othervm -Djava.lang.invoke.MethodHandle.CUSTOMIZE_THRESHOLD=0 TestLambdaFormCustomization
+  */
+public class TestLambdaFormCustomization {
+
+    String str = "test";
+    static final String value = "test" + 42;
+
+    // Trigger concurrent LambdaForm customization for VarHandle invokers
+    void test() throws NoSuchFieldException, IllegalAccessException {
+        VarHandle varHandle = MethodHandles.lookup().in(getClass()).findVarHandle(getClass(), "str", String.class);
+
+        ArrayList<Thread> threads = new ArrayList<>();
+        for (int threadIdx = 0; threadIdx < 10; threadIdx++) {
+            threads.add(new Thread(() -> {
+                for (int i = 0; i < 1000; i++) {
+                    varHandle.compareAndExchange(this, value, value);
+                    varHandle.compareAndExchange(this, value, value);
+                    varHandle.compareAndExchange(this, value, value);
+                }
+            }));
+        }
+        threads.forEach(Thread::start);
+        threads.forEach(t -> {
+            try {
+                t.join();
+            } catch (Throwable e) {
+                throw new IllegalStateException(e);
+            }
+        });
+    }
+
+    public static void main(String[] args) throws Exception {
+        TestLambdaFormCustomization t = new TestLambdaFormCustomization();
+        for (int i = 0; i < 4000; ++i) {
+            t.test();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

Resolved Copyright, probably clean anyways.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340812](https://bugs.openjdk.org/browse/JDK-8340812) needs maintainer approval

### Issue
 * [JDK-8340812](https://bugs.openjdk.org/browse/JDK-8340812): LambdaForm customization via MethodHandle::updateForm is not thread safe (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3024/head:pull/3024` \
`$ git checkout pull/3024`

Update a local copy of the PR: \
`$ git checkout pull/3024` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3024`

View PR using the GUI difftool: \
`$ git pr show -t 3024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3024.diff">https://git.openjdk.org/jdk17u-dev/pull/3024.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3024#issuecomment-2454144359)
</details>
