### PR TITLE
8299739: HashedPasswordFileTest.java and ExceptionTest.java can fail with java.lang.NullPointerException

### DIFF
--- a/test/jdk/javax/management/MBeanServer/ExceptionTest.java
+++ b/test/jdk/javax/management/MBeanServer/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,10 +123,13 @@ public class ExceptionTest {
         } finally {
             try {
                 // Close JMX Connector Client
-                cc.close();
+                if (cc != null) {
+                    cc.close();
+                }
                 // Stop connertor server
-                cs.stop();
-
+                if (cs != null) {
+                    cs.stop();
+                }
             } catch (Exception e) {
                 Utils.printThrowable(e, true);
                 throw new RuntimeException(

--- a/test/jdk/javax/management/security/HashedPasswordFileTest.java
+++ b/test/jdk/javax/management/security/HashedPasswordFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,6 +200,12 @@ public class HashedPasswordFileTest {
         return cs.getAddress();
     }
 
+    private void stopServerSide() throws IOException {
+        if (cs != null) {
+            cs.stop();
+        }
+    }
+
     @Test
     public void testClearTextPasswordFile() throws IOException {
         Boolean[] bvals = new Boolean[]{true, false};
@@ -217,7 +223,7 @@ public class HashedPasswordFileTest {
                 }
                 Assert.assertEquals(isPasswordFileHashed(), bval);
             } finally {
-                cs.stop();
+                stopServerSide();
             }
         }
     }
@@ -241,7 +247,7 @@ public class HashedPasswordFileTest {
                 }
                 Assert.assertEquals(isPasswordFileHashed(), false);
             } finally {
-                cs.stop();
+                stopServerSide();
             }
         }
     }
@@ -263,7 +269,7 @@ public class HashedPasswordFileTest {
                     }
                 }
             } finally {
-                cs.stop();
+                stopServerSide();
             }
         }
     }
@@ -400,7 +406,7 @@ public class HashedPasswordFileTest {
                 }
             }
         } finally {
-            cs.stop();
+            stopServerSide();
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8299739](https://bugs.openjdk.org/browse/JDK-8299739) needs maintainer approval

### Issue
 * [JDK-8299739](https://bugs.openjdk.org/browse/JDK-8299739): HashedPasswordFileTest.java and ExceptionTest.java can fail with java.lang.NullPointerException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3083/head:pull/3083` \
`$ git checkout pull/3083`

Update a local copy of the PR: \
`$ git checkout pull/3083` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3083`

View PR using the GUI difftool: \
`$ git pr show -t 3083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3083.diff">https://git.openjdk.org/jdk17u-dev/pull/3083.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3083#issuecomment-2511431788)
</details>
