### PR TITLE
8325529: Remove unused imports from `ModuleGenerator` test file

### DIFF
--- a/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/SampleApi.java
+++ b/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/SampleApi.java
@@ -22,10 +22,6 @@
  */
 package sampleapi;
 
-import com.sun.source.util.JavacTask;
-import com.sun.tools.javac.api.JavacTaskImpl;
-import com.sun.tools.javac.api.JavacTool;
-import com.sun.tools.javac.util.Context;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -34,17 +30,22 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import static java.util.stream.Collectors.toList;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
+import com.sun.source.util.JavacTask;
+import com.sun.tools.javac.api.JavacTaskImpl;
+import com.sun.tools.javac.api.JavacTool;
+import com.sun.tools.javac.util.Context;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-import sampleapi.generator.ModuleGenerator;
 
+import sampleapi.generator.ModuleGenerator;
 import sampleapi.generator.PackageGenerator;
 
 public class SampleApi {

--- a/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/DocCommentGenerator.java
+++ b/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/DocCommentGenerator.java
@@ -23,17 +23,23 @@
 
 package sampleapi.generator;
 
-import java.io.File;
-import java.io.BufferedInputStream;
-import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+
 import javax.lang.model.element.Modifier;
 
 import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.*;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCIdent;
+import com.sun.tools.javac.tree.JCTree.JCLiteral;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCNewArray;
+import com.sun.tools.javac.tree.JCTree.JCNewClass;
+import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.List;
-import java.util.HashMap;
-import java.util.Map;
 
 class DocCommentGenerator {
 

--- a/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/Documentifier.java
+++ b/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/Documentifier.java
@@ -23,22 +23,24 @@
 
 package sampleapi.generator;
 
-import java.util.ArrayList;
 import java.util.Set;
+
 import javax.lang.model.element.Modifier;
 
-import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.*;
-import com.sun.tools.javac.tree.DocCommentTable;
-import com.sun.tools.javac.parser.ScannerFactory;
-import com.sun.tools.javac.parser.Scanner;
-import com.sun.tools.javac.parser.Tokens.Token;
-import com.sun.tools.javac.parser.Tokens.Comment;
-import com.sun.tools.javac.parser.Tokens.Comment.CommentStyle;
 import com.sun.source.tree.Tree.Kind;
+import com.sun.tools.javac.parser.Scanner;
+import com.sun.tools.javac.parser.ScannerFactory;
+import com.sun.tools.javac.parser.Tokens.Comment;
+import com.sun.tools.javac.parser.Tokens.Token;
+import com.sun.tools.javac.tree.DocCommentTable;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.util.Context;
 
-import sampleapi.util.*;
+import sampleapi.util.PoorDocCommentTable;
 
 class Documentifier {
 

--- a/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/Documentifier.java
+++ b/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/Documentifier.java
@@ -31,6 +31,7 @@ import com.sun.source.tree.Tree.Kind;
 import com.sun.tools.javac.parser.Scanner;
 import com.sun.tools.javac.parser.ScannerFactory;
 import com.sun.tools.javac.parser.Tokens.Comment;
+import com.sun.tools.javac.parser.Tokens.Comment.CommentStyle;
 import com.sun.tools.javac.parser.Tokens.Token;
 import com.sun.tools.javac.tree.DocCommentTable;
 import com.sun.tools.javac.tree.JCTree;

--- a/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/ModuleGenerator.java
+++ b/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/ModuleGenerator.java
@@ -22,31 +22,26 @@
  */
 package sampleapi.generator;
 
-import com.sun.source.tree.ModuleTree.ModuleKind;
-import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.parser.Scanner;
-import com.sun.tools.javac.parser.ScannerFactory;
-import com.sun.tools.javac.parser.Tokens;
-import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.JCDirective;
-import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.TreeMaker;
-import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.Names;
-import com.sun.tools.javac.util.ListBuffer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
+
+import com.sun.source.tree.ModuleTree.ModuleKind;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCDirective;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Names;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import sampleapi.SampleApi;
-import sampleapi.util.PoorDocCommentTable;
-
-import static com.sun.tools.javac.parser.Tokens.Comment.CommentStyle.JAVADOC;
 
 /**
  *

--- a/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/PackageGenerator.java
+++ b/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/generator/PackageGenerator.java
@@ -26,33 +26,45 @@ package sampleapi.generator;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.xml.parsers.DocumentBuilderFactory;
+
+import com.sun.source.util.JavacTask;
+import com.sun.tools.javac.api.JavacTaskImpl;
+import com.sun.tools.javac.api.JavacTool;
+import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCBlock;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
+import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
+import com.sun.tools.javac.tree.JCTree.JCPackageDecl;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
+import com.sun.tools.javac.tree.JCTree.JCTypeParameter;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
+import com.sun.tools.javac.tree.TreeMaker;
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.ListBuffer;
+import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Names;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import com.sun.source.util.JavacTask;
-import com.sun.tools.javac.api.JavacTool;
-import com.sun.tools.javac.api.JavacTaskImpl;
-import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.Name;
-import com.sun.tools.javac.util.Names;
-import com.sun.tools.javac.util.List;
-import com.sun.tools.javac.util.ListBuffer;
-import com.sun.tools.javac.tree.TreeMaker;
-import com.sun.tools.javac.tree.JCTree;
-import com.sun.tools.javac.tree.JCTree.*;
-import com.sun.tools.javac.code.Flags;
-import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.TypeTag;
-import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.code.Symtab;
-import java.nio.file.Path;
-
-import sampleapi.util.*;
+import sampleapi.util.SimpleMultiplier;
 
 public class PackageGenerator {
 

--- a/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/util/SimpleMultiplier.java
+++ b/test/langtools/jdk/javadoc/tool/sampleapi/lib/sampleapi/util/SimpleMultiplier.java
@@ -23,8 +23,8 @@
 
 package sampleapi.util;
 
-import java.util.StringTokenizer;
 import java.util.ArrayList;
+import java.util.StringTokenizer;
 
 /*
  * The class implements unknown number of nested loops. The number of modifiers


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

The backport is clean, but the tests need one of the old imports.

This is the very same edit as done in 21.
Making this a backport from 21 should turn this into a clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325529](https://bugs.openjdk.org/browse/JDK-8325529) needs maintainer approval

### Issue
 * [JDK-8325529](https://bugs.openjdk.org/browse/JDK-8325529): Remove unused imports from `ModuleGenerator` test file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3193/head:pull/3193` \
`$ git checkout pull/3193`

Update a local copy of the PR: \
`$ git checkout pull/3193` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3193`

View PR using the GUI difftool: \
`$ git pr show -t 3193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3193.diff">https://git.openjdk.org/jdk17u-dev/pull/3193.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3193#issuecomment-2577806322)
</details>
