### PR TITLE
8343724: [PPC64] Disallow OptoScheduling

### DIFF
--- a/src/hotspot/cpu/ppc/c2_init_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c2_init_ppc.cpp
@@ -34,21 +34,5 @@
 // Processor dependent initialization of C2 compiler for ppc.
 
 void Compile::pd_compiler2_init() {
-
-  // Power7 and later.
-  if (PowerArchitecturePPC64 > 6) {
-    if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
-      FLAG_SET_ERGO(UsePopCountInstruction, true);
-    }
-  }
-
-  if (!VM_Version::has_isel() && FLAG_IS_DEFAULT(ConditionalMoveLimit)) {
-    FLAG_SET_ERGO(ConditionalMoveLimit, 0);
-  }
-
-  if (OptimizeFill) {
-    warning("OptimizeFill is not supported on this CPU.");
-    FLAG_SET_DEFAULT(OptimizeFill, false);
-  }
-
+  guarantee(CodeEntryAlignment >= InteriorEntryAlignment, "");
 }

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -117,6 +117,17 @@ void VM_Version::initialize() {
     FLAG_SET_ERGO(TrapBasedRangeChecks, false);
   }
 
+  // Power7 and later.
+  if (PowerArchitecturePPC64 > 6) {
+    if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
+      FLAG_SET_ERGO(UsePopCountInstruction, true);
+    }
+  }
+
+  if (!VM_Version::has_isel() && FLAG_IS_DEFAULT(ConditionalMoveLimit)) {
+    FLAG_SET_ERGO(ConditionalMoveLimit, 0);
+  }
+
   if (PowerArchitecturePPC64 >= 8) {
     if (FLAG_IS_DEFAULT(SuperwordUseVSX)) {
       FLAG_SET_ERGO(SuperwordUseVSX, true);
@@ -175,6 +186,17 @@ void VM_Version::initialize() {
       warning("UseByteReverseInstructions specified, but needs at least Power10.");
       FLAG_SET_DEFAULT(UseByteReverseInstructions, false);
     }
+  }
+
+  if (OptimizeFill) {
+    warning("OptimizeFill is not supported on this CPU.");
+    FLAG_SET_DEFAULT(OptimizeFill, false);
+  }
+
+  if (OptoScheduling) {
+    // The OptoScheduling information is not maintained in ppd.ad.
+    warning("OptoScheduling is not supported on this CPU.");
+    FLAG_SET_DEFAULT(OptoScheduling, false);
   }
 #endif
 


### PR DESCRIPTION
Clean backport of [JDK-8343724](https://bugs.openjdk.org/browse/JDK-8343724).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343724](https://bugs.openjdk.org/browse/JDK-8343724) needs maintainer approval

### Issue
 * [JDK-8343724](https://bugs.openjdk.org/browse/JDK-8343724): [PPC64] Disallow OptoScheduling (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3105/head:pull/3105` \
`$ git checkout pull/3105`

Update a local copy of the PR: \
`$ git checkout pull/3105` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3105`

View PR using the GUI difftool: \
`$ git pr show -t 3105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3105.diff">https://git.openjdk.org/jdk17u-dev/pull/3105.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3105#issuecomment-2532831945)
</details>
