### PR TITLE
8340078: Open source several 2D tests

### DIFF
--- a/test/jdk/sun/java2d/GdiRendering/GdiBlitOffscreenTest.java
+++ b/test/jdk/sun/java2d/GdiRendering/GdiBlitOffscreenTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4725045
+ * @key headful
+ * @summary verifies that there are no artifacts due to using
+ * GDI for copies to the back buffer (GDI should only be used
+ * for copies to the screen)
+ * @run main GdiBlitOffscreenTest
+*/
+
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class GdiBlitOffscreenTest {
+
+    static volatile JFrame f;
+    static final int imageW = 100, imageH = 100, FW = 500, FH = 500;
+    static volatile BufferedImage greenImage;
+
+    public static void main(String[] args) throws Exception {
+
+        // First, create an image.
+        greenImage = new BufferedImage(imageW, imageH,
+                                       BufferedImage.TYPE_INT_RGB);
+        Graphics redG = greenImage.getGraphics();
+        redG.setColor(Color.green);
+        redG.fillRect(0, 0, imageW, imageH);
+        redG.setColor(Color.white);
+        redG.drawString("Passed!", 30, 80);
+
+        Robot robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(GdiBlitOffscreenTest::createUI);
+            robot.delay(1000);
+            robot.waitForIdle();
+            Point p = f.getLocationOnScreen();
+            Color c = robot.getPixelColor(p.x+FW/2, p.y+FH/2);
+            if (!c.equals(Color.green)) {
+                throw new RuntimeException("Color is " + c);
+            }
+        } finally {
+            if (f != null) {
+                SwingUtilities.invokeAndWait(f::dispose);
+            }
+        }
+    }
+
+    private static void createUI() {
+        f = new JFrame("GdiBlitOffscreenTest");
+        f.setSize(FW, FH);
+        f.setVisible(true);
+
+        // copy the image to the window.
+        Graphics g = f.getGraphics();
+        g.drawImage(greenImage, 0, 0, null);
+
+        // Now, get on with the rest of the test
+        JComponent app = new GdiBlitOffscreenTestComponent(imageW, imageH, greenImage);
+        app.setSize(500, 500);
+        f.getContentPane().add(app);
+        f.validate();
+        f.repaint();
+    }
+}
+
+class GdiBlitOffscreenTestComponent extends JComponent {
+
+    int imageW, imageH;
+    Image theImage;
+
+    public GdiBlitOffscreenTestComponent(int imageW, int imageH,
+                                         Image theImage)
+    {
+        this.theImage = theImage;
+        this.imageW = imageW;
+        this.imageH = imageH;
+    }
+
+    public void paintComponent(Graphics g) {
+        int imageX = (getWidth() - imageW) / 2;
+        int imageY = (getHeight() - imageH) / 2;
+        g.setColor(Color.blue);
+        g.fillRect(0, 0, getWidth(), getHeight());
+        g.setColor(Color.red);
+        g.fillRect(imageX, imageY, imageW, imageH);
+        g.setColor(Color.white);
+        g.drawString("Failed!", imageX + 30, imageY + 80);
+        g.drawImage(theImage, imageX, imageY, null);
+    }
+
+}

