### PR TITLE
8339902: Open source couple TextField related tests

### DIFF
--- a/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
+++ b/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * summary:
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.InputEvent;
+import java.lang.reflect.InvocationTargetException;
+
+/*
+ * @test
+ * @bug 4038580
+ * @key headful
+ * @requires os.family != "windows"
+ * @summary Caret position not accurate in presence of selected areas
+ * @run main CaretPositionTest
+ */
+
+public class CaretPositionTest extends Frame {
+    private TextField text_field;
+    private Button caretpos_button;
+    private Point onScreen;
+    private Dimension size;
+    String text = "12 45 789";
+    private static volatile int position = -1;
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        CaretPositionTest test = new CaretPositionTest();
+        EventQueue.invokeAndWait(test::setupGUI);
+        try {
+            test.test();
+            if (position != 9) {
+                throw new RuntimeException("Caret position should be at the end of the string");
+            }
+        } finally {
+            EventQueue.invokeAndWait(test::dispose);
+        }
+    }
+
+    public void setupGUI() {
+        setLocationRelativeTo(null);
+        setTitle("CaretPositionTest");
+        setLayout(new FlowLayout());
+        text_field = new TextField(text, 9);
+        caretpos_button=new Button("CaretPosition");
+        add(text_field);
+        add(caretpos_button);
+        pack();
+        setVisible(true);
+        toFront();
+    }
+
+    public void test() throws AWTException, InterruptedException,
+            InvocationTargetException {
+        EventQueue.invokeAndWait(() -> {
+                    onScreen = text_field.getLocationOnScreen();
+                    size = text_field.getSize();
+                });
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.delay(1000);
+        int y = onScreen.y + (size.height / 2);
+        robot.mouseMove(onScreen.x + (size.width / 2), y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseMove(onScreen.x + 3, y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        for (int x = onScreen.x + 5; x < onScreen.x + size.width; x += 2) {
+            robot.mouseMove(x, y);
+        }
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        EventQueue.invokeAndWait(() -> {
+            position = text_field.getCaretPosition();
+        });
+    }
+}

--- a/test/jdk/java/awt/TextField/SetBoundsTest/SetBoundsTest.java
+++ b/test/jdk/java/awt/TextField/SetBoundsTest/SetBoundsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * summary:
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.ScrollPane;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.lang.reflect.InvocationTargetException;
+
+/*
+ * @test
+ * @bug 6198290 6277332
+ * @summary TextField painting is broken when placed on a Scrollpane, XToolkit
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetBoundsTest
+ */
+
+public class SetBoundsTest extends Frame {
+
+    private static final String INSTRUCTIONS = """
+            1) Make active a frame with a scrollpane and a few components.
+            2) Please, focus attention on the text components
+                 placed on the upper half of the frame
+            3) Make sure, that the scrollbar of the frame
+                 have the same position during the test.
+            4) Bring focus to TextField, try deleting the text.
+                 If the text never gets erased, the test failed
+            5) Bring focus to TextArea, try deleting the text.
+                 If the text never gets erased, the test failed
+            6) Please, focus attention on the text components
+                 placed on the lower half of the frame
+            7) Try input something into TextField.
+                 If you can not input anything into TextField, the test failed
+            8) Try input something into TextArea.
+                 If you can not input anything into TextArea, the test failed
+            9) The test passed
+            """;
+
+    public SetBoundsTest() {
+        setTitle("SetBoundsTest Test Frame");
+        setLayout(new GridLayout(2, 1));
+        Panel hw = new Panel();
+        ScrollPane sp = new ScrollPane(ScrollPane.SCROLLBARS_AS_NEEDED);
+        Container lw = new Container();
+        fill(hw);
+        fill(lw);
+
+        sp.add(hw);
+        add(sp);
+        add(lw);
+
+        setSize(600, 600);
+        sp.setScrollPosition(20, 0);
+
+    }
+
+    private void fill(Container c) {
+        Button button = new Button("button");
+        c.add(button);
+        button.setBackground(new Color(0xd3ceac));
+        button.setForeground(new Color(0x000000));
+        button.move(60, 80);
+        button.resize(400, 60);
+        button.show(true);
+
+        TextField textfield = new TextField("textfield");
+        c.add(textfield);
+        textfield.setBackground(new Color(0xd3ceac));
+        textfield.setForeground(new Color(0x000000));
+        textfield.move(60, 20);
+        textfield.resize(400, 40);
+        textfield.show(true);
+
+        TextArea textarea = new TextArea("textarea");
+        c.add(textarea);
+        textarea.setBackground(new Color(0xd3ceac));
+        textarea.setForeground(new Color(0x000000));
+        textarea.move(60, 80);
+        textarea.resize(400, 60);
+        textarea.show(true);
+
+        c.setLayout (new FlowLayout());
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Set Bounds Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .testUI(SetBoundsTest::new)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/TextField/SetEchoCharTest4/SetEchoCharTest4.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharTest4/SetEchoCharTest4.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * summary:
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.lang.reflect.InvocationTargetException;
+
+/*
+ * @test
+ * @bug 4226580
+ * @summary TextField with echoChar add+remove+add seems to be broken
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetEchoCharTest4
+ */
+
+public class SetEchoCharTest4 extends Frame implements ActionListener {
+    TextField tf1 = new TextField(8);
+    TextField tf2 = new TextField(8);
+    TextField tf3 = new TextField(8);
+    Button b = new Button("Click Several Times");
+
+    static final String INSTRUCTIONS = """
+                    Type in the first text field and * characters will echo.
+                    Type in the second text field and $ characters will echo.
+                    Type in the third text field and # characters will echo.
+
+                    Hit the button several times.  All characters should remain
+                    the same and the test should not crash.
+
+                    Make sure the actual text matches what you typed in for each field.
+                    Press Pass if everything's ok, otherwise Fail
+           """;
+
+    public SetEchoCharTest4() {
+        setLayout(new FlowLayout());
+        tf1.setEchoChar('*');
+        tf2.setEchoChar('$');
+        tf3.setEchoChar('#');
+        addStuff();
+        b.addActionListener(this);
+        setSize (200,200);
+    }
+
+    private void addStuff() {
+        add(tf1);
+        add(tf2);
+        add(tf3);
+        add(b);
+    }
+
+    public void actionPerformed(ActionEvent ae) {
+        PassFailJFrame.log("TextField1 = " + tf1.getText());
+        PassFailJFrame.log("TextField2 = " + tf2.getText());
+        PassFailJFrame.log("TextField3 = " + tf3.getText());
+        PassFailJFrame.log("--------------");
+        setVisible(false);
+        remove(tf1);
+        remove(tf2);
+        remove(tf3);
+        remove(b);
+        addStuff();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Set Echo Character Test")
+                .testUI(SetEchoCharTest4::new)
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(40)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/TextField/SetPasswordTest/SetPasswordTest.java
+++ b/test/jdk/java/awt/TextField/SetPasswordTest/SetPasswordTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * summary:
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.lang.reflect.InvocationTargetException;
+
+/*
+ * @test
+ * @bug 4084454
+ * @summary Make sure that you can set the text in a "password mode"
+ *          text field and that it echoes as the current echo char.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetPasswordTest
+ */
+
+public class SetPasswordTest extends Frame implements ActionListener {
+    private String setText = "Set text";
+    private String getText = "Get text";
+    private TextField tfPassword;
+
+    static final String INSTRUCTIONS = """
+            The purpose of this test is to ensure that when using a textField for
+            password entry that text set programmatically is not shown in the clear.
+
+            We also test "pasting" text into the text field.
+
+            1.  Press the "Set Text" button
+                Text should appear as '*' chars
+              - if the string "secret" appears then the test is failed.
+            2.  Use the mouse to select (highlight) all the text and press the DELETE key
+            3.  Use the system's copy/paste functionality to copy a text string from the
+                desktop or this window, and paste it into the text field.
+            4.  Text should appear in the text field as '*' chars
+              - if the string you pasted appears then the test is failed.
+            5.  press the "Get Text" button and the string you pasted
+                should be printed in the log area
+              - if it prints echo symbols instead the test is failed.
+            """;
+
+    public SetPasswordTest() {
+        setLayout(new FlowLayout());
+        tfPassword = new TextField("Initial text", 30);
+        tfPassword.setEchoChar('*');
+        add(tfPassword);
+
+        Button b1 = new Button(setText);
+        b1.addActionListener(this);
+        add(b1);
+
+        Button b2 = new Button(getText);
+        b2.addActionListener(this);
+        add(b2);
+        pack();
+    }
+
+    public void actionPerformed(ActionEvent evt) {
+        String ac = evt.getActionCommand();
+        if (setText.equals(ac)) {
+            tfPassword.setText("secret");
+        }
+
+        if (getText.equals(ac)) {
+            PassFailJFrame.log("Text: \"" + tfPassword.getText() + "\"");
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Set Password Test")
+                .testUI(SetPasswordTest::new)
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(40)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/TextField/ZeroEchoCharTest/ZeroEchoCharTest.java
+++ b/test/jdk/java/awt/TextField/ZeroEchoCharTest/ZeroEchoCharTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * summary:
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.lang.reflect.InvocationTargetException;
+
+/*
+ * @test
+ * @bug 4307281
+ * @summary verify that after setting the echo char to 0 disguises are
+ *          removed and user input is echoed to the screen unchanged.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ZeroEchoCharTest
+ */
+
+public class ZeroEchoCharTest extends Frame implements ActionListener {
+    private final TextField textfield = new TextField();
+    private final Button button1 = new Button("Set echo char to *");
+    private final Button button2 = new Button("Set echo char to 0");
+    static final String INSTRUCTIONS = """
+            1.Type in the text field. The user input must be echoed unchanged.
+            2.Set echo char to '*' by pressing the corresponding button.
+              If all characters in the text field aren't immediately replaced
+              with '*', the test fails.
+            3.Set echo char to 0 by pressing the corresponding button.
+              If disguises in the text field don't immediately revert to
+              the original characters, the test fails.
+            4.Type in the text field. If the input is echoed unchanged,
+              the test passes. Otherwise, the test fails.
+            """;
+
+    public ZeroEchoCharTest() {
+        button1.addActionListener(this);
+        button2.addActionListener(this);
+
+        setLayout(new GridLayout(3, 1));
+
+        add(textfield);
+        add(button1);
+        add(button2);
+        pack();
+    }
+
+    public void actionPerformed(ActionEvent event) {
+        if (event.getSource() == button1) {
+            textfield.setEchoChar('*');
+        } else if (event.getSource() == button2) {
+            textfield.setEchoChar((char)0);
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Zero Echo Char Test")
+                .testUI(ZeroEchoCharTest::new)
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339902](https://bugs.openjdk.org/browse/JDK-8339902) needs maintainer approval

### Issue
 * [JDK-8339902](https://bugs.openjdk.org/browse/JDK-8339902): Open source couple TextField related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3126/head:pull/3126` \
`$ git checkout pull/3126`

Update a local copy of the PR: \
`$ git checkout pull/3126` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3126`

View PR using the GUI difftool: \
`$ git pr show -t 3126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3126.diff">https://git.openjdk.org/jdk17u-dev/pull/3126.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3126#issuecomment-2545536996)
</details>
