### PR TITLE
8305853: java/text/Format/DateFormat/DateFormatRegression.java fails with "Uncaught exception thrown in test method Test4089106"

### DIFF
--- a/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import java.io.*;
  * @bug 4029195 4052408 4056591 4059917 4060212 4061287 4065240 4071441 4073003
  * 4089106 4100302 4101483 4103340 4103341 4104136 4104522 4106807 4108407
  * 4134203 4138203 4148168 4151631 4151706 4153860 4162071 4182066 4209272 4210209
- * 4213086 4250359 4253490 4266432 4406615 4413980 8008577
+ * 4213086 4250359 4253490 4266432 4406615 4413980 8008577 8305853
  * @library /java/text/testlib
  * @run main/othervm -Djava.locale.providers=COMPAT,SPI DateFormatRegression
  */
@@ -357,11 +357,11 @@ public class DateFormatRegression extends IntlTest {
     public void Test4089106() {
         TimeZone def = TimeZone.getDefault();
         try {
-            TimeZone z = new SimpleTimeZone((int)(1.25 * 3600000), "FAKEZONE");
-            TimeZone.setDefault(z);
+            TimeZone customTz = TimeZone.getTimeZone("GMT-08:15");
+            TimeZone.setDefault(customTz);
             SimpleDateFormat f = new SimpleDateFormat();
-            if (!f.getTimeZone().equals(z))
-                errln("Fail: SimpleTimeZone should use TimeZone.getDefault()");
+            if (!f.getTimeZone().equals(customTz))
+                errln("Fail: SimpleDateFormat should use TimeZone.getDefault()");
         }
         finally {
             TimeZone.setDefault(def);


### PR DESCRIPTION
I backport this to improve testing in 17.

Resolved Copyright, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8305853](https://bugs.openjdk.org/browse/JDK-8305853) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305853](https://bugs.openjdk.org/browse/JDK-8305853): java/text/Format/DateFormat/DateFormatRegression.java fails with "Uncaught exception thrown in test method Test4089106" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3213/head:pull/3213` \
`$ git checkout pull/3213`

Update a local copy of the PR: \
`$ git checkout pull/3213` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3213`

View PR using the GUI difftool: \
`$ git pr show -t 3213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3213.diff">https://git.openjdk.org/jdk17u-dev/pull/3213.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3213#issuecomment-2593403882)
</details>
