### PR TITLE
8342609: jpackage test helper function incorrectly removes a directory instead of its contents only

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -370,7 +370,7 @@ final public class TKit {
             try {
                 final List<Path> paths;
                 if (contentsOnly) {
-                    try (var pathStream = Files.walk(root, 0)) {
+                    try (var pathStream = Files.list(root)) {
                         paths = pathStream.collect(Collectors.toList());
                     }
                 } else {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle.
17 has the same issue.

Resolved Copyright, probably clean anyways.



<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8342609](https://bugs.openjdk.org/browse/JDK-8342609) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8342609: jpackage test helper function incorrectly removes a directory instead of its contents only`

### Issue
 * [JDK-8342609](https://bugs.openjdk.org/browse/JDK-8342609): jpackage test helper function incorrectly removes a directory instead of its contents only (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3165/head:pull/3165` \
`$ git checkout pull/3165`

Update a local copy of the PR: \
`$ git checkout pull/3165` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3165`

View PR using the GUI difftool: \
`$ git pr show -t 3165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3165.diff">https://git.openjdk.org/jdk17u-dev/pull/3165.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3165#issuecomment-2559829286)
</details>
