### PR TITLE
8299994: java/security/Policy/Root/Root.java fails when home directory is read-only

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -585,7 +585,8 @@ jdk_security_manual_no_input = \
     sun/security/smartcardio/TestMultiplePresent.java \
     sun/security/smartcardio/TestPresent.java \
     sun/security/smartcardio/TestTransmit.java \
-    sun/security/tools/jarsigner/compatibility/Compatibility.java
+    sun/security/tools/jarsigner/compatibility/Compatibility.java \
+    java/security/Policy/Root/Root.java
 
 jdk_core_manual_interactive = \
     com/sun/jndi/dns/Test6991580.java \

--- a/test/jdk/java/security/Policy/Root/Root.java
+++ b/test/jdk/java/security/Policy/Root/Root.java
@@ -27,15 +27,22 @@
  * @summary User Policy Setting is not recognized on Netscape 6
  *          when invoked as root.
  * @library /test/lib
- * @run testng/othervm Root
+ * @requires os.family != "windows"
+ * @run testng/othervm/manual Root
  */
+
+/*
+* Run test as root user.
+* */
 
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,19 +54,48 @@ public class Root {
     private static final String ROOT = System.getProperty("user.home");
     private static final Path SOURCE = Paths.get(SRC, "Root.policy");
     private static final Path TARGET = Paths.get(ROOT, ".java.policy");
+    private static final Path BACKUP = Paths.get(ROOT, ".backup.policy");
+    private static final String ROOT_USER_ID = "0";
 
     @BeforeTest
     public void setup() throws IOException {
+        // Backup user policy file if it already exists
+        if (TARGET.toFile().exists()) {
+            Files.copy(TARGET, BACKUP, StandardCopyOption.REPLACE_EXISTING);
+        }
         Files.copy(SOURCE, TARGET, StandardCopyOption.REPLACE_EXISTING);
     }
 
     @AfterTest
     public void cleanUp() throws IOException {
         Files.delete(TARGET);
+        // Restore original policy file if backup exists
+        if (BACKUP.toFile().exists()) {
+            Files.copy(BACKUP, TARGET, StandardCopyOption.REPLACE_EXISTING);
+            Files.delete(BACKUP);
+        }
     }
 
     @Test
-    private void test() {
+    private void test() throws InterruptedException, IOException {
+        System.out.println("Run test as root user.");
+
+        Process process = Runtime.getRuntime().exec("id -u");
+        process.waitFor();
+        if (process.exitValue() != 0) {
+            throw new RuntimeException("Failed to retrieve user id.");
+        }
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream()))) {
+            String line = reader.readLine();
+
+            if (!ROOT_USER_ID.equals(line)) {
+                throw new RuntimeException(
+                        "This test needs to be run with root privilege.");
+            }
+        }
+
         Policy p = Policy.getPolicy();
         Assert.assertTrue(p.implies(Root.class.getProtectionDomain(),
                 new AllPermission()));


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

Omitted ProblemList change, problem listing it was not backported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8299994](https://bugs.openjdk.org/browse/JDK-8299994) needs maintainer approval

### Issue
 * [JDK-8299994](https://bugs.openjdk.org/browse/JDK-8299994): java/security/Policy/Root/Root.java fails when home directory is read-only (**Bug** - P3 - Approved)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3104/head:pull/3104` \
`$ git checkout pull/3104`

Update a local copy of the PR: \
`$ git checkout pull/3104` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3104`

View PR using the GUI difftool: \
`$ git pr show -t 3104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3104.diff">https://git.openjdk.org/jdk17u-dev/pull/3104.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3104#issuecomment-2528004609)
</details>
