### PR TITLE
8300416: java.security.MessageDigestSpi clone can result in thread-unsafe clones

### DIFF
--- a/src/java.base/share/classes/java/security/MessageDigestSpi.java
+++ b/src/java.base/share/classes/java/security/MessageDigestSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,7 +204,15 @@ public abstract class MessageDigestSpi {
      */
     public Object clone() throws CloneNotSupportedException {
         if (this instanceof Cloneable) {
-            return super.clone();
+            MessageDigestSpi o = (MessageDigestSpi)super.clone();
+            if (o.tempArray != null) {
+                // New byte arrays are allocated when the ByteBuffer argument
+                // to engineUpdate is not backed by a byte array.
+                // Here, the newly allocated byte array must also be cloned
+                // to prevent threads from sharing the same memory.
+                o.tempArray = tempArray.clone();
+            }
+            return o;
         } else {
             throw new CloneNotSupportedException();
         }


### PR DESCRIPTION
I would like to fix this in 17. 

Resolved Copyright, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8300416](https://bugs.openjdk.org/browse/JDK-8300416) needs maintainer approval

### Issue
 * [JDK-8300416](https://bugs.openjdk.org/browse/JDK-8300416): java.security.MessageDigestSpi clone can result in thread-unsafe clones (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3039/head:pull/3039` \
`$ git checkout pull/3039`

Update a local copy of the PR: \
`$ git checkout pull/3039` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3039`

View PR using the GUI difftool: \
`$ git pr show -t 3039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3039.diff">https://git.openjdk.org/jdk17u-dev/pull/3039.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3039#issuecomment-2470859814)
</details>
