### PR TITLE
8339637: (tz) Update Timezone Data to 2024b

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2024a
+tzdata2024b

--- a/make/data/tzdata/africa
+++ b/make/data/tzdata/africa
@@ -126,17 +126,16 @@ Zone	Africa/Algiers	0:12:12 -	LMT	1891 Mar 16
 
 # Cape Verde / Cabo Verde
 #
-# From Paul Eggert (2018-02-16):
-# Shanks gives 1907 for the transition to +02.
-# For now, ignore that and follow the 1911-05-26 Portuguese decree
-# (see Europe/Lisbon).
+# From Tim Parenti (2024-07-01), per Paul Eggert (2018-02-16):
+# For timestamps before independence, see commentary for Europe/Lisbon.
+# Shanks gives 1907 instead for the transition to -02.
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Atlantic/Cape_Verde -1:34:04 -	LMT	1912 Jan 01  2:00u # Praia
-			-2:00	-	-02	1942 Sep
-			-2:00	1:00	-01	1945 Oct 15
-			-2:00	-	-02	1975 Nov 25  2:00
-			-1:00	-	-01
+			-2:00	-	%z	1942 Sep
+			-2:00	1:00	%z	1945 Oct 15
+			-2:00	-	%z	1975 Nov 25  2:00
+			-1:00	-	%z
 
 # Chad
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
@@ -368,14 +367,12 @@ Zone	Africa/Cairo	2:05:09 -	LMT	1900 Oct
 
 # Guinea-Bissau
 #
-# From Paul Eggert (2018-02-16):
-# Shanks gives 1911-05-26 for the transition to WAT,
-# evidently confusing the date of the Portuguese decree
-# (see Europe/Lisbon) with the date that it took effect.
+# From Tim Parenti (2024-07-01), per Paul Eggert (2018-02-16):
+# For timestamps before independence, see commentary for Europe/Lisbon.
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Bissau	-1:02:20 -	LMT	1912 Jan  1  1:00u
-			-1:00	-	-01	1975
+			-1:00	-	%z	1975
 			 0:00	-	GMT
 
 # Comoros
@@ -440,10 +437,10 @@ Zone	Africa/Bissau	-1:02:20 -	LMT	1912 Jan  1  1:00u
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Nairobi	2:27:16	-	LMT	1908 May
-			2:30	-	+0230	1928 Jun 30 24:00
+			2:30	-	%z	1928 Jun 30 24:00
 			3:00	-	EAT	1930 Jan  4 24:00
-			2:30	-	+0230	1936 Dec 31 24:00
-			2:45	-	+0245	1942 Jul 31 24:00
+			2:30	-	%z	1936 Dec 31 24:00
+			2:45	-	%z	1942 Jul 31 24:00
 			3:00	-	EAT
 
 # Liberia
@@ -614,7 +611,7 @@ Rule Mauritius	2008	only	-	Oct	lastSun	2:00	1:00	-
 Rule Mauritius	2009	only	-	Mar	lastSun	2:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Indian/Mauritius	3:50:00 -	LMT	1907 # Port Louis
-			4:00 Mauritius	+04/+05
+			4:00 Mauritius	%z
 # Agalega Is, Rodriguez
 # no information; probably like Indian/Mauritius
 
@@ -1094,10 +1091,10 @@ Rule	Morocco	2087	only	-	May	11	 2:00	0	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Africa/Casablanca	-0:30:20 -	LMT	1913 Oct 26
-			 0:00	Morocco	+00/+01	1984 Mar 16
-			 1:00	-	+01	1986
-			 0:00	Morocco	+00/+01	2018 Oct 28  3:00
-			 1:00	Morocco	+01/+00
+			 0:00	Morocco	%z	1984 Mar 16
+			 1:00	-	%z	1986
+			 0:00	Morocco	%z	2018 Oct 28  3:00
+			 1:00	Morocco	%z
 
 # Western Sahara
 #
@@ -1111,9 +1108,9 @@ Zone Africa/Casablanca	-0:30:20 -	LMT	1913 Oct 26
 # since most of it was then controlled by Morocco.
 
 Zone Africa/El_Aaiun	-0:52:48 -	LMT	1934 Jan # El Aaiún
-			-1:00	-	-01	1976 Apr 14
-			 0:00	Morocco	+00/+01	2018 Oct 28  3:00
-			 1:00	Morocco	+01/+00
+			-1:00	-	%z	1976 Apr 14
+			 0:00	Morocco	%z	2018 Oct 28  3:00
+			 1:00	Morocco	%z
 
 # Botswana
 # Burundi
@@ -1124,13 +1121,27 @@ Zone Africa/El_Aaiun	-0:52:48 -	LMT	1934 Jan # El Aaiún
 # Zambia
 # Zimbabwe
 #
-# Shanks gives 1903-03-01 for the transition to CAT.
-# Perhaps the 1911-05-26 Portuguese decree
-# https://dre.pt/pdf1sdip/1911/05/12500/23132313.pdf
-# merely made it official?
+# From Tim Parenti (2024-07-01):
+# For timestamps before Mozambique's independence, see commentary for
+# Europe/Lisbon.
+#
+# From Paul Eggert (2024-05-24):
+# The London Gazette, 1903-04-03, page 2245, says that
+# as of 1903-03-03 a time ball at the port of Lourenço Marques
+# (as Maputo was then called) was dropped daily at 13:00:00 LMT,
+# corresponding to 22:49:41.7 GMT, so local time was +02:10:18.3.
+# Conversely, the newspaper South Africa, 1909-02-09, page 321,
+# says the port had just installed an apparatus that communicated
+# "from the controlling clock in the new Observatory at Reuben Point ...
+# exact mean South African time, i.e., 30 deg., or 2 hours East of Greenwich".
+# Although Shanks gives 1903-03-01 for the transition to CAT,
+# evidently the port transitioned to CAT after 1903-03-03 but before
+# the Portuguese legal transition of 1912-01-01 (see Europe/Lisbon commentary).
+# For lack of better info, list 1909 as the transition date.
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Africa/Maputo	2:10:20 -	LMT	1903 Mar
+		#STDOFF	2:10:18.3
+Zone	Africa/Maputo	2:10:18 -	LMT	1909
 			2:00	-	CAT
 
 # Namibia
@@ -1195,7 +1206,7 @@ Rule	Namibia	1995	2017	-	Apr	Sun>=1	2:00	-1:00	WAT
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Africa/Windhoek	1:08:24 -	LMT	1892 Feb 8
-			1:30	-	+0130	1903 Mar
+			1:30	-	%z	1903 Mar
 			2:00	-	SAST	1942 Sep 20  2:00
 			2:00	1:00	SAST	1943 Mar 21  2:00
 			2:00	-	SAST	1990 Mar 21 # independence
@@ -1283,7 +1294,7 @@ Zone	Africa/Windhoek	1:08:24 -	LMT	1892 Feb 8
 Zone	Africa/Lagos	0:13:35 -	LMT	1905 Jul  1
 			0:00	-	GMT	1908 Jul  1
 			0:13:35	-	LMT	1914 Jan  1
-			0:30	-	+0030	1919 Sep  1
+			0:30	-	%z	1919 Sep  1
 			1:00	-	WAT
 
 # São Tomé and Príncipe

--- a/make/data/tzdata/antarctica
+++ b/make/data/tzdata/antarctica
@@ -110,34 +110,34 @@
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Casey	 0	-	-00	1969
-			 8:00	-	+08	2009 Oct 18  2:00
-			11:00	-	+11	2010 Mar  5  2:00
-			 8:00	-	+08	2011 Oct 28  2:00
-			11:00	-	+11	2012 Feb 21 17:00u
-			 8:00	-	+08	2016 Oct 22
-			11:00	-	+11	2018 Mar 11  4:00
-			 8:00	-	+08	2018 Oct  7  4:00
-			11:00	-	+11	2019 Mar 17  3:00
-			 8:00	-	+08	2019 Oct  4  3:00
-			11:00	-	+11	2020 Mar  8  3:00
-			 8:00	-	+08	2020 Oct  4  0:01
-			11:00	-	+11	2021 Mar 14  0:00
-			 8:00	-	+08	2021 Oct  3  0:01
-			11:00	-	+11	2022 Mar 13  0:00
-			 8:00	-	+08	2022 Oct  2  0:01
-			11:00	-	+11	2023 Mar  9  3:00
-			 8:00	-	+08
+			 8:00	-	%z	2009 Oct 18  2:00
+			11:00	-	%z	2010 Mar  5  2:00
+			 8:00	-	%z	2011 Oct 28  2:00
+			11:00	-	%z	2012 Feb 21 17:00u
+			 8:00	-	%z	2016 Oct 22
+			11:00	-	%z	2018 Mar 11  4:00
+			 8:00	-	%z	2018 Oct  7  4:00
+			11:00	-	%z	2019 Mar 17  3:00
+			 8:00	-	%z	2019 Oct  4  3:00
+			11:00	-	%z	2020 Mar  8  3:00
+			 8:00	-	%z	2020 Oct  4  0:01
+			11:00	-	%z	2021 Mar 14  0:00
+			 8:00	-	%z	2021 Oct  3  0:01
+			11:00	-	%z	2022 Mar 13  0:00
+			 8:00	-	%z	2022 Oct  2  0:01
+			11:00	-	%z	2023 Mar  9  3:00
+			 8:00	-	%z
 Zone Antarctica/Davis	0	-	-00	1957 Jan 13
-			7:00	-	+07	1964 Nov
+			7:00	-	%z	1964 Nov
 			0	-	-00	1969 Feb
-			7:00	-	+07	2009 Oct 18  2:00
-			5:00	-	+05	2010 Mar 10 20:00u
-			7:00	-	+07	2011 Oct 28  2:00
-			5:00	-	+05	2012 Feb 21 20:00u
-			7:00	-	+07
+			7:00	-	%z	2009 Oct 18  2:00
+			5:00	-	%z	2010 Mar 10 20:00u
+			7:00	-	%z	2011 Oct 28  2:00
+			5:00	-	%z	2012 Feb 21 20:00u
+			7:00	-	%z
 Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
-			6:00	-	+06	2009 Oct 18  2:00
-			5:00	-	+05
+			6:00	-	%z	2009 Oct 18  2:00
+			5:00	-	%z
 # References:
 # Casey Weather (1998-02-26)
 # http://www.antdiv.gov.au/aad/exop/sfo/casey/casey_aws.html
@@ -313,10 +313,10 @@ Zone Antarctica/Troll	0	-	-00	2005 Feb 12
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Vostok	0	-	-00	1957 Dec 16
-			7:00	-	+07	1994 Feb
+			7:00	-	%z	1994 Feb
 			0	-	-00	1994 Nov
-			7:00	-	+07	2023 Dec 18  2:00
-			5:00	-	+05
+			7:00	-	%z	2023 Dec 18  2:00
+			5:00	-	%z
 
 # S Africa - year-round bases
 # Marion Island, -4653+03752
@@ -349,7 +349,7 @@ Zone Antarctica/Vostok	0	-	-00	1957 Dec 16
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
-			-3:00	-	-03
+			-3:00	-	%z
 
 # Uruguay - year round base
 # Artigas, King George Island, -621104-0585107

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -106,8 +106,8 @@ Rule RussiaAsia	1996	2010	-	Oct	lastSun	 2:00s	0	-
 # Afghanistan
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Kabul	4:36:48 -	LMT	1890
-			4:00	-	+04	1945
-			4:30	-	+0430
+			4:00	-	%z	1945
+			4:30	-	%z
 
 # Armenia
 # From Paul Eggert (2006-03-22):
@@ -139,12 +139,12 @@ Rule Armenia	2011	only	-	Mar	lastSun	 2:00s	1:00	-
 Rule Armenia	2011	only	-	Oct	lastSun	 2:00s	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Yerevan	2:58:00 -	LMT	1924 May  2
-			3:00	-	+03	1957 Mar
-			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
-			3:00 RussiaAsia	+03/+04	1995 Sep 24  2:00s
-			4:00	-	+04	1997
-			4:00 RussiaAsia	+04/+05	2011
-			4:00	Armenia	+04/+05
+			3:00	-	%z	1957 Mar
+			4:00 RussiaAsia %z	1991 Mar 31  2:00s
+			3:00 RussiaAsia	%z	1995 Sep 24  2:00s
+			4:00	-	%z	1997
+			4:00 RussiaAsia	%z	2011
+			4:00	Armenia	%z
 
 # Azerbaijan
 
@@ -165,12 +165,12 @@ Rule	Azer	1997	2015	-	Mar	lastSun	 4:00	1:00	-
 Rule	Azer	1997	2015	-	Oct	lastSun	 5:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Baku	3:19:24 -	LMT	1924 May  2
-			3:00	-	+03	1957 Mar
-			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
-			3:00 RussiaAsia	+03/+04	1992 Sep lastSun  2:00s
-			4:00	-	+04	1996
-			4:00	EUAsia	+04/+05	1997
-			4:00	Azer	+04/+05
+			3:00	-	%z	1957 Mar
+			4:00 RussiaAsia %z	1991 Mar 31  2:00s
+			3:00 RussiaAsia	%z	1992 Sep lastSun  2:00s
+			4:00	-	%z	1996
+			4:00	EUAsia	%z	1997
+			4:00	Azer	%z
 
 # Bangladesh
 # From Alexander Krivenyshev (2009-05-13):
@@ -251,17 +251,17 @@ Rule	Dhaka	2009	only	-	Dec	31	24:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dhaka	6:01:40 -	LMT	1890
 			5:53:20	-	HMT	1941 Oct    # Howrah Mean Time?
-			6:30	-	+0630	1942 May 15
-			5:30	-	+0530	1942 Sep
-			6:30	-	+0630	1951 Sep 30
-			6:00	-	+06	2009
-			6:00	Dhaka	+06/+07
+			6:30	-	%z	1942 May 15
+			5:30	-	%z	1942 Sep
+			6:30	-	%z	1951 Sep 30
+			6:00	-	%z	2009
+			6:00	Dhaka	%z
 
 # Bhutan
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Thimphu	5:58:36 -	LMT	1947 Aug 15 # or Thimbu
-			5:30	-	+0530	1987 Oct
-			6:00	-	+06
+			5:30	-	%z	1987 Oct
+			6:00	-	%z
 
 # British Indian Ocean Territory
 # Whitman and the 1995 CIA time zone map say 5:00, but the
@@ -271,8 +271,8 @@ Zone	Asia/Thimphu	5:58:36 -	LMT	1947 Aug 15 # or Thimbu
 # then contained the Chagos Archipelago).
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Indian/Chagos	4:49:40	-	LMT	1907
-			5:00	-	+05	1996
-			6:00	-	+06
+			5:00	-	%z	1996
+			6:00	-	%z
 
 # Cocos (Keeling) Islands
 # Myanmar (Burma)
@@ -288,9 +288,9 @@ Zone	Indian/Chagos	4:49:40	-	LMT	1907
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Yangon	6:24:47 -	LMT	1880        # or Rangoon
 			6:24:47	-	RMT	1920        # Rangoon local time
-			6:30	-	+0630	1942 May
-			9:00	-	+09	1945 May  3
-			6:30	-	+0630
+			6:30	-	%z	1942 May
+			9:00	-	%z	1945 May  3
+			6:30	-	%z
 
 # China
 
@@ -679,7 +679,7 @@ Zone	Asia/Shanghai	8:05:43	-	LMT	1901
 # Xinjiang time, used by many in western China; represented by Ürümqi / Ürümchi
 # / Wulumuqi.  (Please use Asia/Shanghai if you prefer Beijing time.)
 Zone	Asia/Urumqi	5:50:20	-	LMT	1928
-			6:00	-	+06
+			6:00	-	%z
 
 # Hong Kong
 
@@ -1137,7 +1137,7 @@ Rule	Macau	1979	only	-	Oct	Sun>=16	03:30	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Macau	7:34:10 -	LMT	1904 Oct 30
 			8:00	-	CST	1941 Dec 21 23:00
-			9:00	Macau	+09/+10	1945 Sep 30 24:00
+			9:00	Macau	%z	1945 Sep 30 24:00
 			8:00	Macau	C%sT
 
 
@@ -1180,7 +1180,7 @@ Zone	Asia/Nicosia	2:13:28 -	LMT	1921 Nov 14
 Zone	Asia/Famagusta	2:15:48	-	LMT	1921 Nov 14
 			2:00	Cyprus	EE%sT	1998 Sep
 			2:00	EUAsia	EE%sT	2016 Sep  8
-			3:00	-	+03	2017 Oct 29 1:00u
+			3:00	-	%z	2017 Oct 29 1:00u
 			2:00	EUAsia	EE%sT
 
 # Georgia
@@ -1221,17 +1221,24 @@ Zone	Asia/Famagusta	2:15:48	-	LMT	1921 Nov 14
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Tbilisi	2:59:11 -	LMT	1880
 			2:59:11	-	TBMT	1924 May  2 # Tbilisi Mean Time
-			3:00	-	+03	1957 Mar
-			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
-			3:00 RussiaAsia +03/+04	1992
-			3:00 E-EurAsia	+03/+04	1994 Sep lastSun
-			4:00 E-EurAsia	+04/+05	1996 Oct lastSun
-			4:00	1:00	+05	1997 Mar lastSun
-			4:00 E-EurAsia	+04/+05	2004 Jun 27
-			3:00 RussiaAsia	+03/+04	2005 Mar lastSun  2:00
-			4:00	-	+04
+			3:00	-	%z	1957 Mar
+			4:00 RussiaAsia %z	1991 Mar 31  2:00s
+			3:00 RussiaAsia %z	1992
+			3:00 E-EurAsia	%z	1994 Sep lastSun
+			4:00 E-EurAsia	%z	1996 Oct lastSun
+			4:00	1:00	%z	1997 Mar lastSun
+			4:00 E-EurAsia	%z	2004 Jun 27
+			3:00 RussiaAsia	%z	2005 Mar lastSun  2:00
+			4:00	-	%z
 
 # East Timor
+
+# From Tim Parenti (2024-07-01):
+# The 1912-01-01 transition occurred at 00:00 new time, per the 1911-05-24
+# Portuguese decree (see Europe/Lisbon).  A provision in article 5(c) of the
+# decree prescribed that Timor "will keep counting time in harmony with
+# neighboring foreign colonies, [for] as long as they do not adopt the time
+# that belongs to them in [the Washington Convention] system."
 
 # See Indonesia for the 1945 transition.
 
@@ -1256,11 +1263,11 @@ Zone	Asia/Tbilisi	2:59:11 -	LMT	1880
 # midnight on Saturday, September 16.
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Dili	8:22:20 -	LMT	1912 Jan  1
-			8:00	-	+08	1942 Feb 21 23:00
-			9:00	-	+09	1976 May  3
-			8:00	-	+08	2000 Sep 17  0:00
-			9:00	-	+09
+Zone	Asia/Dili	8:22:20 -	LMT	1911 Dec 31 16:00u
+			8:00	-	%z	1942 Feb 21 23:00
+			9:00	-	%z	1976 May  3
+			8:00	-	%z	2000 Sep 17  0:00
+			9:00	-	%z
 
 # India
 
@@ -1326,9 +1333,9 @@ Zone	Asia/Kolkata	5:53:28 -	LMT	1854 Jun 28 # Kolkata
 			5:53:20	-	HMT	1870	    # Howrah Mean Time?
 			5:21:10	-	MMT	1906 Jan  1 # Madras local time
 			5:30	-	IST	1941 Oct
-			5:30	1:00	+0630	1942 May 15
+			5:30	1:00	%z	1942 May 15
 			5:30	-	IST	1942 Sep
-			5:30	1:00	+0630	1945 Oct 15
+			5:30	1:00	%z	1945 Oct 15
 			5:30	-	IST
 # Since 1970 the following are like Asia/Kolkata:
 #	Andaman Is
@@ -1380,33 +1387,33 @@ Zone Asia/Jakarta	7:07:12 -	LMT	1867 Aug 10
 # Shanks & Pottenger say the next transition was at 1924 Jan 1 0:13,
 # but this must be a typo.
 			7:07:12	-	BMT	1923 Dec 31 16:40u # Batavia
