### PR TITLE
8314225: SIGSEGV in JavaThread::is_lock_owned

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,12 +248,6 @@ bool ReferenceToThreadRootClosure::do_thread_stack_detailed(JavaThread* jt) {
   ReferenceLocateClosure rcl(_callback, OldObjectRoot::_threads, OldObjectRoot::_stack_variable, jt);
 
   if (jt->has_last_Java_frame()) {
-    // Traverse the monitor chunks
-    MonitorChunk* chunk = jt->monitor_chunks();
-    for (; chunk != NULL; chunk = chunk->next()) {
-      chunk->oops_do(&rcl);
-    }
-
     if (rcl.complete()) {
       return true;
     }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1612,7 +1612,7 @@ void Deoptimization::pop_frames_failed_reallocs(JavaThread* thread, vframeArray*
           ObjectSynchronizer::exit(src->obj(), src->lock(), thread);
         }
       }
-      array->element(i)->free_monitors(thread);
+      array->element(i)->free_monitors();
 #ifdef ASSERT
       array->element(i)->set_removed_monitors();
 #endif

--- a/src/hotspot/share/runtime/monitorChunk.cpp
+++ b/src/hotspot/share/runtime/monitorChunk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@
 MonitorChunk::MonitorChunk(int number_on_monitors) {
   _number_of_monitors = number_on_monitors;
   _monitors           = NEW_C_HEAP_ARRAY(BasicObjectLock, number_on_monitors, mtSynchronizer);
-  _next               = NULL;
 }
 
 

--- a/src/hotspot/share/runtime/monitorChunk.hpp
+++ b/src/hotspot/share/runtime/monitorChunk.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,15 +35,10 @@ class MonitorChunk: public CHeapObj<mtSynchronizer> {
   int              _number_of_monitors;
   BasicObjectLock* _monitors;
   BasicObjectLock* monitors() const { return _monitors; }
-  MonitorChunk*    _next;
  public:
   // Constructor
   MonitorChunk(int number_on_monitors);
   ~MonitorChunk();
-
-  // link operations
-  MonitorChunk* next() const                { return _next; }
-  void set_next(MonitorChunk* next)         { _next = next; }
 
   // Tells whether the monitor chunk is linked into the JavaThread
   bool is_linked() const                    { return next() != NULL; }
@@ -53,7 +48,6 @@ class MonitorChunk: public CHeapObj<mtSynchronizer> {
 
   // Returns the index'th monitor
   BasicObjectLock* at(int index)            { assert(index >= 0 && index < number_of_monitors(), "out of bounds check"); return &monitors()[index]; }
-
 
   // Memory management
   void oops_do(OopClosure* f);

--- a/src/hotspot/share/runtime/monitorChunk.hpp
+++ b/src/hotspot/share/runtime/monitorChunk.hpp
@@ -40,9 +40,6 @@ class MonitorChunk: public CHeapObj<mtSynchronizer> {
   MonitorChunk(int number_on_monitors);
   ~MonitorChunk();
 
-  // Tells whether the monitor chunk is linked into the JavaThread
-  bool is_linked() const                    { return next() != NULL; }
-
   // Returns the number of monitors
   int number_of_monitors() const { return _number_of_monitors; }
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -961,7 +961,8 @@ intptr_t ObjectSynchronizer::FastHashCode(Thread* current, oop obj) {
       }
       // Fall thru so we only have one place that installs the hash in
       // the ObjectMonitor.
-    } else if (current->is_lock_owned((address)mark.locker())) {
+    } else if (current->is_Java_thread()
+               && JavaThread::cast(current)->is_lock_owned((address)mark.locker())) {
       // This is a stack lock owned by the calling thread so fetch the
       // displaced markWord from the BasicLock on the stack.
       temp = mark.displaced_mark_helper();

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -962,7 +962,7 @@ intptr_t ObjectSynchronizer::FastHashCode(Thread* current, oop obj) {
       // Fall thru so we only have one place that installs the hash in
       // the ObjectMonitor.
     } else if (current->is_Java_thread()
-               && JavaThread::cast(current)->is_lock_owned((address)mark.locker())) {
+               && current->as_Java_thread()->is_lock_owned((address)mark.locker())) {
       // This is a stack lock owned by the calling thread so fetch the
       // displaced markWord from the BasicLock on the stack.
       temp = mark.displaced_mark_helper();

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -800,10 +800,6 @@ class JavaThread: public Thread {
   }
 
  private:
-  MonitorChunk* _monitor_chunks;              // Contains the off stack monitors
-                                              // allocated during deoptimization
-                                              // and by JNI_MonitorEnter/Exit
-
   enum SuspendFlags {
     // NOTE: avoid using the sign-bit as cc generates different test code
     //       when the sign-bit is used, and sometimes incorrectly - see CR 6398077
@@ -1208,7 +1204,7 @@ class JavaThread: public Thread {
            (_suspend_flags & (_obj_deopt JFR_ONLY(| _trace_flag))) != 0;
   }
 
-  // Fast-locking support
+  // Stack-locking support
   bool is_lock_owned(address adr) const;
 
   // Accessors for vframe array top
@@ -1385,13 +1381,7 @@ class JavaThread: public Thread {
   int depth_first_number() { return _depth_first_number; }
   void set_depth_first_number(int dfn) { _depth_first_number = dfn; }
 
- private:
-  void set_monitor_chunks(MonitorChunk* monitor_chunks) { _monitor_chunks = monitor_chunks; }
-
  public:
-  MonitorChunk* monitor_chunks() const           { return _monitor_chunks; }
-  void add_monitor_chunk(MonitorChunk* chunk);
-  void remove_monitor_chunk(MonitorChunk* chunk);
   bool in_deopt_handler() const                  { return _in_deopt_handler > 0; }
   void inc_in_deopt_handler()                    { _in_deopt_handler++; }
   void dec_in_deopt_handler() {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -497,9 +497,6 @@ class Thread: public ThreadShadow {
   }
 
  public:
-  // Used by fast lock support
-  virtual bool is_lock_owned(address adr) const;
-
   // Check if address is within the given range of this thread's
   // stack:  stack_base() > adr >= limit
   bool is_in_stack_range_incl(address adr, address limit) const {

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -95,7 +95,7 @@ void vframeArrayElement::fill_in(compiledVFrame* vf, bool realloc_failures) {
           dest->set_obj(NULL);
         } else {
           assert(monitor->owner() != nullptr, "monitor owner must not be null");
-          assert(!monitor->owner()->is_unlocked() && !monitor->owner()->has_bias_pattern(), "object must be null or locked, and unbiased");
+          assert(!monitor->owner()->is_unlocked() && !monitor->owner()->has_bias_pattern(), "object must be locked, and unbiased");
           dest->set_obj(monitor->owner());
           assert(ObjectSynchronizer::current_thread_holds_lock(current_thread, Handle(current_thread, dest->obj())),
                  "should be held, before move_to");

--- a/src/hotspot/share/runtime/vframeArray.hpp
+++ b/src/hotspot/share/runtime/vframeArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ class vframeArrayElement {
 
   MonitorChunk* monitors(void) const { return _monitors; }
 
-  void free_monitors(JavaThread* jt);
+  void free_monitors();
 
   StackValueCollection* locals(void) const             { return _locals; }
 


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

I had to resolve the larger part of this change. 
None of my edits change the code essentially, though.

src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
Resolved because of NULL/nullptr difference

src/hotspot/share/runtime/javaThread.cpp|hpp
These files don't exist in 17, they were split off from thread.cpp|hpp.
The modiefied code looks very similar in 17, so I could easily identify 
the changed code and apply the patches.  Usual minor nullptr diffs etc.

src/hotspot/share/runtime/monitorChunk.cpp
Resolved because of NULL/nullptr difference

src/hotspot/share/runtime/monitorChunk.hpp
Resolved because of context diff.

src/hotspot/share/runtime/synchronizer.cpp
Resolved. Different checks in if condition.
One is for the new locking mode in head, the other whether the mask has a locker.
... check ...

src/hotspot/share/runtime/thread.cpp
Resolved because new locking modes added an assertion in removed function is_lock_owned.

src/hotspot/share/runtime/vframeArray.cpp
Resolved. Code differs because 21 has biased locking removed.



To make it build, I had to replace
Javathread::cast() by as_Java_thread() in synchronizer.cpp.

Also I removed is_linked() from monitorChunk.hpp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314225](https://bugs.openjdk.org/browse/JDK-8314225) needs maintainer approval

### Issue
 * [JDK-8314225](https://bugs.openjdk.org/browse/JDK-8314225): SIGSEGV in JavaThread::is_lock_owned (**Bug** - P2 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3177/head:pull/3177` \
`$ git checkout pull/3177`

Update a local copy of the PR: \
`$ git checkout pull/3177` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3177`

View PR using the GUI difftool: \
`$ git pr show -t 3177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3177.diff">https://git.openjdk.org/jdk17u-dev/pull/3177.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3177#issuecomment-2569122004)
</details>
