### PR TITLE
8313710: jcmd: typo in the documentation of JFR.start and JFR.dump

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -201,55 +201,55 @@ final class DCmdDump extends AbstractDCmd {
 
                Options:
 
-                 begin           (Optional) Specify the time from which recording data will be included
-                                 in the dump file. The format is specified as local time.
-                                 (STRING, no default value)
+                 begin            (Optional) Specify the time from which recording data will be
+                                  included in the dump file. The format is specified as local time.
+                                  (STRING, no default value)
 
-                 end             (Optional) Specify the time to which recording data will be included
-                                 in the dump file. The format is specified as local time.
-                                 (STRING, no default value)
+                 end              (Optional) Specify the time to which recording data will be included
+                                  in the dump file. The format is specified as local time.
+                                  (STRING, no default value)
 
-                                 Note: For both begin and end, the time must be in a format that can
-                                 be read by any of these methods:
+                                  Note: For both begin and end, the time must be in a format that can
+                                  be read by any of these methods:
 
-                                  java.time.LocalTime::parse(String),
-                                  java.time.LocalDateTime::parse(String)
-                                  java.time.Instant::parse(String)
+                                   java.time.LocalTime::parse(String),
+                                   java.time.LocalDateTime::parse(String)
+                                   java.time.Instant::parse(String)
 
-                                 For example, "13:20:15", "2020-03-17T09:00:00" or
-                                 "2020-03-17T09:00:00Z".
+                                  For example, "13:20:15", "2020-03-17T09:00:00" or
+                                  "2020-03-17T09:00:00Z".
 
-                                 Note: begin and end times correspond to the timestamps found within
-                                 the recorded information in the flight recording data.
+                                  Note: begin and end times correspond to the timestamps found within
+                                  the recorded information in the flight recording data.
 
-                                 Another option is to use a time relative to the current time that is
-                                 specified by a negative integer followed by "s", "m" or "h".
-                                 For example, "-12h", "-15m" or "-30s"
+                                  Another option is to use a time relative to the current time that is
+                                  specified by a negative integer followed by "s", "m" or "h".
+                                  For example, "-12h", "-15m" or "-30s"
 
-                 filename        (Optional) Name of the file to which the flight recording data is
-                                 dumped. If no filename is given, a filename is generated from the PID
-                                 and the current date. The filename may also be a directory in which
-                                 case, the filename is generated from the PID and the current date in
-                                 the specified directory. (STRING, no default value)
+                 filename         (Optional) Name of the file to which the flight recording data is
+                                  dumped. If no filename is given, a filename is generated from the PID
+                                  and the current date. The filename may also be a directory in which
+                                  case, the filename is generated from the PID and the current date in
+                                  the specified directory. (STRING, no default value)
 
-                 maxage          (Optional) Length of time for dumping the flight recording data to a
-                                 file. (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for
-                                 hours, no default value)
+                 maxage           (Optional) Length of time for dumping the flight recording data to a
+                                  file. (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for
+                                  hours, no default value)
 
-                 maxsize         (Optional) Maximum size for the amount of data to dump from a flight
-                                 recording in bytes if one of the following suffixes is not used:
-                                 'm' or 'M' for megabytes OR 'g' or 'G' for gigabytes.
-                                 (STRING, no default value)
+                 maxsize          (Optional) Maximum size for the amount of data to dump from a flight
+                                  recording in bytes if one of the following suffixes is not used:
+                                  'm' or 'M' for megabytes OR 'g' or 'G' for gigabytes.
+                                  (STRING, no default value)
 
-                 name            (Optional) Name of the recording. If no name is given, data from all
-                                 recordings is dumped. (STRING, no default value)
+                 name             (Optional) Name of the recording. If no name is given, data from all
+                                  recordings is dumped. (STRING, no default value)
 
-                 path-to-gc-root (Optional) Flag for saving the path to garbage collection (GC) roots
-                                 at the time the recording data is dumped. The path information is
-                                 useful for finding memory leaks but collecting it can cause the
-                                 application to pause for a short period of time. Turn on this flag
-                                 only when you have an application that you suspect has a memory
-                                 leak. (BOOLEAN, false)
+                 path-to-gc-roots (Optional) Flag for saving the path to garbage collection (GC) roots
+                                  at the time the recording data is dumped. The path information is
+                                  useful for finding memory leaks but collecting it can cause the
+                                  application to pause for a short period of time. Turn on this flag
+                                  only when you have an application that you suspect has a memory
+                                  leak. (BOOLEAN, false)
 
                Options must be specified using the <key> or <key>=<value> syntax.
 
@@ -261,7 +261,7 @@ final class DCmdDump extends AbstractDCmd {
                 $ jcmd <pid> JFR.dump name=1 filename=%s
                 $ jcmd <pid> JFR.dump maxage=1h
                 $ jcmd <pid> JFR.dump maxage=1h maxsize=50M
-                $ jcmd <pid> JFR.dump fillename=leaks.jfr path-to-gc-root=true
+                $ jcmd <pid> JFR.dump filename=leaks.jfr path-to-gc-roots=true
                 $ jcmd <pid> JFR.dump begin=13:15
                 $ jcmd <pid> JFR.dump begin=13:15 end=21:30:00
                 $ jcmd <pid> JFR.dump end=18:00 maxage=10m

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -306,78 +306,78 @@ final class DCmdStart extends AbstractDCmd {
 
     @Override
     public String[] printHelp() {
-        // 0123456789001234567890012345678900123456789001234567890012345678900123456789001234567890
+            // 0123456789001234567890012345678900123456789001234567890012345678900123456789001234567890
         return """
                Syntax : JFR.start [options]
 
                Options:
 
-                 delay           (Optional) Length of time to wait before starting to record
-                                 (INTEGER followed by 's' for seconds 'm' for minutes or h' for
-                                 hours, 0s)
+                 delay            (Optional) Length of time to wait before starting to record
+                                  (INTEGER followed by 's' for seconds 'm' for minutes or h' for
+                                  hours, 0s)
 
-                 disk            (Optional) Flag for also writing the data to disk while recording
-                                 (BOOLEAN, true)
+                 disk             (Optional) Flag for also writing the data to disk while recording
+                                  (BOOLEAN, true)
 
-                 dumponexit      (Optional) Flag for writing the recording to disk when the Java
-                                 Virtual Machine (JVM) shuts down. If set to 'true' and no value
-                                 is given for filename, the recording is written to a file in the
-                                 directory where the process was started. The file name is a
-                                 system-generated name that contains the process ID, the recording
-                                 ID and the current time stamp. (For example:
-                                 id-1-2021_09_14_09_00.jfr) (BOOLEAN, false)
+                 dumponexit       (Optional) Flag for writing the recording to disk when the Java
+                                  Virtual Machine (JVM) shuts down. If set to 'true' and no value
+                                  is given for filename, the recording is written to a file in the
+                                  directory where the process was started. The file name is a
+                                  system-generated name that contains the process ID, the recording
+                                  ID and the current time stamp. (For example:
+                                  id-1-2021_09_14_09_00.jfr) (BOOLEAN, false)
 
-                 duration        (Optional) Length of time to record. Note that 0s means forever
-                                 (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for
-                                 hours, 0s)
+                 duration         (Optional) Length of time to record. Note that 0s means forever
+                                  (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for
+                                  hours, 0s)
 
-                 filename        (Optional) Name of the file to which the flight recording data is
-                                 written when the recording is stopped. If no filename is given, a
-                                 filename is generated from the PID and the current date and is
-                                 placed in the directory where the process was started. The
-                                 filename may also be a directory in which case, the filename is
-                                 generated from the PID and the current date in the specified
-                                 directory. (STRING, no default value)
+                 filename         (Optional) Name of the file to which the flight recording data is
+                                  written when the recording is stopped. If no filename is given, a
+                                  filename is generated from the PID and the current date and is
+                                  placed in the directory where the process was started. The
+                                  filename may also be a directory in which case, the filename is
+                                  generated from the PID and the current date in the specified
+                                  directory. (STRING, no default value)
 
-                 maxage          (Optional) Maximum time to keep the recorded data on disk. This
-                                 parameter is valid only when the disk parameter is set to true.
-                                 Note 0s means forever. (INTEGER followed by 's' for seconds 'm'
-                                 for minutes or 'h' for hours, 0s)
+                 maxage           (Optional) Maximum time to keep the recorded data on disk. This
+                                  parameter is valid only when the disk parameter is set to true.
+                                  Note 0s means forever. (INTEGER followed by 's' for seconds 'm'
+                                  for minutes or 'h' for hours, 0s)
 
-                 maxsize         (Optional) Maximum size of the data to keep on disk in bytes if
-                                 one of the following suffixes is not used: 'm' or 'M' for
-                                 megabytes OR 'g' or 'G' for gigabytes. This parameter is valid
-                                 only when the disk parameter is set to 'true'. The value must not
-                                 be less than the value for the maxchunksize parameter set with
-                                 the JFR.configure command. (STRING, 0 (no max size))
+                 maxsize          (Optional) Maximum size of the data to keep on disk in bytes if
+                                  one of the following suffixes is not used: 'm' or 'M' for
+                                  megabytes OR 'g' or 'G' for gigabytes. This parameter is valid
+                                  only when the disk parameter is set to 'true'. The value must not
+                                  be less than the value for the maxchunksize parameter set with
+                                  the JFR.configure command. (STRING, 0 (no max size))
 
-                 name            (Optional) Name of the recording. If no name is provided, a name
-                                 is generated. Make note of the generated name that is shown in
-                                 the response to the command so that you can use it with other
-                                 commands. (STRING, system-generated default name)
+                 name             (Optional) Name of the recording. If no name is provided, a name
+                                  is generated. Make note of the generated name that is shown in
+                                  the response to the command so that you can use it with other
+                                  commands. (STRING, system-generated default name)
 
-                 path-to-gc-root (Optional) Flag for saving the path to garbage collection (GC)
-                                 roots at the end of a recording. The path information is useful
-                                 for finding memory leaks but collecting it is time consuming.
-                                 Turn on this flag only when you have an application that you
-                                 suspect has a memory leak. If the settings parameter is set to
-                                 'profile', then the information collected includes the stack
-                                 trace from where the potential leaking object wasallocated.
-                                 (BOOLEAN, false)
+                 path-to-gc-roots (Optional) Flag for saving the path to garbage collection (GC)
+                                  roots at the end of a recording. The path information is useful
+                                  for finding memory leaks but collecting it is time consuming.
+                                  Turn on this flag only when you have an application that you
+                                  suspect has a memory leak. If the settings parameter is set to
+                                  'profile', then the information collected includes the stack
+                                  trace from where the potential leaking object was allocated.
+                                  (BOOLEAN, false)
 
-                 settings        (Optional) Name of the settings file that identifies which events
-                                 to record. To specify more than one file, use the settings
-                                 parameter repeatedly. Include the path if the file is not in
-                                 JAVA-HOME/lib/jfr. The following profiles are included with the
-                                 JDK in the JAVA-HOME/lib/jfr directory: 'default.jfc': collects a
-                                 predefined set of information with low overhead, so it has minimal
-                                 impact on performance and can be used with recordings that run
-                                 continuously; 'profile.jfc': Provides more data than the
-                                 'default.jfc' profile, but with more overhead and impact on
-                                 performance. Use this configuration for short periods of time
-                                 when more information is needed. Use none to start a recording
-                                 without a predefined configuration file. (STRING,
-                                 JAVA-HOME/lib/jfr/default.jfc)
+                 settings         (Optional) Name of the settings file that identifies which events
+                                  to record. To specify more than one file, use the settings
+                                  parameter repeatedly. Include the path if the file is not in
+                                  JAVA-HOME/lib/jfr. The following profiles are included with the
+                                  JDK in the JAVA-HOME/lib/jfr directory: 'default.jfc': collects a
+                                  predefined set of information with low overhead, so it has minimal
+                                  impact on performance and can be used with recordings that run
+                                  continuously; 'profile.jfc': Provides more data than the
+                                  'default.jfc' profile, but with more overhead and impact on
+                                  performance. Use this configuration for short periods of time
+                                  when more information is needed. Use none to start a recording
+                                  without a predefined configuration file. (STRING,
+                                  JAVA-HOME/lib/jfr/default.jfc)
 
                Event settings and .jfc options can also be specified using the following syntax:
 


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

Trivial resolve. 21 has some additional documentation lines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313710](https://bugs.openjdk.org/browse/JDK-8313710) needs maintainer approval

### Issue
 * [JDK-8313710](https://bugs.openjdk.org/browse/JDK-8313710): jcmd: typo in the documentation of JFR.start and JFR.dump (**Bug** - P5 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3088/head:pull/3088` \
`$ git checkout pull/3088`

Update a local copy of the PR: \
`$ git checkout pull/3088` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3088`

View PR using the GUI difftool: \
`$ git pr show -t 3088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3088.diff">https://git.openjdk.org/jdk17u-dev/pull/3088.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3088#issuecomment-2517064967)
</details>
