### PR TITLE
8274170: Add hooks for custom makefiles to augment jtreg test execution

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -200,9 +200,10 @@ $(eval $(call SetTestOpt,FAILURE_HANDLER_TIMEOUT,JTREG))
 $(eval $(call ParseKeywordVariable, JTREG, \
     SINGLE_KEYWORDS := JOBS TIMEOUT_FACTOR FAILURE_HANDLER_TIMEOUT \
         TEST_MODE ASSERT VERBOSE RETAIN MAX_MEM RUN_PROBLEM_LISTS \
-        RETRY_COUNT REPEAT_COUNT MAX_OUTPUT, \
+        RETRY_COUNT REPEAT_COUNT MAX_OUTPUT $(CUSTOM_JTREG_SINGLE_KEYWORDS), \
     STRING_KEYWORDS := OPTIONS JAVA_OPTIONS VM_OPTIONS KEYWORDS \
-        EXTRA_PROBLEM_LISTS LAUNCHER_OPTIONS, \
+        EXTRA_PROBLEM_LISTS LAUNCHER_OPTIONS\
+	        $(CUSTOM_JTREG_STRING_KEYWORDS), \
 ))
 
 ifneq ($(JTREG), )
@@ -843,6 +844,8 @@ define SetupRunJtregTestBody
     endif
   endif
 
+  $$(eval $$(call SetupRunJtregTestCustom, $1))
+
   clean-outputdirs-$1:
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
 	$$(RM) -r $$($1_TEST_RESULTS_DIR)
@@ -945,7 +948,7 @@ define SetupRunSpecialTestBody
   $1_EXITCODE := $$($1_TEST_RESULTS_DIR)/exitcode.txt
 
   $1_FULL_TEST_NAME := $$(strip $$(patsubst special:%, %, $$($1_TEST)))
-  ifneq ($$(findstring :, $$($1_FULL_TEST_NAME)), )
+  ifneq ($$(findstring:, $$($1_FULL_TEST_NAME)), )
     $1_TEST_NAME := $$(firstword $$(subst :, ,$$($1_FULL_TEST_NAME)))
     $1_TEST_ARGS := $$(strip $$(patsubst special:$$($1_TEST_NAME):%, %, $$($1_TEST)))
   else


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

I had to resolve due to context diffs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8274170](https://bugs.openjdk.org/browse/JDK-8274170) needs maintainer approval

### Issue
 * [JDK-8274170](https://bugs.openjdk.org/browse/JDK-8274170): Add hooks for custom makefiles to augment jtreg test execution (**Enhancement** - P4 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3066/head:pull/3066` \
`$ git checkout pull/3066`

Update a local copy of the PR: \
`$ git checkout pull/3066` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3066`

View PR using the GUI difftool: \
`$ git pr show -t 3066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3066.diff">https://git.openjdk.org/jdk17u-dev/pull/3066.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3066#issuecomment-2488781756)
</details>
