### PR TITLE
8333427: langtools/tools/javac/newlines/NewLineTest.java is failing on Japanese Windows

### DIFF
--- a/test/langtools/tools/javac/newlines/NewLineTest.java
+++ b/test/langtools/tools/javac/newlines/NewLineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,9 @@ public class NewLineTest {
                 .options("-J-Dline.separator='@'")
                 .run(Task.Expect.FAIL);
 
-        List<String> lines = Files.readAllLines(javacOutput.toPath(),
-                Charset.defaultCharset());
+        String encoding = System.getProperty("native.encoding");
+        Charset cs = (encoding != null) ? Charset.forName(encoding) : Charset.defaultCharset();
+        List<String> lines = Files.readAllLines(javacOutput.toPath(), cs);
         if (lines.size() != 1) {
             throw new AssertionError("The compiler output should have one line only");
         }


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8333427](https://bugs.openjdk.org/browse/JDK-8333427) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333427](https://bugs.openjdk.org/browse/JDK-8333427): langtools/tools/javac/newlines/NewLineTest.java is failing on Japanese Windows (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3144/head:pull/3144` \
`$ git checkout pull/3144`

Update a local copy of the PR: \
`$ git checkout pull/3144` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3144`

View PR using the GUI difftool: \
`$ git pr show -t 3144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3144.diff">https://git.openjdk.org/jdk17u-dev/pull/3144.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3144#issuecomment-2551085844)
</details>
