### PR TITLE
8311663: Additional refactoring of Locale tests to JUnit

### DIFF
--- a/test/jdk/java/util/Locale/Bug8135061.java
+++ b/test/jdk/java/util/Locale/Bug8135061.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8135061
  * @summary Checks that the Locale.lookup executes properly without throwing
  *          any exception for some specific language ranges
- * @run main Bug8135061
+ * @run junit Bug8135061
  */
 
 import java.util.Collection;
@@ -35,47 +35,46 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 public class Bug8135061 {
 
-    public static void main(String[] args) {
-
-        /* lookup should run without throwing any exception and
-         * return null as the language range does not match with the language
-         * tag
-         */
+    /**
+     * Lookup should run without throwing any exception and return null as
+     * the language range does not match with the language tag.
+     */
+    @Test
+    public void lookupReturnNullTest() {
         List<LanguageRange> ranges = LanguageRange.parse("nv");
         Collection<Locale> locales = Collections.singleton(Locale.ENGLISH);
-
         try {
             Locale match = Locale.lookup(ranges, locales);
-            if (match != null) {
-                throw new RuntimeException("Locale.lookup returned non-null: "
-                        + match);
-            }
+            assertNull(match);
         } catch (Exception ex) {
             throw new RuntimeException("[Locale.lookup failed on language"
                     + " range: " + ranges + " and language tags "
                     + locales + "]", ex);
         }
-
-        /* lookup should run without throwing any exception and
-         * return "nv" as the matching tag
-         */
-        ranges = LanguageRange.parse("i-navajo");
-        locales = Collections.singleton(new Locale("nv"));
-
-        try {
-            Locale match = Locale.lookup(ranges, locales);
-            if (!match.toLanguageTag().equals("nv")) {
-                throw new RuntimeException("Locale.lookup returned unexpected"
-                        + " result: " + match);
-            }
-        } catch (Exception ex) {
-            throw new RuntimeException("[Locale.lookup failed on language"
-                    + " range: " + ranges + " and language tags "
-                    + locales + "]", ex);
-        }
-
     }
 
+    /**
+     * Lookup should run without throwing any exception and return "nv"
+     * as the matching tag.
+     */
+    @Test
+    public void lookupReturnValueTest() {
+        List<LanguageRange> ranges = LanguageRange.parse("i-navajo");
+        Collection<Locale> locales = Collections.singleton(new Locale("nv"));
+        try {
+            Locale match = Locale.lookup(ranges, locales);
+            assertEquals(match.toLanguageTag(), "nv");
+        } catch (Exception ex) {
+            throw new RuntimeException("[Locale.lookup failed on language"
+                    + " range: " + ranges + " and language tags "
+                    + locales + "]", ex);
+        }
+    }
 }

--- a/test/jdk/java/util/Locale/Bug8159420.java
+++ b/test/jdk/java/util/Locale/Bug8159420.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,119 +32,90 @@
  *          "hı-deva", where 'ı' is the LATIN SMALL LETTER DOTLESS I character
  *          which is not allowed in the language ranges/tags.
  * @compile -encoding utf-8 Bug8159420.java
- * @run main Bug8159420
+ * @run junit/othervm -Duser.language=tr -Duser.country=TR Bug8159420
  */
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Locale.LanguageRange;
 import java.util.Locale.FilteringMode;
 import java.util.LinkedHashMap;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.ArrayList;
+import java.util.stream.Stream;
+
 import static java.util.Locale.FilteringMode.EXTENDED_FILTERING;
 import static java.util.Locale.FilteringMode.AUTOSELECT_FILTERING;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class Bug8159420 {
 
-    static boolean err = false;
-
-    public static void main(String[] args) {
-
-        Locale origLocale = null;
-        try {
-
-            origLocale = Locale.getDefault();
-            Locale.setDefault(new Locale("tr", "TR"));
-            testParse();
-            testFilter(EXTENDED_FILTERING);
-            testFilter(AUTOSELECT_FILTERING);
-            testLookup();
-            testMapEquivalents();
-
-            if (err) {
-                throw new RuntimeException("[LocaleMatcher method(s) in turkish"
-                        + " locale failed]");
-            }
-
-        } finally {
-            Locale.setDefault(origLocale);
-        }
-
-    }
-
-    /* Before the fix, the testParse() method was throwing
-     * IllegalArgumentException in Turkish Locale
+    /*
+     * Ensure parse() does not throw IllegalArgumentException for the Turkish Locale
+     * with the given input.
      */
-    private static void testParse() {
+    @Test
+    public void parseTest() {
         String ranges = "HI-Deva, ja-hIrA-JP, RKI";
-        try {
-            LanguageRange.parse(ranges);
-        } catch (Exception ex) {
-            System.err.println("[testParse() failed on range string: "
-                    + ranges + "] due to "+ex);
-            err = true;
-        }
+        assertDoesNotThrow(() -> LanguageRange.parse(ranges));
     }
 
-    /* Before the fix, the testFilter() method was returning empty list in
-     * Turkish Locale
+    /*
+     * Ensure filter() does not return empty list for the Turkish Locale
+     * with the given input.
      */
-    private static void testFilter(FilteringMode mode) {
-
+    @ParameterizedTest
+    @MethodSource("modes")
+    public void filterTest(FilteringMode mode) {
         String ranges = "hi-IN, itc-Ital";
         String tags = "hi-IN, itc-Ital";
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<Locale> tagList = generateLocales(tags);
         String actualLocales = showLocales(Locale.filter(priorityList, tagList, mode));
         String expectedLocales = "hi-IN, itc-Ital";
-
-        if (!expectedLocales.equals(actualLocales)) {
-            System.err.println("testFilter(" + mode + ") failed on language ranges:"
-                    + " [" + ranges + "] and language tags: [" + tags + "]");
-            err = true;
-        }
+        assertEquals(expectedLocales, actualLocales);
     }
 
-    /* Before the fix, the testLookup() method was returning null in Turkish
-     * Locale
+    private static Stream<FilteringMode> modes() {
+        return Stream.of(
+                EXTENDED_FILTERING,
+                AUTOSELECT_FILTERING
+        );
+    }
+
+    /*
+     * Ensure lookup() does not return null for the Turkish Locale with
+     * the given input.
      */
-    private static void testLookup() {
-        boolean error = false;
+    @Test
+    public void lookupTest() {
         String ranges = "hi-IN, itc-Ital";
         String tags = "hi-IN, itc-Ital";
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<Locale> localeList = generateLocales(tags);
-        Locale actualLocale
-                = Locale.lookup(priorityList, localeList);
-        String actualLocaleString = "";
-
-        if (actualLocale != null) {
-            actualLocaleString = actualLocale.toLanguageTag();
-        } else {
-            error = true;
-        }
-
+        Locale actualLocale = Locale.lookup(priorityList, localeList);
+        assertNotNull(actualLocale);
+        String actualLocaleString = actualLocale.toLanguageTag();
         String expectedLocale = "hi-IN";
-
-        if (!expectedLocale.equals(actualLocaleString)) {
-            error = true;
-        }
-
-        if (error) {
-            System.err.println("testLookup() failed on language ranges:"
-                    + " [" + ranges + "] and language tags: [" + tags + "]");
-            err = true;
-        }
-
+        assertEquals(expectedLocale, actualLocaleString);
     }
 
-    /* Before the fix, testMapEquivalents() method was returning only "hi-in"
-     * in Turkish Locale
+    /*
+     * Ensure mapEquivalents() does not only return "hi-in" for the Turkish
+     * Locale with the given input.
      */
-    private static void testMapEquivalents() {
-
+    @Test
+    public void mapEquivalentsTest() {
         String ranges = "HI-IN";
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         HashMap<String, List<String>> map = new LinkedHashMap<>();
@@ -156,38 +127,29 @@ public class Bug8159420 {
         List<LanguageRange> expected = new ArrayList<>();
         expected.add(new LanguageRange("hi-in"));
         expected.add(new LanguageRange("hi-deva-in"));
-        List<LanguageRange> got
-                = LanguageRange.mapEquivalents(priorityList, map);
-
-        if (!areEqual(expected, got)) {
-            System.err.println("testMapEquivalents() failed");
-            err = true;
-        }
-
+        List<LanguageRange> got =
+                LanguageRange.mapEquivalents(priorityList, map);
+        assertEquals(expected, got, getDifferences(expected, got));
     }
 
-    private static boolean areEqual(List<LanguageRange> expected,
+    private static String getDifferences(List<LanguageRange> expected,
             List<LanguageRange> got) {
-
-        boolean error = false;
-        if (expected.equals(got)) {
-            return !error;
-        }
-
+        StringBuilder diffs = new StringBuilder();
         List<LanguageRange> cloneExpected = new ArrayList<>(expected);
         cloneExpected.removeAll(got);
         if (!cloneExpected.isEmpty()) {
-            error = true;
-            System.err.println("Found missing range(s): " + cloneExpected);
+            diffs.append("Found missing range(s): ")
+                    .append(cloneExpected)
+                    .append(System.lineSeparator());
         }
-
-        // not creating the 'got' clone as the list will not be used after this
-        got.removeAll(expected);
+        List<LanguageRange> cloneGot = new ArrayList<>(got);
+        cloneGot.removeAll(expected);
         if (!got.isEmpty()) {
-            error = true;
-            System.err.println("Found extra range(s): " + got);
+            diffs.append("Got extra range(s): ")
+                    .append(cloneGot)
+                    .append(System.lineSeparator());
         }
-        return !error;
+        return diffs.toString();
     }
 
     private static List<Locale> generateLocales(String tags) {
@@ -220,5 +182,4 @@ public class Bug8159420 {
 
         return sb.toString().trim();
     }
-
 }

--- a/test/jdk/java/util/Locale/Bug8166994.java
+++ b/test/jdk/java/util/Locale/Bug8166994.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8166884
@@ -27,41 +28,39 @@
  *          which must generate the same list of language ranges
  *          i.e. the priority list containing equivalents, as in the
  *          first call
+ * @run junit Bug8166994
  */
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Bug8166994 {
 
-    public static void main(String[] args) {
-        List<String> list = Arrays.asList("ccq-aa", "ybd-aa", "rki-aa");
-        String ranges = "ccq-aa";
-        testParseConsistency(list, ranges);
-
+    /*
+     * Checks that consecutive calls to parse the same language ranges
+     * generate the same list of language ranges.
+     */
+    @ParameterizedTest
+    @MethodSource("ranges")
+    public void parseConsistencyTest(List<String> list, String ranges) {
         // consecutive call to check the language range parse consistency
         testParseConsistency(list, ranges);
-
-        // another case with ranges consisting of multiple equivalents and
-        // single equivalents
-        list = Arrays.asList("gfx-xz", "oun-xz", "mwj-xz", "vaj-xz",
-                "taj-xy", "tsf-xy");
-        ranges = "gfx-xz, taj-xy";
         testParseConsistency(list, ranges);
-        // consecutive call to check the language range parse consistency
-        testParseConsistency(list, ranges);
-
     }
 
+    // Ensure that parsing the ranges returns the expected list.
     private static void testParseConsistency(List<String> list, String ranges) {
         List<String> priorityList = parseRanges(ranges);
-        if (!list.equals(priorityList)) {
-            throw new RuntimeException("Failed to parse the language range ["
-                    + ranges + "], Expected: " + list + " Found: "
-                    + priorityList);
-        }
+        assertEquals(list, priorityList, "Failed to parse the language range:");
     }
 
     private static List<String> parseRanges(String s) {
@@ -70,5 +69,13 @@ public class Bug8166994 {
                 .collect(Collectors.toList());
     }
 
+    // Ranges that have multiple equivalents and single equivalents.
+    private static Stream<Arguments> ranges() {
+        return Stream.of(
+                Arguments.of(Arrays.asList("ccq-aa", "ybd-aa", "rki-aa"),
+                        "ccq-aa"),
+                Arguments.of(Arrays.asList("gfx-xz", "oun-xz", "mwj-xz",
+                        "vaj-xz", "taj-xy", "tsf-xy"), "gfx-xz, taj-xy")
+        );
+    }
 }
-

--- a/test/jdk/java/util/Locale/FilteringModeTest.java
+++ b/test/jdk/java/util/Locale/FilteringModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,67 +25,61 @@
  * @test
  * @bug 8210443
  * @summary Check values() and valueOf(String name) of Locale.FilteringMode.
- * @run main FilteringModeTest
+ * @run junit FilteringModeTest
  */
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale.FilteringMode;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FilteringModeTest {
-    private static boolean err = false;
-    private static List<String> modeNames = List.of("AUTOSELECT_FILTERING",
-                                                    "EXTENDED_FILTERING",
-                                                    "IGNORE_EXTENDED_RANGES",
-                                                    "MAP_EXTENDED_RANGES",
-                                                    "REJECT_EXTENDED_RANGES");
 
-    public static void main(String[] args) throws Exception {
-        testValues();
-        testValueOf();
+    private static final List<String> expectedModeNames = List.of(
+            "AUTOSELECT_FILTERING",
+            "EXTENDED_FILTERING",
+            "IGNORE_EXTENDED_RANGES",
+            "MAP_EXTENDED_RANGES",
+            "REJECT_EXTENDED_RANGES"
+    );
 
-        if (err) {
-            throw new RuntimeException("Failed.");
-        }
+    // Ensure valueOf() exceptions are thrown
+    @Test
+    public void valueOfExceptionsTest() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FilteringMode.valueOf("").name());
+        assertThrows(NullPointerException.class,
+                () -> FilteringMode.valueOf(null).name());
     }
 
-    private static void testValueOf() {
-        try {
-            FilteringMode.valueOf("").name();
-            err = true;
-            System.err.println("IAE should be thrown for valueOf(\"\").");
-        } catch (IllegalArgumentException ex) {
-        }
-
-        try {
-            FilteringMode.valueOf(null).name();
-            err = true;
-            System.err.println("NPE should be thrown for valueOf(null).");
-        } catch (NullPointerException ex) {
-        }
-
-        modeNames.forEach((expectedName) -> {
-            String name = FilteringMode.valueOf(expectedName).name();
-            if (!expectedName.equals(name)) {
-                err = true;
-                System.err.println("FilteringMode.valueOf(" + expectedName
-                        + ") returned unexpected value. Expected: "
-                        + expectedName + ", got: " + name);
-            }
-        });
+    // Ensure valueOf() returns expected results
+    @ParameterizedTest
+    @MethodSource("modes")
+    public void valueOfTest(String expectedName) {
+        String name = FilteringMode.valueOf(expectedName).name();
+        assertEquals(expectedName, name);
     }
 
-    private static void testValues() {
+    private static Stream<String> modes() {
+        return expectedModeNames.stream();
+    }
+
+    // Ensure values() returns expected results
+    @Test
+    public void valuesTest() {
         FilteringMode[] modeArray = FilteringMode.values();
-        List<String> modeNames2 = Arrays.stream(modeArray)
+        List<String> actualNames = Arrays.stream(modeArray)
                 .map(mode -> mode.name())
                 .collect(Collectors.toList());
-
-        if (!modeNames.equals(modeNames2)) {
-            err = true;
-            System.err.println("FilteringMode.values() returned unexpected value. Expected:"
-                    + modeNames + " Got:" + modeNames2);
-        }
+        assertEquals(expectedModeNames, actualNames);
     }
 }

--- a/test/jdk/java/util/Locale/HashCodeTest.java
+++ b/test/jdk/java/util/Locale/HashCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,28 +20,35 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 4944561
  * @summary Test hashCode() to have less than 10% of hash code conflicts.
  * @modules jdk.localedata
+ * @run junit HashCodeTest
  */
 
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 public class HashCodeTest {
 
-    public static void main(String[] args) {
+    // Ensure Locale.hashCode() has less than 10% conflicts
+    @Test
+    public void hashConflictsTest() {
         Locale[] locales = Locale.getAvailableLocales();
         int min = Integer.MAX_VALUE;
         int max = Integer.MIN_VALUE;
         Map<Integer, Locale> map = new HashMap<>(locales.length);
         int conflicts = 0;
 
-        for (int i = 0; i < locales.length; i++) {
-            Locale loc = locales[i];
+        for (Locale loc : locales) {
             int hc = loc.hashCode();
             min = Math.min(hc, min);
             max = Math.max(hc, max);
@@ -55,9 +62,7 @@ public class HashCodeTest {
         }
         System.out.println(locales.length + " locales: conflicts=" + conflicts
                 + ", min=" + min + ", max=" + max + ", diff=" + (max - min));
-        if (conflicts >= (locales.length / 10)) {
-            throw new RuntimeException("too many conflicts: " + conflicts
-                    + " per " + locales.length + " locales");
-        }
+        assertFalse(conflicts >= (locales.length / 10),
+                String.format("%s conflicts per %s locales", conflicts, locales.length));
     }
 }

--- a/test/jdk/java/util/Locale/ThaiGov.java
+++ b/test/jdk/java/util/Locale/ThaiGov.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,98 +20,70 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/**
+
+/*
  * @test
  * @bug 4474409
+ * @summary Tests some localized methods with Thai locale
  * @author John O'Conner
  * @modules jdk.localedata
- * @run main/othervm -Djava.locale.providers=COMPAT ThaiGov
+ * @run junit/othervm -Djava.locale.providers=COMPAT ThaiGov
  */
 
-import java.util.*;
-import java.text.*;
+import java.text.DateFormat;
+import java.text.NumberFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ThaiGov {
 
-    ThaiGov() {
-        System.out.println("ThaiGov locale test...");
+    private static final double VALUE = 12345678.234;
+    private static final Locale TH = new Locale("th", "TH", "TH");
 
-    }
-
-    void numberTest() throws RuntimeException {
+    // Test number formatting for thai
+    @Test
+    public void numberTest() {
         final String strExpected = "\u0E51\u0E52\u002C\u0E53\u0E54\u0E55\u002C\u0E56\u0E57\u0E58\u002E\u0E52\u0E53\u0E54";
-        final double value =  12345678.234;
-
-        Locale locTH = new Locale("th", "TH", "TH");
-
-        // th_TH_TH test
-        NumberFormat nf = NumberFormat.getInstance(locTH);
-        String str = nf.format(value);
-
-        if (!strExpected.equals(str)) {
-            throw new RuntimeException();
-        }
-
+        NumberFormat nf = NumberFormat.getInstance(TH);
+        String str = nf.format(VALUE);
+        assertEquals(strExpected, str);
     }
 
-    void currencyTest() throws RuntimeException {
+    // Test currency formatting for Thai
+    @Test
+    public void currencyTest() {
         final String strExpected = "\u0E3F\u0E51\u0E52\u002C\u0E53\u0E54\u0E55\u002C\u0E56\u0E57\u0E58\u002E\u0E52\u0E53";
-        final double value =  12345678.234;
-
-        Locale locTH = new Locale("th", "TH", "TH");
-
-        // th_TH_TH test
-        NumberFormat nf = NumberFormat.getCurrencyInstance(locTH);
-        String str = nf.format(value);
-
-        if (!strExpected.equals(str)) {
-            throw new RuntimeException();
-        }
-
+        NumberFormat nf = NumberFormat.getCurrencyInstance(TH);
+        String str = nf.format(VALUE);
+        assertEquals(strExpected, str);
     }
 
-    void dateTest() throws RuntimeException {
-        Locale locTH = new Locale("th", "TH", "TH");
-        TimeZone tz = TimeZone.getTimeZone("PST");
-
+    // Test date formatting for Thai
+    @Test
+    public void dateTest() {
+        TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
         Calendar calGregorian = Calendar.getInstance(tz, Locale.US);
         calGregorian.clear();
         calGregorian.set(2002, 4, 1, 8, 30);
         final Date date = calGregorian.getTime();
-        Calendar cal = Calendar.getInstance(tz, locTH);
+        Calendar cal = Calendar.getInstance(tz, TH);
         cal.clear();
         cal.setTime(date);
 
 
         final String strExpected = "\u0E27\u0E31\u0E19\u0E1E\u0E38\u0E18\u0E17\u0E35\u0E48\u0020\u0E51\u0020\u0E1E\u0E24\u0E29\u0E20\u0E32\u0E04\u0E21\u0020\u0E1E\u002E\u0E28\u002E\u0020\u0E52\u0E55\u0E54\u0E55\u002C\u0020\u0E58\u0020\u0E19\u0E32\u0E2C\u0E34\u0E01\u0E32\u0020\u0E53\u0E50\u0020\u0E19\u0E32\u0E17\u0E35\u0020\u0E50\u0E50\u0020\u0E27\u0E34\u0E19\u0E32\u0E17\u0E35";
-        Date value =  cal.getTime();
+        Date value = cal.getTime();
 
         // th_TH_TH test
-        DateFormat df = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, locTH);
+        DateFormat df = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, TH);
         df.setTimeZone(tz);
         String str = df.format(value);
-
-        if (!strExpected.equals(str)) {
-            throw new RuntimeException();
-        }
-
+        assertEquals(strExpected, str);
     }
-
-    public static void main(String[] args) {
-
-        ThaiGov app = new ThaiGov();
-        System.out.print("Running numberTest...");
-        app.numberTest();
-        System.out.print("Finished\n");
-        System.out.print("Running currencyTest...");
-        app.currencyTest();
-        System.out.print("Finished\n");
-        System.out.print("Running dateTest...");
-        app.dateTest();
-        System.out.print("Finished\n");
-
-        System.out.println("PASSED");
-    }
-
-
 }

--- a/test/jdk/java/util/Locale/UseOldISOCodesTest.java
+++ b/test/jdk/java/util/Locale/UseOldISOCodesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8295232
+ * @summary Ensures java.locale.useOldISOCodes is statically initialized
+ * @library /test/lib
+ * @run junit UseOldISOCodesTest
+ */
+
+import java.util.Locale;
+import jdk.test.lib.process.ProcessTools;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UseOldISOCodesTest {
+
+    // Ensure java.locale.useOldISOCodes is only interpreted at runtime startup
+    @Test
+    public void staticInitializationTest() throws Exception {
+        ProcessTools.executeTestJvm("-Djava.locale.useOldISOCodes=true", "UseOldISOCodesTest$Runner")
+                .outputTo(System.out)
+                .errorTo(System.err)
+                .shouldHaveExitValue(0);
+    }
+
+    static class Runner {
+        private static final String obsoleteCode = "iw";
+        private static final String newCode = "he";
+
+        public static void main(String[] args) {
+            // Should have no effect
+            System.setProperty("java.locale.useOldISOCodes", "false");
+            Locale locale = new Locale(newCode);
+            assertEquals(obsoleteCode, locale.getLanguage(),
+                    "newCode 'he' was not mapped to 'iw' with useOldISOCodes=true");
+        }
+    }
+}


### PR DESCRIPTION
test/jdk/java/util/Locale/Bug8135061.java
test/jdk/java/util/Locale/Bug8159420.java
test/jdk/java/util/Locale/ThaiGov.java

These three need to be resolved because
"8283698: Refactor Locale constructors used in src/test" is not in 17.
Basically I took over the head version of the test in 21, and reverted the refactored constructor call.

test/jdk/java/util/Locale/UseOldISOCodesTest.java

is not in 17. It was added by "8295232: "java.locale.useOldISOCodes" property is read lazily".
As I understand the error fixed by JDK-8295232 was introduced by closed JDK-8294667. I built
jdk20 before JDK-8295232 was pushed, this causes the test to fail.
With 17 and 20 after this change it passes.  I would like to take the test to 17 to
improve testing along with this change. This would also alert us if a change breaking 
this is backported.
As with the changes above I had to undo JDK-8283698.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8311663](https://bugs.openjdk.org/browse/JDK-8311663) needs maintainer approval

### Issue
 * [JDK-8311663](https://bugs.openjdk.org/browse/JDK-8311663): Additional refactoring of Locale tests to JUnit (**Sub-task** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3196/head:pull/3196` \
`$ git checkout pull/3196`

Update a local copy of the PR: \
`$ git checkout pull/3196` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3196`

View PR using the GUI difftool: \
`$ git pr show -t 3196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3196.diff">https://git.openjdk.org/jdk17u-dev/pull/3196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3196#issuecomment-2579814760)
</details>
