### PR TITLE
8295176: some langtools test pollutes source tree

### DIFF
--- a/test/langtools/tools/javac/options/release/ReleaseOption.java
+++ b/test/langtools/tools/javac/options/release/ReleaseOption.java
@@ -1,10 +1,10 @@
 /**
  * @test /nodynamiccopyright/
  * @bug 8072480
- * @summary Verify that javac rejects Java 8 program with --release 7
+ * @summary Verify that javac rejects Java 17 program with --release 11
  * @compile ReleaseOption.java
- * @compile/fail/ref=ReleaseOption-release7.out -XDrawDiagnostics --release 7 -Xlint:-options ReleaseOption.java
+ * @compile/fail/ref=ReleaseOption.out -XDrawDiagnostics --release 11 ReleaseOption.java
  */
 
-interface ReleaseOption extends java.util.stream.Stream {
+interface ReleaseOption extends java.util.random.RandomGenerator {
 }

--- a/test/langtools/tools/javac/options/release/ReleaseOption.out
+++ b/test/langtools/tools/javac/options/release/ReleaseOption.out
@@ -1,0 +1,2 @@
+ReleaseOption.java:9:49: compiler.err.doesnt.exist: java.util.random
+1 error

--- a/test/langtools/tools/javac/options/release/ReleaseOptionThroughAPI.java
+++ b/test/langtools/tools/javac/options/release/ReleaseOptionThroughAPI.java
@@ -50,11 +50,11 @@ public class ReleaseOptionThroughAPI {
              PrintWriter outWriter = new PrintWriter(out)) {
             Iterable<? extends JavaFileObject> input =
                     fm.getJavaFileObjects(System.getProperty("test.src") + "/ReleaseOption.java");
-            List<String> options = Arrays.asList("--release", "7", "-XDrawDiagnostics", "-Xlint:-options");
+            List<String> options = Arrays.asList("--release", "11", "-XDrawDiagnostics", "-d", ".");
 
             compiler.getTask(outWriter, fm, null, options, null, input).call();
             String expected =
-                    "ReleaseOption.java:9:49: compiler.err.doesnt.exist: java.util.stream" + lineSep +
+                    "ReleaseOption.java:9:49: compiler.err.doesnt.exist: java.util.random" + lineSep +
                     "1 error" + lineSep;
             if (!expected.equals(out.toString())) {
                 throw new AssertionError("Unexpected output: " + out.toString());


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle

I had to resolve both java files as "[8173605: Remove support for source and target 1.7 option in javac](https://github.com/openjdk/jdk/commit/2d18dda3f2074a4f8b9a0c62ece9ac6d5284e93b)" is not in 17.

I think it's ok to raise the tested version to 11 as the change does. 
But the fix described in the bug title is achieved by adding the -d . in the command when 
javac is called through the API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8295176](https://bugs.openjdk.org/browse/JDK-8295176) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8295176: some langtools test pollutes source tree`

### Issue
 * [JDK-8295176](https://bugs.openjdk.org/browse/JDK-8295176): some langtools test pollutes source tree (**Bug** - P3 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3249/head:pull/3249` \
`$ git checkout pull/3249`

Update a local copy of the PR: \
`$ git checkout pull/3249` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3249`

View PR using the GUI difftool: \
`$ git pr show -t 3249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3249.diff">https://git.openjdk.org/jdk17u-dev/pull/3249.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3249#issuecomment-2620879069)
</details>