-			7:20	-	+0720	1932 Nov
-			7:30	-	+0730	1942 Mar 23
-			9:00	-	+09	1945 Sep 23
-			7:30	-	+0730	1948 May
-			8:00	-	+08	1950 May
-			7:30	-	+0730	1964
+			7:20	-	%z	1932 Nov
+			7:30	-	%z	1942 Mar 23
+			9:00	-	%z	1945 Sep 23
+			7:30	-	%z	1948 May
+			8:00	-	%z	1950 May
+			7:30	-	%z	1964
 			7:00	-	WIB
 # west and central Borneo
 Zone Asia/Pontianak	7:17:20	-	LMT	1908 May
 			7:17:20	-	PMT	1932 Nov    # Pontianak MT
-			7:30	-	+0730	1942 Jan 29
-			9:00	-	+09	1945 Sep 23
-			7:30	-	+0730	1948 May
-			8:00	-	+08	1950 May
-			7:30	-	+0730	1964
+			7:30	-	%z	1942 Jan 29
+			9:00	-	%z	1945 Sep 23
+			7:30	-	%z	1948 May
+			8:00	-	%z	1950 May
+			7:30	-	%z	1964
 			8:00	-	WITA	1988 Jan  1
 			7:00	-	WIB
 # Sulawesi, Lesser Sundas, east and south Borneo
 Zone Asia/Makassar	7:57:36 -	LMT	1920
 			7:57:36	-	MMT	1932 Nov    # Macassar MT
-			8:00	-	+08	1942 Feb  9
-			9:00	-	+09	1945 Sep 23
+			8:00	-	%z	1942 Feb  9
+			9:00	-	%z	1945 Sep 23
 			8:00	-	WITA
 # Maluku Islands, West Papua, Papua
 Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
-			9:00	-	+09	1944 Sep  1
-			9:30	-	+0930	1964
+			9:00	-	%z	1944 Sep  1
+			9:30	-	%z	1964
 			9:00	-	WIT
 
 # Iran
@@ -1642,9 +1649,9 @@ Rule	Iran	2021	2022	-	Sep	21	24:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Tehran	3:25:44	-	LMT	1916
 			3:25:44	-	TMT	1935 Jun 13 # Tehran Mean Time
-			3:30	Iran	+0330/+0430 1977 Oct 20 24:00
-			4:00	Iran	+04/+05	1979
-			3:30	Iran	+0330/+0430
+			3:30	Iran	%z	1977 Oct 20 24:00
+			4:00	Iran	%z	1979
+			3:30	Iran	%z
 
 
 # Iraq
@@ -1687,8 +1694,8 @@ Rule	Iraq	1991	2007	-	Oct	 1	3:00s	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Baghdad	2:57:40	-	LMT	1890
 			2:57:36	-	BMT	1918     # Baghdad Mean Time?
-			3:00	-	+03	1982 May
-			3:00	Iraq	+03/+04
+			3:00	-	%z	1982 May
+			3:00	Iraq	%z
 
 
 ###############################################################################
@@ -2285,7 +2292,7 @@ Rule	Jordan	2022	only	-	Feb	lastThu	24:00	1:00	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Amman	2:23:44 -	LMT	1931
 			2:00	Jordan	EE%sT	2022 Oct 28 0:00s
-			3:00	-	+03
+			3:00	-	%z
 
 
 # Kazakhstan
@@ -2496,88 +2503,88 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # Almaty (formerly Alma-Ata), representing most locations in Kazakhstan
 # This includes Abai/Abay (ISO 3166-2 code KZ-10), Aqmola/Akmola (KZ-11),
 # Almaty (KZ-19), Almaty city (KZ-75), Astana city (KZ-71),
-# East Kazkhstan (KZ-63), Jambyl/Zhambyl (KZ-31), Jetisu/Zhetysu (KZ-33),
+# East Kazakhstan (KZ-63), Jambyl/Zhambyl (KZ-31), Jetisu/Zhetysu (KZ-33),
 # Karaganda (KZ-35), North Kazakhstan (KZ-59), Pavlodar (KZ-55),
-# Shyumkent city (KZ-79), Turkistan (KZ-61), and Ulytau (KZ-62).
+# Shymkent city (KZ-79), Turkistan (KZ-61), and Ulytau (KZ-62).
 Zone	Asia/Almaty	5:07:48 -	LMT	1924 May  2 # or Alma-Ata
-			5:00	-	+05	1930 Jun 21
-			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
-			5:00 RussiaAsia	+05/+06	1992 Jan 19  2:00s
-			6:00 RussiaAsia	+06/+07	2004 Oct 31  2:00s
-			6:00	-	+06	2024 Mar  1  0:00
-			5:00	-	+05
+			5:00	-	%z	1930 Jun 21
+			6:00 RussiaAsia %z	1991 Mar 31  2:00s
+			5:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			6:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			6:00	-	%z	2024 Mar  1  0:00
+			5:00	-	%z
 # Qyzylorda (aka Kyzylorda, Kizilorda, Kzyl-Orda, etc.) (KZ-43)
 Zone	Asia/Qyzylorda	4:21:52 -	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
-			4:00 RussiaAsia	+04/+05	1991 Sep 29  2:00s
-			5:00 RussiaAsia	+05/+06	1992 Jan 19  2:00s
-			6:00 RussiaAsia	+06/+07	1992 Mar 29  2:00s
-			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
-			6:00	-	+06	2018 Dec 21  0:00
-			5:00	-	+05
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1991 Sep 29  2:00s
+			5:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			6:00 RussiaAsia	%z	1992 Mar 29  2:00s
+			5:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			6:00	-	%z	2018 Dec 21  0:00
+			5:00	-	%z
 # Qostanay (aka Kostanay, Kustanay) (KZ-39)
 # The 1991/2 rules are unclear partly because of the 1997 Turgai
 # reorganization.
 Zone	Asia/Qostanay	4:14:28 -	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
-			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
-			6:00	-	+06	2024 Mar  1  0:00
-			5:00	-	+05
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			6:00	-	%z	2024 Mar  1  0:00
+			5:00	-	%z
 # Aqtöbe (aka Aktobe, formerly Aktyubinsk) (KZ-15)
 Zone	Asia/Aqtobe	3:48:40	-	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
-			5:00 RussiaAsia	+05/+06	2004 Oct 31  2:00s
-			5:00	-	+05
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			5:00	-	%z
 # Mangghystaū (KZ-47)
 # Aqtau was not founded until 1963, but it represents an inhabited region,
 # so include timestamps before 1963.
 Zone	Asia/Aqtau	3:21:04	-	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
-			5:00 RussiaAsia	+05/+06	1994 Sep 25  2:00s
-			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
-			5:00	-	+05
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	1994 Sep 25  2:00s
+			4:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			5:00	-	%z
 # Atyraū (KZ-23) is like Mangghystaū except it switched from
 # +04/+05 to +05/+06 in spring 1999, not fall 1994.
 Zone	Asia/Atyrau	3:27:44	-	LMT	1924 May  2
-			3:00	-	+03	1930 Jun 21
-			5:00	-	+05	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00s
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
-			5:00 RussiaAsia	+05/+06	1999 Mar 28  2:00s
-			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
-			5:00	-	+05
+			3:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	1999 Mar 28  2:00s
+			4:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			5:00	-	%z
 # West Kazakhstan (KZ-27)
 # From Paul Eggert (2016-03-18):
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 Zone	Asia/Oral	3:25:24	-	LMT	1924 May  2 # or Ural'sk
-			3:00	-	+03	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1989 Mar 26  2:00s
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00s
-			5:00 RussiaAsia	+05/+06	1992 Mar 29  2:00s
-			4:00 RussiaAsia	+04/+05	2004 Oct 31  2:00s
-			5:00	-	+05
+			3:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1989 Mar 26  2:00s
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00s
+			5:00 RussiaAsia	%z	1992 Mar 29  2:00s
+			4:00 RussiaAsia	%z	2004 Oct 31  2:00s
+			5:00	-	%z
 
 # Kyrgyzstan (Kirgizstan)
 # Transitions through 1991 are from Shanks & Pottenger.
@@ -2598,11 +2605,11 @@ Rule	Kyrgyz	1997	2005	-	Mar	lastSun	2:30	1:00	-
 Rule	Kyrgyz	1997	2004	-	Oct	lastSun	2:30	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Bishkek	4:58:24 -	LMT	1924 May  2
-			5:00	-	+05	1930 Jun 21
-			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
-			5:00 RussiaAsia	+05/+06	1991 Aug 31  2:00
-			5:00	Kyrgyz	+05/+06	2005 Aug 12
-			6:00	-	+06
+			5:00	-	%z	1930 Jun 21
+			6:00 RussiaAsia %z	1991 Mar 31  2:00s
+			5:00 RussiaAsia	%z	1991 Aug 31  2:00
+			5:00	Kyrgyz	%z	2005 Aug 12
+			6:00	-	%z
 
 ###############################################################################
 
@@ -2809,16 +2816,16 @@ Rule	NBorneo	1935	1941	-	Dec	14	0:00	0	-
 # and 1982 transition dates are from Mok Ly Yng.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Asia/Kuching	7:21:20	-	LMT	1926 Mar
-			7:30	-	+0730	1933
-			8:00 NBorneo  +08/+0820	1942 Feb 16
-			9:00	-	+09	1945 Sep 12
-			8:00	-	+08
+			7:30	-	%z	1933
+			8:00 NBorneo	%z	1942 Feb 16
+			9:00	-	%z	1945 Sep 12
+			8:00	-	%z
 
 # Maldives
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Malé
 			4:54:00	-	MMT	1960 # Malé Mean Time
-			5:00	-	+05
+			5:00	-	%z
 
 # Mongolia
 
@@ -2920,9 +2927,37 @@ Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Malé
 
 # From Arthur David Olson (2008-05-19):
 # Assume that Choibalsan is indeed offset by 8:00.
-# XXX--in the absence of better information, assume that transition
-# was at the start of 2008-03-31 (the day of Steffen Thorsen's report);
-# this is almost surely wrong.
+
+# From Heitor David Pinto (2024-06-23):
+# Sources about time zones in Mongolia seem to list one of two conflicting
+# configurations.  The first configuration, mentioned in a comment to the TZ
+# database in 1999, citing a Mongolian government website, lists the provinces
+# of Bayan-Ölgii, Khovd and Uvs in UTC+7, and the rest of the country in
+# UTC+8.  The second configuration, mentioned in a comment to the database in
+# 2001, lists Bayan-Ölgii, Khovd, Uvs, Govi-Altai and Zavkhan in UTC+7, Dornod
+# and Sükhbaatar in UTC+9, and the rest of the country in UTC+8.
+#
+# The first configuration is still mentioned by several Mongolian travel
+# agencies:
+# https://www.adventurerider.mn/en/page/about_mongolia
+# http://www.naturetours.mn/nt/mongolia.php
+# https://www.newjuulchin.mn/web/content/7506?unique=fa24a0f6e96e022a3578ee5195ac879638c734ce
+#
+# It also matches these flight schedules in 2013:
+# http://web.archive.org/web/20130722023600/https://www.hunnuair.com/en/timetabled
+# The flight times imply that the airports of Uliastai (Zavkhan), Choibalsan
+# (Dornod) and Altai (Govi-Altai) are in the same time zone as Ulaanbaatar,
+# and Khovd is one hour behind....
+#
+# The second configuration was mentioned by an official of the Mongolian
+# standards agency in an interview in 2014: https://ikon.mn/n/9v6
+# And it's still listed by the Mongolian aviation agency:
+# https://ais.mn/files/aip/eAIP/2023-12-25/html/eSUP/ZM-eSUP-23-04-en-MN.html
+#
+# ... I believe that the first configuration is what is actually observed in
+# Mongolia and has been so all along, at least since 1999.  The second
+# configuration closely matches the ideal time zone boundaries at 97.5° E and
+# 112.5° E but it doesn't seem to be used in practice.
 
 # From Ganbold Tsagaankhuu (2015-03-10):
 # It seems like yesterday Mongolian Government meeting has concluded to use
@@ -2961,25 +2996,18 @@ Rule	Mongol	2015	2016	-	Sep	lastSat	0:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Hovd, a.k.a. Chovd, Dund-Us, Dzhargalant, Khovd, Jirgalanta
 Zone	Asia/Hovd	6:06:36 -	LMT	1905 Aug
-			6:00	-	+06	1978
-			7:00	Mongol	+07/+08
+			6:00	-	%z	1978
+			7:00	Mongol	%z
 # Ulaanbaatar, a.k.a. Ulan Bataar, Ulan Bator, Urga
 Zone	Asia/Ulaanbaatar 7:07:32 -	LMT	1905 Aug
-			7:00	-	+07	1978
-			8:00	Mongol	+08/+09
-# Choibalsan, a.k.a. Bajan Tümen, Bajan Tumen, Chojbalsan,
-# Choybalsan, Sanbejse, Tchoibalsan
-Zone	Asia/Choibalsan	7:38:00 -	LMT	1905 Aug
-			7:00	-	+07	1978
-			8:00	-	+08	1983 Apr
-			9:00	Mongol	+09/+10	2008 Mar 31
-			8:00	Mongol	+08/+09
+			7:00	-	%z	1978
+			8:00	Mongol	%z
 
 # Nepal
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Kathmandu	5:41:16 -	LMT	1920
-			5:30	-	+0530	1986
-			5:45	-	+0545
+			5:30	-	%z	1986
+			5:45	-	%z
 
 # Pakistan
 
@@ -3125,10 +3153,10 @@ Rule Pakistan	2009	only	-	Apr	15	0:00	1:00	S
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Karachi	4:28:12 -	LMT	1907
-			5:30	-	+0530	1942 Sep
-			5:30	1:00	+0630	1945 Oct 15
-			5:30	-	+0530	1951 Sep 30
-			5:00	-	+05	1971 Mar 26
+			5:30	-	%z	1942 Sep
+			5:30	1:00	%z	1945 Oct 15
+			5:30	-	%z	1951 Sep 30
+			5:00	-	%z	1971 Mar 26
 			5:00 Pakistan	PK%sT	# Pakistan Time
 
 # Palestine
@@ -3676,14 +3704,14 @@ Zone	Asia/Hebron	2:20:23	-	LMT	1900 Oct
 # Philippine Star 2014-08-05
 # http://www.philstar.com/headlines/2014/08/05/1354152/pnoy-urged-declare-use-daylight-saving-time
 
-# From Paul Goyette (2018-06-15):
+# From Paul Goyette (2018-06-15) with URLs updated by Guy Harris (2024-02-15):
 # In the Philippines, there is a national law, Republic Act No. 10535
 # which declares the official time here as "Philippine Standard Time".
 # The act [1] even specifies use of PST as the abbreviation, although
 # the FAQ provided by PAGASA [2] uses the "acronym PhST to distinguish
 # it from the Pacific Standard Time (PST)."
-# [1] http://www.officialgazette.gov.ph/2013/05/15/republic-act-no-10535/
-# [2] https://www1.pagasa.dost.gov.ph/index.php/astronomy/philippine-standard-time#republic-act-10535
+# [1] https://www.officialgazette.gov.ph/2013/05/15/republic-act-no-10535/
+# [2] https://prsd.pagasa.dost.gov.ph/index.php/28-astronomy/302-philippine-standard-time
 #
 # From Paul Eggert (2018-06-19):
 # I surveyed recent news reports, and my impression is that "PST" is
@@ -3716,8 +3744,8 @@ Zone	Asia/Manila	-15:56:00 -	LMT	1844 Dec 31
 # Qatar
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Qatar	3:26:08 -	LMT	1920     # Al Dawhah / Doha
-			4:00	-	+04	1972 Jun
-			3:00	-	+03
+			4:00	-	%z	1972 Jun
+			3:00	-	%z
 
 # Kuwait
 # Saudi Arabia
@@ -3767,7 +3795,7 @@ Zone	Asia/Qatar	3:26:08 -	LMT	1920     # Al Dawhah / Doha
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Riyadh	3:06:52 -	LMT	1947 Mar 14
-			3:00	-	+03
+			3:00	-	%z
 
 # Singapore
 # taken from Mok Ly Yng (2003-10-30)
@@ -3775,13 +3803,13 @@ Zone	Asia/Riyadh	3:06:52 -	LMT	1947 Mar 14
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Singapore	6:55:25 -	LMT	1901 Jan  1
 			6:55:25	-	SMT	1905 Jun  1 # Singapore M.T.
-			7:00	-	+07	1933 Jan  1
-			7:00	0:20	+0720	1936 Jan  1
-			7:20	-	+0720	1941 Sep  1
-			7:30	-	+0730	1942 Feb 16
-			9:00	-	+09	1945 Sep 12
-			7:30	-	+0730	1981 Dec 31 16:00u
-			8:00	-	+08
+			7:00	-	%z	1933 Jan  1
+			7:00	0:20	%z	1936 Jan  1
+			7:20	-	%z	1941 Sep  1
+			7:30	-	%z	1942 Feb 16
+			9:00	-	%z	1945 Sep 12
+			7:30	-	%z	1981 Dec 31 16:00u
+			8:00	-	%z
 
 # Spratly Is
 # no information
@@ -3839,13 +3867,13 @@ Zone	Asia/Singapore	6:55:25 -	LMT	1901 Jan  1
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Colombo	5:19:24 -	LMT	1880
 			5:19:32	-	MMT	1906        # Moratuwa Mean Time
-			5:30	-	+0530	1942 Jan  5
-			5:30	0:30	+06	1942 Sep
-			5:30	1:00	+0630	1945 Oct 16  2:00
-			5:30	-	+0530	1996 May 25  0:00
-			6:30	-	+0630	1996 Oct 26  0:30
-			6:00	-	+06	2006 Apr 15  0:30
-			5:30	-	+0530
+			5:30	-	%z	1942 Jan  5
+			5:30	0:30	%z	1942 Sep
+			5:30	1:00	%z	1945 Oct 16  2:00
+			5:30	-	%z	1996 May 25  0:00
+			6:30	-	%z	1996 Oct 26  0:30
+			6:00	-	%z	2006 Apr 15  0:30
+			5:30	-	%z
 
 # Syria
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
@@ -4016,16 +4044,16 @@ Rule	Syria	2009	2022	-	Oct	lastFri	0:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Damascus	2:25:12 -	LMT	1920 # Dimashq
 			2:00	Syria	EE%sT	2022 Oct 28 0:00
-			3:00	-	+03
+			3:00	-	%z
 
 # Tajikistan
 # From Shanks & Pottenger.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dushanbe	4:35:12 -	LMT	1924 May  2
-			5:00	-	+05	1930 Jun 21
-			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
-			5:00	1:00	+06	1991 Sep  9  2:00s
-			5:00	-	+05
+			5:00	-	%z	1930 Jun 21
+			6:00 RussiaAsia %z	1991 Mar 31  2:00s
+			5:00	1:00	%z	1991 Sep  9  2:00s
+			5:00	-	%z
 
 # Cambodia
 # Christmas I
@@ -4035,16 +4063,16 @@ Zone	Asia/Dushanbe	4:35:12 -	LMT	1924 May  2
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Bangkok	6:42:04	-	LMT	1880
 			6:42:04	-	BMT	1920 Apr # Bangkok Mean Time
-			7:00	-	+07
+			7:00	-	%z
 
 # Turkmenistan
 # From Shanks & Pottenger.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Ashgabat	3:53:32 -	LMT	1924 May  2 # or Ashkhabad
-			4:00	-	+04	1930 Jun 21
-			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00
-			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00
-			5:00	-	+05
+			4:00	-	%z	1930 Jun 21
+			5:00 RussiaAsia	%z	1991 Mar 31  2:00
+			4:00 RussiaAsia	%z	1992 Jan 19  2:00
+			5:00	-	%z
 
 # Oman
 # Réunion
@@ -4054,25 +4082,25 @@ Zone	Asia/Ashgabat	3:53:32 -	LMT	1924 May  2 # or Ashkhabad
 # The Crozet Is also observe Réunion time; see the 'antarctica' file.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dubai	3:41:12 -	LMT	1920
-			4:00	-	+04
+			4:00	-	%z
 
 # Uzbekistan
 # Byalokoz 1919 says Uzbekistan was 4:27:53.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Samarkand	4:27:53 -	LMT	1924 May  2
-			4:00	-	+04	1930 Jun 21
-			5:00	-	+05	1981 Apr  1
-			5:00	1:00	+06	1981 Oct  1
-			6:00	-	+06	1982 Apr  1
-			5:00 RussiaAsia	+05/+06	1992
-			5:00	-	+05
+			4:00	-	%z	1930 Jun 21
+			5:00	-	%z	1981 Apr  1
+			5:00	1:00	%z	1981 Oct  1
+			6:00	-	%z	1982 Apr  1
+			5:00 RussiaAsia	%z	1992
+			5:00	-	%z
 # Milne says Tashkent was 4:37:10.8.
 		#STDOFF	4:37:10.8
 Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
