### PR TITLE
8292309: Fix  java/awt/PrintJob/ConstrainedPrintingTest/ConstrainedPrintingTest.java  test

### DIFF
--- a/test/jdk/java/awt/PrintJob/ConstrainedPrintingTest/ConstrainedPrintingTest.java
+++ b/test/jdk/java/awt/PrintJob/ConstrainedPrintingTest/ConstrainedPrintingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,90 +27,89 @@
   @key printer
   @summary verify that child components can draw only inside their
            visible bounds
-  @author das@sparc.spb.su area=awt.print
-  @run main/manual=yesno ConstrainedPrintingTest
+  @library /test/lib
+  @library /javax/accessibility/manual
+  @build lib.ManualTestFrame
+  @build lib.TestResult
+  @build jtreg.SkippedException
+  @run main/manual ConstrainedPrintingTest
 */
 
-// Note there is no @ in front of test above.  This is so that the
-//  harness will not mistake this file as a test file.  It should
-//  only see the html file as a test file. (the harness runs all
-//  valid test files, so it would run this test twice if this file
-//  were valid as well as the html file.)
-// Also, note the area= after Your Name in the author tag.  Here, you
-//  should put which functional area the test falls in.  See the
-//  AWT-core home page -> test areas and/or -> AWT team  for a list of
-//  areas.
-// There are several places where ManualYesNoTest appear.  It is
-//  recommended that these be changed by a global search and replace,
-//  such as  ESC-%  in xemacs.
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.JobAttributes;
+import java.awt.PageAttributes;
+import java.awt.Panel;
+import java.awt.PrintJob;
+import java.awt.Rectangle;
+import java.awt.print.PrinterJob;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.swing.JEditorPane;
+import jtreg.SkippedException;
+import lib.ManualTestFrame;
+import lib.TestResult;
 
