### PR TITLE
8340480: Bad copyright notices in changes from JDK-8339902

### DIFF
--- a/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
+++ b/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.

--- a/test/jdk/java/awt/TextField/SetBoundsTest/SetBoundsTest.java
+++ b/test/jdk/java/awt/TextField/SetBoundsTest/SetBoundsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.

--- a/test/jdk/java/awt/TextField/SetEchoCharTest4/SetEchoCharTest4.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharTest4/SetEchoCharTest4.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.

--- a/test/jdk/java/awt/TextField/SetPasswordTest/SetPasswordTest.java
+++ b/test/jdk/java/awt/TextField/SetPasswordTest/SetPasswordTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.

--- a/test/jdk/java/awt/TextField/ZeroEchoCharTest/ZeroEchoCharTest.java
+++ b/test/jdk/java/awt/TextField/ZeroEchoCharTest/ZeroEchoCharTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340480](https://bugs.openjdk.org/browse/JDK-8340480) needs maintainer approval

### Issue
 * [JDK-8340480](https://bugs.openjdk.org/browse/JDK-8340480): Bad copyright notices in changes from JDK-8339902 (**Bug** - P1 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3186/head:pull/3186` \
`$ git checkout pull/3186`

Update a local copy of the PR: \
`$ git checkout pull/3186` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3186`

View PR using the GUI difftool: \
`$ git pr show -t 3186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3186.diff">https://git.openjdk.org/jdk17u-dev/pull/3186.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3186#issuecomment-2571591589)
</details>
