### PR TITLE
8316149: Open source several Swing JTree JViewport KeyboardManager tests

### DIFF
--- a/test/jdk/javax/swing/JTree/bug4696499.java
+++ b/test/jdk/javax/swing/JTree/bug4696499.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4696499
+ * @summary new tree model asked about nodes of previous tree model
+ * @run main bug4696499
+ */
+
+import java.util.ArrayList;
+
+import javax.swing.JTree;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+
+public class bug4696499 {
+    public static void main(String[] args) throws Exception {
+        JTree tree = new JTree();
+        TreeModel model = new MyModel();
+        tree.setModel(model);
+
+        tree.setSelectionRow(1);
+        model = new MyModel();
+        tree.setModel(model);
+    }
+}
+
+class MyModel implements TreeModel {
+    private Object root = "Root";
+    private ArrayList listeners = new ArrayList();
+    private TreeNode ONE;
+    static int next = 1;
+
+    MyModel() {
+        ONE = new DefaultMutableTreeNode(next);
+        next *= 2;
+    }
+
+    public void addTreeModelListener(TreeModelListener l) {
+        listeners.add(l);
+    }
+
+    public void removeTreeModelListener(TreeModelListener l) {
+        listeners.remove(l);
+    }
+
+    public void valueForPathChanged(TreePath tp, Object newValue) {
+    }
+
+    public Object getRoot() {
+        return root;
+    }
+
+    public boolean isLeaf(Object o) {
+        return o == ONE;
+    }
+
+    public int getIndexOfChild(Object parent, Object child) {
+        if (parent != root || child != ONE) {
+            throw new RuntimeException("This method is called with the child " +
+                    "of the previous tree model");
+        }
+        return 0;
+    }
+
+    public int getChildCount(Object o) {
+        if (o == root) {
+            return 1;
+        }
+        if (o == ONE) {
+            return 0;
+        }
+        throw new IllegalArgumentException(o.toString());
+    }
+
+    public Object getChild(Object o, int index) {
+        if (o != root || index != 0) {
+            throw new IllegalArgumentException(o + ", " + index);
+        }
+        return ONE;
+    }
+}

--- a/test/jdk/javax/swing/JTree/bug5039542.java
+++ b/test/jdk/javax/swing/JTree/bug5039542.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 5039542
+ * @summary JTree's setToolTipText() doesn't work
+ * @run main bug5039542
+ */
+
+import javax.swing.JTree;
+
+public class bug5039542 {
+    public static void main(String[] args) throws Exception {
+        final String exampleStr = "TEST";
+        JTree tree = new JTree();
+        tree.setToolTipText(exampleStr);
+        if (tree.getToolTipText(null) != exampleStr) {
+            throw new RuntimeException("The default JTree tooltip text " +
+                    "have to be used if renderer doesn't provide it.");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JViewport/bug4546474.java
+++ b/test/jdk/javax/swing/JViewport/bug4546474.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4546474
+ * @summary JScrollPane's always-visible scrollbars not updated when
+ * viewport is replaced
+ * @run main bug4546474
+ */
+
+import java.awt.Dimension;
+import java.awt.Robot;
+
+import javax.swing.JPanel;
+import javax.swing.JScrollBar;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+
+public class bug4546474 {
+    static JScrollPane scrollpane;
+    static JScrollBar sbar;
+    static volatile boolean viewChanged;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JPanel panel = new JPanel();
+            panel.setPreferredSize(new Dimension(500, 500));
+            scrollpane = new JScrollPane(panel,
+                    JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                    JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+            sbar = scrollpane.getVerticalScrollBar();
+        });
+
+        Robot robot = new Robot();
+        robot.delay(500);
+        SwingUtilities.invokeAndWait(() -> {
+            sbar.addAdjustmentListener(e -> viewChanged = true);
+            scrollpane.setViewportView(null);
+        });
+        robot.delay(500);
+        if (!viewChanged) {
+            viewChanged = true;
+        }
+        robot.delay(500);
+
+        SwingUtilities.invokeAndWait(() -> {
+            if (sbar.getVisibleAmount() > 0) {
+                throw new RuntimeException("Vertical scrollbar is not " +
+                        "updated when viewport is replaced");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JViewport/bug4677611.java
+++ b/test/jdk/javax/swing/JViewport/bug4677611.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4677611
+ * @summary JViewport sets Opaque after UpdateUI (prevents UI delegates
+ * to determine look)
+ * @run main bug4677611
+ */
+
+import java.awt.Color;
+
+import javax.swing.JScrollPane;
+import javax.swing.JViewport;
+
+public class bug4677611 {
+    public static void main(String[] args) throws Exception {
+        JScrollPane sp = new JScrollPane();
+        JViewport vp = new MyViewport();
+        vp.setBackground(Color.blue);
+        sp.setViewport(vp);
+
+        if (vp.isOpaque()) {
+            throw new RuntimeException("JViewport shouldn't set Opaque " +
+                    "after update the UI");
+        }
+    }
+
+    static class MyViewport extends JViewport {
+        public void updateUI() {
+            setOpaque(false);
+            super.updateUI();
+        }
+    }
+}

--- a/test/jdk/javax/swing/KeyboardManager/bug4345798.java
+++ b/test/jdk/javax/swing/KeyboardManager/bug4345798.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4345798
+ * @summary Tests if Pressing enter to dismiss menu works when a JRootPane
+ * has a default button.
+ * @key headful
+ * @run main bug4345798
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JRootPane;
+import javax.swing.SwingUtilities;
+
+public class bug4345798 {
+    private static JFrame f;
+    private static JButton b;
+    private static JMenu menu;
+    private static volatile boolean passed = true;
+    private static volatile Point p;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                f = new JFrame("bug4345798");
+                JMenuBar mbar = new JMenuBar();
+                JMenuItem item = new JMenuItem("Open...");
+                menu = new JMenu("File");
+                item.addActionListener(new TestActionListener());
+                menu.add(item);
+                mbar.add(menu);
+
+                f.setJMenuBar(mbar);
+
+                b = new JButton("Default");
+                b.addActionListener(new TestActionListener());
+                f.getContentPane().add(b);
+                JRootPane rp = f.getRootPane();
+                rp.setDefaultButton(b);
+
+                f.setSize(200, 200);
+                f.setLocationRelativeTo(null);
+                f.setVisible(true);
+                b.requestFocus();
+            });
+
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> p = menu.getLocationOnScreen());
+            robot.mouseMove(p.x, p.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            robot.keyPress(KeyEvent.VK_F10);
+            robot.keyRelease(KeyEvent.VK_F10);
+
+            robot.keyPress(KeyEvent.VK_DOWN);
+            robot.keyRelease(KeyEvent.VK_DOWN);
+
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+
+        if (!passed) {
+            throw new RuntimeException("Test failed.");
+        }
+    }
+
+    static class TestActionListener implements ActionListener {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (e.getSource() == b) {
+                passed = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8316149](https://bugs.openjdk.org/browse/JDK-8316149) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316149](https://bugs.openjdk.org/browse/JDK-8316149): Open source several Swing JTree JViewport KeyboardManager tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3130/head:pull/3130` \
`$ git checkout pull/3130`

Update a local copy of the PR: \
`$ git checkout pull/3130` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3130`

View PR using the GUI difftool: \
`$ git pr show -t 3130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3130.diff">https://git.openjdk.org/jdk17u-dev/pull/3130.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3130#issuecomment-2547955309)
</details>
