### PR TITLE
8293412: Remove unnecessary java.security.egd overrides

### DIFF
--- a/test/jdk/sun/security/provider/SeedGenerator/SeedGeneratorChoice.java
+++ b/test/jdk/sun/security/provider/SeedGenerator/SeedGeneratorChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 6998583 8141039
  * @summary NativeSeedGenerator is making 8192 byte read requests from
  *             entropy pool on each init.
- * @run main/othervm -Djava.security.egd=file:/dev/random SeedGeneratorChoice
+ * @run main/othervm -Djava.security.egd=file:/dev/urandom SeedGeneratorChoice
  * @run main/othervm -Djava.security.egd=file:filename  SeedGeneratorChoice
  */
 

--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1036,15 +1036,9 @@ public class Compatibility {
         long start = System.currentTimeMillis();
         try {
             String[] cmd;
-            if (Platform.isWindows()) {
-                cmd = new String[args.length + 3];
-                System.arraycopy(args, 0, cmd, 3, args.length);
-            } else {
-                cmd = new String[args.length + 4];
-                cmd[3] = "-J-Djava.security.egd=file:/dev/./urandom";
-                System.arraycopy(args, 0, cmd, 4, args.length);
-            }
 
+            cmd = new String[args.length + 3];
+            System.arraycopy(args, 0, cmd, 3, args.length);
             cmd[0] = toolPath;
             cmd[1] = "-J-Duser.language=en";
             cmd[2] = "-J-Duser.country=US";

--- a/test/lib/jdk/test/lib/SecurityTools.java
+++ b/test/lib/jdk/test/lib/SecurityTools.java
@@ -40,8 +40,7 @@ import jdk.test.lib.process.ProcessTools;
 /**
  * Run security tools (including jarsigner and keytool) in a new process.
  * The en_US locale is always used so a test can always match output to
- * English text. {@code /dev/urandom} is used as entropy source so tool will
- * not block because of entropy scarcity. An argument can be a normal string,
+ * English text.  An argument can be a normal string,
  * {@code -Jvm-options}, {@code $sysProp} or {@code -J$sysProp}.
  */
 public class SecurityTools {
@@ -58,9 +57,6 @@ public class SecurityTools {
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK(tool)
                 .addVMArg("-Duser.language=en")
                 .addVMArg("-Duser.country=US");
-        if (!Platform.isWindows()) {
-            launcher.addVMArg("-Djava.security.egd=file:/dev/./urandom");
-        }
         for (String arg : args) {
             if (arg.startsWith("-J")) {
                 String jarg = arg.substring(2);


### PR DESCRIPTION
I backport this for parity with 11.0.26.

I had to resolve the comment in test/lib/jdk/test/lib/SecurityTools.java.
This is because another test backport adapted the comment to 17u specifics.

SeedGeneratorChoice.java passes, Compatibility.java starts up properly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8293412](https://bugs.openjdk.org/browse/JDK-8293412) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293412](https://bugs.openjdk.org/browse/JDK-8293412): Remove unnecessary java.security.egd overrides (**Enhancement** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3183/head:pull/3183` \
`$ git checkout pull/3183`

Update a local copy of the PR: \
`$ git checkout pull/3183` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3183`

View PR using the GUI difftool: \
`$ git pr show -t 3183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3183.diff">https://git.openjdk.org/jdk17u-dev/pull/3183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3183#issuecomment-2569117311)
</details>