-			5:00	-	+05	1930 Jun 21
-			6:00 RussiaAsia	+06/+07	1991 Mar 31  2:00
-			5:00 RussiaAsia	+05/+06	1992
-			5:00	-	+05
+			5:00	-	%z	1930 Jun 21
+			6:00 RussiaAsia	%z	1991 Mar 31  2:00
+			5:00 RussiaAsia	%z	1992
+			5:00	-	%z
 
 # Vietnam (southern)
 
@@ -4130,7 +4158,7 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 # Võ Nguyên Giáp, Việt Nam Dân Quốc Công Báo, No. 1 (1945-09-29), page 13
 # http://baochi.nlv.gov.vn/baochi/cgi-bin/baochi?a=d&d=JwvzO19450929.2.5&dliv=none
 # It says that on 1945-09-01 at 24:00, Vietnam moved back two hours, to +07.
-# It also mentions a 1945-03-29 decree (by a Japanese Goveror-General)
+# It also mentions a 1945-03-29 decree (by a Japanese Governor-General)
 # to set the time zone to +09, but does not say whether that decree
 # merely legalized an earlier change to +09.
 #
@@ -4151,14 +4179,14 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 		#STDOFF	7:06:30.13
 Zone Asia/Ho_Chi_Minh	7:06:30 -	LMT	1906 Jul  1
 			7:06:30	-	PLMT	1911 May  1 # Phù Liễn MT
-			7:00	-	+07	1942 Dec 31 23:00
-			8:00	-	+08	1945 Mar 14 23:00
-			9:00	-	+09	1945 Sep  1 24:00
-			7:00	-	+07	1947 Apr  1
-			8:00	-	+08	1955 Jul  1 01:00
-			7:00	-	+07	1959 Dec 31 23:00
-			8:00	-	+08	1975 Jun 13
-			7:00	-	+07
+			7:00	-	%z	1942 Dec 31 23:00
+			8:00	-	%z	1945 Mar 14 23:00
+			9:00	-	%z	1945 Sep  1 24:00
+			7:00	-	%z	1947 Apr  1
+			8:00	-	%z	1955 Jul  1 01:00
+			7:00	-	%z	1959 Dec 31 23:00
+			8:00	-	%z	1975 Jun 13
+			7:00	-	%z
 
 # From Paul Eggert (2019-02-19):
 #

--- a/make/data/tzdata/australasia
+++ b/make/data/tzdata/australasia
@@ -66,8 +66,8 @@ Zone Australia/Perth	 7:43:24 -	LMT	1895 Dec
 			 8:00	Aus	AW%sT	1943 Jul
 			 8:00	AW	AW%sT
 Zone Australia/Eucla	 8:35:28 -	LMT	1895 Dec
-			 8:45	Aus +0845/+0945	1943 Jul
-			 8:45	AW  +0845/+0945
+			 8:45	Aus	%z	1943 Jul
+			 8:45	AW	%z
 
 # Queensland
 #
@@ -232,8 +232,8 @@ Rule	LH	2008	max	-	Apr	Sun>=1	2:00	0	-
 Rule	LH	2008	max	-	Oct	Sun>=1	2:00	0:30	-
 Zone Australia/Lord_Howe 10:36:20 -	LMT	1895 Feb
 			10:00	-	AEST	1981 Mar
-			10:30	LH	+1030/+1130 1985 Jul
-			10:30	LH	+1030/+11
+			10:30	LH	%z	1985 Jul
+			10:30	LH	%z
 
 # Australian miscellany
 #
@@ -439,16 +439,16 @@ Rule	Fiji	2019	only	-	Nov	Sun>=8	2:00	1:00	-
 Rule	Fiji	2020	only	-	Dec	20	2:00	1:00	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fiji	11:55:44 -	LMT	1915 Oct 26 # Suva
-			12:00	Fiji	+12/+13
+			12:00	Fiji	%z
 
 # French Polynesia
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Gambier	 -8:59:48 -	LMT	1912 Oct  1 # Rikitea
-			 -9:00	-	-09
+			 -9:00	-	%z
 Zone	Pacific/Marquesas -9:18:00 -	LMT	1912 Oct  1
-			 -9:30	-	-0930
+			 -9:30	-	%z
 Zone	Pacific/Tahiti	 -9:58:16 -	LMT	1912 Oct  1 # Papeete
-			-10:00	-	-10
+			-10:00	-	%z
 # Clipperton (near North America) is administered from French Polynesia;
 # it is uninhabited.
 
@@ -491,7 +491,7 @@ Rule	Guam	1977	only	-	Aug	28	2:00	0	S
 Zone	Pacific/Guam	-14:21:00 -	LMT	1844 Dec 31
 			 9:39:00 -	LMT	1901        # Agana
 			10:00	-	GST	1941 Dec 10 # Guam
-			 9:00	-	+09	1944 Jul 31
+			 9:00	-	%z	1944 Jul 31
 			10:00	Guam	G%sT	2000 Dec 23
 			10:00	-	ChST	# Chamorro Standard Time
 
@@ -503,30 +503,30 @@ Zone	Pacific/Guam	-14:21:00 -	LMT	1844 Dec 31
 # Wallis & Futuna
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Tarawa	 11:32:04 -	LMT	1901 # Bairiki
-			 12:00	-	+12
+			 12:00	-	%z
 
 # Kiribati (except Gilbert Is)
 # See Pacific/Tarawa for the Gilbert Is.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Kanton	  0	-	-00	1937 Aug 31
-			-12:00	-	-12	1979 Oct
-			-11:00	-	-11	1994 Dec 31
-			 13:00	-	+13
+			-12:00	-	%z	1979 Oct
+			-11:00	-	%z	1994 Dec 31
+			 13:00	-	%z
 Zone Pacific/Kiritimati	-10:29:20 -	LMT	1901
-			-10:40	-	-1040	1979 Oct
-			-10:00	-	-10	1994 Dec 31
-			 14:00	-	+14
+			-10:40	-	%z	1979 Oct
+			-10:00	-	%z	1994 Dec 31
+			 14:00	-	%z
 
 # Marshall Is
 # See Pacific/Tarawa for most locations.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Kwajalein	 11:09:20 -	LMT	1901
-			 11:00	-	+11	1937
-			 10:00	-	+10	1941 Apr  1
-			  9:00	-	+09	1944 Feb  6
-			 11:00	-	+11	1969 Oct
-			-12:00	-	-12	1993 Aug 20 24:00
-			 12:00	-	+12
+			 11:00	-	%z	1937
+			 10:00	-	%z	1941 Apr  1
+			  9:00	-	%z	1944 Feb  6
+			 11:00	-	%z	1969 Oct
+			-12:00	-	%z	1993 Aug 20 24:00
+			 12:00	-	%z
 
 # Micronesia
 # For Chuuk and Yap see Pacific/Port_Moresby.
@@ -534,22 +534,22 @@ Zone Pacific/Kwajalein	 11:09:20 -	LMT	1901
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Kosrae	-13:08:04 -	LMT	1844 Dec 31
 			 10:51:56 -	LMT	1901
-			 11:00	-	+11	1914 Oct
-			  9:00	-	+09	1919 Feb  1
-			 11:00	-	+11	1937
-			 10:00	-	+10	1941 Apr  1
-			  9:00	-	+09	1945 Aug
-			 11:00	-	+11	1969 Oct
-			 12:00	-	+12	1999
-			 11:00	-	+11
+			 11:00	-	%z	1914 Oct
+			  9:00	-	%z	1919 Feb  1
+			 11:00	-	%z	1937
+			 10:00	-	%z	1941 Apr  1
+			  9:00	-	%z	1945 Aug
+			 11:00	-	%z	1969 Oct
+			 12:00	-	%z	1999
+			 11:00	-	%z
 
 # Nauru
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Nauru	11:07:40 -	LMT	1921 Jan 15 # Uaobe
-			11:30	-	+1130	1942 Aug 29
-			 9:00	-	+09	1945 Sep  8
-			11:30	-	+1130	1979 Feb 10  2:00
-			12:00	-	+12
+			11:30	-	%z	1942 Aug 29
+			 9:00	-	%z	1945 Sep  8
+			11:30	-	%z	1979 Feb 10  2:00
+			12:00	-	%z
 
 # New Caledonia
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
@@ -560,7 +560,7 @@ Rule	NC	1996	only	-	Dec	 1	2:00s	1:00	-
 Rule	NC	1997	only	-	Mar	 2	2:00s	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Noumea	11:05:48 -	LMT	1912 Jan 13 # Nouméa
-			11:00	NC	+11/+12
+			11:00	NC	%z
 
 
 ###############################################################################
@@ -604,8 +604,8 @@ Zone Pacific/Auckland	11:39:04 -	LMT	1868 Nov  2
 			12:00	NZ	NZ%sT
 
 Zone Pacific/Chatham	12:13:48 -	LMT	1868 Nov  2
-			12:15	-	+1215	1946 Jan  1
-			12:45	Chatham	+1245/+1345
+			12:15	-	%z	1946 Jan  1
+			12:45	Chatham	%z
 
 # Auckland Is
 # uninhabited; Māori and Moriori, colonial settlers, pastoralists, sealers,
@@ -658,8 +658,8 @@ Rule	Cook	1979	1990	-	Oct	lastSun	0:00	0:30	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Rarotonga	13:20:56 -	LMT	1899 Dec 26 # Avarua
 			-10:39:04 -	LMT	1952 Oct 16
-			-10:30	-	-1030	1978 Nov 12
-			-10:00	Cook	-10/-0930
+			-10:30	-	%z	1978 Nov 12
+			-10:00	Cook	%z
 
 ###############################################################################
 
@@ -676,30 +676,30 @@ Zone Pacific/Rarotonga	13:20:56 -	LMT	1899 Dec 26 # Avarua
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Niue	-11:19:40 -	LMT	1952 Oct 16	# Alofi
-			-11:20	-	-1120	1964 Jul
-			-11:00	-	-11
+			-11:20	-	%z	1964 Jul
+			-11:00	-	%z
 
 # Norfolk
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Norfolk	11:11:52 -	LMT	1901 # Kingston
-			11:12	-	+1112	1951
-			11:30	-	+1130	1974 Oct 27 02:00s
-			11:30	1:00	+1230	1975 Mar  2 02:00s
-			11:30	-	+1130	2015 Oct  4 02:00s
-			11:00	-	+11	2019 Jul
-			11:00	AN	+11/+12
+			11:12	-	%z	1951
+			11:30	-	%z	1974 Oct 27 02:00s
+			11:30	1:00	%z	1975 Mar  2 02:00s
+			11:30	-	%z	2015 Oct  4 02:00s
+			11:00	-	%z	2019 Jul
+			11:00	AN	%z
 
 # Palau (Belau)
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Palau	-15:02:04 -	LMT	1844 Dec 31	# Koror
 			  8:57:56 -	LMT	1901
-			  9:00	-	+09
+			  9:00	-	%z
 
 # Papua New Guinea
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 			9:48:32	-	PMMT	1895 # Port Moresby Mean Time
-			10:00	-	+10
+			10:00	-	%z
 #
 # From Paul Eggert (2014-10-13):
 # Base the Bougainville entry on the Arawa-Kieta region, which appears to have
@@ -720,16 +720,16 @@ Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 #
 Zone Pacific/Bougainville 10:22:16 -	LMT	1880
 			 9:48:32 -	PMMT	1895
-			10:00	-	+10	1942 Jul
-			 9:00	-	+09	1945 Aug 21
-			10:00	-	+10	2014 Dec 28  2:00
-			11:00	-	+11
+			10:00	-	%z	1942 Jul
+			 9:00	-	%z	1945 Aug 21
+			10:00	-	%z	2014 Dec 28  2:00
+			11:00	-	%z
 
 # Pitcairn
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Pitcairn	-8:40:20 -	LMT	1901        # Adamstown
-			-8:30	-	-0830	1998 Apr 27  0:00
-			-8:00	-	-08
+			-8:30	-	%z	1998 Apr 27  0:00
+			-8:00	-	%z
 
 # American Samoa
 # Midway
@@ -818,15 +818,15 @@ Rule	WS	2012	2020	-	Sep	lastSun	3:00	1	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Apia	 12:33:04 -	LMT	1892 Jul  5
 			-11:26:56 -	LMT	1911
-			-11:30	-	-1130	1950
-			-11:00	WS	-11/-10	2011 Dec 29 24:00
-			 13:00	WS	+13/+14
+			-11:30	-	%z	1950
+			-11:00	WS	%z	2011 Dec 29 24:00
+			 13:00	WS	%z
 
 # Solomon Is
 # excludes Bougainville, for which see Papua New Guinea
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct  1 # Honiara
-			11:00	-	+11
+			11:00	-	%z
 
 # Tokelau
 #
@@ -849,8 +849,8 @@ Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct  1 # Honiara
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Fakaofo	-11:24:56 -	LMT	1901
-			-11:00	-	-11	2011 Dec 30
-			13:00	-	+13
+			-11:00	-	%z	2011 Dec 30
+			13:00	-	%z
 
 # Tonga
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
@@ -862,9 +862,9 @@ Rule	Tonga	2016	only	-	Nov	Sun>=1	2:00	1:00	-
 Rule	Tonga	2017	only	-	Jan	Sun>=15	3:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Tongatapu	12:19:12 -	LMT	1945 Sep 10
-			12:20	-	+1220	1961
-			13:00	-	+13	1999
-			13:00	Tonga	+13/+14
+			12:20	-	%z	1961
+			13:00	-	%z	1999
+			13:00	Tonga	%z
 
 
 # US minor outlying islands
@@ -953,7 +953,7 @@ Rule	Vanuatu	1992	1993	-	Jan	Sat>=22	24:00	0	-
 Rule	Vanuatu	1992	only	-	Oct	Sat>=22	24:00	1:00	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
-			11:00	Vanuatu	+11/+12
+			11:00	Vanuatu	%z
 
 ###############################################################################
 

--- a/make/data/tzdata/backward
+++ b/make/data/tzdata/backward
@@ -21,12 +21,13 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-# tzdb links for backward compatibility
+# Links and zones for backward compatibility
 
 # This file is in the public domain, so clarified as of
 # 2009-05-17 by Arthur David Olson.
 
 # This file provides links from old or merged timezone names to current ones.
+# It also provides a few zone entries for old naming conventions.
 # Many names changed in 1993 and in 1995, and many merged names moved here
 # in the period from 2013 through 2022.  Several of these names are
 # also present in the file 'backzone', which has data important only
@@ -67,6 +68,8 @@ Link	America/Rio_Branco	Brazil/Acre	#= America/Porto_Acre
 Link	America/Noronha		Brazil/DeNoronha
 Link	America/Sao_Paulo	Brazil/East
 Link	America/Manaus		Brazil/West
+Link	Europe/Brussels		CET
+Link	America/Chicago		CST6CDT
 Link	America/Halifax		Canada/Atlantic
 Link	America/Winnipeg	Canada/Central
 # This line is commented out, as the name exceeded the 14-character limit
@@ -81,6 +84,9 @@ Link	America/Whitehorse	Canada/Yukon
 Link	America/Santiago	Chile/Continental
 Link	Pacific/Easter		Chile/EasterIsland
 Link	America/Havana		Cuba
+Link	Europe/Athens		EET
+Link	America/Panama		EST
+Link	America/New_York	EST5EDT
 Link	Africa/Cairo		Egypt
 Link	Europe/Dublin		Eire
 # Vanguard section, for most .zi parsers.
@@ -119,6 +125,9 @@ Link	America/Jamaica		Jamaica
 Link	Asia/Tokyo		Japan
 Link	Pacific/Kwajalein	Kwajalein
 Link	Africa/Tripoli		Libya
+Link	Europe/Brussels		MET
+Link	America/Phoenix		MST
+Link	America/Denver		MST7MDT
 Link	America/Tijuana		Mexico/BajaNorte
 Link	America/Mazatlan	Mexico/BajaSur
 Link	America/Mexico_City	Mexico/General
@@ -298,6 +307,7 @@ Link	America/Denver		America/Shiprock
 Link	America/Toronto		America/Thunder_Bay
 Link	America/Edmonton	America/Yellowknife
 Link	Pacific/Auckland	Antarctica/South_Pole
+Link	Asia/Ulaanbaatar	Asia/Choibalsan
 Link	Asia/Shanghai		Asia/Chongqing
 Link	Asia/Shanghai		Asia/Harbin
 Link	Asia/Urumqi		Asia/Kashgar
@@ -312,6 +322,7 @@ Link	Europe/Kyiv		Europe/Zaporozhye
 Link	Pacific/Kanton		Pacific/Enderbury
 Link	Pacific/Honolulu	Pacific/Johnston
 Link	Pacific/Port_Moresby	Pacific/Yap
+Link	Europe/Lisbon		WET
 
 
 # Alternate names for the same location
@@ -337,5 +348,7 @@ Link	Europe/Kyiv		Europe/Kiev
 # Classically, Cyprus is in Asia; e.g. see Herodotus, Histories, I.72.
 # However, for various reasons many users expect to find it under Europe.
 Link	Asia/Nicosia		Europe/Nicosia
+Link	Pacific/Honolulu	HST
+Link	America/Los_Angeles	PST8PDT
 Link	Pacific/Guadalcanal	Pacific/Ponape	#= Pacific/Pohnpei
 Link	Pacific/Port_Moresby	Pacific/Truk	#= Pacific/Chuuk

--- a/make/data/tzdata/etcetera
+++ b/make/data/tzdata/etcetera
@@ -28,7 +28,7 @@
 
 # These entries are for uses not otherwise covered by the tz database.
 # Their main practical use is for platforms like Android that lack
-# support for POSIX.1-2017-style TZ strings.  On such platforms these entries
+# support for POSIX proleptic TZ strings.  On such platforms these entries
 # can be useful if the timezone database is wrong or if a ship or
 # aircraft at sea is not in a timezone.
 
@@ -74,29 +74,29 @@ Link	Etc/GMT				GMT
 # so we moved the names into the Etc subdirectory.
 # Also, the time zone abbreviations are now compatible with %z.
 
-Zone	Etc/GMT-14	14	-	+14
-Zone	Etc/GMT-13	13	-	+13
-Zone	Etc/GMT-12	12	-	+12
-Zone	Etc/GMT-11	11	-	+11
-Zone	Etc/GMT-10	10	-	+10
-Zone	Etc/GMT-9	9	-	+09
-Zone	Etc/GMT-8	8	-	+08
-Zone	Etc/GMT-7	7	-	+07
-Zone	Etc/GMT-6	6	-	+06
-Zone	Etc/GMT-5	5	-	+05
-Zone	Etc/GMT-4	4	-	+04
-Zone	Etc/GMT-3	3	-	+03
-Zone	Etc/GMT-2	2	-	+02
-Zone	Etc/GMT-1	1	-	+01
-Zone	Etc/GMT+1	-1	-	-01
-Zone	Etc/GMT+2	-2	-	-02
-Zone	Etc/GMT+3	-3	-	-03
-Zone	Etc/GMT+4	-4	-	-04
-Zone	Etc/GMT+5	-5	-	-05
-Zone	Etc/GMT+6	-6	-	-06
-Zone	Etc/GMT+7	-7	-	-07
-Zone	Etc/GMT+8	-8	-	-08
-Zone	Etc/GMT+9	-9	-	-09
-Zone	Etc/GMT+10	-10	-	-10
-Zone	Etc/GMT+11	-11	-	-11
-Zone	Etc/GMT+12	-12	-	-12
+Zone	Etc/GMT-14	14	-	%z
+Zone	Etc/GMT-13	13	-	%z
+Zone	Etc/GMT-12	12	-	%z
+Zone	Etc/GMT-11	11	-	%z
+Zone	Etc/GMT-10	10	-	%z
+Zone	Etc/GMT-9	9	-	%z
+Zone	Etc/GMT-8	8	-	%z
+Zone	Etc/GMT-7	7	-	%z
+Zone	Etc/GMT-6	6	-	%z
+Zone	Etc/GMT-5	5	-	%z
+Zone	Etc/GMT-4	4	-	%z
+Zone	Etc/GMT-3	3	-	%z
+Zone	Etc/GMT-2	2	-	%z
+Zone	Etc/GMT-1	1	-	%z
+Zone	Etc/GMT+1	-1	-	%z
+Zone	Etc/GMT+2	-2	-	%z
+Zone	Etc/GMT+3	-3	-	%z
+Zone	Etc/GMT+4	-4	-	%z
+Zone	Etc/GMT+5	-5	-	%z
+Zone	Etc/GMT+6	-6	-	%z
+Zone	Etc/GMT+7	-7	-	%z
+Zone	Etc/GMT+8	-8	-	%z
+Zone	Etc/GMT+9	-9	-	%z
+Zone	Etc/GMT+10	-10	-	%z
+Zone	Etc/GMT+11	-11	-	%z
+Zone	Etc/GMT+12	-12	-	%z

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -753,14 +753,6 @@ Rule	Russia	1996	2010	-	Oct	lastSun	 2:00s	0	-
 # Take "abolishing daylight saving time" to mean that time is now considered
 # to be standard.
 