+public class ConstrainedPrintingTest {
 
-
-/**
- * ConstrainedPrintingTest.java
- *
- * summary: verify that child components can draw only inside their
- *          visible bounds
- *
- */
-
-import java.applet.Applet;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
-
-//Manual tests should run as applet tests if possible because they
-// get their environments cleaned up, including AWT threads, any
-// test created threads, and any system resources used by the test
-// such as file descriptors.  (This is normally not a problem as
-// main tests usually run in a separate VM, however on some platforms
-// such as the Mac, separate VMs are not possible and non-applet
-// tests will cause problems).  Also, you don't have to worry about
-// synchronisation stuff in Applet tests the way you do in main
-// tests...
-
-
-public class ConstrainedPrintingTest implements ActionListener
- {
-   //Declare things used in the test, like buttons and labels here
-    final Frame frame = new Frame("PrintTest");
-    final Button button = new Button("Print");
-    final Panel panel = new Panel();
-    final Component testComponent = new Component() {
-        public void paint(Graphics g) {
-            ConstrainedPrintingTest.paintOutsideBounds(this, g, Color.green);
-        }
-        public Dimension getPreferredSize() {
-            return new Dimension(100, 100);
-        }
-    };
-    final Canvas testCanvas = new Canvas() {
-        public void paint(Graphics g) {
-            ConstrainedPrintingTest.paintOutsideBounds(this, g, Color.red);
-            // The frame is sized so that only the upper part of
-            // the canvas is visible. We draw on the lower part,
-            // so that we can verify that the output is clipped
-            // by the parent container bounds.
-            Dimension panelSize = panel.getSize();
-            Rectangle b = getBounds();
-            g.setColor(Color.red);
-            g.setClip(null);
-            for (int i = panelSize.height - b.y; i < b.height; i+= 10) {
-                g.drawLine(0, i, b.width, i);
+    public static void createTestUI() {
+        Frame frame = new Frame("PrintTest");
+        Button button = new Button("Print");
+        Panel panel = new Panel();
+        Component testComponent = new Component() {
+            public void paint(Graphics g) {
+                ConstrainedPrintingTest.paintOutsideBounds(this, g, Color.green);
             }
-        }
-        public Dimension getPreferredSize() {
-            return new Dimension(100, 100);
-        }
-    };
+            public Dimension getPreferredSize() {
+                return new Dimension(100, 100);
+            }
+        };
 
-   public void init()
-    {
-      //Create instructions for the user here, as well as set up
-      // the environment -- set the layout manager, add buttons,
-      // etc.
-        button.addActionListener(this);
+        Canvas testCanvas = new Canvas() {
+            public void paint(Graphics g) {
+                ConstrainedPrintingTest.paintOutsideBounds(this, g, Color.red);
+                // The frame is sized so that only the upper part of
+                // the canvas is visible. We draw on the lower part,
+                // so that we can verify that the output is clipped
+                // by the parent container bounds.
+                Dimension panelSize = panel.getSize();
+                Rectangle b = getBounds();
+                g.setColor(Color.red);
+                g.setClip(null);
+                for (int i = panelSize.height - b.y; i < b.height; i+= 10) {
+                    g.drawLine(0, i, b.width, i);
+                }
+            }
+            public Dimension getPreferredSize() {
+                return new Dimension(100, 100);
+            }
+        };
+
+        button.addActionListener((actionEvent) -> {
+            PageAttributes pa = new PageAttributes();
+            pa.setPrinterResolution(36);
+            PrintJob pjob = frame.getToolkit().getPrintJob(frame, "NewTest",
+                    new JobAttributes(), pa);
+            if (pjob != null) {
+                Graphics pg = pjob.getGraphics();
+                if (pg != null) {
+                    pg.translate(20, 20);
+                    frame.printAll(pg);
+                    pg.dispose();
+                }
+                pjob.end();
+            }
+        });
 
         panel.setBackground(Color.white);
         panel.setLayout(new FlowLayout(FlowLayout.CENTER, 20, 20));
@@ -123,63 +122,8 @@ public class ConstrainedPrintingTest implements ActionListener
         frame.setSize(200, 250);
         frame.validate();
         frame.setResizable(false);
-
-      String[] instructions =
-       {
-         "1.Look at the frame titled \"PrintTest\". If you see green or",
-         "  red lines on the white area below the \"Print\" button, the",
-         "  test fails. Otherwise go to step 2.",
-         "2.Press \"Print\" button. The print dialog will appear. Select",
-         "  a printer and proceed. Look at the output. If you see multiple",
-         "  lines outside of the frame bounds or in the white area below",
-         "  the image of the \"Print\" button, the test fails. Otherwise",
-         "  the test passes."
-       };
-      Sysout.createDialogWithInstructions( instructions );
-
-    }//End  init()
-
-   public void start ()
-    {
-      //Get things going.  Request focus, set size, et cetera
-
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
-
-      //What would normally go into main() will probably go here.
-      //Use System.out.println for diagnostic messages that you want
-      // to read after the test is done.
-      //Use Sysout.println for messages you want the tester to read.
-
-    }// start()
-
-   //The rest of this class is the actions which perform the test...
-
-   //Use Sysout.println to communicate with the user NOT System.out!!
-   //Sysout.println ("Something Happened!");
-
-    public void stop() {
-        frame.setVisible(false);
-    }
-
-    public void destroy() {
-        frame.dispose();
-    }
-
-    public void actionPerformed(ActionEvent e) {
-        PageAttributes pa = new PageAttributes();
-        pa.setPrinterResolution(36);
-        PrintJob pjob = frame.getToolkit().getPrintJob(frame, "NewTest",
-                                                       new JobAttributes(),
-                                                       pa);
-        if (pjob != null) {
-            Graphics pg = pjob.getGraphics();
-            if (pg != null) {
-                pg.translate(20, 20);
-                frame.printAll(pg);
-                pg.dispose();
-            }
-            pjob.end();
-        }
     }
 
     public static void paintOutsideBounds(Component comp,
@@ -204,153 +148,37 @@ public class ConstrainedPrintingTest implements ActionListener
         }
     }
 
-    public static void main(String[] args) {
-        ConstrainedPrintingTest c = new ConstrainedPrintingTest();
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, IOException {
 
-        c.init();
-        c.start();
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
+
+        String instruction = """
+                1.Look at the frame titled "PrintTest". If you see green or,
+                red lines on the white area below the "Print" button, the,
+                test fails. Otherwise go to step 2.,
+                2.Press "Print" button. The print dialog will appear.
+                Select, a printer and proceed. Look at the output.
+                If you see multiple, lines outside of the frame bounds
+                or in the white area below, the image of the "Print"
+                button, the test fails. Otherwise,the test passes.
+                """;
+        Consumer<JEditorPane> testInstProvider = e -> {
+            e.setContentType("text/plain");
+            e.setText(instruction);
+        };
+
+        Supplier<TestResult> resultSupplier = ManualTestFrame.showUI(
+                "Tests ConstrainedPrintingTest",
+                "Wait until the Test UI is seen", testInstProvider);
+        EventQueue.invokeAndWait(ConstrainedPrintingTest::createTestUI);
+
+        //this will block until user decision to pass or fail the test
+        TestResult  testResult = resultSupplier.get();
+        ManualTestFrame.handleResult(testResult,"ConstrainedPrintingTest");
     }
+}
 
- }// class ConstrainedPrintingTest
-
-/* Place other classes related to the test after this line */
-
-
-
-
-
-/****************************************************
- Standard Test Machinery
- DO NOT modify anything below -- it's a standard
-  chunk of code whose purpose is to make user
-  interaction uniform, and thereby make it simpler
-  to read and understand someone else's test.
- ****************************************************/
-
-/**
- This is part of the standard test machinery.
- It creates a dialog (with the instructions), and is the interface
-  for sending text messages to the user.
- To print the instructions, send an array of strings to Sysout.createDialog
-  WithInstructions method.  Put one line of instructions per array entry.
- To display a message for the tester to see, simply call Sysout.println
-  with the string to be displayed.
- This mimics System.out.println but works within the test harness as well
-  as standalone.
- */
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog
- {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("South", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8292309](https://bugs.openjdk.org/browse/JDK-8292309) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292309](https://bugs.openjdk.org/browse/JDK-8292309): Fix  java/awt/PrintJob/ConstrainedPrintingTest/ConstrainedPrintingTest.java  test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3045/head:pull/3045` \
`$ git checkout pull/3045`

Update a local copy of the PR: \
`$ git checkout pull/3045` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3045`

View PR using the GUI difftool: \
`$ git pr show -t 3045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3045.diff">https://git.openjdk.org/jdk17u-dev/pull/3045.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3045#issuecomment-2478758735)
</details>
