### PR TITLE
8335789: [TESTBUG] XparColor.java test fails with Error. Parse Exception: Invalid or unrecognized bugid: @

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/XparColor.java
+++ b/test/jdk/java/awt/print/PrinterJob/XparColor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 4179262
- @ @key printer
+ * @key printer
  * @summary Confirm that transparent colors are printed correctly. The
  * printout should show transparent rings with increasing darkness toward
  * the center.


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8335789](https://bugs.openjdk.org/browse/JDK-8335789) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335789](https://bugs.openjdk.org/browse/JDK-8335789): [TESTBUG] XparColor.java test fails with Error. Parse Exception: Invalid or unrecognized bugid: @<!----> (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3094/head:pull/3094` \
`$ git checkout pull/3094`

Update a local copy of the PR: \
`$ git checkout pull/3094` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3094`

View PR using the GUI difftool: \
`$ git pr show -t 3094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3094.diff">https://git.openjdk.org/jdk17u-dev/pull/3094.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3094#issuecomment-2517510696)
</details>
