### PR TITLE
Backport 2f7ba781bf2e4e6d0fa658c19f86c6c05d60358a

### DIFF
--- a/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
+++ b/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

The code changes have already been backported with [8319567: Update java/lang/invoke tests to support vm flags](https://github.com/openjdk/jdk21u-dev/commit/998ba93aceda49759f2064cabbabe58f0919ad73) .

Only the Copyright remaining.  Let's do this to get the history clean.