### PR TITLE
8330278: Have SSLSocketTemplate.doClientSide use loopback address

### DIFF
--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -273,7 +273,7 @@ public class SSLSocketTemplate extends SSLContextTemplate {
                 configureClientSocket(sslSocket);
                 InetAddress serverAddress = this.serverAddress;
                 InetSocketAddress connectAddress = serverAddress == null
-                        ? new InetSocketAddress("localhost", serverPort)
+                        ? new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort)
                         : new InetSocketAddress(serverAddress, serverPort);
                 sslSocket.connect(connectAddress, 15000);
             } catch (IOException ioe) {

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
@@ -222,7 +223,7 @@ abstract public class TLSBase {
             try {
                 sslContext = SSLContext.getDefault();
                 sock = (SSLSocket)sslContext.getSocketFactory().createSocket();
-                sock.connect(new InetSocketAddress("localhost", serverPort));
+                sock.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort));
                 System.err.println("Client connected using port " +
                         sock.getLocalPort());
                 name = "client(" + sock.toString() + ")";


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle

Resolved import, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330278](https://bugs.openjdk.org/browse/JDK-8330278) needs maintainer approval

### Issue
 * [JDK-8330278](https://bugs.openjdk.org/browse/JDK-8330278): Have SSLSocketTemplate.doClientSide use loopback address (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3036/head:pull/3036` \
`$ git checkout pull/3036`

Update a local copy of the PR: \
`$ git checkout pull/3036` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3036`

View PR using the GUI difftool: \
`$ git pr show -t 3036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3036.diff">https://git.openjdk.org/jdk17u-dev/pull/3036.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3036#issuecomment-2462336425)
</details>
