### PR TITLE
8334777: Test javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java failed with NullPointerException

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,9 @@
  * @bug 6199899
  * @summary Tests reconnection done by a fetching notif thread.
  * @author Shanliang JIANG
+ * @requires vm.compMode != "Xcomp"
+ * @comment Running with -Xcomp is likely to cause a timeout from ServerCommunicatorAdmin
+ *          before addNotificationListener can complete.
  *
  * @run clean NotifReconnectDeadlockTest
  * @run build NotifReconnectDeadlockTest


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334777](https://bugs.openjdk.org/browse/JDK-8334777) needs maintainer approval

### Issue
 * [JDK-8334777](https://bugs.openjdk.org/browse/JDK-8334777): Test javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java failed with NullPointerException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3121/head:pull/3121` \
`$ git checkout pull/3121`

Update a local copy of the PR: \
`$ git checkout pull/3121` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3121`

View PR using the GUI difftool: \
`$ git pr show -t 3121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3121.diff">https://git.openjdk.org/jdk17u-dev/pull/3121.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3121#issuecomment-2545058432)
</details>
