### PR TITLE
8343687: [17u] TestAntiDependencyForPinnedLoads requires UTF-8

### DIFF
--- a/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyForPinnedLoads.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyForPinnedLoads.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8337066
  * @summary Test that MergeMem is skipped when looking for stores
- * @compile -encoding UTF-8 TestAntiDependencyForPinnedLoads2.java
+ * @compile -encoding UTF-8 TestAntiDependencyForPinnedLoads.java
  * @run main/othervm -Xbatch -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,java.lang.StringUTF16::reverse
  *                   compiler.controldependency.TestAntiDependencyForPinnedLoads

--- a/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyForPinnedLoads.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyForPinnedLoads.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8337066
  * @summary Test that MergeMem is skipped when looking for stores
+ * @compile -encoding UTF-8 TestAntiDependencyForPinnedLoads2.java
  * @run main/othervm -Xbatch -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,java.lang.StringUTF16::reverse
  *                   compiler.controldependency.TestAntiDependencyForPinnedLoads


### PR DESCRIPTION
We see this test failing on Windows. 

Forcing UTF-8 fixes the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343687](https://bugs.openjdk.org/browse/JDK-8343687) needs maintainer approval

### Issue
 * [JDK-8343687](https://bugs.openjdk.org/browse/JDK-8343687): [17u] TestAntiDependencyForPinnedLoads requires UTF-8 (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3030/head:pull/3030` \
`$ git checkout pull/3030`

Update a local copy of the PR: \
`$ git checkout pull/3030` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3030`

View PR using the GUI difftool: \
`$ git pr show -t 3030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3030.diff">https://git.openjdk.org/jdk17u-dev/pull/3030.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3030#issuecomment-2459168315)
</details>
