### PR TITLE
8325908: Finish removal of IntlTest and CollatorTest

### DIFF
--- a/test/jdk/java/text/BreakIterator/Bug4533872.java
+++ b/test/jdk/java/text/BreakIterator/Bug4533872.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 4533872 4640853
  * @summary Unit tests for supplementary character support (JSR-204) and Unicode 4.0 support
@@ -62,6 +62,7 @@ public class Bug4533872 {
     /*
      * Test for next(int n)
      */
+    @Test
     void TestNext() {
         iter = BreakIterator.getWordInstance(Locale.US);
 
@@ -84,6 +85,7 @@ public class Bug4533872 {
     /*
      * Test for isBoundary(int n)
      */
+    @Test
     void TestIsBoundary() {
         iter = BreakIterator.getWordInstance(Locale.US);
 
@@ -112,6 +114,7 @@ public class Bug4533872 {
     /*
      * Test mainly for next() and current()
      */
+    @Test
     void TestPrintEachForward() {
         iter = BreakIterator.getWordInstance(Locale.US);
 
@@ -151,6 +154,7 @@ public class Bug4533872 {
     /*
      * Test mainly for previous() and current()
      */
+    @Test
     void TestPrintEachBackward() {
         iter = BreakIterator.getWordInstance(Locale.US);
 
@@ -190,6 +194,7 @@ public class Bug4533872 {
     /*
      * Test mainly for following() and previous()
      */
+    @Test
     void TestPrintAt_1() {
         iter = BreakIterator.getWordInstance(Locale.US);
 
@@ -219,6 +224,7 @@ public class Bug4533872 {
     /*
      * Test mainly for preceding() and next()
      */
+    @Test
     void TestPrintAt_2() {
         iter = BreakIterator.getWordInstance(Locale.US);
 

--- a/test/jdk/java/text/Collator/APITest.java
+++ b/test/jdk/java/text/Collator/APITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,6 @@
  */
 
 /*
- * @test
- * @library /java/text/testlib
- * @summary test Collation API
- * @modules jdk.localedata
- * @run junit APITest
- */
-/*
 (C) Copyright Taligent, Inc. 1996 - All Rights Reserved
 (C) Copyright IBM Corp. 1996 - All Rights Reserved
 
@@ -39,6 +32,14 @@ technology is protected by multiple US and International patents. This notice an
 attribution to Taligent may not be removed.
   Taligent is a registered trademark of Taligent, Inc.
 */
+
+/*
+ * @test
+ * @library /java/text/testlib
+ * @summary test Collation API
+ * @modules jdk.localedata
+ * @run junit APITest
+ */
 
 import java.util.Locale;
 import java.text.Collator;
@@ -59,6 +60,7 @@ public class APITest {
         }
     }
 
+    @Test
     public final void TestProperty( )
     {
         Collator col = null;
@@ -134,6 +136,7 @@ public class APITest {
         System.out.println("Collator property test ended.");
     }
 
+    @Test
     public final void TestHashCode( )
     {
         System.out.println("hashCode tests begin.");
@@ -175,6 +178,7 @@ public class APITest {
     //----------------------------------------------------------------------------
     // ctor -- Tests the constructor methods
     //
+    @Test
     public final void TestCollationKey( )
     {
         System.out.println("testing CollationKey begins...");
@@ -214,6 +218,7 @@ public class APITest {
     //----------------------------------------------------------------------------
     // ctor -- Tests the constructor methods
     //
+    @Test
     public final void TestElemIter( )
     {
         System.out.println("testing sortkey begins...");
@@ -306,6 +311,7 @@ public class APITest {
         System.out.println("testing CollationElementIterator ends...");
     }
 
+    @Test
     public final void TestGetAll()
     {
         Locale[] list = Collator.getAvailableLocales();

--- a/test/jdk/java/text/Format/DateFormat/DateFormatRoundTripTest.java
+++ b/test/jdk/java/text/Format/DateFormat/DateFormatRoundTripTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,22 @@
  * @test
  * @summary test Date Format (Round Trip)
  * @bug 8008577
- * @run junit/othervm -Djava.locale.providers=COMPAT,SPI DateFormatRoundTripTest
+ * @run main/othervm -Djava.locale.providers=COMPAT,SPI DateFormatRoundTripTest
  */
 
-import java.text.*;
-import java.util.*;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
 
 public class DateFormatRoundTripTest {
 

--- a/test/jdk/java/text/Format/NumberFormat/BigDecimalFormat.java
+++ b/test/jdk/java/text/Format/NumberFormat/BigDecimalFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,11 @@
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.text.*;
-import java.util.*;
+import java.text.DecimalFormat;
+import java.text.FieldPosition;
+import java.text.MessageFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -98,6 +101,7 @@ public class BigDecimalFormat {
     /**
      * Test for normal big numbers which have the fraction part
      */
+    @Test
     void test_Format_in_NumberFormat_BigDecimal() {
         String from, to;
 
@@ -519,6 +523,7 @@ public class BigDecimalFormat {
     /**
      * Test for normal big numbers which have the fraction part with multiplier
      */
+    @Test
     void test_Format_in_NumberFormat_BigDecimal_usingMultiplier() {
         String from, to;
 
@@ -579,6 +584,7 @@ public class BigDecimalFormat {
     /**
      * Test for normal big numbers which don't have the fraction part
      */
+    @Test
     void test_Format_in_NumberFormat_BigInteger() {
         String from, to;
 
@@ -719,6 +725,7 @@ public class BigDecimalFormat {
      * Test for normal big numbers which don't have the fraction part with
      * multiplier
      */
+    @Test
     void test_Format_in_NumberFormat_BigInteger_usingMultiplier() {
         String from, to;
 
@@ -774,6 +781,7 @@ public class BigDecimalFormat {
      * Test for normal Long numbers when maximum and minimum digits are
      * specified
      */
+    @Test
     void test_Format_in_NumberFormat_Long_checkDigits() {
         String from, to;
 
@@ -889,6 +897,7 @@ public class BigDecimalFormat {
      *    Double.POSITIVE_INFINITY
      *    Double.NEGATIVE_INFINITY
      */
+    @Test
     void test_Format_in_NumberFormat_SpecialNumber() {
         String from, to;
 
@@ -931,6 +940,7 @@ public class BigDecimalFormat {
      *   (Formatting Long.MIN_VALUE w/ multiplier=-1 used to return a wrong
      *    number.)
      */
+    @Test
     void test_Format_in_NumberFormat_Other() {
         String from, to;
 
@@ -963,6 +973,7 @@ public class BigDecimalFormat {
     /**
      * Test for MessageFormat
      */
+    @Test
     void test_Format_in_MessageFormat() {
         MessageFormat mf = new MessageFormat(
             "  {0, number}\n" +

--- a/test/jdk/java/text/Format/NumberFormat/DFSExponential.java
+++ b/test/jdk/java/text/Format/NumberFormat/DFSExponential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 4068067
  * @summary test NumberFormat with exponential separator symbols. It also tests the new
@@ -30,37 +30,32 @@
  * @run junit DFSExponential
  */
 
-import java.util.*;
-import java.text.*;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class DFSExponential
-{
+public class DFSExponential {
 
-
-   public void DFSExponenTest() throws Exception {
+    @Test
+    public void TestDFSExponential() {
         DecimalFormatSymbols sym = new DecimalFormatSymbols(Locale.US);
-        String pat[] = { "0.####E0", "00.000E00", "##0.####E000", "0.###E0;[0.###E0]"  };
-        double val[] = { 0.01234, 123456789, 1.23e300, -3.141592653e-271 };
-        long lval[] = { 0, -1, 1, 123456789 };
-        String valFormat[][] = {
+        String[] pat = { "0.####E0", "00.000E00", "##0.####E000", "0.###E0;[0.###E0]"};
+        double[] val = { 0.01234, 123456789, 1.23e300, -3.141592653e-271};
+        String[][] valFormat = {
                 {"1.234x10^-2", "1.2346x10^8", "1.23x10^300", "-3.1416x10^-271"},
                 {"12.340x10^-03", "12.346x10^07", "12.300x10^299", "-31.416x10^-272"},
                 {"12.34x10^-003", "123.4568x10^006", "1.23x10^300", "-314.1593x10^-273"},
                 {"1.234x10^-2", "1.235x10^8", "1.23x10^300", "[3.142x10^-271]"},
         };
-
-
-        int ival = 0, ilval = 0;
         System.out.println("Default exponent separator: "+sym.getExponentSeparator());
         try {
             sym.setExponentSeparator("x10^");
         } catch (NullPointerException e){
             fail("null String was passed to set an exponent separator symbol");
-            throw new RuntimeException("Test Malfunction: null String was passed to set an exponent separator symbol" );
         }
         System.out.println("Current exponent separator: "+sym.getExponentSeparator());
 
@@ -69,19 +64,15 @@ public class DFSExponential
             System.out.println("     Pattern: " + fmt.toPattern());
             String locPattern = fmt.toLocalizedPattern();
             System.out.println("     Localized pattern: "+locPattern);
-            //fmt.applyLocalizedPattern(locPattern);
-            //System.out.println("      fmt.applyLocalizedPattern(): "+fmt.toLocalizedPattern());
-
             for (int v=0; v<val.length; ++v) {
                 String s = fmt.format(val[v]);
                 System.out.println("         " + val[v]+" --> "+s);
-                if(valFormat[p][v].equals(s)){
+                if (valFormat[p][v].equals(s)){
                     System.out.println(": Passed");
-                }else{
+                } else{
                    fail(" Failed: Should be formatted as "+valFormat[p][v]+ "but got "+s);
-                   throw new RuntimeException(" Failed: Should be formatted as "+valFormat[p][v]+ "but got "+s);
                 }
            }
-         } //end of the first for loop
-   }
+         }
+    }
 }

--- a/test/jdk/java/text/Format/NumberFormat/DFSSerialization.java
+++ b/test/jdk/java/text/Format/NumberFormat/DFSSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class DFSSerialization{
+
+    @Test
     public void TestDFSSerialization(){
         /*
          * 1. read from the object created using jdk1.4.2

--- a/test/jdk/java/util/TimeZone/Bug4322313.java
+++ b/test/jdk/java/util/TimeZone/Bug4322313.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,8 @@
  * @run junit Bug4322313
  */
 
-import java.io.*;
-import java.text.*;
-import java.util.*;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import org.junit.jupiter.api.Test;
 
@@ -84,6 +83,7 @@ public class Bug4322313 {
         "GMT+09:00 ",
     };
 
+    @Test
     void Test4322313() {
         Locale savedLocale = Locale.getDefault();
         TimeZone savedTimeZone = TimeZone.getDefault();
@@ -227,5 +227,4 @@ public class Bug4322313 {
             System.out.println("TimeZone.getTimeZone() test passed");
         }
     }
-
 }


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325908](https://bugs.openjdk.org/browse/JDK-8325908) needs maintainer approval

### Issue
 * [JDK-8325908](https://bugs.openjdk.org/browse/JDK-8325908): Finish removal of IntlTest and CollatorTest (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3229/head:pull/3229` \
`$ git checkout pull/3229`

Update a local copy of the PR: \
`$ git checkout pull/3229` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3229`

View PR using the GUI difftool: \
`$ git pr show -t 3229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3229.diff">https://git.openjdk.org/jdk17u-dev/pull/3229.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3229#issuecomment-2599739414)
</details>
