### PR TITLE
8319648: java/lang/SecurityManager tests ignore vm flags

### DIFF
--- a/test/jdk/java/lang/SecurityManager/modules/CustomSecurityManagerTest.java
+++ b/test/jdk/java/lang/SecurityManager/modules/CustomSecurityManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class CustomSecurityManagerTest {
 
     @Test(dataProvider = "testCases")
     public void testProvider(List<String> args) throws Throwable {
-        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(args);
+        ProcessBuilder processBuilder = ProcessTools.createTestJavaProcessBuilder(args);
         OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(processBuilder);
         outputAnalyzer.shouldHaveExitValue(0);
     }

--- a/test/jdk/java/lang/System/SecurityManagerWarnings.java
+++ b/test/jdk/java/lang/System/SecurityManagerWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @library /test/lib
  */
 
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
@@ -51,6 +50,7 @@ public class SecurityManagerWarnings {
                     };
                     """);
 
+            System.setProperty("test.noclasspath", "true");
             String testClasses = System.getProperty("test.classes");
 
             allowTest(null, testClasses);
@@ -131,13 +131,11 @@ public class SecurityManagerWarnings {
     static OutputAnalyzer run(String prop, String cp) throws Exception {
         ProcessBuilder pb;
         if (prop == null) {
-            pb = new ProcessBuilder(
-                    JDKToolFinder.getJDKTool("java"),
+            pb = ProcessTools.createTestJavaProcessBuilder(
                     "-cp", cp,
                     "SecurityManagerWarnings", "run");
         } else {
-            pb = new ProcessBuilder(
-                    JDKToolFinder.getJDKTool("java"),
+            pb = ProcessTools.createTestJavaProcessBuilder(
                     "-cp", cp,
                     "-Djava.security.manager=" + prop,
                     "-Djava.security.policy=policy",


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319648](https://bugs.openjdk.org/browse/JDK-8319648) needs maintainer approval

### Issue
 * [JDK-8319648](https://bugs.openjdk.org/browse/JDK-8319648): java/lang/SecurityManager tests ignore vm flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3090/head:pull/3090` \
`$ git checkout pull/3090`

Update a local copy of the PR: \
`$ git checkout pull/3090` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3090`

View PR using the GUI difftool: \
`$ git pr show -t 3090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3090.diff">https://git.openjdk.org/jdk17u-dev/pull/3090.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3090#issuecomment-2517202617)
</details>
