### PR TITLE
8328697: SubMenuShowTest and SwallowKeyEvents tests stabilization

### DIFF
--- a/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/SubMenuShowTest/SubMenuShowTest.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/SubMenuShowTest/SubMenuShowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,19 +21,6 @@
  * questions.
  */
 
-/*
-  @test
-  @key headful
-  @bug 6380743 8158380 8198624
-  @summary Submenu should be shown by mnemonic key press.
-  @author anton.tarasov@...: area=awt.focus
-  @library ../../../regtesthelpers
-  @library /test/lib
-  @build Util
-  @build jdk.test.lib.Platform
-  @run main SubMenuShowTest
-*/
-
 import java.awt.Robot;
 import java.awt.BorderLayout;
 import java.awt.event.KeyEvent;
@@ -48,6 +35,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jdk.test.lib.Platform;
 import test.java.awt.regtesthelpers.Util;
 
+/*
+  @test
+  @key headful
+  @bug 6380743 8158380 8198624
+  @summary Submenu should be shown by mnemonic key press.
+  @library /java/awt/regtesthelpers
+  @library /test/lib
+  @build Util
+  @build jdk.test.lib.Platform
+  @run main SubMenuShowTest
+*/
 public class SubMenuShowTest {
     private static Robot robot;
     private static JFrame frame;
@@ -116,6 +114,8 @@ public class SubMenuShowTest {
     }
 
     public static void doTest() {
+        robot.waitForIdle();
+        robot.delay(1000);
         boolean isMacOSX = Platform.isOSX();
         if (isMacOSX) {
             robot.keyPress(KeyEvent.VK_CONTROL);

--- a/test/jdk/java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java
+++ b/test/jdk/java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,20 +21,6 @@
  * questions.
  */
 
-/*
-  @test
-  @key headful
-  @bug       7154072 7161320
-  @summary   Tests that key events with modifiers are not swallowed.
-  @author    anton.tarasov: area=awt.focus
-  @library   ../../../regtesthelpers
-  @library /test/lib
-  @modules java.desktop/sun.awt
-  @build jdk.test.lib.Platform
-  @build     Util
-  @run       main SwallowKeyEvents
-*/
-
 import jdk.test.lib.Platform;
 import java.awt.AWTException;
 import java.awt.Frame;
@@ -43,6 +29,20 @@ import java.awt.TextField;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import test.java.awt.regtesthelpers.Util;
+
+/*
+  @test
+  @key headful
+  @bug 7154072 7161320
+  @summary Tests that key events with modifiers are not swallowed.
+  @requires (os.family != "windows")
+  @library /java/awt/regtesthelpers
+  @library /test/lib
+  @modules java.desktop/sun.awt
+  @build jdk.test.lib.Platform
+  @build Util
+  @run main SwallowKeyEvents
+*/
 
 public class SwallowKeyEvents {
     static final int PRESS_COUNT = 10;
@@ -83,6 +83,8 @@ public class SwallowKeyEvents {
         });
 
         test();
+        r.waitForIdle();
+        r.delay(500);
 
         System.out.println("key_pressed count: " + keyPressedCount);
 


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8328697](https://bugs.openjdk.org/browse/JDK-8328697) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328697](https://bugs.openjdk.org/browse/JDK-8328697): SubMenuShowTest and SwallowKeyEvents tests stabilization (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3063/head:pull/3063` \
`$ git checkout pull/3063`

Update a local copy of the PR: \
`$ git checkout pull/3063` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3063`

View PR using the GUI difftool: \
`$ git pr show -t 3063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3063.diff">https://git.openjdk.org/jdk17u-dev/pull/3063.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3063#issuecomment-2486489328)
</details>
