### PR TITLE
8339892: Several security shell tests don't set TESTJAVAOPTS

### DIFF
--- a/test/jdk/java/security/Security/ClassLoaderDeadlock/ClassLoaderDeadlock.sh
+++ b/test/jdk/java/security/Security/ClassLoaderDeadlock/ClassLoaderDeadlock.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ ${COMPILEJAVA}${FILESEP}bin${FILESEP}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} \
         ${TESTSRC}${FILESEP}provider${FILESEP}HashProvider.java
 
 # run the test
-${TESTJAVA}${FILESEP}bin${FILESEP}java ${TESTVMOPTS} \
+${TESTJAVA}${FILESEP}bin${FILESEP}java ${TESTVMOPTS} ${TESTJAVAOPTS} \
         -classpath "${TESTCLASSES}${PATHSEP}${TESTSRC}${FILESEP}Deadlock.jar" \
 	-Djava.awt.headless=true \
         ClassLoaderDeadlock

--- a/test/jdk/java/security/Security/ClassLoaderDeadlock/Deadlock.sh
+++ b/test/jdk/java/security/Security/ClassLoaderDeadlock/Deadlock.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -62,5 +62,5 @@ esac
 
 JAVA="${TESTJAVA}${FILESEP}bin${FILESEP}java"
 
-${JAVA} ${TESTVMOPTS} -cp "${TESTCLASSES}${PATHSEP}${TESTSRC}${FILESEP}Deadlock.jar" Deadlock
+${JAVA} ${TESTVMOPTS} ${TESTJAVAOPTS} -cp "${TESTCLASSES}${PATHSEP}${TESTSRC}${FILESEP}Deadlock.jar" Deadlock
 

--- a/test/jdk/java/security/cert/CertificateFactory/slowstream.sh
+++ b/test/jdk/java/security/cert/CertificateFactory/slowstream.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -50,5 +50,5 @@ esac
 
 ${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} -d . \
         ${TESTSRC}${FS}SlowStream.java
-${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} -Dtest.src=${TESTSRC} SlowStreamWriter | \
-        ${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} SlowStreamReader
+${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS} -Dtest.src=${TESTSRC} SlowStreamWriter | \
+        ${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS} SlowStreamReader

--- a/test/jdk/sun/security/krb5/runNameEquals.sh
+++ b/test/jdk/sun/security/krb5/runNameEquals.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ EXIT_STATUS=0
 
 if [ "${NATIVE}" = "true" ] ; then
     echo "Testing native provider"
-    ${TESTJAVA}${FILESEP}bin${FILESEP}java ${TESTVMOPTS} \
+    ${TESTJAVA}${FILESEP}bin${FILESEP}java ${TESTVMOPTS} ${TESTJAVAOPTS} \
         -classpath ${TESTCLASSES} \
         -Dsun.security.jgss.native=true \
         ${TEST}
@@ -114,7 +114,7 @@ if [ "${NATIVE}" = "true" ] ; then
 fi
 
 echo "Testing java provider"
-${TESTJAVA}${FILESEP}bin${FILESEP}java ${TESTVMOPTS} \
+${TESTJAVA}${FILESEP}bin${FILESEP}java ${TESTVMOPTS} ${TESTJAVAOPTS} \
         -classpath ${TESTCLASSES} \
         -Djava.security.krb5.realm=R \
         -Djava.security.krb5.kdc=127.0.0.1 \

--- a/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
+++ b/test/jdk/sun/security/pkcs11/Provider/MultipleLogins.sh
@@ -122,7 +122,7 @@ ${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} \
         ${TESTSRC}${FS}MultipleLogins.java \
         ${TESTSRC}${FS}..${FS}PKCS11Test.java
 
-TEST_ARGS="${TESTVMOPTS} -classpath ${TESTCLASSPATH} \
+TEST_ARGS="${TESTVMOPTS} ${TESTJAVAOPTS} -classpath ${TESTCLASSPATH} \
         --add-modules jdk.crypto.cryptoki \
         --add-exports jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED \
         -DCUSTOM_DB_DIR=${TESTCLASSES} \

--- a/test/jdk/sun/security/provider/PolicyFile/getinstance/getinstance.sh
+++ b/test/jdk/sun/security/provider/PolicyFile/getinstance/getinstance.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 #
-# Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ ${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} -d ${TESTCLA
 ${COMPILEJAVA}${FS}bin${FS}javac ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} -d ${TESTCLASSES}${FS}app \
         ${TESTSRC}${FS}GetInstance.java
 
