### PR TITLE
8294067: [macOS] javax/swing/JComboBox/6559152/bug6559152.java Cannot select an item from popup with the ENTER key.

### DIFF
--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -24,29 +24,32 @@
 /*
  * @test
  * @key headful
- * @bug 6559152
+ * @bug 6559152 8294067
  * @summary Checks that you can select an item in JComboBox with keyboard
  *          when it is a JTable cell editor.
  * @run main bug6559152
  */
 
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
 import javax.swing.DefaultCellEditor;
+import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
-import javax.swing.JComboBox;
+import javax.swing.JTable;
 import javax.swing.SwingUtilities;
 import javax.swing.table.DefaultTableModel;
-import javax.swing.JTable;
-import java.awt.Point;
-import java.awt.event.KeyEvent;
-import java.awt.event.InputEvent;
-import java.awt.Robot;
 
 public class bug6559152 {
     private static JFrame frame;
     private static JComboBox cb;
     private static Robot robot;
     private static Point p = null;
+    private static Dimension d;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -69,6 +72,7 @@ public class bug6559152 {
             try {
                 SwingUtilities.invokeAndWait(() -> {
                     p = comp.getLocationOnScreen();
+                    d = comp.getSize();
                 });
             } catch (IllegalStateException e) {
                 try {
@@ -97,7 +101,7 @@ public class bug6559152 {
     }
 
     private static void test() throws Exception {
-        robot.mouseMove(p.x, p.y);
+        robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
         robot.waitForIdle();
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8294067](https://bugs.openjdk.org/browse/JDK-8294067) needs maintainer approval

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8294067: [macOS] javax/swing/JComboBox/6559152/bug6559152.java Cannot select an item from popup with the ENTER key.`

### Issue
 * [JDK-8294067](https://bugs.openjdk.org/browse/JDK-8294067): [macOS] javax/swing/JComboBox/6559152/bug6559152.java Cannot select an item from popup with the ENTER key. (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3223/head:pull/3223` \
`$ git checkout pull/3223`

Update a local copy of the PR: \
`$ git checkout pull/3223` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3223`

View PR using the GUI difftool: \
`$ git pr show -t 3223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3223.diff">https://git.openjdk.org/jdk17u-dev/pull/3223.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3223#issuecomment-2598160456)
</details>
