### PR TITLE
8333391: Test com/sun/jdi/InterruptHangTest.java failed: Thread was never interrupted during sleep

### DIFF
--- a/test/jdk/com/sun/jdi/InterruptHangTest.java
+++ b/test/jdk/com/sun/jdi/InterruptHangTest.java
@@ -62,8 +62,10 @@ class InterruptHangTarg {
         for (int ii = 0; ii < 200; ii++) {
             answer++;
             try {
-                // Give other thread a chance to run
-                Thread.sleep(100);
+                // Give other thread a chance to interrupt. Normally only a very short
+                // sleep is needed, but we need to account for unexpected delays in
+                // the interrupt due to machine and network hiccups.
+                Thread.sleep(10*1000);
             } catch (InterruptedException ee) {
                 System.out.println("Debuggee interruptee: interrupted at iteration: "
                                    + ii);


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8333391](https://bugs.openjdk.org/browse/JDK-8333391) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333391](https://bugs.openjdk.org/browse/JDK-8333391): Test com/sun/jdi/InterruptHangTest.java failed: Thread was never interrupted during sleep (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3122/head:pull/3122` \
`$ git checkout pull/3122`

Update a local copy of the PR: \
`$ git checkout pull/3122` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3122`

View PR using the GUI difftool: \
`$ git pr show -t 3122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3122.diff">https://git.openjdk.org/jdk17u-dev/pull/3122.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3122#issuecomment-2545076436)
</details>
