### PR TITLE
8343101: Rework BasicTest.testTemp test cases

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestBuilder.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TestBuilder.java
@@ -392,6 +392,9 @@ final class TestBuilder implements AutoCloseable {
     }
 
     private static Object fromString(String value, Class toType) {
+        if (toType.isEnum()) {
+            return Enum.valueOf(toType, value);
+        }
         Function<String, Object> converter = conv.get(toType);
         if (converter == null) {
             throw new RuntimeException(String.format(

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -61,6 +61,22 @@ public class WindowsHelper {
         return Path.of(cmd.getArgumentValue("--install-dir", cmd::name));
     }
 
+    // Tests have problems on windows where path in the temp dir are too long
+    // for the wix tools.  We can't use a tempDir outside the TKit's WorkDir, so
+    // we minimize both the tempRoot directory name (above) and the tempDir name
+    // (below) to the extension part (which is necessary to differenciate between
+    // the multiple PackageTypes that will be run for one JPackageCommand).
+    // It might be beter if the whole work dir name was shortened from:
+    // jtreg_open_test_jdk_tools_jpackage_share_jdk_jpackage_tests_BasicTest_java.
+    public static Path getTempDirectory(JPackageCommand cmd, Path tempRoot) {
+        String ext = cmd.outputBundle().getFileName().toString();
+        int i = ext.lastIndexOf(".");
+        if (i > 0 && i < (ext.length() - 1)) {
+            ext = ext.substring(i+1);
+        }
+        return tempRoot.resolve(ext);
+    }
+
     private static void runMsiexecWithRetries(Executor misexec) {
         Executor.Result result = null;
         for (int attempt = 0; attempt < 8; ++attempt) {


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

This is based on the commit to 21. I needed to resolve again, though:
https://bugs.openjdk.org/browse/JDK-8291978: jpackage: allow to override primary l10n files on Windows is not in 17.

I include some of the edits of 8291978 in this change, as they nicely clean up the test code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8343101](https://bugs.openjdk.org/browse/JDK-8343101) needs maintainer approval
- [x] [JDK-8343178](https://bugs.openjdk.org/browse/JDK-8343178) needs maintainer approval
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8343101](https://bugs.openjdk.org/browse/JDK-8343101): Rework BasicTest.testTemp test cases (**Enhancement** - P4 - Approved)
 * [JDK-8343178](https://bugs.openjdk.org/browse/JDK-8343178): Test BasicTest.java javac compile fails cannot find symbol (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3176/head:pull/3176` \
`$ git checkout pull/3176`

Update a local copy of the PR: \
`$ git checkout pull/3176` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3176`

View PR using the GUI difftool: \
`$ git pr show -t 3176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3176.diff">https://git.openjdk.org/jdk17u-dev/pull/3176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3176#issuecomment-2563653330)
</details>
