### PR TITLE
8320916: jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java failed with "OutOfMemoryError: GC overhead limit exceeded"

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/stacktrace/AllocationStackTrace.java
+++ b/test/jdk/jdk/jfr/event/gc/stacktrace/AllocationStackTrace.java
@@ -79,7 +79,7 @@ class HumongousMemoryAllocator extends MemoryAllocator {
 class OldGenMemoryAllocator extends MemoryAllocator {
 
     private List<byte[]> list = new ArrayList<byte[]>();
-    private int counter = 6000;
+    private int counter = 5000;
 
     @Override
     public void allocate() {
@@ -87,7 +87,7 @@ class OldGenMemoryAllocator extends MemoryAllocator {
             list.add(new byte[10 * KB]);
         } else {
             list = new ArrayList<byte[]>();
-            counter = 6000;
+            counter = 5000;
         }
 
         garbage = list;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [69384745](https://github.com/openjdk/jdk/commit/693847452f208446a34186f142fe2c56a49ceceb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Albert Mingkun Yang on 30 Nov 2023 and was reviewed by Stefan Johansson and Thomas Schatzl.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320916](https://bugs.openjdk.org/browse/JDK-8320916) needs maintainer approval

### Issue
 * [JDK-8320916](https://bugs.openjdk.org/browse/JDK-8320916): jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java failed with "OutOfMemoryError: GC overhead limit exceeded" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3109/head:pull/3109` \
`$ git checkout pull/3109`

Update a local copy of the PR: \
`$ git checkout pull/3109` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3109`

View PR using the GUI difftool: \
`$ git pr show -t 3109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3109.diff">https://git.openjdk.org/jdk17u-dev/pull/3109.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3109#issuecomment-2537715414)
</details>
