### PR TITLE
8346671: java/nio/file/Files/probeContentType/Basic.java fails on Windows 2025

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 
 import jdk.test.lib.Platform;
 import jdk.test.lib.OSVersion;
+import jdk.internal.util.StaticProperty;
 
 /**
  * Uses Files.probeContentType to probe html file, custom file type, and minimal
@@ -82,7 +83,7 @@ public class Basic {
         if (!expected.equals(actual)) {
             if (!Platform.isWindows()) {
                 Path userMimeTypes =
-                    Paths.get(System.getProperty("user.home"), ".mime.types");
+                    Paths.get(StaticProperty.userHome(), ".mime.types");
                 checkMimeTypesFile(userMimeTypes);
 
                 Path etcMimeTypes = Paths.get("/etc/mime.types");
@@ -187,9 +188,10 @@ public class Basic {
         exTypes.add(new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")));
         // exTypes.add(new ExType("wasm", List.of("application/wasm")));  Note. "wasm" is added via JDK-8297609 (Java 20) which not exist in current java version yet
 
-        // extensions with content type that differs on Windows 11+
+        // extensions with content type that differs on Windows 11+ and
+        // Windows Server 2025
         if (Platform.isWindows() &&
-            (System.getProperty("os.name").endsWith("11") ||
+            (System.getProperty("os.name").matches("^.*[11|2025]$") ||
                 new OSVersion(10, 0).compareTo(OSVersion.current()) > 0)) {
             System.out.println("Windows 11+ detected: using different types");
             exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip", "application/x-compressed")));


### PR DESCRIPTION
I backport this because we see problems on our Windows Server 2025 test machines.

I had to resolve.
StaticProperty.osName() is not in 17.
Also, two changes are missing in 17:

[8287237: (fs) Files.probeContentType returns null if filename contains hash mark on Linux](https://github.com/openjdk/jdk/commit/8071b2311caaacd714d74f12aee6cb7c2fe700fa)
[8297609: Add application/wasm MIME type for wasm file extension](https://github.com/openjdk/jdk/commit/914ef07fed960f940e1591318b9f00938b37bf09)

I don't think these should be backported as prereq.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346671](https://bugs.openjdk.org/browse/JDK-8346671) needs maintainer approval

### Issue
 * [JDK-8346671](https://bugs.openjdk.org/browse/JDK-8346671): java/nio/file/Files/probeContentType/Basic.java fails on Windows 2025 (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3259/head:pull/3259` \
`$ git checkout pull/3259`

Update a local copy of the PR: \
`$ git checkout pull/3259` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3259`

View PR using the GUI difftool: \
`$ git pr show -t 3259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3259.diff">https://git.openjdk.org/jdk17u-dev/pull/3259.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3259#issuecomment-2624491236)
</details>
