### PR TITLE
8340116: test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java can fail due to regex

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java
+++ b/test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java
@@ -244,9 +244,8 @@ public class PreserveRawManifestEntryAndDigest {
      * @see "concise_jarsigner.sh"
      */
     String[] getExpectedJarSignerOutputUpdatedContentNotValidatedBySignerA(
-            String jarFilename, String digestalg,
             String firstAddedFilename, String secondAddedFilename) {
-        final String TS = ".{28,29}"; // matches a timestamp
+        final String TS = ".{28,34}"; // matches a timestamp
         List<String> expLines = new ArrayList<>();
         expLines.add("s k   *\\d+ " + TS + " META-INF/MANIFEST[.]MF");
         expLines.add("      *\\d+ " + TS + " META-INF/B[.]SF");
@@ -348,7 +347,6 @@ public class PreserveRawManifestEntryAndDigest {
         assertMatchByLines(
                 fromFirstToSecondEmptyLine(o.getStdout().split("\\R")),
                 getExpectedJarSignerOutputUpdatedContentNotValidatedBySignerA(
-                        jarFilename4, digestalg,
                         firstAddedFilename, secondAddedFilename));
 
         // double-check reading the files with a verifying JarFile


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340116](https://bugs.openjdk.org/browse/JDK-8340116) needs maintainer approval

### Issue
 * [JDK-8340116](https://bugs.openjdk.org/browse/JDK-8340116): test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java can fail due to regex (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3141/head:pull/3141` \
`$ git checkout pull/3141`

Update a local copy of the PR: \
`$ git checkout pull/3141` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3141`

View PR using the GUI difftool: \
`$ git pr show -t 3141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3141.diff">https://git.openjdk.org/jdk17u-dev/pull/3141.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3141#issuecomment-2550939602)
</details>