-# These are for backward compatibility with older versions.
-
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	WET		0:00	EU	WE%sT
-Zone	CET		1:00	C-Eur	CE%sT
-Zone	MET		1:00	C-Eur	ME%sT
-Zone	EET		2:00	EU	EE%sT
-
 # Previous editions of this database used abbreviations like MET DST
 # for Central European Summer Time, but this didn't agree with common usage.
 
@@ -894,7 +886,7 @@ Zone	Europe/Minsk	1:50:16 -	LMT	1880
 			3:00	Russia	MSK/MSD	1990
 			3:00	-	MSK	1991 Mar 31  2:00s
 			2:00	Russia	EE%sT	2011 Mar 27  2:00s
-			3:00	-	+03
+			3:00	-	%z
 
 # Belgium
 # Luxembourg
@@ -1199,22 +1191,22 @@ Rule	Thule	2007	max	-	Nov	Sun>=1	2:00	0	S
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Danmarkshavn -1:14:40 -	LMT	1916 Jul 28
-			-3:00	-	-03	1980 Apr  6  2:00
-			-3:00	EU	-03/-02	1996
+			-3:00	-	%z	1980 Apr  6  2:00
+			-3:00	EU	%z	1996
 			0:00	-	GMT
 #
 # Use the old name Scoresbysund, as the current name Ittoqqortoormiit
 # exceeds tzdb's 14-letter limit and has no common English abbreviation.
 Zone America/Scoresbysund -1:27:52 -	LMT	1916 Jul 28 # Ittoqqortoormiit
-			-2:00	-	-02	1980 Apr  6  2:00
-			-2:00	C-Eur	-02/-01	1981 Mar 29
-			-1:00	EU	-01/+00 2024 Mar 31
-			-2:00	EU	-02/-01
+			-2:00	-	%z	1980 Apr  6  2:00
+			-2:00	C-Eur	%z	1981 Mar 29
+			-1:00	EU	%z	2024 Mar 31
+			-2:00	EU	%z
 Zone America/Nuuk	-3:26:56 -	LMT	1916 Jul 28 # Godthåb
-			-3:00	-	-03	1980 Apr  6  2:00
-			-3:00	EU	-03/-02	2023 Mar 26  1:00u
-			-2:00	-	-02	2023 Oct 29  1:00u
-			-2:00	EU	-02/-01
+			-3:00	-	%z	1980 Apr  6  2:00
+			-3:00	EU	%z	2023 Mar 26  1:00u
+			-2:00	-	%z	2023 Oct 29  1:00u
+			-2:00	EU	%z
 Zone America/Thule	-4:35:08 -	LMT	1916 Jul 28 # Pituffik
 			-4:00	Thule	A%sT
 
@@ -2086,10 +2078,39 @@ Zone	Europe/Warsaw	1:24:00 -	LMT	1880
 
 # Portugal
 
-# From Paul Eggert (2014-08-11), after a heads-up from Stephen Colebourne:
-# According to a Portuguese decree (1911-05-26)
-# https://dre.pt/application/dir/pdf1sdip/1911/05/12500/23132313.pdf
-# Lisbon was at -0:36:44.68, but switched to GMT on 1912-01-01 at 00:00.
+# From Tim Parenti (2024-07-01), per Alois Treindl (2021-02-07) and Michael
+# Deckers (2021-02-10):
+# http://oal.ul.pt/documentos/2018/01/hl1911a2018.pdf/
+# The Astronomical Observatory of Lisbon has published a list detailing the
+# historical transitions in legal time within continental Portugal.  It
+# directly references many decrees and ordinances which are, in turn,
+# referenced below.  They can be viewed in the public archives of the Diário da
+# República (until 1976-04-09 known as the Diário do Govêrno) at
+# https://dre.pt/ (in Portuguese).
+#
+# Most of the Rules below have been updated simply to match the Observatory's
+# listing for continental (mainland) Portugal.  Although there are over 50
+# referenced decrees and ordinances, only the handful with comments below have
+# been verified against the text, typically to provide additional confidence
+# wherever dates provided by Whitman and Shanks & Pottenger had disagreed.
+# See further below for the Azores and Madeira.
+
+# From Tim Parenti (2024-07-01), per Paul Eggert (2014-08-11), after a
+# heads-up from Stephen Colebourne:
+# According to a 1911-05-24 Portuguese decree, Lisbon was at -0:36:44.68, but
+# switched to GMT on 1912-01-01 at 00:00.
+# https://dre.pt/dr/detalhe/decreto/593090
+# https://dre.pt/application/conteudo/593090
+# The decree made legal time throughout Portugal and her possessions
+# "subordinate to the Greenwich meridian, according to the principle adopted at
+# the Washington Convention in 1884" and eliminated the "difference of five
+# minutes between the internal and external clocks of railway stations".
+#
+# The decree was gazetted in the 1911-05-30 issue of Diário do Govêrno, and is
+# considered to be dated 1911-05-24 by that issue's summary; however, the text
+# of the decree itself is dated 1911-05-26.  The Diário da República website
+# notes the discrepancy, but later laws and the Observatory all seem to refer
+# to this decree by the 1911-05-24 date.
 #
 # From Michael Deckers (2018-02-15):
 # article 5 [of the 1911 decree; Deckers's translation] ...:
@@ -2097,37 +2118,62 @@ Zone	Europe/Warsaw	1:24:00 -	LMT	1880
 # according to the 2nd article, the civil day January 1, 1912 begins,
 # all clocks therefore having to be advanced or set back correspondingly ...
 
-# From Rui Pedro Salgueiro (1992-11-12):
-# Portugal has recently (September, 27) changed timezone
-# (from WET to MET or CET) to harmonize with EEC.
-#
-# Martin Bruckmann (1996-02-29) reports via Peter Ilieve
-# that Portugal is reverting to 0:00 by not moving its clocks this spring.
-# The new Prime Minister was fed up with getting up in the dark in the winter.
-#
-# From Paul Eggert (1996-11-12):
-# IATA SSIM (1991-09) reports several 1991-09 and 1992-09 transitions
-# at 02:00u, not 01:00u.  Assume that these are typos.
-# IATA SSIM (1991/1992) reports that the Azores were at -1:00.
-# IATA SSIM (1993-02) says +0:00; later issues (through 1996-09) say -1:00.
-# Guess that the Azores changed to EU rules in 1992 (since that's when Portugal
-# harmonized with EU rules), and that they stayed +0:00 that winter.
-#
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-# DSH writes that despite Decree 1,469 (1915), the change to the clocks was not
-# done every year, depending on what Spain did, because of railroad schedules.
-# Go with Shanks & Pottenger.
+# From Tim Parenti (2024-07-01), per Paul Eggert (1999-01-30):
+# DSH writes in their history that Decreto 1469 of 1915-03-30 established
+# summer time and that, "despite" this, the change to the clocks was not done
+# every year, depending on what Spain did, because of railroad schedules.
+# In fact, that decree had nothing to do with DST; rather, it regulated the
+# sending of time signals.  But we do see linkage to Spain in the 1920s below.
+# https://dre.pt/dr/detalhe/decreto/1469-1915-285721
+# https://dre.pt/application/conteudo/285721
+#
+# According to the Observatory, standard time was first advanced by Decreto
+# 2433 of 1916-06-09 and restored by Decreto 2712 of 1916-10-28.  While Whitman
+# gives 1916-10-31 for the latter transition, Shanks & Pottenger agrees more
+# closely with the decree, which stated that its provision "will start sixty
+# minutes after the end of 31 October, according to the current time," i.e.,
+# 01:00 on 1 November.
+# https://dre.pt/dr/detalhe/decreto/2433-1916-267192
+# https://dre.pt/application/conteudo/267192
+# https://dre.pt/dr/detalhe/decreto/2712-1916-590937
+# https://dre.pt/application/conteudo/590937
 Rule	Port	1916	only	-	Jun	17	23:00	1:00	S
-# Whitman gives 1916 Oct 31; go with Shanks & Pottenger.
 Rule	Port	1916	only	-	Nov	 1	 1:00	0	-
-Rule	Port	1917	only	-	Feb	28	23:00s	1:00	S
-Rule	Port	1917	1921	-	Oct	14	23:00s	0	-
-Rule	Port	1918	only	-	Mar	 1	23:00s	1:00	S
-Rule	Port	1919	only	-	Feb	28	23:00s	1:00	S
-Rule	Port	1920	only	-	Feb	29	23:00s	1:00	S
-Rule	Port	1921	only	-	Feb	28	23:00s	1:00	S
+# From Tim Parenti (2024-07-01):
+# Article 7 of Decreto 2922 of 1916-12-30 stated that "the legal time will be
+# advanced by sixty minutes from 1 March to 31 October."  Per Article 15, this
+# came into force from 1917-01-01.  Just before the first fall back, Decreto
+# 3446 of 1917-10-11 changed the annual end date to 14 October.
+# https://dre.pt/dr/detalhe/decreto/2922-1916-261894
+# https://dre.pt/application/conteudo/261894
+# https://dre.pt/dr/detalhe/decreto/3446-1917-495161
+# https://dre.pt/application/conteudo/495161
+# This annual change was revoked by Decreto 8038 of 1922-02-18.
+# https://dre.pt/dr/detalhe/decreto/8038-1922-569751
+# https://dre.pt/application/conteudo/569751
+Rule	Port	1917	1921	-	Mar	 1	 0:00	1:00	S
+Rule	Port	1917	1921	-	Oct	14	24:00	0	-
+# From Tim Parenti (2024-07-01):
+# Decreto 9592 of 1924-04-14 noted that "France maintains the advance of legal
+# time in the summer and Spain has now adopted it for the first time" and
+# considered "that the absence of similar measures would cause serious
+# difficulties for international rail connections with consequent repercussions
+# on domestic service hours..." along with "inconvenient analogues...for postal
+# and telegraph services."  Summer time would be in effect from 17 April to 4
+# October, with the spring change explicitly specified by bringing clocks
+# forward from 16 April 23:00.
+# https://dre.pt/dr/detalhe/decreto/9592-1924-652133
+# https://dre.pt/application/conteudo/652133
+#
+# Decreto 10700, issued 1925-04-16, noted that Spain had not continued summer
+# time, declared that "the current legal hour prior to 17 April remains
+# unchanged from that day forward", and revoked legislation to the contrary,
+# just a day before summer time would have otherwise resumed.
+# https://dre.pt/dr/detalhe/decreto/10700-1925-437826
+# https://dre.pt/application/conteudo/437826
 Rule	Port	1924	only	-	Apr	16	23:00s	1:00	S
-Rule	Port	1924	only	-	Oct	14	23:00s	0	-
+Rule	Port	1924	only	-	Oct	 4	23:00s	0	-
 Rule	Port	1926	only	-	Apr	17	23:00s	1:00	S
 Rule	Port	1926	1929	-	Oct	Sat>=1	23:00s	0	-
 Rule	Port	1927	only	-	Apr	 9	23:00s	1:00	S
@@ -2139,6 +2185,8 @@ Rule	Port	1931	1932	-	Oct	Sat>=1	23:00s	0	-
 Rule	Port	1932	only	-	Apr	 2	23:00s	1:00	S
 Rule	Port	1934	only	-	Apr	 7	23:00s	1:00	S
 # Whitman gives 1934 Oct 5; go with Shanks & Pottenger.
+# Note: The 1935 law specified 10-06 00:00, not 10-05 24:00, but the following
+# is equivalent and more succinct.
 Rule	Port	1934	1938	-	Oct	Sat>=1	23:00s	0	-
 # Shanks & Pottenger give 1935 Apr 30; go with Whitman.
 Rule	Port	1935	only	-	Mar	30	23:00s	1:00	S
@@ -2149,10 +2197,19 @@ Rule	Port	1938	only	-	Mar	26	23:00s	1:00	S
 Rule	Port	1939	only	-	Apr	15	23:00s	1:00	S
 # Whitman gives 1939 Oct 7; go with Shanks & Pottenger.
 Rule	Port	1939	only	-	Nov	18	23:00s	0	-
+# From Tim Parenti (2024-07-01):
+# Portaria 9465 of 1940-02-17 advanced clocks from Saturday 1940-02-24 23:00.
+# The clocks were restored by Portaria 9658, issued Monday 1940-10-07,
+# effective from 24:00 that very night, which agrees with Shanks & Pottenger;
+# Whitman gives Saturday 1940-10-05 instead.
+# https://dre.pt/dr/detalhe/portaria/9465-1940-189096
+# https://dre.pt/application/conteudo/189096
+# https://dre.pt/dr/detalhe/portaria/9658-1940-196729
+# https://dre.pt/application/conteudo/196729
 Rule	Port	1940	only	-	Feb	24	23:00s	1:00	S
-# Shanks & Pottenger give 1940 Oct 7; go with Whitman.
-Rule	Port	1940	1941	-	Oct	 5	23:00s	0	-
+Rule	Port	1940	only	-	Oct	 7	23:00s	0	-
 Rule	Port	1941	only	-	Apr	 5	23:00s	1:00	S
+Rule	Port	1941	only	-	Oct	 5	23:00s	0	-
 Rule	Port	1942	1945	-	Mar	Sat>=8	23:00s	1:00	S
 Rule	Port	1942	only	-	Apr	25	22:00s	2:00	M # Midsummer
 Rule	Port	1942	only	-	Aug	15	22:00s	1:00	S
@@ -2162,66 +2219,195 @@ Rule	Port	1943	1945	-	Aug	Sat>=25	22:00s	1:00	S
 Rule	Port	1944	1945	-	Apr	Sat>=21	22:00s	2:00	M
 Rule	Port	1946	only	-	Apr	Sat>=1	23:00s	1:00	S
 Rule	Port	1946	only	-	Oct	Sat>=1	23:00s	0	-
-# Whitman says DST was not observed in 1950; go with Shanks & Pottenger.
-# Whitman gives Oct lastSun for 1952 on; go with Shanks & Pottenger.
-Rule	Port	1947	1965	-	Apr	Sun>=1	 2:00s	1:00	S
+# From Tim Parenti (2024-07-01), per Alois Treindl (2021-02-07):
+# The Astronomical Observatory of Lisbon cites Portaria 11767 of 1947-03-28 for
+# 1947 and Portaria 12286 of 1948-02-19 for 1948.
+# https://dre.pt/dr/detalhe/portaria/11767-1947-414787
+# https://dre.pt/application/conteudo/414787
+# https://dre.pt/dr/detalhe/portaria/12286-1948-152953
+# https://dre.pt/application/conteudo/152953
+#
+# Although the latter ordinance explicitly had the 1948-10-03 transition
+# scheduled for 02:00 rather than 03:00 as had been used in 1947, Decreto-Lei
+# 37048 of 1948-09-07 recognized "that it is advisable to definitely set...the
+# 'summer time' regime", and fixed the fall transition at 03:00 moving forward.
+# https://dre.pt/dr/detalhe/decreto-lei/37048-1948-373810
+# https://dre.pt/application/conteudo/373810
+# While the Observatory only cites this act for 1949-1965 and not for 1948, it
+# does not appear to have had any provision delaying its effect, so assume that
+# it overrode the prior ordinance for 1948-10-03.
+#
+# Whitman says DST was not observed in 1950 and gives Oct lastSun for 1952 on.
+# The Observatory, however, agrees with Shanks & Pottenger that 1950 was not an
+# exception and that Oct Sun>=1 was maintained through 1965.
+Rule	Port	1947	1966	-	Apr	Sun>=1	 2:00s	1:00	S
 Rule	Port	1947	1965	-	Oct	Sun>=1	 2:00s	0	-
-Rule	Port	1977	only	-	Mar	27	 0:00s	1:00	S
-Rule	Port	1977	only	-	Sep	25	 0:00s	0	-
-Rule	Port	1978	1979	-	Apr	Sun>=1	 0:00s	1:00	S
-Rule	Port	1978	only	-	Oct	 1	 0:00s	0	-
-Rule	Port	1979	1982	-	Sep	lastSun	 1:00s	0	-
-Rule	Port	1980	only	-	Mar	lastSun	 0:00s	1:00	S
-Rule	Port	1981	1982	-	Mar	lastSun	 1:00s	1:00	S
-Rule	Port	1983	only	-	Mar	lastSun	 2:00s	1:00	S
+# From Tim Parenti (2024-07-01):
+# Decreto-Lei 47233 of 1966-10-01 considered that the "duality" in time was
+# "the cause of serious disturbances" and noted that "the countries with which
+# we have the most frequent contacts...have already adopted" a solution
+# coinciding with the extant "summer time".  It established that the former
+# "summer time" would apply year-round on the mainland and adjacent islands
+# with immediate effect, as the fall back would have otherwise occurred later
+# that evening.
+# https://dre.pt/dr/detalhe/decreto-lei/47233-1966-293729
+# Model this by changing zones without changing clocks at the
+# previously-appointed fall back time.
+#
+# Decreto-Lei 309/76 of 1976-04-27 acknowledged that those international
+# contacts had returned to adopting seasonal times, and considered that the
+# year-round advancement "entails considerable sacrifices for the vast majority
+# of the working population during the winter months", including morning
+# visibility concerns for schoolchildren.  It specified, beginning 1976-09-26
+# 01:00, an annual return to UT+00 on the mainland from 00:00 UT on Sep lastSun
+# to 00:00 UT on Mar lastSun (unless the latter date fell on Easter, in which
+# case it was to be brought forward to the preceding Sunday).  It also assigned
+# the Permanent Time Commission to study and propose revisions for the Azores
+# and Madeira, neither of which resumed DST until 1982 (as described further
+# below).
+# https://dre.pt/dr/detalhe/decreto-lei/309-1976-502063
+Rule	Port	1976	only	-	Sep	lastSun	 1:00	0	-
+Rule	Port	1977	only	-	Mar	lastSun	 0:00s	1:00	S
+Rule	Port	1977	only	-	Sep	lastSun	 0:00s	0	-
+# From Tim Parenti (2024-07-01):
+# Beginning in 1978, rather than triggering the Easter rule of the 1976 decree
+# (Easter fell on 1978-03-26), Article 5 was used instead, which allowed DST
+# dates to be changed by order of the Minister of Education and Scientific
+# Research, upon consultation with the Permanent Time Commission, "whenever
+# considered convenient."  As such, a series of one-off ordinances were
+# promulgated for the mainland in 1978 through 1980, after which the 1976
+# decree naturally came back into force from 1981.
+Rule	Port	1978	1980	-	Apr	Sun>=1	 1:00s	1:00	S
+Rule	Port	1978	only	-	Oct	 1	 1:00s	0	-
+Rule	Port	1979	1980	-	Sep	lastSun	 1:00s	0	-
+Rule	Port	1981	1986	-	Mar	lastSun	 0:00s	1:00	S
+Rule	Port	1981	1985	-	Sep	lastSun	 0:00s	0	-
+# From Tim Parenti (2024-07-01):
+# Decreto-Lei 44-B/86 of 1986-03-07 switched mainland Portugal's transition
+# times from 0:00s to 1:00u to harmonize with the EEC from 1986-03-30.
+# https://dre.pt/dr/detalhe/decreto-lei/44-b-1986-628280
+# (Transitions of 1:00s as previously reported and used by the W-Eur rules,
+# though equivalent, appear to have been fiction here.)  Madeira continued to
+# use 0:00s for spring 1986 before joining with the mainland using 1:00u in the
+# fall; meanwhile, in the Azores the two were equivalent, so the law specifying
+# 0:00s wasn't touched until 1992.  (See below for more on the islands.)
+#
+# From Rui Pedro Salgueiro (1992-11-12):
+# Portugal has recently (September, 27) changed timezone
+# (from WET to MET or CET) to harmonize with EEC.
+#
+# Martin Bruckmann (1996-02-29) reports via Peter Ilieve
+# that Portugal is reverting to 0:00 by not moving its clocks this spring.
+# The new Prime Minister was fed up with getting up in the dark in the winter.
+#
+# From Paul Eggert (1996-11-12):
+# IATA SSIM (1991-09) reports several 1991-09 and 1992-09 transitions
+# at 02:00u, not 01:00u.  Assume that these are typos.
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 		#STDOFF	-0:36:44.68
 Zone	Europe/Lisbon	-0:36:45 -	LMT	1884
 			-0:36:45 -	LMT	1912 Jan  1  0:00u # Lisbon MT
