### PR TITLE
8321818: vmTestbase/nsk/stress/strace/strace015.java failed with 'Cannot read the array length because "<local4>" is null'

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,6 +155,11 @@ public class strace007 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,6 +159,11 @@ public class strace008 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,6 +159,11 @@ public class strace009 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace010.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace010.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,6 +177,11 @@ public class strace010 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace011.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace011.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,6 +178,11 @@ public class strace011 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace012.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace012.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -182,6 +182,11 @@ public class strace012 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace013.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace013.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,6 +170,11 @@ public class strace013 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace014.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace014.java
@@ -173,6 +173,11 @@ public class strace014 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,6 +174,11 @@ public class strace015 {
         StackTraceElement[] all;
         for (int i = 1; i < THRD_COUNT; i++) {
             all = (StackTraceElement[]) traces.get(threads[i]);
+            if (all == null) {
+                complain("No stacktrace for thread " + threads[i].getName() +
+                         " was found in the set of all traces");
+                return false;
+            }
             int k = all.length;
             if (count - k > 2) {
                 complain("wrong lengths of stack traces:\n\t"


### PR DESCRIPTION
Resolved. These tests were touched by virtual threads and two follow-up cleanups I do not want to backport.

I think it will be clean anyways.   Only context mismatches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321818](https://bugs.openjdk.org/browse/JDK-8321818) needs maintainer approval

### Issue
 * [JDK-8321818](https://bugs.openjdk.org/browse/JDK-8321818): vmTestbase/nsk/stress/strace/strace015.java failed with 'Cannot read the array length because "&lt;local4&gt;" is null' (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3234/head:pull/3234` \
`$ git checkout pull/3234`

Update a local copy of the PR: \
`$ git checkout pull/3234` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3234`

View PR using the GUI difftool: \
`$ git pr show -t 3234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3234.diff">https://git.openjdk.org/jdk17u-dev/pull/3234.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3234#issuecomment-2602615115)
</details>
