### PR TITLE
8328553: Get rid of JApplet in test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java

### DIFF
--- a/test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java
+++ b/test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ import java.net.URL;
 import javax.swing.BoxLayout;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
-import javax.swing.JApplet;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.UIManager;
@@ -42,10 +41,8 @@ import javax.swing.border.SoftBevelBorder;
 
 /**
  * A generic SwingSet2 demo module
- *
- * @author Jeff Dinkins
  */
-public class DemoModule extends JApplet {
+public class DemoModule extends JPanel {
 
     // The preferred size of the demo
     private int PREFERRED_WIDTH = 680;
@@ -214,10 +211,6 @@ public class DemoModule extends JApplet {
         demo.mainImpl();
     }
 
-    public void init() {
-        getContentPane().setLayout(new BorderLayout());
-        getContentPane().add(getDemoPanel(), BorderLayout.CENTER);
-    }
-
     void updateDragEnabled(boolean dragEnabled) {}
 }
+


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328553](https://bugs.openjdk.org/browse/JDK-8328553) needs maintainer approval

### Issue
 * [JDK-8328553](https://bugs.openjdk.org/browse/JDK-8328553): Get rid of JApplet in test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3164/head:pull/3164` \
`$ git checkout pull/3164`

Update a local copy of the PR: \
`$ git checkout pull/3164` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3164`

View PR using the GUI difftool: \
`$ git pr show -t 3164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3164.diff">https://git.openjdk.org/jdk17u-dev/pull/3164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3164#issuecomment-2558417930)
</details>
