### PR TITLE
8281234: The -protected option is not always checked in keytool and jarsigner

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1287,6 +1287,7 @@ public final class Main {
             kssave = true;
         } else if (command == LIST) {
             if (storePass == null
+                    && !protectedPath
                     && !KeyStoreUtil.isWindowsKeyStore(storetype)
                     && !isPasswordlessKeyStore) {
                 printNoIntegrityWarning();
@@ -1686,6 +1687,7 @@ public final class Main {
         throws Exception
     {
         if (storePass == null
+                && !protectedPath
                 && !KeyStoreUtil.isWindowsKeyStore(storetype)
                 && !isPasswordlessKeyStore) {
             printNoIntegrityWarning();

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -2151,7 +2151,7 @@ public class Main {
                     && !KeyStoreUtil.isWindowsKeyStore(storetype)) {
                 storepass = getPass
                         (rb.getString("Enter.Passphrase.for.keystore."));
-            } else if (!token && storepass == null && prompt) {
+            } else if (!token && storepass == null && prompt && !protectedPath) {
                 storepass = getPass
                         (rb.getString("Enter.Passphrase.for.keystore."));
             }

--- a/test/jdk/sun/security/tools/jarsigner/AutoKeyStore.java
+++ b/test/jdk/sun/security/tools/jarsigner/AutoKeyStore.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8281234
+ * @summary The -protected option is not always checked in keytool and jarsigner
+ * @library /test/lib
+ * @modules java.base/sun.security.tools.keytool
+ *          java.base/sun.security.x509
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.util.JarUtils;
+import sun.security.tools.keytool.CertAndKeyGen;
+import sun.security.x509.X500Name;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarFile;
+
+public class AutoKeyStore {
+
+    public static void main(String[] args) throws Exception {
+
+        JarUtils.createJarFile(Path.of("unsigned.jar"), Path.of("."),
+                Files.writeString(Path.of("file"), "hello"));
+
+        SecurityTools.keytool("""
+                -J--add-exports -Jjava.base/sun.security.tools.keytool=ALL-UNNAMED
+                -J--add-exports -Jjava.base/sun.security.x509=ALL-UNNAMED
+                -providerClass AutoKeyStore$AutoProvider
+                -providerPath $test.classes
+                -storetype AUTO -keystore NONE -protected
+                -list
+                """).shouldHaveExitValue(0)
+                .shouldContain("Keystore type: AUTO")
+                .shouldContain("Keystore provider: AUTO")
+                .shouldContain("PrivateKeyEntry");
+
+        SecurityTools.jarsigner("""
+                -J--add-exports -Jjava.base/sun.security.tools.keytool=ALL-UNNAMED
+                -J--add-exports -Jjava.base/sun.security.x509=ALL-UNNAMED
+                                -J-cp -J$test.classes
+                -providerClass AutoKeyStore$AutoProvider
+                -storetype AUTO -keystore NONE -protected
+                -signedJar signed.jar
+                unsigned.jar
+                one
+                """).shouldHaveExitValue(0)
+                .shouldContain("jar signed.");
+
+        Asserts.assertTrue(new JarFile("signed.jar")
+                .getEntry("META-INF/ONE.EC") != null);
+    }
+
+    public static class AutoProvider extends Provider {
+        public AutoProvider() {
+            super("AUTO", "1.1.1", "auto");
+            put("KeyStore.AUTO", "AutoKeyStore$KeyStoreImpl");
+        }
+    }
+
+    // This keystore is not based on file. Whenever it's loaded
+    // a self-sign certificate is generated inside
+    public static class KeyStoreImpl extends KeyStoreSpi {
+
+        private PrivateKey pri;
+        private PublicKey pub;
+        private X509Certificate cert;
+
+        @Override
+        public Key engineGetKey(String alias, char[] password) {
+            return pri;
+        }
+
+        @Override
+        public Certificate[] engineGetCertificateChain(String alias) {
+            return new Certificate[] { cert };
+        }
+
+        @Override
+        public Certificate engineGetCertificate(String alias) {
+            return cert;
+        }
+
+        @Override
+        public Date engineGetCreationDate(String alias) {
+            return new Date();
+        }
+
+        @Override
+        public void engineSetKeyEntry(String alias, Key key, char[] password, Certificate[] chain) throws KeyStoreException {
+            throw new KeyStoreException("Not supported");
+        }
+
+        @Override
+        public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+            throw new KeyStoreException("Not supported");
+        }
+
+        @Override
+        public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
+            throw new KeyStoreException("Not supported");
+        }
+
+        @Override
+        public void engineDeleteEntry(String alias) throws KeyStoreException {
+            throw new KeyStoreException("Not supported");
+        }
+
+        @Override
+        public Enumeration<String> engineAliases() {
+            return Collections.enumeration(List.of("one"));
+        }
+
+        @Override
+        public boolean engineContainsAlias(String alias) {
+            return alias.equalsIgnoreCase("one");
+        }
+
+        @Override
+        public int engineSize() {
+            return 1;
+        }
+
+        @Override
+        public boolean engineIsKeyEntry(String alias) {
+            return true;
+        }
+
+        @Override
+        public boolean engineIsCertificateEntry(String alias) {
+            return false;
+        }
+
+        @Override
+        public String engineGetCertificateAlias(Certificate cert) {
+            return "one";
+        }
+
+        @Override
+        public void engineStore(OutputStream stream, char[] password) {
+        }
+
+        @Override
+        public void engineLoad(InputStream stream, char[] password) throws IOException {
+            try {
+                CertAndKeyGen cag = new CertAndKeyGen("EC", "SHA256withECDSA");
+                cag.generate("secp256r1");
+                pri = cag.getPrivateKey();
+                pub = cag.getPublicKey();
+                cert = cag.getSelfCertificate(new X500Name("CN=one"), 3600);
+            } catch (Exception e) {
+                throw new IOException("Not loaded");
+            }
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/SecurityTools.java
+++ b/test/lib/jdk/test/lib/SecurityTools.java
@@ -42,7 +42,7 @@ import jdk.test.lib.process.ProcessTools;
  * The en_US locale is always used so a test can always match output to
  * English text. {@code /dev/urandom} is used as entropy source so tool will
  * not block because of entropy scarcity. An argument can be a normal string,
- * {@code -Jvm-options}, or {@code $sysProp}.
+ * {@code -Jvm-options}, {@code $sysProp} or {@code -J$sysProp}.
  */
 public class SecurityTools {
 

--- a/test/lib/jdk/test/lib/SecurityTools.java
+++ b/test/lib/jdk/test/lib/SecurityTools.java
@@ -41,8 +41,8 @@ import jdk.test.lib.process.ProcessTools;
  * Run security tools (including jarsigner and keytool) in a new process.
  * The en_US locale is always used so a test can always match output to
  * English text. {@code /dev/urandom} is used as entropy source so tool will
- * not block because of entropy scarcity. {@code -Jvm-options} is supported
- * as an argument.
+ * not block because of entropy scarcity. An argument can be a normal string,
+ * {@code -Jvm-options}, or {@code $sysProp}.
  */
 public class SecurityTools {
 
@@ -63,10 +63,17 @@ public class SecurityTools {
         }
         for (String arg : args) {
             if (arg.startsWith("-J")) {
-                launcher.addVMArg(arg.substring(2));
+                String jarg = arg.substring(2);
+                if (jarg.length() > 1 && jarg.charAt(0) == '$') {
+                    launcher.addVMArg(System.getProperty(jarg.substring(1)));
+                } else {
+                    launcher.addVMArg(jarg);
+                }
             } else if (Platform.isWindows() && arg.isEmpty()) {
                 // JDK-6518827: special handling for empty argument on Windows
                 launcher.addToolArg("\"\"");
+            } else if (arg.length() > 1 && arg.charAt(0) == '$') {
+                launcher.addToolArg(System.getProperty(arg.substring(1)));
             } else {
                 launcher.addToolArg(arg);
             }


### PR DESCRIPTION
I would like to fix this issue in 17. I think it's important to get this feature rigtht.

I had to work around missing "8281175: Add a -providerPath option to jarsigner" in the test, else the patch would be clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8281234](https://bugs.openjdk.org/browse/JDK-8281234) needs maintainer approval

### Issue
 * [JDK-8281234](https://bugs.openjdk.org/browse/JDK-8281234): The -protected option is not always checked in keytool and jarsigner (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3163/head:pull/3163` \
`$ git checkout pull/3163`

Update a local copy of the PR: \
`$ git checkout pull/3163` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3163`

View PR using the GUI difftool: \
`$ git pr show -t 3163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3163.diff">https://git.openjdk.org/jdk17u-dev/pull/3163.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3163#issuecomment-2558413684)
</details>
