### PR TITLE
8302225: SunJCE Provider doesn't validate key sizes when using 'constrained' transforms for AES/KW and AES/KWP

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/KeyWrapCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/KeyWrapCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,6 +121,25 @@ abstract class KeyWrapCipher extends CipherSpi {
         public AES256_KWP_NoPadding() {
             super(new AESKeyWrapPadded(), null, 32);
         }
+    }
+
+    // validate the key algorithm/encoding and then returns the key bytes
+    // which callers should erase after use
+    private static byte[] checkKey(Key key, int fixedKeySize)
+            throws InvalidKeyException {
+
+        byte[] keyBytes = key.getEncoded();
+        if (keyBytes == null) {
+            throw new InvalidKeyException("Null key");
+        }
+        int keyLen = keyBytes.length;
+        if (!key.getAlgorithm().equalsIgnoreCase("AES") ||
+            !AESCrypt.isKeySizeValid(keyLen) ||
+            (fixedKeySize != -1 && fixedKeySize != keyLen)) {
+                throw new InvalidKeyException("Invalid key length: " +
+                        keyLen + " bytes");
+        }
+        return keyBytes;
     }
 
     // store the specified bytes, e.g. in[inOfs...(inOfs+inLen-1)] into
@@ -294,10 +313,8 @@ abstract class KeyWrapCipher extends CipherSpi {
     // actual impl for various engineInit(...) methods
     private void implInit(int opmode, Key key, byte[] iv, SecureRandom random)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
-        byte[] keyBytes = key.getEncoded();
-        if (keyBytes == null) {
-            throw new InvalidKeyException("Null key");
-        }
+        byte[] keyBytes = checkKey(key, fixedKeySize);
+
         this.opmode = opmode;
         boolean decrypting = (opmode == Cipher.DECRYPT_MODE ||
                 opmode == Cipher.UNWRAP_MODE);
@@ -658,21 +675,11 @@ abstract class KeyWrapCipher extends CipherSpi {
      * @exception InvalidKeyException if <code>key</code> is invalid.
      */
     protected int engineGetKeySize(Key key) throws InvalidKeyException {
-        byte[] encoded = key.getEncoded();
-        if (encoded == null)  {
-            throw new InvalidKeyException("Cannot decide key length");
-        }
+        byte[] keyBytes = checkKey(key, fixedKeySize);
+        // only need length; erase immediately
+        Arrays.fill(keyBytes, (byte) 0);
+        return Math.multiplyExact(keyBytes.length, 8);
 
-        // only need length
-        Arrays.fill(encoded, (byte) 0);
-        int keyLen = encoded.length;
-        if (!key.getAlgorithm().equalsIgnoreCase("AES") ||
-            !AESCrypt.isKeySizeValid(keyLen) ||
-            (fixedKeySize != -1 && fixedKeySize != keyLen)) {
-            throw new InvalidKeyException("Invalid key length: " +
-                    keyLen + " bytes");
-        }
-        return Math.multiplyExact(keyLen, 8);
     }
 
     /**

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8248268
+ * @bug 8248268 8302225
  * @summary Verify cipher key size restriction is enforced properly with IKE
  * @run main TestKeySizeCheck
  */
@@ -42,6 +42,8 @@ public class TestKeySizeCheck {
             BYTES_32[i] = (byte) i;
         }
     }
+
+    private static final int[] AES_KEYSIZES = { 128, 192, 256 };
 
     private static SecretKey getKey(int sizeInBytes) {
         if (sizeInBytes <= BYTES_32.length) {
@@ -64,7 +66,7 @@ public class TestKeySizeCheck {
         int[] modes = { Cipher.ENCRYPT_MODE, Cipher.WRAP_MODE };
         for (int ks : invalidKeySizes) {
             System.out.println("keysize: " + ks);
-            SecretKey key = getKey(ks);
+            SecretKey key = getKey(ks >> 3);
 
             for (int m : modes) {
                 try {
@@ -72,9 +74,23 @@ public class TestKeySizeCheck {
                     throw new RuntimeException("Expected IKE not thrown for "
                             + getModeStr(m));
                 } catch (InvalidKeyException ike) {
-                    System.out.println(" => expected IKE thrown for "
-                            + getModeStr(m));
+                    System.out.println(getModeStr(m) + " => got expected IKE");
                 }
+            }
+        }
+
+        // now test against the valid key size(s) and make sure they work
+        int underscoreIdx = algo.indexOf("_");
+        int[] validKeySizes = (algo.indexOf("_") == -1 ?
+            AES_KEYSIZES : new int[] { Integer.parseInt(algo.substring
+                    (underscoreIdx + 1, underscoreIdx + 4)) });
+        for (int ks : validKeySizes) {
+            System.out.println("keysize: " + ks);
+            SecretKey key = getKey(ks >> 3);
+
+            for (int m : modes) {
+                c.init(m, key);
+                System.out.println(getModeStr(m) + " => ok");
             }
         }
     }


### PR DESCRIPTION
I would like to fix this issue in the sun crypto provider.

Clean backport except for Copyright, probably recognized clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8302225](https://bugs.openjdk.org/browse/JDK-8302225) needs maintainer approval

### Issue
 * [JDK-8302225](https://bugs.openjdk.org/browse/JDK-8302225): SunJCE Provider doesn't validate key sizes when using 'constrained' transforms for AES/KW and AES/KWP (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3047/head:pull/3047` \
`$ git checkout pull/3047`

Update a local copy of the PR: \
`$ git checkout pull/3047` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3047`

View PR using the GUI difftool: \
`$ git pr show -t 3047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3047.diff">https://git.openjdk.org/jdk17u-dev/pull/3047.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3047#issuecomment-2482653088)
</details>
