### PR TITLE
8282314: nsk/jvmti/SuspendThread/suspendthrd003 may leak memory

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SuspendThread/suspendthrd003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,9 @@ public class suspendthrd003 extends DebugeeClass {
         int res = -1;
         long start_time = System.currentTimeMillis();
         while (System.currentTimeMillis() < start_time + (timeMax * 1000)) {
+            // Start each loop with a clear log buffer so we only
+            // track the run that can potentially fail:
+            log.clearLogBuffer();
             count++;
 
             // Original suspendthrd001 test block starts here:

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -472,6 +472,13 @@ public class Log extends FinalizableObject {
     }
 
     /////////////////////////////////////////////////////////////////
+
+    /**
+     * Clear all messages from log buffer.
+     */
+    public synchronized void clearLogBuffer() {
+        logBuffer.clear();
+    }
 
     /**
      * Print all messages from log buffer which were hidden because


### PR DESCRIPTION
I backport this to improve testing in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8282314](https://bugs.openjdk.org/browse/JDK-8282314) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282314](https://bugs.openjdk.org/browse/JDK-8282314): nsk/jvmti/SuspendThread/suspendthrd003 may leak memory (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3220/head:pull/3220` \
`$ git checkout pull/3220`

Update a local copy of the PR: \
`$ git checkout pull/3220` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3220`

View PR using the GUI difftool: \
`$ git pr show -t 3220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3220.diff">https://git.openjdk.org/jdk17u-dev/pull/3220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3220#issuecomment-2597673835)
</details>
