### PR TITLE
8342541: Exclude List/KeyEventsTest/KeyEventsTest.java from running on macOS

### DIFF
--- a/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
+++ b/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
@@ -21,17 +21,6 @@
  * questions.
  */
 
-/*
-  @test
-  @key headful
-  @bug 6190768 6190778
-  @summary Tests that triggering events on AWT list by pressing CTRL + HOME,
-           CTRL + END, PG-UP, PG-DOWN similar Motif behavior
-  @library /test/lib
-  @build jdk.test.lib.Platform
-  @run main KeyEventsTest
-*/
-
 import java.awt.BorderLayout;
 import java.awt.EventQueue;
 import java.awt.KeyboardFocusManager;
@@ -50,6 +39,17 @@ import java.awt.event.KeyListener;
 
 import jdk.test.lib.Platform;
 
+/*
+ * @test
+ * @key headful
+ * @bug 6190768 6190778
+ * @requires os.family != "mac"
+ * @summary Tests that triggering events on AWT list by pressing CTRL + HOME,
+ *          CTRL + END, PG-UP, PG-DOWN similar Motif behavior
+ * @library /test/lib
+ * @build jdk.test.lib.Platform
+ * @run main KeyEventsTest
+ */
 public class KeyEventsTest {
     TestState currentState;
     final Object LOCK = new Object();
@@ -261,13 +261,7 @@ public class KeyEventsTest {
 
     private void doTest() throws Exception {
 
-        boolean isWin = false;
-        if (Platform.isWindows()) {
-            isWin = true;
-        } else if (Platform.isOSX()) {
-            System.out.println("Not for OS X");
-            return;
-        }
+        boolean isWin = Platform.isWindows();
 
         System.out.println("multiple? selectedMoved? ?scrollMoved keyID? template? action?");
         test(new TestState(false, false, false, KeyEvent.VK_PAGE_UP, isWin?false:false));


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8342541](https://bugs.openjdk.org/browse/JDK-8342541) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342541](https://bugs.openjdk.org/browse/JDK-8342541): Exclude List/KeyEventsTest/KeyEventsTest.java from running on macOS (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3147/head:pull/3147` \
`$ git checkout pull/3147`

Update a local copy of the PR: \
`$ git checkout pull/3147` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3147`

View PR using the GUI difftool: \
`$ git pr show -t 3147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3147.diff">https://git.openjdk.org/jdk17u-dev/pull/3147.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3147#issuecomment-2551341555)
</details>
