### PR TITLE
8341927: Replace hardcoded security providers with new test.provider.name system property

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -44,6 +44,9 @@
 <li><a href="#docker-tests">Docker Tests</a></li>
 <li><a href="#non-us-locale">Non-US locale</a></li>
 <li><a href="#pkcs11-tests">PKCS11 Tests</a></li>
+<li><a href="#testing-with-alternative-security-providers"
+id="toc-testing-with-alternative-security-providers">Testing with
+alternative security providers</a></li>
 <li><a href="#client-ui-tests">Client UI Tests</a></li>
 </ul></li>
 </ul>
@@ -242,6 +245,18 @@ $ make test JTREG=&quot;VM_OPTIONS=-Duser.language=en -Duser.country=US&quot; TE
 <pre><code>$ make test TEST=&quot;jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java&quot; \
     JTREG=&quot;JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/NSS-libs&quot;</code></pre>
 <p>For more notes about the PKCS11 tests, please refer to test/jdk/sun/security/pkcs11/README.</p>
+<h3 id="testing-with-alternative-security-providers">Testing with
+alternative security providers</h3>
+<p>Some security tests use a hardcoded provider for
+<code>KeyFactory</code>, <code>Cipher</code>,
+<code>KeyPairGenerator</code>, <code>KeyGenerator</code>,
+<code>AlgorithmParameterGenerator</code>, <code>KeyAgreement</code>,
+<code>Mac</code>, <code>MessageDigest</code>, <code>SecureRandom</code>,
+<code>Signature</code>, <code>AlgorithmParameters</code>,
+<code>Configuration</code>, <code>Policy</code>, or
+<code>SecretKeyFactory</code> objects. Specify the
+<code>-Dtest.provider.name=NAME</code> property to use a different
+provider for the service(s).</p>
 <h3 id="client-ui-tests">Client UI Tests</h3>
 <h4 id="system-key-shortcuts">System key shortcuts</h4>
 <p>Some Client UI tests use key sequences which may be reserved by the operating system. Usually that causes the test failure. So it is highly recommended to disable system key shortcuts prior testing. The steps to access and disable system key shortcuts for various platforms are provided below.</p>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -551,6 +551,15 @@ $ make test TEST="jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java" \
 For more notes about the PKCS11 tests, please refer to
 test/jdk/sun/security/pkcs11/README.
 
+### Testing with alternative security providers
+
+Some security tests use a hardcoded provider for `KeyFactory`, `Cipher`,
+`KeyPairGenerator`, `KeyGenerator`, `AlgorithmParameterGenerator`,
+`KeyAgreement`, `Mac`, `MessageDigest`, `SecureRandom`, `Signature`,
+`AlgorithmParameters`, `Configuration`, `Policy`, or `SecretKeyFactory` objects.
+Specify the `-Dtest.provider.name=NAME` property to use a different provider for
+the service(s).
+
 ### Client UI Tests
 
 #### System key shortcuts

