### PR TITLE
8346908: Update JDK 17 javadoc man page

### DIFF
--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -584,6 +584,12 @@ For example:
 .TP
 .B \f[CB]\-docfilessubdirs\f[R]
 Recursively copies doc\-file subdirectories.
+Enables deep copying of doc\-files directories.
+Subdirectories and all contents are recursively copied to the
+destination.
+For example, the directory \f[CB]doc\-files/example/images\f[R] and all of
+its contents are copied.
+There is also an option to exclude subdirectories.
 .RS
 .RE
 .TP
@@ -602,12 +608,7 @@ For example,
 .TP
 .B \f[CB]\-excludedocfilessubdir\f[R] \f[I]name\f[R]
 Excludes any doc files sub directories with the given name.
-Enables deep copying of doc\-files directories.
-Subdirectories and all contents are recursively copied to the
-destination.
-For example, the directory \f[CB]doc\-files/example/images\f[R] and all of
-its contents are copied.
-There is also an option to exclude subdirectories.
+See \f[B]\f[VB]-docfilessubdirs\f[B]\f[R].
 .RS
 .RE
 .TP


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

I "implemented" this based on the description in the bug.

Obviously the description of the flag ended up at the wrong one..

tested this by calling

man build/.../images/jdk/man/man1/javadoc.1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8346908](https://bugs.openjdk.org/browse/JDK-8346908) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346908](https://bugs.openjdk.org/browse/JDK-8346908): Update JDK 17 javadoc man page (**Sub-task** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3243/head:pull/3243` \
`$ git checkout pull/3243`

Update a local copy of the PR: \
`$ git checkout pull/3243` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3243`

View PR using the GUI difftool: \
`$ git pr show -t 3243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3243.diff">https://git.openjdk.org/jdk17u-dev/pull/3243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3243#issuecomment-2615014137)
</details>
