### PR TITLE
8339261: Logs truncated in test javax/net/ssl/DTLS/DTLSRehandshakeTest.java

### DIFF
--- a/test/jdk/javax/net/ssl/DTLS/TEST.properties
+++ b/test/jdk/javax/net/ssl/DTLS/TEST.properties
@@ -6,3 +6,4 @@ modules = \
     java.security.jgss/sun.security.krb5.internal:+open \
     java.security.jgss/sun.security.krb5.internal.ktab \
     java.base/sun.security.util
+maxOutputSize = 2500000


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8339261](https://bugs.openjdk.org/browse/JDK-8339261) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339261](https://bugs.openjdk.org/browse/JDK-8339261): Logs truncated in test javax/net/ssl/DTLS/DTLSRehandshakeTest.java (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3100/head:pull/3100` \
`$ git checkout pull/3100`

Update a local copy of the PR: \
`$ git checkout pull/3100` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3100`

View PR using the GUI difftool: \
`$ git pr show -t 3100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3100.diff">https://git.openjdk.org/jdk17u-dev/pull/3100.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3100#issuecomment-2517709521)
</details>
