### PR TITLE
8320691: Timeout handler on Windows takes 2 hours to complete

### DIFF
--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -57,8 +57,8 @@ native.stack.args=-c "~*kP n;qd" -p %p
 native.stack.params.repeat=6
 
 native.core.app=cdb
-native.core.args=-c ".dump /f core.%p;qd" -p %p
-native.core.params.timeout=3600000
+native.core.args=-c ".dump /mA core.%p;qd" -p %p
+native.core.params.timeout=600000
 ################################################################################
 # environment info to gather
 ################################################################################


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8320691](https://bugs.openjdk.org/browse/JDK-8320691) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320691](https://bugs.openjdk.org/browse/JDK-8320691): Timeout handler on Windows takes 2 hours to complete (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3256/head:pull/3256` \
`$ git checkout pull/3256`

Update a local copy of the PR: \
`$ git checkout pull/3256` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3256`

View PR using the GUI difftool: \
`$ git pr show -t 3256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3256.diff">https://git.openjdk.org/jdk17u-dev/pull/3256.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3256#issuecomment-2624643178)
</details>
