### PR TITLE
8294316: SA core file support is broken on macosx-x64 starting with macOS 12.x

### DIFF
--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -297,11 +297,16 @@ static bool read_core_segments(struct ps_prochandle* ph) {
         print_debug("failed to read LC_SEGMENT_64 i = %d!\n", i);
         goto err;
       }
-      if (add_map_info(ph, fd, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize, segcmd.flags) == NULL) {
-        print_debug("Failed to add map_info at i = %d\n", i);
-        goto err;
+      // The base of the library is offset by a random amount which ends up as a load command with a
+      // filesize of 0.  This must be ignored otherwise the base address of the library is wrong.
+      if (segcmd.filesize != 0) {
+        if (add_map_info(ph, fd, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize, segcmd.flags) == NULL) {
+          print_debug("Failed to add map_info at i = %d\n", i);
+          goto err;
+        }
       }
-      print_debug("LC_SEGMENT_64 added: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
+      print_debug("LC_SEGMENT_64 %s: nsects=%d fileoff=0x%llx vmaddr=0x%llx vmsize=0x%llx filesize=0x%llx %s\n",
+                  segcmd.filesize == 0 ? "with filesize == 0 ignored" : "added",
                   segcmd.nsects, segcmd.fileoff, segcmd.vmaddr, segcmd.vmsize,
                   segcmd.filesize, &segcmd.segname[0]);
     } else if (lcmd.cmd == LC_THREAD || lcmd.cmd == LC_UNIXTHREAD) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -115,13 +115,13 @@ serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 generic-all
 
-serviceability/sa/ClhsdbCDSCore.java  8294316,8267433 macosx-x64
-serviceability/sa/ClhsdbFindPC.java#id1  8294316,8267433 macosx-x64
-serviceability/sa/ClhsdbFindPC.java#id3  8294316,8267433 macosx-x64
-serviceability/sa/ClhsdbPmap.java#id1  8294316,8267433 macosx-x64
-serviceability/sa/ClhsdbPstack.java#id1  8294316,8267433 macosx-x64
-serviceability/sa/TestJmapCore.java  8294316,8267433 macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java  8294316,8267433 macosx-x64
+serviceability/sa/ClhsdbCDSCore.java  8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id1  8267433 macosx-x64
+serviceability/sa/ClhsdbFindPC.java#id3  8267433 macosx-x64
+serviceability/sa/ClhsdbPmap.java#id1  8267433 macosx-x64
+serviceability/sa/ClhsdbPstack.java#id1  8267433 macosx-x64
+serviceability/sa/TestJmapCore.java  8267433 macosx-x64
+serviceability/sa/TestJmapCoreMetaspace.java  8267433 macosx-x64
 
 #############################################################################
 


### PR DESCRIPTION
A mostly clean backport of [JDK-8294316](https://bugs.openjdk.org/browse/JDK-8294316) to properly parse core files in macOS 12 and later. Load commands with length zero are now discarded.

The fix doesn't affect directly to SA tests in 17, but it's being backported to 11 as this is the cause of https://github.com/openjdk/jdk11u-dev/pull/2967#issuecomment-2538048579.

Tests in 17 continue to pass in all platforms, including macos.

The change is not clean as there were merge conflicts in `ProblemList.txt`, as these usually differ between JDK versions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8294316](https://bugs.openjdk.org/browse/JDK-8294316) needs maintainer approval

### Issue
 * [JDK-8294316](https://bugs.openjdk.org/browse/JDK-8294316): SA core file support is broken on macosx-x64 starting with macOS 12.x (**Bug** - P4 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3150/head:pull/3150` \
`$ git checkout pull/3150`

Update a local copy of the PR: \
`$ git checkout pull/3150` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3150`

View PR using the GUI difftool: \
`$ git pr show -t 3150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3150.diff">https://git.openjdk.org/jdk17u-dev/pull/3150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3150#issuecomment-2552184295)
</details>
