### PR TITLE
8290400: Must run exe installers in jpackage jtreg tests without UI

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/WindowsHelper.java
@@ -148,7 +148,9 @@ public class WindowsHelper {
         BiConsumer<JPackageCommand, Boolean> installExe = (cmd, install) -> {
             cmd.verifyIsOfType(PackageType.WIN_EXE);
             Executor exec = new Executor().setExecutable(cmd.outputBundle());
-            if (!install) {
+            if (install) {
+                exec.addArgument("/qn").addArgument("/norestart");
+            } else {
                 exec.addArgument("uninstall");
             }
             runMsiexecWithRetries(exec);


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8290400](https://bugs.openjdk.org/browse/JDK-8290400) needs maintainer approval

### Issue
 * [JDK-8290400](https://bugs.openjdk.org/browse/JDK-8290400): Must run exe installers in jpackage jtreg tests without UI (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3189/head:pull/3189` \
`$ git checkout pull/3189`

Update a local copy of the PR: \
`$ git checkout pull/3189` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3189`

View PR using the GUI difftool: \
`$ git pr show -t 3189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3189.diff">https://git.openjdk.org/jdk17u-dev/pull/3189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3189#issuecomment-2577021338)
</details>
