### PR TITLE
8328085: C2: Use after free in PhaseChaitin::Register_Allocate()

### DIFF
--- a/src/hotspot/share/opto/postaloc.cpp
+++ b/src/hotspot/share/opto/postaloc.cpp
@@ -403,7 +403,6 @@ bool PhaseChaitin::eliminate_copy_of_constant(Node* val, Node* n,
 // as they get encountered with the merge node and keep adding these defs to the merge inputs.
 void PhaseChaitin::merge_multidefs() {
   Compile::TracePhase tp("mergeMultidefs", &timers[_t_mergeMultidefs]);
-  ResourceMark rm;
   // Keep track of the defs seen in registers and collect their uses in the block.
   RegToDefUseMap reg2defuse(_max_reg, _max_reg, RegDefUse());
   for (uint i = 0; i < _cfg.number_of_blocks(); i++) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [a21862ab](https://github.com/openjdk/jdk21u-dev/commit/a21862ab00317842da006eae453865badd4dc30f) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by Richard Reingruber on 17 Dec 2024 and had no reviewers.

I'd consider the risk medium. There could be scenarios with higher memory usage in c2 register allocation.
I've done some testing with which did not reveal higher higher memory usage.
(the measuring code was part of the [original pull request](https://github.com/openjdk/jdk/pull/22200/commits))

```
Max. ResourceArea size in KB after C2 PhaseChaitin::merge_multidefs

DaCapo Benchmark        Basline        Pull Request

avrora                  2273           2259
batik                   3456           3179
biojava                 3372           3541
cassandra               563            595
eclipse                 4044           4090
fop                     3986           3986
graphchi                3024           3024
h2                      3826           3712
h2o                     5750           5962
jme                     2209           2147
jython                  9734           9774
kafka                   3115           3493
luindex                 3380           3447
lusearch                3866           3381
pmd                     6497           5779
spring                  4771           4944
sunflow                 3088           3088
tomcat                  3375           3467
tradebeans              3348           3672
tradesoap               3480           3353
xalan                   3476           3106
zxing                   3741           4766
```

`zxing` results are volatile. I've made 3 additional runs:
```
Max. ResourceArea size in KB after C2 PhaseChaitin::merge_multidefs running DaCapo::zxing

Baseline:     3844 6146 5448
Pull Request: 6013 3615 4472
```

The fix passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests.
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le and AIX.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328085](https://bugs.openjdk.org/browse/JDK-8328085) needs maintainer approval

### Issue
 * [JDK-8328085](https://bugs.openjdk.org/browse/JDK-8328085): C2: Use after free in PhaseChaitin::Register_Allocate() (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3197/head:pull/3197` \
`$ git checkout pull/3197`

Update a local copy of the PR: \
`$ git checkout pull/3197` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3197`

View PR using the GUI difftool: \
`$ git pr show -t 3197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3197.diff">https://git.openjdk.org/jdk17u-dev/pull/3197.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3197#issuecomment-2587215409)
</details>
