### PR TITLE
8312518: [macos13] setFullScreenWindow() shows black screen on macOS 13 & above

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1695,6 +1695,7 @@ JNI_COCOA_ENTER(env);
             int shieldLevel = CGShieldingWindowLevel();
             window.preFullScreenLevel = [nsWindow level];
             [nsWindow setLevel: shieldLevel];
+            [nsWindow makeKeyAndOrderFront: nil];
 
             NSRect screenRect = [[nsWindow screen] frame];
             [nsWindow setFrame:screenRect display:YES];

--- a/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
+++ b/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Robot;
+import jtreg.SkippedException;
+
+import static java.awt.EventQueue.invokeAndWait;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8312518
+ * @library /test/lib
+ * @summary Setting fullscreen window using setFullScreenWindow() shows up
+ *          as black screen on newer macOS versions (13 & 14).
+ */
+
+public class SetFullScreenTest {
+    private static Frame frame;
+    private static GraphicsDevice gd;
+    private static Robot robot;
+    private static volatile int width;
+    private static volatile int height;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            invokeAndWait(() -> {
+                gd = GraphicsEnvironment.getLocalGraphicsEnvironment().
+                        getDefaultScreenDevice();
+                if (!gd.isFullScreenSupported()) {
+                    throw new SkippedException("Full Screen mode not supported");
+                }
+            });
+
+            invokeAndWait(() -> {
+                frame = new Frame("Test FullScreen mode");
+                frame.setBackground(Color.RED);
+                frame.setSize(100, 100);
+                frame.setLocation(10, 10);
+                frame.setVisible(true);
+            });
+            robot.delay(1000);
+
+            invokeAndWait(() -> gd.setFullScreenWindow(frame));
+            robot.waitForIdle();
+            robot.delay(300);
+
+            invokeAndWait(() -> {
+                width = gd.getFullScreenWindow().getWidth();
+                height = gd.getFullScreenWindow().getHeight();
+            });
+
+            if (!robot.getPixelColor(width / 2, height / 2).equals(Color.RED)) {
+                System.err.println("Actual color: " + robot.getPixelColor(width / 2, height / 2)
+                                    + " Expected color: " + Color.RED);
+                throw new RuntimeException("Test Failed! Window not in full screen mode");
+            }
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

Resolved copyright, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312518](https://bugs.openjdk.org/browse/JDK-8312518) needs maintainer approval

### Issue
 * [JDK-8312518](https://bugs.openjdk.org/browse/JDK-8312518): [macos13] setFullScreenWindow() shows black screen on macOS 13 &amp; above (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3181/head:pull/3181` \
`$ git checkout pull/3181`

Update a local copy of the PR: \
`$ git checkout pull/3181` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3181`

View PR using the GUI difftool: \
`$ git pr show -t 3181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3181.diff">https://git.openjdk.org/jdk17u-dev/pull/3181.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3181#issuecomment-2566356110)
</details>
