### PR TITLE
8284291: sun/security/krb5/auto/Renew.java fails intermittently on Windows 11

### DIFF
--- a/test/jdk/sun/security/krb5/auto/Renew.java
+++ b/test/jdk/sun/security/krb5/auto/Renew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,10 @@ public class Renew {
         Date d1 = c.s().getPrivateCredentials(KerberosTicket.class).iterator().next().getAuthTime();
 
         // 6s is longer than half of 10s
-        Thread.sleep(6000);
+        Date expiring = new Date(d1.getTime() + 6000);
+        while (new Date().before(expiring)) {
+            Thread.sleep(500);
+        }
 
         // The second login uses the cache
         c = Context.fromJAAS("second");


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8284291](https://bugs.openjdk.org/browse/JDK-8284291) needs maintainer approval

### Issue
 * [JDK-8284291](https://bugs.openjdk.org/browse/JDK-8284291): sun/security/krb5/auto/Renew.java fails intermittently on Windows 11 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3044/head:pull/3044` \
`$ git checkout pull/3044`

Update a local copy of the PR: \
`$ git checkout pull/3044` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3044`

View PR using the GUI difftool: \
`$ git pr show -t 3044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3044.diff">https://git.openjdk.org/jdk17u-dev/pull/3044.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3044#issuecomment-2478752541)
</details>