-			 0:00	Port	WE%sT	1966 Apr  3  2:00
+			 0:00	Port	WE%sT	1966 Oct  2  2:00s
 			 1:00	-	CET	1976 Sep 26  1:00
-			 0:00	Port	WE%sT	1983 Sep 25  1:00s
-			 0:00	W-Eur	WE%sT	1992 Sep 27  1:00s
+			 0:00	Port	WE%sT	1986
+			 0:00	EU	WE%sT	1992 Sep 27  1:00u
 			 1:00	EU	CE%sT	1996 Mar 31  1:00u
 			 0:00	EU	WE%sT
+
+# From Tim Parenti (2024-07-01):
+# For the Azores and Madeira, legislation was followed from the laws currently
+# in force as listed at:
+# https://oal.ul.pt/hora-legal/legislacao/
+# working backward through references of revocation and abrogation to
+# Decreto-Lei 47233 of 1966-10-01, the last time DST was abolished across the
+# mainland and its adjacent islands.  Because of that reference, it is
+# therefore assumed that DST rules in the islands prior to 1966 were like that
+# of the mainland, though most legislation of the time didn't explicitly
+# specify DST practices for the islands.
 Zone Atlantic/Azores	-1:42:40 -	LMT	1884        # Ponta Delgada
 			-1:54:32 -	HMT	1912 Jan  1  2:00u # Horta MT
 # Vanguard section, for zic and other parsers that support %z.
-#			-2:00	Port	%z	1966 Apr  3  2:00
-#			-1:00	Port	%z	1983 Sep 25  1:00s
-#			-1:00	W-Eur	%z	1992 Sep 27  1:00s
+			-2:00	Port	%z	1966 Oct  2  2:00s
+# From Tim Parenti (2024-07-01):
+# While Decreto-Lei 309/76 of 1976-04-27 reintroduced DST on the mainland by
+# falling back on 1976-09-26, it assigned the Permanent Time Commission to
+# study and propose revisions for the Azores and Madeira.  Decreto Regional
+# 9/77/A of 1977-05-17 affirmed that "the legal time remained unchanged in the
+# Azores" at UT-1, and would remain there year-round.
+# https://dre.pt/dr/detalhe/decreto-regional/9-1977-252066
+#
+# Decreto Regional 2/82/A, published 1982-03-02, adopted DST in the same
+# fashion as the mainland used at the time.
+# https://dre.pt/dr/detalhe/decreto-regional/2-1982-599965
+# Though transitions in the Azores officially remained at 0:00s through 1992,
+# this was equivalent to the EU-style 1:00u adopted by the mainland in 1986, so
+# model it as such.
+			-1:00	-	%z	1982 Mar 28  0:00s
+			-1:00	Port	%z	1986
 # Rearguard section, for parsers lacking %z; see ziguard.awk.
-			-2:00	Port	-02/-01	1942 Apr 25 22:00s
-			-2:00	Port	+00	1942 Aug 15 22:00s
-			-2:00	Port	-02/-01	1943 Apr 17 22:00s
-			-2:00	Port	+00	1943 Aug 28 22:00s
-			-2:00	Port	-02/-01	1944 Apr 22 22:00s
-			-2:00	Port	+00	1944 Aug 26 22:00s
-			-2:00	Port	-02/-01	1945 Apr 21 22:00s
-			-2:00	Port	+00	1945 Aug 25 22:00s
-			-2:00	Port	-02/-01	1966 Apr  3  2:00
-			-1:00	Port	-01/+00	1983 Sep 25  1:00s
-			-1:00	W-Eur	-01/+00	1992 Sep 27  1:00s
+#			-2:00	Port	-02/-01	1942 Apr 25 22:00s
+#			-2:00	Port	+00	1942 Aug 15 22:00s
+#			-2:00	Port	-02/-01	1943 Apr 17 22:00s
+#			-2:00	Port	+00	1943 Aug 28 22:00s
+#			-2:00	Port	-02/-01	1944 Apr 22 22:00s
+#			-2:00	Port	+00	1944 Aug 26 22:00s
+#			-2:00	Port	-02/-01	1945 Apr 21 22:00s
+#			-2:00	Port	+00	1945 Aug 25 22:00s
+#			-2:00	Port	-02/-01	1966 Oct  2  2:00s
+#			-1:00	-	-01	1982 Mar 28  0:00s
+#			-1:00	Port	-01/+00	1986
 # End of rearguard section.
-			 0:00	EU	WE%sT	1993 Mar 28  1:00u
-			-1:00	EU	-01/+00
+#
+# From Paul Eggert (1996-11-12):
+# IATA SSIM (1991/1992) reports that the Azores were at -1:00.
+# IATA SSIM (1993-02) says +0:00; later issues (through 1996-09) say -1:00.
+#
+# From Tim Parenti (2024-07-01):
+# After mainland Portugal had shifted forward an hour from 1992-09-27, Decreto
+# Legislativo Regional 29/92/A of 1992-12-23 sought to "reduce the time
+# difference" by shifting the Azores forward as well from 1992-12-27.  Just six
+# months later, this was revoked by Decreto Legislativo Regional 9/93/A, citing
+# "major changes in work habits and way of life."  Though the revocation didn't
+# give a transition time, it was signed Wednesday 1993-06-16; assume it took
+# effect later that evening, and that an EU-style spring forward (to +01) was
+# still observed in the interim on 1993-03-28.
+# https://dre.pt/dr/detalhe/decreto-legislativo-regional/29-1992-621553
+# https://dre.pt/dr/detalhe/decreto-legislativo-regional/9-1993-389633
+			-1:00	EU	%z	1992 Dec 27  1:00s
+			 0:00	EU	WE%sT	1993 Jun 17  1:00u
+			-1:00	EU	%z
+
 Zone Atlantic/Madeira	-1:07:36 -	LMT	1884        # Funchal
 			-1:07:36 -	FMT	1912 Jan  1  1:00u # Funchal MT
 # Vanguard section, for zic and other parsers that support %z.
-#			-1:00	Port	%z	1966 Apr  3  2:00
+			-1:00	Port	%z	1966 Oct  2  2:00s
 # Rearguard section, for parsers lacking %z; see ziguard.awk.
-			-1:00	Port	-01/+00	1942 Apr 25 22:00s
-			-1:00	Port	+01	1942 Aug 15 22:00s
-			-1:00	Port	-01/+00	1943 Apr 17 22:00s
-			-1:00	Port	+01	1943 Aug 28 22:00s
-			-1:00	Port	-01/+00	1944 Apr 22 22:00s
-			-1:00	Port	+01	1944 Aug 26 22:00s
-			-1:00	Port	-01/+00	1945 Apr 21 22:00s
-			-1:00	Port	+01	1945 Aug 25 22:00s
-			-1:00	Port	-01/+00	1966 Apr  3  2:00
+#			-1:00	Port	-01/+00	1942 Apr 25 22:00s
+#			-1:00	Port	+01	1942 Aug 15 22:00s
+#			-1:00	Port	-01/+00	1943 Apr 17 22:00s
+#			-1:00	Port	+01	1943 Aug 28 22:00s
+#			-1:00	Port	-01/+00	1944 Apr 22 22:00s
+#			-1:00	Port	+01	1944 Aug 26 22:00s
+#			-1:00	Port	-01/+00	1945 Apr 21 22:00s
+#			-1:00	Port	+01	1945 Aug 25 22:00s
+#			-1:00	Port	-01/+00	1966 Oct  2  2:00s
 # End of rearguard section.
-			 0:00	Port	WE%sT	1983 Sep 25  1:00s
+#
+# From Tim Parenti (2024-07-01):
+# Decreto Regional 5/82/M, published 1982-04-03, established DST transitions at
+# 0:00u, which for Madeira is equivalent to the mainland's rules (0:00s) at the
+# time.  It came into effect the day following its publication, Sunday
+# 1982-04-04, thus resuming Madeira's DST practice about a week later than the
+# mainland and the Azores.
+# https://dre.pt/dr/detalhe/decreto-regional/5-1982-608273
+#
+# Decreto Legislativo Regional 18/86/M, published 1986-10-01, adopted EU-style
+# rules (1:00u) and entered into immediate force after being signed on
+# 1986-07-31.
+# https://dre.pt/dr/detalhe/decreto-legislativo-regional/18-1986-221705
+			 0:00	-	WET	1982 Apr  4
+			 0:00	Port	WE%sT	1986 Jul 31
 			 0:00	EU	WE%sT
 
 # Romania
@@ -2433,7 +2619,7 @@ Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
 			 2:00	Poland	EE%sT	1946 Apr  7
 			 3:00	Russia	MSK/MSD	1989 Mar 26  2:00s
 			 2:00	Russia	EE%sT	2011 Mar 27  2:00s
-			 3:00	-	+03	2014 Oct 26  2:00s
+			 3:00	-	%z	2014 Oct 26  2:00s
 			 2:00	-	EET
 
 
@@ -2683,14 +2869,14 @@ Zone Europe/Simferopol	 2:16:24 -	LMT	1880
 # http://publication.pravo.gov.ru/Document/View/0001201602150056
 
 Zone Europe/Astrakhan	 3:12:12 -	LMT	1924 May
-			 3:00	-	+03	1930 Jun 21
-			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 4:00	-	+04	1992 Mar 29  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04	2014 Oct 26  2:00s
-			 3:00	-	+03	2016 Mar 27  2:00s
-			 4:00	-	+04
+			 3:00	-	%z	1930 Jun 21
+			 4:00	Russia	%z	1989 Mar 26  2:00s
+			 3:00	Russia	%z	1991 Mar 31  2:00s
+			 4:00	-	%z	1992 Mar 29  2:00s
+			 3:00	Russia	%z	2011 Mar 27  2:00s
+			 4:00	-	%z	2014 Oct 26  2:00s
+			 3:00	-	%z	2016 Mar 27  2:00s
+			 4:00	-	%z
 
 # From Paul Eggert (2016-11-11):
 # Europe/Volgograd covers:
@@ -2720,15 +2906,15 @@ Zone Europe/Astrakhan	 3:12:12 -	LMT	1924 May
 # http://publication.pravo.gov.ru/Document/View/0001202012220002
 
 Zone Europe/Volgograd	 2:57:40 -	LMT	1920 Jan  3
-			 3:00	-	+03	1930 Jun 21
-			 4:00	-	+04	1961 Nov 11
-			 4:00	Russia	+04/+05	1988 Mar 27  2:00s
+			 3:00	-	%z	1930 Jun 21
+			 4:00	-	%z	1961 Nov 11
+			 4:00	Russia	%z	1988 Mar 27  2:00s
 			 3:00	Russia	MSK/MSD	1991 Mar 31  2:00s
-			 4:00	-	+04	1992 Mar 29  2:00s
+			 4:00	-	%z	1992 Mar 29  2:00s
 			 3:00	Russia	MSK/MSD	2011 Mar 27  2:00s
 			 4:00	-	MSK	2014 Oct 26  2:00s
 			 3:00	-	MSK	2018 Oct 28  2:00s
-			 4:00	-	+04	2020 Dec 27  2:00s
+			 4:00	-	%z	2020 Dec 27  2:00s
 			 3:00	-	MSK
 
 # From Paul Eggert (2016-11-11):
@@ -2743,14 +2929,14 @@ Zone Europe/Volgograd	 2:57:40 -	LMT	1920 Jan  3
 # http://publication.pravo.gov.ru/Document/View/0001201611220031
 
 Zone Europe/Saratov	 3:04:18 -	LMT	1919 Jul  1  0:00u
-			 3:00	-	+03	1930 Jun 21
-			 4:00	Russia	+04/+05	1988 Mar 27  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 4:00	-	+04	1992 Mar 29  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04	2014 Oct 26  2:00s
-			 3:00	-	+03	2016 Dec  4  2:00s
-			 4:00	-	+04
+			 3:00	-	%z	1930 Jun 21
+			 4:00	Russia	%z	1988 Mar 27  2:00s
+			 3:00	Russia	%z	1991 Mar 31  2:00s
+			 4:00	-	%z	1992 Mar 29  2:00s
+			 3:00	Russia	%z	2011 Mar 27  2:00s
+			 4:00	-	%z	2014 Oct 26  2:00s
+			 3:00	-	%z	2016 Dec  4  2:00s
+			 4:00	-	%z
 
 # From Paul Eggert (2016-03-18):
 # Europe/Kirov covers:
@@ -2758,10 +2944,10 @@ Zone Europe/Saratov	 3:04:18 -	LMT	1919 Jul  1  0:00u
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 #
 Zone Europe/Kirov	 3:18:48 -	LMT	1919 Jul  1  0:00u
-			 3:00	-	+03	1930 Jun 21
-			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
+			 3:00	-	%z	1930 Jun 21
+			 4:00	Russia	%z	1989 Mar 26  2:00s
 			 3:00	Russia	MSK/MSD	1991 Mar 31  2:00s
-			 4:00	-	+04	1992 Mar 29  2:00s
+			 4:00	-	%z	1992 Mar 29  2:00s
 			 3:00	Russia	MSK/MSD	2011 Mar 27  2:00s
 			 4:00	-	MSK	2014 Oct 26  2:00s
 			 3:00	-	MSK
@@ -2776,15 +2962,15 @@ Zone Europe/Kirov	 3:18:48 -	LMT	1919 Jul  1  0:00u
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 
 Zone Europe/Samara	 3:20:20 -	LMT	1919 Jul  1  0:00u
-			 3:00	-	+03	1930 Jun 21
-			 4:00	-	+04	1935 Jan 27
-			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 2:00	Russia	+02/+03	1991 Sep 29  2:00s
-			 3:00	-	+03	1991 Oct 20  3:00
-			 4:00	Russia	+04/+05	2010 Mar 28  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04
+			 3:00	-	%z	1930 Jun 21
+			 4:00	-	%z	1935 Jan 27
+			 4:00	Russia	%z	1989 Mar 26  2:00s
+			 3:00	Russia	%z	1991 Mar 31  2:00s
+			 2:00	Russia	%z	1991 Sep 29  2:00s
+			 3:00	-	%z	1991 Oct 20  3:00
+			 4:00	Russia	%z	2010 Mar 28  2:00s
+			 3:00	Russia	%z	2011 Mar 27  2:00s
+			 4:00	-	%z
 
 # From Paul Eggert (2016-03-18):
 # Europe/Ulyanovsk covers:
@@ -2800,14 +2986,14 @@ Zone Europe/Samara	 3:20:20 -	LMT	1919 Jul  1  0:00u
 # http://publication.pravo.gov.ru/Document/View/0001201603090051
 
 Zone Europe/Ulyanovsk	 3:13:36 -	LMT	1919 Jul  1  0:00u
-			 3:00	-	+03	1930 Jun 21
-			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
-			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
-			 2:00	Russia	+02/+03	1992 Jan 19  2:00s
-			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
-			 4:00	-	+04	2014 Oct 26  2:00s
-			 3:00	-	+03	2016 Mar 27  2:00s
-			 4:00	-	+04
+			 3:00	-	%z	1930 Jun 21
+			 4:00	Russia	%z	1989 Mar 26  2:00s
+			 3:00	Russia	%z	1991 Mar 31  2:00s
+			 2:00	Russia	%z	1992 Jan 19  2:00s
+			 3:00	Russia	%z	2011 Mar 27  2:00s
+			 4:00	-	%z	2014 Oct 26  2:00s
+			 3:00	-	%z	2016 Mar 27  2:00s
+			 4:00	-	%z
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
 # Asia/Yekaterinburg covers...
@@ -2832,12 +3018,12 @@ Zone Europe/Ulyanovsk	 3:13:36 -	LMT	1919 Jul  1  0:00u
 		#STDOFF	 4:02:32.9
 Zone Asia/Yekaterinburg	 4:02:33 -	LMT	1916 Jul  3
 			 3:45:05 -	PMT	1919 Jul 15  4:00
-			 4:00	-	+04	1930 Jun 21
-			 5:00	Russia	+05/+06	1991 Mar 31  2:00s
-			 4:00	Russia	+04/+05	1992 Jan 19  2:00s
-			 5:00	Russia	+05/+06	2011 Mar 27  2:00s
-			 6:00	-	+06	2014 Oct 26  2:00s
-			 5:00	-	+05
+			 4:00	-	%z	1930 Jun 21
+			 5:00	Russia	%z	1991 Mar 31  2:00s
+			 4:00	Russia	%z	1992 Jan 19  2:00s
+			 5:00	Russia	%z	2011 Mar 27  2:00s
+			 6:00	-	%z	2014 Oct 26  2:00s
+			 5:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -2847,12 +3033,12 @@ Zone Asia/Yekaterinburg	 4:02:33 -	LMT	1916 Jul  3
 # Byalokoz 1919 says Omsk was 4:53:30.
 
 Zone Asia/Omsk		 4:53:30 -	LMT	1919 Nov 14
-			 5:00	-	+05	1930 Jun 21
-			 6:00	Russia	+06/+07	1991 Mar 31  2:00s
-			 5:00	Russia	+05/+06	1992 Jan 19  2:00s
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07	2014 Oct 26  2:00s
-			 6:00	-	+06
+			 5:00	-	%z	1930 Jun 21
+			 6:00	Russia	%z	1991 Mar 31  2:00s
+			 5:00	Russia	%z	1992 Jan 19  2:00s
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z	2014 Oct 26  2:00s
+			 6:00	-	%z
 
 # From Paul Eggert (2016-02-22):
 # Asia/Barnaul covers:
@@ -2885,14 +3071,14 @@ Zone Asia/Omsk		 4:53:30 -	LMT	1919 Nov 14
 # http://publication.pravo.gov.ru/Document/View/0001201603090038
 
 Zone Asia/Barnaul	 5:35:00 -	LMT	1919 Dec 10
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	1995 May 28
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07	2014 Oct 26  2:00s
-			 6:00	-	+06	2016 Mar 27  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	1995 May 28
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z	2014 Oct 26  2:00s
+			 6:00	-	%z	2016 Mar 27  2:00s
+			 7:00	-	%z
 
 # From Paul Eggert (2016-03-18):
 # Asia/Novosibirsk covers:
@@ -2906,14 +3092,14 @@ Zone Asia/Barnaul	 5:35:00 -	LMT	1919 Dec 10
 # http://publication.pravo.gov.ru/Document/View/0001201607040064
 
 Zone Asia/Novosibirsk	 5:31:40 -	LMT	1919 Dec 14  6:00
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	1993 May 23 # say Shanks & P.
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07	2014 Oct 26  2:00s
-			 6:00	-	+06	2016 Jul 24  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	1993 May 23 # say Shanks & P.
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z	2014 Oct 26  2:00s
+			 6:00	-	%z	2016 Jul 24  2:00s
+			 7:00	-	%z
 
 # From Paul Eggert (2016-03-18):
 # Asia/Tomsk covers:
@@ -2958,14 +3144,14 @@ Zone Asia/Novosibirsk	 5:31:40 -	LMT	1919 Dec 14  6:00
 # http://publication.pravo.gov.ru/Document/View/0001201604260048
 
 Zone	Asia/Tomsk	 5:39:51 -	LMT	1919 Dec 22
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	2002 May  1  3:00
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07	2014 Oct 26  2:00s
-			 6:00	-	+06	2016 May 29  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	2002 May  1  3:00
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z	2014 Oct 26  2:00s
+			 6:00	-	%z	2016 May 29  2:00s
+			 7:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -2996,12 +3182,12 @@ Zone	Asia/Tomsk	 5:39:51 -	LMT	1919 Dec 22
 # realigning itself with KRAT.
 
 Zone Asia/Novokuznetsk	 5:48:48 -	LMT	1924 May  1
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	2010 Mar 28  2:00s
-			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	2010 Mar 28  2:00s
+			 6:00	Russia	%z	2011 Mar 27  2:00s
+			 7:00	-	%z
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
 # Asia/Krasnoyarsk covers...
