### PR TITLE
8345296: AArch64: VM crashes with SIGILL when prctl is disallowed

### DIFF
--- a/src/hotspot/cpu/aarch64/register_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/register_aarch64.hpp
@@ -140,7 +140,13 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
     max_slots_per_register = 8,
     save_slots_per_register = 2,
     slots_per_neon_register = 4,
-    extra_save_slots_per_neon_register = slots_per_neon_register - save_slots_per_register
+    extra_save_slots_per_neon_register = slots_per_neon_register - save_slots_per_register,
+    neon_vl = 16,
+    // VLmax: The maximum sve vector length is determined by the hardware
+    // sve_vl_min <= VLmax <= sve_vl_max.
+    sve_vl_min = 16,
+    // Maximum supported vector length across all CPUs
+    sve_vl_max = 256
   };
 
   // construction


### PR DESCRIPTION
Ref. https://github.com/openjdk/jdk/pull/22479

> We have caught this in some prod environments, where prctl is forbidden by the sandboxing mechanism. This fails the JVM

Does not apply cleanly, the backport depends on `FloatRegister` changes from [JDK-8339063](https://bugs.openjdk.org/browse/JDK-8339063) which are included in `src/hotspot/cpu/aarch64/register_aarch64.hpp`.

Additional testing:

- [x] Verified the bug is fixed with the seccomp repro from [JDK-8345296](https://bugs.openjdk.org/browse/JDK-8345296?focusedId=14727386&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14727386): Segfault without the patch, works with.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345296](https://bugs.openjdk.org/browse/JDK-8345296) needs maintainer approval

### Issue
 * [JDK-8345296](https://bugs.openjdk.org/browse/JDK-8345296): AArch64: VM crashes with SIGILL when prctl is disallowed (**Bug** - P3 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3111/head:pull/3111` \
`$ git checkout pull/3111`

Update a local copy of the PR: \
`$ git checkout pull/3111` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3111`

View PR using the GUI difftool: \
`$ git pr show -t 3111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3111.diff">https://git.openjdk.org/jdk17u-dev/pull/3111.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3111#issuecomment-2539079228)
</details>
