### PR TITLE
8342681: TestLoadBypassesNullCheck.java fails improperly specified VM option

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
@@ -28,10 +28,14 @@
  * @requires vm.flavor == "server"
  * @requires vm.gc.Shenandoah
  *
- * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:+StressGCM
- *                   -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 -XX:StressSeed=270847015 TestLoadBypassesNullCheck
- * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:+StressGCM
- *                   -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 TestLoadBypassesNullCheck
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ *                   -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM -XX:StressSeed=270847015
+ *                   TestLoadBypassesNullCheck
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ *                   -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
+ *                   TestLoadBypassesNullCheck
  *
  */
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8bcd4920](https://github.com/openjdk/jdk/commit/8bcd4920f1b03d0ef8e295e53557c629f05ceaa4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 22 Oct 2024 and was reviewed by Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342681](https://bugs.openjdk.org/browse/JDK-8342681) needs maintainer approval

### Issue
 * [JDK-8342681](https://bugs.openjdk.org/browse/JDK-8342681): TestLoadBypassesNullCheck.java fails improperly specified VM option (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3027/head:pull/3027` \
`$ git checkout pull/3027`

Update a local copy of the PR: \
`$ git checkout pull/3027` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3027`

View PR using the GUI difftool: \
`$ git pr show -t 3027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3027.diff">https://git.openjdk.org/jdk17u-dev/pull/3027.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3027#issuecomment-2456073337)
</details>