@@ -3015,12 +3201,12 @@ Zone Asia/Novokuznetsk	 5:48:48 -	LMT	1924 May  1
 # Byalokoz 1919 says Krasnoyarsk was 6:11:26.
 
 Zone Asia/Krasnoyarsk	 6:11:26 -	LMT	1920 Jan  6
-			 6:00	-	+06	1930 Jun 21
-			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
-			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
-			 7:00	Russia	+07/+08	2011 Mar 27  2:00s
-			 8:00	-	+08	2014 Oct 26  2:00s
-			 7:00	-	+07
+			 6:00	-	%z	1930 Jun 21
+			 7:00	Russia	%z	1991 Mar 31  2:00s
+			 6:00	Russia	%z	1992 Jan 19  2:00s
+			 7:00	Russia	%z	2011 Mar 27  2:00s
+			 8:00	-	%z	2014 Oct 26  2:00s
+			 7:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -3037,12 +3223,12 @@ Zone Asia/Krasnoyarsk	 6:11:26 -	LMT	1920 Jan  6
 
 Zone Asia/Irkutsk	 6:57:05 -	LMT	1880
 			 6:57:05 -	IMT	1920 Jan 25 # Irkutsk Mean Time
-			 7:00	-	+07	1930 Jun 21
-			 8:00	Russia	+08/+09	1991 Mar 31  2:00s
-			 7:00	Russia	+07/+08	1992 Jan 19  2:00s
-			 8:00	Russia	+08/+09	2011 Mar 27  2:00s
-			 9:00	-	+09	2014 Oct 26  2:00s
-			 8:00	-	+08
+			 7:00	-	%z	1930 Jun 21
+			 8:00	Russia	%z	1991 Mar 31  2:00s
+			 7:00	Russia	%z	1992 Jan 19  2:00s
+			 8:00	Russia	%z	2011 Mar 27  2:00s
+			 9:00	-	%z	2014 Oct 26  2:00s
+			 8:00	-	%z
 
 
 # From Tim Parenti (2014-07-06):
@@ -3059,13 +3245,13 @@ Zone Asia/Irkutsk	 6:57:05 -	LMT	1880
 # http://publication.pravo.gov.ru/Document/View/0001201512300107
 
 Zone Asia/Chita	 7:33:52 -	LMT	1919 Dec 15
-			 8:00	-	+08	1930 Jun 21
-			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
-			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
-			 9:00	Russia	+09/+10	2011 Mar 27  2:00s
-			10:00	-	+10	2014 Oct 26  2:00s
-			 8:00	-	+08	2016 Mar 27  2:00
-			 9:00	-	+09
+			 8:00	-	%z	1930 Jun 21
+			 9:00	Russia	%z	1991 Mar 31  2:00s
+			 8:00	Russia	%z	1992 Jan 19  2:00s
+			 9:00	Russia	%z	2011 Mar 27  2:00s
+			10:00	-	%z	2014 Oct 26  2:00s
+			 8:00	-	%z	2016 Mar 27  2:00
+			 9:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -3105,12 +3291,12 @@ Zone Asia/Chita	 7:33:52 -	LMT	1919 Dec 15
 # Byalokoz 1919 says Yakutsk was 8:38:58.
 
 Zone Asia/Yakutsk	 8:38:58 -	LMT	1919 Dec 15
-			 8:00	-	+08	1930 Jun 21
-			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
-			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
-			 9:00	Russia	+09/+10	2011 Mar 27  2:00s
-			10:00	-	+10	2014 Oct 26  2:00s
-			 9:00	-	+09
+			 8:00	-	%z	1930 Jun 21
+			 9:00	Russia	%z	1991 Mar 31  2:00s
+			 8:00	Russia	%z	1992 Jan 19  2:00s
+			 9:00	Russia	%z	2011 Mar 27  2:00s
+			10:00	-	%z	2014 Oct 26  2:00s
+			 9:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -3128,12 +3314,12 @@ Zone Asia/Yakutsk	 8:38:58 -	LMT	1919 Dec 15
 # Go with Byalokoz.
 
 Zone Asia/Vladivostok	 8:47:31 -	LMT	1922 Nov 15
-			 9:00	-	+09	1930 Jun 21
-			10:00	Russia	+10/+11	1991 Mar 31  2:00s
-			 9:00	Russia	+09/+10	1992 Jan 19  2:00s
-			10:00	Russia	+10/+11	2011 Mar 27  2:00s
-			11:00	-	+11	2014 Oct 26  2:00s
-			10:00	-	+10
+			 9:00	-	%z	1930 Jun 21
+			10:00	Russia	%z	1991 Mar 31  2:00s
+			 9:00	Russia	%z	1992 Jan 19  2:00s
+			10:00	Russia	%z	2011 Mar 27  2:00s
+			11:00	-	%z	2014 Oct 26  2:00s
+			10:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -3151,14 +3337,14 @@ Zone Asia/Vladivostok	 8:47:31 -	LMT	1922 Nov 15
 # This transition is no doubt wrong, but we have no better info.
 
 Zone Asia/Khandyga	 9:02:13 -	LMT	1919 Dec 15
-			 8:00	-	+08	1930 Jun 21
-			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
-			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
-			 9:00	Russia	+09/+10	2004
-			10:00	Russia	+10/+11	2011 Mar 27  2:00s
-			11:00	-	+11	2011 Sep 13  0:00s # Decree 725?
-			10:00	-	+10	2014 Oct 26  2:00s
-			 9:00	-	+09
+			 8:00	-	%z	1930 Jun 21
+			 9:00	Russia	%z	1991 Mar 31  2:00s
+			 8:00	Russia	%z	1992 Jan 19  2:00s
+			 9:00	Russia	%z	2004
+			10:00	Russia	%z	2011 Mar 27  2:00s
+			11:00	-	%z	2011 Sep 13  0:00s # Decree 725?
+			10:00	-	%z	2014 Oct 26  2:00s
+			 9:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -3174,14 +3360,14 @@ Zone Asia/Khandyga	 9:02:13 -	LMT	1919 Dec 15
 
 # The Zone name should be Asia/Yuzhno-Sakhalinsk, but that's too long.
 Zone Asia/Sakhalin	 9:30:48 -	LMT	1905 Aug 23
-			 9:00	-	+09	1945 Aug 25
-			11:00	Russia	+11/+12	1991 Mar 31  2:00s # Sakhalin T
-			10:00	Russia	+10/+11	1992 Jan 19  2:00s
-			11:00	Russia	+11/+12	1997 Mar lastSun  2:00s
-			10:00	Russia	+10/+11	2011 Mar 27  2:00s
-			11:00	-	+11	2014 Oct 26  2:00s
-			10:00	-	+10	2016 Mar 27  2:00s
-			11:00	-	+11
+			 9:00	-	%z	1945 Aug 25
+			11:00	Russia	%z	1991 Mar 31  2:00s # Sakhalin T
+			10:00	Russia	%z	1992 Jan 19  2:00s
+			11:00	Russia	%z	1997 Mar lastSun  2:00s
+			10:00	Russia	%z	2011 Mar 27  2:00s
+			11:00	-	%z	2014 Oct 26  2:00s
+			10:00	-	%z	2016 Mar 27  2:00s
+			11:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -3204,13 +3390,13 @@ Zone Asia/Sakhalin	 9:30:48 -	LMT	1905 Aug 23
 # http://publication.pravo.gov.ru/Document/View/0001201604050038
 
 Zone Asia/Magadan	10:03:12 -	LMT	1924 May  2
-			10:00	-	+10	1930 Jun 21 # Magadan Time
-			11:00	Russia	+11/+12	1991 Mar 31  2:00s
-			10:00	Russia	+10/+11	1992 Jan 19  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12	2014 Oct 26  2:00s
-			10:00	-	+10	2016 Apr 24  2:00s
-			11:00	-	+11
+			10:00	-	%z	1930 Jun 21 # Magadan Time
+			11:00	Russia	%z	1991 Mar 31  2:00s
+			10:00	Russia	%z	1992 Jan 19  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z	2014 Oct 26  2:00s
+			10:00	-	%z	2016 Apr 24  2:00s
+			11:00	-	%z
 
 
 # From Tim Parenti (2014-07-06):
@@ -3255,12 +3441,12 @@ Zone Asia/Magadan	10:03:12 -	LMT	1924 May  2
 # Go with Srednekolymsk.
 
 Zone Asia/Srednekolymsk	10:14:52 -	LMT	1924 May  2
-			10:00	-	+10	1930 Jun 21
-			11:00	Russia	+11/+12	1991 Mar 31  2:00s
-			10:00	Russia	+10/+11	1992 Jan 19  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12	2014 Oct 26  2:00s
-			11:00	-	+11
+			10:00	-	%z	1930 Jun 21
+			11:00	Russia	%z	1991 Mar 31  2:00s
+			10:00	Russia	%z	1992 Jan 19  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z	2014 Oct 26  2:00s
+			11:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -3278,14 +3464,14 @@ Zone Asia/Srednekolymsk	10:14:52 -	LMT	1924 May  2
 # UTC+12 since at least then, too.
 
 Zone Asia/Ust-Nera	 9:32:54 -	LMT	1919 Dec 15
-			 8:00	-	+08	1930 Jun 21
-			 9:00	Russia	+09/+10	1981 Apr  1
-			11:00	Russia	+11/+12	1991 Mar 31  2:00s
-			10:00	Russia	+10/+11	1992 Jan 19  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12	2011 Sep 13  0:00s # Decree 725?
-			11:00	-	+11	2014 Oct 26  2:00s
-			10:00	-	+10
+			 8:00	-	%z	1930 Jun 21
+			 9:00	Russia	%z	1981 Apr  1
+			11:00	Russia	%z	1991 Mar 31  2:00s
+			10:00	Russia	%z	1992 Jan 19  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z	2011 Sep 13  0:00s # Decree 725?
+			11:00	-	%z	2014 Oct 26  2:00s
+			10:00	-	%z
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -3298,12 +3484,12 @@ Zone Asia/Ust-Nera	 9:32:54 -	LMT	1919 Dec 15
 # The Zone name should be Asia/Petropavlovsk-Kamchatski or perhaps
 # Asia/Petropavlovsk-Kamchatsky, but these are too long.
 Zone Asia/Kamchatka	10:34:36 -	LMT	1922 Nov 10
-			11:00	-	+11	1930 Jun 21
-			12:00	Russia	+12/+13	1991 Mar 31  2:00s
-			11:00	Russia	+11/+12	1992 Jan 19  2:00s
-			12:00	Russia	+12/+13	2010 Mar 28  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12
+			11:00	-	%z	1930 Jun 21
+			12:00	Russia	%z	1991 Mar 31  2:00s
+			11:00	Russia	%z	1992 Jan 19  2:00s
+			12:00	Russia	%z	2010 Mar 28  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z
 
 
 # From Tim Parenti (2014-07-03):
@@ -3311,13 +3497,13 @@ Zone Asia/Kamchatka	10:34:36 -	LMT	1922 Nov 10
 # 87	RU-CHU	Chukotka Autonomous Okrug
 
 Zone Asia/Anadyr	11:49:56 -	LMT	1924 May  2
-			12:00	-	+12	1930 Jun 21
-			13:00	Russia	+13/+14	1982 Apr  1  0:00s
-			12:00	Russia	+12/+13	1991 Mar 31  2:00s
-			11:00	Russia	+11/+12	1992 Jan 19  2:00s
-			12:00	Russia	+12/+13	2010 Mar 28  2:00s
-			11:00	Russia	+11/+12	2011 Mar 27  2:00s
-			12:00	-	+12
+			12:00	-	%z	1930 Jun 21
+			13:00	Russia	%z	1982 Apr  1  0:00s
+			12:00	Russia	%z	1991 Mar 31  2:00s
+			11:00	Russia	%z	1992 Jan 19  2:00s
+			12:00	Russia	%z	2010 Mar 28  2:00s
+			11:00	Russia	%z	2011 Mar 27  2:00s
+			12:00	-	%z
 
 # Bosnia & Herzegovina
 # Croatia
@@ -3436,7 +3622,7 @@ Zone	Africa/Ceuta	-0:21:16 -	LMT	1901 Jan  1  0:00u
 			 1:00	-	CET	1986
 			 1:00	EU	CE%sT
 Zone	Atlantic/Canary	-1:01:36 -	LMT	1922 Mar # Las Palmas de Gran C.
-			-1:00	-	-01	1946 Sep 30  1:00
+			-1:00	-	%z	1946 Sep 30  1:00
 			 0:00	-	WET	1980 Apr  6  0:00s
 			 0:00	1:00	WEST	1980 Sep 28  1:00u
 			 0:00	EU	WE%sT
@@ -3517,8 +3703,8 @@ Zone	Atlantic/Canary	-1:01:36 -	LMT	1922 Mar # Las Palmas de Gran C.
 # but if no one is present after 11 at night, could be postponed until one
 # hour before the beginning of service.
 
-# From Paul Eggert (2013-09-11):
-# Round BMT to the nearest even second, 0:29:46.
+# From Paul Eggert (2024-05-24):
+# Express BMT as 0:29:45.500, approximately the same precision 7° 26' 22.50".
 #
 # We can find no reliable source for Shanks's assertion that all of Switzerland
 # except Geneva switched to Bern Mean Time at 00:00 on 1848-09-12.  This book:
@@ -3557,6 +3743,7 @@ Rule	Swiss	1941	1942	-	May	Mon>=1	1:00	1:00	S
 Rule	Swiss	1941	1942	-	Oct	Mon>=1	2:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Zurich	0:34:08 -	LMT	1853 Jul 16 # See above comment.
+		#STDOFF	0:29:45.500
 			0:29:46	-	BMT	1894 Jun    # Bern Mean Time
 			1:00	Swiss	CE%sT	1981
 			1:00	EU	CE%sT
@@ -3754,7 +3941,7 @@ Rule	Turkey	1996	2006	-	Oct	lastSun	1:00s	0	-
 Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 			1:56:56	-	IMT	1910 Oct # Istanbul Mean Time?
 			2:00	Turkey	EE%sT	1978 Jun 29
-			3:00	Turkey	+03/+04	1984 Nov  1  2:00
+			3:00	Turkey	%z	1984 Nov  1  2:00
 			2:00	Turkey	EE%sT	2007
 			2:00	EU	EE%sT	2011 Mar 27  1:00u
 			2:00	-	EET	2011 Mar 28  1:00u
@@ -3763,7 +3950,7 @@ Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 			2:00	EU	EE%sT	2015 Oct 25  1:00u
 			2:00	1:00	EEST	2015 Nov  8  1:00u
 			2:00	EU	EE%sT	2016 Sep  7
-			3:00	-	+03
+			3:00	-	%z
 
 # Ukraine
 #

--- a/make/data/tzdata/leapseconds
+++ b/make/data/tzdata/leapseconds
@@ -92,11 +92,11 @@ Leap	2016	Dec	31	23:59:60	+	S
 # Any additional leap seconds will come after this.
 # This Expires line is commented out for now,
 # so that pre-2020a zic implementations do not reject this file.
-#Expires 2024	Dec	28	00:00:00
+#Expires 2025	Jun	28	00:00:00
 
 # POSIX timestamps for the data in this file:
-#updated 1704708379 (2024-01-08 10:06:19 UTC)
-#expires 1735344000 (2024-12-28 00:00:00 UTC)
+#updated 1720104763 (2024-07-04 14:52:43 UTC)
+#expires 1751068800 (2025-06-28 00:00:00 UTC)
 
 #	Updated through IERS Bulletin C (https://hpiers.obspm.fr/iers/bul/bulc/bulletinc.dat)
-#	File expires on 28 December 2024
+#	File expires on 28 June 2025

--- a/make/data/tzdata/northamerica
+++ b/make/data/tzdata/northamerica
@@ -208,26 +208,6 @@ Rule	US	1987	2006	-	Apr	Sun>=1	2:00	1:00	D
 Rule	US	2007	max	-	Mar	Sun>=8	2:00	1:00	D
 Rule	US	2007	max	-	Nov	Sun>=1	2:00	0	S
 
-# From Arthur David Olson, 2005-12-19
-# We generate the files specified below to guard against old files with
-# obsolete information being left in the time zone binary directory.
-# We limit the list to names that have appeared in previous versions of
-# this time zone package.
-# We do these as separate Zones rather than as Links to avoid problems if
-# a particular place changes whether it observes DST.
-# We put these specifications here in the northamerica file both to
-# increase the chances that they'll actually get compiled and to
-# avoid the need to duplicate the US rules in another file.
-
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	EST		 -5:00	-	EST
-Zone	MST		 -7:00	-	MST
-Zone	HST		-10:00	-	HST
-Zone	EST5EDT		 -5:00	US	E%sT
-Zone	CST6CDT		 -6:00	US	C%sT
-Zone	MST7MDT		 -7:00	US	M%sT
-Zone	PST8PDT		 -8:00	US	P%sT
-
 # From U. S. Naval Observatory (1989-01-19):
 # USA  EASTERN       5 H  BEHIND UTC    NEW YORK, WASHINGTON
 # USA  EASTERN       4 H  BEHIND UTC    APR 3 - OCT 30
@@ -2396,6 +2376,81 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 # the researchers who prepared the Decrees page failed to find some of
 # the relevant documents.
 
+# From Heitor David Pinto (2024-08-04):
+# In 1931, the decree implementing DST specified that it would take
+# effect on 30 April....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=192270&pagina=2&seccion=1
+#
+# In 1981, the decree changing Campeche, Yucatán and Quintana Roo to UTC-5
+# specified that it would enter into force on 26 December 1981 at 2:00....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4705667&fecha=23/12/1981&cod_diario=202796
+#
+# In 1982, the decree returning Campeche and Yucatán to UTC-6 specified that
+# it would enter into force on 2 November 1982 at 2:00....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=205689&pagina=3&seccion=0
+#
+# Quintana Roo changed to UTC-6 on 4 January 1983 at 0:00, and again
+# to UTC-5 on 26 October 1997 at 2:00....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4787355&fecha=28/12/1982&cod_diario=206112
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=209559&pagina=15&seccion=0
+#
+# Durango, Coahuila, Nuevo León and Tamaulipas were set to UTC-7 on 1 January
+# 1922, and changed to UTC-6 on 10 June 1927.  Then Durango, Coahuila and
+# Nuevo León (but not Tamaulipas) returned to UTC-7 on 15 November 1930,
+# observed DST in 1931, and changed again to UTC-6 on 1 April 1932....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4441846&fecha=29/12/1921&cod_diario=187468
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4541520&fecha=09/06/1927&cod_diario=193920
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4491963&fecha=15/11/1930&cod_diario=190835
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4418437&fecha=21/01/1932&cod_diario=185588
+#
+# ... the ... 10 June 1927 ... decree only said 10 June 1927, without
+# specifying a time, so I suppose that it should be considered at 0:00.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4541520&fecha=09/06/1927&cod_diario=193920
+#
+# In 1942, the decree changing Baja California, Baja California Sur, Sonora,
+# Sinaloa and Nayarit to UTC-7 was published on 24 April, but it said that it
+# would apply from 1 April, so it's unclear when the change actually
+# occurred. The database currently shows 24 April 1942.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=192203&pagina=2&seccion=1
+#
+# Baja California Sur, Sonora, Sinaloa and Nayarit never used UTC-8.  The ...
+# 14 January 1949 ... change [to UTC-8] only occurred in Baja California.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4515613&fecha=13/01/1949&cod_diario=192309
+#
+# In 1945, the decree changing Baja California to UTC-8 specified that it
+# would take effect on the third day from its publication.
+# It was published on 12 November, so it would take effect on 15 November....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4555049&fecha=12/11/1945&cod_diario=194763
+#
+# In 1948, the decree changing Baja California to UTC-7 specified that it
+# would take effect on "this date".  The decree was made on 13 March,
+# but published on 5 April, so it's unclear when the change actually occurred.
+# The database currently shows 5 April 1948.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?cod_diario=188624&pagina=2&seccion=0
+#
+# In 1949, the decree changing Baja California to UTC-8 was published on 13
+# January, but it said that it would apply from 1 January, so it's unclear when
+# the change actually occurred.  The database currently shows 14 January 1949.
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4515613&fecha=13/01/1949&cod_diario=192309
+#
+# Baja California also observed UTC-7 from 1 May to 24 September 1950,
+# from 29 April to 30 September 1951 at 2:00,
+# and from 27 April to 28 September 1952 at 2:00....
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4600403&fecha=29/04/1950&cod_diario=197505
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4623553&fecha=23/09/1950&cod_diario=198805
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4469444&fecha=27/04/1951&cod_diario=189317
+# https://www.dof.gob.mx/nota_to_imagen_fs.php?codnota=4533868&fecha=10/03/1952&cod_diario=193465
+#
+# All changes in Baja California from 1948 to 1952 match those in California,
+# on the same dates or with a difference of one day.
+# So it may be easier to implement these changes as DST with rule CA
+# during this whole period.
+#
+# From Paul Eggert (2024-08-18):
+# For now, maintain the slightly-different history for Baja California,
+# as we have no information on whether 1948/1952 clocks in Tijuana followed
+# the decrees or followed San Diego.
+
 # From Alan Perry (1996-02-15):
 # A guy from our Mexico subsidiary finally found the Presidential Decree
 # outlining the timezone changes in Mexico.
