### PR TITLE
Backport 130a9f138759c2f8504a83a6f3a93b1f219f0a42

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *     its usages, please look through the README.
  *
  * @library /test/lib ../warnings
- * @compile -source 1.7 -target 1.7 JdkUtils.java
+ * @compile -source 1.8 -target 1.8 JdkUtils.java
  * @run main/manual/othervm Compatibility
  */
 
@@ -67,7 +67,6 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
@@ -460,7 +459,7 @@ public class Compatibility {
         if (RSA.equals(keyAlgorithm) || DSA.equals(keyAlgorithm)) {
             return new int[] { 1024, 2048, 0 }; // 0 is no keysize specified
         } else if (EC.equals(keyAlgorithm)) {
-            return new int[] { 384, 571, 0 }; // 0 is no keysize specified
+            return new int[] { 384, 521, 0 }; // 0 is no keysize specified
         } else {
             throw new RuntimeException("problem determining key sizes");
         }
@@ -717,7 +716,7 @@ public class Compatibility {
         try {
             String match = "^  ("
                     + "  Signature algorithm: " + signItem.certInfo.
-                            expectedSigalg() + ", " + signItem.certInfo.
+                            expectedSigalg(signItem) + ", " + signItem.certInfo.
                             expectedKeySize() + "-bit key"
                     + ")|("
                     + "  Digest algorithm: " + signItem.expectedDigestAlg()
@@ -845,6 +844,7 @@ public class Compatibility {
 
             if (isWeakAlg(signItem.expectedDigestAlg())
                     && line.contains(Test.WEAK_ALGORITHM_WARNING)) continue;
+            if (line.contains(Test.WEAK_KEY_WARNING)) continue;
             if (Test.CERTIFICATE_SELF_SIGNED.equals(line)) continue;
             if (Test.HAS_EXPIRED_CERT_VERIFYING_WARNING.equals(line)
                     && signItem.certInfo.expired) continue;
@@ -1183,19 +1183,56 @@ public class Compatibility {
         }
 
         private String expectedSigalg() {
-            return (DEFAULT.equals(this.digestAlgorithm) ? this.digestAlgorithm
-                    : "SHA-256").replace("-", "") + "with" +
-                    keyAlgorithm + (EC.equals(keyAlgorithm) ? "DSA" : "");
+            return "SHA256with" + keyAlgorithm + (EC.equals(keyAlgorithm) ? "DSA" : "");
+        }
+
+        private String expectedSigalg(SignItem signer) {
+            if (!DEFAULT.equals(digestAlgorithm)) {
+                return "SHA256with" + keyAlgorithm + (EC.equals(keyAlgorithm) ? "DSA" : "");
+
+            } else {
+                // default algorithms documented for jarsigner here:
+                // https://docs.oracle.com/en/java/javase/17/docs/specs/man/jarsigner.html#supported-algorithms
+                // https://docs.oracle.com/en/java/javase/20/docs/specs/man/jarsigner.html#supported-algorithms
+                int expectedKeySize = expectedKeySize();
+                switch (keyAlgorithm) {
+                    case DSA:
+                        return "SHA256withDSA";
+                    case RSA: {
+                        if ((signer.jdkInfo.majorVersion >= 20 && expectedKeySize < 624)
+                                || (signer.jdkInfo.majorVersion < 20 && expectedKeySize <= 3072)) {
+                            return "SHA256withRSA";
+                        } else if (expectedKeySize <= 7680) {
+                            return "SHA384withRSA";
+                        } else {
+                            return "SHA512withRSA";
+                        }
+                    }
+                    case EC: {
+                        if (signer.jdkInfo.majorVersion < 20 && expectedKeySize < 384) {
+                            return "SHA256withECDSA";
+                        } else if (expectedKeySize < 512) {
+                            return "SHA384withECDSA";
+                        } else {
+                            return "SHA512withECDSA";
+                        }
+                    }
+                    default:
+                        throw new RuntimeException("Unsupported/expected key algorithm: " + keyAlgorithm);
+                }
+            }
         }
 
         private int expectedKeySize() {
             if (keySize != 0) return keySize;
 
             // defaults
-            if (RSA.equals(keyAlgorithm) || DSA.equals(keyAlgorithm)) {
+            if (RSA.equals(keyAlgorithm)) {
+                return jdkInfo.majorVersion >= 20 ? 3072 : 2048;
+            } else if (DSA.equals(keyAlgorithm)) {
                 return 2048;
             } else if (EC.equals(keyAlgorithm)) {
-                return 256;
+                return jdkInfo.majorVersion >= 20 ? 384 : 256;
             } else {
                 throw new RuntimeException("problem determining key size");
             }
@@ -1391,7 +1428,9 @@ public class Compatibility {
         }
 
         String expectedDigestAlg() {
-            return digestAlgorithm != null ? digestAlgorithm : "SHA-256";
+            return digestAlgorithm != null
+                    ? digestAlgorithm
+                    : jdkInfo.majorVersion >= 20 ? "SHA-384" : "SHA-256";
         }
 
         private SignItem tsaDigestAlgorithm(String tsaDigestAlgorithm) {
@@ -1540,7 +1579,7 @@ public class Compatibility {
         s_values_add.accept(i -> i.unsignedJar + " -> " + i.signedJar);
         s_values_add.accept(i -> i.certInfo.toString());
         s_values_add.accept(i -> i.jdkInfo.version);
-        s_values_add.accept(i -> i.certInfo.expectedSigalg());
+        s_values_add.accept(i -> i.certInfo.expectedSigalg(i));
         s_values_add.accept(i ->
                 null2Default(i.digestAlgorithm, i.expectedDigestAlg()));
         s_values_add.accept(i -> i.tsaIndex == -1 ? "" :

--- a/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
+++ b/test/jdk/sun/security/tools/jarsigner/warnings/Test.java
@@ -148,6 +148,9 @@ public abstract class Test {
             = "algorithm is considered a security risk. "
             + "This algorithm will be disabled in a future update.";
 
+    static final String WEAK_KEY_WARNING
+            = "This key size will be disabled in a future update.";
+
     static final String JAR_SIGNED = "jar signed.";
 
     static final String JAR_VERIFIED = "jar verified.";


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

I had to resolve because "8267319: Use larger default key sizes and algorithms based on CNSA" is not backported.  This is just the change that makes this backport necessary so that compatibility between 21 and 17 can be tested.