### PR TITLE
Backport d7c85b194dcb2c312afe18e62a87b1708d4f14bb

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -77,7 +77,7 @@ public abstract class PKCS11Test {
 
     // Version of the NSS artifact. This coincides with the version of
     // the NSS version
-    private static final String NSS_BUNDLE_VERSION = "3.96";
+    private static final String NSS_BUNDLE_VERSION = "3.101";
     private static final String NSSLIB = "jpg.tests.jdk.nsslib";
 
     static double nss_version = -1;

--- a/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
+++ b/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,12 @@ public class TestDSAKeyLength extends PKCS11Test {
 
     @Override
     protected boolean skipTest(Provider provider) {
-        if (isNSS(provider) && (getNSSVersion() == 0.0 || getNSSVersion() >= 3.14)) {
-            System.out.println("Skip testing NSS " + getNSSVersion());
+        double version = getNSSVersion();
+        String[] versionStrs = Double.toString(version).split("\\.");
+        int major = Integer.parseInt(versionStrs[0]);
+        int minor = Integer.parseInt(versionStrs[1]);
+        if (isNSS(provider) && (version == 0.0 || (major >= 3 && minor >= 14))) {
+            System.out.println("Skip testing NSS " + version);
             return true;
         }
 


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

I verified that the ProblemList change, which is omitted in 21, is not needed in 17 either.