-${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS}  \
+${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS}  \
 -Xbootclasspath/a:"${TESTCLASSES}${FS}boot" \
 -classpath "${TESTCLASSES}${FS}app" -Djava.security.manager \
 -Djava.security.policy=GetInstance.policy \
@@ -110,7 +110,7 @@ if [ $status1 -ne 0 ]; then
      echo "Failed on first test"
 fi
 
-${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS}  \
+${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS}  \
 -classpath "${TESTCLASSES}${FS}boot${PS}${TESTCLASSES}${FS}app" \
 -Djava.security.manager \
 -Djava.security.policy=GetInstance.policy \

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/NotifyHandshakeTest.sh
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/NotifyHandshakeTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ rm -rf com edu
 # This is the only thing we really care about as far as
 # test status goes.
 #
-${TESTJAVA}${FILESEP}bin${FILESEP}java ${TESTVMOPTS} \
+${TESTJAVA}${FILESEP}bin${FILESEP}java ${TESTVMOPTS} ${TESTJAVAOPTS} \
     -Dtest.src=${TESTSRC} \
     -classpath "com.jar${PATHSEP}edu.jar" \
     -Djava.security.manager \

--- a/test/jdk/sun/security/util/Pem/encoding.sh
+++ b/test/jdk/sun/security/util/Pem/encoding.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,6 @@
 # jtreg does not like -Dfile.encoding=UTF-16 inside a @run main line,
 # therefore a shell test is written.
 
-$TESTJAVA/bin/java $TESTVMOPTS -cp $TESTCLASSES \
+$TESTJAVA/bin/java $TESTVMOPTS $TESTJAVAOPTS -cp $TESTCLASSES \
         -Dfile.encoding=UTF-16 \
         PemEncoding $TESTSRC/../HostnameMatcher/cert5.crt

--- a/test/jdk/sun/security/validator/certreplace.sh
+++ b/test/jdk/sun/security/validator/certreplace.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -85,4 +85,4 @@ $KT -delete -alias user
 
 EXTRAOPTS="--add-exports java.base/sun.security.validator=ALL-UNNAMED"
 $JAVAC ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} ${EXTRAOPTS} -d . ${TESTSRC}${FS}CertReplace.java
-$JAVA ${TESTVMOPTS} ${EXTRAOPTS} CertReplace certreplace.jks certreplace.certs
+$JAVA ${TESTVMOPTS} ${TESTJAVAOPTS} ${EXTRAOPTS} CertReplace certreplace.jks certreplace.certs

--- a/test/jdk/sun/security/validator/samedn.sh
+++ b/test/jdk/sun/security/validator/samedn.sh
@@ -81,5 +81,5 @@ $KT -delete -alias user
 
 EXTRAOPTS="--add-exports java.base/sun.security.validator=ALL-UNNAMED"
 $JAVAC ${TESTJAVACOPTS} ${TESTTOOLVMOPTS} ${EXTRAOPTS} -d . ${TESTSRC}${FS}CertReplace.java
-$JAVA ${TESTVMOPTS} ${EXTRAOPTS} CertReplace samedn.jks samedn1.certs || exit 1
-$JAVA ${TESTVMOPTS} ${EXTRAOPTS} CertReplace samedn.jks samedn2.certs || exit 2
+$JAVA ${TESTVMOPTS} ${TESTJAVAOPTS} ${EXTRAOPTS} CertReplace samedn.jks samedn1.certs || exit 1
+$JAVA ${TESTVMOPTS} ${TESTJAVAOPTS} ${EXTRAOPTS} CertReplace samedn.jks samedn2.certs || exit 2


### PR DESCRIPTION
I backport this for parity with 17.0.14-oracle.

Resolved one Copyright, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339892](https://bugs.openjdk.org/browse/JDK-8339892) needs maintainer approval

### Issue
 * [JDK-8339892](https://bugs.openjdk.org/browse/JDK-8339892): Several security shell tests don't set TESTJAVAOPTS (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3081/head:pull/3081` \
`$ git checkout pull/3081`

Update a local copy of the PR: \
`$ git checkout pull/3081` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3081`

View PR using the GUI difftool: \
`$ git pr show -t 3081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3081.diff">https://git.openjdk.org/jdk17u-dev/pull/3081.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3081#issuecomment-2511276700)
</details>
