### PR TITLE
8343129: Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values

### DIFF
--- a/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
+++ b/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
@@ -171,8 +171,10 @@ TEST_VM(ThreadsListHandle, sanity) {
       // Verify the current thread refers to tlh2:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh2.list())
           << "thr->_threads_hazard_ptr must match tlh2.list()";
-      EXPECT_EQ(tlh1.list(), tlh2.list())
-          << "tlh1.list() must match tlh2.list()";
+    // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+    // until the root cause of test failure(JDK-8315141) has been fixed
+    //   EXPECT_EQ(tlh1.list(), tlh2.list())
+    //       << "tlh1.list() must match tlh2.list()";
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr2)
           << "thr->_threads_list_ptr must match list_ptr2";
       EXPECT_NE(list_ptr1, list_ptr2)
@@ -291,8 +293,10 @@ TEST_VM(ThreadsListHandle, sanity) {
       // Verify the current thread refers to tlh2:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh2.list())
           << "thr->_threads_hazard_ptr must match tlh2.list()";
-      EXPECT_EQ(tlh1.list(), tlh2.list())
-          << "tlh1.list() must match tlh2.list()";
+    // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+    // until the root cause of test failure(JDK-8315141) has been fixed
+    //   EXPECT_EQ(tlh1.list(), tlh2.list())
+    //       << "tlh1.list() must match tlh2.list()";
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr2)
           << "thr->_threads_list_ptr must match list_ptr2";
       EXPECT_NE(list_ptr1, list_ptr2)
@@ -339,8 +343,10 @@ TEST_VM(ThreadsListHandle, sanity) {
         // Verify the current thread refers to tlh3:
         EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh3.list())
             << "thr->_threads_hazard_ptr must match tlh3.list()";
-        EXPECT_EQ(tlh1.list(), tlh3.list())
-            << "tlh1.list() must match tlh3.list()";
+        // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+        // until the root cause of test failure(JDK-8315141) has been fixed
+        // EXPECT_EQ(tlh1.list(), tlh3.list())
+        //     << "tlh1.list() must match tlh3.list()";
         EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr3)
             << "thr->_threads_list_ptr must match list_ptr3";
         EXPECT_NE(list_ptr1, list_ptr3)
@@ -523,8 +529,10 @@ TEST_VM(ThreadsListHandle, sanity) {
       // Verify the current thread refers to tlh2a:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh2a.list())
           << "thr->_threads_hazard_ptr must match tlh2a.list()";
-      EXPECT_EQ(tlh1.list(), tlh2a.list())
-          << "tlh1.list() must match tlh2a.list()";
+    // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+    // until the root cause of test failure(JDK-8315141) has been fixed
+    //   EXPECT_EQ(tlh1.list(), tlh2a.list())
+    //       << "tlh1.list() must match tlh2a.list()";
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr2a)
           << "thr->_threads_list_ptr must match list_ptr2a";
       EXPECT_NE(list_ptr1, list_ptr2a)
@@ -601,8 +609,10 @@ TEST_VM(ThreadsListHandle, sanity) {
       // Verify the current thread refers to tlh2b:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh2b.list())
           << "thr->_threads_hazard_ptr must match tlh2b.list()";
-      EXPECT_EQ(tlh1.list(), tlh2b.list())
-          << "tlh1.list() must match tlh2b.list()";
+    // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+    // until the root cause of test failure(JDK-8315141) has been fixed
+    //   EXPECT_EQ(tlh1.list(), tlh2b.list())
+    //       << "tlh1.list() must match tlh2b.list()";
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr2b)
           << "thr->_threads_list_ptr must match list_ptr2b";
       EXPECT_NE(list_ptr1, list_ptr2b)


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [59fcfae6](https://github.com/openjdk/jdk/commit/59fcfae63090f6659a94a9e3dd0705739ec1b074) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 19 Nov 2024 and was reviewed by David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343129](https://bugs.openjdk.org/browse/JDK-8343129) needs maintainer approval

### Issue
 * [JDK-8343129](https://bugs.openjdk.org/browse/JDK-8343129): Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3108/head:pull/3108` \
`$ git checkout pull/3108`

Update a local copy of the PR: \
`$ git checkout pull/3108` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3108`

View PR using the GUI difftool: \
`$ git pr show -t 3108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3108.diff">https://git.openjdk.org/jdk17u-dev/pull/3108.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3108#issuecomment-2537665604)
</details>
