### PR TITLE
8341316: [macos] javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java fails sometimes in macos

### DIFF
--- a/test/jdk/javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java
@@ -29,66 +29,64 @@
  * @run main ProgressMonitorEscapeKeyPress
  */
 
-import java.awt.AWTException;
-import java.awt.EventQueue;
-import java.awt.Robot;
-import java.awt.event.KeyEvent;
+
 import javax.swing.JFrame;
 import javax.swing.ProgressMonitor;
 import javax.swing.SwingUtilities;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class ProgressMonitorEscapeKeyPress {
 
+    static volatile int counter = 0;
     static ProgressMonitor monitor;
-    static int counter = 0;
-    static TestThread robotThread;
+    static TestThread testThread;
     static JFrame frame;
+    static CountDownLatch progressLatch;
+    static Robot robot;
 
 
     public static void main(String[] args) throws Exception {
-
-        createTestUI();
-
-        monitor = new ProgressMonitor(frame, "Progress", null, 0, 100);
-
-        robotThread = new TestThread();
-        robotThread.start();
-
-        for (counter = 0; counter <= 100; counter += 10) {
-            Thread.sleep(1000);
-
-            EventQueue.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    if (!monitor.isCanceled()) {
-                        monitor.setProgress(counter);
-                        System.out.println("Progress bar is in progress");
-                    }
-                }
-            });
-
-            if (monitor.isCanceled()) {
-                break;
+        try {
+            progressLatch = new CountDownLatch(20);
+            createTestUI();
+            robot = new Robot();
+            robot.setAutoDelay(50);
+            robot.setAutoWaitForIdle(true);
+            testThread = new TestThread();
+            testThread.start();
+            Thread.sleep(100);
+            if (progressLatch.await(15, TimeUnit.SECONDS)) {
+                System.out.println("Progress monitor completed 20%, lets press Esc...");
+                robot.keyPress(KeyEvent.VK_ESCAPE);
+                robot.keyRelease(KeyEvent.VK_ESCAPE);
+                System.out.println("ESC pressed....");
+            } else {
+                System.out.println("Failure : No status available from Progress monitor...");
+                throw new RuntimeException(
+                        "Can't get the status from Progress monitor even after waiting too long..");
             }
-        }
 
-        disposeTestUI();
-
-        if (counter >= monitor.getMaximum()) {
-            throw new RuntimeException("Escape key did not cancel the ProgressMonitor");
+            if (counter >= monitor.getMaximum()) {
+                throw new RuntimeException("Escape key did not cancel the ProgressMonitor");
+            }
+            System.out.println("Test Passed...");
+        } finally {
+            disposeTestUI();
         }
     }
 
-     private static void createTestUI() throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-           @Override
-           public void run() {
-                frame = new JFrame("Test");
-                frame.setSize(300, 300);
-                frame.setLocationByPlatform(true);
-                frame.setVisible(true);
-              }});
-     }
+    private static void createTestUI() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            frame = new JFrame("Test");
+            frame.setSize(300, 300);
+            monitor = new ProgressMonitor(frame, "Progress", "1", 0, 100);
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            frame.setLocationByPlatform(true);
+        });
+    }
 
 
      private static void disposeTestUI() throws Exception {
@@ -100,26 +98,25 @@ public class ProgressMonitorEscapeKeyPress {
 
 
 class TestThread extends Thread {
-
-    Robot testRobot;
-
-    TestThread() throws AWTException {
-        super();
-        testRobot = new Robot();
-    }
-
     @Override
     public void run() {
-        try {
-            // Sleep for 5 seconds - so that the ProgressMonitor starts
-            Thread.sleep(5000);
-
-            // Press and release Escape key
-            testRobot.keyPress(KeyEvent.VK_ESCAPE);
-            testRobot.delay(20);
-            testRobot.keyRelease(KeyEvent.VK_ESCAPE);
-        } catch (InterruptedException ex) {
-            throw new RuntimeException("Exception in TestThread");
+        System.out.println("TestThread started.........");
+        for (ProgressMonitorEscapeKeyPress.counter = 0;
+             ProgressMonitorEscapeKeyPress.counter <= 100;
+             ProgressMonitorEscapeKeyPress.counter += 1) {
+            ProgressMonitorEscapeKeyPress.robot.delay(100);
+            ProgressMonitor monitor = ProgressMonitorEscapeKeyPress.monitor;
+            if (!monitor.isCanceled()) {
+                monitor.setNote("" + ProgressMonitorEscapeKeyPress.counter);
+                monitor.setProgress(ProgressMonitorEscapeKeyPress.counter);
+                ProgressMonitorEscapeKeyPress.progressLatch.countDown();
+                System.out.println("Progress bar is in progress....."
+                        + ProgressMonitorEscapeKeyPress.counter + "%");
+            }
+            if (monitor.isCanceled()) {
+                System.out.println("$$$$$$$$$$$$$$$ Monitor canceled");
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341316](https://bugs.openjdk.org/browse/JDK-8341316) needs maintainer approval

### Issue
 * [JDK-8341316](https://bugs.openjdk.org/browse/JDK-8341316): [macos] javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java fails sometimes in macos (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3225/head:pull/3225` \
`$ git checkout pull/3225`

Update a local copy of the PR: \
`$ git checkout pull/3225` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3225`

View PR using the GUI difftool: \
`$ git pr show -t 3225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3225.diff">https://git.openjdk.org/jdk17u-dev/pull/3225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3225#issuecomment-2598170706)
</details>
