### PR TITLE
8334305: Remove all code for  nsk.share.Log verbose mode

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ public class MatMul {
     }
 
     public int run() {
-        log = new Log(System.out, verbose);
+        log = new Log(System.out);
         log.display("Parallel matrix multiplication test");
 
         Matrix a = Matrix.randomMatrix(dim);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launchnosuspend/launchnosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launchnosuspend/launchnosuspend001.java
@@ -71,7 +71,6 @@ public class launchnosuspend001 {
 
         argHandler = new ArgumentHandler(args);
         log = new Log(this.out, argHandler);
-        //log.enableVerbose(true);
     }
 
     private PrintStream out;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter_tagged/HeapFilter.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter_tagged/HeapFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,6 @@ public class HeapFilter extends DebugeeClass {
         log = new Log(out, argHandler);
         testObjects = new Object[]{new TaggedClass(),
                                    new UntaggedClass()};
-        log.enableVerbose(true);
         log.display("Verifying reachable objects.");
         status = checkStatus(status);
         testObjects = null;

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ public class isexceeded001 {
     public static int run(String[] argv, PrintStream out) {
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         Log log = new Log(out, argHandler);
-        log.enableVerbose(true);
 
         monitor = Monitor.getMemoryMonitor(log, argHandler);
         List pools = monitor.getMemoryPoolMBeans();

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ public class isexceeded001 {
     public static int run(String[] argv, PrintStream out) {
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         Log log = new Log(out, argHandler);
-        log.enableVerbose(true); // show log output
 
         MemoryMonitor monitor = Monitor.getMemoryMonitor(log, argHandler);
         List pools = monitor.getMemoryPoolMBeans();

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/lowmem/lowmem001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/lowmem/lowmem001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class lowmem001 extends ThreadedGCTest {
 
     @Override
     public void run() {
-        Log log = new Log(System.out, true);
+        Log log = new Log(System.out);
         // System.err is duplicated into buffer
         // it should be empty
         MyStream stream = new MyStream(System.err);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -191,6 +191,7 @@ public class Log extends FinalizableObject {
      * the given <code>argsHandler</code>.
      */
     public Log(PrintStream stream, ArgumentParser argsParser) {
+        this(stream);
         traceLevel = argsParser.getTraceLevel();
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -36,15 +36,9 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Vector;
 
-import nsk.share.test.LazyFormatString;
 
 /**
- * This class helps to print test-execution trace messages
- * and filter them when execution mode is not verbose.
- * <p>
- * Verbose mode if defined by providing <i>-verbose</i> command line
- * option, handled by <code>ArgumentParser</code>. Use <code>verbose()</code>
- * method to determine which mode is used.
+ * This class helps to print test-execution trace messages.
  * <p>
  * <code>Log</code> provides with two main methods to print messages:
  * <ul>
@@ -63,7 +57,6 @@ import nsk.share.test.LazyFormatString;
  * To provide printing messages from different sources into one log
  * with distinct prefixes use internal <code>Log.Logger</code> class.
  *
- * @see #verbose()
  * @see #complain(String)
  * @see #display(String)
  * @see ArgumentParser
@@ -77,18 +70,6 @@ public class Log extends FinalizableObject {
      */
     @Deprecated
     protected PrintStream out = null;
-
-    /**
-     * Is log-mode verbose?
-     * Always enabled.
-     */
-    private final boolean verbose = true;
-
-    /**
-     * Should log messages prefixed with timestamps?
-     * Always enabled.
-     */
-    private final boolean timestamp = true;
 
     /**
      * Names for trace levels
@@ -207,31 +188,13 @@ public class Log extends FinalizableObject {
 
     /**
      * Incarnate new Log for the given <code>stream</code>; and
-     * either for verbose or for non-verbose mode accordingly to
-     * the given <code>verbose</code> key.
-     */
-    public Log(PrintStream stream, boolean verbose) {
-        this(stream);
-    }
-
-    /**
-     * Incarnate new Log for the given <code>stream</code>; and
-     * either for verbose or for non-verbose mode accordingly to
      * the given <code>argsHandler</code>.
      */
     public Log(PrintStream stream, ArgumentParser argsParser) {
-        this(stream, argsParser.verbose());
         traceLevel = argsParser.getTraceLevel();
     }
 
     /////////////////////////////////////////////////////////////////
-
-    /**
-     * Return <i>true</i> if log mode is verbose.
-     */
-    public boolean verbose() {
-        return verbose;
-    }
 
     /**
      * Return <i>true</i> if printing errors summary at exit is enabled.
@@ -313,9 +276,6 @@ public class Log extends FinalizableObject {
     @Deprecated
     public synchronized void println(String message) {
         doPrint(message);
-        if (!verbose() && isVerboseOnErrorEnabled()) {
-            keepLog(composeLine(message));
-        }
     }
 
     /**
@@ -329,9 +289,6 @@ public class Log extends FinalizableObject {
      */
     @Deprecated
     public synchronized void comment(String message) {
-        if (!verbose()) {
-            doPrint(message);
-        }
     }
 
     /**
@@ -361,19 +318,10 @@ public class Log extends FinalizableObject {
     }
 
     /**
-     * Print <code>message</code> to the assigned output stream,
-     * if log mode is verbose. The <code>message</code> will be lost,
-     * if execution mode is non-verbose, and there is no error messages
-     * printed.
+     * Print <code>message</code> to the assigned output stream.
      */
     public synchronized void display(Object message) {
-        if (verbose()) {
-            doPrint(message.toString());
-        } else if (isVerboseOnErrorEnabled()) {
-            keepLog(composeLine(message.toString()));
-        } else {
-            // ignore
-        }
+        doPrint(message.toString());
     }
 
     /**
@@ -382,15 +330,6 @@ public class Log extends FinalizableObject {
      * into <code>errorsBuffer</code>.
      */
     public synchronized void complain(Object message) {
-        if (!verbose() && isVerboseOnErrorEnabled()) {
-            PrintStream stream = findOutStream();
-            stream.println("#>  ");
-            stream.println("#>  WARNING: switching log to verbose mode,");
-            stream.println("#>      because error is complained");
-            stream.println("#>  ");
-            stream.flush();
-            enableVerbose(true);
-        }
         String msgStr = message.toString();
         printError(msgStr);
         if (isErrorsSummaryEnabled()) {
@@ -458,10 +397,7 @@ public class Log extends FinalizableObject {
     /////////////////////////////////////////////////////////////////
 
     /**
-     * Redirect log to the given <code>stream</code>, and switch
-     * log mode to verbose.
-     * Prints errors summary to current stream, cancel current stream
-     * and switches to new stream. Turns on verbose mode for new stream.
+     * Redirect log to the given <code>stream</code>.
      *
      * @deprecated  This method is obsolete.
      */
@@ -478,20 +414,6 @@ public class Log extends FinalizableObject {
      */
     public synchronized void clearLogBuffer() {
         logBuffer.clear();
-    }
-
-    /**
-     * Print all messages from log buffer which were hidden because
-     * of non-verbose mode,
-     */
-    private synchronized void flushLogBuffer() {
-        if (!logBuffer.isEmpty()) {
-            PrintStream stream = findOutStream();
-            for (int i = 0; i < logBuffer.size(); i++) {
-                stream.println(logBuffer.elementAt(i));
-            }
-            stream.flush();
-        }
     }
 
     /**
@@ -518,18 +440,15 @@ public class Log extends FinalizableObject {
      * Compose line to print possible prefixing it with timestamp.
      */
     private String composeLine(String message) {
-        if (timestamp) {
-            long time = System.currentTimeMillis();
-            long ms = time % 1000;
-            time /= 1000;
-            long secs = time % 60;
-            time /= 60;
-            long mins = time % 60;
-            time /= 60;
-            long hours = time % 24;
-            return "[" + hours + ":" + mins + ":" + secs + "." + ms + "] " + message;
-        }
-        return message;
+        long time = System.currentTimeMillis();
+        long ms = time % 1000;
+        time /= 1000;
+        long secs = time % 60;
+        time /= 60;
+        long mins = time % 60;
+        time /= 60;
+        long hours = time % 24;
+        return "[" + hours + ":" + mins + ":" + secs + "." + ms + "] " + message;
     }
 
     /**
@@ -561,13 +480,6 @@ public class Log extends FinalizableObject {
                 throw new TestBug("Exception in Log.printError(): " + e);
             };
         }
-    }
-
-    /**
-     * Keep the given log <code>message</code> into <code>logBuffer</code>.
-     */
-    private synchronized void keepLog(String message) {
-        logBuffer.addElement(message);
     }
 
     /**
@@ -603,7 +515,7 @@ public class Log extends FinalizableObject {
      * Print errors summary if mode is verbose, flush and cancel output stream.
      */
     protected void finalize() {
-        if (verbose() && isErrorsSummaryEnabled()) {
+        if (isErrorsSummaryEnabled()) {
             printErrorsSummary();
         }
         if (out != null)

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODTestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class AODTestRunner {
     protected AODRunnerArgParser argParser;
 
     protected AODTestRunner(String[] args) {
-        log = new Log(System.out, true);
+        log = new Log(System.out);
 
         argParser = createArgParser(args);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AbstractJarAgent.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AbstractJarAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,7 +157,7 @@ abstract public class AbstractJarAgent {
         if (name == null)
             throw new TestBug("Agent name wasn't specified");
 
-        log = new Log(System.out, true);
+        log = new Log(System.out);
     }
 
     /*

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/DummyTargetApplication.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/DummyTargetApplication.java
@@ -39,7 +39,7 @@ it sends signal that it is ready for test and waits for signal permitting finish
  */
 public class DummyTargetApplication {
 
-    protected Log log = new Log(System.out, true);
+    protected Log log = new Log(System.out);
 
     protected AODTargetArgParser argParser;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/TargetApplicationWaitingAgents.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/TargetApplicationWaitingAgents.java
@@ -213,7 +213,7 @@ public class TargetApplicationWaitingAgents {
             if (targetApplicationInitialized)
                 throw new TestBug("TargetApplication already initialized");
 
-            log = new Log(System.out, true);
+            log = new Log(System.out);
 
             argParser = createArgParser(args);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/JVMTITest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/JVMTITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class JVMTITest {
 
         AgentsAttacher attacher = new AgentsAttacher(Utils.findCurrentVMIdUsingJPS(jdkPath),
                 agents,
-                new Log(System.out, true));
+                new Log(System.out));
         attacher.attachAgents();
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/coverage/parentheses/Parentheses.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/coverage/parentheses/Parentheses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class Parentheses {
 
     public void run() throws IOException, ReflectiveOperationException {
 
-        log = new Log(System.out, verbose);
+        log = new Log(System.out);
 
         InstructionSequence instructionSequence = null;
         for (int i = 0; i < iterations * stressOptions.getIterationsFactor(); i++) {


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

Resolved Log.java. Some code adaptions and additional changes needed to make it work.

I include JDK-8341412, as I need a review anyways. Tests mentioned in 8341412 all pass, too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8341412](https://bugs.openjdk.org/browse/JDK-8341412) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334305](https://bugs.openjdk.org/browse/JDK-8334305) needs maintainer approval

### Issues
 * [JDK-8334305](https://bugs.openjdk.org/browse/JDK-8334305): Remove all code for  nsk.share.Log verbose mode (**Enhancement** - P4 - Approved)
 * [JDK-8341412](https://bugs.openjdk.org/browse/JDK-8341412): Various test failures after JDK-8334305 (**Bug** - P1 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3231/head:pull/3231` \
`$ git checkout pull/3231`

Update a local copy of the PR: \
`$ git checkout pull/3231` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3231`

View PR using the GUI difftool: \
`$ git pr show -t 3231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3231.diff">https://git.openjdk.org/jdk17u-dev/pull/3231.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3231#issuecomment-2602482661)
</details>
