### PR TITLE
8293345: SunPKCS11 provider checks on PKCS11 Mechanism are problematic

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,6 +126,9 @@ final class Config {
 
     // whether to print debug info during startup
     private boolean showInfo = false;
+
+    // whether to allow legacy mechanisms
+    private boolean allowLegacy = false;
 
     // template manager, initialized from parsed attributes
     private TemplateManager templateManager;
@@ -255,6 +258,10 @@ final class Config {
 
     boolean getShowInfo() {
         return (SunPKCS11.debug != null) || showInfo;
+    }
+
+    boolean getAllowLegacy() {
+        return allowLegacy;
     }
 
     TemplateManager getTemplateManager() {
@@ -450,6 +457,8 @@ final class Config {
                 destroyTokenAfterLogout = parseBooleanEntry(word);
             } else if (word.equals("showInfo")) {
                 showInfo = parseBooleanEntry(word);
+            } else if (word.equals("allowLegacy")) {
+                allowLegacy = parseBooleanEntry(word);
             } else if (word.equals("keyStoreCompatibilityMode")) {
                 keyStoreCompatibilityMode = parseBooleanEntry(word);
             } else if (word.equals("explicitCancel")) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1055,25 +1055,6 @@ public final class SunPKCS11 extends AuthProvider {
         }
     }
 
-    private static boolean isLegacy(CK_MECHANISM_INFO mechInfo)
-            throws PKCS11Exception {
-        // assume full support if no mech info available
-        // For vendor-specific mechanisms, often no mech info is provided
-        boolean partialSupport = false;
-
-        if (mechInfo != null) {
-            if ((mechInfo.flags & CKF_DECRYPT) != 0) {
-                // non-legacy cipher mechs should support encryption
-                partialSupport |= ((mechInfo.flags & CKF_ENCRYPT) == 0);
-            }
-            if ((mechInfo.flags & CKF_VERIFY) != 0) {
-                // non-legacy signature mechs should support signing
-                partialSupport |= ((mechInfo.flags & CKF_SIGN) == 0);
-            }
-        }
-        return partialSupport;
-    }
-
     // test if a token is present and initialize this provider for it if so.
     // does nothing if no token is found
     // called from constructor and by poller
@@ -1124,12 +1105,6 @@ public final class SunPKCS11 extends AuthProvider {
                 }
                 continue;
             }
-            if (isLegacy(mechInfo)) {
-                if (showInfo) {
-                    System.out.println("DISABLED due to legacy");
-                }
-                continue;
-            }
 
             // we do not know of mechs with the upper 32 bits set
             if (longMech >>> 32 != 0) {
@@ -1144,9 +1119,25 @@ public final class SunPKCS11 extends AuthProvider {
             if (ds == null) {
                 continue;
             }
+            boolean allowLegacy = config.getAllowLegacy();
             for (Descriptor d : ds) {
                 Integer oldMech = supportedAlgs.get(d);
                 if (oldMech == null) {
+
+                    // assume full support if no mech info available
+                    if (!allowLegacy && mechInfo != null) {
+                        if ((d.type == CIP &&
+                                (mechInfo.flags & CKF_ENCRYPT) == 0) ||
+                                (d.type == SIG &&
+                                (mechInfo.flags & CKF_SIGN) == 0)) {
+                            if (showInfo) {
+                                System.out.println("DISABLED " +  d.type +
+                                        " " + d.algorithm +
+                                        " due to partial support");
+                            }
+                            continue;
+                        }
+                    }
                     supportedAlgs.put(d, integerMech);
                     continue;
                 }


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.


Config.java:
Resolve and adapt because of unsupported switch syntax.

SunPKCS11.java: I had to resolve becuase
"8301553: Support Password-Based Cryptography in SunPKCS11"
is not in 17. Context code has different control flow. 
Patched code is unchanged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8293345](https://bugs.openjdk.org/browse/JDK-8293345) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8343498](https://bugs.openjdk.org/browse/JDK-8343498) to be approved

### Issues
 * [JDK-8293345](https://bugs.openjdk.org/browse/JDK-8293345): SunPKCS11 provider checks on PKCS11 Mechanism are problematic (**Enhancement** - P3 - Approved)
 * [JDK-8343498](https://bugs.openjdk.org/browse/JDK-8343498): SunPKCS11 provider checks on PKCS11 Mechanism are problematic (**CSR**)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3092/head:pull/3092` \
`$ git checkout pull/3092`

Update a local copy of the PR: \
`$ git checkout pull/3092` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3092`

View PR using the GUI difftool: \
`$ git pr show -t 3092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3092.diff">https://git.openjdk.org/jdk17u-dev/pull/3092.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3092#issuecomment-2517316173)
</details>
