### PR TITLE
8329692: Add more details to FrameStateTest.java test instructions

### DIFF
--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -21,15 +21,6 @@
  * questions.
  */
 
-/*
- * FrameStateTest.java
- *
- * summary: Checks that when setState(Frame.ICONIFIED) is called before
- *      setVisible(true) the Frame is shown in the proper iconified state.
- *      The problem was that it did not honor the initial iconic state, but
- *      instead was shown in the NORMAL state.
- */
-
 import java.awt.Button;
 import java.awt.Checkbox;
 import java.awt.CheckboxGroup;
@@ -52,9 +43,9 @@ import javax.swing.Timer;
  * @test
  * @bug 4157271
  * @summary Checks that when a Frame is created it honors the state it
- *       was set to. The bug was that if setState(Frame.ICONIFIED) was
- *       called before setVisible(true) the Frame would be shown in NORMAL
- *       state instead of ICONIFIED.
+ *          was set to. The bug was that if setState(Frame.ICONIFIED) was
+ *          called before setVisible(true) the Frame would be shown in NORMAL
+ *          state instead of ICONIFIED.
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual FrameStateTest
@@ -68,29 +59,33 @@ public class FrameStateTest implements ActionListener {
         setVisible(true) the Frame is shown in the proper iconified state.
         The problem was that it did not honor the initial iconic state, but
         instead was shown in the NORMAL state.
-        </p><hr/><p>
-
+        </p><hr/>
         Steps to try to reproduce this problem:
-        </p><p>
+        <p>
         Select the different options for the Frame:
             <ul>
-                <li><i>{Normal, Non-resizalbe}</i></li>
+                <li><i>{Normal, Non-resizable}</i></li>
                 <li><i>{Normal, Resizable}</i></li>
                 <li><i>{Iconified, Resizable}</i></li>
-                <li><i>{Iconified, Non-resizalbe}</i></li>
+                <li><i>{Iconified, Non-resizable}</i></li>
             </ul>
         After choosing the Frame's state click the
         Create Frame button.<br>
-        After the Frame (Frame State Test (Window2)) comes
-        up make sure the proper behavior occurred<br>
-        (Frame shown in proper state).<br>
+        After the Frame (Frame State Test (Window2)) comes up make sure the
+        proper behavior occurred (Frame shown in proper state).<br>
         Click the Dispose button to close the Frame.<br>
-
         </p><hr/><p>
 
-        Do the above steps for all the different Frame state combinations available.<br>
-        If you observe the proper behavior the test has passed, Press the Pass button.<br>
-        Otherwise the test has failed, Press the Fail button.
+        Do the above steps for all the different Frame state combinations
+        available.<br>
+        For "Hide, Iconify and Show" case, the frame is hidden then iconified
+        hence Window2 is not seen on-screen when shown as the frame is still
+        in the ICONIFIED state. Window2 is visible on-screen when it is restored
+        to NORMAL state as observed with "Hide, Iconify, Show and Restore" case.
+        <br><br>
+
+        If you observe the proper behavior for all the combinations,
+        press PASS else FAIL.<br>
         </p><p>
         Note: In Frame State Test (Window2) you can also chose the different
         buttons to see different Frame behavior.<br>An example of a problem that
@@ -106,9 +101,9 @@ public class FrameStateTest implements ActionListener {
     Button btnDispose = new Button("Dispose Frame");
     CheckboxGroup cbgState = new CheckboxGroup();
     CheckboxGroup cbgResize = new CheckboxGroup();
-    Checkbox cbIconState = new Checkbox("Frame state ICONIFIED", cbgState, true);
-    Checkbox cbNormState = new Checkbox("Frame state NORMAL", cbgState, false);
-    Checkbox cbNonResize = new Checkbox("Frame non-resizable", cbgResize, false);
+    Checkbox cbIconState = new Checkbox("Frame State ICONIFIED", cbgState, true);
+    Checkbox cbNormState = new Checkbox("Frame State NORMAL", cbgState, false);
+    Checkbox cbNonResize = new Checkbox("Frame Non-Resizable", cbgResize, false);
     Checkbox cbResize = new Checkbox("Frame Resizable", cbgResize, true);
 
     CreateFrame icontst;
@@ -116,12 +111,12 @@ public class FrameStateTest implements ActionListener {
     public static void main(String[] args) throws Exception {
         PassFailJFrame
                 .builder()
-                .title("GetBoundsResizeTest Instructions")
+                .title("Frame State and Size Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(10)
-                .rows(25)
+                .rows(27)
                 .columns(70)
-                .logArea(10)
+                .logArea(6)
                 .splitUIBottom(() -> new FrameStateTest().createPanel())
                 .build()
                 .awaitAndCheck();
@@ -149,7 +144,7 @@ public class FrameStateTest implements ActionListener {
         if (evt.getSource() == btnCreate) {
             btnCreate.setEnabled(false);
             btnDispose.setEnabled(true);
-            icontst =new CreateFrame(cbIconState.getState(), cbResize.getState());
+            icontst = new CreateFrame(cbIconState.getState(), cbResize.getState());
             icontst.setVisible(true);
         } else if (evt.getSource() == btnDispose) {
             btnCreate.setEnabled(true);
@@ -166,7 +161,7 @@ public class FrameStateTest implements ActionListener {
         String name = "Frame State Test";
 
         CreateFrame(boolean iconified, boolean resizable) {
-            setTitle("Frame State Test (Window 2)");
+            setTitle("Test Window (Window 2)");
 
             isResizable = resizable;
 
@@ -175,13 +170,13 @@ public class FrameStateTest implements ActionListener {
                     ((isResizable) ? "RESIZABLE" : "NON-RESIZABLE"));
 
             setLayout(new FlowLayout());
-            add(b1 = new Button("resizable"));
-            add(b2 = new Button("resize"));
-            add(b3 = new Button("iconify"));
-            add(b4 = new Button("iconify and restore"));
-            add(b5 = new Button("hide and show"));
-            add(b6 = new Button("hide, iconify and show"));
-            add(b7 = new Button("hide, iconify, show, and restore"));
+            add(b1 = new Button("Resizable"));
+            add(b2 = new Button("Resize"));
+            add(b3 = new Button("Iconify"));
+            add(b4 = new Button("Iconify and Restore"));
+            add(b5 = new Button("Hide and Show"));
+            add(b6 = new Button("Hide, Iconify and Show"));
+            add(b7 = new Button("Hide, Iconify, Show and Restore"));
             b1.addActionListener(this);
             b2.addActionListener(this);
             b3.addActionListener(this);
@@ -191,10 +186,9 @@ public class FrameStateTest implements ActionListener {
             b7.addActionListener(this);
             addWindowListener(this);
 
-            setBounds(100, 2, 200, 200);
+            setBounds(100, 2, 300, 200);
             setState(iconified ? Frame.ICONIFIED : Frame.NORMAL);
             setResizable(isResizable);
-            pack();
             setVisible(true);
         }
 
@@ -320,11 +314,11 @@ public class FrameStateTest implements ActionListener {
 
         public void stateLog(String message) {
             PassFailJFrame
-                .log("[State=%d] %s %s".formatted(getState(), name, message));
+                .log("[Current State = %d] %s %s".formatted(getState(), name, message));
         }
 
         public void stateLog() {
-            PassFailJFrame.log("[State=" + getState() + "]");
+            PassFailJFrame.log("[Current State = " + getState() + "]");
         }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329692](https://bugs.openjdk.org/browse/JDK-8329692) needs maintainer approval

### Issue
 * [JDK-8329692](https://bugs.openjdk.org/browse/JDK-8329692): Add more details to FrameStateTest.java test instructions (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3255/head:pull/3255` \
`$ git checkout pull/3255`

Update a local copy of the PR: \
`$ git checkout pull/3255` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3255`

View PR using the GUI difftool: \
`$ git pr show -t 3255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3255.diff">https://git.openjdk.org/jdk17u-dev/pull/3255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3255#issuecomment-2623788946)
</details>
