### PR TITLE
8226933: [TEST_BUG]GTK L&F: There is no swatches or RGB tab in JColorChooser

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,6 @@
  */
 
 import java.awt.Color;
-import java.awt.Font;
 import javax.swing.JColorChooser;
 import javax.swing.UIManager;
 
@@ -30,40 +29,37 @@ import jtreg.SkippedException;
 
 /*
  * @test
- * @bug 4887836
+ * @bug 4419255
  * @library /java/awt/regtesthelpers /test/lib
  * @build PassFailJFrame
- * @summary Checks for white area under the JColorChooser Swatch tab
- * @run main/manual Test4887836
+ * @summary Tests if Metal Slider's thumb isn't clipped
+ * @run main/manual bug4419255
  */
 
-public class Test4887836 {
+public class bug4419255 {
 
     public static void main(String[] args) throws Exception {
 
         // ColorChooser UI design is different for GTK L&F.
-        // There is no Swatches tab available for GTK L&F, skip the testing.
+        // There is no RGB tab available for GTK L&F, skip the testing.
         if (UIManager.getLookAndFeel().getName().contains("GTK")) {
             throw new SkippedException("Test not applicable for GTK L&F");
         }
-
         String instructions = """
-                                If you do not see white area under the \"Swatches\" tab,
-                                then test passed, otherwise it failed.""";
+                Choose RGB tab. If sliders' thumbs are painted correctly
+                (top is not clipped, black line is visible),
+                then test passed. Otherwise it failed.""";
 
         PassFailJFrame.builder()
-                .title("Test4759306")
+                .title("bug4419255")
                 .instructions(instructions)
                 .columns(40)
-                .testUI(Test4887836::createColorChooser)
+                .testUI(bug4419255::createColorChooser)
                 .build()
                 .awaitAndCheck();
     }
 
     private static JColorChooser createColorChooser() {
-        JColorChooser chooser = new JColorChooser(Color.LIGHT_GRAY);
-
-        UIManager.put("Label.font", new Font("Font.DIALOG", 0, 36));
-        return chooser;
+        return new JColorChooser(Color.BLUE);
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8226933](https://bugs.openjdk.org/browse/JDK-8226933) needs maintainer approval

### Issue
 * [JDK-8226933](https://bugs.openjdk.org/browse/JDK-8226933): [TEST_BUG]GTK L&amp;F: There is no swatches or RGB tab in JColorChooser (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3198/head:pull/3198` \
`$ git checkout pull/3198`

Update a local copy of the PR: \
`$ git checkout pull/3198` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3198`

View PR using the GUI difftool: \
`$ git pr show -t 3198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3198.diff">https://git.openjdk.org/jdk17u-dev/pull/3198.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3198#issuecomment-2580657228)
</details>
