### PR TITLE
8335142: compiler/c1/TestTraceLinearScanLevel.java occasionally times out with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestTraceLinearScanLevel.java
+++ b/test/hotspot/jtreg/compiler/c1/TestTraceLinearScanLevel.java
@@ -26,8 +26,8 @@
  * @bug 8251093
  * @summary Sanity check the flag TraceLinearScanLevel with the highest level in a silent HelloWorld program.
  *
- * @requires vm.debug == true & vm.compiler1.enabled
- * @run main/othervm -XX:TraceLinearScanLevel=4 compiler.c1.TestTraceLinearScanLevel
+ * @requires vm.debug == true & vm.compiler1.enabled & vm.compMode != "Xcomp"
+ * @run main/othervm -Xbatch -XX:TraceLinearScanLevel=4 compiler.c1.TestTraceLinearScanLevel
  */
 package compiler.c1;
 


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8335142](https://bugs.openjdk.org/browse/JDK-8335142) needs maintainer approval

### Issue
 * [JDK-8335142](https://bugs.openjdk.org/browse/JDK-8335142): compiler/c1/TestTraceLinearScanLevel.java occasionally times out with -Xcomp (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3034/head:pull/3034` \
`$ git checkout pull/3034`

Update a local copy of the PR: \
`$ git checkout pull/3034` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3034`

View PR using the GUI difftool: \
`$ git pr show -t 3034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3034.diff">https://git.openjdk.org/jdk17u-dev/pull/3034.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3034#issuecomment-2461907702)
</details>