--- a/test/jdk/sun/java2d/GdiRendering/GdiLockTest.java
+++ b/test/jdk/sun/java2d/GdiRendering/GdiLockTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4693644
+ * @summary verifies that there are no artifacts due to copying with GDI
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual GdiLockTest
+*/
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.Graphics;
+
+public class GdiLockTest {
+
+        static final String INSTRUCTIONS = """
+            A window will open up next to these instructions.
+            The text you see in that window should blink on and off.
+            If it never disappears, then the test has failed.
+        """;
+
+    public static void main(String[] argv) throws Exception {
+        PassFailJFrame.builder()
+                .title("GdiLockTest")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(5)
+                .columns(45)
+                .testUI(GdiLockTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("GdiLockTest");
+        f.setSize(300, 300);
+        GdiLockTestComponent test = new GdiLockTestComponent();
+        Thread t = new Thread(test);
+        f.add(test);
+        t.start();
+        return f;
+    }
+}
+
+class GdiLockTestComponent extends Component implements Runnable {
+
+    boolean textVisible = true;
+
+    public void paint(Graphics g) {
+        g.setColor(Color.white);
+        g.fillRect(0, 0, getWidth(), getHeight());
+        g.setColor(Color.black);
+        if (!textVisible) {
+            g.setClip(200, 200, 300, 300);
+        }
+        g.drawString("This text should be blinking", 10, 30);
+        if (!textVisible) {
+            g.setClip(0, 0, getWidth(), getHeight());
+        }
+    }
+
+    public void run() {
+        while (true) {
+            repaint();
+            textVisible = !textVisible;
+            try {
+                Thread.sleep(500);
+            } catch (Exception e) {}
+        }
+    }
+}

--- a/test/jdk/sun/java2d/SunGraphics2D/DrawRoundRect0Bug.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/DrawRoundRect0Bug.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4515761
+ * @summary verify that drawRoundRect produces correct output for 0 w/h
+ */
+
+import java.awt.Color;
+import static java.awt.Color.*;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+public class DrawRoundRect0Bug {
+
+    public static void main(String argv[]) {
+        BufferedImage img = new BufferedImage(250, 250, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = img.createGraphics();
+
+        g.setColor(white);
+        g.fillRect(0, 0, img.getWidth(), img.getHeight());
+
+        g.setColor(green);
+        g.drawLine(150, 90, 150, 110);
+        if (img.getRGB(150, 100) != green.getRGB()) {
+            throw new RuntimeException("Vertical line not green");
+        }
+
+        g.setColor(blue);
+        g.drawRoundRect(160, 90, 0, 20, 4, 4);
+        if (img.getRGB(160, 100) != blue.getRGB()) {
+            throw new RuntimeException("Vertical (ie zero width) round rect not blue");
+        }
+
+        g.setColor(green);
+        g.drawLine(150, 140, 170, 140);
+        if (img.getRGB(160, 140) != green.getRGB()) {
+            throw new RuntimeException("Horizontal line not green");
+        }
+
+        g.setColor(blue);
+        g.drawRoundRect(150, 150, 20, 0, 4, 4);
+        if (img.getRGB(160, 150) != blue.getRGB()) {
+            throw new RuntimeException("Horizontal (ie zero height) round rect not blue");
+        }
+    }
+
+}

--- a/test/jdk/sun/java2d/SunGraphics2D/RevalidateBug.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/RevalidateBug.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4652373
+ * @summary verify that SunGraphics2D survives surface revalidation
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RevalidateBug
+ * @requires (os.family == "windows")
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+
+public class RevalidateBug {
+
+    private static final String INSTRUCTIONS = """
+        This bug only reproduces on Windows systems with a task manager that can lock the computer.
+
+        This test draws a grayscale gradient in a window.
+
+        After the gradient becomes visible above, use ctrl-alt-del to bring up
+        the task manager and lock the computer.
+        Then unlock the computer and the gradient should be repainted to pass.
+
+        If the gradient does not appear after unlocking (or if the test gets
+        an error on its own after unlocking the computer) then it fails.
+        """;
+
+    public static void main(String[] argv) throws Exception {
+        PassFailJFrame.builder()
+                .title("RevalidateBug")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(12)
+                .columns(50)
+                .testUI(RevalidateBug::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createUI() {
+
+        JComponent comp = new JComponent() {
+
+            protected void paintComponent(Graphics g) {
+                super.paintComponent(g);
+                System.out.println("paintComponent");
+                Graphics2D g2d = (Graphics2D) g;
+
+                Insets insets = getInsets();
+                Rectangle rect =
+                    new Rectangle(insets.left, insets.top,
+                                  getWidth() - insets.right - insets.left,
+                                  getHeight() - insets.top - insets.bottom);
+                g2d.setPaint(new GradientPaint(rect.x, rect.y, Color.white,
+                                               rect.x + rect.width, rect.y, Color.black));
+
+                System.out.println(rect + " w:" + getWidth() + " h:"+getHeight());
+
+                g2d.fillRect(0, 0, getWidth(), getHeight());
+            }
+
+            public Dimension getPreferredSize() {
+                return new Dimension(500, 500);
+            }
+        };
+
+        JFrame f = new JFrame("RevalidateTest");
+        f.add(comp);
+        f.pack();
+        return f;
+    }
+
+}

--- a/test/jdk/sun/java2d/SunGraphics2D/ScaledPolyTest.java
+++ b/test/jdk/sun/java2d/SunGraphics2D/ScaledPolyTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4516037
+ * @summary verify that scaled Polygons honor the transform
+ */
+
+import java.awt.Color;
+import static java.awt.Color.*;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.awt.image.BufferedImage;
+
+public class ScaledPolyTest {
+
+    public static void main(String[] args) {
+
+        Polygon poly = new Polygon();
+        poly.addPoint(20, 10);
+        poly.addPoint(30, 30);
+        poly.addPoint(10, 30);
+        poly.addPoint(20, 10);
+
+        int height = 300;
+        int width = 300;
+        BufferedImage bi = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = bi.createGraphics();
+        g2d.setColor(Color.white);
+        g2d.fillRect(0, 0, bi.getWidth(), bi.getHeight());
+
+        g2d.translate(10, 10);
+        g2d.scale(2, 2);
+        g2d.setColor(Color.yellow);
+        g2d.fill(poly);
+        g2d.setColor(Color.blue);
+        g2d.draw(poly);
+
+        /*
+         * Examine each row of the image.
+         * If the stroked polygon is correctly aligned on the filled polygon,
+         * if there is anything except white on the line,
+         * the transition will always be white+->blue+->yellow*->blue*->white+
+         */
+        int bluePix = blue.getRGB();
+        int yellowPix = yellow.getRGB();
+        int whitePix = white.getRGB();
+        for (int y = 0; y < height; y++ ) {
+            int x = 0;
+            int pix = whitePix;
+
+            while (pix == whitePix && x < width) pix = bi.getRGB(x++, y);
+            if (pix == whitePix && x == width) continue; // all white row.
+
+            if (pix != bluePix) throw new RuntimeException("Expected blue");
+
+            while (pix == bluePix) pix = bi.getRGB(x++, y);
+
+            if (pix == yellowPix) {
+               while (pix == yellowPix) pix = bi.getRGB(x++, y);
+               if (pix != bluePix) throw new RuntimeException("Expected blue");
+               while (pix == bluePix) pix = bi.getRGB(x++, y);
+               if (pix != whitePix) throw new RuntimeException("Expected white");
+            }
+
+            while (pix == whitePix && x < width) pix = bi.getRGB(x++, y);
+            if (pix == whitePix && x == width) {
+                continue;
+            } else {
+                throw new RuntimeException("Expected white to finish the row");
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340078](https://bugs.openjdk.org/browse/JDK-8340078) needs maintainer approval

### Issue
 * [JDK-8340078](https://bugs.openjdk.org/browse/JDK-8340078): Open source several 2D tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3260/head:pull/3260` \
`$ git checkout pull/3260`

Update a local copy of the PR: \
`$ git checkout pull/3260` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3260`

View PR using the GUI difftool: \
`$ git pr show -t 3260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3260.diff">https://git.openjdk.org/jdk17u-dev/pull/3260.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3260#issuecomment-2624592485)
</details>
