### PR TITLE
8336257: Additional tests in jmxremote/startstop to match on PID not app name

### DIFF
--- a/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class JMXStartStopTest {
 
     private static final boolean verbose = false;
 
-    private static ManagementAgentJcmd jcmd = new ManagementAgentJcmd(TEST_APP_NAME, verbose);
+    private static ManagementAgentJcmd jcmd;
 
     private static void dbg_print(String msg) {
         if (verbose) {
@@ -347,6 +347,7 @@ public class JMXStartStopTest {
                                                 "the requested port not being available");
                     }
                     pid = p.pid();
+                    jcmd = new ManagementAgentJcmd(p, verbose);
                 } catch (TimeoutException e) {
                     if (p != null) {
                         p.destroy();

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,6 @@ public class JMXStatusPerfCountersTest {
 
     @BeforeTest
     public void setup() {
-        jcmd = new ManagementAgentJcmd(TEST_APP_NAME, false);
     }
 
     @BeforeMethod
@@ -76,6 +75,7 @@ public class JMXStatusPerfCountersTest {
             TEST_APP_NAME, testAppPb,
             (Predicate<String>)l->l.trim().equals("main enter")
         );
+        jcmd = new ManagementAgentJcmd(testApp, false);
     }
 
     @AfterMethod


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [687601eb](https://github.com/openjdk/jdk/commit/687601ebcaedf133fd4d5cecc42c5aadf9c73f3c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Kevin Walls on 11 Jul 2024 and was reviewed by Chris Plummer, Alan Bateman, Alex Menkov and Daniel D. Daugherty.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8336257](https://bugs.openjdk.org/browse/JDK-8336257) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336257](https://bugs.openjdk.org/browse/JDK-8336257): Additional tests in jmxremote/startstop to match on PID not app name (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3060/head:pull/3060` \
`$ git checkout pull/3060`

Update a local copy of the PR: \
`$ git checkout pull/3060` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3060`

View PR using the GUI difftool: \
`$ git pr show -t 3060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3060.diff">https://git.openjdk.org/jdk17u-dev/pull/3060.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3060#issuecomment-2486037199)
</details>
