### PR TITLE
8317738: CodeCacheFullCountTest failed with "VirtualMachineError: Out of space in CodeCache for method handle intrinsic"

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -67,7 +67,7 @@ public class CodeCacheFullCountTest {
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         // Ignore adapter creation failures
-        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache for adapters")) {
+        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache")) {
             oa.reportDiagnosticSummary();
             throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
         }


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317738](https://bugs.openjdk.org/browse/JDK-8317738) needs maintainer approval

### Issue
 * [JDK-8317738](https://bugs.openjdk.org/browse/JDK-8317738): CodeCacheFullCountTest failed with "VirtualMachineError: Out of space in CodeCache for method handle intrinsic" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3054/head:pull/3054` \
`$ git checkout pull/3054`

Update a local copy of the PR: \
`$ git checkout pull/3054` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3054`

View PR using the GUI difftool: \
`$ git pr show -t 3054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3054.diff">https://git.openjdk.org/jdk17u-dev/pull/3054.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3054#issuecomment-2483493404)
</details>
