### PR TITLE
8341453: java/awt/a11y/AccessibleJTableTest.java fails in some cases where the test tables are not visible

### DIFF
--- a/test/jdk/java/awt/a11y/AccessibleJTableTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,22 +26,22 @@
  * @test
  * @bug 8267388
  * @summary Test implementation of NSAccessibilityTable protocol peer
- * @author Artem.Semenov@jetbrains.com
  * @run main/manual AccessibleJTableTest
  * @requires (os.family == "windows" | os.family == "mac")
  */
 
-import javax.swing.*;
-import javax.swing.event.TableModelEvent;
-import javax.swing.event.TableModelListener;
-import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableModel;
-
-import java.awt.*;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.AbstractTableModel;
 
 public class AccessibleJTableTest extends AccessibleComponentTest {
     private static final String[] columnNames = {"One", "Two", "Three"};
@@ -67,6 +67,7 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
                 + "If you can hear table cells ctrl+tab further and press PASS, otherwise press FAIL.\n";
 
         JTable table = new JTable(data, columnNames);
+        table.setPreferredScrollableViewportSize(table.getPreferredSize());
         JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());
         JScrollPane scrollPane = new JScrollPane(table);
@@ -82,12 +83,13 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
                 + "Turn screen reader on, and Tab to the table.\n"
                 + "Using arrow keys navigate to the last cell in the first row in the table."
                 + "Screen reader should announce it as \"Column 3 row 1\"\n\n"
-                + "Using mouse drag the header of the last culumn so the last column becomes the first one."
+                + "Using mouse drag the header of the last column so the last column becomes the first one."
                 + "Wait for the screen reader to finish announcing new position in table.\n\n"
                 + "If new position in table corresponds to the new table layout ctrl+tab further "
                 + "and press PASS, otherwise press FAIL.\n";
 
         JTable table = new JTable(data, columnNames);
+        table.setPreferredScrollableViewportSize(table.getPreferredSize());
         JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());
         JScrollPane scrollPane = new JScrollPane(table);
@@ -105,7 +107,9 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
                 + "If you can hear second table name: \"second table\" - ctrl+tab further and press PASS, otherwise press FAIL.\n";
 
         JTable table = new JTable(data, columnNames);
+        table.setPreferredScrollableViewportSize(table.getPreferredSize());
         JTable secondTable = new JTable(data, columnNames);
+        secondTable.setPreferredScrollableViewportSize(secondTable.getPreferredSize());
         secondTable.getAccessibleContext().setAccessibleName("Second table");
         JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());
@@ -126,8 +130,8 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
                 + "If you hear changes in the table - ctrl+tab further and press PASS, otherwise press FAIL.\n";
 
         JTable table = new JTable(new TestTableModel(3, 3));
-
-                JPanel panel = new JPanel();
+        table.setPreferredScrollableViewportSize(table.getPreferredSize());
+        JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());
         JScrollPane scrollPane = new JScrollPane(table);
         panel.add(scrollPane);


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

The issue addressed by this change is fixed.
But the test does not exactly do what is requested by the description.
Maybe the description is shaky, or mac behaves different from windows and
the description is not tailerd for this. E.g., it does not anouce the cell position if
entering the table. It does so when reordering the columns. Also, some of the
buttons in the third test are not visible. They work, though.
I verified this is the same if run on jdk head.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8341453](https://bugs.openjdk.org/browse/JDK-8341453) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341453](https://bugs.openjdk.org/browse/JDK-8341453): java/awt/a11y/AccessibleJTableTest.java fails in some cases where the test tables are not visible (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3226/head:pull/3226` \
`$ git checkout pull/3226`

Update a local copy of the PR: \
`$ git checkout pull/3226` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3226`

View PR using the GUI difftool: \
`$ git pr show -t 3226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3226.diff">https://git.openjdk.org/jdk17u-dev/pull/3226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3226#issuecomment-2598187256)
</details>
