### PR TITLE
8348905: Add support to specify the JDK for compiling Jtreg tests

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -78,6 +78,9 @@ $(eval $(call IncludeCustomExtension, RunTests.gmk))
 
 # This is the JDK that we will test
 JDK_UNDER_TEST := $(JDK_IMAGE_DIR)
+# The JDK used to compile jtreg test code. By default it is the same as
+# JDK_UNDER_TEST.
+JDK_FOR_COMPILE := $(JDK_IMAGE_DIR)
 
 TEST_RESULTS_DIR := $(OUTPUTDIR)/test-results
 TEST_SUPPORT_DIR := $(OUTPUTDIR)/test-support
@@ -882,6 +885,7 @@ define SetupRunJtregTestBody
       $$(JTREG_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
           -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
           $$($1_JTREG_BASIC_OPTIONS) \
+          -compilejdk:$$(JDK_FOR_COMPILE) \
           -testjdk:$$(JDK_UNDER_TEST) \
           -dir:$$(JTREG_TOPDIR) \
           -reportDir:$$($1_TEST_RESULTS_DIR) \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [cbe9ec53](https://github.com/openjdk/jdk/commit/cbe9ec530fc248be74766ff6ff32761cd415a6f0) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository. This backport support set to an alternative JDK directory that is different from the JDK running the tests through `JDK_FOR_COMPILE`, shows as below command.

```shell
make test CONF=linux-x86_64-server-fastdebug TEST="jtreg:test/hotspot/jtreg/native_sanity/JniVersion.java" JDK_IMAGE_DIR=$PWD/build/linux-x86_64-server-fastdebug/images/jdk JDK_FOR_COMPILE=$PWD/build/linux-x86_64-server-release/images/jdk
```

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8348905](https://bugs.openjdk.org/browse/JDK-8348905) needs maintainer approval

### Issue
 * [JDK-8348905](https://bugs.openjdk.org/browse/JDK-8348905): Add support to specify the JDK for compiling Jtreg tests (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3257/head:pull/3257` \
`$ git checkout pull/3257`

Update a local copy of the PR: \
`$ git checkout pull/3257` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3257`

View PR using the GUI difftool: \
`$ git pr show -t 3257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3257.diff">https://git.openjdk.org/jdk17u-dev/pull/3257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3257#issuecomment-2623954588)
</details>
