### PR TITLE
8336692: Redo fix for JDK-8284620

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -135,10 +135,11 @@ CodeBuffer::~CodeBuffer() {
     // Previous incarnations of this buffer are held live, so that internal
     // addresses constructed before expansions will not be confused.
     cb->free_blob();
-    // free any overflow storage
-    delete cb->_overflow_arena;
   }
-
+  if (_overflow_arena != nullptr) {
+    // free any overflow storage
+    delete _overflow_arena;
+  }
   // Claim is that stack allocation ensures resources are cleaned up.
   // This is resource clean up, let's hope that all were properly copied out.
   NOT_PRODUCT(free_strings();)
@@ -940,8 +941,6 @@ void CodeBuffer::take_over_code_from(CodeBuffer* cb) {
     CodeSection* this_sect = code_section(n);
     this_sect->take_over_code_from(cb_sect);
   }
-  _overflow_arena = cb->_overflow_arena;
-  cb->_overflow_arena = NULL;
   // Make sure the old cb won't try to use it or free it.
   DEBUG_ONLY(cb->_blob = (BufferBlob*)badAddress);
 }


### PR DESCRIPTION
I backport this for parity with 21.0.6-oracle

Resolved due to nullptr differences.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8336692](https://bugs.openjdk.org/browse/JDK-8336692) needs maintainer approval

### Issue
 * [JDK-8336692](https://bugs.openjdk.org/browse/JDK-8336692): Redo fix for JDK-8284620 (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3112/head:pull/3112` \
`$ git checkout pull/3112`

Update a local copy of the PR: \
`$ git checkout pull/3112` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3112`

View PR using the GUI difftool: \
`$ git pr show -t 3112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3112.diff">https://git.openjdk.org/jdk17u-dev/pull/3112.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3112#issuecomment-2541203491)
</details>