--- a/test/jdk/com/sun/crypto/provider/CICO/CICODESFuncTest.java
+++ b/test/jdk/com/sun/crypto/provider/CICO/CICODESFuncTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,8 @@ public class CICODESFuncTest {
     private static final int IV_LENGTH = 8;
 
     public static void main(String[] args) throws Exception {
-        Provider provider = Security.getProvider("SunJCE");
+        Provider provider = Security.getProvider(
+                                    System.getProperty("test.provider.name", "SunJCE"));
         if (provider == null) {
             throw new RuntimeException("SunJCE provider does not exist.");
         }

--- a/test/jdk/com/sun/crypto/provider/CICO/CICOSkipTest.java
+++ b/test/jdk/com/sun/crypto/provider/CICO/CICOSkipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,9 +204,10 @@ class CipherGenerator {
             AlgorithmParameterSpec aps) throws NoSuchAlgorithmException,
             NoSuchPaddingException, InvalidKeyException,
             InvalidAlgorithmParameterException {
-        Provider provider = Security.getProvider("SunJCE");
+        String providerName = System.getProperty("test.provider.name", "SunJCE");
+        Provider provider = Security.getProvider(providerName);
         if (provider == null) {
-            throw new RuntimeException("SunJCE provider does not exist.");
+            throw new RuntimeException(providerName + " provider does not exist.");
         }
         Cipher ci1 = Cipher.getInstance(algo, provider);
         ci1.init(Cipher.ENCRYPT_MODE, key, aps);

--- a/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/AESPBEWrapper.java
+++ b/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/AESPBEWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,9 +69,10 @@ public class AESPBEWrapper extends AbstractPBEWrapper {
      */
     @Override
     protected Cipher initCipher(int mode) throws GeneralSecurityException {
-        Provider provider = Security.getProvider("SunJCE");
+        String providerName = System.getProperty("test.provider.name", "SunJCE");
+        Provider provider = Security.getProvider(providerName);
         if (provider == null) {
-            throw new RuntimeException("SunJCE provider does not exist.");
+            throw new RuntimeException(providerName + ": provider does not exist.");
         }
         // get Cipher instance
         Cipher ci = Cipher.getInstance(transformation, provider);

--- a/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/DefaultPBEWrapper.java
+++ b/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/DefaultPBEWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,9 +58,10 @@ public class DefaultPBEWrapper extends AbstractPBEWrapper {
      */
     @Override
     protected Cipher initCipher(int mode) throws  GeneralSecurityException {
-        Provider provider = Security.getProvider("SunJCE");
+        String providerName = System.getProperty("test.provider.name", "SunJCE");
+        Provider provider = Security.getProvider(providerName);
         if (provider == null) {
-            throw new RuntimeException("SunJCE provider does not exist.");
+            throw new RuntimeException(providerName + ": provider does not exist.");
         }
         SecretKey key = SecretKeyFactory.getInstance(baseAlgo)
                 .generateSecret(new PBEKeySpec(password.toCharArray()));

--- a/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/PBKDF2Wrapper.java
+++ b/test/jdk/com/sun/crypto/provider/CICO/PBEFunc/PBKDF2Wrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,9 +89,10 @@ public class PBKDF2Wrapper extends AbstractPBEWrapper {
      */
     @Override
     protected Cipher initCipher(int mode) throws GeneralSecurityException {
-        Provider provider = Security.getProvider("SunJCE");
+        String providerName = System.getProperty("test.provider.name", "SunJCE");
+        Provider provider = Security.getProvider(providerName);
         if (provider == null) {
-            throw new RuntimeException("SunJCE provider does not exist.");
+            throw new RuntimeException(providerName + ": provider does not exist.");
         }
         // Generate secret key
         PBEKeySpec pbeKeySpec = new PBEKeySpec(password.toCharArray(),

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/Encrypt.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/Encrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,8 @@ public class Encrypt {
     }
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
         for (String alg : ALGORITHMS) {
             for (int keyStrength : KEY_STRENGTHS) {
                 if (keyStrength > Cipher.getMaxAllowedKeyLength(alg)) {

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMLargeDataKAT.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMLargeDataKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,8 @@ public class GCMLargeDataKAT {
 
     byte[] encrypt(int inLen) {
         try {
-            cipher = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+            cipher = Cipher.getInstance("AES/GCM/NoPadding",
+                    System.getProperty("test.provider.name", "SunJCE"));
             cipher.init(Cipher.ENCRYPT_MODE, key, spec);
             return cipher.doFinal(plaintext, 0, inLen);
         } catch (Exception e) {
@@ -125,7 +126,8 @@ public class GCMLargeDataKAT {
             return false;
         }
         try {
-            cipher = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+            cipher = Cipher.getInstance("AES/GCM/NoPadding",
+                    System.getProperty("test.provider.name", "SunJCE"));
             cipher.init(Cipher.DECRYPT_MODE, key, spec);
             result = cipher.doFinal(data);
         } catch (Exception e) {

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,8 @@ public class GCMParameterSpecTest {
         AAD = Helper.generateBytes(AADLength);
 
         // init a secret key
-        KeyGenerator kg = KeyGenerator.getInstance("AES", "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance("AES",
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(keyLength);
         key = kg.generateKey();
     }
@@ -211,7 +212,8 @@ public class GCMParameterSpecTest {
 
     private Cipher createCipher(int mode, GCMParameterSpec spec)
             throws Exception {
-        Cipher cipher = Cipher.getInstance(TRANSFORMATION, "SunJCE");
+        Cipher cipher = Cipher.getInstance(TRANSFORMATION,
+                System.getProperty("test.provider.name", "SunJCE"));
         cipher.init(mode, key, spec);
         return cipher;
     }

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/KeyWrapper.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/KeyWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class KeyWrapper {
 
     static final String AES = "AES";
     static final String TRANSFORMATION = "AES/GCM/NoPadding";
-    static final String PROVIDER = "SunJCE";
+    static final String PROVIDER = System.getProperty("test.provider.name", "SunJCE");
     static final int KEY_LENGTH = 128;
 
     public static void main(String argv[]) throws Exception {

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/ReadWriteSkip.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/ReadWriteSkip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class ReadWriteSkip {
     static final int BLOCK = 50;
     static final int SAVE = 45;
     static final int DISCARD = BLOCK - SAVE;
-    static final String PROVIDER = "SunJCE";
+    static final String PROVIDER = System.getProperty("test.provider.name", "SunJCE");
     static final String AES = "AES";
     static final String GCM = "GCM";
     static final String PADDING = "NoPadding";

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/SameBuffer.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/SameBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import jdk.test.lib.Convert;
  */
 public class SameBuffer {
 
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunJCE");
     private static final String AES = "AES";
     private static final String GCM = "GCM";
     private static final String PADDING = "NoPadding";

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/SealedObjectTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/SealedObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ public class SealedObjectTest {
 
     private static final String AES = "AES";
     private static final String TRANSFORMATION = "AES/GCM/NoPadding";
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunJCE");
     private static final int KEY_LENGTH = 128;
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/WrongAAD.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/WrongAAD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import javax.crypto.KeyGenerator;
  */
 public class WrongAAD {
 
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunJCE");
     private static final String TRANSFORMATION = "AES/GCM/NoPadding";
     private static final int TEXT_SIZE = 800;
     private static final int KEY_SIZE = 128;

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/CICO.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/CICO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class CICO {
         "cFB24", "cFB32", "Cfb40", "CFB72", "OfB", "OfB20", "OfB48",
         "OfB56", "OFB64", "OFB112", "CFB112", "pCbC" };
     private static final String[] PADDING = { "noPadding", "pkcs5padding" };
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunJCE");
     private static final int NREADS = 3;
     private static final int KEY_LENGTH = 128;
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/CTR.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/CTR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,8 @@ public class CTR {
 
     private static final String ALGORITHM = "AES";
 
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER =
+                            System.getProperty("test.provider.name", "SunJCE");
 
     private static final String[] MODES = {"CTR","CFB24","OFB32","GCM"};
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/Padding.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,8 @@ import javax.crypto.spec.IvParameterSpec;
 public class Padding {
 
     private static final String ALGORITHM = "AES";
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER =
+                            System.getProperty("test.provider.name", "SunJCE");
     private static final String[] MODES_PKCS5PAD = {
         "ECb", "CbC", "PCBC", "OFB",
         "OFB150", "cFB", "CFB7", "cFB8", "cFB16", "cFB24", "cFB32",

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4511676.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4511676.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,12 @@ public class Test4511676 {
 
     public boolean execute() throws Exception {
 
-        Cipher ci = Cipher.getInstance(ALGO, "SunJCE");
+        Cipher ci = Cipher.getInstance(ALGO,
+                System.getProperty("test.provider.name", "SunJCE"));
 
         // TEST FIX 4511676
-        KeyGenerator kg = KeyGenerator.getInstance(ALGO, "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance(ALGO,
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(KEYSIZE*8);
         SecretKey key = kg.generateKey();
         try {

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4512524.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4512524.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,10 +45,12 @@ public class Test4512524 {
     public void execute(String mode) throws Exception {
 
         String transformation = ALGO+"/"+mode+"/"+PADDING;
-        Cipher ci = Cipher.getInstance(transformation, "SunJCE");
+        Cipher ci = Cipher.getInstance(transformation,
+                System.getProperty("test.provider.name", "SunJCE"));
 
         // TEST FIX 4512524
-        KeyGenerator kg = KeyGenerator.getInstance(ALGO, "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance(ALGO,
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(KEYSIZE*8);
         SecretKey key = kg.generateKey();
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4512704.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4512704.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,9 +45,11 @@ public class Test4512704 {
 
         AlgorithmParameterSpec aps = null;
         String transformation = ALGO + "/" + mode + "/"+PADDING;
-        Cipher ci = Cipher.getInstance(transformation, "SunJCE");
+        Cipher ci = Cipher.getInstance(transformation,
+                System.getProperty("test.provider.name", "SunJCE"));
 
-        KeyGenerator kg = KeyGenerator.getInstance(ALGO, "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance(ALGO,
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(KEYSIZE*8);
         SecretKey key = kg.generateKey();
         // TEST FIX 4512704

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4513830.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4513830.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,10 +52,12 @@ public class Test4513830 {
         byte[] plainText=new byte[125];
         rdm.nextBytes(plainText);
 
-        Cipher ci = Cipher.getInstance(ALGO+"/"+MODE+"/"+PADDING, "SunJCE");
+        Cipher ci = Cipher.getInstance(ALGO+"/"+MODE+"/"+PADDING,
+                System.getProperty("test.provider.name", "SunJCE"));
 
         // TEST FIX 4513830
-        KeyGenerator kg = KeyGenerator.getInstance(ALGO, "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance(ALGO,
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(KEYSIZE*8);
         SecretKey key = kg.generateKey();
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4517355.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4517355.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,10 @@ public class Test4517355 {
     public void execute(String mode, String padding) throws Exception {
         String transformation = ALGO + "/" + mode + "/" + padding;
 
-        Cipher ci = Cipher.getInstance(transformation, "SunJCE");
-        KeyGenerator kg = KeyGenerator.getInstance(ALGO, "SunJCE");
+        Cipher ci = Cipher.getInstance(transformation,
+                System.getProperty("test.provider.name", "SunJCE"));
+        KeyGenerator kg = KeyGenerator.getInstance(ALGO,
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(KEYSIZE*8);
         SecretKey key = kg.generateKey();
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4626070.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/Test4626070.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,10 @@ public class Test4626070 {
 
     public void execute(String mode, String padding) throws Exception {
         String transformation = ALGO + "/" + mode + "/" + padding;
-        Cipher ci = Cipher.getInstance(transformation, "SunJCE");
-        KeyGenerator kg = KeyGenerator.getInstance(ALGO, "SunJCE");
+        Cipher ci = Cipher.getInstance(transformation,
+                System.getProperty("test.provider.name", "SunJCE"));
+        KeyGenerator kg = KeyGenerator.getInstance(ALGO,
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(KEYSIZE*8);
         SecretKey key = kg.generateKey();
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCipher.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ import javax.crypto.spec.SecretKeySpec;
 public class TestAESCipher {
 
     private static final String ALGORITHM = "AES";
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunJCE");
     private static final String[] MODES = { "ECb", "CbC", "CTR", "PCBC", "OFB",
         "OFB150", "cFB", "CFB7", "cFB8", "cFB16", "cFB24", "cFB32",
         "Cfb40", "cfB48", "cfB56", "cfB64", "cfB72", "cfB80", "cfB88",

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCiphers/Dynamic.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCiphers/Dynamic.java
@@ -46,7 +46,7 @@ public class Dynamic {
     static final String[] PADDING = {
         "NoPadding", "PKCS5Padding", "ISO10126Padding"
     };
-    static final String SUNJCE = "SunJCE";
+    static final String PROVIDER = System.getProperty("test.provider.name", "SunJCE");
 
     Cipher ci = null;
     byte[] iv = null;
@@ -128,8 +128,8 @@ public class Dynamic {
             new Random().nextBytes(plainText);
 
             String transformation = algo + "/" + mo + "/" + pad;
-            ci = Cipher.getInstance(transformation, SUNJCE);
-            KeyGenerator kg = KeyGenerator.getInstance(algo, SUNJCE);
+            ci = Cipher.getInstance(transformation, PROVIDER);
+            KeyGenerator kg = KeyGenerator.getInstance(algo, PROVIDER);
             if (keyStrength > Cipher.getMaxAllowedKeyLength(transformation)) {
                 // skip if this key length is larger than what's
                 // configured in the jce jurisdiction policy files

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithProviderChange.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithProviderChange.java
@@ -33,7 +33,7 @@ import java.security.Security;
 
 public class TestAESWithProviderChange extends Dynamic {
     public static void main(String argv[]) throws Exception {
-        Security.removeProvider(SUNJCE);
+        Security.removeProvider(PROVIDER);
         Security.addProvider(new com.sun.crypto.provider.SunJCE());
         new TestAESWithProviderChange().run(argv);
     }

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithRemoveAddProvider.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithRemoveAddProvider.java
@@ -34,8 +34,8 @@ import java.security.Provider;
 
 public class TestAESWithRemoveAddProvider extends Dynamic {
     public static void main(String argv[]) throws Exception {
-        Provider pJCE = Security.getProvider(SUNJCE);
-        Security.removeProvider(SUNJCE);
+        Provider pJCE = Security.getProvider(PROVIDER);
+        Security.removeProvider(PROVIDER);
         Security.addProvider(pJCE);
         new TestAESWithRemoveAddProvider().run(argv);
     }

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCiphers/testAES.policy
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestAESCiphers/testAES.policy
@@ -1,6 +1,7 @@
 grant codeBase "file:${test.classes}/*" {
-    permission java.security.SecurityPermission "removeProvider.SunJCE";
-    permission java.security.SecurityPermission "insertProvider.SunJCE";
+    permission java.security.SecurityPermission "removeProvider.*";
+    permission java.security.SecurityPermission "insertProvider.*";
     permission java.lang.RuntimePermission
                "accessClassInPackage.com.sun.crypto.provider";
+    permission java.util.PropertyPermission "test.provider.name", "read";
 };

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestCICOWithGCM.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestCICOWithGCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,8 @@ import java.util.*;
 public class TestCICOWithGCM {
     public static void main(String[] args) throws Exception {
         //init Secret Key
-        KeyGenerator kg = KeyGenerator.getInstance("AES", "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance("AES",
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(128);
         SecretKey key = kg.generateKey();
 
@@ -53,9 +54,11 @@ public class TestCICOWithGCM {
         rdm.nextBytes(plainText);
 
         //init ciphers
-        Cipher encCipher = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+        Cipher encCipher = Cipher.getInstance("AES/GCM/NoPadding",
+                System.getProperty("test.provider.name", "SunJCE"));
         encCipher.init(Cipher.ENCRYPT_MODE, key);
-        Cipher decCipher = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+        Cipher decCipher = Cipher.getInstance("AES/GCM/NoPadding",
+                System.getProperty("test.provider.name", "SunJCE"));
         decCipher.init(Cipher.DECRYPT_MODE, key, encCipher.getParameters());
 
         //init cipher streams

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestCICOWithGCMAndAAD.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestCICOWithGCMAndAAD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,8 @@ import javax.crypto.*;
 public class TestCICOWithGCMAndAAD {
     public static void main(String[] args) throws Exception {
         //init Secret Key
-        KeyGenerator kg = KeyGenerator.getInstance("AES", "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance("AES",
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(128);
         SecretKey key = kg.generateKey();
 
@@ -53,10 +54,12 @@ public class TestCICOWithGCMAndAAD {
         byte[] aad2 = aad.clone();
         aad2[50]++;
 
-        Cipher encCipher = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+        Cipher encCipher = Cipher.getInstance("AES/GCM/NoPadding",
+                System.getProperty("test.provider.name", "SunJCE"));
         encCipher.init(Cipher.ENCRYPT_MODE, key);
         encCipher.updateAAD(aad);
-        Cipher decCipher = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+        Cipher decCipher = Cipher.getInstance("AES/GCM/NoPadding",
+                System.getProperty("test.provider.name", "SunJCE"));
         decCipher.init(Cipher.DECRYPT_MODE, key, encCipher.getParameters());
         decCipher.updateAAD(aad);
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestCopySafe.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestCopySafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,8 @@ public class TestCopySafe {
 
     public static void main(String[] argv) throws Exception {
 
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
 
         AlgorithmParameterSpec params = null;
         boolean result = true;

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestGCMKeyAndIvCheck.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestGCMKeyAndIvCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,8 @@ public class TestGCMKeyAndIvCheck {
     }
 
     public void test() throws Exception {
-        Cipher c = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+        Cipher c = Cipher.getInstance("AES/GCM/NoPadding",
+                System.getProperty("test.provider.name", "SunJCE"));
 
         SecretKey key = new SecretKeySpec(new byte[16], "AES");
         // First try parameter-less init.

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestISO10126Padding.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestISO10126Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,8 @@ public class TestISO10126Padding {
 
     private TestISO10126Padding() throws Exception {
         // setup
-        KeyGenerator kg = KeyGenerator.getInstance(ALGO, "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance(ALGO,
+                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(KEYSIZE*8);
         key = kg.generateKey();
     }
@@ -59,7 +60,8 @@ public class TestISO10126Padding {
         // TEST#1 --
         // generate the cipher text using manually-supplied
         // XML Encryption padding
-        Cipher ci = Cipher.getInstance(TRANS + "/NoPadding", "SunJCE");
+        Cipher ci = Cipher.getInstance(TRANS + "/NoPadding",
+                System.getProperty("test.provider.name", "SunJCE"));
         ci.init(Cipher.ENCRYPT_MODE, key);
         byte[] paddedData = new byte[ci.getBlockSize()];
         System.arraycopy(data, 0, paddedData, 0, data.length);
@@ -68,7 +70,8 @@ public class TestISO10126Padding {
         byte[] cipherText = ci.doFinal(paddedData);
 
         // decrypt using ISO10126Padding
-        ci = Cipher.getInstance(TRANS + "/ISO10126Padding", "SunJCE");
+        ci = Cipher.getInstance(TRANS + "/ISO10126Padding",
+                System.getProperty("test.provider.name", "SunJCE"));
         ci.init(Cipher.DECRYPT_MODE, key);
         byte[] recovered = ci.doFinal(cipherText);
         if (!Arrays.equals(data, recovered)) {
@@ -76,7 +79,8 @@ public class TestISO10126Padding {
         }
         // TEST#2 --
         // generate the cipher text using ISO10126Padding
-        ci = Cipher.getInstance(TRANS + "/ISO10126Padding", "SunJCE");
+        ci = Cipher.getInstance(TRANS + "/ISO10126Padding",
+                System.getProperty("test.provider.name", "SunJCE"));
         ci.init(Cipher.ENCRYPT_MODE, key);
         cipherText = ci.doFinal(data);
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestKATForECB_IV.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestKATForECB_IV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,8 @@ public class TestKATForECB_IV
 
     public boolean execute() throws Exception {
         String transformation = ALGO+"/"+MODE+"/"+PADDING;
-        Cipher c = Cipher.getInstance(transformation, "SunJCE");
+        Cipher c = Cipher.getInstance(transformation,
+                System.getProperty("test.provider.name", "SunJCE"));
         for (int i=0; i<KEYS.length; i++) {
             SecretKey aesKey = constructAESKey(KEYS[i]);
             if (aesKey.getEncoded().length*8 >

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestKATForECB_VK.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestKATForECB_VK.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -707,7 +707,8 @@ public class TestKATForECB_VK
 
     public boolean execute() throws Exception {
         String transformation = ALGO+"/"+MODE+"/"+PADDING;
-        Cipher c = Cipher.getInstance(transformation, "SunJCE");
+        Cipher c = Cipher.getInstance(transformation,
+                System.getProperty("test.provider.name", "SunJCE"));
 
         for (int i=0; i<KEY_SIZES.length; i++) {
             if (KEY_SIZES[i]*8 >

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestKATForECB_VT.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestKATForECB_VT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -513,7 +513,8 @@ public class TestKATForECB_VT
 
     public boolean execute() throws Exception {
         String transformation = ALGO+"/"+MODE+"/"+PADDING;
-        Cipher c = Cipher.getInstance(transformation, "SunJCE");
+        Cipher c = Cipher.getInstance(transformation,
+                System.getProperty("test.provider.name", "SunJCE"));
 
         for (int i=0; i<KEY_SIZES.length; i++) {
             if (KEY_SIZES[i]*8 >

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestKATForGCM.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestKATForGCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -278,7 +278,8 @@ public class TestKATForGCM {
     };
 
     void executeArray(TestVector tv) throws Exception {
-        Cipher c = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+        Cipher c = Cipher.getInstance("AES/GCM/NoPadding",
+                System.getProperty("test.provider.name", "SunJCE"));
         try {
             System.out.println("Test #" + tv.id + ": byte[].");
 
@@ -320,7 +321,8 @@ public class TestKATForGCM {
     }
 
     void executeByteBuffer(TestVector tv, boolean direct, int offset) throws Exception {
-        Cipher c = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+        Cipher c = Cipher.getInstance("AES/GCM/NoPadding",
+                System.getProperty("test.provider.name", "SunJCE"));
 
         ByteBuffer src;
         ByteBuffer ctdst;

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestNoPaddingModes.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestNoPaddingModes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,8 @@ public class TestNoPaddingModes {
     };
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
         String transformation;
         for (String mode : MODES) {
             for (String padding : PADDINGS) {
@@ -50,7 +51,8 @@ public class TestNoPaddingModes {
 
                 System.out.println("Test using " + transformation);
                 try {
-                    Cipher c = Cipher.getInstance(transformation, "SunJCE");
+                    Cipher c = Cipher.getInstance(transformation,
+                            System.getProperty("test.provider.name", "SunJCE"));
                     throw new RuntimeException("=> Fail, no exception thrown");
                 } catch (NoSuchAlgorithmException | NoSuchPaddingException ex) {
                     System.out.println("=> Expected ex: " + ex);

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestNonexpanding.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestNonexpanding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,8 @@ import javax.crypto.spec.GCMParameterSpec;
 public class TestNonexpanding {
 
     private static final String ALGORITHM = "AES";
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER =
+                        System.getProperty("test.provider.name", "SunJCE");
     private static final String[] MODES = { "ECb", "CbC", "OFB", "OFB150",
         "cFB", "CFB7", "cFB8", "cFB16", "cFB24", "cFB32", "Cfb40", "cfB48",
         "cfB56", "cfB64", "cfB72", "cfB80", "cfB88", "cfB96", "cfb104",

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestSameBuffer.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestSameBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,8 @@ import javax.crypto.spec.IvParameterSpec;
 public class TestSameBuffer {
 
     private static final String ALGORITHM = "AES";
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER =
+                            System.getProperty("test.provider.name", "SunJCE");
     private static final String[] MODES = { "ECb", "CbC", "OFB", "CFB150",
         "cFB", "CFB7", " cFB8", "cFB16", "cFB24", "cFB32", "Cfb40",
         "cfB48", " cfB56", "cfB64", "cfB72", "cfB80", "cfB88", "cfB96",

--- a/test/jdk/com/sun/crypto/provider/Cipher/AES/TestShortBuffer.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AES/TestShortBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ public class TestShortBuffer {
         for (int i = 0; i < MODES.length; i++) {
             System.out.println("===== TESTING MODE " + MODES[i] + " =====");
             Cipher ci = Cipher.getInstance(ALGO+"/"+MODES[i]+"/PKCS5Padding",
-                                           "SunJCE");
+                    System.getProperty("test.provider.name", "SunJCE"));
             TestShortBuffer test = null;
             int stored = 0;
             AlgorithmParameters params = null;

--- a/test/jdk/com/sun/crypto/provider/Cipher/CTR/CounterMode.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/CTR/CounterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,7 +162,8 @@ public class CounterMode {
                     continue;
                 }
                 System.out.println("Running test " + i +  " (" + alg + ")");
-                Cipher cipher = Cipher.getInstance(alg + "/CTR/NoPadding", "SunJCE");
+                Cipher cipher = Cipher.getInstance(alg + "/CTR/NoPadding",
+                                System.getProperty("test.provider.name", "SunJCE"));
                 SecretKeySpec key = new SecretKeySpec(KEYS[i], alg);
                 IvParameterSpec iv = new IvParameterSpec(IVS[i]);
                 byte[] plainText = PLAIN[i];

--- a/test/jdk/com/sun/crypto/provider/Cipher/CTS/CTSMode.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/CTS/CTSMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,7 +156,7 @@ public class CTSMode {
             }
             System.out.println("Running test1_" + i +  " (" + algo + ")");
             Cipher cipher = Cipher.getInstance(algo+ "/CTS/NoPadding",
-                                               "SunJCE");
+                    System.getProperty("test.provider.name", "SunJCE"));
             byte[] plainText = PLAIN1[i];
             byte[] cipherText = CIPHER1[i];
             cipher.init(Cipher.ENCRYPT_MODE, KEY1, IV1);
@@ -194,7 +194,8 @@ public class CTSMode {
                 continue;
             }
             Cipher cipher =
-                Cipher.getInstance(algo+"/CTS/NoPadding", "SunJCE");
+                Cipher.getInstance(algo+"/CTS/NoPadding",
+                        System.getProperty("test.provider.name", "SunJCE"));
             int blockSize = cipher.getBlockSize();
             SecretKeySpec key = new SecretKeySpec(new byte[keySize], algo);
             // Make sure encryption works for inputs with valid length
@@ -226,7 +227,8 @@ public class CTSMode {
             IvParameterSpec iv2 = new IvParameterSpec(IV2_SRC, 0, blockSize);
             cipher.init(Cipher.ENCRYPT_MODE, key, iv2);
             Cipher cipher2 =
-                Cipher.getInstance(algo+"/CBC/NoPadding", "SunJCE");
+                Cipher.getInstance(algo+"/CBC/NoPadding",
+                        System.getProperty("test.provider.name", "SunJCE"));
             cipher2.init(Cipher.ENCRYPT_MODE, key, iv2);
 
             byte[] eout = cipher.doFinal(IV2_SRC, 0, blockSize);
@@ -294,7 +296,8 @@ public class CTSMode {
                 continue;
             }
             Cipher cipher =
-                Cipher.getInstance(algo+ "/CTS/NoPadding", "SunJCE");
+                Cipher.getInstance(algo+ "/CTS/NoPadding",
+                        System.getProperty("test.provider.name", "SunJCE"));
             byte[] plainText = PLAIN1[i];
             byte[] cipherText = CIPHER1[i];
             byte[] enc = new byte[plainText.length];

--- a/test/jdk/com/sun/crypto/provider/Cipher/DES/KeyWrapping.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/DES/KeyWrapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,8 @@ import java.security.*;
 public class KeyWrapping {
 
     public static void main(String[] args) throws Exception {
-        Cipher c1 = Cipher.getInstance("DES", "SunJCE");
+        Cipher c1 = Cipher.getInstance("DES",
+                            System.getProperty("test.provider.name", "SunJCE"));
         Cipher c2 = Cipher.getInstance("DES");
 
         KeyGenerator keyGen = KeyGenerator.getInstance("DES");

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,9 +259,12 @@ public class NISTWrapKAT {
             System.out.println("=> skip, exceeds max allowed size " + allowed);
             return;
         }
-        Cipher c1 = Cipher.getInstance(algo, "SunJCE");
-        Cipher c2 = Cipher.getInstance(algo, "SunJCE");
-        Cipher c3 = Cipher.getInstance(algo, "SunJCE");
+        Cipher c1 = Cipher.getInstance(algo,
+                            System.getProperty("test.provider.name", "SunJCE"));
+        Cipher c2 = Cipher.getInstance(algo,
+                            System.getProperty("test.provider.name", "SunJCE"));
+        Cipher c3 = Cipher.getInstance(algo,
+                            System.getProperty("test.provider.name", "SunJCE"));
 
         byte[] keyVal = toBytes(key, keyLen << 1);
         byte[] dataVal = toBytes(data, dataLen << 1);
@@ -318,9 +321,12 @@ public class NISTWrapKAT {
             System.out.println("=> skip, exceeds max allowed size " + allowed);
             return;
         }
-        Cipher c1 = Cipher.getInstance(algo, "SunJCE");
-        Cipher c2 = Cipher.getInstance(algo, "SunJCE");
-        Cipher c3 = Cipher.getInstance(algo, "SunJCE");
+        Cipher c1 = Cipher.getInstance(algo,
+                            System.getProperty("test.provider.name", "SunJCE"));
+        Cipher c2 = Cipher.getInstance(algo,
+                            System.getProperty("test.provider.name", "SunJCE"));
+        Cipher c3 = Cipher.getInstance(algo,
+                            System.getProperty("test.provider.name", "SunJCE"));
 
         byte[] keyVal = toBytes(key, keyLen << 1);
         byte[] dataVal = toBytes(data, dataLen << 1);

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,8 @@ import javax.crypto.spec.PBEParameterSpec;
  */
 
 public class TestCipherKeyWrapperTest {
-    private static final String SUN_JCE = "SunJCE";
+    private static final String PROVIDER_NAME =
+                                System.getProperty("test.provider.name", "SunJCE");
     // Blowfish Variable key length: 32 bits to 448 bits
     private static final int BLOWFISH_MIN_KEYSIZE = 32;
     private static final int BLOWFISH_MAX_KEYSIZE = 448;
@@ -152,9 +153,9 @@ public class TestCipherKeyWrapperTest {
         // PBE and public wrapper test.
         String[] publicPrivateAlgos = new String[] { "DiffieHellman", "DSA",
                 "RSA" };
-        Provider provider = Security.getProvider(SUN_JCE);
+        Provider provider = Security.getProvider(PROVIDER_NAME);
         if (provider == null) {
-            throw new RuntimeException("SUN_JCE provider not exist");
+            throw new RuntimeException(PROVIDER_NAME + " provider not exist");
         }
 
         test.wrapperPBEKeyTest(provider);

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestGeneral.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestGeneral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,7 +176,8 @@ public class TestGeneral {
 
         String ALGO = "AES/KW/PKCS5Padding";
         System.out.println("Testing " + ALGO);
-        Cipher c = Cipher.getInstance(ALGO, "SunJCE");
+        Cipher c = Cipher.getInstance(ALGO,
+                    System.getProperty("test.provider.name", "SunJCE"));
 
         // test all possible pad lengths, i.e. 1 - 16
         for (int i = 1; i <= MAX_KW_PKCS5PAD_LEN; i++) {
@@ -187,7 +188,8 @@ public class TestGeneral {
 
         ALGO = "AES/KW/NoPadding";
         System.out.println("Testing " + ALGO);
-        c = Cipher.getInstance(ALGO, "SunJCE");
+        c = Cipher.getInstance(ALGO,
+                    System.getProperty("test.provider.name", "SunJCE"));
         testEnc(c, data, data.length, KW_IV_LEN, 0);
         testEnc(c, data, data.length >> 1, KW_IV_LEN, 0);
         testWrap(c, data, data.length, KW_IV_LEN, 0);
@@ -196,7 +198,8 @@ public class TestGeneral {
 
         ALGO = "AES/KWP/NoPadding";
         System.out.println("Testing " + ALGO);
-        c = Cipher.getInstance(ALGO, "SunJCE");
+        c = Cipher.getInstance(ALGO,
+                    System.getProperty("test.provider.name", "SunJCE"));
 
         // test all possible pad lengths, i.e. 0 - 7
         for (int i = 0; i <= MAX_KWP_PAD_LEN; i++) {

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,8 @@ public class TestKeySizeCheck {
             throws Exception {
 
         System.out.println("Testing " + algo);
-        Cipher c = Cipher.getInstance(algo, "SunJCE");
+        Cipher c = Cipher.getInstance(algo,
+                System.getProperty("test.provider.name", "SunJCE"));
 
         int[] modes = { Cipher.ENCRYPT_MODE, Cipher.WRAP_MODE };
         for (int ks : invalidKeySizes) {

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/XMLEncKAT.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/XMLEncKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,8 @@ public class XMLEncKAT {
         String cKeyAlg, String[] base64Wrapped) throws Exception {
         System.out.println("Testing " + cAlg + " Cipher with " +
             8*cKeyVal.length + "-bit key");
-        Cipher c = Cipher.getInstance(cAlg, "SunJCE");
+        Cipher c = Cipher.getInstance(cAlg,
+                System.getProperty("test.provider.name", "SunJCE"));
         SecretKey cKey = new SecretKeySpec(cKeyVal, cKeyAlg);
         c.init(Cipher.UNWRAP_MODE, cKey);
         Key[] key = new SecretKey[base64Wrapped.length];

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/DecryptWithoutParameters.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/DecryptWithoutParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,8 @@ public class DecryptWithoutParameters {
 
     public static void main(String argv[]) throws Exception {
         String algo = "PBEWithMD5AndDES";
-        Cipher cipher = Cipher.getInstance(algo, "SunJCE");
+        Cipher cipher = Cipher.getInstance(algo,
+                                    System.getProperty("test.provider.name", "SunJCE"));
         SecretKey key = new SecretKeySpec(new byte[5], algo);
         try {
             cipher.init(Cipher.DECRYPT_MODE, key);

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/NegativeLength.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/NegativeLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,9 @@ public class NegativeLength {
 
     public static void main(String[] args) throws Exception {
         SecretKeyFactory skf = SecretKeyFactory.getInstance(
-            "PBKDF2WithHmacSHA1", "SunJCE");
+            "PBKDF2WithHmacSHA1",
+                System.getProperty("test.provider.name", "SunJCE"));
+
 
         // Create a valid PBEKeySpec
         PBEKeySpec pbeks = new PBEKeySpec(

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEInvalidParamsTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEInvalidParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,8 @@ public class PBEInvalidParamsTest {
             System.out.println("=>testing " + algo);
             SecretKeyFactory skf = SecretKeyFactory.getInstance(algo);
             SecretKey key = skf.generateSecret(ks);
-            Cipher c = Cipher.getInstance(algo, "SunJCE");
+            Cipher c = Cipher.getInstance(algo,
+                                System.getProperty("test.provider.name", "SunJCE"));
             try {
                 c.init(Cipher.ENCRYPT_MODE, key, INVALID_PARAMS);
                 throw new Exception("Test Failed: expected IAPE is " +

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEKeyCleanupTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEKeyCleanupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,8 @@ import javax.crypto.spec.PBEKeySpec;
  */
 public class PBEKeyCleanupTest {
 
-    private final static String SunJCEProvider = "SunJCE";
+    private final static String PROVIDER_NAME =
+                            System.getProperty("test.provider.name", "SunJCE");
 
     private static final String PASS_PHRASE = "some hidden string";
     private static final int ITERATION_COUNT = 1000;
@@ -60,7 +61,7 @@ public class PBEKeyCleanupTest {
         char[] password = new char[] {'f', 'o', 'o'};
         PBEKeySpec pbeKeySpec = new PBEKeySpec(password);
         SecretKeyFactory keyFac =
-                SecretKeyFactory.getInstance(algorithm, SunJCEProvider);
+                SecretKeyFactory.getInstance(algorithm, PROVIDER_NAME);
 
         testCleanupSecret(algorithm, keyFac.generateSecret(pbeKeySpec));
     }
@@ -72,7 +73,7 @@ public class PBEKeyCleanupTest {
         PBEKeySpec pbeKeySpec = new PBEKeySpec(PASS_PHRASE.toCharArray(), salt,
                 ITERATION_COUNT, KEY_SIZE);
         SecretKeyFactory keyFac =
-                SecretKeyFactory.getInstance(algorithm, SunJCEProvider);
+                SecretKeyFactory.getInstance(algorithm, PROVIDER_NAME);
 
         testCleanupSecret(algorithm, keyFac.generateSecret(pbeKeySpec));
     }

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEKeysAlgorithmNames.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEKeysAlgorithmNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,8 @@ public class PBEKeysAlgorithmNames {
 
         for (String s : algs) {
             System.out.println("Testing " + s);
-            SecretKeyFactory skf = SecretKeyFactory.getInstance(s, "SunJCE");
+            SecretKeyFactory skf = SecretKeyFactory.getInstance(s,
+                                    System.getProperty("test.provider.name", "SunJCE"));
 
             System.out.println("    Checking skf.getAlgorithm()");
             if (!skf.getAlgorithm().equalsIgnoreCase(s)) {

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEParametersTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,8 @@ public class PBEParametersTest {
             String algo = PBE_ALGOS[i];
             SecretKeyFactory skf = SecretKeyFactory.getInstance(algo);
             SecretKey key = skf.generateSecret(ks);
-            Cipher c = Cipher.getInstance(algo, "SunJCE");
+            Cipher c = Cipher.getInstance(algo,
+                                System.getProperty("test.provider.name", "SunJCE"));
             c.init(Cipher.ENCRYPT_MODE, key);
             c.doFinal(new byte[10]); // force the generation of parameters
             AlgorithmParameters params = c.getParameters();

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBESameBuffer/PBESameBuffer.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBESameBuffer/PBESameBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public class PBESameBuffer {
     public boolean test(String[] args, PrintStream out) {
         boolean result = true;
 
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
 
         for (int loop : OFFSETS) {
             OUTPUT_OFFSET = loop;

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBESealedObject.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBESealedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,9 +76,12 @@ public class PBESealedObject {
         "PBEWithHmacSHA512AndAES_256"
     };
 
+    private static final String PROVIDER_NAME =
+                    System.getProperty("test.provider.name", "SunJCE");
+
     public static void main(String[] args) {
         PBESealedObject test = new PBESealedObject();
-        Provider sunjce = Security.getProvider("SunJCE");
+        Provider sunjce = Security.getProvider(PROVIDER_NAME);
 
         if (!test.runAll(sunjce, System.out)) {
             throw new RuntimeException("One or more tests have failed....");
@@ -158,7 +161,7 @@ public class PBESealedObject {
                 return false;
             }
 
-            unsealedKey = (SecretKey) so.getObject(key, "SunJCE");
+            unsealedKey = (SecretKey) so.getObject(key, PROVIDER_NAME);
             return Arrays.equals(unsealedKey.getEncoded(), key.getEncoded());
         } catch (InvalidKeyException ex) {
             if (baseAlgo.endsWith("TRIPLEDES") || baseAlgo.endsWith("AES_256")) {

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PKCS12Cipher.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PKCS12Cipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,8 @@ public class PKCS12Cipher {
         new SecureRandom().nextBytes(input);
         char[] PASSWD = { 'p','a','s','s','w','o','r','d' };
         long start = System.currentTimeMillis();
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                            System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + p.getName() + "...");
         runTest("PBEWithSHA1AndDESede", input, PASSWD, p);
         runTest("PBEWithSHA1AndRC2_40", input, PASSWD, p);

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PKCS12CipherKAT.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PKCS12CipherKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,7 +179,8 @@ public class PKCS12CipherKAT {
 
     static void runTests(Test[] tests) throws Exception {
         long start = System.currentTimeMillis();
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + p.getName() + "...");
         Cipher.getInstance("PBEWithSHA1AndRC2_40", p);
         Cipher.getInstance("PBEWithSHA1AndDESede", p);

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/TestCipherKeyWrapperPBEKey.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/TestCipherKeyWrapperPBEKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,8 @@ public class TestCipherKeyWrapperPBEKey {
     public static void main(String[] args) {
 
         TestCipherKeyWrapperPBEKey test = new TestCipherKeyWrapperPBEKey();
-        Provider sunjce = Security.getProvider("SunJCE");
+        Provider sunjce = Security.getProvider(
+                            System.getProperty("test.provider.name", "SunJCE"));
 
         if (!test.runAll(sunjce, System.out)) {
             throw new RuntimeException("One or more tests have failed....");

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/TestCipherPBECons.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/TestCipherPBECons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,8 @@ public class TestCipherPBECons {
 
     public static void main(String[] args) {
         TestCipherPBECons test = new TestCipherPBECons();
-        Provider sunjce = Security.getProvider("SunJCE");
+        Provider sunjce = Security.getProvider(
+                            System.getProperty("test.provider.name", "SunJCE"));
 
         if (!test.runAll(sunjce, System.out)) {
             throw new RuntimeException("One or more tests have failed....");

--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEP.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,9 +47,10 @@ public class TestOAEP {
 
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
-        cp = Security.getProvider("SunJCE");
+        cp = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + cp.getName() + "...");
-        Provider kfp = Security.getProvider("SunRsaSign");
+        Provider kfp = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunRsaSign"));
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", kfp);
         kpg.initialize(768);
         KeyPair kp = kpg.generateKeyPair();

--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPPadding.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPPadding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,9 +52,11 @@ public class TestOAEPPadding {
     static boolean failed = false;
 
     public static void main(String args[]) throws Exception {
-        cp = Security.getProvider("SunJCE");
+        cp = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + cp.getName() + "...");
-        Provider kfp = Security.getProvider("SunRsaSign");
+        Provider kfp = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunRsaSign"));
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", kfp);
         kpg.initialize(2048);
         KeyPair kp = kpg.generateKeyPair();

--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPParameterSpec.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,8 @@ public class TestOAEPParameterSpec {
         byte[] p) throws Exception {
         OAEPParameterSpec spec = new OAEPParameterSpec(mdName, "MGF1",
             mgfSpec, new PSource.PSpecified(p));
-        cp = Security.getProvider("SunJCE");
+        cp = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + cp.getName() + "...");
         AlgorithmParameters ap = AlgorithmParameters.getInstance("OAEP", cp);
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPWithParams.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPWithParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,9 +54,11 @@ public class TestOAEPWithParams {
     };
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
-        cp = Security.getProvider("SunJCE");
+        cp = Security.getProvider(
+                    System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + cp.getName() + "...");
-        Provider kfp = Security.getProvider("SunRsaSign");
+        Provider kfp = Security.getProvider(
+                System.getProperty("test.provider.name", "SunRsaSign"));
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", kfp);
         kpg.initialize(768);
         KeyPair kp = kpg.generateKeyPair();

--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEP_KAT.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEP_KAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,8 +57,10 @@ public class TestOAEP_KAT {
 
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
-        Provider provider = Security.getProvider("SunJCE");
-        Provider kfProvider = Security.getProvider("SunRsaSign");
+        Provider provider = Security.getProvider(
+                            System.getProperty("test.provider.name", "SunJCE"));
+        Provider kfProvider = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunRsaSign"));
         System.out.println("Testing provider " + provider.getName() + "...");
         Cipher c = Cipher.getInstance("RSA/ECB/OAEPwithSHA1andMGF1Padding", provider);
         KeyFactory kf = KeyFactory.getInstance("RSA", kfProvider);

--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestRSA.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestRSA.java
@@ -168,7 +168,8 @@ public class TestRSA {
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
 
-        p = Security.getProvider("SunJCE");
+        p = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + p.getName() + "...");
 
         KeyFactory kf;

--- a/test/jdk/com/sun/crypto/provider/Cipher/TestCipher.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/TestCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import javax.crypto.spec.SecretKeySpec;
  */
 public abstract class TestCipher {
 
-    private final String SUNJCE = "SunJCE";
+    private final String PROVIDER_NAME = System.getProperty("test.provider.name", "SunJCE");
     private final String ALGORITHM;
     private final String[] MODES;
     private final String[] PADDINGS;
@@ -138,8 +138,8 @@ public abstract class TestCipher {
         out.println("Testing: " + TRANSFORMATION);
 
         // Initialization
-        Cipher ci = Cipher.getInstance(TRANSFORMATION, SUNJCE);
-        KeyGenerator kg = KeyGenerator.getInstance(ALGORITHM, SUNJCE);
+        Cipher ci = Cipher.getInstance(TRANSFORMATION, PROVIDER_NAME);
+        KeyGenerator kg = KeyGenerator.getInstance(ALGORITHM, PROVIDER_NAME);
         if (keySize != 0) {
             kg.init(keySize);
         }

--- a/test/jdk/com/sun/crypto/provider/Cipher/TextLength/SameBufferOverwrite.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/TextLength/SameBufferOverwrite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,9 +44,11 @@ public class SameBufferOverwrite {
     SameBufferOverwrite(String algo, String transformation)
         throws Exception {
 
-        KeyGenerator kg = KeyGenerator.getInstance(algo, "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance(algo,
+                            System.getProperty("test.provider.name", "SunJCE"));
         skey = kg.generateKey();
-        c = Cipher.getInstance(transformation, "SunJCE");
+        c = Cipher.getInstance(transformation,
+                            System.getProperty("test.provider.name", "SunJCE"));
     }
 
     /*

--- a/test/jdk/com/sun/crypto/provider/Cipher/UTIL/StrongOrUnlimited.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/UTIL/StrongOrUnlimited.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,8 @@ public class StrongOrUnlimited {
         // decide if the installed jurisdiction policy file is the
         // unlimited version
         boolean isUnlimited = true;
-        Cipher c = Cipher.getInstance("AES", "SunJCE");
+        Cipher c = Cipher.getInstance("AES",
+                System.getProperty("test.provider.name", "SunJCE"));
 
         try {
             c.init(Cipher.ENCRYPT_MODE,

--- a/test/jdk/com/sun/crypto/provider/Cipher/UTIL/SunJCEGetInstance.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/UTIL/SunJCEGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,9 +40,10 @@ public class SunJCEGetInstance {
         Cipher jce;
 
         try{
+            String providerName = System.getProperty("test.provider.name", "SunJCE");
             // Remove SunJCE from Provider list
-            Provider prov = Security.getProvider("SunJCE");
-            Security.removeProvider("SunJCE");
+            Provider prov = Security.getProvider(providerName);
+            Security.removeProvider(providerName);
             // Create our own instance of SunJCE provider.  Purposefully not
             // using SunJCE.getInstance() so we can have our own instance
             // for the test.

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/DHKeyFactory.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/DHKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,8 @@ public class DHKeyFactory {
         dhSkipParamSpec = new DHParameterSpec(skip1024Modulus,
                                               skip1024Base);
 
-        KeyPairGenerator kpgen = KeyPairGenerator.getInstance("DH", "SunJCE");
+        KeyPairGenerator kpgen = KeyPairGenerator.getInstance("DH",
+                                    System.getProperty("test.provider.name", "SunJCE"));
         kpgen.initialize(dhSkipParamSpec);
         KeyPair kp = kpgen.generateKeyPair();
 
@@ -72,7 +73,8 @@ public class DHKeyFactory {
         // get the private key encoding
         byte[] privKeyEnc = kp.getPrivate().getEncoded();
 
-        KeyFactory kfac = KeyFactory.getInstance("DH", "SunJCE");
+        KeyFactory kfac = KeyFactory.getInstance("DH",
+                                System.getProperty("test.provider.name", "SunJCE"));
 
         X509EncodedKeySpec x509KeySpec = new X509EncodedKeySpec(pubKeyEnc);
         PublicKey pubKey = kfac.generatePublic(x509KeySpec);

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/DHKeyGenSpeed.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/DHKeyGenSpeed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,8 @@ public class DHKeyGenSpeed {
 
         // generate keyPairs using parameters
         KeyPairGenerator keyGen =
-            KeyPairGenerator.getInstance("DH", "SunJCE");
+            KeyPairGenerator.getInstance("DH",
+                    System.getProperty("test.provider.name", "SunJCE"));
         start = System.currentTimeMillis();
         keyGen.initialize(spec);
         KeyPair keys = keyGen.generateKeyPair();

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/SameDHKeyStressTest.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/SameDHKeyStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,8 @@ public class SameDHKeyStressTest {
         Key[] keyArchives = new Key[numParties];
         try {
             // generate AlogirhtmParameterSpec
-            AlgorithmParameterGenerator apg = AlgorithmParameterGenerator.getInstance("DH","SunJCE");
+            AlgorithmParameterGenerator apg = AlgorithmParameterGenerator.getInstance("DH",
+                                            System.getProperty("test.provider.name", "SunJCE"));
             AlgorithmParameterSpec aps = new DHGenParameterSpec(512, 64);
             apg.init(aps);
             DHParameterSpec spec = apg.generateParameters().
@@ -139,8 +140,10 @@ class KAParticipant {
     public KAParticipant(String pName, String algo) throws NoSuchAlgorithmException, NoSuchProviderException {
         name = pName;
         algorithm = algo;
-        keyGen = KeyPairGenerator.getInstance(algo,"SunJCE");
-        ka = KeyAgreement.getInstance(algo,"SunJCE");
+        keyGen = KeyPairGenerator.getInstance(algo,
+                    System.getProperty("test.provider.name", "SunJCE"));
+        ka = KeyAgreement.getInstance(algo,
+                    System.getProperty("test.provider.name", "SunJCE"));
     }
 
     public void initialize(AlgorithmParameterSpec spec) throws InvalidAlgorithmParameterException, InvalidKeyException {

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/SupportedDHKeys.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/SupportedDHKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,8 @@ public class SupportedDHKeys {
     public static void main(String[] args) throws Exception {
         for (SupportedKeySize keySize : SupportedKeySize.values()) {
             System.out.println("Checking " + keySize.primeSize + " ...");
-            KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "SunJCE");
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH",
+                                    System.getProperty("test.provider.name", "SunJCE"));
             kpg.initialize(keySize.primeSize);
             KeyPair kp = kpg.generateKeyPair();
             checkKeyPair(kp, keySize.primeSize);

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,12 +49,14 @@ public class SupportedDHParamGens {
 
         System.out.println("Checking " + primeSize + " ...");
         AlgorithmParameterGenerator apg =
-                AlgorithmParameterGenerator.getInstance("DH", "SunJCE");
+                AlgorithmParameterGenerator.getInstance("DH",
+                        System.getProperty("test.provider.name", "SunJCE"));
         apg.init(primeSize);
         AlgorithmParameters ap = apg.generateParameters();
         DHParameterSpec spec = ap.getParameterSpec(DHParameterSpec.class);
 
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "SunJCE");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH",
+                        System.getProperty("test.provider.name", "SunJCE"));
         kpg.initialize(spec);
         KeyPair kp = kpg.generateKeyPair();
         checkKeyPair(kp, primeSize);

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/TestExponentSize.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/TestExponentSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,8 @@ public class TestExponentSize {
 
     public static void main(String[] args) throws Exception {
         KeyPair kp;
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", "SunJCE");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH",
+                                System.getProperty("test.provider.name", "SunJCE"));
 
         // Sun's default uses a default psize of 2048 and
         // lsize of (pSize / 2) but at least 384 bits

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/UnsupportedDHKeys.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/UnsupportedDHKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,8 @@ public class UnsupportedDHKeys {
             try {
                 System.out.println("Checking " + keySize.primeSize + " ...");
                 KeyPairGenerator kpg =
-                        KeyPairGenerator.getInstance("DH", "SunJCE");
+                        KeyPairGenerator.getInstance("DH",
+                                System.getProperty("test.provider.name", "SunJCE"));
                 kpg.initialize(keySize.primeSize);
 
                 throw new Exception("Should not support " + keySize.primeSize);

--- a/test/jdk/com/sun/crypto/provider/KeyFactory/PBKDF2HmacSHA1FactoryTest.java
+++ b/test/jdk/com/sun/crypto/provider/KeyFactory/PBKDF2HmacSHA1FactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,8 @@ public class PBKDF2HmacSHA1FactoryTest {
     };
 
     private static void test() throws Exception {
-        SecretKeyFactory skf = SecretKeyFactory.getInstance(ALGO, "SunJCE");
+        SecretKeyFactory skf = SecretKeyFactory.getInstance(ALGO,
+                    System.getProperty("test.provider.name", "SunJCE"));
 
         for (int i = 0; i < TEST_VECTORS.length; i++) {
             System.out.println("=>Testing vector#" + (i+1));

--- a/test/jdk/com/sun/crypto/provider/KeyFactory/TestProviderLeak.java
+++ b/test/jdk/com/sun/crypto/provider/KeyFactory/TestProviderLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,8 @@ public class TestProviderLeak {
     public static void main(String [] args) throws Exception {
         // Prepare the test
         final SecretKeyFactory skf =
-            SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1", "SunJCE");
+            SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1",
+                    System.getProperty("test.provider.name", "SunJCE"));
         final PBEKeySpec pbeKS = new PBEKeySpec(
             "passPhrase".toCharArray(), new byte [] { 0 }, 5, 512);
 

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/Test4628062.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/Test4628062.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,8 @@ public class Test4628062 {
     private static final int[] HMACSHA512_SIZES = { 64 };
 
     public boolean execute(String algo, int[] keySizes) throws Exception {
-        KeyGenerator kg = KeyGenerator.getInstance(algo, "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance(algo,
+                System.getProperty("test.provider.name", "SunJCE"));
 
         // TEST FIX 4628062
         Key keyWithDefaultSize = kg.generateKey();

--- a/test/jdk/com/sun/crypto/provider/KeyGenerator/TestExplicitKeyLength.java
+++ b/test/jdk/com/sun/crypto/provider/KeyGenerator/TestExplicitKeyLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,8 @@ public class TestExplicitKeyLength {
         { 64, 80 }; // in bits
 
     public static void runTest(String algo, int keysize) throws Exception {
-        KeyGenerator kg = KeyGenerator.getInstance(algo, "SunJCE");
+        KeyGenerator kg = KeyGenerator.getInstance(algo,
+                                System.getProperty("test.provider.name", "SunJCE"));
         kg.init(keysize);
         Key generatedKey = kg.generateKey();
         int actualSizeInBits = generatedKey.getEncoded().length*8;

--- a/test/jdk/com/sun/crypto/provider/Mac/DigestCloneabilityTest.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/DigestCloneabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,8 @@ public class DigestCloneabilityTest {
         // make SampleProvider the most preferred, so its digest impl is picked
         int status = Security.insertProviderAt(p, 1);
         try {
-            Mac mac = Mac.getInstance(ALGO, "SunJCE");
+            Mac mac = Mac.getInstance(ALGO,
+                    System.getProperty("test.provider.name", "SunJCE"));
             // do a complete mac generation and check if the supplied
             // digest is used
             mac.init(new SecretKeySpec(new byte[512>>3], ALGO));
@@ -72,7 +73,8 @@ public class DigestCloneabilityTest {
 
             public CloneableDigest() throws NoSuchAlgorithmException {
                 try {
-                    md = MessageDigest.getInstance("SHA-512", "SUN");
+                    md = MessageDigest.getInstance("SHA-512",
+                            System.getProperty("test.provider.name", "SUN"));
                 } catch (NoSuchProviderException nspe) {
                     // should never happen
                 }

--- a/test/jdk/com/sun/crypto/provider/Mac/EmptyByteBufferTest.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/EmptyByteBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,8 @@ public class EmptyByteBufferTest implements MacTest {
         SecretKey key = Utils.getSecretKeySpec();
 
         // instantiate Mac object and init it with a SecretKey
-        Mac mac = Mac.getInstance(alg, "SunJCE");
+        Mac mac = Mac.getInstance(alg,
+                System.getProperty("test.provider.name", "SunJCE"));
         mac.init(key);
 
         // prepare buffer

--- a/test/jdk/com/sun/crypto/provider/Mac/HmacPBESHA1.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/HmacPBESHA1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ public class HmacPBESHA1 {
     };
     private static final int[] MAC_LENGTHS = { 20, 20, 28, 32, 48, 64 };
     private static final String KEY_ALGO = "PBE";
-    private static final String PROVIDER = "SunJCE";
+    private static final String PROVIDER =
+            System.getProperty("test.provider.name", "SunJCE");
 
     private static SecretKey key = null;
 

--- a/test/jdk/com/sun/crypto/provider/Mac/HmacSaltLengths.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/HmacSaltLengths.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,8 @@ public class HmacSaltLengths {
         new SecureRandom().nextBytes(input);
         char[] PASSWD = { 'p','a','s','s','w','o','r','d' };
         long start = System.currentTimeMillis();
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + p.getName() + "...");
         for (String algo : ALGOS) {
             runTest(algo, input, PASSWD, p);

--- a/test/jdk/com/sun/crypto/provider/Mac/LargeByteBufferTest.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/LargeByteBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,8 @@ public class LargeByteBufferTest implements MacTest {
         SecretKey key = Utils.getSecretKeySpec();
 
         // instantiate Mac object and init it with a SecretKey
-        Mac mac = Mac.getInstance(alg, "SunJCE");
+        Mac mac = Mac.getInstance(alg,
+                System.getProperty("test.provider.name", "SunJCE"));
         mac.init(key);
 
         // prepare buffer

--- a/test/jdk/com/sun/crypto/provider/Mac/MacClone.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/MacClone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,8 @@ public class MacClone {
         //
         // Clone an uninitialized Mac object
         //
-        Mac mac = Mac.getInstance(algo, "SunJCE");
+        Mac mac = Mac.getInstance(algo,
+                    System.getProperty("test.provider.name", "SunJCE"));
         Mac macClone = (Mac)mac.clone();
         System.out.println(macClone.getProvider().toString());
         System.out.println(macClone.getAlgorithm());
@@ -77,7 +78,8 @@ public class MacClone {
         //
         // Clone an initialized Mac object
         //
-        mac = Mac.getInstance(algo, "SunJCE");
+        mac = Mac.getInstance(algo,
+                    System.getProperty("test.provider.name", "SunJCE"));
         mac.init(skey, params);
         macClone = (Mac)mac.clone();
         System.out.println(macClone.getProvider().toString());

--- a/test/jdk/com/sun/crypto/provider/Mac/MacKAT.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/MacKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -333,7 +333,8 @@ public class MacKAT {
 
     static void runTests(Test[] tests) throws Exception {
         long start = System.currentTimeMillis();
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + p.getName() + "...");
         for (int i = 0; i < tests.length; i++) {
             Test test = tests[i];

--- a/test/jdk/com/sun/crypto/provider/Mac/MacSameTest.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/MacSameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,8 @@ public class MacSameTest implements MacTest {
             NoSuchProviderException, InvalidKeyException {
         Mac mac;
         try {
-            mac = Mac.getInstance(algo, "SunJCE");
+            mac = Mac.getInstance(algo,
+                    System.getProperty("test.provider.name", "SunJCE"));
         } catch (NoSuchAlgorithmException nsae) {
             // depending on Solaris configuration,
             // it can support HMAC or not with Mac

--- a/test/jdk/com/sun/crypto/provider/Mac/NullByteBufferTest.java
+++ b/test/jdk/com/sun/crypto/provider/Mac/NullByteBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,8 @@ public class NullByteBufferTest implements MacTest {
         SecretKey key = Utils.getSecretKeySpec();
 
         // instantiate Mac object and init it with a SecretKey
-        Mac mac = Mac.getInstance(alg, "SunJCE");
+        Mac mac = Mac.getInstance(alg,
+                System.getProperty("test.provider.name", "SunJCE"));
         mac.init(key);
 
         try {

--- a/test/jdk/com/sun/crypto/provider/NSASuiteB/TestAESOids.java
+++ b/test/jdk/com/sun/crypto/provider/NSASuiteB/TestAESOids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,8 @@ import javax.crypto.spec.IvParameterSpec;
  */
 public class TestAESOids {
 
-    private static final String PROVIDER_NAME = "SunJCE";
+    private static final String PROVIDER_NAME =
+            System.getProperty("test.provider.name", "SunJCE");
     private static final byte[] INPUT = "1234567890123456".getBytes();
 
     private static final List<DataTuple> DATA = Arrays.asList(

--- a/test/jdk/com/sun/crypto/provider/NSASuiteB/TestAESWrapOids.java
+++ b/test/jdk/com/sun/crypto/provider/NSASuiteB/TestAESWrapOids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ import javax.crypto.SecretKey;
  */
 public class TestAESWrapOids {
 
-    private static final String PROVIDER_NAME = "SunJCE";
+    private static final String PROVIDER_NAME =
+            System.getProperty("test.provider.name", "SunJCE");
 
     private static final List<DataTuple> DATA = Arrays.asList(
             new DataTuple("2.16.840.1.101.3.4.1.5", "AESWrap_128"),

--- a/test/jdk/com/sun/crypto/provider/NSASuiteB/TestHmacSHAOids.java
+++ b/test/jdk/com/sun/crypto/provider/NSASuiteB/TestHmacSHAOids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,8 @@ import javax.crypto.SecretKey;
  */
 public class TestHmacSHAOids {
 
-    private static final String PROVIDER_NAME = "SunJCE";
+    private static final String PROVIDER_NAME =
+            System.getProperty("test.provider.name", "SunJCE");
     private static final byte[] INPUT = "1234567890".getBytes();
 
     private static final List<DataTuple> DATA = Arrays.asList(

--- a/test/jdk/com/sun/crypto/provider/TLS/TestKeyMaterial.java
+++ b/test/jdk/com/sun/crypto/provider/TLS/TestKeyMaterial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,8 @@ public class TestKeyMaterial extends Utils {
     private static int PREFIX_LENGTH = "km-master:  ".length();
 
     public static void main(String[] args) throws Exception {
-        Provider provider = Security.getProvider("SunJCE");
+        Provider provider = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
 
         InputStream in = new FileInputStream(new File(BASE, "keymatdata.txt"));
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));

--- a/test/jdk/com/sun/crypto/provider/TLS/TestLeadingZeroes.java
+++ b/test/jdk/com/sun/crypto/provider/TLS/TestLeadingZeroes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,8 @@ import javax.crypto.interfaces.*;
 
 public class TestLeadingZeroes {
 
-    private static final String SUNJCE = "SunJCE";
+    private static final String PROVIDER_NAME =
+                            System.getProperty("test.provider.name", "SunJCE");
     // Hex formatter to upper case with ":" delimiter
     private static final HexFormat HEX_FORMATTER = HexFormat.ofDelimiter(":").withUpperCase();
 
@@ -73,7 +74,7 @@ public class TestLeadingZeroes {
             kfac.generatePrivate(new PKCS8EncodedKeySpec(bobPrivKeyEnc));
 
         // generate normal shared secret
-        KeyAgreement aliceKeyAgree = KeyAgreement.getInstance("DH", SUNJCE);
+        KeyAgreement aliceKeyAgree = KeyAgreement.getInstance("DH", PROVIDER_NAME);
         aliceKeyAgree.init(alicePrivKey);
         aliceKeyAgree.doPhase(bobPubKey, true);
         byte[] sharedSecret = aliceKeyAgree.generateSecret();

--- a/test/jdk/com/sun/crypto/provider/TLS/TestMasterSecret.java
+++ b/test/jdk/com/sun/crypto/provider/TLS/TestMasterSecret.java
@@ -49,7 +49,8 @@ public class TestMasterSecret extends Utils {
     private static int PREFIX_LENGTH = "m-premaster:  ".length();
 
     public static void main(String[] args) throws Exception {
-        Provider provider = Security.getProvider("SunJCE");
+        Provider provider = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
 
         InputStream in = new FileInputStream(new File(BASE, "masterdata.txt"));
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));

--- a/test/jdk/com/sun/crypto/provider/TLS/TestPRF.java
+++ b/test/jdk/com/sun/crypto/provider/TLS/TestPRF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,8 @@ public class TestPRF extends Utils {
     private static int PREFIX_LENGTH = "prf-output: ".length();
 
     public static void main(String[] args) throws Exception {
-        Provider provider = Security.getProvider("SunJCE");
+        Provider provider = Security.getProvider(
+                                System.getProperty("test.provider.name", "SunJCE"));
 
         InputStream in = new FileInputStream(new File(BASE, "prfdata.txt"));
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));

--- a/test/jdk/com/sun/crypto/provider/TLS/TestPRF12.java
+++ b/test/jdk/com/sun/crypto/provider/TLS/TestPRF12.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,8 @@ public class TestPRF12 extends Utils {
     private static int PREFIX_LENGTH = "prf-output: ".length();
 
     public static void main(String[] args) throws Exception {
-        Provider provider = Security.getProvider("SunJCE");
+        Provider provider = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
 
         InputStream in = new FileInputStream(new File(BASE, "prf12data.txt"));
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));

--- a/test/jdk/com/sun/crypto/provider/TLS/TestPremaster.java
+++ b/test/jdk/com/sun/crypto/provider/TLS/TestPremaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,8 @@ import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
 public class TestPremaster {
 
     public static void main(String[] args) throws Exception {
-        Provider provider = Security.getProvider("SunJCE");
+        Provider provider = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
 
         KeyGenerator kg;
 

--- a/test/jdk/com/sun/jdi/ClassesByName2Test.java
+++ b/test/jdk/com/sun/jdi/ClassesByName2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,8 @@ class ClassesByName2Targ {
                     public void run () {
                         try {
                             java.security.KeyPairGenerator keyGen =
-                                java.security.KeyPairGenerator.getInstance("DSA", "SUN");
+                                    java.security.KeyPairGenerator.getInstance("DSA",
+                                            System.getProperty("test.provider.name", "SUN"));
                         } catch (Exception e) {
                             e.printStackTrace();
                         }

--- a/test/jdk/java/security/KeyAgreement/KeyAgreementTest.java
+++ b/test/jdk/java/security/KeyAgreement/KeyAgreementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class KeyAgreementTest {
 
         String kaAlgo = args[0];
         String kpgAlgo = args[1];
-        String provider = args[2];
+        String provider = System.getProperty("test.provider.name", args[2]);
         System.out.println("Testing " + kaAlgo);
         AlgoSpec aSpec = AlgoSpec.valueOf(AlgoSpec.class, kaAlgo);
         List<AlgorithmParameterSpec> specs = aSpec.getAlgorithmParameterSpecs();

--- a/test/jdk/java/security/KeyAgreement/KeySizeTest.java
+++ b/test/jdk/java/security/KeyAgreement/KeySizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class KeySizeTest {
     public static void main(String[] args) throws Exception {
 
         String kaAlgo = args[0];
-        String provider = args[1];
+        String provider = System.getProperty("test.provider.name", args[1]);
         String kpgAlgo = args[2];
         int keySize = Integer.parseInt(args[3]);
         testKeyAgreement(provider, kaAlgo, kpgAlgo, keySize);

--- a/test/jdk/java/security/KeyAgreement/KeySpecTest.java
+++ b/test/jdk/java/security/KeyAgreement/KeySpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class KeySpecTest {
     public static void main(String[] args) throws Exception {
 
         String kaAlgo = args[0];
-        String provider = args[1];
+        String provider = System.getProperty("test.provider.name", args[1]);
         String kpgAlgo = args[2];
         KeyPair kp = genKeyPair(provider, kpgAlgo,
                 (args.length > 3) ? args[3] : kpgAlgo);

--- a/test/jdk/java/security/KeyAgreement/MultiThreadTest.java
+++ b/test/jdk/java/security/KeyAgreement/MultiThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class MultiThreadTest {
     public static void main(String[] args) throws Exception {
 
         String kaAlgo = args[0];
-        String provider = args[1];
+        String provider = System.getProperty("test.provider.name", args[1]);
         String kpgAlgo = args[2];
         KeyPairGenerator kpg = genKeyGenerator(provider, kpgAlgo,
                 (args.length > 3) ? args[3] : kpgAlgo);

--- a/test/jdk/java/security/KeyAgreement/NegativeTest.java
+++ b/test/jdk/java/security/KeyAgreement/NegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class NegativeTest {
     public static void main(String[] args) throws Exception {
 
         String kaAlgo = args[0];
-        String provider = args[1];
+        String provider = System.getProperty("test.provider.name", args[1]);
         String kpgAlgo = args[2];
         int keySize = Integer.parseInt(args[3]);
         String kpgInit = (args.length > 4) ? args[4] : args[2];

--- a/test/jdk/java/security/KeyFactory/GenerateRSAPrivateCrtKey.java
+++ b/test/jdk/java/security/KeyFactory/GenerateRSAPrivateCrtKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,8 @@ public class GenerateRSAPrivateCrtKey {
                                      new BigInteger(1, coeff));
 
         // Create an RSA private key from the CRT specification
-        KeyFactory kf = KeyFactory.getInstance("RSA", "SunRsaSign");
+        KeyFactory kf = KeyFactory.getInstance("RSA",
+                System.getProperty("test.provider.name", "SunRsaSign"));
         RSAPrivateCrtKey rsaPriKey =
             (RSAPrivateCrtKey) kf.generatePrivate(rsaCrtSpec);
 

--- a/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
+++ b/test/jdk/java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java
@@ -69,7 +69,8 @@ public class KeyFactoryGetKeySpecForInvalidSpec {
     }
 
     public static void main(String[] args) throws Exception {
-        KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA", "SunRsaSign");
+        KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA",
+                System.getProperty("test.provider.name", "SunRsaSign"));
         kg.initialize(2048);
         KeyPair pair = kg.generateKeyPair();
 

--- a/test/jdk/java/security/KeyPairGenerator/GenerateRSAKeyPair.java
+++ b/test/jdk/java/security/KeyPairGenerator/GenerateRSAKeyPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,8 @@ public class GenerateRSAKeyPair {
 
         RSAKeyGenParameterSpec rsaSpec =
         new RSAKeyGenParameterSpec (1024, RSAKeyGenParameterSpec.F4);
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "SunRsaSign");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA",
+                System.getProperty("test.provider.name", "SunRsaSign"));
         kpg.initialize(rsaSpec);
 
         // test generateKeyPair

--- a/test/jdk/java/security/KeyRep/Serial.java
+++ b/test/jdk/java/security/KeyRep/Serial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,9 @@ import javax.crypto.spec.*;
 public class Serial {
 
     // providers
-    private static final String SUN = "SUN";
-    private static final String RSA = "SunRsaSign";
-    private static final String JCE = "SunJCE";
+    private static final String SUN = System.getProperty("test.provider.name", "SUN");
+    private static final String RSA = System.getProperty("test.provider.name", "SunRsaSign");
+    private static final String JCE = System.getProperty("test.provider.name", "SunJCE");
 
     public static void main(String[] args) throws Exception {
 

--- a/test/jdk/java/security/KeyRep/Serial.policy
+++ b/test/jdk/java/security/KeyRep/Serial.policy
@@ -1,3 +1,4 @@
 grant {
+    permission java.util.PropertyPermission "test.provider.name", "read";
     // XXX note package access is *not* granted to the 'sun' package
 };

--- a/test/jdk/java/security/MessageDigest/ByteBuffers.java
+++ b/test/jdk/java/security/MessageDigest/ByteBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.security.*;
 public class ByteBuffers {
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SUN");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SUN"));
         Random random = new Random();
         int n = 10 * 1024;
         byte[] t = new byte[n];

--- a/test/jdk/java/security/MessageDigest/TestCloneable.java
+++ b/test/jdk/java/security/MessageDigest/TestCloneable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,14 +43,16 @@ public class TestCloneable {
     private static final Class<CloneNotSupportedException> CNSE =
             CloneNotSupportedException.class;
 
+    private static String providerName = System.getProperty("test.provider.name", "SUN");
+
     @DataProvider
     public Object[][] testData() {
         return new Object[][] {
-            { "MD2", "SUN" }, { "MD5", "SUN" }, { "SHA-1", "SUN" },
-            { "SHA-224", "SUN" }, { "SHA-256", "SUN" },
-            { "SHA-384", "SUN" }, { "SHA-512", "SUN" },
-            { "SHA3-224", "SUN" }, { "SHA3-256", "SUN" },
-            { "SHA3-384", "SUN" }, { "SHA3-512", "SUN" }
+            { "MD2", providerName }, { "MD5", providerName }, { "SHA-1", providerName },
+            { "SHA-224", providerName }, { "SHA-256", providerName },
+            { "SHA-384", providerName }, { "SHA-512", providerName },
+            { "SHA3-224", providerName }, { "SHA3-256", providerName },
+            { "SHA3-384", providerName }, { "SHA3-512", providerName }
         };
     }
 

--- a/test/jdk/java/security/SecureRandom/DefaultAlgo.java
+++ b/test/jdk/java/security/SecureRandom/DefaultAlgo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,8 +87,9 @@ public class DefaultAlgo {
                     p.remove("SecureRandom." + s);
                     out.println("removed "  + s);
                 }
-                validate(new SecureRandom(), "SUN",
-                        SunEntries.DEF_SECURE_RANDOM_ALGO);
+                validate(new SecureRandom(), System.getProperty("test.provider.name", "SUN"),
+                        System.getProperty("test.default.secure.random.algorithm.name",
+                                SunEntries.DEF_SECURE_RANDOM_ALGO));
             } else {
                 validate(new SecureRandom(), pName, algos[0]);
             }

--- a/test/jdk/java/security/SecureRandom/DefaultProvider.java
+++ b/test/jdk/java/security/SecureRandom/DefaultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class DefaultProvider {
         out.println("TEST: Default provider with constructor");
         SecureRandom secureRandom = new SecureRandom();
         String provider = secureRandom.getProvider().getName();
-        if (!provider.equals("SUN")) {
+        if (!provider.equals(System.getProperty("test.provider.name", "SUN"))) {
             throw new RuntimeException("Unexpected provider name: "
                     + provider);
         }
@@ -51,7 +51,7 @@ public class DefaultProvider {
         /* Test default provider with getInstance(String algorithm) */
         out.println("TEST: SHA1PRNG supported on all platforms by SUN provider");
         String algorithm = "SHA1PRNG";
-        provider = "SUN";
+        provider = System.getProperty("test.provider.name", "SUN");
 
         SecureRandom instance = SecureRandom.getInstance(algorithm);
         assertInstance(instance, algorithm, provider);
@@ -61,7 +61,7 @@ public class DefaultProvider {
             out.println("TEST: NativePRNG supported on all platforms"
                     + "(except Windows), by SUN provider");
             algorithm = "NativePRNG";
-            provider = "SUN";
+            provider = System.getProperty("test.provider.name", "SUN");
         } else {
             out.println(
                     "TEST: Windows-PRNG supported on windows by SunMSCAPI provider");

--- a/test/jdk/java/security/SecureRandom/GetInstanceTest.java
+++ b/test/jdk/java/security/SecureRandom/GetInstanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,8 @@ public class GetInstanceTest {
                     + "'securerandom.strongAlgorithms'.");
         }
         try {
-            Security.setProperty(STRONG_ALG_SEC_PROP, "DRBG:SUN");
+            Security.setProperty(STRONG_ALG_SEC_PROP, "DRBG:" +
+                    System.getProperty("test.provider.name", SUN_PROVIDER));
             sr = matchExc(() -> SecureRandom.getInstanceStrong(),
                     PASS, NoSuchAlgorithmException.class,
                     "PASS - Undefined security Property "
@@ -123,7 +124,8 @@ public class GetInstanceTest {
         // Test for getInstance(algorithm, provider) method.
         checkAttributes(
                 matchExc(() -> SecureRandom.getInstance(srAlgo,
-                                Security.getProvider(SUN_PROVIDER)),
+                                Security.getProvider(
+                                        System.getProperty("test.provider.name", SUN_PROVIDER))),
                         !(nsa(mech)),
                         NoSuchAlgorithmException.class,
                         String.format("PASS - It is expected to fail for"
@@ -132,7 +134,8 @@ public class GetInstanceTest {
                 mech);
         // Test for getInstance(algorithm, providerName) method.
         checkAttributes(
-                matchExc(() -> SecureRandom.getInstance(srAlgo, SUN_PROVIDER),
+                matchExc(() -> SecureRandom.getInstance(srAlgo,
+                                System.getProperty("test.provider.name", SUN_PROVIDER)),
                         !(nsa(mech)), NoSuchAlgorithmException.class,
                         String.format("PASS - It is expected to fail for "
                                 + "getInstance(algorithm, providerName) when "
@@ -175,7 +178,8 @@ public class GetInstanceTest {
             // Test for getInstance(algorithm, params, provider) method.
             checkAttributes(
                     matchExc(() -> SecureRandom.getInstance(srAlgo, param,
-                                    Security.getProvider(SUN_PROVIDER)),
+                                    Security.getProvider(System.getProperty(
+                                            "test.provider.name", SUN_PROVIDER))),
                             (isDRBG(mech)) && (isValidDRBGParam(param)),
                             getExcType(mech, param),
                             String.format("PASS - It is expected to fail "
@@ -186,7 +190,7 @@ public class GetInstanceTest {
             // Test for getInstance(algorithm, params, providerName) method.
             checkAttributes(
                     matchExc(() -> SecureRandom.getInstance(srAlgo, param,
-                                    SUN_PROVIDER),
+                                    System.getProperty("test.provider.name", SUN_PROVIDER)),
                             (isDRBG(mech)) && (isValidDRBGParam(param)),
                             getExcType(mech, param),
                             String.format("PASS - It is expected to fail "
@@ -306,7 +310,8 @@ public class GetInstanceTest {
             return;
         }
         Asserts.assertEquals(sr.getAlgorithm(), (isDRBG(mech) ? "DRBG" : mech));
-        Asserts.assertEquals(sr.getProvider().getName(), SUN_PROVIDER);
+        String expectedProviderName = System.getProperty("test.provider.name", SUN_PROVIDER);
+        Asserts.assertEquals(sr.getProvider().getName(), expectedProviderName);
     }
 
 }

--- a/test/jdk/java/security/Security/CaseInsensitiveAlgNames.java
+++ b/test/jdk/java/security/Security/CaseInsensitiveAlgNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,14 @@ public class CaseInsensitiveAlgNames {
             md = MessageDigest.getInstance("shA1");
 
             // MessageDigest with provider
-            md = MessageDigest.getInstance("SHA", "SUN");
-            md = MessageDigest.getInstance("sha", "SUN");
-            md = MessageDigest.getInstance("Sha-1", "SUN");
-            md = MessageDigest.getInstance("shA1", "SUN");
+            md = MessageDigest.getInstance("SHA",
+                    System.getProperty("test.provider.name", "SUN"));
+            md = MessageDigest.getInstance("sha",
+                    System.getProperty("test.provider.name", "SUN"));
+            md = MessageDigest.getInstance("Sha-1",
+                    System.getProperty("test.provider.name", "SUN"));
+            md = MessageDigest.getInstance("shA1",
+                    System.getProperty("test.provider.name", "SUN"));
 
             // KeyPairGenerator without provider
             KeyPairGenerator kGen = KeyPairGenerator.getInstance("DSA");
@@ -54,11 +58,15 @@ public class CaseInsensitiveAlgNames {
             kGen = KeyPairGenerator.getInstance("1.2.840.10040.4.1");
 
             // KeyPairGenerator with provider
-            kGen = KeyPairGenerator.getInstance("DSA", "SUN");
-            kGen = KeyPairGenerator.getInstance("dsa", "SUN");
-            kGen = KeyPairGenerator.getInstance("dSA", "SUN");
+            kGen = KeyPairGenerator.getInstance("DSA",
+                    System.getProperty("test.provider.name", "SUN"));
+            kGen = KeyPairGenerator.getInstance("dsa",
+                    System.getProperty("test.provider.name", "SUN"));
+            kGen = KeyPairGenerator.getInstance("dSA",
+                    System.getProperty("test.provider.name", "SUN"));
             kGen = KeyPairGenerator.getInstance("OId.1.2.840.10040.4.1",
-                                                "SUN");
-            kGen = KeyPairGenerator.getInstance("1.2.840.10040.4.1", "SUN");
+                    System.getProperty("test.provider.name", "SUN"));
+            kGen = KeyPairGenerator.getInstance("1.2.840.10040.4.1",
+                    System.getProperty("test.provider.name", "SUN"));
     }
 }

--- a/test/jdk/java/security/Signature/ByteBuffers.java
+++ b/test/jdk/java/security/Signature/ByteBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,8 @@ import java.security.*;
 public class ByteBuffers {
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SUN");
+        Provider p = Security.getProvider(
+                            System.getProperty("test.provider.name", "SUN"));
         Random random = new Random();
         int n = 10 * 1024;
         byte[] t = new byte[n];

--- a/test/jdk/java/security/Signature/NONEwithRSA.java
+++ b/test/jdk/java/security/Signature/NONEwithRSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javax.crypto.*;
 public class NONEwithRSA {
 
     public static void main(String[] args) throws Exception {
-//      showProvider(Security.getProvider("SUN"));
+//      showProvider(Security.getProvider(System.getProperty("test.provider.name", "SUN")));
         Random random = new Random();
         byte[] b = new byte[16];
         random.nextBytes(b);
@@ -66,9 +66,11 @@ public class NONEwithRSA {
             throw new Exception("decryption failed");
         }
 
-        sig = Signature.getInstance("NONEwithRSA", "SunJCE");
+        sig = Signature.getInstance("NONEwithRSA",
+                System.getProperty("test.provider.name", "SunJCE"));
         sig.initSign(kp.getPrivate());
-        sig = Signature.getInstance("NONEwithRSA", Security.getProvider("SunJCE"));
+        sig = Signature.getInstance("NONEwithRSA", Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE")));
         sig.initSign(kp.getPrivate());
 
         try {

--- a/test/jdk/java/security/Signature/SignatureGetInstance.java
+++ b/test/jdk/java/security/Signature/SignatureGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,8 @@ public class SignatureGetInstance {
         MyPubKey testPub = new MyPubKey();
 
         testDblInit(testPriv, testPub, true, "TestProvider");
-        testDblInit(kp.getPrivate(), kp.getPublic(), true, "SunRsaSign");
+        testDblInit(kp.getPrivate(), kp.getPublic(), true,
+                        System.getProperty("test.provider.name", "SunRsaSign"));
         testDblInit(testPriv, kp.getPublic(), false, null);
         testDblInit(kp.getPrivate(), testPub, false, null);
 
@@ -59,7 +60,7 @@ public class SignatureGetInstance {
         testSetAndInit(null, kp.getPrivate(), true);
         testSetAndInit(null, kp.getPublic(), true);
 
-        String provName = "SunRsaSign";
+        String provName = System.getProperty("test.provider.name", "SunRsaSign");
         testSetAndInit(provName, testPriv, false);
         testSetAndInit(provName, testPub, false);
         testSetAndInit(provName, kp.getPrivate(), true);

--- a/test/jdk/java/security/Signature/TestCloneable.java
+++ b/test/jdk/java/security/Signature/TestCloneable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,21 +42,25 @@ public class TestCloneable {
 
     @DataProvider
     public Object[][] testData() {
+        String dsaProviderName = System.getProperty("test.provider.name", "SUN");
+        String ecProviderName  = System.getProperty("test.provider.name", "SunEC");
+        String rsaProviderName = System.getProperty("test.provider.name", "SunRsaSign");
+
         return new Object[][] {
-            { "SHA1withDSA", "SUN" }, { "NONEwithDSA", "SUN" },
-            { "SHA224withDSA", "SUN" }, { "SHA256withDSA", "SUN" },
-            { "EdDSA", "SunEC" }, { "Ed25519", "SunEC" }, { "Ed448", "SunEC" },
-            { "SHA1withECDSA", "SunEC" }, { "SHA224withECDSA", "SunEC" },
-            { "SHA256withECDSA", "SunEC" }, { "SHA384withECDSA", "SunEC" },
-            { "SHA512withECDSA", "SunEC" }, { "NONEwithECDSA", "SunEC" },
-            { "MD2withRSA", "SunRsaSign" }, { "MD5withRSA", "SunRsaSign" },
-            { "SHA1withRSA", "SunRsaSign" }, { "SHA224withRSA", "SunRsaSign" },
-            { "SHA256withRSA", "SunRsaSign" },
-            { "SHA384withRSA", "SunRsaSign" },
-            { "SHA512withRSA", "SunRsaSign" },
-            { "SHA512/224withRSA", "SunRsaSign" },
-            { "SHA512/256withRSA", "SunRsaSign" },
-            { "RSASSA-PSS", "SunRsaSign" },
+            { "SHA1withDSA", dsaProviderName }, { "NONEwithDSA", dsaProviderName },
+            { "SHA224withDSA", dsaProviderName }, { "SHA256withDSA", dsaProviderName },
+            { "EdDSA", ecProviderName }, { "Ed25519", ecProviderName }, { "Ed448", ecProviderName },
+            { "SHA1withECDSA", ecProviderName }, { "SHA224withECDSA", ecProviderName },
+            { "SHA256withECDSA", ecProviderName }, { "SHA384withECDSA", ecProviderName },
+            { "SHA512withECDSA", ecProviderName }, { "NONEwithECDSA", ecProviderName },
+            { "MD2withRSA", rsaProviderName }, { "MD5withRSA", rsaProviderName },
+            { "SHA1withRSA", rsaProviderName }, { "SHA224withRSA", rsaProviderName },
+            { "SHA256withRSA", rsaProviderName },
+            { "SHA384withRSA", rsaProviderName },
+            { "SHA512withRSA", rsaProviderName },
+            { "SHA512/224withRSA", rsaProviderName },
+            { "SHA512/256withRSA", rsaProviderName },
+            { "RSASSA-PSS", rsaProviderName },
             { "NONEwithRSA", "SunMSCAPI" },
             { "SHA1withRSA", "SunMSCAPI" }, { "SHA256withRSA", "SunMSCAPI" },
             { "SHA384withRSA", "SunMSCAPI" }, { "SHA512withRSA", "SunMSCAPI" },

--- a/test/jdk/java/security/Signature/TestInitSignWithMyOwnRandom.java
+++ b/test/jdk/java/security/Signature/TestInitSignWithMyOwnRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,8 @@ public class TestInitSignWithMyOwnRandom {
     public static void main(String[] argv) throws Exception {
         // any signature implementation will do as long as
         // it needs a random source
-        Provider p = Security.getProvider("SUN");
+        Provider p = Security.getProvider(
+                            System.getProperty("test.provider.name", "SUN"));
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA", p);
         kpg.initialize(512);
         KeyPair kp = kpg.generateKeyPair();

--- a/test/jdk/java/security/SignedObject/Chain.java
+++ b/test/jdk/java/security/SignedObject/Chain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,10 @@ public class Chain {
         Sun("SUN"),
         SunEC("SunEC"),
         SunJSSE("SunJSSE"),
-        SunMSCAPI("SunMSCAPI");
+        SunMSCAPI("SunMSCAPI"),
+        TestProvider_or_SunRsaSign(System.getProperty("test.provider.name", "SunRsaSign")),
+        TestProvider_or_Sun(System.getProperty("test.provider.name", "SUN")),
+        TestProvider_or_SunEC(System.getProperty("test.provider.name", "SunEC"));
 
         final String name;
 
@@ -166,9 +169,9 @@ public class Chain {
         new Test(SigAlg.SHA3_256withRSA, KeyAlg.RSA, Provider.Default),
         new Test(SigAlg.SHA3_384withRSA, KeyAlg.RSA, Provider.Default),
         new Test(SigAlg.SHA3_512withRSA, KeyAlg.RSA, Provider.Default),
-        new Test(SigAlg.SHA1withDSA, KeyAlg.DSA, Provider.Sun, 1024),
-        new Test(SigAlg.SHA224withDSA, KeyAlg.DSA, Provider.Sun, 2048),
-        new Test(SigAlg.SHA256withDSA, KeyAlg.DSA, Provider.Sun, 2048),
+        new Test(SigAlg.SHA1withDSA, KeyAlg.DSA, Provider.TestProvider_or_Sun, 1024),
+        new Test(SigAlg.SHA224withDSA, KeyAlg.DSA, Provider.TestProvider_or_Sun, 2048),
+        new Test(SigAlg.SHA256withDSA, KeyAlg.DSA, Provider.TestProvider_or_Sun, 2048),
     };
 
     private static final String str = "to-be-signed";
@@ -190,7 +193,7 @@ public class Chain {
         Iterator<String> mdAlgs = SigTestUtil.getDigestAlgorithms
             (SignatureType.RSASSA_PSS, keysize).iterator();
         while (mdAlgs.hasNext()) {
-            result &= runTest(new Test(pss, KeyAlg.RSA, Provider.SunRsaSign,
+            result &= runTest(new Test(pss, KeyAlg.RSA, Provider.TestProvider_or_SunRsaSign,
                 keysize, SigTestUtil.generateDefaultParameter
                     (SignatureType.RSASSA_PSS, mdAlgs.next())));
         }

--- a/test/jdk/java/security/SignedObject/Copy.java
+++ b/test/jdk/java/security/SignedObject/Copy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class Copy {
                 signature);
         System.out.println("Signature algorithm: " + so.getAlgorithm());
 
-        signature = Signature.getInstance(DSA, "SUN");
+        signature = Signature.getInstance(DSA, System.getProperty("test.provider.name", "SUN"));
         if (!so.verify(kp.getPublic(), signature)) {
             throw new RuntimeException("Verification failed");
         }

--- a/test/jdk/java/security/misc/GetInstanceNullsEmpties.java
+++ b/test/jdk/java/security/misc/GetInstanceNullsEmpties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,8 @@ import java.util.Arrays;
  */
 public class GetInstanceNullsEmpties {
 
-    private static final Provider SUN = Security.getProvider("SUN");
+    private static final String providerName = System.getProperty("test.provider.name", "SUN");
+    private static final Provider provider = Security.getProvider(providerName);
 
     /*
      * See if there are more than "expected" number of getInstance() methods,
@@ -168,14 +169,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -190,14 +191,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -212,14 +213,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -234,14 +235,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -257,14 +258,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "", csp);
 
         m = getInstance(clazz, STRING, CertStoreParameters.class, STRING);
-        run(m, NullPointerException.class, null, csp, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", csp, "SUN");
+        run(m, NullPointerException.class, null, csp, providerName);
+        run(m, NoSuchAlgorithmException.class, "", csp, providerName);
         run(m, IllegalArgumentException.class, "FOO", csp, null);
         run(m, IllegalArgumentException.class, "FOO", csp, "");
 
         m = getInstance(clazz, STRING, CertStoreParameters.class, PROVIDER);
-        run(m, NullPointerException.class, null, csp, SUN);
-        run(m, NoSuchAlgorithmException.class, "", csp, SUN);
+        run(m, NullPointerException.class, null, csp, provider);
+        run(m, NoSuchAlgorithmException.class, "", csp, provider);
         run(m, IllegalArgumentException.class, "FOO", csp, null);
     }
 
@@ -279,14 +280,14 @@ public class GetInstanceNullsEmpties {
         run(m, CertificateException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, CertificateException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, CertificateException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, CertificateException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, CertificateException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -305,14 +306,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NoSuchAlgorithmException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NoSuchAlgorithmException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NoSuchAlgorithmException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NoSuchAlgorithmException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -329,15 +330,15 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "", cp);
 
         m = getInstance(clazz, STRING, Configuration.Parameters.class, STRING);
-        run(m, NullPointerException.class, null, cp, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", cp, "SUN");
+        run(m, NullPointerException.class, null, cp, providerName);
+        run(m, NoSuchAlgorithmException.class, "", cp, providerName);
         run(m, IllegalArgumentException.class, "FOO", cp, null);
         run(m, IllegalArgumentException.class, "FOO", cp, "");
 
         m = getInstance(clazz, STRING, Configuration.Parameters.class,
                 PROVIDER);
-        run(m, NullPointerException.class, null, cp, SUN);
-        run(m, NoSuchAlgorithmException.class, "", cp, SUN);
+        run(m, NullPointerException.class, null, cp, provider);
+        run(m, NoSuchAlgorithmException.class, "", cp, provider);
         run(m, IllegalArgumentException.class, "FOO", cp, null);
     }
 
@@ -352,14 +353,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -374,14 +375,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -396,14 +397,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -418,14 +419,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -440,14 +441,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -462,14 +463,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -488,14 +489,14 @@ public class GetInstanceNullsEmpties {
         run(m, KeyStoreException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, KeyStoreException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, KeyStoreException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, KeyStoreException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, KeyStoreException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -510,14 +511,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -532,14 +533,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -556,14 +557,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "", pp);
 
         m = getInstance(clazz, STRING, Policy.Parameters.class, STRING);
-        run(m, NullPointerException.class, null, pp, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", pp, "SUN");
+        run(m, NullPointerException.class, null, pp, providerName);
+        run(m, NoSuchAlgorithmException.class, "", pp, providerName);
         run(m, IllegalArgumentException.class, "FOO", pp, null);
         run(m, IllegalArgumentException.class, "FOO", pp, "");
 
         m = getInstance(clazz, STRING, Policy.Parameters.class, PROVIDER);
-        run(m, NullPointerException.class, null, pp, SUN);
-        run(m, NoSuchAlgorithmException.class, "", pp, SUN);
+        run(m, NullPointerException.class, null, pp, provider);
+        run(m, NoSuchAlgorithmException.class, "", pp, provider);
         run(m, IllegalArgumentException.class, "FOO", pp, null);
     }
 
@@ -578,14 +579,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -600,14 +601,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -624,14 +625,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
 
         m = getInstance(clazz, STRING, SecureRandomParameters.class);
@@ -639,14 +640,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "", srp);
 
         m = getInstance(clazz, STRING, SecureRandomParameters.class, STRING);
-        run(m, NullPointerException.class, null, srp, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", srp, "SUN");
+        run(m, NullPointerException.class, null, srp, providerName);
+        run(m, NoSuchAlgorithmException.class, "", srp, providerName);
         run(m, IllegalArgumentException.class, "FOO", srp, null);
         run(m, IllegalArgumentException.class, "FOO", srp, "");
 
         m = getInstance(clazz, STRING, SecureRandomParameters.class, PROVIDER);
-        run(m, NullPointerException.class, null, srp, SUN);
-        run(m, NoSuchAlgorithmException.class, "", srp, SUN);
+        run(m, NullPointerException.class, null, srp, provider);
+        run(m, NoSuchAlgorithmException.class, "", srp, provider);
         run(m, IllegalArgumentException.class, "FOO", srp, null);
     }
 
@@ -661,14 +662,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 
@@ -683,14 +684,14 @@ public class GetInstanceNullsEmpties {
         run(m, NoSuchAlgorithmException.class, "");
 
         m = getInstance(clazz, STRING, STRING);
-        run(m, NullPointerException.class, null, "SUN");
-        run(m, NoSuchAlgorithmException.class, "", "SUN");
+        run(m, NullPointerException.class, null, providerName);
+        run(m, NoSuchAlgorithmException.class, "", providerName);
         run(m, IllegalArgumentException.class, "FOO", null);
         run(m, IllegalArgumentException.class, "FOO", "");
 
         m = getInstance(clazz, STRING, PROVIDER);
-        run(m, NullPointerException.class, null, SUN);
-        run(m, NoSuchAlgorithmException.class, "", SUN);
+        run(m, NullPointerException.class, null, provider);
+        run(m, NoSuchAlgorithmException.class, "", provider);
         run(m, IllegalArgumentException.class, "FOO", null);
     }
 }

--- a/test/jdk/javax/crypto/Cipher/ByteBuffers.java
+++ b/test/jdk/javax/crypto/Cipher/ByteBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,8 @@ import javax.crypto.spec.*;
 public class ByteBuffers {
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunJCE"));
         Random random = new Random();
         int n = 10 * 1024;
         byte[] t = new byte[n];

--- a/test/jdk/javax/crypto/Cipher/CipherInputStreamExceptions.java
+++ b/test/jdk/javax/crypto/Cipher/CipherInputStreamExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -357,10 +357,12 @@ public class CipherInputStreamExceptions {
     static byte[] encryptedText(String mode, byte[] pt) throws Exception{
         Cipher c;
         if (mode.compareTo("GCM") == 0) {
-            c = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+            c = Cipher.getInstance("AES/GCM/NoPadding",
+                    System.getProperty("test.provider.name", "SunJCE"));
             c.init(Cipher.ENCRYPT_MODE, key, gcmspec);
         } else if (mode.compareTo("CBC") == 0) {
-            c = Cipher.getInstance("AES/CBC/PKCS5Padding", "SunJCE");
+            c = Cipher.getInstance("AES/CBC/PKCS5Padding",
+                    System.getProperty("test.provider.name", "SunJCE"));
             c.init(Cipher.ENCRYPT_MODE, key, iv);
         } else {
             return null;
@@ -380,10 +382,12 @@ public class CipherInputStreamExceptions {
         Cipher c;
 
         if (mode.compareTo("GCM") == 0) {
-            c = Cipher.getInstance("AES/GCM/NoPadding", "SunJCE");
+            c = Cipher.getInstance("AES/GCM/NoPadding",
+                    System.getProperty("test.provider.name", "SunJCE"));
             c.init(Cipher.DECRYPT_MODE, key, gcmspec);
         } else if (mode.compareTo("CBC") == 0) {
-            c = Cipher.getInstance("AES/CBC/PKCS5Padding", "SunJCE");
+            c = Cipher.getInstance("AES/CBC/PKCS5Padding",
+                    System.getProperty("test.provider.name", "SunJCE"));
             c.init(Cipher.DECRYPT_MODE, key, iv);
         } else {
             return null;

--- a/test/jdk/javax/crypto/Cipher/GetMaxAllowed.java
+++ b/test/jdk/javax/crypto/Cipher/GetMaxAllowed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,8 @@ public class GetMaxAllowed {
         // decide if the installed jurisdiction policy file is the
         // unlimited version
         boolean isUnlimited = true;
-        Cipher c = Cipher.getInstance("AES", "SunJCE");
+        Cipher c = Cipher.getInstance("AES",
+                System.getProperty("test.provider.name", "SunJCE"));
         try {
             c.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(new byte[24], "AES"));
         } catch (InvalidKeyException ike) {

--- a/test/jdk/javax/crypto/Cipher/TestCipherMode.java
+++ b/test/jdk/javax/crypto/Cipher/TestCipherMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,9 @@ public class TestCipherMode {
 
     public static void main(String[] argv) throws Exception {
 
-        TestCipherMode test = new TestCipherMode("SunJCE", TRANSFORMATIONS);
+        TestCipherMode test = new TestCipherMode(
+                            System.getProperty("test.provider.name", "SunJCE"),
+                            TRANSFORMATIONS);
         System.out.println("All Tests Passed");
    }
 

--- a/test/jdk/javax/crypto/Cipher/TestGetInstance.java
+++ b/test/jdk/javax/crypto/Cipher/TestGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,16 +42,19 @@ public class TestGetInstance {
     }
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(
+                System.getProperty("test.provider.name", "SunJCE"));
 
         Cipher c;
 
         c = Cipher.getInstance("PBEWithMD5AndTripleDES");
         same(p, c.getProvider());
 
-        c = Cipher.getInstance("des", "SunJCE");
+        c = Cipher.getInstance("des",
+                System.getProperty("test.provider.name", "SunJCE"));
         same(p, c.getProvider());
-        c = Cipher.getInstance("des/cbc/pkcs5padding", "SunJCE");
+        c = Cipher.getInstance("des/cbc/pkcs5padding",
+                System.getProperty("test.provider.name", "SunJCE"));
         same(p, c.getProvider());
 
         c = Cipher.getInstance("des", p);
@@ -66,7 +69,8 @@ public class TestGetInstance {
             System.out.println(e);
         }
         try {
-            c = Cipher.getInstance("DES/XYZ/PKCS5Padding", "SunJCE");
+            c = Cipher.getInstance("DES/XYZ/PKCS5Padding",
+                    System.getProperty("test.provider.name", "SunJCE"));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);
@@ -85,7 +89,8 @@ public class TestGetInstance {
             System.out.println(e);
         }
         try {
-            c = Cipher.getInstance("DES/CBC/XYZPadding", "SunJCE");
+            c = Cipher.getInstance("DES/CBC/XYZPadding",
+                    System.getProperty("test.provider.name", "SunJCE"));
             throw new AssertionError();
         } catch (NoSuchPaddingException e) {
             System.out.println(e);
@@ -104,7 +109,8 @@ public class TestGetInstance {
             System.out.println(e);
         }
         try {
-            c = Cipher.getInstance("foo", "SunJCE");
+            c = Cipher.getInstance("foo",
+                    System.getProperty("test.provider.name", "SunJCE"));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);
@@ -117,13 +123,15 @@ public class TestGetInstance {
         }
 
         try {
-            c = Cipher.getInstance("foo", "SUN");
+            c = Cipher.getInstance("foo",
+                    System.getProperty("test.provider.name", "SUN"));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);
         }
         try {
-            c = Cipher.getInstance("foo", Security.getProvider("SUN"));
+            c = Cipher.getInstance("foo", Security.getProvider(
+                    System.getProperty("test.provider.name", "SUN")));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);

--- a/test/jdk/javax/crypto/CipherSpi/DirectBBRemaining.java
+++ b/test/jdk/javax/crypto/CipherSpi/DirectBBRemaining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,8 @@ public class DirectBBRemaining {
         random.nextBytes(keyBytes);
         SecretKey key = new SecretKeySpec(keyBytes, "DES");
 
-        Cipher cipher = Cipher.getInstance("DES/CBC/PKCS5Padding", "SunJCE");
+        Cipher cipher = Cipher.getInstance("DES/CBC/PKCS5Padding",
+                System.getProperty("test.provider.name", "SunJCE"));
         cipher.init(Cipher.ENCRYPT_MODE, key);
 
         /*

--- a/test/jdk/javax/crypto/CryptoPermission/AllPermCheck.java
+++ b/test/jdk/javax/crypto/CryptoPermission/AllPermCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class AllPermCheck {
     }
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + p.getName() + "...");
         if (Cipher.getMaxAllowedKeyLength("DES") == Integer.MAX_VALUE) {
             // skip this test for unlimited jurisdiction policy files

--- a/test/jdk/javax/crypto/CryptoPermission/LowercasePermCheck.java
+++ b/test/jdk/javax/crypto/CryptoPermission/LowercasePermCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class LowercasePermCheck {
     };
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + p.getName() + "...");
         if (Cipher.getMaxAllowedKeyLength("DES") == Integer.MAX_VALUE) {
             // skip this test for unlimited jurisdiction policy files

--- a/test/jdk/javax/crypto/CryptoPermission/RSANoLimit.java
+++ b/test/jdk/javax/crypto/CryptoPermission/RSANoLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,7 @@ public class RSANoLimit {
     };
     public static void main(String[] args) throws Exception {
         boolean result = true;
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + p.getName() + "...");
         // Test#1: make sure Cipher.getMaxAllowedKeyLength returns the
         // correct value

--- a/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetAlgName.java
+++ b/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetAlgName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,9 +52,11 @@ public class GetAlgName {
             String algo = ALGOS[i];
             // generate AlgorithmParameters object
             SecretKeyFactory skf =
-                SecretKeyFactory.getInstance(algo, "SunJCE");
+                    SecretKeyFactory.getInstance(algo,
+                            System.getProperty("test.provider.name", "SunJCE"));
             SecretKey key = skf.generateSecret(ks);
-            Cipher c = Cipher.getInstance(algo, "SunJCE");
+            Cipher c = Cipher.getInstance(algo,
+                    System.getProperty("test.provider.name", "SunJCE"));
             c.init(Cipher.ENCRYPT_MODE, key);
             c.doFinal(BYTES); // force the parameter generation if not already
 

--- a/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeySpec.java
+++ b/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class GetKeySpec {
             PBEParameterSpec goodParamSpec =
                 new PBEParameterSpec(new byte[8], 1024);
             GOOD_PARAMS = AlgorithmParameters.getInstance
-                (cipherAlg, "SunJCE");
+                    (cipherAlg, System.getProperty("test.provider.name", "SunJCE"));
             GOOD_PARAMS.init(goodParamSpec);
         } catch (Exception ex) {
             // should never happen
@@ -102,7 +102,7 @@ public class GetKeySpec {
         byte[] encryptedData = parse(encryptedPKCS8);
         boolean result = true;
 
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
 
         // generate encrypted data and EncryptedPrivateKeyInfo object
         EncryptedPrivateKeyInfo epki =

--- a/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException.java
+++ b/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class GetKeySpecException {
 
     static {
         try {
-            sunjce = Security.getProvider("SunJCE");
+            sunjce = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
             PBEParameterSpec badParamSpec =
                 new PBEParameterSpec(new byte[10], 10);
             BAD_PARAMS = AlgorithmParameters.getInstance(cipherAlg, sunjce);
@@ -61,7 +61,7 @@ public class GetKeySpecException {
             GOOD_PARAMS.init(goodParamSpec);
             PBEKeySpec keySpec = new PBEKeySpec(passwd);
             SecretKeyFactory skf =
-                SecretKeyFactory.getInstance(cipherAlg, "SunJCE");
+                SecretKeyFactory.getInstance(cipherAlg, System.getProperty("test.provider.name", "SunJCE"));
             cipherKey = skf.generateSecret(keySpec);
         } catch (Exception ex) {
             // should never happen
@@ -164,7 +164,7 @@ public class GetKeySpecException {
         // TEST#3: getKeySpec(Key, String)
         System.out.println("Testing getKeySpec(Key, String)...");
         try {
-            pkcs8Spec = epki.getKeySpec(null, "SunJCE");
+            pkcs8Spec = epki.getKeySpec(null, System.getProperty("test.provider.name", "SunJCE"));
             throwException("Should throw NPE for null Key!");
         } catch (NullPointerException npe) {
             System.out.println("Expected NPE thrown");
@@ -176,13 +176,13 @@ public class GetKeySpecException {
             System.out.println("Expected NPE thrown");
         }
         try {
-            pkcs8Spec = epki.getKeySpec(INVALID_KEY, "SunJCE");
+            pkcs8Spec = epki.getKeySpec(INVALID_KEY, System.getProperty("test.provider.name", "SunJCE"));
             throwException("Should throw IKE for invalid Key!");
         } catch (InvalidKeyException ikse) {
             System.out.println("Expected IKE thrown");
         }
         try {
-            pkcs8Spec = epkiBad.getKeySpec(cipherKey, "SunJCE");
+            pkcs8Spec = epkiBad.getKeySpec(cipherKey, System.getProperty("test.provider.name", "SunJCE"));
             throwException("Should throw IKE for corrupted epki!");
         } catch (InvalidKeyException ike) {
             System.out.println("Expected IKE thrown");
@@ -195,8 +195,9 @@ public class GetKeySpecException {
             System.out.println("Expected NSAE thrown");
         }
         try {
-            Security.removeProvider("SunJCE");
-            pkcs8Spec = epki.getKeySpec(cipherKey, "SunJCE");
+            Security.removeProvider(System.getProperty("test.provider.name", "SunJCE"));
+            pkcs8Spec = epki.getKeySpec(cipherKey,
+                    System.getProperty("test.provider.name", "SunJCE"));
             throwException("Should throw NSPE for unconfigured provider!");
         } catch (NoSuchProviderException nspe) {
             System.out.println("Expected NSPE thrown");

--- a/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java
+++ b/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,8 @@ public class GetKeySpecException2 {
         // TEST#1: getKeySpec(Cipher) with Cipher in an illegal state,
         // i.e. WRAP_MODE, UNWRAP_MODE.
         System.out.println("Testing getKeySpec(Cipher) with WRAP_MODE...");
-        Cipher c = Cipher.getInstance(cipherAlg, "SunJCE");
+        Cipher c = Cipher.getInstance(cipherAlg,
+                System.getProperty("test.provider.name", "SunJCE"));
         MyPBEKey key = new MyPBEKey(passwd);
         c.init(Cipher.WRAP_MODE, key);
         try {

--- a/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecInvalidEncoding.java
+++ b/test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecInvalidEncoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class GetKeySpecInvalidEncoding {
             PBEParameterSpec goodParamSpec =
                 new PBEParameterSpec(new byte[8], 6);
             GOOD_PARAMS = AlgorithmParameters.getInstance
-                (cipherAlg, "SunJCE");
+                    (cipherAlg, System.getProperty("test.provider.name", "SunJCE"));
             GOOD_PARAMS.init(goodParamSpec);
         } catch (Exception ex) {
             // should never happen
@@ -101,7 +101,7 @@ public class GetKeySpecInvalidEncoding {
         }
         byte[] encryptedData = parse(encryptedPKCS8);
 
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
 
         // generate encrypted data and EncryptedPrivateKeyInfo object
         EncryptedPrivateKeyInfo epki =

--- a/test/jdk/javax/crypto/KeyGenerator/TestGetInstance.java
+++ b/test/jdk/javax/crypto/KeyGenerator/TestGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,13 +43,14 @@ public class TestGetInstance {
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
 
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
 
         KeyGenerator kg;
 
         kg = KeyGenerator.getInstance("des");
         System.out.println("Default: " + kg.getProvider().getName());
-        kg = KeyGenerator.getInstance("des", "SunJCE");
+        kg = KeyGenerator.getInstance("des",
+                System.getProperty("test.provider.name", "SunJCE"));
         same(p, kg.getProvider());
         kg = KeyGenerator.getInstance("des", p);
         same(p, kg.getProvider());
@@ -61,7 +62,8 @@ public class TestGetInstance {
             System.out.println(e);
         }
         try {
-            kg = KeyGenerator.getInstance("foo", "SunJCE");
+            kg = KeyGenerator.getInstance("foo",
+                    System.getProperty("test.provider.name", "SunJCE"));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);
@@ -74,13 +76,15 @@ public class TestGetInstance {
         }
 
         try {
-            kg = KeyGenerator.getInstance("foo", "SUN");
+            kg = KeyGenerator.getInstance("foo",
+                    System.getProperty("test.provider.name", "SUN"));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);
         }
         try {
-            kg = KeyGenerator.getInstance("foo", Security.getProvider("SUN"));
+            kg = KeyGenerator.getInstance("foo",
+                    Security.getProvider(System.getProperty("test.provider.name", "SUN")));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);

--- a/test/jdk/javax/crypto/KeyGenerator/TestKGParity.java
+++ b/test/jdk/javax/crypto/KeyGenerator/TestKGParity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,8 +54,10 @@ public class TestKGParity {
         Provider[] providers = Security.getProviders();
         for (Provider p : providers) {
             String prvName = p.getName();
-            if (prvName.startsWith("SunJCE")
-                    || prvName.startsWith("SunPKCS11-")) {
+            if ((System.getProperty("test.provider.name") != null &&
+                    prvName.equals(System.getProperty("test.provider.name"))) ||
+                    (System.getProperty("test.provider.name") == null &&
+                            (prvName.startsWith("SunJCE") || prvName.startsWith("SunPKCS11-")))) {
                 for (String algorithm : ALGORITHM_ARR) {
                     if (!runTest(p, algorithm)) {
                         throw new RuntimeException(

--- a/test/jdk/javax/crypto/Mac/ByteBuffers.java
+++ b/test/jdk/javax/crypto/Mac/ByteBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import javax.crypto.spec.*;
 public class ByteBuffers {
 
     public static void main(String[] args) throws Exception {
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
         Random random = new Random();
         int n = 10 * 1024;
         byte[] t = new byte[n];

--- a/test/jdk/javax/crypto/Mac/TestGetInstance.java
+++ b/test/jdk/javax/crypto/Mac/TestGetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,13 +43,13 @@ public class TestGetInstance {
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
 
-        Provider p = Security.getProvider("SunJCE");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunJCE"));
 
         Mac mac;
 
         mac = Mac.getInstance("hmacmd5");
         System.out.println("Default: " + mac.getProvider().getName());
-        mac = Mac.getInstance("hmacmd5", "SunJCE");
+        mac = Mac.getInstance("hmacmd5", System.getProperty("test.provider.name", "SunJCE"));
         same(p, mac.getProvider());
         mac = Mac.getInstance("hmacmd5", p);
         same(p, mac.getProvider());
@@ -61,7 +61,7 @@ public class TestGetInstance {
             System.out.println(e);
         }
         try {
-            mac = Mac.getInstance("foo", "SunJCE");
+            mac = Mac.getInstance("foo", System.getProperty("test.provider.name", "SunJCE"));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);
@@ -74,13 +74,14 @@ public class TestGetInstance {
         }
 
         try {
-            mac = Mac.getInstance("foo", "SUN");
+            mac = Mac.getInstance("foo", System.getProperty("test.provider.name", "SUN"));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);
         }
         try {
-            mac = Mac.getInstance("foo", Security.getProvider("SUN"));
+            mac = Mac.getInstance("foo", Security.getProvider(
+                    System.getProperty("test.provider.name", "SUN")));
             throw new AssertionError();
         } catch (NoSuchAlgorithmException e) {
             System.out.println(e);

--- a/test/jdk/javax/crypto/SecretKeyFactory/SecKFTranslateTest.java
+++ b/test/jdk/javax/crypto/SecretKeyFactory/SecKFTranslateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,8 @@ import javax.security.auth.DestroyFailedException;
  */
 
 public class SecKFTranslateTest {
-    private static final String SUN_JCE = "SunJCE";
+    private static final String PROVIDER_NAME =
+                        System.getProperty("test.provider.name", "SunJCE");
 
     public static void main(String[] args) throws Exception {
 
@@ -77,10 +78,10 @@ public class SecKFTranslateTest {
         Random random = new Random();
         // Initialization
         SecretKeyFactory skf = SecretKeyFactory.getInstance(algo.toString(),
-                SUN_JCE);
+                PROVIDER_NAME);
 
         random.nextBytes(plainText);
-        Cipher ci = Cipher.getInstance(algo.toString(), SUN_JCE);
+        Cipher ci = Cipher.getInstance(algo.toString(), PROVIDER_NAME);
         // Encryption
         ci.init(Cipher.ENCRYPT_MODE, key1, aps[0]);
         byte[] cipherText = new byte[ci.getOutputSize(plainText.length)];

--- a/test/jdk/javax/crypto/SecretKeyFactory/SecKeyFacSunJCEPrf.java
+++ b/test/jdk/javax/crypto/SecretKeyFactory/SecKeyFacSunJCEPrf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,8 @@ public class SecKeyFacSunJCEPrf {
         Security.insertProviderAt(evilProv, 1);
 
         SecretKeyFactory pbkdf2 =
-                SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1", "SunJCE");
+                SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1",
+                        System.getProperty("test.provider.name", "SunJCE"));
         PBEKeySpec pbks = new PBEKeySpec(PASS, SALT, ITER, 160);
 
         SecretKey secKey1 = pbkdf2.generateSecret(pbks);

--- a/test/jdk/javax/crypto/SecretKeyFactory/evilprov/com/evilprovider/EvilHmacSHA1.java
+++ b/test/jdk/javax/crypto/SecretKeyFactory/evilprov/com/evilprovider/EvilHmacSHA1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,8 @@ public final class EvilHmacSHA1 extends MacSpi {
     private final Mac internalMac;
 
     public EvilHmacSHA1() throws GeneralSecurityException {
-        internalMac = Mac.getInstance("HmacSHA1", "SunJCE");
+        internalMac = Mac.getInstance("HmacSHA1",
+                System.getProperty("test.provider.name", "SunJCE"));
     }
 
     @Override

--- a/test/jdk/javax/security/auth/login/Configuration/GetInstance.java
+++ b/test/jdk/javax/security/auth/login/Configuration/GetInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,12 +84,14 @@ public class GetInstance {
 
     private int testStringProvider(int testnum) throws Exception {
         // get an instance of JavaLoginConfig from SUN
-        Configuration c = Configuration.getInstance(JAVA_CONFIG, null, "SUN");
+        Configuration c = Configuration.getInstance(JAVA_CONFIG, null,
+                System.getProperty("test.provider.name", "SUN"));
         doTest(c, testnum++);
 
         // get an instance of JavaLoginConfig from SunRsaSign
         try {
-            c = Configuration.getInstance(JAVA_CONFIG, null, "SunRsaSign");
+            c = Configuration.getInstance(JAVA_CONFIG, null,
+                    System.getProperty("test.provider.name", "SunRsaSign"));
             throw new SecurityException("test " + testnum++ + " failed");
         } catch (NoSuchAlgorithmException nsae) {
             // good
@@ -112,14 +114,16 @@ public class GetInstance {
         // get an instance of JavaLoginConfig from SUN
         Configuration c = Configuration.getInstance(JAVA_CONFIG,
                                 null,
-                                Security.getProvider("SUN"));
+                                Security.getProvider(
+                                        System.getProperty("test.provider.name", "SUN")));
         doTest(c, testnum++);
 
         // get an instance of JavaLoginConfig from SunRsaSign
         try {
             c = Configuration.getInstance(JAVA_CONFIG,
                                 null,
-                                Security.getProvider("SunRsaSign"));
+                                Security.getProvider(
+                                        System.getProperty("test.provider.name","SunRsaSign")));
             throw new SecurityException("test " + testnum++ + " failed");
         } catch (NoSuchAlgorithmException nsae) {
             // good
@@ -186,7 +190,7 @@ public class GetInstance {
         try {
             Configuration c = Configuration.getInstance(JAVA_CONFIG,
                                 new BadParam(),
-                                "SUN");
+                                System.getProperty("test.provider.name","SUN"));
             throw new SecurityException("test " + testnum++ + " failed");
         } catch (IllegalArgumentException iae) {
             // good
@@ -196,7 +200,7 @@ public class GetInstance {
         try {
             Configuration c = Configuration.getInstance(JAVA_CONFIG,
                                 new BadParam(),
-                                Security.getProvider("SUN"));
+                                Security.getProvider(System.getProperty("test.provider.name","SUN")));
             throw new SecurityException("test " + testnum++ + " failed");
         } catch (IllegalArgumentException iae) {
             // good
@@ -285,7 +289,7 @@ public class GetInstance {
         testnum = doCommon(c, testnum);
 
         // test getProvider
-        if ("SUN".equals(c.getProvider().getName())) {
+        if (System.getProperty("test.provider.name","SUN").equals(c.getProvider().getName())) {
             System.out.println("test " + testnum + " (getProvider) passed");
         } else {
             throw new SecurityException("test " + testnum +
@@ -325,7 +329,7 @@ public class GetInstance {
         }
 
         // test getProvider
-        if ("SUN".equals(c.getProvider().getName())) {
+        if (System.getProperty("test.provider.name","SUN").equals(c.getProvider().getName())) {
             System.out.println("test " + testnum + " (getProvider) passed");
         } else {
             throw new SecurityException("test " + testnum +

--- a/test/jdk/javax/security/auth/login/Configuration/GetInstanceSecurity.grantedPolicy
+++ b/test/jdk/javax/security/auth/login/Configuration/GetInstanceSecurity.grantedPolicy
@@ -1,4 +1,5 @@
 grant {
+    permission java.util.PropertyPermission "test.provider.name", "read";
     permission java.util.PropertyPermission "test.src", "read";
     permission java.io.FilePermission "${test.src}${/}*", "read";
 

--- a/test/jdk/javax/security/auth/login/Configuration/GetInstanceSecurity.java
+++ b/test/jdk/javax/security/auth/login/Configuration/GetInstanceSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class GetInstanceSecurity {
 
         try {
             Configuration c = Configuration.getInstance
-                        (JAVA_CONFIG, null, "SUN");
+                        (JAVA_CONFIG, null, System.getProperty("test.provider.name","SUN"));
             throw new RuntimeException("did not catch security exception");
         } catch (SecurityException se) {
             // good
@@ -59,7 +59,8 @@ public class GetInstanceSecurity {
 
         try {
             Configuration c = Configuration.getInstance
-                        (JAVA_CONFIG, null, Security.getProvider("SUN"));
+                        (JAVA_CONFIG, null, Security.getProvider(
+                                System.getProperty("test.provider.name","SUN")));
             throw new RuntimeException("did not catch security exception");
         } catch (SecurityException se) {
             // good
@@ -71,7 +72,8 @@ public class GetInstanceSecurity {
                                 "GetInstanceSecurity.grantedPolicy");
         URI uri = file.toURI();
         URIParameter param = new URIParameter(uri);
-        Policy p = Policy.getInstance("JavaPolicy", param, "SUN");
+        Policy p = Policy.getInstance("JavaPolicy", param,
+                System.getProperty("test.provider.name","SUN"));
         Policy.setPolicy(p);
 
         // retry operations
@@ -88,7 +90,7 @@ public class GetInstanceSecurity {
 
         try {
             Configuration c = Configuration.getInstance
-                        (JAVA_CONFIG, uriParam, "SUN");
+                        (JAVA_CONFIG, uriParam, System.getProperty("test.provider.name","SUN"));
             // good
         } catch (SecurityException se) {
             throw new RuntimeException("unexpected SecurityException");
@@ -96,7 +98,8 @@ public class GetInstanceSecurity {
 
         try {
             Configuration c = Configuration.getInstance
-                        (JAVA_CONFIG, uriParam, Security.getProvider("SUN"));
+                        (JAVA_CONFIG, uriParam, Security.getProvider(
+                                System.getProperty("test.provider.name","SUN")));
             // good
         } catch (SecurityException se) {
             throw new RuntimeException("unexpected SecurityException");

--- a/test/jdk/javax/security/auth/login/Configuration/GetInstanceSecurity.policy
+++ b/test/jdk/javax/security/auth/login/Configuration/GetInstanceSecurity.policy
@@ -1,6 +1,6 @@
 
 grant {
-
+    permission java.util.PropertyPermission "test.provider.name", "read";
     permission java.util.PropertyPermission "test.src", "read";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www";
     permission java.io.FilePermission

--- a/test/jdk/sun/security/ec/InvalidCurve.java
+++ b/test/jdk/sun/security/ec/InvalidCurve.java
@@ -38,7 +38,8 @@ public class InvalidCurve {
 
         KeyPairGenerator keyGen;
         try {
-            keyGen = KeyPairGenerator.getInstance("EC", "SunEC");
+            keyGen = KeyPairGenerator.getInstance("EC",
+                    System.getProperty("test.provider.name", "SunEC"));
             ECGenParameterSpec brainpoolSpec =
                 new ECGenParameterSpec("brainpoolP160r1");
             keyGen.initialize(brainpoolSpec);

--- a/test/jdk/sun/security/ec/NSASuiteB/TestSHAwithECDSASignatureOids.java
+++ b/test/jdk/sun/security/ec/NSASuiteB/TestSHAwithECDSASignatureOids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class TestSHAwithECDSASignatureOids {
 
     public static void main(String[] args) throws Exception {
         TestSignatureOidHelper helper = new TestSignatureOidHelper("EC",
-                "SunEC", 256, DATA);
+                System.getProperty("test.provider.name", "SunEC"), 256, DATA);
         helper.execute();
     }
 }

--- a/test/jdk/sun/security/ec/SignatureDigestTruncate.java
+++ b/test/jdk/sun/security/ec/SignatureDigestTruncate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,17 +96,20 @@ public class SignatureDigestTruncate {
         byte[] expectedSig = hex.parseHex(sigStr);
 
         AlgorithmParameters params =
-            AlgorithmParameters.getInstance("EC", "SunEC");
+            AlgorithmParameters.getInstance("EC",
+                    System.getProperty("test.provider.name", "SunEC"));
         params.init(new ECGenParameterSpec(curveName));
         ECParameterSpec ecParams =
             params.getParameterSpec(ECParameterSpec.class);
 
-        KeyFactory kf = KeyFactory.getInstance("EC", "SunEC");
+        KeyFactory kf = KeyFactory.getInstance("EC",
+                            System.getProperty("test.provider.name", "SunEC"));
         BigInteger s = new BigInteger(1, privateKey);
         ECPrivateKeySpec privKeySpec = new ECPrivateKeySpec(s, ecParams);
         PrivateKey privKey = kf.generatePrivate(privKeySpec);
 
-        Signature sig = Signature.getInstance(alg, "SunEC");
+        Signature sig = Signature.getInstance(alg,
+                            System.getProperty("test.provider.name", "SunEC"));
         sig.initSign(privKey, new FixedRandom(k));
         sig.update(msg);
         byte[] computedSig = sig.sign();

--- a/test/jdk/sun/security/ec/SignatureKAT.java
+++ b/test/jdk/sun/security/ec/SignatureKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,16 +132,19 @@ public class SignatureKAT {
         System.out.println("Testing " + td.sigName + " with " + td.cd.name);
 
         AlgorithmParameters params =
-            AlgorithmParameters.getInstance("EC", "SunEC");
+            AlgorithmParameters.getInstance("EC",
+                    System.getProperty("test.provider.name", "SunEC"));
         params.init(new ECGenParameterSpec(td.cd.name));
         ECParameterSpec ecParams =
             params.getParameterSpec(ECParameterSpec.class);
 
-        KeyFactory kf = KeyFactory.getInstance("EC", "SunEC");
+        KeyFactory kf = KeyFactory.getInstance("EC",
+                System.getProperty("test.provider.name", "SunEC"));
         PrivateKey privKey = kf.generatePrivate
                 (new ECPrivateKeySpec(td.cd.priv, ecParams));
 
-        Signature sig = Signature.getInstance(td.sigName, "SunEC");
+        Signature sig = Signature.getInstance(td.sigName,
+                System.getProperty("test.provider.name", "SunEC"));
         sig.initSign(privKey);
         sig.update(td.cd.msgBytes);
         // NOTE: there is no way to set the nonce value into current SunEC

--- a/test/jdk/sun/security/ec/SignedObjectChain.java
+++ b/test/jdk/sun/security/ec/SignedObjectChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class SignedObjectChain {
     private static class Test extends Chain.Test {
 
         public Test(Chain.SigAlg sigAlg) {
-            super(sigAlg, Chain.KeyAlg.EC, Chain.Provider.SunEC);
+            super(sigAlg, Chain.KeyAlg.EC, Chain.Provider.TestProvider_or_SunEC);
         }
     }
 

--- a/test/jdk/sun/security/ec/TestEC.java
+++ b/test/jdk/sun/security/ec/TestEC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ public class TestEC {
     }
 
     public static void main0(String[] args) throws Exception {
-        Provider p = Security.getProvider("SunEC");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name", "SunEC"));
 
         if (p == null) {
             throw new NoSuchProviderException("Can't get SunEC provider");

--- a/test/jdk/sun/security/ec/ed/EdCRLSign.java
+++ b/test/jdk/sun/security/ec/ed/EdCRLSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class EdCRLSign {
     private static final String OID25519 = "OID.1.3.101.112";
     private static final String OIDN448 = "1.3.101.113";
     private static final String OID448 = "OID.1.3.101.113";
-    private static final String PROVIDER = "SunEC";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunEC");
     private static final SecureRandom S_RND = new SecureRandom(new byte[]{0x1});
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/security/ec/ed/EdDSAKeyCompatibility.java
+++ b/test/jdk/sun/security/ec/ed/EdDSAKeyCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class EdDSAKeyCompatibility {
     private static final String EDDSA = "EdDSA";
     private static final String ED25519 = "Ed25519";
     private static final String ED448 = "Ed448";
-    private static final String PROVIDER = "SunEC";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunEC");
 
     public static void main(String[] args) throws Exception {
 

--- a/test/jdk/sun/security/ec/ed/EdDSAKeySize.java
+++ b/test/jdk/sun/security/ec/ed/EdDSAKeySize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class EdDSAKeySize {
     private static final String OID25519 = "OID.1.3.101.112";
     private static final String OIDN448 = "1.3.101.113";
     private static final String OID448 = "OID.1.3.101.113";
-    private static final String PROVIDER = "SunEC";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunEC");
     private static final SecureRandom RND = new SecureRandom(new byte[]{0x1});
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/security/ec/ed/EdDSANegativeTest.java
+++ b/test/jdk/sun/security/ec/ed/EdDSANegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class EdDSANegativeTest {
     private static final String EDDSA = "EdDSA";
     private static final String ED25519 = "Ed25519";
     private static final String ED448 = "Ed448";
-    private static final String PROVIDER = "SunEC";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunEC");
     private static final String OTHER = "other";
     private static final byte[] MSG = "TEST".getBytes();
 

--- a/test/jdk/sun/security/ec/ed/EdDSAParamSpec.java
+++ b/test/jdk/sun/security/ec/ed/EdDSAParamSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ public class EdDSAParamSpec {
     private static final String EDDSA = "EdDSA";
     private static final String ED25519 = "Ed25519";
     private static final String ED448 = "Ed448";
-    private static final String PROVIDER = "SunEC";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunEC");
     private static final byte[] MSG = "TEST".getBytes();
     private static final SecureRandom RND = new SecureRandom(new byte[]{0x1});
 

--- a/test/jdk/sun/security/ec/ed/EdDSAReuseTest.java
+++ b/test/jdk/sun/security/ec/ed/EdDSAReuseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class EdDSAReuseTest {
     private static final String EDDSA = "EdDSA";
     private static final String ED25519 = "Ed25519";
     private static final String ED448 = "Ed448";
-    private static final String PROVIDER = "SunEC";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunEC");
     private static final String MSG = "TEST";
     private static final int REUSE = 20;
     private static final int ONCE = 1;

--- a/test/jdk/sun/security/ec/ed/EdDSATest.java
+++ b/test/jdk/sun/security/ec/ed/EdDSATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class EdDSATest {
     private static final String OID25519 = "OID.1.3.101.112";
     private static final String OIDN448 = "1.3.101.113";
     private static final String OID448 = "OID.1.3.101.113";
-    private static final String PROVIDER = "SunEC";
+    private static final String PROVIDER = System.getProperty("test.provider.name", "SunEC");
     private static final byte[] MSG = "TEST".getBytes();
     private static final SecureRandom S_RND = new SecureRandom(new byte[]{0x1});
 

--- a/test/jdk/sun/security/ec/ed/TestEdDSA.java
+++ b/test/jdk/sun/security/ec/ed/TestEdDSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -462,10 +462,14 @@ public class TestEdDSA {
      * when the algorithm ID for a specific curve is specified.
      */
     private static void runCurveMixTest() throws Exception {
-        runCurveMixTest("SunEC", "Ed25519", 448);
-        runCurveMixTest("SunEC", "Ed25519", "Ed448");
-        runCurveMixTest("SunEC", "Ed448", 255);
-        runCurveMixTest("SunEC", "Ed448", "Ed25519");
+        runCurveMixTest(System.getProperty("test.provider.name", "SunEC"),
+                "Ed25519", 448);
+        runCurveMixTest(System.getProperty("test.provider.name", "SunEC"),
+                "Ed25519", "Ed448");
+        runCurveMixTest(System.getProperty("test.provider.name", "SunEC"),
+                "Ed448", 255);
+        runCurveMixTest(System.getProperty("test.provider.name", "SunEC"),
+                "Ed448", "Ed25519");
     }
 
     private static void runCurveMixTest(String providerName, String name,

--- a/test/jdk/sun/security/jca/PreferredProviderNegativeTest.java
+++ b/test/jdk/sun/security/jca/PreferredProviderNegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public class PreferredProviderNegativeTest {
 
         String expected;
         String value = args[1];
-        expected = "SunJCE";
+        expected = System.getProperty("test.provider.name", "SunJCE");
 
         if (args.length >= 2) {
             switch (args[0]) {

--- a/test/jdk/sun/security/mscapi/InteropWithSunRsaSign.java
+++ b/test/jdk/sun/security/mscapi/InteropWithSunRsaSign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,11 +103,13 @@ public class InteropWithSunRsaSign {
                 "-------", "----------------", "------", "--------", "------");
 
         // KeyPairGenerator chooses SPI when getInstance() is called.
-        String[] provsForKPG = {"SunRsaSign", "SunMSCAPI"};
+        String[] provsForKPG = {System.getProperty("test.provider.name", "SunRsaSign"),
+                "SunMSCAPI"};
 
         // "-" means no preferred provider. In this case, SPI is chosen
         // when initSign/initVerify is called. Worth testing.
-        String[] provsForSignature = {"SunRsaSign", "SunMSCAPI", "-"};
+        String[] provsForSignature = {System.getProperty("test.provider.name", "SunRsaSign"),
+                "SunMSCAPI", "-"};
 
         int pos = 0;
         for (String pg : provsForKPG) {

--- a/test/jdk/sun/security/pkcs/pkcs8/TestLeadingZeros.java
+++ b/test/jdk/sun/security/pkcs/pkcs8/TestLeadingZeros.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,8 @@ public class TestLeadingZeros {
     };
 
     public static void main(String[] argv) throws Exception {
-        KeyFactory factory = KeyFactory.getInstance("DSA", "SUN");
+        KeyFactory factory = KeyFactory.getInstance("DSA",
+                                System.getProperty("test.provider.name", "SUN"));
 
         for (String encodings : PKCS8_ENCODINGS) {
             byte[] encodingBytes = hexToBytes(encodings);

--- a/test/jdk/sun/security/pkcs11/Cipher/EncryptionPadding.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/EncryptionPadding.java
@@ -93,9 +93,10 @@ public class EncryptionPadding extends PKCS11Test {
             sunPKCS11cipher.doFinal(ByteBuffer.allocate(0), cipherText);
         }
 
-        Cipher sunJCECipher = Cipher.getInstance(transformation, "SunJCE");
-        sunJCECipher.init(Cipher.DECRYPT_MODE, key);
-        byte[] sunJCEPlain = sunJCECipher.doFinal(cipherText.array());
+        Cipher providerCipher = Cipher.getInstance(transformation,
+                System.getProperty("test.provider.name", "SunJCE"));
+        providerCipher.init(Cipher.DECRYPT_MODE, key);
+        byte[] sunJCEPlain = providerCipher.doFinal(cipherText.array());
 
         if (!Arrays.equals(plainText, sunJCEPlain)) {
             throw new Exception("Cross-provider cipher test failed.");

--- a/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class TestPKCS5PaddingError extends PKCS11Test {
                             KeyGenerator.getInstance(currTest.keyAlgo, p);
                     SecretKey key = kg.generateKey();
                     Cipher c1 = Cipher.getInstance(currTest.transformation,
-                                                   "SunJCE");
+                               System.getProperty("test.provider.name", "SunJCE"));
                     c1.init(Cipher.ENCRYPT_MODE, key);
                     byte[] cipherText = c1.doFinal(plainText);
                     AlgorithmParameters params = c1.getParameters();

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,8 @@ public class TestRSACipher extends PKCS11Test {
 
         for (String rsaAlgo: RSA_ALGOS) {
             Cipher c1 = Cipher.getInstance(rsaAlgo, p);
-            Cipher c2 = Cipher.getInstance(rsaAlgo, "SunJCE");
+            Cipher c2 = Cipher.getInstance(rsaAlgo,
+                            System.getProperty("test.provider.name", "SunJCE"));
 
             c1.init(Cipher.ENCRYPT_MODE, publicKey);
             e = c1.doFinal(b);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,8 @@ public class TestRSACipherWrap extends PKCS11Test {
 
         for (String rsaAlgo: RSA_ALGOS) {
             Cipher cipherPKCS11 = Cipher.getInstance(rsaAlgo, p);
-            Cipher cipherJce = Cipher.getInstance(rsaAlgo, "SunJCE");
+            Cipher cipherJce = Cipher.getInstance(rsaAlgo,
+                                System.getProperty("test.provider.name", "SunJCE"));
 
             String algos[] = {"AES", "RC2", "Blowfish"};
             int keySizes[] = {128, 256};

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,8 @@ public class TestRawRSACipher extends PKCS11Test {
         plainText[0] = 0; // to ensure that it's less than modulus
 
         Cipher c1 = Cipher.getInstance("RSA/ECB/NoPadding", p);
-        Cipher c2 = Cipher.getInstance("RSA/ECB/NoPadding", "SunJCE");
+        Cipher c2 = Cipher.getInstance("RSA/ECB/NoPadding",
+                        System.getProperty("test.provider.name", "SunJCE"));
 
         c1.init(Cipher.ENCRYPT_MODE, kp.getPublic());
         c2.init(Cipher.DECRYPT_MODE, kp.getPrivate());

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
@@ -102,7 +102,7 @@ public class TestSymmCiphers extends PKCS11Test {
                     SecretKey key = kg.generateKey();
                     Cipher c1 = Cipher.getInstance(currTest.transformation, p);
                     Cipher c2 = Cipher.getInstance(currTest.transformation,
-                            "SunJCE");
+                            System.getProperty("test.provider.name", "SunJCE"));
 
                     byte[] plainTxt = new byte[currTest.dataSize];
                     random.nextBytes(plainTxt);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
@@ -87,7 +87,7 @@ public class TestSymmCiphersNoPad extends PKCS11Test {
                     SecretKey key = kg.generateKey();
                     Cipher c1 = Cipher.getInstance(currTest.transformation, p);
                     Cipher c2 = Cipher.getInstance(currTest.transformation,
-                                                   "SunJCE");
+                               System.getProperty("test.provider.name", "SunJCE"));
 
                     byte[] plainTxt = new byte[currTest.dataSize];
                     random.nextBytes(plainTxt);

--- a/test/jdk/sun/security/pkcs11/KeyAgreement/TestDH.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/TestDH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,8 @@ public class TestDH extends PKCS11Test {
             throw new Exception("Secrets (1,2) do not match");
         }
 
-        ka2 = KeyAgreement.getInstance("DH", "SunJCE");
+        ka2 = KeyAgreement.getInstance("DH",
+                    System.getProperty("test.provider.name", "SunJCE"));
         ka2.init(kp1.getPrivate());
         ka2.doPhase(kp2.getPublic(), true);
         System.out.println("Derive 3...");
@@ -101,7 +102,8 @@ public class TestDH extends PKCS11Test {
 
         ka1.init(kp1.getPrivate());
         ka1.doPhase(kp2.getPublic(), true);
-        System.out.println("Derive " + algorithm + " using SunJCE...");
+        System.out.println("Derive " + algorithm + " using " +
+                    System.getProperty("test.provider.name", "SunJCE") + "...");
         key1 = ka1.generateSecret(algorithm);
 
         ka2.init(kp1.getPrivate());

--- a/test/jdk/sun/security/pkcs11/KeyAgreement/TestInterop.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/TestInterop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,8 @@ public class TestInterop extends PKCS11Test {
             DHPrivateKeySpec privateSpec;
             KeyFactory kf = KeyFactory.getInstance("DH");
             KeyAgreement ka = KeyAgreement.getInstance("DH", prov);
-            KeyAgreement kbSunJCE = KeyAgreement.getInstance("DH", "SunJCE");
+            KeyAgreement kbSunJCE = KeyAgreement.getInstance("DH",
+                    System.getProperty("test.provider.name", "SunJCE"));
             DHPrivateKeySpec privSpecA = new DHPrivateKeySpec(xa, p, g);
             DHPublicKeySpec pubSpecA = new DHPublicKeySpec(ya, p, g);
             PrivateKey privA = kf.generatePrivate(privSpecA);

--- a/test/jdk/sun/security/pkcs11/KeyStore/Basic.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,7 +142,8 @@ public class Basic extends PKCS11Test {
 
         // get private keys
         KeyFactory kf = KeyFactory.getInstance("RSA");
-        KeyFactory dsaKf = KeyFactory.getInstance("DSA", "SUN");
+        KeyFactory dsaKf = KeyFactory.getInstance("DSA",
+                System.getProperty("test.provider.name", "SUN"));
 
         ObjectInputStream ois1 = new ObjectInputStream
                         (new FileInputStream(new File(DIR, "pk1.key")));

--- a/test/jdk/sun/security/pkcs11/MessageDigest/ReinitDigest.java
+++ b/test/jdk/sun/security/pkcs11/MessageDigest/ReinitDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,8 @@ public class ReinitDigest extends PKCS11Test {
     private void doTest(String alg, Provider p, byte[] data1, byte[] data2)
             throws Exception {
         System.out.println("Testing " + alg);
-        MessageDigest md1 = MessageDigest.getInstance(alg, "SUN");
+        MessageDigest md1 = MessageDigest.getInstance(alg,
+                System.getProperty("test.provider.name", "SUN"));
         byte[] d1 = md1.digest(data1);
         MessageDigest md2 = MessageDigest.getInstance(alg, p);
         checkInstances(md1, md2);

--- a/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,8 @@ public class SigInteropPSS extends PKCS11Test {
         }
 
         Signature sigSunRsaSign =
-                Signature.getInstance("RSASSA-PSS", "SunRsaSign");
+                Signature.getInstance("RSASSA-PSS",
+                        System.getProperty("test.provider.name", "SunRsaSign"));
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", p);
         kpg.initialize(3072);

--- a/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS2.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SigInteropPSS2.java
@@ -51,9 +51,10 @@ public class SigInteropPSS2 extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
 
+        String providerName = System.getProperty("test.provider.name", "SunRsaSign");
         Signature sigPkcs11;
         Signature sigSunRsaSign =
-                Signature.getInstance("RSASSA-PSS", "SunRsaSign");
+                Signature.getInstance("RSASSA-PSS", providerName);
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", p);
             kpg.initialize(3072);

--- a/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
+++ b/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
@@ -62,7 +62,8 @@ public class TestDSAKeyLength extends PKCS11Test {
 
     @Override
     public void main(Provider provider) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA", "SUN");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA",
+                System.getProperty("test.provider.name", "SUN"));
         kpg.initialize(2048, new SecureRandom());
         KeyPair pair = kpg.generateKeyPair();
 

--- a/test/jdk/sun/security/pkcs11/policy
+++ b/test/jdk/sun/security/pkcs11/policy
@@ -1,3 +1,4 @@
 grant {
     permission java.lang.RuntimePermission "setSecurityManager";
+    permission java.util.PropertyPermission "test.provider.name", "read";
 };

--- a/test/jdk/sun/security/pkcs11/rsa/GenKeyStore.java
+++ b/test/jdk/sun/security/pkcs11/rsa/GenKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,8 @@ public class GenKeyStore {
 
     private static void generateKeyPair(KeyStore ks, int keyLength, String alias) throws Exception {
         System.out.println("Generating " + keyLength + " keypair " + alias + "...");
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "SunRsaSign");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA",
+                System.getProperty("test.provider.name", "SunRsaSign"));
         kpg.initialize(keyLength);
         KeyPair kp = kpg.generateKeyPair();
         addToKeyStore(ks, kp, alias);

--- a/test/jdk/sun/security/pkcs11/rsa/rsakeys.ks.policy
+++ b/test/jdk/sun/security/pkcs11/rsa/rsakeys.ks.policy
@@ -1,4 +1,5 @@
 grant {
     permission java.lang.RuntimePermission "setSecurityManager";
     permission java.io.FilePermission "${test.src}/rsakeys.ks", "read";
+    permission java.util.PropertyPermission "test.provider.name", "read";
 };

--- a/test/jdk/sun/security/provider/DSA/SupportedDSAParamGen.java
+++ b/test/jdk/sun/security/provider/DSA/SupportedDSAParamGen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,8 @@ public class SupportedDSAParamGen {
 
     public static void main(String[] args) throws Exception {
         AlgorithmParameterGenerator apg =
-            AlgorithmParameterGenerator.getInstance("DSA", "SUN");
+            AlgorithmParameterGenerator.getInstance("DSA",
+                System.getProperty("test.provider.name", "SUN"));
 
         DSAGenParameterSpec spec = new DSAGenParameterSpec(
                 Integer.valueOf(args[0]).intValue(),

--- a/test/jdk/sun/security/provider/DSA/TestAlgParameterGenerator.java
+++ b/test/jdk/sun/security/provider/DSA/TestAlgParameterGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,8 @@ public class TestAlgParameterGenerator {
 
     public static void main(String[] args) throws Exception {
         AlgorithmParameterGenerator apg
-                = AlgorithmParameterGenerator.getInstance("DSA", "SUN");
+                = AlgorithmParameterGenerator.getInstance("DSA",
+                    System.getProperty("test.provider.name", "SUN"));
         long start, stop;
 
         // make sure no-init still works

--- a/test/jdk/sun/security/provider/DSA/TestDSA.java
+++ b/test/jdk/sun/security/provider/DSA/TestDSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ public class TestDSA {
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
 
-        Provider provider = Security.getProvider("SUN");
+        Provider provider = Security.getProvider(System.getProperty("test.provider.name", "SUN"));
         System.out.println("Testing provider " + provider + "...");
 
         KeyFactory kf = KeyFactory.getInstance("DSA", provider);

--- a/test/jdk/sun/security/provider/DSA/TestDSA2.java
+++ b/test/jdk/sun/security/provider/DSA/TestDSA2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,8 @@ public class TestDSA2 {
     // NOTE: need to explictly specify provider since the more
     // preferred provider SunPKCS11 provider only supports up
     // 1024 bits.
-    private static final String PROV = "SUN";
+    private static final String PROV =
+                System.getProperty("test.provider.name", "SUN");
 
     private static final String[] SIG_ALGOS = {
         "NONEwithDSA",

--- a/test/jdk/sun/security/provider/DSA/TestKeyPairGenerator.java
+++ b/test/jdk/sun/security/provider/DSA/TestKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,10 +57,12 @@ public class TestKeyPairGenerator {
         // problem was when not calling initialize()
         // do that twice to artifically inflate the time
         // on JDKs that do not have the fix
-        kpg = KeyPairGenerator.getInstance("DSA", "SUN");
+        kpg = KeyPairGenerator.getInstance("DSA",
+                System.getProperty("test.provider.name", "SUN"));
         kp = kpg.generateKeyPair();
 
-        kpg = KeyPairGenerator.getInstance("DSA", "SUN");
+        kpg = KeyPairGenerator.getInstance("DSA",
+                System.getProperty("test.provider.name", "SUN"));
         kp = kpg.generateKeyPair();
 
         // some other basic tests

--- a/test/jdk/sun/security/provider/MessageDigest/DigestKAT.java
+++ b/test/jdk/sun/security/provider/MessageDigest/DigestKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public class DigestKAT {
 
     static void runTests(Test[] tests) throws Exception {
         long start = System.currentTimeMillis();
-        Provider p = Security.getProvider("SUN");
+        Provider p = Security.getProvider(System.getProperty("test.provider.name","SUN"));
         System.out.println("Testing provider " + p.getName() + "...");
         for (int i = 0; i < tests.length; i++) {
             Test test = tests[i];

--- a/test/jdk/sun/security/provider/MessageDigest/Offsets.java
+++ b/test/jdk/sun/security/provider/MessageDigest/Offsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,8 @@ public class Offsets {
 
     private static void test(String algorithm, int minOfs, int maxOfs, int minLen, int maxLen) throws Exception {
         Random random = new Random();
-        MessageDigest md = MessageDigest.getInstance(algorithm, "SUN");
+        MessageDigest md = MessageDigest.getInstance(algorithm,
+                            System.getProperty("test.provider.name", "SUN"));
         System.out.println("Testing " + algorithm + "...");
         outOfBounds(md, 16, 0, 32);
         outOfBounds(md, 16, -8, 16);

--- a/test/jdk/sun/security/provider/MessageDigest/TestSHAClone.java
+++ b/test/jdk/sun/security/provider/MessageDigest/TestSHAClone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,8 @@ public class TestSHAClone {
 
 
     public static void main(String[] argv) throws Exception {
-        Provider p = Security.getProvider("SUN");
+        Provider p = Security.getProvider(
+                System.getProperty("test.provider.name", "SUN"));
         for (int i=0; i<ALGOS.length; i++) {
             TestSHAClone test = new TestSHAClone(ALGOS[i], p);
             test.run();

--- a/test/jdk/sun/security/provider/NSASuiteB/TestDSAGenParameterSpec.java
+++ b/test/jdk/sun/security/provider/NSASuiteB/TestDSAGenParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,8 @@ import java.security.spec.InvalidParameterSpecException;
 public class TestDSAGenParameterSpec {
 
     private static final String ALGORITHM_NAME = "DSA";
-    private static final String PROVIDER_NAME = "SUN";
+    private static final String PROVIDER_NAME =
+                System.getProperty("test.provider.name", "SUN");
 
     private static void testDSAGenParameterSpec(DataTuple dataTuple)
             throws NoSuchAlgorithmException, NoSuchProviderException,

--- a/test/jdk/sun/security/provider/NSASuiteB/TestSHAOids.java
+++ b/test/jdk/sun/security/provider/NSASuiteB/TestSHAOids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,8 @@ import java.util.List;
  */
 public class TestSHAOids {
 
-    private static final String PROVIDER_NAME = "SUN";
+    private static final String PROVIDER_NAME =
+            System.getProperty("test.provider.name", "SUN");
     private static final byte[] INPUT = "1234567890".getBytes();
 
     private static final List<DataTuple> DATA = Arrays.asList(

--- a/test/jdk/sun/security/provider/NSASuiteB/TestSHAwithDSASignatureOids.java
+++ b/test/jdk/sun/security/provider/NSASuiteB/TestSHAwithDSASignatureOids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ public class TestSHAwithDSASignatureOids {
 
     public static void main(String[] args) throws Exception {
         TestSignatureOidHelper helper = new TestSignatureOidHelper("DSA",
-                "SUN", 1024, DATA);
+                System.getProperty("test.provider.name", "SUN"), 1024, DATA);
         helper.execute();
     }
 }

--- a/test/jdk/sun/security/rsa/BrokenRSAPrivateCrtKey.java
+++ b/test/jdk/sun/security/rsa/BrokenRSAPrivateCrtKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,9 @@ import java.math.BigInteger;
 public class BrokenRSAPrivateCrtKey {
     public static void main(String[] args) throws Exception {
         KeyPairGenerator generator =
-                KeyPairGenerator.getInstance("RSA", "SunRsaSign");
-        generator.initialize(512);
+                KeyPairGenerator.getInstance("RSA",
+                        System.getProperty("test.provider.name", "SunRsaSign"));
+        generator.initialize(2048);
 
         KeyPair pair = generator.generateKeyPair();
 
@@ -55,7 +56,8 @@ public class BrokenRSAPrivateCrtKey {
                 privatekey.getPrimeExponentQ(),
                 privatekey.getCrtCoefficient());
 
-        KeyFactory factory = KeyFactory.getInstance("RSA", "SunRsaSign");
+        KeyFactory factory = KeyFactory.getInstance("RSA",
+                System.getProperty("test.provider.name", "SunRsaSign"));
 
         PrivateKey privatekey2 = factory.generatePrivate(spec);
 

--- a/test/jdk/sun/security/rsa/GenKeyStore.java
+++ b/test/jdk/sun/security/rsa/GenKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,8 @@ public class GenKeyStore {
 
     private static void generateKeyPair(KeyStore ks, int keyLength, String alias) throws Exception {
         System.out.println("Generating " + keyLength + " keypair " + alias + "...");
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "SunRsaSign");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA",
+                System.getProperty("test.provider.name", "SunRsaSign"));
         kpg.initialize(keyLength);
         KeyPair kp = kpg.generateKeyPair();
         addToKeyStore(ks, kp, alias);

--- a/test/jdk/sun/security/rsa/KeySizeTest.java
+++ b/test/jdk/sun/security/rsa/KeySizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,8 @@ public class KeySizeTest {
     /**
      * JDK default RSA Provider.
      */
-    private static final String PROVIDER_NAME = "SunRsaSign";
+    private static final String PROVIDER_NAME =
+            System.getProperty("test.provider.name", "SunRsaSign");
 
     public static void main(String[] args) throws Exception {
         int iKeyPairSize = Integer.parseInt(args[0]);

--- a/test/jdk/sun/security/rsa/PrivateKeyEqualityTest.java
+++ b/test/jdk/sun/security/rsa/PrivateKeyEqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ public class PrivateKeyEqualityTest {
     /**
      * JDK default RSA Provider.
      */
-    private static final String PROVIDER_NAME = "SunRsaSign";
+    private static final String PROVIDER_NAME =
+            System.getProperty("test.provider.name", "SunRsaSign");
 
     public static void main(String[] args) throws NoSuchAlgorithmException,
             NoSuchProviderException, InvalidKeySpecException {

--- a/test/jdk/sun/security/rsa/SignatureTest.java
+++ b/test/jdk/sun/security/rsa/SignatureTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,8 @@ public class SignatureTest {
     /**
      * JDK default RSA Provider.
      */
-    private static final String PROVIDER = "SunRsaSign";
+    private static final String PROVIDER =
+            System.getProperty("test.provider.name", "SunRsaSign");
 
     /**
      * How much times signature updated.

--- a/test/jdk/sun/security/rsa/SpecTest.java
+++ b/test/jdk/sun/security/rsa/SpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,8 @@ public class SpecTest {
     /**
      * JDK default RSA Provider.
      */
-    private static final String PROVIDER = "SunRsaSign";
+    private static final String PROVIDER =
+                System.getProperty("test.provider.name", "SunRsaSign");
 
     /**
      *

--- a/test/jdk/sun/security/rsa/TestCACerts.java
+++ b/test/jdk/sun/security/rsa/TestCACerts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,8 @@ import java.security.cert.*;
 
 public class TestCACerts {
 
-    private final static String PROVIDER = "SunRsaSign";
+    private final static String PROVIDER =
+            System.getProperty("test.provider.name", "SunRsaSign");
 
     private final static char SEP = File.separatorChar;
 

--- a/test/jdk/sun/security/rsa/TestKeyFactory.java
+++ b/test/jdk/sun/security/rsa/TestKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -228,7 +228,8 @@ public class TestKeyFactory {
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
         KeyStore ks = getKeyStore();
-        KeyFactory kf = KeyFactory.getInstance("RSA", "SunRsaSign");
+        KeyFactory kf = KeyFactory.getInstance("RSA",
+                System.getProperty("test.provider.name", "SunRsaSign"));
         for (Enumeration e = ks.aliases(); e.hasMoreElements(); ) {
             String alias = (String)e.nextElement();
             Key key = null;

--- a/test/jdk/sun/security/rsa/TestKeyPairGenerator.java
+++ b/test/jdk/sun/security/rsa/TestKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,8 @@ public class TestKeyPairGenerator {
 
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
-        provider = Security.getProvider("SunRsaSign");
+        provider = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunRsaSign"));
         data = new byte[2048];
         // keypair generation is very slow, test only a few short keys
         int[] keyLengths = {512, 512, 1024};

--- a/test/jdk/sun/security/rsa/TestKeyPairGeneratorExponent.java
+++ b/test/jdk/sun/security/rsa/TestKeyPairGeneratorExponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,8 @@ public class TestKeyPairGeneratorExponent {
 
     public static void main(String[] args) throws Exception {
         KeyPairGenerator kpg =
-                KeyPairGenerator.getInstance("RSA", "SunRsaSign");
+                KeyPairGenerator.getInstance("RSA",
+                    System.getProperty("test.provider.name", "SunRsaSign"));
 
         for(BigInteger validExponent : validExponents) {
             testValidExponents(kpg, validExponent);

--- a/test/jdk/sun/security/rsa/TestKeyPairGeneratorInit.java
+++ b/test/jdk/sun/security/rsa/TestKeyPairGeneratorInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,8 @@ public class TestKeyPairGeneratorInit {
 
     public static void main(String[] args) throws Exception {
         KeyPairGenerator kpg =
-            KeyPairGenerator.getInstance("RSA", "SunRsaSign");
+            KeyPairGenerator.getInstance("RSA",
+                    System.getProperty("test.provider.name", "SunRsaSign"));
         MySecureRandom rnd = new MySecureRandom();
         kpg.initialize(2048, rnd);
         System.out.println("Generate keypair then check");

--- a/test/jdk/sun/security/rsa/TestKeyPairGeneratorLength.java
+++ b/test/jdk/sun/security/rsa/TestKeyPairGeneratorLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,8 @@ public class TestKeyPairGeneratorLength {
     }
 
     private static void test(int len) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "SunRsaSign");
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA",
+                        System.getProperty("test.provider.name", "SunRsaSign"));
         kpg.initialize(len);
         for (int i = 0; i < 6; i++) {
             System.out.println("Generating keypair " + len + " bit keypair " + (i + 1) + "...");

--- a/test/jdk/sun/security/rsa/TestRSAOidSupport.java
+++ b/test/jdk/sun/security/rsa/TestRSAOidSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,14 +59,16 @@ public class TestRSAOidSupport {
         X509EncodedKeySpec x509Spec = new X509EncodedKeySpec
                 (toByteArray(DER_BYTES));
         String keyAlgo = "RSA";
-        KeyFactory kf = KeyFactory.getInstance(keyAlgo, "SunRsaSign");
+        KeyFactory kf = KeyFactory.getInstance(keyAlgo,
+                System.getProperty("test.provider.name", "SunRsaSign"));
         RSAPublicKey rsaKey = (RSAPublicKey) kf.generatePublic(x509Spec);
 
         if (rsaKey.getAlgorithm() != keyAlgo) {
             throw new RuntimeException("Key algo should be " + keyAlgo +
                     ", but got " + rsaKey.getAlgorithm());
         }
-        kf = KeyFactory.getInstance("RSASSA-PSS", "SunRsaSign");
+        kf = KeyFactory.getInstance("RSASSA-PSS",
+                System.getProperty("test.provider.name", "SunRsaSign"));
         try {
             kf.generatePublic(x509Spec);
             throw new RuntimeException("Should throw IKSE");

--- a/test/jdk/sun/security/rsa/TestSigGen15.java
+++ b/test/jdk/sun/security/rsa/TestSigGen15.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,8 @@ public class TestSigGen15 {
     static boolean runTest(List<SigRecord> records) throws Exception {
         boolean success = true;
         //for (Provider provider : Security.getProviders()) {
-        Provider p = Security.getProvider("SunRsaSign");
+        Provider p = Security.getProvider(
+                System.getProperty("test.provider.name","SunRsaSign"));
         KeyFactory kf = KeyFactory.getInstance("RSA", p);
         for (SigRecord sr : records) {
             System.out.println("==Testing Record : " + sr + "==");

--- a/test/jdk/sun/security/rsa/TestSignatures.java
+++ b/test/jdk/sun/security/rsa/TestSignatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,8 @@ public class TestSignatures {
 
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
-        provider = Security.getProvider("SunRsaSign");
+        provider = Security.getProvider(
+                        System.getProperty("test.provider.name", "SunRsaSign"));
         data = new byte[2048];
         new Random().nextBytes(data);
         KeyStore ks = getKeyStore();

--- a/test/jdk/sun/security/rsa/WithoutNULL.java
+++ b/test/jdk/sun/security/rsa/WithoutNULL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,8 @@ public class WithoutNULL {
                 b8oaWkxk069jDTM1RhllPJZkAjeQRbw4gkg4N6wKZz9B/jdSRMNJg/b9QdRYZOHOBxsEHMbUREPV
                 DoCOLaxB8eIXX0EWkiE=""");
 
-        Signature s = Signature.getInstance("SHA1withRSA", "SunRsaSign");
+        Signature s = Signature.getInstance("SHA1withRSA",
+                System.getProperty("test.provider.name", "SunRsaSign"));
         s.initVerify(KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(key)));
         if (!s.verify(sig)) {
             throw new RuntimeException("Does not verify");

--- a/test/jdk/sun/security/rsa/pss/PSSKeyCompatibility.java
+++ b/test/jdk/sun/security/rsa/pss/PSSKeyCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,8 @@ public class PSSKeyCompatibility {
 
     private static final String ALGO = "RSASSA-PSS";
     private static final String OID = "1.2.840.113549.1.1.10";
-    private static final String PROVIDER = "SunRsaSign";
+    private static final String PROVIDER =
+                System.getProperty("test.provider.name", "SunRsaSign");
 
     public static void main(String[] args) {
 

--- a/test/jdk/sun/security/rsa/pss/PSSParametersTest.java
+++ b/test/jdk/sun/security/rsa/pss/PSSParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,8 @@ public class PSSParametersTest {
     /**
      * JDK default RSA Provider.
      */
-    private static final String PROVIDER = "SunRsaSign";
+    private static final String PROVIDER =
+            System.getProperty("test.provider.name", "SunRsaSign");
 
     private static final String PSS_ALGO = "RSASSA-PSS";
     private static final String PSS_OID = "1.2.840.113549.1.1.10";

--- a/test/jdk/sun/security/rsa/pss/SerializedPSSKey.java
+++ b/test/jdk/sun/security/rsa/pss/SerializedPSSKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,8 @@ public class SerializedPSSKey {
 
     private static final String ALGO = "RSASSA-PSS";
     private static final String OID = "1.2.840.113549.1.1.10";
-    private static final String PROVIDER = "SunRsaSign";
+    private static final String PROVIDER =
+                    System.getProperty("test.provider.name", "SunRsaSign");
     private static final int KEY_SIZE = 2048;
     private static final byte[] DATA = "Test".getBytes();
     /**

--- a/test/jdk/sun/security/rsa/pss/SignatureTest2.java
+++ b/test/jdk/sun/security/rsa/pss/SignatureTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,8 @@ public class SignatureTest2 {
     /**
      * JDK default RSA Provider.
      */
-    private static final String PROVIDER = "SunRsaSign";
+    private static final String PROVIDER =
+                System.getProperty("test.provider.name", "SunRsaSign");
 
     /**
      * How much times signature updated.

--- a/test/jdk/sun/security/rsa/pss/SignatureTestPSS.java
+++ b/test/jdk/sun/security/rsa/pss/SignatureTestPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,8 @@ public class SignatureTestPSS {
     /**
      * JDK default RSA Provider.
      */
-    private static final String PROVIDER = "SunRsaSign";
+    private static final String PROVIDER =
+                System.getProperty("test.provider.name", "SunRsaSign");
 
     /**
      * How much times signature updated.

--- a/test/jdk/sun/security/rsa/pss/TestPSSKeySupport.java
+++ b/test/jdk/sun/security/rsa/pss/TestPSSKeySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,7 +131,8 @@ public class TestPSSKeySupport {
 
     public static void main(String[] args) throws Exception {
         KeyPairGenerator kpg =
-            KeyPairGenerator.getInstance(ALGO, "SunRsaSign");
+            KeyPairGenerator.getInstance(ALGO,
+                    System.getProperty("test.provider.name", "SunRsaSign"));
 
         // Algorithm-Independent Initialization
         kpg.initialize(2048);
@@ -152,7 +153,8 @@ public class TestPSSKeySupport {
         KeyPair kp3 = kpg.generateKeyPair();
         checkKeyPair(kp3);
 
-        KeyFactory kf = KeyFactory.getInstance(ALGO, "SunRsaSign");
+        KeyFactory kf = KeyFactory.getInstance(ALGO,
+                            System.getProperty("test.provider.name", "SunRsaSign"));
         test(kf, kp.getPublic());
         test(kf, kp.getPrivate());
         test(kf, kp2.getPublic());

--- a/test/jdk/sun/security/rsa/pss/TestSigGenPSS.java
+++ b/test/jdk/sun/security/rsa/pss/TestSigGenPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,8 @@ public class TestSigGenPSS {
 
     public static void main(String[] args) throws Exception {
         //for (Provider provider : Security.getProviders()) {
-        Provider p = Security.getProvider("SunRsaSign");
+        Provider p = Security.getProvider(
+                System.getProperty("test.provider.name", "SunRsaSign"));
         Signature sig;
         try {
             sig = Signature.getInstance("RSASSA-PSS", p);

--- a/test/jdk/sun/security/ssl/HandshakeHash/DigestBase.java
+++ b/test/jdk/sun/security/ssl/HandshakeHash/DigestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,13 +59,13 @@ class DigestBase extends MessageDigestSpi {
 
     public static final class SHA extends DigestBase {
         public SHA() throws Exception {
-            super("SHA", "SUN");
+            super("SHA", System.getProperty("test.provider.name", "SUN"));
         }
     }
 
     public static final class SHA256 extends DigestBase {
         public SHA256() throws Exception {
-            super("SHA-256", "SUN");
+            super("SHA-256", System.getProperty("test.provider.name", "SUN"));
         }
     }
 }

--- a/test/jdk/sun/security/x509/X509CRLImpl/Verify.java
+++ b/test/jdk/sun/security/x509/X509CRLImpl/Verify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,8 @@ public class Verify {
          * Verify CRL with its own public key.
          * Should pass.
          */
-        verifyCRL(crlIssuerCertPubKey, "SunRsaSign");
+        verifyCRL(crlIssuerCertPubKey,
+                System.getProperty("test.provider.name", "SunRsaSign"));
 
         /*
          * Try to verify CRL with a provider that does not have a Signature
@@ -107,7 +108,8 @@ public class Verify {
          * Should fail with NoSuchAlgorithmException.
          */
         try {
-            verifyCRL(crlIssuerCertPubKey, "SUN");
+            verifyCRL(crlIssuerCertPubKey,
+                System.getProperty("test.provider.name", "SUN"));
             throw new RuntimeException("Didn't catch the exception properly");
         } catch (NoSuchAlgorithmException e) {
             System.out.println("Caught the correct exception.");
@@ -118,7 +120,8 @@ public class Verify {
          * Should fail with SignatureException.
          */
         try {
-            verifyCRL(selfSignedCertPubKey, "SunRsaSign");
+            verifyCRL(selfSignedCertPubKey,
+                    System.getProperty("test.provider.name","SunRsaSign"));
             throw new RuntimeException("Didn't catch the exception properly");
         } catch (SignatureException e) {
             System.out.println("Caught the correct exception.");
@@ -148,6 +151,7 @@ public class Verify {
             throws CRLException, NoSuchAlgorithmException, InvalidKeyException,
             SignatureException {
         Provider provider = Security.getProvider(providerName);
+        System.out.println("Provider = " + provider.getName());
         if (provider == null) {
             throw new RuntimeException("Provider " + providerName
                                                    + " not found.");

--- a/test/jdk/sun/security/x509/X509CertImpl/Verify.java
+++ b/test/jdk/sun/security/x509/X509CertImpl/Verify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,8 @@ public class Verify {
          * Verify certificate with its own public key.
          * Should pass.
          */
-        verifyCert(selfSignedCertPubKey,"SunRsaSign");
+        verifyCert(selfSignedCertPubKey,
+                System.getProperty("test.provider.name", "SunRsaSign"));
 
         /*
          * Try to verify certificate with a provider that does not have a
@@ -86,7 +87,8 @@ public class Verify {
          * Should fail with NoSuchAlgorithmException.
          */
         try {
-            verifyCert(selfSignedCertPubKey, "SunJCE");
+            verifyCert(selfSignedCertPubKey,
+                System.getProperty("test.provider.name", "SunJCE"));
             throw new RuntimeException("Didn't catch the exception properly");
         } catch (NoSuchAlgorithmException e) {
             System.out.println("Caught the correct exception.");
@@ -98,7 +100,8 @@ public class Verify {
          * Should fail with NoSuchAlgorithmException.
          */
         try {
-            verifyCert(selfSignedCertPubKey, "SUN");
+            verifyCert(selfSignedCertPubKey,
+                System.getProperty("test.provider.name", "SUN"));
             throw new RuntimeException("Didn't catch the exception properly");
         } catch (NoSuchAlgorithmException e) {
             System.out.println("Caught the correct exception.");
@@ -109,7 +112,8 @@ public class Verify {
          * Should fail with SignatureException.
          */
         try {
-            verifyCert(crlIssuerCertPubKey, "SunRsaSign");
+            verifyCert(crlIssuerCertPubKey,
+                System.getProperty("test.provider.name", "SunRsaSign"));
             throw new RuntimeException("Didn't catch the exception properly");
         } catch (SignatureException e) {
             System.out.println("Caught the correct exception.");


### PR DESCRIPTION
I backport this for parity with Oracle 17.0.14. The backport is based on the commit to 21.

Tests passed including win tests. Three files are not real tests, I double-checked these.

I had to resolve a lot of files, but all except three only differed in the Copyright year.

Resolved files
================

doc/testing.html
Resolved. Context differences.

test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
test/jdk/com/sun/crypto/provider/Cipher/PBE/DecryptWithoutParameters.java
test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEInvalidParamsTest.java
test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEKeysAlgorithmNames.java
test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEParametersTest.java
test/jdk/com/sun/crypto/provider/Cipher/PBE/PBESealedObject.java
test/jdk/com/sun/crypto/provider/Cipher/PBE/TestCipherKeyWrapperPBEKey.java
test/jdk/com/sun/crypto/provider/KeyGenerator/Test4628062.java
test/jdk/com/sun/crypto/provider/Mac/HmacPBESHA1.java
test/jdk/com/sun/crypto/provider/Mac/HmacSaltLengths.java
test/jdk/com/sun/crypto/provider/Mac/MacClone.java
test/jdk/com/sun/crypto/provider/NSASuiteB/TestHmacSHAOids.java
All these test lack 8288050: Add support of SHA-512/224 and SHA-512/256 to the PBKDF2 and PBES2 impls in SunJCE provider
All only Copyright except for
DecryptWithoutParameters.java: Test in 17 has less and other test cases, adapted change to this.

test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestGeneral.java
Test was modified in 18 by 8271745: Correct block size for KW,KWP mode and use fixed IV for KWP mode for SunJCE
Test in 17 has other test cases, adapted change to this.

test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java
Test was modified in 8302225: SunJCE Provider doesn't validate key sizes when using 'constrained' transforms for AES/KW and AES/KWP
Backport started.
Resolved Copyright.

test/jdk/com/sun/crypto/provider/KeyAgreement/TestExponentSize.java
Modified in 19 by 8267319: Use larger default key sizes and algorithms based on CNSA
Resolved Copyright.

test/jdk/com/sun/jdi/ClassesByName2Test.java
Modified by virtual threads changes.
Resolved Copyright.

test/jdk/javax/crypto/EncryptedPrivateKeyInfo/GetAlgName.java
Modified in 20 by 8296442: EncryptedPrivateKeyInfo can be created with an uninitialized AlgorithmParameters. This is a follow-up of a cleanup change also in 20.
Resolved Copyright.



Files not in 17
===============

test/jdk/com/sun/crypto/provider/KeyGenerator/Test6227536.java
This test came in 20 with 6227536: KeyGenerator.init() methods do not throw IllegalArgumentException for keysize == 0
Not a candidate for backport.

test/jdk/sun/security/ec/ECDSAPrimitive.java
Depends on 8333754: Add a Test against ECDSA and ECDH NIST Test vector
which is a candidate for backport, but it's not trivial to do so.
I would like to proceed with this change, anyways.

test/jdk/sun/security/ec/ECDSAPrvGreaterThanOrder.java
This test came in 18 with 8272385: Enforce ECPrivateKey d value to be in the range [1, n-1] for SunEC provider
Not a candidate for backport. Throws new exception.

test/jdk/sun/security/ec/OidInstance.java
This test came in 19 with 8279801: EC KeyFactory and KeyPairGenerator do not have aliases for OID format
Hmm, I think this would be nice-to-have in 17. It's not
critical. But I don't want to drive this now.

test/jdk/sun/security/pkcs11/Cipher/KeyWrap/NISTWrapKAT.java
test/jdk/sun/security/pkcs11/Cipher/KeyWrap/TestGeneral.java
Both came in 18 with 8264849: Add KW and KWP support to PKCS11 provider.
Seems to be a follow-up Enhancement enabled by a change that came in 17.

test/jdk/sun/security/pkcs11/Cipher/PBECipher.java
test/jdk/sun/security/pkcs11/Mac/PBAMac.java
Both came in 21 with 8301553: Support Password-Based Cryptography in SunPKCS11
Not a candidate for backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343848](https://bugs.openjdk.org/browse/JDK-8343848) needs maintainer approval
- [x] [JDK-8341927](https://bugs.openjdk.org/browse/JDK-8341927) needs maintainer approval

### Issues
 * [JDK-8341927](https://bugs.openjdk.org/browse/JDK-8341927): Replace hardcoded security providers with new test.provider.name system property (**Enhancement** - P2 - Approved)
 * [JDK-8343848](https://bugs.openjdk.org/browse/JDK-8343848): Fix typo of property name in TestOAEPPadding after 8341927 (**Bug** - P5 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3049/head:pull/3049` \
`$ git checkout pull/3049`

Update a local copy of the PR: \
`$ git checkout pull/3049` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3049`

View PR using the GUI difftool: \
`$ git pr show -t 3049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3049.diff">https://git.openjdk.org/jdk17u-dev/pull/3049.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3049#issuecomment-2483049480)
</details>
