### PR TITLE
8345368: java/io/File/createTempFile/SpecialTempFile.java fails on Windows Server 2025

### DIFF
--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 
 import jdk.test.lib.Platform;
 import jdk.test.lib.OSVersion;
+import jdk.internal.util.StaticProperty;
 
 public class SpecialTempFile {
     private static void test(String name, String[] prefix, String[] suffix,
@@ -111,7 +112,7 @@ public class SpecialTempFile {
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
         boolean exceptionExpected =
-            !(System.getProperty("os.name").endsWith("11") ||
+            !(System.getProperty("os.name").matches("^.*[11|2025]$") ||
               new OSVersion(10, 0).compareTo(OSVersion.current()) > 0);
         test("ReservedName", resvPre, resvSuf, exceptionExpected);
     }


### PR DESCRIPTION
I backport this because we see reported problems on our Windows Server 2025 box.

Resolved because StaticProperty has no osName() in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345368](https://bugs.openjdk.org/browse/JDK-8345368) needs maintainer approval

### Issue
 * [JDK-8345368](https://bugs.openjdk.org/browse/JDK-8345368): java/io/File/createTempFile/SpecialTempFile.java fails on Windows Server 2025 (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3258/head:pull/3258` \
`$ git checkout pull/3258`

Update a local copy of the PR: \
`$ git checkout pull/3258` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3258`

View PR using the GUI difftool: \
`$ git pr show -t 3258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3258.diff">https://git.openjdk.org/jdk17u-dev/pull/3258.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3258#issuecomment-2624406986)
</details>
