### PR TITLE
8337410: The makefiles should set problemlist and adjust timeout basing on the given VM flags

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -739,8 +739,6 @@ define SetupRunJtregTestBody
   # we may end up with a lot of JVM's
   $1_JTREG_MAX_RAM_PERCENTAGE := $$(shell $(AWK) 'BEGIN { print 25 / $$($1_JTREG_JOBS); }')
 
-  JTREG_TIMEOUT_FACTOR ?= 4
-
   JTREG_VERBOSE ?= fail,error,summary
   JTREG_RETAIN ?= fail,error
   JTREG_RUN_PROBLEM_LISTS ?= false
@@ -815,6 +813,24 @@ define SetupRunJtregTestBody
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$($1_JTREG_PROBLEM_LIST))
   endif
 
+  JTREG_ALL_OPTIONS := $$(JTREG_JAVA_OPTIONS) $$(JTREG_VM_OPTIONS)
+
+  JTREG_AUTO_PROBLEM_LISTS :=
+  JTREG_AUTO_TIMEOUT_FACTOR := 4
+
+  ifneq ($$(findstring -Xcomp, $$(JTREG_ALL_OPTIONS)), )
+    JTREG_AUTO_PROBLEM_LISTS += ProblemList-Xcomp.txt
+    JTREG_AUTO_TIMEOUT_FACTOR := 10
+  endif
+
+  ifneq ($$(findstring -XX:+UseZGC, $$(JTREG_ALL_OPTIONS)), )
+    ifneq ($$(findstring -XX:-ZGenerational, $$(JTREG_ALL_OPTIONS)), )
+      JTREG_AUTO_PROBLEM_LISTS += ProblemList-zgc.txt
+    else
+      JTREG_AUTO_PROBLEM_LISTS += ProblemList-generational-zgc.txt
+    endif
+  endif
+
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \
@@ -845,6 +861,18 @@ define SetupRunJtregTestBody
   endif
 
   $$(eval $$(call SetupRunJtregTestCustom, $1))
+
+  # SetupRunJtregTestCustom might also adjust JTREG_AUTO_ variables
+  # so set the final results after setting values from custom setup
+  ifneq ($$(JTREG_AUTO_PROBLEM_LISTS), )
+    # Accept both absolute paths as well as relative to the current test root.
+    $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \
+        $$(JTREG_AUTO_PROBLEM_LISTS) \
+        $$(addprefix $$($1_TEST_ROOT)/, $$(JTREG_AUTO_PROBLEM_LISTS)) \
+    ))
+  endif
+
+  JTREG_TIMEOUT_FACTOR ?= $$(JTREG_AUTO_TIMEOUT_FACTOR)
 
   clean-outputdirs-$1:
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

Resolved Copyritht, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337410](https://bugs.openjdk.org/browse/JDK-8337410) needs maintainer approval

### Issue
 * [JDK-8337410](https://bugs.openjdk.org/browse/JDK-8337410): The makefiles should set problemlist and adjust timeout basing on the given VM flags (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3072/head:pull/3072` \
`$ git checkout pull/3072`

Update a local copy of the PR: \
`$ git checkout pull/3072` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3072`

View PR using the GUI difftool: \
`$ git pr show -t 3072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3072.diff">https://git.openjdk.org/jdk17u-dev/pull/3072.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3072#issuecomment-2493400812)
</details>
