### PR TITLE
8311306: Test com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java failed: out of expected range

### DIFF
--- a/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
+++ b/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
@@ -29,6 +29,7 @@
  *          getThreadUserTime(long[]).
  * @author  Paul Hohensee
  * @requires vm.compMode != "Xcomp"
+ * @run main/othervm ThreadCpuTimeArray
  */
 
 import java.lang.management.*;


### PR DESCRIPTION
Fix request [17u]


Resolved because later JDK-8325137 was already backported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311306](https://bugs.openjdk.org/browse/JDK-8311306) needs maintainer approval

### Issue
 * [JDK-8311306](https://bugs.openjdk.org/browse/JDK-8311306): Test com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java failed: out of expected range (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3192/head:pull/3192` \
`$ git checkout pull/3192`

Update a local copy of the PR: \
`$ git checkout pull/3192` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3192`

View PR using the GUI difftool: \
`$ git pr show -t 3192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3192.diff">https://git.openjdk.org/jdk17u-dev/pull/3192.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3192#issuecomment-2577779772)
</details>
