### PR TITLE
8341424: GHA: Collect hs_errs from build time failures

### DIFF
--- a/.github/scripts/gen-build-failure-report.sh
+++ b/.github/scripts/gen-build-failure-report.sh
@@ -24,11 +24,18 @@
 # questions.
 #
 
+# Import common utils
+. .github/scripts/report-utils.sh
+
 GITHUB_STEP_SUMMARY="$1"
 BUILD_DIR="$(ls -d build/*)"
 
 # Send signal to the do-build action that we failed
 touch "$BUILD_DIR/build-failure"
+
+# Collect hs_errs for build-time crashes, e.g. javac, jmod, jlink, CDS.
+# These usually land in make/
+hs_err_files=$(ls make/hs_err*.log 2> /dev/null || true)
 
 (
   echo '### :boom: Build failure summary'
@@ -46,6 +53,20 @@ touch "$BUILD_DIR/build-failure"
   echo '</details>'
   echo ''
 
+  for hs_err in $hs_err_files; do
+    echo "<details><summary><b>View HotSpot error log: "$hs_err"</b></summary>"
+    echo ''
+    echo '```'
+    echo "$hs_err:"
+    echo ''
+    cat "$hs_err"
+    echo '```'
+    echo '</details>'
+    echo ''
+  done
+
   echo ''
   echo ':arrow_right: To see the entire test log, click the job in the list to the left. To download logs, see the `failure-logs` [artifact above](#artifacts).'
 ) >> $GITHUB_STEP_SUMMARY
+
+truncate_summary

--- a/.github/scripts/gen-test-results.sh
+++ b/.github/scripts/gen-test-results.sh
@@ -24,6 +24,9 @@
 # questions.
 #
 
+# Import common utils
+. .github/scripts/report-utils.sh
+
 GITHUB_STEP_SUMMARY="$1"
 
 test_suite_name=$(cat build/run-test-prebuilt/test-support/test-last-ids.txt)
@@ -89,18 +92,6 @@ for test in $failures $errors; do
   fi
 done >> $GITHUB_STEP_SUMMARY
 
-# With many failures, the summary can easily exceed 1024 kB, the limit set by Github
-# Trim it down if so.
-summary_size=$(wc -c < $GITHUB_STEP_SUMMARY)
-if [[ $summary_size -gt 1000000 ]]; then
-  # Trim to below 1024 kB, and cut off after the last detail group
-  head -c 1000000 $GITHUB_STEP_SUMMARY | tac | sed -n -e '/<\/details>/,$ p' | tac > $GITHUB_STEP_SUMMARY.tmp
-  mv $GITHUB_STEP_SUMMARY.tmp $GITHUB_STEP_SUMMARY
-  (
-    echo ''
-    echo ':x: **WARNING: Summary is too large and has been truncated.**'
-    echo ''
-  )  >> $GITHUB_STEP_SUMMARY
-fi
-
 echo ':arrow_right: To see the entire test log, click the job in the list to the left.'  >> $GITHUB_STEP_SUMMARY
+
+truncate_summary

--- a/.github/scripts/report-utils.sh
+++ b/.github/scripts/report-utils.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+function truncate_summary() {
+  # With large hs_errs, the summary can easily exceed 1024 kB, the limit set by Github
+  # Trim it down if so.
+  summary_size=$(wc -c < $GITHUB_STEP_SUMMARY)
+  if [[ $summary_size -gt 1000000 ]]; then
+    # Trim to below 1024 kB, and cut off after the last detail group
+    head -c 1000000 $GITHUB_STEP_SUMMARY | tac | sed -n -e '/<\/details>/,$ p' | tac > $GITHUB_STEP_SUMMARY.tmp
+    mv $GITHUB_STEP_SUMMARY.tmp $GITHUB_STEP_SUMMARY
+    (
+      echo ''
+      echo ':x: **WARNING: Summary is too large and has been truncated.**'
+      echo ''
+    )  >> $GITHUB_STEP_SUMMARY
+  fi
+}


### PR DESCRIPTION
Backport of [JDK-8341424](https://bugs.openjdk.org/browse/JDK-8341424) and companion [JDK-8342704](https://bugs.openjdk.org/browse/JDK-8342704)

This collects hs_errs when they happen with GitHub Actions, which may be useful during reviews. The idea is to backport this to 11 too.

Low risk, as this affects GHA actions only. GHA builds and tests run correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342704](https://bugs.openjdk.org/browse/JDK-8342704) needs maintainer approval
- [x] [JDK-8341424](https://bugs.openjdk.org/browse/JDK-8341424) needs maintainer approval

### Issues
 * [JDK-8341424](https://bugs.openjdk.org/browse/JDK-8341424): GHA: Collect hs_errs from build time failures (**Enhancement** - P4 - Approved)
 * [JDK-8342704](https://bugs.openjdk.org/browse/JDK-8342704): GHA: Report truncation is broken after JDK-8341424 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3152/head:pull/3152` \
`$ git checkout pull/3152`

Update a local copy of the PR: \
`$ git checkout pull/3152` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3152`

View PR using the GUI difftool: \
`$ git pr show -t 3152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3152.diff">https://git.openjdk.org/jdk17u-dev/pull/3152.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3152#issuecomment-2553607583)
</details>
