### PR TITLE
8298513: vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy009/TestDescription.java fails with usage tracker

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -292,7 +292,7 @@ public class suspendpolicy009 extends JDIBase {
 
         for (int i = 0; ; i++) {
 
-            breakpointForCommunication();
+            breakpointForCommunication(debuggeeName);
 
             int instruction = ((IntegerValue)
                                (debuggeeClass.getValue(debuggeeClass.fieldByName("instruction")))).value();


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8298513](https://bugs.openjdk.org/browse/JDK-8298513) needs maintainer approval

### Issue
 * [JDK-8298513](https://bugs.openjdk.org/browse/JDK-8298513): vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy009/TestDescription.java fails with usage tracker (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3046/head:pull/3046` \
`$ git checkout pull/3046`

Update a local copy of the PR: \
`$ git checkout pull/3046` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3046`

View PR using the GUI difftool: \
`$ git pr show -t 3046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3046.diff">https://git.openjdk.org/jdk17u-dev/pull/3046.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3046#issuecomment-2479034747)
</details>
