### PR TITLE
8322766: Micro bench SSLHandshake should use default algorithms

### DIFF
--- a/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
+++ b/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,11 +80,12 @@ public class SSLHandshake {
         KeyStore ks = TestCertificates.getKeyStore();
         KeyStore ts = TestCertificates.getTrustStore();
 
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(
+                KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(ks, new char[0]);
 
-        TrustManagerFactory tmf =
-                TrustManagerFactory.getInstance("SunX509");
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+                TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(ts);
 
         SSLContext sslCtx = SSLContext.getInstance(tlsVersion);

--- a/test/micro/org/openjdk/bench/java/security/TestCertificates.java
+++ b/test/micro/org/openjdk/bench/java/security/TestCertificates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,12 +115,12 @@ class TestCertificates {
     private TestCertificates() {}
 
     public static KeyStore getKeyStore() throws GeneralSecurityException, IOException {
-        KeyStore result = KeyStore.getInstance("JKS");
+        KeyStore result = KeyStore.getInstance(KeyStore.getDefaultType());
         result.load(null, null);
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         Certificate serverCert = cf.generateCertificate(
                 new ByteArrayInputStream(
-                        TestCertificates.SERVER_CERT.getBytes(StandardCharsets.ISO_8859_1)));
+                        SERVER_CERT.getBytes(StandardCharsets.ISO_8859_1)));
         Certificate caCert = cf.generateCertificate(
                 new ByteArrayInputStream(
                         CA_CERT.getBytes(StandardCharsets.ISO_8859_1)));
@@ -135,7 +135,7 @@ class TestCertificates {
     }
 
     public static KeyStore getTrustStore() throws GeneralSecurityException, IOException {
-        KeyStore result = KeyStore.getInstance("JKS");
+        KeyStore result = KeyStore.getInstance(KeyStore.getDefaultType());
         result.load(null, null);
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
         Certificate rootcaCert = cf.generateCertificate(


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8322766](https://bugs.openjdk.org/browse/JDK-8322766) needs maintainer approval

### Issue
 * [JDK-8322766](https://bugs.openjdk.org/browse/JDK-8322766): Micro bench SSLHandshake should use default algorithms (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3062/head:pull/3062` \
`$ git checkout pull/3062`

Update a local copy of the PR: \
`$ git checkout pull/3062` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3062`

View PR using the GUI difftool: \
`$ git pr show -t 3062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3062.diff">https://git.openjdk.org/jdk17u-dev/pull/3062.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3062#issuecomment-2486480965)
</details>
