### PR TITLE
8342811: java/net/httpclient/PlainProxyConnectionTest.java failed: Unexpected connection count: 5

### DIFF
--- a/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
+++ b/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@ import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import jdk.httpclient.test.lib.common.HttpServerAdapters;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -51,15 +53,28 @@ import static java.net.Proxy.NO_PROXY;
  * @bug 8230526
  * @summary Verifies that PlainProxyConnections are cached and reused properly. We do this by
  *          verifying that the remote address of the HTTP exchange (on the fake proxy server)
- *          is always the same InetSocketAddress.
- * @modules jdk.httpserver
- * @run main/othervm PlainProxyConnectionTest
- * @author danielfuchs
+ *          is always the same InetSocketAddress. Logging verbosity is increased to aid in
+ *          diagnosis of intermittent failures.
+ * @library /test/lib
+ *          /test/jdk/java/net/httpclient/lib
+ * @run main/othervm
+ *      -Djdk.httpclient.HttpClient.log=headers,requests,trace
+ *      -Djdk.internal.httpclient.debug=true
+ *      PlainProxyConnectionTest
  */
 public class PlainProxyConnectionTest {
 
+    // Increase logging verbosity to troubleshoot intermittent failures
+    static {
+        HttpServerAdapters.enableServerLogging();
+    }
+
     static final String RESPONSE = "<html><body><p>Hello World!</body></html>";
-    static final String PATH = "/foo/";
+
+    // Adding some salt to the path to avoid other parallel running tests mistakenly connect to our test server
+    private static final String PATH = String.format(
+            "/%s-%d", PlainProxyConnectionTest.class.getSimpleName(), PlainProxyConnectionTest.class.hashCode());
+
     static final ConcurrentLinkedQueue<InetSocketAddress> connections = new ConcurrentLinkedQueue<>();
 
     // For convenience the server is used both as a plain server and as a plain proxy.


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

I had to resolve because "8308310:` HttpClient: Avoid logging or locking from within synchronized blocks" is not in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342811](https://bugs.openjdk.org/browse/JDK-8342811) needs maintainer approval

### Issue
 * [JDK-8342811](https://bugs.openjdk.org/browse/JDK-8342811): java/net/httpclient/PlainProxyConnectionTest.java failed: Unexpected connection count: 5 (**Bug** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3146/head:pull/3146` \
`$ git checkout pull/3146`

Update a local copy of the PR: \
`$ git checkout pull/3146` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3146`

View PR using the GUI difftool: \
`$ git pr show -t 3146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3146.diff">https://git.openjdk.org/jdk17u-dev/pull/3146.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3146#issuecomment-2551222708)
</details>
