### PR TITLE
8307297: Move some DnD tests to open

### DIFF
--- a/test/jdk/java/awt/dnd/DragSourceSerializationTest.java
+++ b/test/jdk/java/awt/dnd/DragSourceSerializationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.dnd.DragSource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/*
+  @test
+  @bug 4407057
+  @summary tests that deserialized DragSource has a non-null flavor map
+  @key headful
+  @run main DragSourceSerializationTest
+*/
+
+public class DragSourceSerializationTest {
+
+    public static void main(String[] args) throws Exception {
+        try {
+            final DragSource dragSource = DragSource.getDefaultDragSource();
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream    oos  = new ObjectOutputStream(baos);
+            oos.writeObject(dragSource);
+            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+            ObjectInputStream ois = new ObjectInputStream(bais);
+
+            final DragSource copy = (DragSource)ois.readObject();
+            if (copy.getFlavorMap() == null) {
+                throw new RuntimeException("getFlavorMap() returns null");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/jdk/java/awt/dnd/DragTriggerEventTest.java
+++ b/test/jdk/java/awt/dnd/DragTriggerEventTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.GridLayout;
+import java.awt.Robot;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Dimension;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JList;
+
+/*
+  @test
+  @bug 4388802
+  @summary tests that a drag can be initiated with MOUSE_MOVED event
+  @key headful
+  @run main DragTriggerEventTest
+*/
+
+public class DragTriggerEventTest {
+
+    volatile JFrame frame;
+    volatile JList list;
+    volatile DropTargetPanel panel;
+    volatile Point srcPoint;
+    volatile Rectangle cellBounds;
+    volatile Point dstPoint;
+    volatile Dimension d;
+    static final int FRAME_ACTIVATION_TIMEOUT = 3000;
+    volatile boolean mouse1Pressed = false;
+    volatile boolean ctrlPressed = false;
+
+    public static void main(String[] args) throws Exception {
+        DragTriggerEventTest test = new DragTriggerEventTest();
+        EventQueue.invokeAndWait(test::init);
+        try {
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (test.frame != null) {
+                    test.frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        list = new JList(new String[] {"one", "two", "three", "four"});
+        list.setDragEnabled(true);
+        panel = new DropTargetPanel();
+
+        frame = new JFrame();
+        frame.setTitle("DragTriggerEventTest");
+        frame.setLocation(200, 200);
+        frame.getContentPane().setLayout(new GridLayout(2, 1));
+        frame.getContentPane().add(list);
+        frame.getContentPane().add(panel);
+
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public void start() throws Exception {
+        Robot robot;
+        robot = new Robot();
+
+        EventQueue.invokeAndWait(() -> {
+            srcPoint = list.getLocationOnScreen();
+            cellBounds = list.getCellBounds(0, 0);
+        });
+
+        srcPoint.translate(cellBounds.x + cellBounds.width / 2,
+                           cellBounds.y + cellBounds.height / 2);
+
+        EventQueue.invokeAndWait(() -> {
+            dstPoint = panel.getLocationOnScreen();
+            d = panel.getSize();
+        });
+        dstPoint.translate(d.width / 2, d.height / 2);
+
+        for (int delay = 32; delay < 10000 && !panel.getResult(); delay *= 2) {
+            System.err.println("attempt to drag with delay " + delay);
+            robot.mouseMove(srcPoint.x, srcPoint.y);
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            mouse1Pressed = true;
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            mouse1Pressed = false;
+
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            ctrlPressed = true;
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            mouse1Pressed = true;
+
+            Point p = new Point(srcPoint);
+            while (!p.equals(dstPoint)) {
+                p.translate(sign(dstPoint.x - p.x),
+                            sign(dstPoint.y - p.y));
+                robot.mouseMove(p.x, p.y);
+                robot.delay(delay);
+            }
+        }
+        if (mouse1Pressed) {
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        }
+        if (ctrlPressed) {
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+        }
+
+        EventQueue.invokeAndWait(() -> {
+            if (!panel.getResult()) {
+                throw new RuntimeException("The test failed.");
+            }
+        });
+    }
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+}
+
+class DropTargetPanel extends JPanel implements DropTargetListener {
+
+    private boolean passed = false;
+    final Dimension preferredDimension = new Dimension(200, 100);
+
+    public DropTargetPanel() {
+        setDropTarget(new DropTarget(this, this));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {
+        passed = true;
+    }
+
+    public void dragExit(DropTargetEvent dte) {
+        passed = true;
+    }
+
+    public void dragOver(DropTargetDragEvent dtde) {
+        passed = true;
+    }
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {
+        passed = true;
+    }
+
+    public void drop(DropTargetDropEvent dtde) {
+        passed = true;
+        dtde.rejectDrop();
+    }
+
+    public boolean getResult() {
+        return passed;
+    }
+}

--- a/test/jdk/java/awt/dnd/DropActionChangeTest.java
+++ b/test/jdk/java/awt/dnd/DropActionChangeTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JFrame;
+import java.awt.AWTEvent;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.StringSelection;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.AWTEventListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+/*
+  @test
+  @bug 4896462
+  @summary tests that drop action is computed correctly
+  @key headful
+  @run main DropActionChangeTest
+*/
+
+public class DropActionChangeTest extends JFrame implements AWTEventListener {
+    Robot robot;
+    Frame frame;
+    Panel panel;
+    private volatile boolean failed;
+    private volatile boolean dropEnd;
+    private volatile Component clickedComponent;
+    private final Object LOCK = new Object();
+    static final int FRAME_ACTIVATION_TIMEOUT = 3000;
+    static final int DROP_COMPLETION_TIMEOUT = 5000;
+    static final int MOUSE_RELEASE_TIMEOUT = 2000;
+
+    public static void main(String[] args) throws Exception {
+        DropActionChangeTest test = new DropActionChangeTest();
+        EventQueue.invokeAndWait(test::init);
+        try {
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (test.frame != null) {
+                    test.frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        getToolkit().addAWTEventListener(this, AWTEvent.MOUSE_EVENT_MASK);
+
+        setSize (200,200);
+        setTitle("DropActionChangeTest");
+        setVisible(true);
+        validate();
+
+        frame = new Frame("Empty Frame with Panel");
+        panel = new Panel();
+        frame.add(panel);
+        frame.setBounds(300, 300, 300, 300);
+        failed = false;
+
+        final DragSourceListener dsl = new DragSourceAdapter() {
+            public void dragDropEnd(DragSourceDropEvent e) {
+                System.err.println("DragSourseListener.dragDropEnd(): " +
+                        "drop action=" + e.getDropAction());
+                if (e.getDropAction() != DnDConstants.ACTION_MOVE) {
+                    System.err.println("FAILURE: wrong drop action:" + e.getDropAction());
+                    failed = true;
+                }
+                synchronized (LOCK) {
+                    dropEnd = true;
+                    LOCK.notifyAll();
+                }
+            }
+        };
+
+        DragGestureListener dgl = new DragGestureListener() {
+            public void dragGestureRecognized(DragGestureEvent dge) {
+                dge.startDrag(null, new StringSelection("test"), dsl);
+            }
+        };
+
+        new DragSource().createDefaultDragGestureRecognizer(panel,
+                DnDConstants.ACTION_COPY_OR_MOVE, dgl);
+
+        DropTargetListener dtl = new DropTargetAdapter() {
+            public void dragEnter(DropTargetDragEvent e) {
+                System.err.println("DropTargetListener.dragEnter(): " +
+                        "user drop action=" + e.getDropAction());
+                e.acceptDrag(e.getDropAction());
+            }
+
+            public void dragOver(DropTargetDragEvent e) {
+                e.acceptDrag(e.getDropAction());
+            }
+            public void drop(DropTargetDropEvent e) {
+                System.err.println("DropTargetListener.drop(): " +
+                        "user drop action=" + e.getDropAction());
+                e.acceptDrop(e.getDropAction());
+                e.dropComplete(true);
+            }
+        };
+
+        new DropTarget(panel, dtl);
+
+        frame.setVisible(true);
+    }
+
+    public void start() {
+        try {
+            robot = new Robot();
+
+            Point startPoint = panel.getLocationOnScreen();
+            startPoint.translate(50, 50);
+
+            if (!pointInComponent(robot, startPoint, panel)) {
+                System.err.println("WARNING: Couldn't locate source panel");
+                return;
+            }
+
+
+            Point medPoint = new Point(startPoint.x + (DragSource.getDragThreshold()+10)*2,
+                                       startPoint.y);
+            Point endPoint = new Point(startPoint.x + (DragSource.getDragThreshold()+10)*4,
+                                       startPoint.y);
+
+            synchronized (LOCK) {
+                robot.keyPress(KeyEvent.VK_CONTROL);
+                robot.mouseMove(startPoint.x, startPoint.y);
+                robot.mousePress(InputEvent.BUTTON1_MASK);
+                Util.doDrag(robot, startPoint, medPoint);
+                robot.keyRelease(KeyEvent.VK_CONTROL);
+                Util.doDrag(robot, medPoint, endPoint);
+                robot.mouseRelease(InputEvent.BUTTON1_MASK);
+                LOCK.wait(DROP_COMPLETION_TIMEOUT);
+            }
+            if (!dropEnd) {
+                System.err.println("DragSourseListener.dragDropEnd() was not called, returning");
+                return;
+            }
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
+        if (failed) {
+            throw new RuntimeException("wrong drop action!");
+        }
+
+        System.err.println("test passed!");
+    }
+
+    public void reset() {
+        clickedComponent = null;
+    }
+
+    public void eventDispatched(AWTEvent e) {
+        if (e.getID() == MouseEvent.MOUSE_RELEASED) {
+            clickedComponent = (Component)e.getSource();
+            synchronized (LOCK) {
+                LOCK.notifyAll();
+            }
+        }
+    }
+
+    boolean pointInComponent(Robot robot, Point p, Component comp)
+      throws InterruptedException {
+        robot.waitForIdle();
+        reset();
+        robot.mouseMove(p.x, p.y);
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        synchronized (LOCK) {
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            LOCK.wait(MOUSE_RELEASE_TIMEOUT);
+        }
+
+        Component c = clickedComponent;
+
+        while (c != null && c != comp) {
+            c = c.getParent();
+        }
+
+        return c == comp;
+    }
+}
+
+
+class Util {
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+
+    public static void doDrag(Robot robot, Point startPoint, Point endPoint) {
+       for (Point p = new Point(startPoint); !p.equals(endPoint);
+                p.translate(Util.sign(endPoint.x - p.x),
+                            Util.sign(endPoint.y - p.y))) {
+           robot.mouseMove(p.x, p.y);
+           try {
+               Thread.sleep(100);
+           } catch (InterruptedException e) {
+             e.printStackTrace();
+           }
+       }
+    }
+}

--- a/test/jdk/java/awt/dnd/DropActionChangedTest.java
+++ b/test/jdk/java/awt/dnd/DropActionChangedTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/*
+  @test
+  @bug 4357930
+  @summary tests that dropActionChanged() is not invoked if the drop gesture
+           is not modified.
+  @key headful
+  @run main DropActionChangedTest
+*/
+
+public class DropActionChangedTest {
+
+    volatile Frame frame;
+    volatile DragSourcePanel dragSourcePanel;
+    volatile DropTargetPanel dropTargetPanel;
+
+    public static void main(String[] args) throws Exception {
+        DropActionChangedTest test = new DropActionChangedTest();
+        EventQueue.invokeAndWait(test::init);
+        try {
+            test.start();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (test.frame != null) {
+                    test.frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        dragSourcePanel = new DragSourcePanel();
+        dropTargetPanel = new DropTargetPanel();
+
+        frame = new Frame();
+        frame.setTitle("DropTargetAddNotifyNPETest");
+        frame.setLocation(200, 200);
+        frame.setLayout(new GridLayout(2, 1));
+        frame.add(dragSourcePanel);
+        frame.add(dropTargetPanel);
+
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public void start() throws Exception {
+        Robot robot = new Robot();
+        robot.delay(2000);
+        robot.mouseMove(250, 250);
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.delay(1000);
+        for (int y = 250; y < 350; y+=5) {
+                robot.mouseMove(250, y);
+                robot.delay(100);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        if (dropTargetPanel.isDropActionChangedTriggered()) {
+            throw new RuntimeException("The test failed.");
+        }
+    }
+}
+
+class DragSourceButton extends Button implements Serializable,
+                                                 Transferable,
+                                                 DragGestureListener,
+                                                 DragSourceListener {
+    private final DataFlavor dataflavor =
+        new DataFlavor(Button.class, "DragSourceButton");
+
+    public DragSourceButton() {
+        this("DragSourceButton");
+    }
+
+    public DragSourceButton(String str) {
+        super(str);
+
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY,
+                                              this);
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(null, this, this);
+    }
+
+    public void dragEnter(DragSourceDragEvent dsde) {}
+
+    public void dragExit(DragSourceEvent dse) {}
+
+    public void dragOver(DragSourceDragEvent dsde) {}
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {}
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {}
+
+    public Object getTransferData(DataFlavor flavor)
+      throws UnsupportedFlavorException, IOException {
+
+        if (!isDataFlavorSupported(flavor)) {
+            throw new UnsupportedFlavorException(flavor);
+        }
+
+        Object retObj = null;
+
+        ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
+        ObjectOutputStream ooStream = new ObjectOutputStream(baoStream);
+        ooStream.writeObject(this);
+
+        ByteArrayInputStream baiStream = new ByteArrayInputStream(baoStream.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(baiStream);
+        try {
+            retObj = ois.readObject();
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.toString());
+        }
+
+        return retObj;
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[] { dataflavor };
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor dflavor) {
+        return dataflavor.equals(dflavor);
+    }
+}
+
+class DragSourcePanel extends Panel {
+
+    final Dimension preferredDimension = new Dimension(200, 100);
+
+    public DragSourcePanel() {
+        setLayout(new GridLayout(1, 1));
+        add(new DragSourceButton());
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+}
+
+class DropTargetPanel extends Panel implements DropTargetListener {
+
+    final Dimension preferredDimension = new Dimension(200, 100);
+    private boolean dropActionChangedTriggered = false;
+
+    public DropTargetPanel() {
+        setDropTarget(new DropTarget(this, this));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {}
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {}
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+        }
+
+        DataFlavor[] dfs = dtde.getCurrentDataFlavors();
+        Component comp = null;
+
+        if (dfs != null && dfs.length >= 1) {
+            Transferable transfer = dtde.getTransferable();
+
+            try {
+                comp = (Component)transfer.getTransferData(dfs[0]);
+            } catch (Throwable e) {
+                e.printStackTrace();
+                dtc.dropComplete(false);
+            }
+        }
+        dtc.dropComplete(true);
+
+        add(comp);
+    }
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {
+        dropActionChangedTriggered = true;
+        throw new RuntimeException("dropActionChanged triggered");
+    }
+
+    public boolean isDropActionChangedTriggered() {
+        return dropActionChangedTriggered;
+    }
+}

--- a/test/jdk/java/awt/dnd/DropPerformanceTest.java
+++ b/test/jdk/java/awt/dnd/DropPerformanceTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.JButton;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/*
+  @test
+  @bug 4484996
+  @summary Tests that drop doesn't take too much time on Win 95/98.
+  @key headful
+  @run main DropPerformanceTest
+*/
+
+public class DropPerformanceTest {
+
+    public static final int CODE_NOT_RETURNED = -1;
+    public static final int CODE_OK = 0;
+    public static final int CODE_FAILURE = 1;
+    public static final int FRAME_ACTIVATION_TIMEOUT = 2000;
+    public static final int DROP_COMPLETION_TIMEOUT = 4000;
+    public static final int TIME_THRESHOLD = 40000;
+
+    private int returnCode = CODE_NOT_RETURNED;
+
+    final Frame frame = new Frame();
+    Robot robot = null;
+    DropTargetPanel dtpanel = null;
+    DragSourcePanel dspanel = null;
+
+    public static void main(String[] args) throws Exception {
+        DropPerformanceTest test = new DropPerformanceTest();
+        if (args.length > 0) {
+            test.run(args);
+        } else {
+            EventQueue.invokeAndWait(test::init);
+            try {
+                test.start();
+            } finally {
+                EventQueue.invokeAndWait(() -> {
+                    if (test.frame != null) {
+                        test.frame.dispose();
+                    }
+                });
+            }
+        }
+    }
+
+    public void run(String[] args) {
+        try {
+            if (args.length != 4) {
+                throw new RuntimeException("Incorrect command line arguments.");
+            }
+
+            int x = Integer.parseInt(args[0]);
+            int y = Integer.parseInt(args[1]);
+            int w = Integer.parseInt(args[2]);
+            int h = Integer.parseInt(args[3]);
+
+            dspanel = new DragSourcePanel();
+
+            frame.setTitle("DropPerformanceTest Drop Source Frame");
+            frame.setLocation(100, 200);
+            frame.add(dspanel);
+            frame.pack();
+            frame.setVisible(true);
+
+            Thread.sleep(FRAME_ACTIVATION_TIMEOUT);
+
+            Point sourcePoint = dspanel.getLocationOnScreen();
+            Dimension d = dspanel.getSize();
+            sourcePoint.translate(d.width / 2, d.height / 2);
+
+            Point targetPoint = new Point(x + w / 2, y + h / 2);
+
+            robot = new Robot();
+            robot.mouseMove(sourcePoint.x, sourcePoint.y);
+            robot.mousePress(InputEvent.BUTTON1_MASK);
+            for (; !sourcePoint.equals(targetPoint);
+                 sourcePoint.translate(sign(targetPoint.x - sourcePoint.x),
+                                       sign(targetPoint.y - sourcePoint.y))) {
+                robot.mouseMove(sourcePoint.x, sourcePoint.y);
+                Thread.sleep(10);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+
+            Thread.sleep(DROP_COMPLETION_TIMEOUT);
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+            System.exit(DropPerformanceTest.CODE_FAILURE);
+        }
+
+        System.exit(DropPerformanceTest.CODE_OK);
+    } // run()
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+
+    public void init() {
+        dtpanel = new DropTargetPanel();
+
+        frame.setTitle("Drop Target Frame");
+        frame.setLocation(250, 200);
+        frame.add(dtpanel);
+
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    private void launchChildVM() {
+        try {
+            Thread.sleep(FRAME_ACTIVATION_TIMEOUT);
+
+            Point p = dtpanel.getLocationOnScreen();
+            Dimension d = dtpanel.getSize();
+
+            String javaPath = System.getProperty("java.home", "");
+            String command = javaPath + File.separator + "bin" +
+                File.separator + "java -cp " + System.getProperty("test.classes", ".") +
+                " DropPerformanceTest " +
+                p.x + " " + p.y + " " + d.width + " " + d.height;
+            Process process = Runtime.getRuntime().exec(command);
+            returnCode = process.waitFor();
+            InputStream errorStream = process.getErrorStream();
+            int count = errorStream.available();
+            if (count > 0) {
+                byte[] b = new byte[count];
+                errorStream.read(b);
+                System.err.println("========= Child VM System.err ========");
+                System.err.print(new String(b));
+                System.err.println("======================================");
+            }
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+        switch (returnCode) {
+            case CODE_NOT_RETURNED:
+                System.err.println("Child VM: failed to start");
+                break;
+            case CODE_OK:
+                System.err.println("Child VM: normal termination");
+                break;
+            case CODE_FAILURE:
+                System.err.println("Child VM: abnormal termination");
+                break;
+        }
+        if (returnCode != CODE_OK) {
+            throw new RuntimeException("The test failed.");
+        }
+    }
+
+    public void start() {
+        launchChildVM();
+        System.err.println("Drop consumed " + dtpanel.getDropTime() + " milliseconds");
+        if (dtpanel.getDropTime() > TIME_THRESHOLD) {
+            throw new RuntimeException("The test failed: drop took too much time");
+        }
+    }
+}
+
+class DragSourceButton extends JButton
+                              implements Transferable, Serializable,
+                                         DragGestureListener, DragSourceListener {
+
+    public DataFlavor dataflavor = new DataFlavor(DragSourceButton.class, "Source");
+
+    DragSourceButton(String str) {
+        super(str);
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY, this);
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(null, this, this);
+    }
+
+    public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+        Object ret = null;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(this);
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        try {
+            ret = (DragSourceButton)ois.readObject();
+        } catch (ClassNotFoundException cannotHappen) {
+            return null;
+        }
+        return ret;
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[] { dataflavor };
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor dflavor) {
+        return dataflavor.equals(dflavor);
+    }
+
+    public void dragEnter(DragSourceDragEvent dsde) {}
+
+    public void dragExit(DragSourceEvent dse) {}
+
+    public void dragOver(DragSourceDragEvent dsde) {}
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {}
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {}
+}
+
+class DragSourcePanel extends Panel {
+
+    final Dimension preferredDimension = new Dimension(100, 50);
+
+    public DragSourcePanel() {
+        setLayout(new GridLayout(1, 1));
+        add(new DragSourceButton("Drag me"));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+}
+
+class DropTargetPanel extends Panel implements DropTargetListener {
+
+    final Dimension preferredDimension = new Dimension(100, 50);
+    private long dropTime = 0;
+
+    public DropTargetPanel() {
+        setBackground(Color.green);
+        setDropTarget(new DropTarget(this, this));
+    }
+
+    public long getDropTime() {
+        return dropTime;
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {
+        dtde.acceptDrag(DnDConstants.ACTION_COPY);
+    }
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {
+        dtde.acceptDrag(DnDConstants.ACTION_COPY);
+    }
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+            return;
+        }
+
+        Transferable t = dtde.getTransferable();
+        DataFlavor[] dfs = t.getTransferDataFlavors();
+
+        long before = System.currentTimeMillis();
+
+        if (dfs != null && dfs.length >= 1) {
+            Object obj = null;
+            try {
+                obj = t.getTransferData(dfs[0]);
+            } catch (IOException ioe) {
+                dtc.dropComplete(false);
+                return;
+            } catch (UnsupportedFlavorException ufe) {
+                dtc.dropComplete(false);
+                return;
+            }
+
+            if (obj != null) {
+                Component comp = (Component)obj;
+                add(comp);
+            }
+        }
+
+        long after = System.currentTimeMillis();
+        dropTime = after - before;
+
+        synchronized (this) {
+            notifyAll();
+        }
+
+        dtc.dropComplete(true);
+        validate();
+    }
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+}

--- a/test/jdk/java/awt/dnd/DropTargetAddNotifyNPETest.java
+++ b/test/jdk/java/awt/dnd/DropTargetAddNotifyNPETest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetListener;
+
+/*
+  @test
+  @bug 4462285
+  @summary tests that DropTarget.addNotify doesn't throw NPE if peer hierarchy
+           is incomplete
+  @key headful
+  @run main DropTargetAddNotifyNPETest
+*/
+
+public class DropTargetAddNotifyNPETest {
+
+    volatile Component component1;
+    volatile Component component2;
+    volatile Frame frame;
+    volatile DropTargetListener dtListener;
+    volatile DropTarget dropTarget1;
+    volatile DropTarget dropTarget2;
+
+    public static void main(String[] args) throws Exception {
+        DropTargetAddNotifyNPETest test = new DropTargetAddNotifyNPETest();
+        EventQueue.invokeAndWait(() -> {
+            test.init();
+            if (test.frame != null) {
+                test.frame.dispose();
+            }
+        });
+    }
+
+    public void init() {
+        component1 = new LWComponent();
+        component2 = new LWComponent();
+        frame = new Frame("DropTargetAddNotifyNPETest");
+        dtListener = new DropTargetAdapter() {
+            public void drop(DropTargetDropEvent dtde) {
+                dtde.rejectDrop();
+            }
+        };
+        dropTarget1 = new DropTarget(component1, dtListener);
+        dropTarget2 = new DropTarget(component2, dtListener);
+
+        frame.add(component2);
+        component1.addNotify();
+        component2.addNotify();
+    }
+}
+
+class LWComponent extends Component {}

--- a/test/jdk/java/awt/dnd/DropTargetNullFlavorMapTest.java
+++ b/test/jdk/java/awt/dnd/DropTargetNullFlavorMapTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.datatransfer.SystemFlavorMap;
+import java.awt.dnd.DropTarget;
+
+/*
+  @test
+  @bug 4785476
+  @summary tests that DropTarget.setFlavorMap(null) works properly
+  @key headful
+  @run main DropTargetNullFlavorMapTest
+*/
+public class DropTargetNullFlavorMapTest {
+
+    public static void main(String[] args) {
+        DropTargetNullFlavorMapTest test = new DropTargetNullFlavorMapTest();
+        test.init();
+    }
+
+    public void init() {
+        final DropTarget dropTarget = new DropTarget();
+
+        if (!SystemFlavorMap.getDefaultFlavorMap().equals(dropTarget.getFlavorMap())) {
+            System.err.println("Default flavor map: " + SystemFlavorMap.getDefaultFlavorMap());
+            System.err.println("DropTarget's flavor map: " + dropTarget.getFlavorMap());
+            throw new RuntimeException("Incorrect flavor map.");
+        }
+
+        Thread.currentThread().setContextClassLoader(new ClassLoader() {});
+
+        dropTarget.setFlavorMap(null);
+
+        if (!SystemFlavorMap.getDefaultFlavorMap().equals(dropTarget.getFlavorMap())) {
+            System.err.println("Default flavor map: " + SystemFlavorMap.getDefaultFlavorMap());
+            System.err.println("DropTarget's flavor map: " + dropTarget.getFlavorMap());
+            throw new RuntimeException("Incorrect flavor map.");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8307297](https://bugs.openjdk.org/browse/JDK-8307297) needs maintainer approval

### Issue
 * [JDK-8307297](https://bugs.openjdk.org/browse/JDK-8307297): Move some DnD tests to open (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3052/head:pull/3052` \
`$ git checkout pull/3052`

Update a local copy of the PR: \
`$ git checkout pull/3052` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3052`

View PR using the GUI difftool: \
`$ git pr show -t 3052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3052.diff">https://git.openjdk.org/jdk17u-dev/pull/3052.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3052#issuecomment-2483467022)
</details>
