### PR TITLE
8324807: Manual printer tests have no Pass/Fail buttons, instructions close set 2

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/Collate2DPrintingTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/Collate2DPrintingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,63 +21,90 @@
  * questions.
  */
 
-/**
+import java.awt.Graphics;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.io.InputStream;
+import java.io.Reader;
+
+import javax.print.Doc;
+import javax.print.DocFlavor;
+import javax.print.DocPrintJob;
+import javax.print.PrintException;
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.attribute.DocAttributeSet;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.standard.Copies;
+import javax.print.attribute.standard.SheetCollate;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JOptionPane;
+
+/*
  * @test
  * @bug 6362683 8012381
  * @summary Collation should work.
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual Collate2DPrintingTest
  */
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import javax.print.attribute.standard.*;
-import javax.print.attribute.*;
-import javax.print.*;
-import java.io.*;
-
-public class Collate2DPrintingTest
-    extends Frame implements Doc, Printable, ActionListener {
-
-        Button print2D = new Button("2D Print");
-        Button printMerlin = new Button("PrintService");
-        PrinterJob pj = PrinterJob.getPrinterJob();
-        PrintService defService = null;
+public class Collate2DPrintingTest implements Doc, Printable {
+    private static JComponent createTestUI() {
         HashPrintRequestAttributeSet prSet = new HashPrintRequestAttributeSet();
-
-    public Collate2DPrintingTest() {
-
-        Panel butPanel = new Panel();
-        butPanel.add(print2D);
-        butPanel.add(printMerlin);
-        print2D.addActionListener(this);
-        printMerlin.addActionListener(this);
-        addWindowListener (new WindowAdapter() {
-            public void windowClosing (WindowEvent e) {
-                dispose();
-            }
-        });
-        add("South", butPanel);
-
-        defService = PrintServiceLookup.lookupDefaultPrintService();
-        PrintService[] pservice;
-        if (defService == null) {
-            pservice = PrintServiceLookup.lookupPrintServices(null, null);
-            if (pservice.length == 0) {
-                throw new RuntimeException("No printer found.  TEST ABORTED");
-            }
-            defService = pservice[0];
-        }
+        PrintService defService = PrintServiceLookup.lookupDefaultPrintService();
         prSet.add(SheetCollate.COLLATED);
         prSet.add(new Copies(2));
-        pj.setPrintable(Collate2DPrintingTest.this);
-        setSize(300, 200);
-        setVisible(true);
+
+        JButton print2D = new JButton("2D Print");
+        print2D.addActionListener((ae) -> {
+            try {
+                PrinterJob pj = PrinterJob.getPrinterJob();
+                pj.setPrintable(new Collate2DPrintingTest());
+                if (pj.printDialog(prSet)) {
+                    pj.print(prSet);
+                }
+            } catch (PrinterException ex) {
+                ex.printStackTrace();
+                String msg = "PrinterException: " + ex.getMessage();
+                JOptionPane.showMessageDialog(print2D, msg, "Error occurred",
+                        JOptionPane.ERROR_MESSAGE);
+                PassFailJFrame.forceFail(msg);
+            }
+        });
+
+        JButton printMerlin = new JButton("PrintService");
+        printMerlin.addActionListener((ae) -> {
+            try {
+                DocPrintJob pj = defService.createPrintJob();
+                pj.print(new Collate2DPrintingTest(), prSet);
+            } catch (PrintException ex) {
+                ex.printStackTrace();
+                String msg = "PrintException: " + ex.getMessage();
+                JOptionPane.showMessageDialog(printMerlin, msg, "Error occurred",
+                        JOptionPane.ERROR_MESSAGE);
+                PassFailJFrame.forceFail(msg);
+            }
+        });
+
+        Box main = Box.createVerticalBox();
+        main.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        main.add(Box.createVerticalGlue());
+        main.add(print2D);
+        main.add(Box.createVerticalStrut(4));
+        main.add(printMerlin);
+        main.add(Box.createVerticalGlue());
+        return main;
     }
 
-
+    @Override
     public int print(Graphics g, PageFormat pf, int pageIndex)
-          throws PrinterException {
+            throws PrinterException {
         g.drawString("Page: " + pageIndex, 100, 100);
         if (pageIndex == 2) {
             return Printable.NO_SUCH_PAGE;
@@ -86,168 +113,51 @@ public class Collate2DPrintingTest
         }
     }
 
-    public void actionPerformed (ActionEvent ae) {
-        try {
-            if (ae.getSource() == print2D) {
-                if (pj.printDialog(prSet)) {
-                    pj.print(prSet);
-                }
-            } else {
-                DocPrintJob pj = defService.createPrintJob();
-                pj.print(this, prSet);
-            }
-            System.out.println ("DONE");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
+    @Override
     public DocAttributeSet getAttributes() {
         return null;
     }
 
+    @Override
     public DocFlavor getDocFlavor() {
-        DocFlavor flavor = DocFlavor.SERVICE_FORMATTED.PRINTABLE;
-        return flavor;
+        return DocFlavor.SERVICE_FORMATTED.PRINTABLE;
     }
 
+    @Override
     public Object getPrintData() {
         return this;
     }
 
+    @Override
     public Reader getReaderForText() {
         return null;
     }
 
+    @Override
     public InputStream getStreamForBytes() {
         return null;
     }
 
-  public static void main( String[] args) {
+    private static final String INSTRUCTIONS =
+            "Click on the '2D Print' button.\n" +
+            "Choose copies as '2' with 'Collated' checkbox and Print\n" +
+            "\n" +
+            "Click on the 'PrintService', should get a print from default printer\n" +
+            "\n" +
+            "If you get only one copy or non 'Collated' prints from any of the above cases, " +
+            "test failed";
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "The print result should be collated."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-     new Collate2DPrintingTest();
-  }
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .splitUI(Collate2DPrintingTest::createTestUI)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 }
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.setVisible(true);
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.setVisible(true);
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      setVisible(true);
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/DrawImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/DrawImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,262 +21,119 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.awt.image.BufferedImageOp;
+import java.awt.image.RescaleOp;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+/*
  * @test
  * @bug 4329866
  * @key printer
  * @summary Confirm that no printing exception is generated.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual DrawImage
  */
+public class DrawImage {
+    private static final int OBJECT_BORDER = 15;
 
-import java.util.*;
-import java.text.*;
-import java.io.*;
-import java.net.*;
-import java.awt.*;
-import java.awt.font.*;
-import java.awt.geom.*;
-import java.awt.print.*;
-import java.awt.event.*;
-import java.awt.image.*;
-import java.awt.image.renderable.*;
-import javax.swing.*;
-import javax.swing.text.*;
-import javax.swing.border.*;
-import javax.swing.event.*;
+    private static final String INSTRUCTIONS =
+            "This test will automatically initiate a print\n\n" +
+            "Test passes if you get a printout of a gray rectangle\n" +
+            "with white text without any exception.";
 
-public class DrawImage
-{
-    protected static final double _hwBorder = 72 / 4;       // 1/4 inch
-    protected static final double _border = 72 / 4;         // 1/4 inch
-    protected static final int _objectBorder = 15;
-    protected static final int _verticalGap = 20;
-    protected static final int _textIndent = 150;
+    private final BufferedImage image;
+    private final PageFormat pageFormat;
 
-    protected BufferedImage _image;
-
-    protected PageFormat  _pageFormat;
-
-    public DrawImage(BufferedImage image) {
-        _image = image;
+    private DrawImage(BufferedImage image) {
+        this.image = image;
         PrinterJob pj = PrinterJob.getPrinterJob();
-        _pageFormat = pj.defaultPage();
+        pageFormat = pj.defaultPage();
+    }
 
- }
-
-
-    protected int printImage(Graphics g, PageFormat pf, BufferedImage image) {
-        Graphics2D g2D = (Graphics2D)g;
-        g2D.transform(new AffineTransform(_pageFormat.getMatrix()));
-
-        int paperW = (int)pf.getImageableWidth(), paperH =
-            (int)pf.getImageableHeight();
-
-        int x = (int)pf.getImageableX(), y = (int)pf.getImageableY();
-        g2D.setClip(x, y, paperW, paperH);
-
-        // print images
-        if (image != null ) {
-            int imageH = image.getHeight(), imageW = image.getWidth();
-            // make slightly smaller (25) than max possible width
-            float scaleFactor = ((float)((paperW - 25) - _objectBorder -
-                                         _objectBorder) / (float)(imageW));
-            int scaledW = (int)(imageW * scaleFactor),
-                scaledH = (int)(imageH *scaleFactor);
-            BufferedImageOp scaleOp = new RescaleOp(scaleFactor, 0, null);
-            g2D.drawImage(image, scaleOp, x + _objectBorder, y + _objectBorder);
-            y += _objectBorder + scaledH + _objectBorder;
-            return Printable.PAGE_EXISTS;
-        }
-        else {
+    private int printImage(Graphics g, PageFormat pf, int pageIndex) {
+        if (pageIndex > 0) {
             return Printable.NO_SUCH_PAGE;
         }
+
+        int paperW = (int) pageFormat.getImageableWidth();
+        int paperH = (int) pageFormat.getImageableHeight();
+        int x = (int) pageFormat.getImageableX();
+        int y = (int) pageFormat.getImageableY();
+
+        // Make the image slightly smaller (25) than max possible width
+        float scaleFactor = ((float) ((paperW - 25) - OBJECT_BORDER - OBJECT_BORDER)
+                                   / (float) (image.getWidth()));
+
+        BufferedImageOp scaleOp = new RescaleOp(scaleFactor, 0, null);
+
+        Graphics2D g2D = (Graphics2D) g;
+        g2D.transform(new AffineTransform(pageFormat.getMatrix()));
+        g2D.setClip(x, y, paperW, paperH);
+        g2D.drawImage(image, scaleOp, x + OBJECT_BORDER, y + OBJECT_BORDER);
+
+        return Printable.PAGE_EXISTS;
     }
 
-    public void print() {
-        try {
-            final PrinterJob pj = PrinterJob.getPrinterJob();
-            pj.setJobName("Print Image");
-            pj.setPrintable(new Printable() {
-                public int print(Graphics g, PageFormat pf, int pageIndex) {
-                    int result = NO_SUCH_PAGE;
-                    if (pageIndex == 0) {
-                        result = printImage(g, _pageFormat, _image);
-                    }
-                    return result;
-                }
-            });
-            if (pj.printDialog()) {
-                try { pj.print(); }
-                catch (PrinterException e) {
-                    System.out.println(e);
-                }
-            }
-
-        }
-        catch (Exception e) {
-            e.printStackTrace(System.out);
+    private void print() throws PrinterException {
+        final PrinterJob pj = PrinterJob.getPrinterJob();
+        pj.setJobName("Print Image");
+        pj.setPrintable(this::printImage);
+        if (pj.printDialog()) {
+            pj.print();
+        } else {
+            PassFailJFrame.forceFail("User cancelled printing");
         }
     }
 
-    public static void main(String[] args) {
-                                String[] instructions =
-           {
-            "You must have a printer available to perform this test.",
-            "The test passes if you get a printout of a gray rectangle",
-                                                "with white text without any exception."
-          };
-
-         Sysout.createDialog( );
-         Sysout.printInstructions( instructions );
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
         BufferedImage image = prepareFrontImage();
+
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
+
         DrawImage pt = new DrawImage(image);
         pt.print();
-        //      System.exit(0);
+        passFailJFrame.awaitAndCheck();
     }
 
-
-
-    public static BufferedImage prepareFrontImage() {
+    private static BufferedImage prepareFrontImage() {
         // build my own test images
         BufferedImage result = new BufferedImage(400, 200,
-                                                 BufferedImage.TYPE_BYTE_GRAY);
+                                   BufferedImage.TYPE_BYTE_GRAY);
+        int w = result.getWidth();
+        int h = result.getHeight();
 
-        Graphics2D g2D = (Graphics2D)result.getGraphics();
+        Graphics2D g2D = (Graphics2D) result.getGraphics();
         g2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                              RenderingHints.VALUE_ANTIALIAS_OFF);
-        int w = result.getWidth(), h = result.getHeight();
-
         g2D.setColor(Color.gray);
         g2D.fill(new Rectangle(0, 0, w, h));
-
         g2D.setColor(Color.white);
 
-        AffineTransform original = g2D.getTransform();
-        AffineTransform originXform = AffineTransform.getTranslateInstance(w /
-5, h / 5);
+        AffineTransform originXform = AffineTransform.getTranslateInstance(
+                w / 5.0, h / 5.0);
         g2D.transform(originXform);
-
-
         g2D.drawString("Front Side", 20, h / 2);
+        g2D.dispose();
 
         return result;
     }
-
-
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/DrawStringMethods.java
+++ b/test/jdk/java/awt/print/PrinterJob/DrawStringMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,31 +21,46 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.font.FontRenderContext;
+import java.awt.print.Book;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterJob;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+
+/*
  * @test
  * @bug 4185019
  * @key printer
  * @summary Confirm that all of the drawString methods on Graphics2D
  *          work for printer graphics objects.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual DrawStringMethods
  */
-
-import java.awt.*;
-import java.text.*;
-import java.awt.font.*;
-import java.awt.print.*;
-
 public class DrawStringMethods implements Printable {
+    private static final String INSTRUCTIONS =
+            " This test will automatically initiate a print.\n" +
+            "\n" +
+            " Confirm that the following methods are printed:\n" +
+            " For Graphics: drawString, drawString, drawChars, drawBytes\n" +
+            " For Graphics2D: drawString, drawString, drawGlyphVector";
 
-    public static void main(String args[]) {
-        String[] instructions =
-        {
-            "Confirm that the methods are printed.",
-            " For Graphics: drawString, drawString, drawChars, drawBytes",
-            " For Graphics2D: drawString, drawString, drawGlyphVector"
-        };
-        Sysout.createDialogWithInstructions( instructions );
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
 
         PrinterJob pjob = PrinterJob.getPrinterJob();
         PageFormat pf = pjob.defaultPage();
@@ -53,18 +68,16 @@ public class DrawStringMethods implements Printable {
 
         book.append(new DrawStringMethods(), pf);
         pjob.setPageable(book);
+        pjob.print();
 
-        try {
-            pjob.print();
-        } catch (PrinterException e) {
-            throw new RuntimeException(e.getMessage());
-        }
+        passFailJFrame.awaitAndCheck();
     }
 
-    public static AttributedCharacterIterator getIterator(String s) {
+    private static AttributedCharacterIterator getIterator(String s) {
         return new AttributedString(s).getIterator();
     }
 
+    @Override
     public int print(Graphics g, PageFormat pf, int pageIndex) {
         int ix = (int) pf.getImageableX();
         int iy = (int) pf.getImageableY();
@@ -93,7 +106,7 @@ public class DrawStringMethods implements Printable {
 
         iy += 30;
         s = "drawBytes(byte data[], int offset, int length, int x, int y)";
-        byte data[] = new byte[s.length()];
+        byte[] data = new byte[s.length()];
         for (int i = 0; i < data.length; i++) {
             data[i] = (byte) s.charAt(i);
         }
@@ -116,7 +129,7 @@ public class DrawStringMethods implements Printable {
 
             iy += 30;
             s = "drawString(AttributedCharacterIterator iterator, "+
-                           "float x, float y)";
+                "float x, float y)";
             g.drawLine(ix, iy, ix+10, iy);
             g2d.drawString(getIterator(s), (float) ix+20, (float) iy);
 
@@ -133,119 +146,3 @@ public class DrawStringMethods implements Printable {
         return PAGE_EXISTS;
     }
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog
- {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("South", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-     //chop up each into pieces maxSringLength long
-     remainingStr = instructions[ i ];
-     while( remainingStr.length() > 0 )
-      {
-        //if longer than max then chop off first max chars to print
-        if( remainingStr.length() >= maxStringLength )
-         {
-           //Try to chop on a word boundary
-           int posOfSpace = remainingStr.
-          lastIndexOf( ' ', maxStringLength - 1 );
-
-           if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-           printStr = remainingStr.substring( 0, posOfSpace + 1 );
-           remainingStr = remainingStr.substring( posOfSpace + 1 );
-         }
-        //else just print
-        else
-         {
-           printStr = remainingStr;
-           remainingStr = "";
-         }
-
-            instructionsText.append( printStr + "\n" );
-
-      }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/InvalidPage.java
+++ b/test/jdk/java/awt/print/PrinterJob/InvalidPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,223 +21,118 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Paper;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JOptionPane;
+
+/*
  * @test InvalidPage.java
  * @bug 4671634 6506286
  * @summary Invalid page format can crash win32 JRE
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual InvalidPage
  */
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-
-public class InvalidPage extends Frame implements Printable {
-
-  PrinterJob pJob;
-  PageFormat pf;
-
-  public InvalidPage() {
-    super ("Validate Page Test");
-    pJob = PrinterJob.getPrinterJob();
-    pf = pJob.defaultPage();
-    Paper p = pf.getPaper();
-    p.setImageableArea(0,0,p.getWidth(), p.getHeight());
-    pf.setPaper(p);
-    setLayout(new FlowLayout());
-    Panel panel = new Panel();
-    Button printButton = new Button ("Print");
-    printButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                    try {
-                         if (pJob.printDialog()) {
-                             pJob.setPrintable(InvalidPage.this, pf);
-                             pJob.print();
-                    }
-                    } catch (PrinterException pe ) {
-                    }
+public class InvalidPage implements Printable {
+    private static JComponent createTestUI() {
+        JButton b = new JButton("Print");
+        b.addActionListener((ae) -> {
+            try {
+                PrinterJob job = PrinterJob.getPrinterJob();
+                PageFormat pf = job.defaultPage();
+                Paper p = pf.getPaper();
+                p.setImageableArea(0, 0, p.getWidth(), p.getHeight());
+                pf.setPaper(p);
+                job.setPrintable(new InvalidPage(), pf);
+                if (job.printDialog()) {
+                    job.print();
                 }
-    });
-    panel.add (printButton);
-    add(panel);
+            } catch (PrinterException ex) {
+                ex.printStackTrace();
+                String msg = "PrinterException: " + ex.getMessage();
+                JOptionPane.showMessageDialog(b, msg, "Error occurred",
+                        JOptionPane.ERROR_MESSAGE);
+                PassFailJFrame.forceFail(msg);
+            }
+        });
 
-    addWindowListener (new WindowAdapter() {
-         public void windowClosing (WindowEvent e) {
-            dispose();
-            System.exit (0);
-         }
+        Box main = Box.createHorizontalBox();
+        main.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+        main.add(Box.createHorizontalGlue());
+        main.add(b);
+        main.add(Box.createHorizontalGlue());
+        return main;
+    }
 
-      });
-      setSize (200, 200);
-      setVisible (true);
-  }
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+        if (pageIndex > 1) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-  public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+        Graphics2D g2d = (Graphics2D) graphics;
+        g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+        g2d.drawString("ORIGIN", 30, 30);
+        g2d.drawString("X THIS WAY", 200, 50);
+        g2d.drawString("Y THIS WAY", 60, 200);
+        g2d.drawRect(0, 0,
+                (int) pageFormat.getImageableWidth(),
+                (int) pageFormat.getImageableHeight());
+        if (pageIndex == 0) {
+            g2d.setColor(Color.black);
+        } else {
+            g2d.setColor(new Color(0, 0, 0, 128));
+        }
+        g2d.drawRect(1, 1,
+                (int) pageFormat.getImageableWidth() - 2,
+                (int) pageFormat.getImageableHeight() - 2);
+        g2d.drawLine(0, 0,
+                (int) pageFormat.getImageableWidth(),
+                (int) pageFormat.getImageableHeight());
+        g2d.drawLine((int) pageFormat.getImageableWidth(), 0,
+                0, (int) pageFormat.getImageableHeight());
 
-     if (pageIndex > 1) {
-        return Printable.NO_SUCH_PAGE;
-     }
+        return Printable.PAGE_EXISTS;
+    }
 
-     Graphics2D g2d = (Graphics2D)graphics;
+    private static final String INSTRUCTIONS =
+            " Press the print button, which brings up a print dialog.\n" +
+            " In the dialog select a printer and press the print button.\n\n" +
+            " Repeat for all the printers as you have installed\n" +
+            " On Solaris and Linux just one printer is sufficient.\n\n" +
+            " Collect the output and examine it, each print job has two pages\n" +
+            " of very similar output, except that the 2nd page of the job may\n" +
+            " appear in a different colour, and the output near the edge of\n" +
+            " the page may be clipped. This is OK. Hold up both pieces of paper\n" +
+            " to the light and confirm that the lines and text (where present)\n" +
+            " are positioned identically on both pages\n\n" +
+            " The test fails if the output from the two\n" +
+            " pages of a job is aligned differently";
 
-     g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
-     g2d.drawString("ORIGIN", 30, 30);
-     g2d.drawString("X THIS WAY", 200, 50);
-     g2d.drawString("Y THIS WAY", 60 , 200);
-     g2d.drawRect(0,0,(int)pageFormat.getImageableWidth(),
-                      (int)pageFormat.getImageableHeight());
-     if (pageIndex == 0) {
-        g2d.setColor(Color.black);
-     } else {
-        g2d.setColor(new Color(0,0,0,128));
-     }
-     g2d.drawRect(1,1,(int)pageFormat.getImageableWidth()-2,
-                      (int)pageFormat.getImageableHeight()-2);
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-     g2d.drawLine(0,0,
-                  (int)pageFormat.getImageableWidth(),
-                  (int)pageFormat.getImageableHeight());
-     g2d.drawLine((int)pageFormat.getImageableWidth(),0,
-                   0,(int)pageFormat.getImageableHeight());
-     return  Printable.PAGE_EXISTS;
-  }
-
-  public static void main( String[] args) {
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "Press the print button, which brings up a print dialog and",
-         "in the dialog select a printer and press the print button",
-         "in the dialog. Repeat for as many printers as you have installed",
-         "On solaris and linux just one printer is sufficient",
-         "Collect the output and examine it, each print job has two pages",
-         "of very similar output, except that the 2nd page of the job may",
-         "appear in a different colour, and the output near the edge of",
-         "the page may be clipped. This is OK. Hold up both pieces of paper",
-         "to the light and confirm that the lines and text (where present)",
-         "are positioned identically on both pages",
-         "The test fails if the JRE crashes, or if the output from the two",
-         "pages of a job is aligned differently"
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-     new InvalidPage();
-  }
-
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(10)
+                .splitUI(InvalidPage::createTestUI)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/JobName/PrinterJobName.java
+++ b/test/jdk/java/awt/print/PrinterJob/JobName/PrinterJobName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,173 +21,55 @@
  * questions.
  */
 
-/**
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterJob;
+
+/*
  * @test
  * @bug 4205601
  * @summary setJobName should be used by PrinterJob
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual PrinterJobName
  */
-
-import java.awt.*;
-import java.awt.print.*;
-
 public class PrinterJobName implements Printable {
+    private static final String THE_NAME = "Testing the Job name setting";
 
+    private static final String INSTRUCTIONS =
+            "This test prints a page with a banner/job name of\n\n" +
+            THE_NAME;
 
-  static String theName = "Testing the Jobname setting";
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-  public static void main(String[] args) {
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
 
-       String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test prints a page with a banner/job name of",
-          theName
-       };
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setJobName(THE_NAME);
+        job.setPrintable(new PrinterJobName());
+        job.print();
+        passFailJFrame.awaitAndCheck();
+    }
 
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-      PrinterJob job = PrinterJob.getPrinterJob();
-      job.setJobName(theName);
-      job.setPrintable(new PrinterJobName());
-      try {
-          job.print();
-          System.out.println("PRINTING DONE.");
-      }
-      catch (Exception exc) {
-          System.out.println("Printer Exception");
-      }
-  }
-
-
+    @Override
     public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-      if (pgIndex > 0 ) {
-          return Printable.NO_SUCH_PAGE;
-      }
+        if (pgIndex > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-      double iw = pgFmt.getImageableWidth();
-      double ih = pgFmt.getImageableHeight();
-      Graphics2D g2d = (Graphics2D)g;
-      g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-      g2d.drawString("Name is: "+theName,20,20 );
-      return Printable.PAGE_EXISTS;
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+        g2d.drawString("Name is: " + THE_NAME, 20, 20);
+        return Printable.PAGE_EXISTS;
     }
-
 }
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/NumCopies.java
+++ b/test/jdk/java/awt/print/PrinterJob/NumCopies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,169 +21,56 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+/*
  * @test
  * @bug 4258003
  * @summary Checks the right number of copies are printed
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual NumCopies
  */
-
-import java.awt.*;
-import java.awt.print.*;
-
 public class NumCopies implements Printable {
+    private static final String INSTRUCTIONS =
+            "This test should print four pages, which are \n" +
+            "two copies of each page with the text :-\n" +
+            "'This is page number N', where N is 0 and 1.\n" +
+            "The pages should be uncollated.";
 
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new RuntimeException("Printer not configured or available.");
+        }
 
-  public static void main(String[] args) {
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .build();
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test should print a total of four pages which are two",
-         " copies of each of two pages which consist of the text :-",
-         "'This is page number N', where N is 0 and 1.",
-         "The pages should be uncollated."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-    PrinterJob job = PrinterJob.getPrinterJob();
-    job.setCopies(2);
-    job.setPrintable(new NumCopies());
-    try {
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setCopies(2);
+        job.setPrintable(new NumCopies());
         job.print();
+        passFailJFrame.awaitAndCheck();
     }
-    catch (Exception exc) {
-        System.out.println("Printer Exception");
+
+    @Override
+    public int print(Graphics g, PageFormat pf, int pageIndex)
+            throws PrinterException {
+        if (pageIndex > 1) {
+            return NO_SUCH_PAGE;
+        }
+        g.translate((int) pf.getImageableX(), (int) pf.getImageableY());
+        g.setColor(Color.black);
+        g.drawString("This is page number " + pageIndex, 50, 50);
+        return PAGE_EXISTS;
     }
-  }
-
-  public int print(Graphics g, PageFormat pf, int pageIndex)
-                   throws PrinterException {
-
-    if (pageIndex > 1) {
-         return NO_SUCH_PAGE;
-    }
-    g.translate((int)pf.getImageableX(), (int)pf.getImageableY());
-    g.setColor(Color.black);
-    g.drawString("This is page number " + Integer.toString(pageIndex), 50, 50);
-    return PAGE_EXISTS ;
-   }
-
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8324807](https://bugs.openjdk.org/browse/JDK-8324807) needs maintainer approval

### Issue
 * [JDK-8324807](https://bugs.openjdk.org/browse/JDK-8324807): Manual printer tests have no Pass/Fail buttons, instructions close set 2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3205/head:pull/3205` \
`$ git checkout pull/3205`

Update a local copy of the PR: \
`$ git checkout pull/3205` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3205`

View PR using the GUI difftool: \
`$ git pr show -t 3205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3205.diff">https://git.openjdk.org/jdk17u-dev/pull/3205.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3205#issuecomment-2586486690)
</details>
