### PR TITLE
8342181: Update tests to use stronger Key and Salt size

### DIFF
--- a/test/jdk/com/sun/crypto/provider/Cipher/DES/KeyWrapping.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/DES/KeyWrapping.java
@@ -24,11 +24,13 @@
 /*
  * @test
  * @bug 0000000
+ * @library /test/lib
  * @summary KeyWrapping
  * @author Jan Luehe
  */
 import javax.crypto.*;
 import java.security.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class KeyWrapping {
 
@@ -71,8 +73,9 @@ public class KeyWrapping {
         if (!msg.equals(new String(clearText)))
             throw new Exception("The unwrapped session key is corrupted.");
 
-        KeyPairGenerator kpairGen = KeyPairGenerator.getInstance("DSA");
-        kpairGen.initialize(1024);
+        String kpgAlgorithm = "DSA";
+        KeyPairGenerator kpairGen = KeyPairGenerator.getInstance(kpgAlgorithm);
+        kpairGen.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
 
         KeyPair kpair = kpairGen.genKeyPair();
 

--- a/test/jdk/com/sun/crypto/provider/Cipher/DES/Sealtest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/DES/Sealtest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,20 +24,23 @@
 /*
  * @test
  * @bug 0000000 7055362
+ * @library /test/lib
  * @summary Sealtest
  * @author Jan Luehe
  */
 import java.io.*;
 import java.security.*;
 import javax.crypto.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class Sealtest {
 
     public static void main(String[] args) throws Exception {
 
         // create DSA keypair
-        KeyPairGenerator kpgen = KeyPairGenerator.getInstance("DSA");
-        kpgen.initialize(512);
+        String kpgAlgorithm = "DSA";
+        KeyPairGenerator kpgen = KeyPairGenerator.getInstance(kpgAlgorithm);
+        kpgen.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp = kpgen.generateKeyPair();
 
         // create DES key

--- a/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
@@ -50,10 +50,12 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.PBEParameterSpec;
+import jdk.test.lib.security.SecurityUtils;
 
 /*
  * @test
  * @bug 8048599 8248268
+ * @library /test/lib
  * @summary  Tests for key wrap and unwrap operations
  */
 
@@ -263,7 +265,7 @@ public class TestCipherKeyWrapperTest {
             System.out.println("Generate key pair (algorithm: " + algo
                     + ", provider: " + p.getName() + ")");
             KeyPairGenerator kpg = KeyPairGenerator.getInstance(algo);
-            kpg.initialize(512);
+            kpg.initialize(SecurityUtils.getTestKeySize(algo));
             KeyPair kp = kpg.genKeyPair();
             // key generated
             String algoWrap = "DES";

--- a/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEKeyCleanupTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/PBE/PBEKeyCleanupTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @library /test/lib
  * @modules java.base/com.sun.crypto.provider:+open
  * @run main/othervm PBEKeyCleanupTest
  * @summary Verify that key storage is cleared
@@ -38,6 +39,7 @@ import java.util.Random;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
+import jdk.test.lib.security.SecurityUtils;
 
 /**
  * Test that the array holding the key bytes is cleared when it is
@@ -67,7 +69,7 @@ public class PBEKeyCleanupTest {
     }
 
     private static void testPBKSecret(String algorithm) throws Exception {
-        byte[] salt = new byte[8];
+        byte[] salt = new byte[SecurityUtils.getTestSaltSize()];
         new Random().nextBytes(salt);
         char[] password = new char[] {'f', 'o', 'o'};
         PBEKeySpec pbeKeySpec = new PBEKeySpec(PASS_PHRASE.toCharArray(), salt,

--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPPadding.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPPadding.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8020081 8022669
+ * @library /test/lib
  * @summary encryption/decryption test for using OAEPPadding with
  * OAEPParameterSpec specified and not specified during a Cipher.init().
  * @author Anthony Scarpino
@@ -43,7 +44,7 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.spec.PSource;
-
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestOAEPPadding {
     private static RSAPrivateKey privateKey;
@@ -57,8 +58,9 @@ public class TestOAEPPadding {
         System.out.println("Testing provider " + cp.getName() + "...");
         Provider kfp = Security.getProvider(
                         System.getProperty("test.provider.name", "SunRsaSign"));
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", kfp);
-        kpg.initialize(2048);
+        String kpgAlgorithm = "RSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, kfp);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp = kpg.generateKeyPair();
         privateKey = (RSAPrivateKey)kp.getPrivate();
         publicKey = (RSAPublicKey)kp.getPublic();

--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPWithParams.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPWithParams.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4923484 8146293
+ * @library /test/lib
  * @summary encryption/decryption test for using OAEPParameterSpec.
  * @author Valerie Peng
  */
@@ -35,6 +36,7 @@ import java.security.spec.MGF1ParameterSpec;
 import javax.crypto.*;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.OAEPParameterSpec;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestOAEPWithParams {
 
@@ -59,8 +61,9 @@ public class TestOAEPWithParams {
         System.out.println("Testing provider " + cp.getName() + "...");
         Provider kfp = Security.getProvider(
                 System.getProperty("test.provider.name", "SunRsaSign"));
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", kfp);
-        kpg.initialize(768);
+        String kpgAlgorithm = "RSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, kfp);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp = kpg.generateKeyPair();
         privateKey = kp.getPrivate();
         publicKey = kp.getPublic();

--- a/test/jdk/com/sun/crypto/provider/KeyAgreement/DHKeyAgreementPadding.java
+++ b/test/jdk/com/sun/crypto/provider/KeyAgreement/DHKeyAgreementPadding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,21 +34,22 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.util.Arrays;
 import java.util.HexFormat;
+import jdk.test.lib.security.SecurityUtils;
 
 public class DHKeyAgreementPadding {
 
     public static void main(String[] args) throws Exception {
-
-        byte[] aliceSecret = new byte[80];
-        byte[] bobSecret = new byte[80];
-
-        KeyAgreement alice = KeyAgreement.getInstance("DiffieHellman");
-        KeyAgreement bob = KeyAgreement.getInstance("DiffieHellman");
+        String kpgAlgorithm = "DiffieHellman";
+        KeyAgreement alice = KeyAgreement.getInstance(kpgAlgorithm);
+        KeyAgreement bob = KeyAgreement.getInstance(kpgAlgorithm);
+        int keySizeBits = SecurityUtils.getTestKeySize(kpgAlgorithm);
+        byte[] aliceSecret = new byte[keySizeBits / 8];
+        byte[] bobSecret = new byte[keySizeBits / 8];
 
         // The probability of an error is 0.2% or 1/500. Try more times.
         for (int i = 0; i < 5000; i++) {
-            KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("DiffieHellman");
-            keyPairGen.initialize(512);
+            KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance(kpgAlgorithm);
+            keyPairGen.initialize(keySizeBits);
             KeyPair aliceKeyPair = keyPairGen.generateKeyPair();
             KeyPair bobKeyPair = keyPairGen.generateKeyPair();
 

--- a/test/jdk/com/sun/crypto/provider/KeyFactory/TestProviderLeak.java
+++ b/test/jdk/com/sun/crypto/provider/KeyFactory/TestProviderLeak.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6578538 8027624
+ * @library /test/lib
  * @summary com.sun.crypto.provider.SunJCE instance leak using KRB5 and
  *     LoginContext
  * @author Brad Wetmore
@@ -45,6 +46,7 @@ import javax.crypto.spec.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestProviderLeak {
     private static final int MB = 1024 * 1024;
@@ -109,7 +111,7 @@ public class TestProviderLeak {
             SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1",
                     System.getProperty("test.provider.name", "SunJCE"));
         final PBEKeySpec pbeKS = new PBEKeySpec(
-            "passPhrase".toCharArray(), new byte [] { 0 }, 5, 512);
+            "passPhrase".toCharArray(), new byte [SecurityUtils.getTestSaltSize()], 1000, 512);
 
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Callable<SecretKey> task = new Callable<SecretKey>() {

--- a/test/jdk/com/sun/org/apache/xml/internal/security/SignatureKeyInfo.java
+++ b/test/jdk/com/sun/org/apache/xml/internal/security/SignatureKeyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.math.BigInteger;
 import java.security.*;
+import jdk.test.lib.security.SecurityUtils;
 
 import static jdk.test.lib.Asserts.assertEquals;
 
@@ -160,7 +161,7 @@ public class SignatureKeyInfo {
 
     private static KeyPair getKeyPair(String algorithm) throws NoSuchAlgorithmException {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm);
-        keyGen.initialize(2048);
+        keyGen.initialize(SecurityUtils.getTestKeySize(algorithm));
 
         return keyGen.genKeyPair();
     }

--- a/test/jdk/java/security/KeyAgreement/KeySpecTest.java
+++ b/test/jdk/java/security/KeyAgreement/KeySpecTest.java
@@ -24,6 +24,7 @@
  /*
  * @test
  * @bug 8184359
+ * @library /test/lib
  * @summary Standard tests on KeySpec, KeyFactory, KeyPairs and Keys.
  *  Arguments order <KeyExchangeAlgorithm> <Provider> <KeyGenAlgorithm> <Curve*>
  * @run main KeySpecTest DiffieHellman SunJCE DiffieHellman
@@ -55,6 +56,7 @@ import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.DHPublicKeySpec;
+import jdk.test.lib.security.SecurityUtils;
 
 public class KeySpecTest {
 
@@ -78,7 +80,7 @@ public class KeySpecTest {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgo, provider);
         switch (kpgInit) {
             case "DiffieHellman":
-                kpg.initialize(512);
+                kpg.initialize(SecurityUtils.getTestKeySize(kpgInit));
                 break;
             case "EC":
                 kpg.initialize(256);

--- a/test/jdk/java/security/KeyAgreement/MultiThreadTest.java
+++ b/test/jdk/java/security/KeyAgreement/MultiThreadTest.java
@@ -24,6 +24,7 @@
  /*
  * @test
  * @bug 8184359
+ * @library /test/lib
  * @summary KeyPairGenerator Test with multiple threads.
  *  Arguments order <KeyExchangeAlgorithm> <Provider> <KeyGenAlgorithm> <Curve*>
  * @run main MultiThreadTest DiffieHellman SunJCE DiffieHellman
@@ -39,6 +40,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import javax.crypto.KeyAgreement;
+import jdk.test.lib.security.SecurityUtils;
 
 /**
  * This test targets KeyPairGenerator API related issue in a multi threaded
@@ -68,7 +70,7 @@ public class MultiThreadTest {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgo, provider);
         switch (kpgInit) {
             case "DiffieHellman":
-                kpg.initialize(512);
+                kpg.initialize(SecurityUtils.getTestKeySize(kpgInit));
                 break;
             case "EC":
                 kpg.initialize(256);

--- a/test/jdk/java/security/KeyAgreement/NegativeTest.java
+++ b/test/jdk/java/security/KeyAgreement/NegativeTest.java
@@ -35,7 +35,7 @@
  *  Arguments order <KeyExchangeAlgorithm> <Provider> <KeyGenAlgorithm>
  *                  <keySize> <Curve*>
  * @library /test/lib
- * @run main NegativeTest DiffieHellman SunJCE DiffieHellman 1024
+ * @run main NegativeTest DiffieHellman SunJCE DiffieHellman 2048
  * @run main NegativeTest ECDH SunEC EC 256
  * @run main NegativeTest XDH SunEC XDH 255 X25519
  * @run main NegativeTest XDH SunEC XDH 448 X448
@@ -59,6 +59,7 @@ import java.security.spec.XECPublicKeySpec;
 import java.util.Arrays;
 import java.util.HexFormat;
 import javax.crypto.KeyAgreement;
+import jdk.test.lib.security.SecurityUtils;
 
 public class NegativeTest {
 
@@ -93,7 +94,7 @@ public class NegativeTest {
                 Security.getProvider(provider));
         switch (kpgInit) {
             case "DiffieHellman":
-                kpg.initialize(512);
+                kpg.initialize(SecurityUtils.getTestKeySize(kpgInit));
                 break;
             case "EC":
                 kpg.initialize(256);

--- a/test/jdk/java/security/KeyFactory/Failover.java
+++ b/test/jdk/java/security/KeyFactory/Failover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 4894125 7054918 8130181
- * @library ../testlibrary
+ * @library ../testlibrary /test/lib
  * @summary test that failover for KeyFactory works
  * @author Andreas Sterbenz
  */
@@ -34,6 +34,7 @@ import java.util.*;
 import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class Failover {
 
@@ -72,8 +73,9 @@ public class Failover {
         // somewhat more real tests using DSA
         System.out.println("DSA tests...");
 
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA");
-        kpg.initialize(512);
+        String kpgAlgorithm = "DSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp = kpg.generateKeyPair();
 
         kf = KeyFactory.getInstance("DSA");

--- a/test/jdk/java/security/KeyPairGenerator/GenerateKeypair.java
+++ b/test/jdk/java/security/KeyPairGenerator/GenerateKeypair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,18 +24,21 @@
 /*
  * @test
  * @bug 4221800
+ * @library /test/lib
  * @summary Test restored generateKeyPair method
  */
 
 import java.security.KeyPairGenerator;
 import java.security.KeyPair;
+import jdk.test.lib.security.SecurityUtils;
 
 public class GenerateKeypair {
 
     public static void main(String[] args) throws Exception {
 
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA");
-        kpg.initialize(512);
+        String kpgAlgorithm = "DSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
 
         // test generateKeyPair
         KeyPair kpair = kpg.generateKeyPair();

--- a/test/jdk/java/security/KeyPairGenerator/GenerateRSAKeyPair.java
+++ b/test/jdk/java/security/KeyPairGenerator/GenerateRSAKeyPair.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4297026
+ * @library /test/lib
  * @summary Make sure that RSA Keypair generation using
  * java.security.spec.RSAKeyGenParameterSpec passes
  */
@@ -31,14 +32,17 @@
 import java.security.KeyPairGenerator;
 import java.security.KeyPair;
 import java.security.spec.RSAKeyGenParameterSpec;
+import jdk.test.lib.security.SecurityUtils;
 
 public class GenerateRSAKeyPair {
 
     public static void main(String[] args) throws Exception {
 
+        String kpgAlgorithm = "RSA";
         RSAKeyGenParameterSpec rsaSpec =
-        new RSAKeyGenParameterSpec (1024, RSAKeyGenParameterSpec.F4);
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA",
+        new RSAKeyGenParameterSpec (SecurityUtils.getTestKeySize(kpgAlgorithm),
+                RSAKeyGenParameterSpec.F4);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm,
                 System.getProperty("test.provider.name", "SunRsaSign"));
         kpg.initialize(rsaSpec);
 

--- a/test/jdk/java/security/Provider/SupportsParameter.java
+++ b/test/jdk/java/security/Provider/SupportsParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4911081 8130181
+ * @library /test/lib
  * @summary verify that Provider.Service.supportsParameter() works
  * @author Andreas Sterbenz
  */
@@ -33,12 +34,14 @@ import java.security.Provider.Service;
 
 import javax.crypto.*;
 import javax.crypto.spec.SecretKeySpec;
+import jdk.test.lib.security.SecurityUtils;
 
 public class SupportsParameter {
 
     public static void main(String[] args) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DSA");
-        kpg.initialize(512);
+        String kpgAlgorithm = "DSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp = kpg.generateKeyPair();
         PublicKey dsaPublicKey = kp.getPublic();
         PrivateKey dsaPrivateKey = kp.getPrivate();

--- a/test/jdk/java/security/Signature/NONEwithRSA.java
+++ b/test/jdk/java/security/Signature/NONEwithRSA.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4955844
+ * @library /test/lib
  * @summary ensure that the NONEwithRSA adapter works correctly
  * @author Andreas Sterbenz
  * @key randomness
@@ -34,6 +35,7 @@ import java.util.*;
 import java.security.*;
 
 import javax.crypto.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class NONEwithRSA {
 
@@ -43,8 +45,9 @@ public class NONEwithRSA {
         byte[] b = new byte[16];
         random.nextBytes(b);
 
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(512);
+        String kpgAlgorithm = "RSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp = kpg.generateKeyPair();
 
         Signature sig = Signature.getInstance("NONEwithRSA");

--- a/test/jdk/java/security/Signature/ResetAfterException.java
+++ b/test/jdk/java/security/Signature/ResetAfterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,12 @@
 /**
  * @test
  * @bug 8149802
+ * @library /test/lib
  * @summary Ensure that Signature objects are reset after verification errored out.
  */
 import java.util.Arrays;
 import java.security.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class ResetAfterException {
 
@@ -51,18 +53,19 @@ public class ResetAfterException {
             boolean res = true;
             System.out.println("Testing Provider: " + p.getName());
             KeyPairGenerator keyGen = null;
+            String kpgAlgorithm = "RSA";
             try {
                 // It's possible that some provider, e.g. SunMSCAPI,
                 // doesn't work well with keys from other providers
                 // so we use the same provider to generate key first
-                keyGen = KeyPairGenerator.getInstance("RSA", p);
+                keyGen = KeyPairGenerator.getInstance(kpgAlgorithm, p);
             } catch (NoSuchAlgorithmException nsae) {
-                keyGen = KeyPairGenerator.getInstance("RSA");
+                keyGen = KeyPairGenerator.getInstance(kpgAlgorithm);
             }
             if (keyGen == null) {
                 throw new RuntimeException("Error: No support for RSA KeyPairGenerator");
             }
-            keyGen.initialize(1024);
+            keyGen.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
             KeyPair keyPair = keyGen.generateKeyPair();
 
             sig.initSign(keyPair.getPrivate());

--- a/test/jdk/java/security/Signature/VerifyRangeCheckOverflow.java
+++ b/test/jdk/java/security/Signature/VerifyRangeCheckOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
 
 /* @test
  * @bug 7172149
+ * @library /test/lib
  * @summary AIOOBE from Signature.verify after integer overflow
  * @author Jonathan Lu
  */
@@ -35,12 +36,14 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
 import java.security.Signature;
+import jdk.test.lib.security.SecurityUtils;
 
 public class VerifyRangeCheckOverflow {
 
     public static void main(String[] args) throws Exception {
-        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("DSA");
-        keyPairGenerator.initialize(1024);
+        String kpgAlgorithm = "DSA";
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(kpgAlgorithm);
+        keyPairGenerator.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair keys = keyPairGenerator.generateKeyPair();
         PublicKey publicKey = keys.getPublic();
         byte[] sigBytes = new byte[100];

--- a/test/jdk/java/security/cert/X509Certificate/GetSigAlgParams.java
+++ b/test/jdk/java/security/cert/X509Certificate/GetSigAlgParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,14 @@
 /*
  * @test
  * @bug 8259428
+ * @library /test/lib
  * @summary Verify X509Certificate.getSigAlgParams() returns new array each
  *          time it is called
  * @modules java.base/sun.security.tools.keytool java.base/sun.security.x509
  */
 
 import java.security.cert.X509Certificate;
+import jdk.test.lib.security.SecurityUtils;
 import sun.security.tools.keytool.CertAndKeyGen;
 import sun.security.x509.X500Name;
 
@@ -38,7 +40,7 @@ public class GetSigAlgParams {
     public static void main(String[] args) throws Exception {
 
         CertAndKeyGen cakg = new CertAndKeyGen("RSASSA-PSS", "RSASSA-PSS");
-        cakg.generate(1024);
+        cakg.generate(SecurityUtils.getTestKeySize("RSA"));
         X509Certificate c = cakg.getSelfCertificate(new X500Name("CN=Me"), 100);
         if (c.getSigAlgParams() == c.getSigAlgParams()) {
             throw new Exception("Encoded params are the same byte array");

--- a/test/jdk/javax/crypto/SecretKeyFactory/SecKeyFacSunJCEPrf.java
+++ b/test/jdk/javax/crypto/SecretKeyFactory/SecKeyFacSunJCEPrf.java
@@ -42,11 +42,11 @@ import com.evilprovider.*;
 public class SecKeyFacSunJCEPrf {
 
     // One of the PBKDF2 HMAC-SHA1 test vectors from RFC 6070
-    private static final byte[] SALT = "salt".getBytes();
+    private static final byte[] SALT = "16-byte salt val".getBytes();
     private static final char[] PASS = "password".toCharArray();
     private static final int ITER = 4096;
     private static final byte[] EXP_OUT =
-            HexFormat.of().parseHex("4B007901B765489ABEAD49D926F721D065A429C1");
+            HexFormat.of().parseHex("D2CACD3F1D44AF293C704F0B1005338D903C688C");
 
     public static void main(String[] args) throws Exception {
         // Instantiate the Evil Provider and insert it in the

--- a/test/jdk/javax/security/auth/Destroyable/KeyDestructionTest.java
+++ b/test/jdk/javax/security/auth/Destroyable/KeyDestructionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6263419
+ * @library /test/lib
  * @summary No way to clean the memory for a java.security.Key
  */
 
@@ -32,10 +33,12 @@ import java.util.*;
 import javax.crypto.*;
 import javax.security.auth.Destroyable;
 import javax.security.auth.DestroyFailedException;
+import jdk.test.lib.security.SecurityUtils;
 
 public class KeyDestructionTest {
     public static void main(String[] args) throws Exception {
-        KeyPair keypair = generateKeyPair("RSA", 1024);
+        String kpgAlgorithm = "RSA";
+        KeyPair keypair = generateKeyPair(kpgAlgorithm, SecurityUtils.getTestKeySize(kpgAlgorithm));
 
         // Check keys that support and have implemented key destruction
         testKeyDestruction(new MyDestroyableSecretKey());

--- a/test/jdk/jdk/security/jarsigner/Spec.java
+++ b/test/jdk/jdk/security/jarsigner/Spec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import com.sun.jarsigner.ContentSigner;
 import com.sun.jarsigner.ContentSignerParameters;
 import jdk.security.jarsigner.JarSigner;
 import jdk.test.lib.util.JarUtils;
+import jdk.test.lib.security.SecurityUtils;
 import sun.security.provider.certpath.X509CertPath;
 
 import java.io.File;
@@ -181,14 +182,16 @@ public class Spec {
         assertTrue(JarSigner.Builder.getDefaultDigestAlgorithm().equals("SHA-256"));
 
         // Calculating large DSA and RSA keys are too slow.
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(1024);
+        String kpgRSA = "RSA";
+        String kpgDSA = "DSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgRSA);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgRSA));
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())
                     .equals("SHA256withRSA"));
 
-        kpg = KeyPairGenerator.getInstance("DSA");
-        kpg.initialize(1024);
+        kpg = KeyPairGenerator.getInstance(kpgDSA);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgDSA))
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())
                 .equals("SHA256withDSA"));

--- a/test/jdk/jdk/security/jarsigner/Spec.java
+++ b/test/jdk/jdk/security/jarsigner/Spec.java
@@ -191,6 +191,7 @@ public class Spec {
                     .equals("SHA256withRSA"));
 
         kpg = KeyPairGenerator.getInstance(kpgDSA);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgDSA));
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())
                 .equals("SHA256withDSA"));

--- a/test/jdk/jdk/security/jarsigner/Spec.java
+++ b/test/jdk/jdk/security/jarsigner/Spec.java
@@ -191,7 +191,6 @@ public class Spec {
                     .equals("SHA256withRSA"));
 
         kpg = KeyPairGenerator.getInstance(kpgDSA);
-        kpg.initialize(SecurityUtils.getTestKeySize(kpgDSA))
         assertTrue(JarSigner.Builder
                 .getDefaultSignatureAlgorithm(kpg.generateKeyPair().getPrivate())
                 .equals("SHA256withDSA"));

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
@@ -44,6 +44,7 @@ import java.util.Random;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestRSACipher extends PKCS11Test {
 
@@ -58,8 +59,10 @@ public class TestRSACipher extends PKCS11Test {
             System.out.println("Not supported by provider, skipping");
             return;
         }
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", p);
-        kpg.initialize(1024);
+        String kpgAlgorithm = "RSA";
+        int keySize = SecurityUtils.getTestKeySize(kpgAlgorithm);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, p);
+        kpg.initialize(keySize);
         KeyPair kp = kpg.generateKeyPair();
         PublicKey publicKey = kp.getPublic();
         PrivateKey privateKey = kp.getPrivate();
@@ -113,7 +116,8 @@ public class TestRSACipher extends PKCS11Test {
             c1.update(b);
             e = c1.doFinal();
 
-            c1.update(new byte[256]);
+            // Longer buffer size to verify IllegalBlockSizeException is thrown
+            c1.update(new byte[keySize / 4]);
             try {
                 e = c1.doFinal();
                 throw new Exception("completed call");

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
@@ -43,6 +43,7 @@ import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestRSACipherWrap extends PKCS11Test {
 
@@ -57,8 +58,9 @@ public class TestRSACipherWrap extends PKCS11Test {
             System.out.println(RSA_ALGOS[0] + " unsupported, skipping");
             return;
         }
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", p);
-        kpg.initialize(1024);
+        String kpgAlgorithm = "RSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, p);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp = kpg.generateKeyPair();
 
         for (String rsaAlgo: RSA_ALGOS) {

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.Random;
 import javax.crypto.Cipher;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestRawRSACipher extends PKCS11Test {
 
@@ -53,8 +54,9 @@ public class TestRawRSACipher extends PKCS11Test {
             return;
         }
 
-        final int KEY_LEN = 1024;
-        KeyPairGenerator kpGen = KeyPairGenerator.getInstance("RSA", p);
+        String kpgAlgorithm = "RSA";
+        final int KEY_LEN = SecurityUtils.getTestKeySize(kpgAlgorithm);
+        KeyPairGenerator kpGen = KeyPairGenerator.getInstance(kpgAlgorithm, p);
         kpGen.initialize(KEY_LEN);
         KeyPair kp = kpGen.generateKeyPair();
         Random random = new Random();

--- a/test/jdk/sun/security/pkcs11/KeyAgreement/TestDH.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/TestDH.java
@@ -38,6 +38,7 @@ import java.security.Provider;
 import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import javax.crypto.SecretKey;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestDH extends PKCS11Test {
 
@@ -47,8 +48,9 @@ public class TestDH extends PKCS11Test {
             System.out.println("DH not supported, skipping");
             return;
         }
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("DH", p);
-        kpg.initialize(512);
+        String kpgAlgorithm = "DH";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, p);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp1 = kpg.generateKeyPair();
         KeyPair kp2 = kpg.generateKeyPair();
 

--- a/test/jdk/sun/security/provider/KeyStore/CaseSensitiveAliases.java
+++ b/test/jdk/sun/security/provider/KeyStore/CaseSensitiveAliases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug     5091374 5100603
+ * @library /test/lib
  * @summary make sure the JKS case sensitivity works correctly
  * @author  Andreas Sterbenz
  */
@@ -34,6 +35,7 @@ import java.util.*;
 import java.security.*;
 import java.security.cert.*;
 import java.security.cert.Certificate;
+import jdk.test.lib.security.SecurityUtils;
 
 public class CaseSensitiveAliases {
 
@@ -90,8 +92,9 @@ public class CaseSensitiveAliases {
         X509Certificate[] a1 = {c1};
         X509Certificate[] a2 = {c2};
 
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(512);
+        String kpgAlgorithm = "RSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         PrivateKey p1 = kpg.generateKeyPair().getPrivate();
         PrivateKey p2 = kpg.generateKeyPair().getPrivate();
 

--- a/test/jdk/sun/security/provider/NSASuiteB/TestSHAwithDSASignatureOids.java
+++ b/test/jdk/sun/security/provider/NSASuiteB/TestSHAwithDSASignatureOids.java
@@ -23,10 +23,12 @@
 
 import java.util.Arrays;
 import java.util.List;
+import jdk.test.lib.security.SecurityUtils;
 
 /*
  * @test
  * @bug 8075286
+ * @library /test/lib
  * @summary Test the SHAwithDSA signature algorithm OIDs in JDK.
  *          OID and algorithm transformation string should match.
  *          Both could be able to be used to generate the algorithm instance.
@@ -40,8 +42,10 @@ public class TestSHAwithDSASignatureOids {
             new OidAlgorithmPair("2.16.840.1.101.3.4.3.2", "SHA256withDSA"));
 
     public static void main(String[] args) throws Exception {
-        TestSignatureOidHelper helper = new TestSignatureOidHelper("DSA",
-                System.getProperty("test.provider.name", "SUN"), 1024, DATA);
+        String kpgAlgorithm = "DSA";
+        TestSignatureOidHelper helper = new TestSignatureOidHelper(kpgAlgorithm,
+                System.getProperty("test.provider.name", "SUN"),
+                SecurityUtils.getTestKeySize(kpgAlgorithm), DATA);
         helper.execute();
     }
 }

--- a/test/jdk/sun/security/rsa/BrokenRSAPrivateCrtKey.java
+++ b/test/jdk/sun/security/rsa/BrokenRSAPrivateCrtKey.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 4503229 8220016
+ * @library /test/lib
  * @summary default RSA KeyFactory can return broken RSAPrivateCrtKey objects
  *      This test was taken directly from the bug report, which
  *      was fixed in the crippled JSAFE provider, and needed
@@ -35,13 +36,15 @@ import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
 import java.math.BigInteger;
+import jdk.test.lib.security.SecurityUtils;
 
 public class BrokenRSAPrivateCrtKey {
     public static void main(String[] args) throws Exception {
+        String kpgAlgorithm = "RSA";
         KeyPairGenerator generator =
-                KeyPairGenerator.getInstance("RSA",
+                KeyPairGenerator.getInstance(kpgAlgorithm,
                         System.getProperty("test.provider.name", "SunRsaSign"));
-        generator.initialize(2048);
+        generator.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
 
         KeyPair pair = generator.generateKeyPair();
 

--- a/test/jdk/sun/security/rsa/TestKeyPairGenerator.java
+++ b/test/jdk/sun/security/rsa/TestKeyPairGenerator.java
@@ -40,6 +40,7 @@ import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
 
+import jdk.test.lib.security.SecurityUtils;
 import jdk.test.lib.SigTestUtil;
 import static jdk.test.lib.SigTestUtil.SignatureType;
 
@@ -114,12 +115,13 @@ public class TestKeyPairGenerator {
         provider = Security.getProvider(
                         System.getProperty("test.provider.name", "SunRsaSign"));
         data = new byte[2048];
-        // keypair generation is very slow, test only a few short keys
-        int[] keyLengths = {512, 512, 1024};
+        String kpgAlgorithm = "RSA";
+        int keySize = SecurityUtils.getTestKeySize(kpgAlgorithm);
+        int[] keyLengths = {keySize, keySize, keySize + 1024};
         BigInteger[] pubExps = {null, BigInteger.valueOf(3), null};
         KeyPair[] keyPairs = new KeyPair[3];
         new Random().nextBytes(data);
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", provider);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, provider);
         for (int i = 0; i < keyLengths.length; i++) {
             int len = keyLengths[i];
             BigInteger exp = pubExps[i];

--- a/test/jdk/sun/security/rsa/TestKeyPairGeneratorExponent.java
+++ b/test/jdk/sun/security/rsa/TestKeyPairGeneratorExponent.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8216012
+ * @library /test/lib
  * @summary Tests the RSA public key exponent for KeyPairGenerator
  * @run main/timeout=60 TestKeyPairGeneratorExponent
  */
@@ -33,14 +34,16 @@ import java.math.BigInteger;
 import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestKeyPairGeneratorExponent {
-    private static int keyLen = 512;
+    private static final String KPG_ALGORITHM = "RSA";
+    private static final int KEY_LENGTH = SecurityUtils.getTestKeySize(KPG_ALGORITHM);
 
     private static BigInteger[] validExponents = new BigInteger[] {
         RSAKeyGenParameterSpec.F0,
         RSAKeyGenParameterSpec.F4,
-        BigInteger.ONE.shiftLeft(keyLen - 1).subtract(BigInteger.ONE)
+        BigInteger.ONE.shiftLeft(KEY_LENGTH - 1).subtract(BigInteger.ONE)
     };
 
     private static BigInteger[] invalidExponents = new BigInteger[] {
@@ -55,7 +58,7 @@ public class TestKeyPairGeneratorExponent {
             BigInteger exponent) {
         System.out.println("Testing exponent = " + exponent.toString(16));
         try {
-            kpg.initialize(new RSAKeyGenParameterSpec(keyLen, exponent));
+            kpg.initialize(new RSAKeyGenParameterSpec(KEY_LENGTH, exponent));
             kpg.generateKeyPair();
             System.out.println("OK, key pair generated");
         } catch(InvalidAlgorithmParameterException iape){
@@ -67,7 +70,7 @@ public class TestKeyPairGeneratorExponent {
             BigInteger exponent) {
         System.out.println("Testing exponent = " + exponent.toString(16));
         try {
-            kpg.initialize(new RSAKeyGenParameterSpec(keyLen, exponent));
+            kpg.initialize(new RSAKeyGenParameterSpec(KEY_LENGTH, exponent));
             kpg.generateKeyPair();
             throw new RuntimeException("Error: Expected IAPE not thrown.");
         } catch(InvalidAlgorithmParameterException iape){
@@ -81,7 +84,7 @@ public class TestKeyPairGeneratorExponent {
 
     public static void main(String[] args) throws Exception {
         KeyPairGenerator kpg =
-                KeyPairGenerator.getInstance("RSA",
+                KeyPairGenerator.getInstance(KPG_ALGORITHM,
                     System.getProperty("test.provider.name", "SunRsaSign"));
 
         for(BigInteger validExponent : validExponents) {

--- a/test/jdk/sun/security/rsa/TestKeyPairGeneratorInit.java
+++ b/test/jdk/sun/security/rsa/TestKeyPairGeneratorInit.java
@@ -24,11 +24,13 @@
 /**
  * @test
  * @bug     8211049
+ * @library /test/lib
  * @summary make sure the supplied SecureRandom object is used
  */
 
 import java.security.*;
 import java.security.interfaces.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestKeyPairGeneratorInit {
 
@@ -45,11 +47,12 @@ public class TestKeyPairGeneratorInit {
     }
 
     public static void main(String[] args) throws Exception {
+        String kpgAlgorithm = "RSA";
         KeyPairGenerator kpg =
-            KeyPairGenerator.getInstance("RSA",
+            KeyPairGenerator.getInstance(kpgAlgorithm,
                     System.getProperty("test.provider.name", "SunRsaSign"));
         MySecureRandom rnd = new MySecureRandom();
-        kpg.initialize(2048, rnd);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm), rnd);
         System.out.println("Generate keypair then check");
         KeyPair kp = kpg.generateKeyPair();
         if (!rnd.isUsed) {

--- a/test/jdk/sun/security/rsa/TestKeyPairGeneratorLength.java
+++ b/test/jdk/sun/security/rsa/TestKeyPairGeneratorLength.java
@@ -24,23 +24,27 @@
 /**
  * @test
  * @bug     5078280
+ * @library /test/lib
  * @summary make sure generated key pairs are exactly the requested length
  * @author  Andreas Sterbenz
  */
 
 import java.security.*;
 import java.security.interfaces.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestKeyPairGeneratorLength {
+    private static final String KPG_ALGORITHM = "RSA";
+    private static final int KEY_LENGTH = SecurityUtils.getTestKeySize(KPG_ALGORITHM);
 
     public static void main(String[] args) throws Exception {
-        test(512);
-        test(513);
+        test(KEY_LENGTH);
+        test(KEY_LENGTH + 1);
         System.out.println("Done.");
     }
 
     private static void test(int len) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA",
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(KPG_ALGORITHM,
                         System.getProperty("test.provider.name", "SunRsaSign"));
         kpg.initialize(len);
         for (int i = 0; i < 6; i++) {

--- a/test/jdk/sun/security/rsa/pss/DefaultParamSpec.java
+++ b/test/jdk/sun/security/rsa/pss/DefaultParamSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,12 @@ import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Date;
+import jdk.test.lib.security.SecurityUtils;
 
 /**
  * @test
  * @bug 8242811
+ * @library /test/lib
  * @modules java.base/sun.security.x509
  * @summary AlgorithmId::getDefaultAlgorithmParameterSpec returns incompatible
  *          PSSParameterSpec for an RSASSA-PSS key
@@ -42,7 +44,7 @@ public class DefaultParamSpec {
     public static void main(String[] args) throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS");
         KeyFactory kf = KeyFactory.getInstance("RSASSA-PSS");
-        kpg.initialize(new RSAKeyGenParameterSpec(2048,
+        kpg.initialize(new RSAKeyGenParameterSpec(SecurityUtils.getTestKeySize("RSA"),
                 RSAKeyGenParameterSpec.F4,
                 new PSSParameterSpec(
                         "SHA-384", "MGF1",

--- a/test/jdk/sun/security/rsa/pss/InitAgain.java
+++ b/test/jdk/sun/security/rsa/pss/InitAgain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,12 @@
  */
 import java.security.*;
 import java.security.spec.*;
+import jdk.test.lib.security.SecurityUtils;
 
 /**
  * @test
  * @bug 8205445
+ * @library /test/lib
  * @summary Make sure old state is cleared when init is called again
  */
 public class InitAgain {
@@ -40,8 +42,9 @@ public class InitAgain {
         s1.setParameter(PSSParameterSpec.DEFAULT);
         s2.setParameter(PSSParameterSpec.DEFAULT);
 
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(1024);
+        String kpgAlgorithm = "RSA";
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm);
+        kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));
         KeyPair kp = kpg.generateKeyPair();
 
         s1.initSign(kp.getPrivate());

--- a/test/jdk/sun/security/rsa/pss/SerializedPSSKey.java
+++ b/test/jdk/sun/security/rsa/pss/SerializedPSSKey.java
@@ -50,9 +50,11 @@ import java.security.spec.RSAPrivateCrtKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import jdk.test.lib.security.SecurityUtils;
 
 /**
  * @test @bug 8242335
+ * @library /test/lib
  * @summary Test RSASSA-PSS serialized keys
  * @run main SerializedPSSKey
  */
@@ -62,7 +64,7 @@ public class SerializedPSSKey {
     private static final String OID = "1.2.840.113549.1.1.10";
     private static final String PROVIDER =
                     System.getProperty("test.provider.name", "SunRsaSign");
-    private static final int KEY_SIZE = 2048;
+    private static final int KEY_SIZE = SecurityUtils.getTestKeySize("RSA");
     private static final byte[] DATA = "Test".getBytes();
     /**
      * Digest algorithms to test w/ RSASSA-PSS signature algorithms

--- a/test/jdk/sun/security/rsa/pss/TestPSSKeySupport.java
+++ b/test/jdk/sun/security/rsa/pss/TestPSSKeySupport.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8146293 8242556 8172366 8254717
+ * @library /test/lib
  * @summary Test RSASSA-PSS Key related support such as KeyPairGenerator
  * and KeyFactory of the SunRsaSign provider
  */
@@ -35,6 +36,7 @@ import java.math.BigInteger;
 import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
+import jdk.test.lib.security.SecurityUtils;
 
 public class TestPSSKeySupport {
 
@@ -130,12 +132,13 @@ public class TestPSSKeySupport {
     }
 
     public static void main(String[] args) throws Exception {
+        int keySize = SecurityUtils.getTestKeySize("RSA");
         KeyPairGenerator kpg =
             KeyPairGenerator.getInstance(ALGO,
                     System.getProperty("test.provider.name", "SunRsaSign"));
 
         // Algorithm-Independent Initialization
-        kpg.initialize(2048);
+        kpg.initialize(keySize);
         KeyPair kp = kpg.generateKeyPair();
         checkKeyPair(kp);
         BigInteger pubExp = ((RSAPublicKey)kp.getPublic()).getPublicExponent();
@@ -143,13 +146,13 @@ public class TestPSSKeySupport {
         // Algorithm-specific Initialization
         PSSParameterSpec params = new PSSParameterSpec("SHA-256", "MGF1",
             MGF1ParameterSpec.SHA256, 32, 1);
-        kpg.initialize(new RSAKeyGenParameterSpec(2048, pubExp, params));
+        kpg.initialize(new RSAKeyGenParameterSpec(keySize, pubExp, params));
         KeyPair kp2 = kpg.generateKeyPair();
         checkKeyPair(kp2);
 
         params = new PSSParameterSpec("SHA3-256", "MGF1",
             new MGF1ParameterSpec("SHA3-256"), 32, 1);
-        kpg.initialize(new RSAKeyGenParameterSpec(2048, pubExp, params));
+        kpg.initialize(new RSAKeyGenParameterSpec(keySize, pubExp, params));
         KeyPair kp3 = kpg.generateKeyPair();
         checkKeyPair(kp3);
 

--- a/test/jdk/sun/security/x509/AlgorithmId/NonStandardNames.java
+++ b/test/jdk/sun/security/x509/AlgorithmId/NonStandardNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 7180907 8277224
+ * @library /test/lib
  * @summary Jarsigner -verify fails if rsa file used sha-256 with authenticated attributes
  * @modules java.base/sun.security.pkcs
  *          java.base/sun.security.tools.keytool
@@ -36,6 +37,7 @@
 import java.security.MessageDigest;
 import java.security.Signature;
 import java.security.cert.X509Certificate;
+import jdk.test.lib.security.SecurityUtils;
 import sun.security.pkcs.ContentInfo;
 import sun.security.pkcs.PKCS7;
 import sun.security.pkcs.PKCS9Attribute;
@@ -52,8 +54,9 @@ public class NonStandardNames {
         byte[] data = "Hello".getBytes();
         X500Name n = new X500Name("cn=Me");
 
-        CertAndKeyGen cakg = new CertAndKeyGen("RSA", "SHA256withRSA");
-        cakg.generate(1024);
+        String kpgAlgorithm = "RSA";
+        CertAndKeyGen cakg = new CertAndKeyGen(kpgAlgorithm, "SHA256withRSA");
+        cakg.generate(SecurityUtils.getTestKeySize(kpgAlgorithm));
         X509Certificate cert = cakg.getSelfCertificate(n, 1000);
 
         MessageDigest md = MessageDigest.getInstance("SHA-256");

--- a/test/lib/jdk/test/lib/security/SecurityUtils.java
+++ b/test/lib/jdk/test/lib/security/SecurityUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,27 @@ import java.util.stream.Stream;
  * Common library for various security test helper functions.
  */
 public final class SecurityUtils {
+
+    /*
+     * Key Sizes for various algorithms.
+     */
+    private enum KeySize{
+        RSA(2048),
+        DSA(2048),
+        DH(2048);
+
+        private final int keySize;
+        KeySize(int keySize) {
+            this.keySize = keySize;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(keySize);
+        }
+    }
+
+    private final static int DEFAULT_SALTSIZE = 16;
 
     private static String getCacerts() {
         String sep = File.separator;
@@ -105,6 +126,25 @@ public final class SecurityUtils {
      */
     public static void removeAlgsFromDSigPolicy(String... algs) {
         removeFromDSigPolicy("disallowAlg", List.<String>of(algs));
+    }
+
+    /**
+     * Returns a salt size for tests
+     */
+    public static int getTestSaltSize() {
+        return DEFAULT_SALTSIZE;
+    }
+
+    /**
+     * Returns a key size in bits for tests, depending on the specified algorithm
+     */
+    public static int getTestKeySize(String algo) {
+        return switch (algo) {
+            case "RSA" -> KeySize.RSA.keySize;
+            case "DSA" -> KeySize.DSA.keySize;
+            case "DH", "DiffieHellman" -> KeySize.DH.keySize;
+            default -> throw new RuntimeException("Test key size not defined for " + algo);
+        };
     }
 
     private static void removeFromDSigPolicy(String rule, List<String> algs) {


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

This is based on the change to 21.
I resolved three files:
jdk/jdk17u-dev/pull/

test/jdk/com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java
Trivial resolve because
https://bugs.openjdk.org/browse/JDK-8288050: Add support of SHA-512/224 and SHA-512/256 to the PBKDF2 and PBES2 impls in SunJCE provider
is missing in 17.

test/jdk/java/security/Signature/ResetAfterException.java
Copyright because
https://bugs.openjdk.org/browse/JDK-8284191: Replace usages of 'a the' in hotspot and java.base
is missin in 17.

test/jdk/jdk/security/jarsigner/Spec.java
Trivial resolve due to context difference.
Two changes to this file are missing in 17:
https://bugs.openjdk.org/browse/JDK-8267319: Use larger default key sizes and algorithms based on CNSA
https://bugs.openjdk.org/browse/JDK-8303410: Remove ContentSigner APIs and jarsigner -altsigner and -altsignerpath options

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342181](https://bugs.openjdk.org/browse/JDK-8342181) needs maintainer approval

### Issue
 * [JDK-8342181](https://bugs.openjdk.org/browse/JDK-8342181): Update tests to use stronger Key and Salt size (**Sub-task** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3069/head:pull/3069` \
`$ git checkout pull/3069`

Update a local copy of the PR: \
`$ git checkout pull/3069` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3069`

View PR using the GUI difftool: \
`$ git pr show -t 3069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3069.diff">https://git.openjdk.org/jdk17u-dev/pull/3069.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3069#issuecomment-2491026557)
</details>