@@ -2599,7 +2654,7 @@ Zone America/Dawson	-9:17:40 -	LMT	1900 Aug 20
 # http://puentelibre.mx/noticia/ciudad_juarez_cambio_horario_noviembre_2022/
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Mexico	1931	only	-	May	1	23:00	1:00	D
+Rule	Mexico	1931	only	-	April	30	0:00	1:00	D
 Rule	Mexico	1931	only	-	Oct	1	0:00	0	S
 Rule	Mexico	1939	only	-	Feb	5	0:00	1:00	D
 Rule	Mexico	1939	only	-	Jun	25	0:00	0	S
@@ -2618,14 +2673,16 @@ Rule	Mexico	2002	2022	-	Oct	lastSun	2:00	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Quintana Roo; represented by Cancún
 Zone America/Cancun	-5:47:04 -	LMT	1922 Jan  1  6:00u
-			-6:00	-	CST	1981 Dec 23
+			-6:00	-	CST	1981 Dec 26  2:00
+			-5:00	-	EST	1983 Jan  4  0:00
+			-6:00	Mexico	C%sT	1997 Oct 26  2:00
 			-5:00	Mexico	E%sT	1998 Aug  2  2:00
 			-6:00	Mexico	C%sT	2015 Feb  1  2:00
 			-5:00	-	EST
 # Campeche, Yucatán; represented by Mérida
 Zone America/Merida	-5:58:28 -	LMT	1922 Jan  1  6:00u
-			-6:00	-	CST	1981 Dec 23
-			-5:00	-	EST	1982 Dec  2
+			-6:00	-	CST	1981 Dec 26  2:00
+			-5:00	-	EST	1982 Nov  2  2:00
 			-6:00	Mexico	C%sT
 # Coahuila, Nuevo León, Tamaulipas (near US border)
 # This includes the following municipios:
@@ -2642,12 +2699,15 @@ Zone America/Matamoros	-6:30:00 -	LMT	1922 Jan  1  6:00u
 			-6:00	US	C%sT
 # Durango; Coahuila, Nuevo León, Tamaulipas (away from US border)
 Zone America/Monterrey	-6:41:16 -	LMT	1922 Jan  1  6:00u
+			-7:00	-	MST	1927 Jun 10
+			-6:00	-	CST	1930 Nov 15
+			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1988
 			-6:00	US	C%sT	1989
 			-6:00	Mexico	C%sT
 # Central Mexico
 Zone America/Mexico_City -6:36:36 -	LMT	1922 Jan  1  7:00u
-			-7:00	-	MST	1927 Jun 10 23:00
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
 			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	Mexico	C%sT	2001 Sep 30  2:00
@@ -2658,7 +2718,7 @@ Zone America/Mexico_City -6:36:36 -	LMT	1922 Jan  1  7:00u
 # Práxedis G Guerrero.
 # http://gaceta.diputados.gob.mx/PDF/65/2a022/nov/20221124-VII.pdf
 Zone America/Ciudad_Juarez -7:05:56 -	LMT	1922 Jan  1  7:00u
-			-7:00	-	MST	1927 Jun 10 23:00
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
 			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1996
@@ -2673,7 +2733,7 @@ Zone America/Ciudad_Juarez -7:05:56 -	LMT	1922 Jan  1  7:00u
 # Benavides.
 # http://gaceta.diputados.gob.mx/PDF/65/2a022/nov/20221124-VII.pdf
 Zone America/Ojinaga	-6:57:40 -	LMT	1922 Jan  1  7:00u
-			-7:00	-	MST	1927 Jun 10 23:00
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
 			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1996
@@ -2685,7 +2745,7 @@ Zone America/Ojinaga	-6:57:40 -	LMT	1922 Jan  1  7:00u
 			-6:00	US	C%sT
 # Chihuahua (away from US border)
 Zone America/Chihuahua	-7:04:20 -	LMT	1922 Jan  1  7:00u
-			-7:00	-	MST	1927 Jun 10 23:00
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
 			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1996
@@ -2695,23 +2755,21 @@ Zone America/Chihuahua	-7:04:20 -	LMT	1922 Jan  1  7:00u
 			-6:00	-	CST
 # Sonora
 Zone America/Hermosillo	-7:23:52 -	LMT	1922 Jan  1  7:00u
-			-7:00	-	MST	1927 Jun 10 23:00
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
 			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1942 Apr 24
-			-7:00	-	MST	1949 Jan 14
-			-8:00	-	PST	1970
+			-7:00	-	MST	1996
 			-7:00	Mexico	M%sT	1999
 			-7:00	-	MST
 
 # Baja California Sur, Nayarit (except Bahía de Banderas), Sinaloa
 Zone America/Mazatlan	-7:05:40 -	LMT	1922 Jan  1  7:00u
-			-7:00	-	MST	1927 Jun 10 23:00
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
 			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1942 Apr 24
-			-7:00	-	MST	1949 Jan 14
-			-8:00	-	PST	1970
+			-7:00	-	MST	1970
 			-7:00	Mexico	M%sT
 
 # Bahía de Banderas
@@ -2744,27 +2802,32 @@ Zone America/Mazatlan	-7:05:40 -	LMT	1922 Jan  1  7:00u
 # Use "Bahia_Banderas" to keep the name to fourteen characters.
 
 Zone America/Bahia_Banderas -7:01:00 -	LMT	1922 Jan  1  7:00u
-			-7:00	-	MST	1927 Jun 10 23:00
+			-7:00	-	MST	1927 Jun 10
 			-6:00	-	CST	1930 Nov 15
 			-7:00	Mexico	M%sT	1932 Apr  1
 			-6:00	-	CST	1942 Apr 24
-			-7:00	-	MST	1949 Jan 14
-			-8:00	-	PST	1970
+			-7:00	-	MST	1970
 			-7:00	Mexico	M%sT	2010 Apr  4  2:00
 			-6:00	Mexico	C%sT
 
 # Baja California
 Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  7:00u
 			-7:00	-	MST	1924
-			-8:00	-	PST	1927 Jun 10 23:00
+			-8:00	-	PST	1927 Jun 10
 			-7:00	-	MST	1930 Nov 15
 			-8:00	-	PST	1931 Apr  1
 			-8:00	1:00	PDT	1931 Sep 30
 			-8:00	-	PST	1942 Apr 24
 			-8:00	1:00	PWT	1945 Aug 14 23:00u
-			-8:00	1:00	PPT	1945 Nov 12 # Peace
+			-8:00	1:00	PPT	1945 Nov 15 # Peace
 			-8:00	-	PST	1948 Apr  5
 			-8:00	1:00	PDT	1949 Jan 14
+			-8:00	-	PST	1950 May  1
+			-8:00	1:00	PDT	1950 Sep 24
+			-8:00	-	PST	1951 Apr 29  2:00
+			-8:00	1:00	PDT	1951 Sep 30  2:00
+			-8:00	-	PST	1952 Apr 27  2:00
+			-8:00	1:00	PDT	1952 Sep 28  2:00
 			-8:00	-	PST	1954
 			-8:00	CA	P%sT	1961
 			-8:00	-	PST	1976
@@ -3573,8 +3636,8 @@ Zone America/Puerto_Rico -4:24:25 -	LMT	1899 Mar 28 12:00 # San Juan
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Miquelon	-3:44:40 -	LMT	1911 Jun 15 # St Pierre
 			-4:00	-	AST	1980 May
-			-3:00	-	-03	1987
-			-3:00	Canada	-03/-02
+			-3:00	-	%z	1987
+			-3:00	Canada	%z
 
 # Turks and Caicos
 #

--- a/make/data/tzdata/southamerica
+++ b/make/data/tzdata/southamerica
@@ -425,11 +425,11 @@ Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	-
 Zone America/Argentina/Buenos_Aires -3:53:48 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May    # Córdoba Mean Time
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	Arg	-03/-02
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	Arg	%z
 #
 # Córdoba (CB), Santa Fe (SF), Entre Ríos (ER), Corrientes (CN), Misiones (MN),
 # Chaco (CC), Formosa (FM), Santiago del Estero (SE)
@@ -444,120 +444,120 @@ Zone America/Argentina/Buenos_Aires -3:53:48 - LMT	1894 Oct 31
 		#STDOFF	       -4:16:48.25
 Zone America/Argentina/Cordoba -4:16:48 - LMT	1894 Oct 31
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1991 Mar  3
-			-4:00	-	-04	1991 Oct 20
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	Arg	-03/-02
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  3
+			-4:00	-	%z	1991 Oct 20
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	Arg	%z
 #
 # Salta (SA), La Pampa (LP), Neuquén (NQ), Rio Negro (RN)
 Zone America/Argentina/Salta -4:21:40 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1991 Mar  3
-			-4:00	-	-04	1991 Oct 20
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	Arg	-03/-02	2008 Oct 18
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  3
+			-4:00	-	%z	1991 Oct 20
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Tucumán (TM)
 Zone America/Argentina/Tucuman -4:20:52 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1991 Mar  3
-			-4:00	-	-04	1991 Oct 20
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	-	-03	2004 Jun  1
-			-4:00	-	-04	2004 Jun 13
-			-3:00	Arg	-03/-02
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  3
+			-4:00	-	%z	1991 Oct 20
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 Jun  1
+			-4:00	-	%z	2004 Jun 13
+			-3:00	Arg	%z
 #
 # La Rioja (LR)
 Zone America/Argentina/La_Rioja -4:27:24 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1991 Mar  1
-			-4:00	-	-04	1991 May  7
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	-	-03	2004 Jun  1
-			-4:00	-	-04	2004 Jun 20
-			-3:00	Arg	-03/-02	2008 Oct 18
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  1
+			-4:00	-	%z	1991 May  7
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 Jun  1
+			-4:00	-	%z	2004 Jun 20
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # San Juan (SJ)
 Zone America/Argentina/San_Juan -4:34:04 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1991 Mar  1
-			-4:00	-	-04	1991 May  7
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	-	-03	2004 May 31
-			-4:00	-	-04	2004 Jul 25
-			-3:00	Arg	-03/-02	2008 Oct 18
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  1
+			-4:00	-	%z	1991 May  7
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 May 31
+			-4:00	-	%z	2004 Jul 25
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Jujuy (JY)
 Zone America/Argentina/Jujuy -4:21:12 -	LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1990 Mar  4
-			-4:00	-	-04	1990 Oct 28
-			-4:00	1:00	-03	1991 Mar 17
-			-4:00	-	-04	1991 Oct  6
-			-3:00	1:00	-02	1992
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	Arg	-03/-02	2008 Oct 18
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1990 Mar  4
+			-4:00	-	%z	1990 Oct 28
+			-4:00	1:00	%z	1991 Mar 17
+			-4:00	-	%z	1991 Oct  6
+			-3:00	1:00	%z	1992
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Catamarca (CT), Chubut (CH)
 Zone America/Argentina/Catamarca -4:23:08 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1991 Mar  3
-			-4:00	-	-04	1991 Oct 20
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	-	-03	2004 Jun  1
-			-4:00	-	-04	2004 Jun 20
-			-3:00	Arg	-03/-02	2008 Oct 18
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1991 Mar  3
+			-4:00	-	%z	1991 Oct 20
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 Jun  1
+			-4:00	-	%z	2004 Jun 20
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Mendoza (MZ)
 Zone America/Argentina/Mendoza -4:35:16 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1990 Mar  4
-			-4:00	-	-04	1990 Oct 15
-			-4:00	1:00	-03	1991 Mar  1
-			-4:00	-	-04	1991 Oct 15
-			-4:00	1:00	-03	1992 Mar  1
-			-4:00	-	-04	1992 Oct 18
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	-	-03	2004 May 23
-			-4:00	-	-04	2004 Sep 26
-			-3:00	Arg	-03/-02	2008 Oct 18
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1990 Mar  4
+			-4:00	-	%z	1990 Oct 15
+			-4:00	1:00	%z	1991 Mar  1
+			-4:00	-	%z	1991 Oct 15
+			-4:00	1:00	%z	1992 Mar  1
+			-4:00	-	%z	1992 Oct 18
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 May 23
+			-4:00	-	%z	2004 Sep 26
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # San Luis (SL)
 
@@ -567,53 +567,53 @@ Rule	SanLuis	2007	2008	-	Oct	Sun>=8	0:00	1:00	-
 Zone America/Argentina/San_Luis -4:25:24 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1990
-			-3:00	1:00	-02	1990 Mar 14
-			-4:00	-	-04	1990 Oct 15
-			-4:00	1:00	-03	1991 Mar  1
-			-4:00	-	-04	1991 Jun  1
-			-3:00	-	-03	1999 Oct  3
-			-4:00	1:00	-03	2000 Mar  3
-			-3:00	-	-03	2004 May 31
-			-4:00	-	-04	2004 Jul 25
-			-3:00	Arg	-03/-02	2008 Jan 21
-			-4:00	SanLuis	-04/-03	2009 Oct 11
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1990
+			-3:00	1:00	%z	1990 Mar 14
+			-4:00	-	%z	1990 Oct 15
+			-4:00	1:00	%z	1991 Mar  1
+			-4:00	-	%z	1991 Jun  1
+			-3:00	-	%z	1999 Oct  3
+			-4:00	1:00	%z	2000 Mar  3
+			-3:00	-	%z	2004 May 31
+			-4:00	-	%z	2004 Jul 25
+			-3:00	Arg	%z	2008 Jan 21
+			-4:00	SanLuis	%z	2009 Oct 11
+			-3:00	-	%z
 #
 # Santa Cruz (SC)
 Zone America/Argentina/Rio_Gallegos -4:36:52 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	-	-03	2004 Jun  1
-			-4:00	-	-04	2004 Jun 20
-			-3:00	Arg	-03/-02	2008 Oct 18
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 Jun  1
+			-4:00	-	%z	2004 Jun 20
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 #
 # Tierra del Fuego, Antártida e Islas del Atlántico Sur (TF)
 Zone America/Argentina/Ushuaia -4:33:12 - LMT	1894 Oct 31
 		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
-			-4:00	-	-04	1930 Dec
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1999 Oct  3
-			-4:00	Arg	-04/-03	2000 Mar  3
-			-3:00	-	-03	2004 May 30
-			-4:00	-	-04	2004 Jun 20
-			-3:00	Arg	-03/-02	2008 Oct 18
-			-3:00	-	-03
+			-4:00	-	%z	1930 Dec
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1999 Oct  3
+			-4:00	Arg	%z	2000 Mar  3
+			-3:00	-	%z	2004 May 30
+			-4:00	-	%z	2004 Jun 20
+			-3:00	Arg	%z	2008 Oct 18
+			-3:00	-	%z
 
 # Bolivia
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/La_Paz	-4:32:36 -	LMT	1890
 			-4:32:36 -	CMT	1931 Oct 15 # Calamarca MT
 			-4:32:36 1:00	BST	1932 Mar 21 # Bolivia ST
-			-4:00	-	-04
+			-4:00	-	%z
 
 # Brazil
 
@@ -984,12 +984,12 @@ Rule	Brazil	2018	only	-	Nov	Sun>=1	0:00	1:00	-
 #
 # Fernando de Noronha (administratively part of PE)
 Zone America/Noronha	-2:09:40 -	LMT	1914
-			-2:00	Brazil	-02/-01	1990 Sep 17
-			-2:00	-	-02	1999 Sep 30
-			-2:00	Brazil	-02/-01	2000 Oct 15
-			-2:00	-	-02	2001 Sep 13
-			-2:00	Brazil	-02/-01	2002 Oct  1
-			-2:00	-	-02
+			-2:00	Brazil	%z	1990 Sep 17
+			-2:00	-	%z	1999 Sep 30
+			-2:00	Brazil	%z	2000 Oct 15
+			-2:00	-	%z	2001 Sep 13
+			-2:00	Brazil	%z	2002 Oct  1
+			-2:00	-	%z
 # Other Atlantic islands have no permanent settlement.
 # These include Trindade and Martim Vaz (administratively part of ES),
 # Rocas Atoll (RN), and the St Peter and St Paul Archipelago (PE).
@@ -1002,119 +1002,119 @@ Zone America/Noronha	-2:09:40 -	LMT	1914
 # In the north a very small part from the river Javary (now Jari I guess,
 # the border with Amapá) to the Amazon, then to the Xingu.
 Zone America/Belem	-3:13:56 -	LMT	1914
-			-3:00	Brazil	-03/-02	1988 Sep 12
-			-3:00	-	-03
+			-3:00	Brazil	%z	1988 Sep 12
+			-3:00	-	%z
 #
 # west Pará (PA)
 # West Pará includes Altamira, Óbidos, Prainha, Oriximiná, and Santarém.
 Zone America/Santarem	-3:38:48 -	LMT	1914
-			-4:00	Brazil	-04/-03	1988 Sep 12
-			-4:00	-	-04	2008 Jun 24  0:00
-			-3:00	-	-03
+			-4:00	Brazil	%z	1988 Sep 12
+			-4:00	-	%z	2008 Jun 24  0:00
+			-3:00	-	%z
 #
 # Maranhão (MA), Piauí (PI), Ceará (CE), Rio Grande do Norte (RN),
 # Paraíba (PB)
 Zone America/Fortaleza	-2:34:00 -	LMT	1914
-			-3:00	Brazil	-03/-02	1990 Sep 17
-			-3:00	-	-03	1999 Sep 30
-			-3:00	Brazil	-03/-02	2000 Oct 22
-			-3:00	-	-03	2001 Sep 13
-			-3:00	Brazil	-03/-02	2002 Oct  1
-			-3:00	-	-03
+			-3:00	Brazil	%z	1990 Sep 17
+			-3:00	-	%z	1999 Sep 30
+			-3:00	Brazil	%z	2000 Oct 22
+			-3:00	-	%z	2001 Sep 13
+			-3:00	Brazil	%z	2002 Oct  1
+			-3:00	-	%z
 #
 # Pernambuco (PE) (except Atlantic islands)
 Zone America/Recife	-2:19:36 -	LMT	1914
-			-3:00	Brazil	-03/-02	1990 Sep 17
-			-3:00	-	-03	1999 Sep 30
-			-3:00	Brazil	-03/-02	2000 Oct 15
-			-3:00	-	-03	2001 Sep 13
-			-3:00	Brazil	-03/-02	2002 Oct  1
-			-3:00	-	-03
+			-3:00	Brazil	%z	1990 Sep 17
+			-3:00	-	%z	1999 Sep 30
+			-3:00	Brazil	%z	2000 Oct 15
+			-3:00	-	%z	2001 Sep 13
+			-3:00	Brazil	%z	2002 Oct  1
+			-3:00	-	%z
 #
 # Tocantins (TO)
 Zone America/Araguaina	-3:12:48 -	LMT	1914
-			-3:00	Brazil	-03/-02	1990 Sep 17
-			-3:00	-	-03	1995 Sep 14
-			-3:00	Brazil	-03/-02	2003 Sep 24
-			-3:00	-	-03	2012 Oct 21
-			-3:00	Brazil	-03/-02	2013 Sep
-			-3:00	-	-03
+			-3:00	Brazil	%z	1990 Sep 17
+			-3:00	-	%z	1995 Sep 14
+			-3:00	Brazil	%z	2003 Sep 24
+			-3:00	-	%z	2012 Oct 21
+			-3:00	Brazil	%z	2013 Sep
+			-3:00	-	%z
 #
 # Alagoas (AL), Sergipe (SE)
 Zone America/Maceio	-2:22:52 -	LMT	1914
