### PR TITLE
8327505: Test com/sun/jmx/remote/NotificationMarshalVersions/TestSerializationMismatch.java fails

### DIFF
--- a/test/jdk/com/sun/jmx/remote/NotificationMarshalVersions/Client/Client.java
+++ b/test/jdk/com/sun/jmx/remote/NotificationMarshalVersions/Client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
 public class Client {
+
+    public static final int COUNTER_TIMEOUT_SECONDS = 60;
+
     public static void run(String url) throws Exception {
         final int notifEmittedCnt = 10;
         final CountDownLatch counter = new CountDownLatch(notifEmittedCnt);
@@ -84,8 +87,8 @@ public class Client {
         System.out.println();
         try {
             System.out.println("waiting for " + notifEmittedCnt + " notifications to arrive");
-            if (!counter.await(30, TimeUnit.SECONDS)) {
-                throw new InterruptedException();
+            if (!counter.await(COUNTER_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw new Error("Client: Counter await expired");
             }
             if (duplNotification.get()) {
                 System.out.println("ERROR: received duplicated notifications");
@@ -94,7 +97,7 @@ public class Client {
             System.out.println("\nshutting down client");
         } catch (InterruptedException e) {
             System.out.println("ERROR: notification processing thread interrupted");
-            throw new Error("notification thread interrupted unexpectedly");
+            throw new Error("notification thread interrupted unexpectedly", e);
         }
     }
 }


### PR DESCRIPTION
This fix makes sense in 17, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8327505](https://bugs.openjdk.org/browse/JDK-8327505) needs maintainer approval

### Issue
 * [JDK-8327505](https://bugs.openjdk.org/browse/JDK-8327505): Test com/sun/jmx/remote/NotificationMarshalVersions/TestSerializationMismatch.java fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3202/head:pull/3202` \
`$ git checkout pull/3202`

Update a local copy of the PR: \
`$ git checkout pull/3202` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3202`

View PR using the GUI difftool: \
`$ git pr show -t 3202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3202.diff">https://git.openjdk.org/jdk17u-dev/pull/3202.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3202#issuecomment-2583287111)
</details>
