### PR TITLE
8337810: ProblemList BasicDirectoryModel/LoaderThreadCount.java on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -696,6 +696,7 @@ javax/sound/midi/Sequencer/Looping.java 8136897 generic-all
 # jdk_swing
 
 javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,windows-all
+javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java 8333880 windows-all
 
 javax/swing/JFrame/MaximizeWindowTest.java 8321289 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all


### PR DESCRIPTION
I want to ProblemList this in 17, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8337810](https://bugs.openjdk.org/browse/JDK-8337810) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337810](https://bugs.openjdk.org/browse/JDK-8337810): ProblemList BasicDirectoryModel/LoaderThreadCount.java on Windows (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3031/head:pull/3031` \
`$ git checkout pull/3031`

Update a local copy of the PR: \
`$ git checkout pull/3031` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3031`

View PR using the GUI difftool: \
`$ git pr show -t 3031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3031.diff">https://git.openjdk.org/jdk17u-dev/pull/3031.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3031#issuecomment-2460002426)
</details>