-			-3:00	Brazil	-03/-02	1990 Sep 17
-			-3:00	-	-03	1995 Oct 13
-			-3:00	Brazil	-03/-02	1996 Sep  4
-			-3:00	-	-03	1999 Sep 30
-			-3:00	Brazil	-03/-02	2000 Oct 22
-			-3:00	-	-03	2001 Sep 13
-			-3:00	Brazil	-03/-02	2002 Oct  1
-			-3:00	-	-03
+			-3:00	Brazil	%z	1990 Sep 17
+			-3:00	-	%z	1995 Oct 13
+			-3:00	Brazil	%z	1996 Sep  4
+			-3:00	-	%z	1999 Sep 30
+			-3:00	Brazil	%z	2000 Oct 22
+			-3:00	-	%z	2001 Sep 13
+			-3:00	Brazil	%z	2002 Oct  1
+			-3:00	-	%z
 #
 # Bahia (BA)
 # There are too many Salvadors elsewhere, so use America/Bahia instead
 # of America/Salvador.
 Zone America/Bahia	-2:34:04 -	LMT	1914
-			-3:00	Brazil	-03/-02	2003 Sep 24
-			-3:00	-	-03	2011 Oct 16
-			-3:00	Brazil	-03/-02	2012 Oct 21
-			-3:00	-	-03
+			-3:00	Brazil	%z	2003 Sep 24
+			-3:00	-	%z	2011 Oct 16
+			-3:00	Brazil	%z	2012 Oct 21
+			-3:00	-	%z
 #
 # Goiás (GO), Distrito Federal (DF), Minas Gerais (MG),
 # Espírito Santo (ES), Rio de Janeiro (RJ), São Paulo (SP), Paraná (PR),
 # Santa Catarina (SC), Rio Grande do Sul (RS)
 Zone America/Sao_Paulo	-3:06:28 -	LMT	1914
-			-3:00	Brazil	-03/-02	1963 Oct 23  0:00
-			-3:00	1:00	-02	1964
-			-3:00	Brazil	-03/-02
+			-3:00	Brazil	%z	1963 Oct 23  0:00
+			-3:00	1:00	%z	1964
+			-3:00	Brazil	%z
 #
 # Mato Grosso do Sul (MS)
 Zone America/Campo_Grande -3:38:28 -	LMT	1914
-			-4:00	Brazil	-04/-03
+			-4:00	Brazil	%z
 #
 # Mato Grosso (MT)
 Zone America/Cuiaba	-3:44:20 -	LMT	1914
-			-4:00	Brazil	-04/-03	2003 Sep 24
-			-4:00	-	-04	2004 Oct  1
-			-4:00	Brazil	-04/-03
+			-4:00	Brazil	%z	2003 Sep 24
+			-4:00	-	%z	2004 Oct  1
+			-4:00	Brazil	%z
 #
 # Rondônia (RO)
 Zone America/Porto_Velho -4:15:36 -	LMT	1914
-			-4:00	Brazil	-04/-03	1988 Sep 12
-			-4:00	-	-04
+			-4:00	Brazil	%z	1988 Sep 12
+			-4:00	-	%z
 #
 # Roraima (RR)
 Zone America/Boa_Vista	-4:02:40 -	LMT	1914
-			-4:00	Brazil	-04/-03	1988 Sep 12
-			-4:00	-	-04	1999 Sep 30
-			-4:00	Brazil	-04/-03	2000 Oct 15
-			-4:00	-	-04
+			-4:00	Brazil	%z	1988 Sep 12
+			-4:00	-	%z	1999 Sep 30
+			-4:00	Brazil	%z	2000 Oct 15
+			-4:00	-	%z
 #
 # east Amazonas (AM): Boca do Acre, Jutaí, Manaus, Floriano Peixoto
 # The great circle line from Tabatinga to Porto Acre divides
 # east from west Amazonas.
 Zone America/Manaus	-4:00:04 -	LMT	1914
-			-4:00	Brazil	-04/-03	1988 Sep 12
-			-4:00	-	-04	1993 Sep 28
-			-4:00	Brazil	-04/-03	1994 Sep 22
-			-4:00	-	-04
+			-4:00	Brazil	%z	1988 Sep 12
+			-4:00	-	%z	1993 Sep 28
+			-4:00	Brazil	%z	1994 Sep 22
+			-4:00	-	%z
 #
 # west Amazonas (AM): Atalaia do Norte, Boca do Maoco, Benjamin Constant,
 #	Eirunepé, Envira, Ipixuna
 Zone America/Eirunepe	-4:39:28 -	LMT	1914
-			-5:00	Brazil	-05/-04	1988 Sep 12
-			-5:00	-	-05	1993 Sep 28
-			-5:00	Brazil	-05/-04	1994 Sep 22
-			-5:00	-	-05	2008 Jun 24  0:00
-			-4:00	-	-04	2013 Nov 10
-			-5:00	-	-05
+			-5:00	Brazil	%z	1988 Sep 12
+			-5:00	-	%z	1993 Sep 28
+			-5:00	Brazil	%z	1994 Sep 22
+			-5:00	-	%z	2008 Jun 24  0:00
+			-4:00	-	%z	2013 Nov 10
+			-5:00	-	%z
 #
 # Acre (AC)
 Zone America/Rio_Branco	-4:31:12 -	LMT	1914
-			-5:00	Brazil	-05/-04	1988 Sep 12
-			-5:00	-	-05	2008 Jun 24  0:00
-			-4:00	-	-04	2013 Nov 10
-			-5:00	-	-05
+			-5:00	Brazil	%z	1988 Sep 12
+			-5:00	-	%z	2008 Jun 24  0:00
+			-4:00	-	%z	2013 Nov 10
+			-5:00	-	%z
 
 # Chile
 
@@ -1382,36 +1382,36 @@ Rule	Chile	2023	max	-	Sep	Sun>=2	4:00u	1:00	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Santiago	-4:42:45 -	LMT	1890
 			-4:42:45 -	SMT	1910 Jan 10 # Santiago Mean Time
-			-5:00	-	-05	1916 Jul  1
+			-5:00	-	%z	1916 Jul  1
 			-4:42:45 -	SMT	1918 Sep 10
-			-4:00	-	-04	1919 Jul  1
+			-4:00	-	%z	1919 Jul  1
 			-4:42:45 -	SMT	1927 Sep  1
-			-5:00	Chile	-05/-04	1932 Sep  1
-			-4:00	-	-04	1942 Jun  1
-			-5:00	-	-05	1942 Aug  1
-			-4:00	-	-04	1946 Jul 14 24:00
-			-4:00	1:00	-03	1946 Aug 28 24:00 # central CL
-			-5:00	1:00	-04	1947 Mar 31 24:00
-			-5:00	-	-05	1947 May 21 23:00
-			-4:00	Chile	-04/-03
+			-5:00	Chile	%z	1932 Sep  1
+			-4:00	-	%z	1942 Jun  1
+			-5:00	-	%z	1942 Aug  1
+			-4:00	-	%z	1946 Jul 14 24:00
+			-4:00	1:00	%z	1946 Aug 28 24:00 # central CL
+			-5:00	1:00	%z	1947 Mar 31 24:00
+			-5:00	-	%z	1947 May 21 23:00
+			-4:00	Chile	%z
 Zone America/Punta_Arenas -4:43:40 -	LMT	1890
 			-4:42:45 -	SMT	1910 Jan 10
-			-5:00	-	-05	1916 Jul  1
+			-5:00	-	%z	1916 Jul  1
 			-4:42:45 -	SMT	1918 Sep 10
-			-4:00	-	-04	1919 Jul  1
+			-4:00	-	%z	1919 Jul  1
 			-4:42:45 -	SMT	1927 Sep  1
-			-5:00	Chile	-05/-04	1932 Sep  1
-			-4:00	-	-04	1942 Jun  1
-			-5:00	-	-05	1942 Aug  1
-			-4:00	-	-04	1946 Aug 28 24:00
-			-5:00	1:00	-04	1947 Mar 31 24:00
-			-5:00	-	-05	1947 May 21 23:00
-			-4:00	Chile	-04/-03	2016 Dec  4
-			-3:00	-	-03
+			-5:00	Chile	%z	1932 Sep  1
+			-4:00	-	%z	1942 Jun  1
+			-5:00	-	%z	1942 Aug  1
+			-4:00	-	%z	1946 Aug 28 24:00
+			-5:00	1:00	%z	1947 Mar 31 24:00
+			-5:00	-	%z	1947 May 21 23:00
+			-4:00	Chile	%z	2016 Dec  4
+			-3:00	-	%z
 Zone Pacific/Easter	-7:17:28 -	LMT	1890
 			-7:17:28 -	EMT	1932 Sep    # Easter Mean Time
-			-7:00	Chile	-07/-06	1982 Mar 14 3:00u # Easter Time
-			-6:00	Chile	-06/-05
+			-7:00	Chile	%z	1982 Mar 14 3:00u # Easter Time
+			-6:00	Chile	%z
 #
 # Salas y Gómez Island is uninhabited.
 # Other Chilean locations, including Juan Fernández Is, Desventuradas Is,
@@ -1431,10 +1431,10 @@ Zone Pacific/Easter	-7:17:28 -	LMT	1890
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Palmer	0	-	-00	1965
-			-4:00	Arg	-04/-03	1969 Oct  5
-			-3:00	Arg	-03/-02	1982 May
-			-4:00	Chile	-04/-03	2016 Dec  4
-			-3:00	-	-03
+			-4:00	Arg	%z	1969 Oct  5
+			-3:00	Arg	%z	1982 May
+			-4:00	Chile	%z	2016 Dec  4
+			-3:00	-	%z
 
 # Colombia
 
@@ -1453,7 +1453,7 @@ Rule	CO	1993	only	-	Feb	 6	24:00	0	-
 		#STDOFF	-4:56:16.4
 Zone	America/Bogota	-4:56:16 -	LMT	1884 Mar 13
 			-4:56:16 -	BMT	1914 Nov 23 # Bogotá Mean Time
-			-5:00	CO	-05/-04
+			-5:00	CO	%z
 # Malpelo, Providencia, San Andres
 # no information; probably like America/Bogota
 
@@ -1484,10 +1484,10 @@ Rule	Ecuador	1993	only	-	Feb	 5	0:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Guayaquil	-5:19:20 -	LMT	1890
 			-5:14:00 -	QMT	1931 # Quito Mean Time
-			-5:00	Ecuador	-05/-04
+			-5:00	Ecuador	%z
 Zone Pacific/Galapagos	-5:58:24 -	LMT	1931 # Puerto Baquerizo Moreno
-			-5:00	-	-05	1986
-			-6:00	Ecuador	-06/-05
+			-5:00	-	%z	1986
+			-6:00	Ecuador	%z
 
 # Falklands
 
@@ -1587,10 +1587,10 @@ Rule	Falk	2001	2010	-	Sep	Sun>=1	2:00	1:00	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Atlantic/Stanley	-3:51:24 -	LMT	1890
 			-3:51:24 -	SMT	1912 Mar 12 # Stanley Mean Time
-			-4:00	Falk	-04/-03	1983 May
-			-3:00	Falk	-03/-02	1985 Sep 15
-			-4:00	Falk	-04/-03	2010 Sep  5  2:00
-			-3:00	-	-03
+			-4:00	Falk	%z	1983 May
+			-3:00	Falk	%z	1985 Sep 15
+			-4:00	Falk	%z	2010 Sep  5  2:00
+			-3:00	-	%z
 
 # French Guiana
 # For the 1911/1912 establishment of standard time in French possessions, see:
@@ -1598,8 +1598,8 @@ Zone Atlantic/Stanley	-3:51:24 -	LMT	1890
 # page 752, 18b.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul  1
-			-4:00	-	-04	1967 Oct
-			-3:00	-	-03
+			-4:00	-	%z	1967 Oct
+			-3:00	-	%z
 
 # Guyana
 
@@ -1633,10 +1633,10 @@ Zone America/Cayenne	-3:29:20 -	LMT	1911 Jul  1
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Guyana	-3:52:39 -	LMT	1911 Aug  1 # Georgetown
-			-4:00	-	-04	1915 Mar  1
-			-3:45	-	-0345	1975 Aug  1
-			-3:00	-	-03	1992 Mar 29  1:00
-			-4:00	-	-04
+			-4:00	-	%z	1915 Mar  1
+			-3:45	-	%z	1975 Aug  1
+			-3:00	-	%z	1992 Mar 29  1:00
+			-4:00	-	%z
 
 # Paraguay
 #
@@ -1734,9 +1734,9 @@ Rule	Para	2013	max	-	Mar	Sun>=22	0:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Asuncion	-3:50:40 -	LMT	1890
 			-3:50:40 -	AMT	1931 Oct 10 # Asunción Mean Time
-			-4:00	-	-04	1972 Oct
-			-3:00	-	-03	1974 Apr
-			-4:00	Para	-04/-03
+			-4:00	-	%z	1972 Oct
+			-3:00	-	%z	1974 Apr
+			-4:00	Para	%z
 
 # Peru
 #
@@ -1763,12 +1763,12 @@ Rule	Peru	1994	only	-	Apr	 1	0:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Lima	-5:08:12 -	LMT	1890
 			-5:08:36 -	LMT	1908 Jul 28 # Lima Mean Time?
-			-5:00	Peru	-05/-04
+			-5:00	Peru	%z
 
 # South Georgia
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Atlantic/South_Georgia -2:26:08 -	LMT	1890 # Grytviken
-			-2:00	-	-02
+			-2:00	-	%z
 
 # South Sandwich Is
 # uninhabited; scientific personnel have wintered
@@ -1778,8 +1778,8 @@ Zone Atlantic/South_Georgia -2:26:08 -	LMT	1890 # Grytviken
 Zone America/Paramaribo	-3:40:40 -	LMT	1911
 			-3:40:52 -	PMT	1935     # Paramaribo Mean Time
 			-3:40:36 -	PMT	1945 Oct    # The capital moved?
-			-3:30	-	-0330	1984 Oct
-			-3:00	-	-03
+			-3:30	-	%z	1984 Oct
+			-3:00	-	%z
 
 # Uruguay
 # From Paul Eggert (1993-11-18):
@@ -1994,15 +1994,15 @@ Rule	Uruguay	2006	2014	-	Oct	Sun>=1	 2:00	1:00	-
 # This Zone can be simplified once we assume zic %z.
 Zone America/Montevideo	-3:44:51 -	LMT	1908 Jun 10
 			-3:44:51 -	MMT	1920 May  1 # Montevideo MT
-			-4:00	-	-04	1923 Oct  1
-			-3:30	Uruguay	-0330/-03 1942 Dec 14
-			-3:00	Uruguay	-03/-0230 1960
-			-3:00	Uruguay	-03/-02	1968
-			-3:00	Uruguay	-03/-0230 1970
-			-3:00	Uruguay	-03/-02	1974
-			-3:00	Uruguay	-03/-0130 1974 Mar 10
-			-3:00	Uruguay	-03/-0230 1974 Dec 22
-			-3:00	Uruguay	-03/-02
+			-4:00	-	%z	1923 Oct  1
+			-3:30	Uruguay	%z	1942 Dec 14
+			-3:00	Uruguay	%z	1960
+			-3:00	Uruguay	%z	1968
+			-3:00	Uruguay	%z	1970
+			-3:00	Uruguay	%z	1974
+			-3:00	Uruguay	%z	1974 Mar 10
+			-3:00	Uruguay	%z	1974 Dec 22
+			-3:00	Uruguay	%z
 
 # Venezuela
 #
@@ -2036,7 +2036,7 @@ Zone America/Montevideo	-3:44:51 -	LMT	1908 Jun 10
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	America/Caracas	-4:27:44 -	LMT	1890
 			-4:27:40 -	CMT	1912 Feb 12 # Caracas Mean Time?
-			-4:30	-	-0430	1965 Jan  1  0:00
-			-4:00	-	-04	2007 Dec  9  3:00
-			-4:30	-	-0430	2016 May  1  2:30
-			-4:00	-	-04
+			-4:30	-	%z	1965 Jan  1  0:00
+			-4:00	-	%z	2007 Dec  9  3:00
+			-4:30	-	%z	2016 May  1  2:30
+			-4:00	-	%z

--- a/make/data/tzdata/zone.tab
+++ b/make/data/tzdata/zone.tab
@@ -287,8 +287,7 @@ MK	+4159+02126	Europe/Skopje
 ML	+1239-00800	Africa/Bamako
 MM	+1647+09610	Asia/Yangon
 MN	+4755+10653	Asia/Ulaanbaatar	most of Mongolia
-MN	+4801+09139	Asia/Hovd	Bayan-Olgiy, Govi-Altai, Hovd, Uvs, Zavkhan
-MN	+4804+11430	Asia/Choibalsan	Dornod, Sukhbaatar
+MN	+4801+09139	Asia/Hovd	Bayan-Olgii, Hovd, Uvs
 MO	+221150+1133230	Asia/Macau
 MP	+1512+14545	Pacific/Saipan
 MQ	+1436-06105	America/Martinique

--- a/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
@@ -1,1 +1,1 @@
-tzdata2024a
+tzdata2024b

--- a/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
@@ -53,6 +53,7 @@ Link	America/Tijuana		Mexico/BajaNorte
 Link	America/Mazatlan	Mexico/BajaSur
 Link	America/Mexico_City	Mexico/General
 Link	Pacific/Auckland	NZ
+Link	Asia/Ulaanbaatar	Asia/Choibalsan
 Link	Pacific/Chatham		NZ-CHAT
 Link	America/Denver		Navajo	#= America/Shiprock
 Link	Asia/Shanghai		PRC

--- a/test/jdk/sun/util/calendar/zi/TestZoneInfo310.java
+++ b/test/jdk/sun/util/calendar/zi/TestZoneInfo310.java
@@ -50,7 +50,9 @@ public class TestZoneInfo310 {
             "..", "..", "make", "data", "tzdata");
         String tzfiles = "africa antarctica asia australasia europe northamerica southamerica backward etcetera gmt";
         Path jdk_tzdir = Paths.get(System.getProperty("test.src"), "tzdata_jdk");
-        String jdk_tzfiles = "jdk11_backward";
+        // tz2024b_overridden_zones file is created to preserve the behaviour of
+        // "EST", "MST", and "HST" when timezone 2024b changes are applied
+        String jdk_tzfiles = "jdk11_backward tz2024b_overridden_zones";
         String zidir = TESTDIR + File.separator + "zi";
         File fZidir = new File(zidir);
         if (!fZidir.exists()) {

--- a/test/jdk/sun/util/calendar/zi/tzdata_jdk/tz2024b_overridden_zones
+++ b/test/jdk/sun/util/calendar/zi/tzdata_jdk/tz2024b_overridden_zones
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+
+# TZdata2024b changes announced on 5th September 2024 includes changes to
+# "EST", "MST", and "HST", i.e., changing those time zones from distinct
+# time zones to links to other time zones. Previously
+# they were defined as fixed offset zones,
+# e.g., "EST" is "-05:00" without any DST transitions.
+# With 2024b, "EST" is now a link to "America/Panama."
+# This change has Java 8+ specification implications in java.time.ZoneId.SHORT_IDS field
+# Solution for jdk24+ to modify the mappings in ZoneId class which requires modification of the spec.
+# Update releases will not make the ZoneId changes due to current specification.
+
+# Zone	NAME		GMTOFF	RULES/SAVE	FORMAT	[UNTIL]
+Zone    EST              -5:00  -       EST
+Zone    MST              -7:00  -       MST
+Zone    HST             -10:00  -       HST


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

This is based on the commit to 21.

I replaced the path to tzdata to the other location in 17 in the patch.
Like this, the change applies clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339637](https://bugs.openjdk.org/browse/JDK-8339637) needs maintainer approval
- [x] Change requires CSR request [JDK-8342331](https://bugs.openjdk.org/browse/JDK-8342331) to be approved

### Issues
 * [JDK-8339637](https://bugs.openjdk.org/browse/JDK-8339637): (tz) Update Timezone Data to 2024b (**Enhancement** - P3 - Approved)
 * [JDK-8342331](https://bugs.openjdk.org/browse/JDK-8342331): (tz) Update Timezone Data to 2024b (**CSR**)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3068/head:pull/3068` \
`$ git checkout pull/3068`

Update a local copy of the PR: \
`$ git checkout pull/3068` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3068`

View PR using the GUI difftool: \
`$ git pr show -t 3068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3068.diff">https://git.openjdk.org/jdk17u-dev/pull/3068.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3068#issuecomment-2490809129)
</details>
