### PR TITLE
8341722: Fix some warnings as errors when building on Linux with toolchain clang

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -421,7 +421,6 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLo
   jboolean isCopy;
   jlongArray array;
   jlong *regs;
-  int i;
 
   struct ps_prochandle* ph = get_proc_handle(env, this_obj);
   if (get_lwp_regs(ph, lwp_id, &gregs) != true) {

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
@@ -359,7 +359,6 @@ static struct symtab* build_symtab_internal(int fd, const char *filename, bool t
 
     if (shdr->sh_type == sym_section) {
       ELF_SYM  *syms;
-      int rslt;
       size_t size, n, j, htab_sz;
 
       // FIXME: there could be multiple data buffers associated with the
@@ -393,7 +392,8 @@ static struct symtab* build_symtab_internal(int fd, const char *filename, bool t
         goto bad;
       }
 
-      rslt = hcreate_r(n, symtab->hash_table);
+      // int rslt =
+      hcreate_r(n, symtab->hash_table);
       // guarantee(rslt, "unexpected failure: hcreate_r");
 
       // shdr->sh_link points to the section that contains the actual strings

--- a/src/jdk.jpackage/share/native/common/Log.cpp
+++ b/src/jdk.jpackage/share/native/common/Log.cpp
@@ -40,10 +40,6 @@ namespace {
     // variables are initialized if any. This will result in AV. To avoid such
     // use cases keep logging module free from static variables that require
     // initialization with functions called by CRT.
-    //
-
-    // by default log everything
-    const Logger::LogLevel defaultLogLevel = Logger::LOG_TRACE;
 
     char defaultLogAppenderMemory[sizeof(StreamLogAppender)] = {};
 


### PR DESCRIPTION
Backport of 8341722 from 21u-dev; symtab.c coding needed manual adjustment; os_linux part of commit not in 17

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341722](https://bugs.openjdk.org/browse/JDK-8341722) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341722](https://bugs.openjdk.org/browse/JDK-8341722): Fix some warnings as errors when building on Linux with toolchain clang (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3179/head:pull/3179` \
`$ git checkout pull/3179`

Update a local copy of the PR: \
`$ git checkout pull/3179` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3179`

View PR using the GUI difftool: \
`$ git pr show -t 3179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3179.diff">https://git.openjdk.org/jdk17u-dev/pull/3179.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3179#issuecomment-2565471540)
</details>
