### PR TITLE
8343599: Kmem limit and max values swapped when printing container information

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -225,9 +225,9 @@ void CgroupV1Subsystem::print_version_specific_info(outputStream* st) {
   jlong kmem_limit = kernel_memory_limit_in_bytes();
   jlong kmem_max_usage = kernel_memory_max_usage_in_bytes();
 
+  OSContainer::print_container_helper(st, kmem_limit, "kernel_memory_limit_in_bytes");
   OSContainer::print_container_helper(st, kmem_usage, "kernel_memory_usage_in_bytes");
-  OSContainer::print_container_helper(st, kmem_limit, "kernel_memory_max_usage_in_bytes");
-  OSContainer::print_container_helper(st, kmem_max_usage, "kernel_memory_limit_in_bytes");
+  OSContainer::print_container_helper(st, kmem_max_usage, "kernel_memory_max_usage_in_bytes");
 }
 
 char * CgroupV1Subsystem::cpu_cpuset_cpus() {


### PR DESCRIPTION
Backport of JDK-8343599 Kmem limit and max values swapped when printing container information

Clean backport. 
Passed tier1 tests. 
Passed gtests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343599](https://bugs.openjdk.org/browse/JDK-8343599) needs maintainer approval

### Issue
 * [JDK-8343599](https://bugs.openjdk.org/browse/JDK-8343599): Kmem limit and max values swapped when printing container information (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3227/head:pull/3227` \
`$ git checkout pull/3227`

Update a local copy of the PR: \
`$ git checkout pull/3227` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3227`

View PR using the GUI difftool: \
`$ git pr show -t 3227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3227.diff">https://git.openjdk.org/jdk17u-dev/pull/3227.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3227#issuecomment-2598611297)
</details>
