### PR TITLE
8315486: vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
@@ -51,20 +51,28 @@ public class forceEarlyReturn002a extends AbstractJDWPDebuggee {
 
             return true;
         } else if (command.equals(COMMAND_START_NEW_THREAD)) {
-            Thread thread = new Thread(new Runnable() {
-                public void run() {
-                    log.display("Thread exit");
-                }
-            });
-
-            thread.setName("forceEarlyReturn002a_NewThread");
-            thread.start();
+            testNewThread.start();
 
             return true;
         }
 
         return false;
     }
+
+    @Override
+    protected void init(String args[]) {
+        super.init(args);
+
+        // create thread for "NewThread" command in advance
+        testNewThread = new Thread(new Runnable() {
+            public void run() {
+                log.display("Thread exit");
+            }
+        });
+        testNewThread.setName("forceEarlyReturn002a_NewThread");
+    }
+
+    private static Thread testNewThread;
 
     private Thread testThreadInNative;
 


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315486](https://bugs.openjdk.org/browse/JDK-8315486) needs maintainer approval

### Issue
 * [JDK-8315486](https://bugs.openjdk.org/browse/JDK-8315486): vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3248/head:pull/3248` \
`$ git checkout pull/3248`

Update a local copy of the PR: \
`$ git checkout pull/3248` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3248`

View PR using the GUI difftool: \
`$ git pr show -t 3248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3248.diff">https://git.openjdk.org/jdk17u-dev/pull/3248.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3248#issuecomment-2619269616)
</details>
