### PR TITLE
8316559: Refactor some util/Calendar tests to JUnit

### DIFF
--- a/test/jdk/java/util/Calendar/BuddhistCalendarTest.java
+++ b/test/jdk/java/util/Calendar/BuddhistCalendarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,191 +24,200 @@
 /*
  * @test
  * @bug 4817812 4847186 4956227 4956479
- * @summary Confirm that BuddhistCalendar's add(), roll() and toString() work correctly with Buddhist Era years.
+ * @summary Confirm that BuddhistCalendar's add(), roll(), set(), and toString()
+ *          work correctly with Buddhist Era years.
+ * @run junit BuddhistCalendarTest
  */
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
-import static java.util.Calendar.*;
+import java.util.stream.Stream;
+
+import static java.util.Calendar.APRIL;
+import static java.util.Calendar.DATE;
+import static java.util.Calendar.DECEMBER;
+import static java.util.Calendar.ERA;
+import static java.util.Calendar.FEBRUARY;
+import static java.util.Calendar.JANUARY;
+import static java.util.Calendar.MAY;
+import static java.util.Calendar.MONTH;
+import static java.util.Calendar.WEEK_OF_YEAR;
+import static java.util.Calendar.YEAR;
+
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BuddhistCalendarTest {
 
     private static final Locale THAI_LOCALE = new Locale("th", "TH");
 
-    public static void main(String[] args) {
-        testAddRoll();
-        testToString();
-        testException();
-        testLeastMax();
+    /*
+     * Test some add values for the BuddhistCalendar. This test compares the same field
+     * as the one added.
+     */
+    @ParameterizedTest
+    @MethodSource("addDataProvider")
+    public void buddhistAddTest(Calendar cal, int amount, int fieldToAdd) {
+        int base = cal.get(YEAR);
+        cal.add(fieldToAdd, amount);
+        int yearAfterRoll = cal.get(YEAR);
+        assertEquals(yearAfterRoll, base+amount, String.format(
+                "Added: %s to field: %s", amount, fieldToAdd));
     }
 
-    /**
-     * 4817812
+    /*
+     * Given in the format: Calendar, amount to add, and field to add.
+     * Test adding of positive and negative year values.
      */
-    static void testAddRoll() {
-        Calendar cal;
-        int base, year;
+    private static Stream<Arguments> addDataProvider() {
+        return Stream.of(
+                Arguments.of(getBuddhistCalendar(), 1, YEAR),
+                Arguments.of(getBuddhistCalendar(), -3, YEAR)
+        );
+    }
 
-        /*
-         * Test: BuddhistCalendar.add(YEAR)
-         */
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        cal.add(YEAR, 1);
-        year = cal.get(YEAR);
-        check(year, base+1, "add(+YEAR)");
+    /*
+     * Test some add values for the BuddhistCalendar. Compare a bigger field
+     * (year) than the one added (month). Larger field should roll over.
+     */
+    @ParameterizedTest
+    @MethodSource("alternateAddDataProvider")
+    public void buddhistAlternateAddTest(Calendar cal, int amount, int fieldToAdd) {
+        int base = cal.get(YEAR);
+        cal.add(fieldToAdd, amount);
+        int yearAfterRoll = cal.get(YEAR);
+        assertEquals(yearAfterRoll, (amount>0) ? (base+1): (base-1), String.format(
+                "Added: %s to field: %s", amount, fieldToAdd));
+    }
 
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        cal.add(YEAR, -3);
-        year = cal.get(YEAR);
-        check(year, base-3, "add(-YEAR)");
+    /*
+     * Given in the format: Calendar, amount to add, and field to add.
+     * Test adding of positive and negative month values.
+     */
+    private static Stream<Arguments> alternateAddDataProvider() {
+        return Stream.of(
+                Arguments.of(getBuddhistCalendarBuilder().set(MONTH, DECEMBER).build(), 2, MONTH),
+                Arguments.of(getBuddhistCalendarBuilder().set(MONTH, FEBRUARY).build(), -4, MONTH)
+                );
+    }
 
-        /*
-         * Test BuddhistCalendar.add(MONTH)
-         */
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        cal.set(MONTH, DECEMBER);
-        cal.add(MONTH, 2);
-        year = cal.get(YEAR);
-        check(year, base+1, "add(+MONTH)");
+    /*
+     * Test some roll values for the BuddhistCalendar. Compare same field
+     * that was rolled, value should change.
+     */
+    @ParameterizedTest
+    @MethodSource("rollProvider")
+    public void buddhistRollTest(Calendar cal, int amount, int fieldToRoll) {
+        int base = cal.get(YEAR);
+        cal.roll(fieldToRoll, amount);
+        int year = cal.get(YEAR);
+        assertEquals(year, base+amount, "Rolling field should change value");
+    }
 
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        cal.set(MONTH, FEBRUARY);
-        cal.add(MONTH, -4);
-        year = cal.get(YEAR);
-        check(year, base-1, "add(-MONTH)");
+    /*
+     * Given in the format: Calendar, amount to roll, and field to roll.
+     * Test rolling of positive and negative year values.
+     */
+    private static Stream<Arguments> rollProvider() {
+        return Stream.of(
+                Arguments.of(getBuddhistCalendar(), 2, YEAR),
+                Arguments.of(getBuddhistCalendar(), -4, YEAR)
+        );
+    }
 
-        /*
-         * Test BuddhistCalendar.roll(YEAR)
-         */
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        cal.roll(YEAR, 2);
-        year = cal.get(YEAR);
-        check(year, base+2, "roll(+YEAR)");
+    /*
+     * Set some calendar values and roll, however, measure a different
+     * field than the field that was rolled. Rolling should not change the
+     * larger field.
+     */
+    @ParameterizedTest
+    @MethodSource("alternateRollProvider")
+    public void buddhistAlternateRollTest(Calendar cal, int amount, int fieldToRoll) {
+        int base = cal.get(YEAR);
+        cal.roll(fieldToRoll, amount);
+        int year = cal.get(YEAR);
+        assertEquals(year, base, "Rolling smaller field should not change bigger field");
+    }
 
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        cal.roll(YEAR, -4);
-        year = cal.get(YEAR);
-        check(year, base-4, "roll(-YEAR)");
+    /*
+     * Given in the format: Calendar, amount to roll, and field to roll.
+     * Test rolling of positive and negative week_of_year values.
+     */
+    private static Stream<Arguments> alternateRollProvider() {
+        return Stream.of(
+                Arguments.of(getBuddhistCalendarBuilder().set(YEAR, 2543)
+                        .set(MONTH, DECEMBER).set(DATE, 31).build(), 10, WEEK_OF_YEAR),
+                Arguments.of(getBuddhistCalendarBuilder().set(YEAR, 2543)
+                        .set(MONTH, JANUARY).set(DATE, 1).build(), -10, WEEK_OF_YEAR)
+        );
+    }
 
-        /*
-         * Test BuddhistCalendar.roll(WEEK_OF_YEAR)
-         */
-        cal = getBuddhistCalendar();
-        cal.set(YEAR, 2543);   // A.D.2000
-        cal.set(MONTH, DECEMBER);
-        cal.set(DATE, 31);
-        base = cal.get(YEAR);
-        check(base, 2543, "roll(+WEEK_OF_YEAR)");
-        cal.roll(WEEK_OF_YEAR, 10);
-        year = cal.get(YEAR);
-        check(year, base, "roll(+WEEK_OF_YEAR)");
-
-        cal = getBuddhistCalendar();
-        cal.set(YEAR, 2543);   // A.D.2000
-        cal.set(MONTH, JANUARY);
-        cal.set(DATE, 1);
-        base = cal.get(YEAR);
-        check(base, 2543, "roll(+WEEK_OF_YEAR)");
-        cal.roll(WEEK_OF_YEAR, -10);
-        year = cal.get(YEAR);
-        check(year, base, "roll(-WEEK_OF_YEAR)");
-
-        /*
-         * Test Calendar.set(year, month, date)
-         */
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
+    // Test the overloaded set() methods. Check year value.
+    @Test
+    public void buddhistSetTest() {
+        Calendar cal = getBuddhistCalendar();
         cal.set(3001, APRIL, 10);
-        year = cal.get(YEAR);
-        check(year, 3001, "set(year, month, date)");
-
-        /*
-         * Test Calendar.set(year, month, date, hour, minute)
-         */
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
+        assertEquals(cal.get(YEAR), 3001);
         cal.set(3020, MAY, 20, 9, 10);
-        year = cal.get(YEAR);
-        check(year, 3020, "set(year, month, date, hour, minute)");
-
-        /*
-         * Test Calendar.set(year, month, date, hour, minute, second)
-         */
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        cal.set(3120, MAY, 20, 9, 10, 52);
-        year = cal.get(YEAR);
-        check(year, 3120, "set(year, month, date, hour, minute, second)");
-
-        /*
-         * Test BuddhistCalendar.getActualMaximum(YEAR);
-         *    set(YEAR)/get(YEAR) in this method doesn't affect the real
-         *    YEAR value because a clone is used with set()&get().
-         */
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        int limit = cal.getActualMaximum(YEAR);
-        year = cal.get(YEAR);
-        check(year, base, "BuddhistCalendar.getActualMaximum(YEAR)");
-
-        /*
-         * Test BuddhistCalendar.getActualMinimum(YEAR);
-         *   This doesn't call set(YEAR) nor get(YEAR), though.
-         */
-        cal = getBuddhistCalendar();
-        base = cal.get(YEAR);
-        limit = cal.getActualMinimum(YEAR);
-        year = cal.get(YEAR);
-        check(year, base, "BuddhistCalendar.getActualMinimum(YEAR)");
+        assertEquals(cal.get(YEAR), 3020);
+        cal.set(3120, MAY, 20, 9, 10, 52 );
+        assertEquals(cal.get(YEAR), 3120);
     }
 
-    /**
-     * 4847186: BuddhistCalendar: toString() returns Gregorian year
+    /*
+     * Test BuddhistCalendar.getActualMaximum(YEAR);
+     * set(YEAR)/get(YEAR) in this method doesn't affect the real
+     * YEAR value because a clone is used with set() and get().
      */
-    static void testToString() {
+    @Test
+    public void buddhistActualMaximumTest() {
+        Calendar cal = getBuddhistCalendar();
+        int base = cal.get(YEAR);
+        int ignored = cal.getActualMaximum(YEAR);
+        int year = cal.get(YEAR);
+        assertEquals(year, base, "BuddhistCalendar.getActualMaximum(YEAR)");
+    }
+
+    // Test BuddhistCalendar.getActualMinimum(YEAR), doesn't call set(YEAR) nor get(YEAR).
+    @Test
+    public void buddhistActualMinimumTest() {
+        Calendar cal = getBuddhistCalendar();
+        int base = cal.get(YEAR);
+        int ignored = cal.getActualMinimum(YEAR);
+        int year = cal.get(YEAR);
+        assertEquals(year, base, "BuddhistCalendar.getActualMinimum(YEAR)");
+    }
+
+    // 4847186: BuddhistCalendar: toString() returns Gregorian year
+    @Test
+    public void buddhistToStringTest() {
         Calendar cal = getBuddhistCalendar();
         int year = cal.get(YEAR);
         String s = cal.toString();
         String y = s.replaceAll(".+,YEAR=(\\d+),.+", "$1");
-        if (Integer.parseInt(y) != year) {
-            throw new RuntimeException("toString(): wrong year value: got " + y
-                                       + ", expected " + year);
-        }
+        assertEquals(year, Integer.parseInt(y), "Wrong year value");
     }
 
-    /**
-     * 4956479: BuddhistCalendar methods may return wrong values after exception
-     */
-    static void testException() {
+    // 4956479: BuddhistCalendar methods may return wrong values after exception
+    @Test
+    public void buddhistValuesAfterExceptionTest() {
         Calendar cal = getBuddhistCalendar();
         int year = cal.get(YEAR);
-        boolean exceptionOccurred = false;
-        try {
-            cal.add(100, +1); // cause exception
-        } catch (Exception e) {
-            exceptionOccurred = true;
-        }
-        if (!exceptionOccurred) {
-            throw new RuntimeException("testException: test case failed: no exception thrown");
-        }
+        assertThrows(IllegalArgumentException.class, ()-> cal.add(100, +1));
         int year2 = cal.get(YEAR);
-        if (year2 != year) {
-            throw new RuntimeException("wrong year value after exception: got " + year2
-                                       + ", expected " + year);
-        }
+        assertEquals(year2, year, "Wrong year value after exception thrown");
     }
 
-    /**
-     * 4956227: getLeastMaximum(WEEK_OF_MONTH) return diff. val. for Greg. and Buddhist Calendar
-     */
-    static void testLeastMax() {
+    // 4956227: getLeastMaximum(WEEK_OF_MONTH) return diff. val. for Greg. and Buddhist Calendar
+    @Test
+    public void buddhistLeastMaximumTest() {
         Calendar bc = getBuddhistCalendar();
         // Specify THAI_LOCALE to get the same params for WEEK
         // calculations (6904680).
@@ -219,25 +228,17 @@ public class BuddhistCalendarTest {
             }
             int bn = bc.getLeastMaximum(f);
             int gn = gc.getLeastMaximum(f);
-            if (bn != gn) {
-                throw new RuntimeException("inconsistent Least Max value for " + Koyomi.getFieldName(f)
-                                           + ": Buddhist=" + bn
-                                           + ": Gregorian=" + gn);
-            }
+            assertEquals(bn, gn, "Inconsistent Least Max value for " + Koyomi.getFieldName(f));
         }
     }
 
-    /**
-     * @return a BuddhistCalendar
-     */
-    static Calendar getBuddhistCalendar() {
+    // Utility to get a new Buddhist Calendar Builder (to allow setting of other values)
+    private static Calendar.Builder getBuddhistCalendarBuilder() {
+        return new Calendar.Builder().setLocale(THAI_LOCALE);
+    }
+
+    // Utility to get a new Buddhist calendar
+    private static Calendar getBuddhistCalendar() {
         return Calendar.getInstance(THAI_LOCALE);
-    }
-
-    static void check(int got, int expected, String s) {
-        if (got != expected) {
-            throw new RuntimeException("Failed: " +
-                s + ": got:" + got + ", expected:" + expected);
-        }
     }
 }

--- a/test/jdk/java/util/Calendar/Bug4302966.java
+++ b/test/jdk/java/util/Calendar/Bug4302966.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,18 +26,22 @@
  * @bug 4302966 8176841
  * @modules jdk.localedata
  * @summary In Czech Republic first day of week is Monday not Sunday
+ * @run junit Bug4302966
  */
 
 import java.util.Calendar;
 import java.util.Locale;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class Bug4302966 {
 
-    public static void main(String[] args) {
+    // Specific day of week test for Czech locale
+    public void czechDayOfWeekTest() {
         Calendar czechCalendar = Calendar.getInstance(new Locale("cs", "CZ"));
         int firstDayOfWeek = czechCalendar.getFirstDayOfWeek();
-        if (firstDayOfWeek != Calendar.MONDAY) {
-            throw new RuntimeException();
-        }
+        assertEquals(firstDayOfWeek, Calendar.MONDAY);
     }
 }

--- a/test/jdk/java/util/Calendar/Bug4766302.java
+++ b/test/jdk/java/util/Calendar/Bug4766302.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,16 +24,21 @@
 /*
  * @test
  * @bug 4766302
- * @summary Make sure that computeTime call doesn't reset the isTimeSet value.
+ * @summary Make sure that calling computeTime doesn't reset the isTimeSet value.
+ * @run junit Bug4766302
  */
 
 import java.util.GregorianCalendar;
 
-@SuppressWarnings("serial")
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class Bug4766302 {
 
+    // Extend GregorianCalendar to check the protected value of isTimeSet
+    @SuppressWarnings("serial")
     static class MyCalendar extends GregorianCalendar {
-
         boolean isTimeStillSet() {
             return isTimeSet;
         }
@@ -43,11 +48,11 @@ public class Bug4766302 {
         }
     }
 
-    public static void main(String[] args) {
+    // Check the value of isTimeStillSet() after calling computeTime()
+    @Test
+    public void validateIsTimeSetTest() {
         MyCalendar cal = new MyCalendar();
         cal.computeTime();
-        if (!cal.isTimeStillSet()) {
-            throw new RuntimeException("computeTime() call reset isTimeSet.");
-        }
+        assertTrue(cal.isTimeStillSet(), "computeTime() call reset isTimeSet.");
     }
 }

--- a/test/jdk/java/util/Calendar/bug4028518.java
+++ b/test/jdk/java/util/Calendar/bug4028518.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,33 +24,30 @@
 /*
  * @test
  * @bug 4028518
- * @summary Make sure cloned GregorianCalendar is unchanged by modifying its original.
+ * @summary Ensure cloned GregorianCalendar is unchanged when modifying its original.
+ * @run junit bug4028518
  */
 
-import java.util.GregorianCalendar ;
-import static java.util.Calendar.*;
+import java.util.GregorianCalendar;
+
+import static java.util.Calendar.DAY_OF_MONTH;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class bug4028518 {
 
-    public static void main(String[] args)
-    {
+    /*
+     * Ensure modifying the original GregorianCalendar does not
+     * modify the cloned one as well
+     */
+    @Test
+    public void clonedShouldNotChangeOriginalTest() {
         GregorianCalendar cal1 = new GregorianCalendar() ;
         GregorianCalendar cal2 = (GregorianCalendar) cal1.clone() ;
-
-        printdate(cal1, "cal1: ") ;
-        printdate(cal2, "cal2 - cloned(): ") ;
         cal1.add(DAY_OF_MONTH, 1) ;
-        printdate(cal1, "cal1 after adding 1 day: ") ;
-        printdate(cal2, "cal2 should be unmodified: ") ;
-        if (cal1.get(DAY_OF_MONTH) == cal2.get(DAY_OF_MONTH)) {
-            throw new RuntimeException("cloned GregorianCalendar modified");
-        }
-    }
-
-    private static void printdate(GregorianCalendar cal, String string)
-    {
-        System.out.println(string + (cal.get(MONTH) + 1)
-                           + "/" + cal.get(DAY_OF_MONTH)
-                           + "/" + cal.get(YEAR)) ;
+        assertNotEquals(cal1.get(DAY_OF_MONTH), cal2.get(DAY_OF_MONTH),
+                "Cloned calendar should not have same value as original");
     }
 }

--- a/test/jdk/java/util/Calendar/bug4100311.java
+++ b/test/jdk/java/util/Calendar/bug4100311.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,24 +24,29 @@
 /*
  * @test
  * @bug 4100311
- * @summary Make sure set(DAY_OF_YEAR, 1) works.
+ * @summary Ensure set(DAY_OF_YEAR, 1) works.
+ * @run junit bug4100311
  */
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Date;
 
-public class bug4100311
-{
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class bug4100311 {
+
+    // GregorianCalendar should be able to date to january 1st properly
     @SuppressWarnings("deprecation")
-    public static void main(String args[])
-    {
+    @Test
+    public void dayOfYearIsOneTest() {
         GregorianCalendar cal = new GregorianCalendar();
         cal.set(Calendar.YEAR, 1997);
         cal.set(Calendar.DAY_OF_YEAR, 1);
-        Date d = cal.getTime();             // Should be Jan 1
-        if (d.getMonth() != 0 || d.getDate() != 1) {
-            throw new RuntimeException("Date isn't Jan 1");
-        }
+        Date d = cal.getTime();
+        assertEquals(0, d.getMonth(), "Date: "+d+" isn't January 1st");
+        assertEquals(1, d.getDate(),"Date: "+d+" isn't January 1st");
     }
 }

--- a/test/jdk/java/util/Calendar/bug4243802.java
+++ b/test/jdk/java/util/Calendar/bug4243802.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,70 +24,88 @@
 /*
  * @test
  * @bug 4243802
- * @summary confirm that Calendar.setTimeInMillis() and
- * getTimeInMillis() can be called from a user program. (They used to
- * be protected methods.)
- * @library /java/text/testlib
+ * @summary confirm that Calendar.setTimeInMillis() and getTimeInMillis()
+ *          can be called from a user program. They used to be protected methods.
+ * @run junit bug4243802
  */
 
-import java.util.*;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
 
-public class bug4243802 extends IntlTest {
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
-    public static void main(String[] args) throws Exception {
-        new bug4243802().run(args);
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class bug4243802 {
+
+    private static final TimeZone savedTz = TimeZone.getDefault();
+    private static final Locale savedLocale = Locale.getDefault();
+
+    // Save JVM default Locale and TimeZone
+    @BeforeAll
+    static void initAll() {
+        Locale.setDefault(Locale.US);
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
     }
 
-    /**
-     * 4243802: RFE: need way to set the date of a calendar without a Date object
+    // Restore JVM default Locale and TimeZone
+    @AfterAll
+    static void tearDownAll() {
+        Locale.setDefault(savedLocale);
+        TimeZone.setDefault(savedTz);
+    }
+
+    /*
+     * Test getTimeInMillis() and setTimeInMillis(). Compare a Calendar
+     * set with a traditional date to one set using setTimeInMillis(),
+     * where both Calendars should be of equal times.
      */
-    public void Test4243802() {
-        TimeZone saveZone = TimeZone.getDefault();
-        Locale saveLocale = Locale.getDefault();
-        try {
-            Locale.setDefault(Locale.US);
-            TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+    @Test
+    public void setCalendarWithoutDateTest() {
+        Calendar cal1 = Calendar.getInstance();
+        Calendar cal2 = Calendar.getInstance();
 
-            Calendar cal1 = Calendar.getInstance();
-            Calendar cal2 = Calendar.getInstance();
+        cal1.clear();
+        cal2.clear();
 
-            cal1.clear();
-            cal2.clear();
-            cal1.set(2001, Calendar.JANUARY, 25, 1, 23, 45);
-            cal2.setTimeInMillis(cal1.getTimeInMillis());
-            if ((cal2.get(Calendar.YEAR) != 2001) ||
-                (cal2.get(Calendar.MONTH) != Calendar.JANUARY) ||
-                (cal2.get(Calendar.DAY_OF_MONTH) != 25) ||
-                (cal2.get(Calendar.HOUR_OF_DAY) != 1) ||
-                (cal2.get(Calendar.MINUTE) != 23) ||
-                (cal2.get(Calendar.SECOND) != 45) ||
-                (cal2.get(Calendar.MILLISECOND) != 0)) {
-                 errln("Failed: expected 1/25/2001 1:23:45.000" +
-                       ", got " + (cal2.get(Calendar.MONTH)+1) + "/" +
-                       cal2.get(Calendar.DAY_OF_MONTH) +"/" +
-                       cal2.get(Calendar.YEAR) + " " +
-                       cal2.get(Calendar.HOUR_OF_DAY) + ":" +
-                       cal2.get(Calendar.MINUTE) + ":" +
-                       cal2.get(Calendar.SECOND) + "." +
-                       toMillis(cal2.get(Calendar.MILLISECOND)));
-            }
-            logln("Passed.");
-        }
-        finally {
-            Locale.setDefault(saveLocale);
-            TimeZone.setDefault(saveZone);
-        }
+        cal1.set(2001, Calendar.JANUARY, 25, 1, 23, 45);
+        // Build the second calendar using the getTimeInMillis of the first
+        cal2.setTimeInMillis(cal1.getTimeInMillis());
+
+        assertEquals(2001, cal2.get(Calendar.YEAR), getErrMsg(cal1));
+        assertEquals(Calendar.JANUARY, cal2.get(Calendar.MONTH), getErrMsg(cal1));
+        assertEquals(25, cal2.get(Calendar.DAY_OF_MONTH), getErrMsg(cal1));
+        assertEquals(1, cal2.get(Calendar.HOUR_OF_DAY), getErrMsg(cal1));
+        assertEquals(23, cal2.get(Calendar.MINUTE), getErrMsg(cal1));
+        assertEquals(45, cal2.get(Calendar.SECOND), getErrMsg(cal1));
+        assertEquals(0, cal2.get(Calendar.MILLISECOND), getErrMsg(cal1));
     }
 
-    private String toMillis(int m) {
-        StringBuffer sb = new StringBuffer();
+    // Utility to build a long error message
+    private static String getErrMsg(Calendar cal) {
+        return "Failed: expected 1/25/2001 1:23:45.000" +
+                ", got " + (cal.get(Calendar.MONTH)+1) + "/" +
+                cal.get(Calendar.DAY_OF_MONTH) +"/" +
+                cal.get(Calendar.YEAR) + " " +
+                cal.get(Calendar.HOUR_OF_DAY) + ":" +
+                cal.get(Calendar.MINUTE) + ":" +
+                cal.get(Calendar.SECOND) + "." +
+                toMillis(cal.get(Calendar.MILLISECOND));
+    }
+
+    // Utility to convert value to format of expected milisecond value
+    private static String toMillis(int m) {
+        StringBuilder sb = new StringBuilder();
         if (m < 100) {
             sb.append('0');
         }
         if (m < 10) {
             sb.append('0');
         }
-        sb.append(m);
-        return sb.toString();
+        return sb.append(m).toString();
     }
 }

--- a/test/jdk/java/util/Calendar/bug4316678.java
+++ b/test/jdk/java/util/Calendar/bug4316678.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,49 +21,62 @@
  * questions.
  */
 
-import java.io.*;
-import java.util.*;
-import java.text.*;
-
-/**
+/*
  * @test
  * @bug 4316678
- * @summary test that Calendar's Serializasion works correctly.
- * @library /java/text/testlib
+ * @summary test that Calendar's Serialization works correctly.
+ * @run junit bug4316678
  */
-public class bug4316678 extends IntlTest {
 
-    public static void main(String[] args) throws Exception {
-        new bug4316678().run(args);
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class bug4316678 {
+
+    private static final String serializedData = "bug4316678.ser";
+    private static final TimeZone savedTz = TimeZone.getDefault();
+
+    // Save JVM default Locale and TimeZone
+    @BeforeAll
+    static void initAll() {
+        TimeZone.setDefault(TimeZone.getTimeZone("PST"));
     }
 
-    public void Test4316678() throws Exception {
-        GregorianCalendar gc1;
+    // Restore JVM default Locale and TimeZone
+    @AfterAll
+    static void tearDownAll() {
+        TimeZone.setDefault(savedTz);
+    }
+
+    // Test that a serialized GregorianCalendar has the expected values
+    @Test
+    public void serializationTest() throws IOException, ClassNotFoundException {
+        GregorianCalendar gc1 = new GregorianCalendar(2000, Calendar.OCTOBER, 10);
         GregorianCalendar gc2;
-        TimeZone saveZone = TimeZone.getDefault();
-
-        try {
-            TimeZone.setDefault(TimeZone.getTimeZone("PST"));
-
-            gc1 = new GregorianCalendar(2000, Calendar.OCTOBER, 10);
-            try (ObjectOutputStream out
-                    = new ObjectOutputStream(new FileOutputStream("bug4316678.ser"))) {
-                out.writeObject(gc1);
-            }
-
-            try (ObjectInputStream in
-                    = new ObjectInputStream(new FileInputStream("bug4316678.ser"))) {
-                gc2 = (GregorianCalendar)in.readObject();
-            }
-
-            gc1.set(Calendar.DATE, 16);
-            gc2.set(Calendar.DATE, 16);
-            if (!gc1.getTime().equals(gc2.getTime())) {
-                errln("Invalid Time :" + gc2.getTime() +
-                    ", expected :" + gc1.getTime());
-            }
-        } finally {
-            TimeZone.setDefault(saveZone);
+        try (ObjectOutputStream out
+                = new ObjectOutputStream(new FileOutputStream(serializedData))) {
+            out.writeObject(gc1);
         }
+
+        try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(serializedData))) {
+            gc2 = (GregorianCalendar)in.readObject();
+        }
+
+        gc1.set(Calendar.DATE, 16);
+        gc2.set(Calendar.DATE, 16);
+        assertEquals(gc2.getTime(), gc1.getTime(),
+                "Times should be equal after serialization");
     }
 }

--- a/test/jdk/java/util/Calendar/bug4372743.java
+++ b/test/jdk/java/util/Calendar/bug4372743.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,21 +25,106 @@
  * @test
  * @bug 4372743
  * @summary test that checks transitions of ERA and YEAR which are caused by add(MONTH).
- * @library /java/text/testlib
+ * @run junit bug4372743
  */
 
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
-import static java.util.GregorianCalendar.*;
+import static java.util.GregorianCalendar.AD;
+import static java.util.GregorianCalendar.APRIL;
+import static java.util.GregorianCalendar.AUGUST;
+import static java.util.GregorianCalendar.BC;
+import static java.util.GregorianCalendar.DECEMBER;
+import static java.util.GregorianCalendar.ERA;
+import static java.util.GregorianCalendar.FEBRUARY;
+import static java.util.GregorianCalendar.JANUARY;
+import static java.util.GregorianCalendar.JULY;
+import static java.util.GregorianCalendar.JUNE;
+import static java.util.GregorianCalendar.MARCH;
+import static java.util.GregorianCalendar.MAY;
+import static java.util.GregorianCalendar.MONTH;
+import static java.util.GregorianCalendar.NOVEMBER;
+import static java.util.GregorianCalendar.OCTOBER;
+import static java.util.GregorianCalendar.SEPTEMBER;
+import static java.util.GregorianCalendar.YEAR;
 
-public class bug4372743 extends IntlTest {
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
-    public static void main(String[] args) throws Exception {
-        new bug4372743().run(args);
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class bug4372743 {
+
+    private static final TimeZone savedTz = TimeZone.getDefault();
+
+    // Save JVM default Locale and TimeZone
+    @BeforeAll
+    static void initAll() {
+        TimeZone.setDefault(TimeZone.getTimeZone("PST"));
     }
 
-    private int[][] data = {
+    // Restore JVM default Locale and TimeZone
+    @AfterAll
+    static void tearDownAll() {
+        TimeZone.setDefault(savedTz);
+    }
+
+    /*
+     * Set GregorianCalendar to (March 3, A.D. 2) and test adding
+     * to the month field. Ensure that the added field is as expected.
+     */
+    @ParameterizedTest
+    @MethodSource("A_D_Values")
+    public void A_D_Test(GregorianCalendar gc, int monthValue) {
+        for (int i = 0; i < tableSize; i+=(-monthValue)) {
+            check(gc, i);
+            gc.add(MONTH, monthValue);
+        }
+    }
+
+    // Given in format: (A.D.) GregorianCalendar, amount to add
+    private static Stream<Arguments> A_D_Values() {
+        return Stream.of(
+                Arguments.of(new GregorianCalendar(2, MARCH, 3), -1),
+                Arguments.of(new GregorianCalendar(2, MARCH, 3), -7));
+    }
+
+    /*
+     * Set GregorianCalendar to (March 10, 2 B.C.) and test adding
+     * to the month field. Ensure that the added field is as expected.
+     */
+    @ParameterizedTest
+    @MethodSource("B_C_Values")
+    public void B_C_Test(GregorianCalendar gc, int monthValue) {
+            gc.add(YEAR, -3);
+            for (int i = tableSize - 1; i >= 0; i-=monthValue) {
+                check(gc, i);
+                gc.add(MONTH, monthValue);
+            }
+    }
+
+    // Given in format: (B.C.) GregorianCalendar, amount to add
+    private static Stream<Arguments> B_C_Values() {
+        return Stream.of(
+                Arguments.of(new GregorianCalendar(2, OCTOBER, 10), 1),
+                Arguments.of(new GregorianCalendar(2, OCTOBER, 10), 8));
+    }
+
+    // Check golden data array with actual value
+    private void check(GregorianCalendar gc, int index) {
+        assertEquals(data[index][ERA], gc.get(ERA), "Invalid era");
+        assertEquals(data[index][YEAR], gc.get(YEAR), "Invalid year");
+        assertEquals(data[index][MONTH], gc.get(MONTH), "Invalid month");
+    }
+
+    // Expected ERA, YEAR, and MONTH combinations
+    private final int[][] data = {
         {AD, 2, MARCH},
         {AD, 2, FEBRUARY},
         {AD, 2, JANUARY},
@@ -70,61 +155,5 @@ public class bug4372743 extends IntlTest {
         {BC, 2, DECEMBER},
         {BC, 2, NOVEMBER},
         {BC, 2, OCTOBER}};
-    private int tablesize = data.length;
-
-    private void check(GregorianCalendar gc, int index) {
-        if (gc.get(ERA) != data[index][ERA]) {
-            errln("Invalid era :" + gc.get(ERA)
-                    + ", expected :" + data[index][ERA]);
-        }
-        if (gc.get(YEAR) != data[index][YEAR]) {
-            errln("Invalid year :" + gc.get(YEAR)
-                    + ", expected :" + data[index][YEAR]);
-        }
-        if (gc.get(MONTH) != data[index][MONTH]) {
-            errln("Invalid month :" + gc.get(MONTH)
-                    + ", expected :" + data[index][MONTH]);
-        }
-    }
-
-    public void Test4372743() {
-        GregorianCalendar gc;
-        TimeZone saveZone = TimeZone.getDefault();
-
-        try {
-            TimeZone.setDefault(TimeZone.getTimeZone("PST"));
-
-            /* Set March 3, A.D. 2 */
-            gc = new GregorianCalendar(2, MARCH, 3);
-            for (int i = 0; i < tablesize; i++) {
-                check(gc, i);
-                gc.add(MONTH, -1);
-            }
-
-            /* Again, Set March 3, A.D. 2 */
-            gc = new GregorianCalendar(2, MARCH, 3);
-            for (int i = 0; i < tablesize; i += 7) {
-                check(gc, i);
-                gc.add(MONTH, -7);
-            }
-
-            /* Set March 10, 2 B.C. */
-            gc = new GregorianCalendar(2, OCTOBER, 10);
-            gc.add(YEAR, -3);
-            for (int i = tablesize - 1; i >= 0; i--) {
-                check(gc, i);
-                gc.add(MONTH, 1);
-            }
-
-            /* Again, Set March 10, 2 B.C. */
-            gc = new GregorianCalendar(2, OCTOBER, 10);
-            gc.add(YEAR, -3);
-            for (int i = tablesize - 1; i >= 0; i -= 8) {
-                check(gc, i);
-                gc.add(MONTH, 8);
-            }
-        } finally {
-            TimeZone.setDefault(saveZone);
-        }
-    }
+    private final int tableSize = data.length;
 }

--- a/test/jdk/java/util/Calendar/bug4401223.java
+++ b/test/jdk/java/util/Calendar/bug4401223.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,73 +24,59 @@
 /*
  * @test
  * @bug 4401223
- * @summary Make sure that GregorianCalendar doesn't cause IllegalArgumentException at some special situations which are related to the Leap Year.
- * @library /java/text/testlib
+ * @summary Make sure that GregorianCalendar doesn't cause
+ *          IllegalArgumentException at some special situations which are
+ *          related to the Leap Year.
+ * @run junit bug4401223
  */
 
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import static java.util.GregorianCalendar.*;
+import static java.util.GregorianCalendar.DATE;
+import static java.util.GregorianCalendar.DAY_OF_YEAR;
+import static java.util.GregorianCalendar.DECEMBER;
+import static java.util.GregorianCalendar.FEBRUARY;
+import static java.util.GregorianCalendar.MONTH;
+import static java.util.GregorianCalendar.YEAR;
 
-public class bug4401223 extends IntlTest {
+import org.junit.jupiter.api.Test;
 
-    public void Test4401223a() {
-        int status = 0;
-        String s = null;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-        try {
-            @SuppressWarnings("deprecation")
-            Date date = new Date(2000 - 1900, FEBRUARY, 29);
-            GregorianCalendar gc = new GregorianCalendar();
+public class bug4401223 {
+
+    // Ensure IAE not thrown for date: 12-29-00
+    @SuppressWarnings("deprecation")
+    @Test
+    public void checkExceptionTest() {
+        Date date = new Date(2000 - 1900, FEBRUARY, 29);
+        GregorianCalendar gc = new GregorianCalendar();
+        assertDoesNotThrow(() -> {
             gc.setTime(date);
             gc.setLenient(false);
             gc.set(YEAR, 2001);
-            s = "02/29/00 & set(YEAR,2001) = " + gc.getTime().toString();
-        } catch (Exception ex) {
-            status++;
-            s = "Exception occurred for 2/29/00 & set(YEAR,2001): " + ex;
-        }
-        if (status > 0) {
-            errln(s);
-        } else {
-            logln(s);
-        }
+        }, "Exception occurred for 2/29/00 & set(YEAR,2001)");
     }
 
-    public void Test4401223b() {
-        int status = 0;
-        String s = null;
-
-        try {
-            @SuppressWarnings("deprecation")
-            Date date = new Date(2000 - 1900, DECEMBER, 31);
-            GregorianCalendar gc = new GregorianCalendar();
+    // Ensure IAE not thrown for date: 12-31-00. Validate expected values.
+    @SuppressWarnings("deprecation")
+    @Test
+    public void checkExceptionAndValuesTest() {
+        Date date = new Date(2000 - 1900, DECEMBER, 31);
+        GregorianCalendar gc = new GregorianCalendar();
+        assertDoesNotThrow(() -> {
             gc.setTime(date);
             gc.setLenient(false);
             gc.set(YEAR, 2001);
+        }, "Exception occurred for 12/31/00 & set(YEAR,2001)");
 
-            if (gc.get(YEAR) != 2001
-                    || gc.get(MONTH) != DECEMBER
-                    || gc.get(DATE) != 31
-                    || gc.get(DAY_OF_YEAR) != 365) {
-                status++;
-                s = "Wrong Date : 12/31/00 & set(YEAR,2001) ---> " + gc.getTime().toString();
-            } else {
-                s = "12/31/00 & set(YEAR,2001) = " + gc.getTime().toString();
-            }
-        } catch (Exception ex) {
-            status++;
-            s = "Exception occurred for 12/31/00 & set(YEAR,2001) : " + ex;
-        }
-        if (status > 0) {
-            errln(s);
-        } else {
-            logln(s);
-        }
-    }
+        String errMsg = "Wrong date,  got: " + gc.getTime();
 
-    public static void main(String[] args) throws Exception {
-        new bug4401223().run(args);
+        assertEquals(2001, gc.get(YEAR), errMsg);
+        assertEquals(DECEMBER, gc.get(MONTH), errMsg);
+        assertEquals(31, gc.get(DATE), errMsg);
+        assertEquals(365, gc.get(DAY_OF_YEAR), errMsg);
     }
 }


### PR DESCRIPTION
Resolved
test/jdk/java/util/Calendar/BuddhistCalendarTest.java
and
test/jdk/java/util/Calendar/Bug4302966.java
as "8283698: Refactor Locale constructors used in src/test" is not in 17. 
This caused that previous backports were unclean, but unfortunately 
cannot be backported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316559](https://bugs.openjdk.org/browse/JDK-8316559) needs maintainer approval

### Issue
 * [JDK-8316559](https://bugs.openjdk.org/browse/JDK-8316559): Refactor some util/Calendar tests to JUnit (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3188/head:pull/3188` \
`$ git checkout pull/3188`

Update a local copy of the PR: \
`$ git checkout pull/3188` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3188`

View PR using the GUI difftool: \
`$ git pr show -t 3188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3188.diff">https://git.openjdk.org/jdk17u-dev/pull/3188.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3188#issuecomment-2571608333)
</details>
