### PR TITLE
8340547: Starting many threads can delay safepoints

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2862,9 +2862,10 @@ JVM_ENTRY(void, JVM_StartThread(JNIEnv* env, jobject jthread))
   // We must release the Threads_lock before we can post a jvmti event
   // in Thread::start.
   {
+    MutexLocker throttle_ml(UseThreadsLockThrottleLock ? ThreadsLockThrottle_lock : NULL);
     // Ensure that the C++ Thread and OSThread structures aren't freed before
     // we operate.
-    MutexLocker mu(Threads_lock);
+    MutexLocker ml(Threads_lock);
 
     // Since JDK 5 the java.lang.Thread threadStatus is used to prevent
     // re-starting an already started thread, so we should usually find

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2110,6 +2110,10 @@ const intx ObjectAlignmentInBytes = 8;
           "more eagerly at the cost of higher overhead. A value of 0 "      \
           "(default) disables native heap trimming.")                       \
           range(0, UINT_MAX)                                                \
+                                                                            \
+  product(bool, UseThreadsLockThrottleLock, true, DIAGNOSTIC,               \
+          "Use an extra lock during Thread start and exit to alleviate"     \
+          "contention on Threads_lock.")                                    \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -276,7 +276,7 @@ void mutex_init() {
   def(PerfDataManager_lock         , PaddedMutex  , leaf,        true,  _safepoint_check_always); // used for synchronized access to PerfDataManager resources
 
   def(Threads_lock                 , PaddedMonitor, barrier,     true,  _safepoint_check_always);  // Used for safepoint protocol.
-  def(ThreadsLockThrottle_lock     , PaddedMonitor, barrier,     true,  _safepoint_check_always);
+  def(ThreadsLockThrottle_lock     , PaddedMonitor, nonleaf,     false, _safepoint_check_always);
   def(NonJavaThreadsList_lock      , PaddedMutex,   barrier,     true,  _safepoint_check_never);
   def(NonJavaThreadsListSync_lock  , PaddedMutex,   leaf,        true,  _safepoint_check_never);
 

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -68,6 +68,7 @@ Mutex*   MethodData_lock              = NULL;
 Mutex*   TouchedMethodLog_lock        = NULL;
 Mutex*   RetData_lock                 = NULL;
 Monitor* VMOperation_lock             = NULL;
+Monitor* ThreadsLockThrottle_lock     = NULL;
 Monitor* Threads_lock                 = NULL;
 Mutex*   NonJavaThreadsList_lock      = NULL;
 Mutex*   NonJavaThreadsListSync_lock  = NULL;
@@ -275,6 +276,7 @@ void mutex_init() {
   def(PerfDataManager_lock         , PaddedMutex  , leaf,        true,  _safepoint_check_always); // used for synchronized access to PerfDataManager resources
 
   def(Threads_lock                 , PaddedMonitor, barrier,     true,  _safepoint_check_always);  // Used for safepoint protocol.
+  def(ThreadsLockThrottle_lock     , PaddedMonitor, barrier,     true,  _safepoint_check_always);
   def(NonJavaThreadsList_lock      , PaddedMutex,   barrier,     true,  _safepoint_check_never);
   def(NonJavaThreadsListSync_lock  , PaddedMutex,   leaf,        true,  _safepoint_check_never);
 

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -60,6 +60,8 @@ extern Mutex*   MethodData_lock;                 // a lock on installation of me
 extern Mutex*   TouchedMethodLog_lock;           // a lock on allocation of LogExecutedMethods info
 extern Mutex*   RetData_lock;                    // a lock on installation of RetData inside method data
 extern Monitor* VMOperation_lock;                // a lock on queue of vm_operations waiting to execute
+extern Monitor* ThreadsLockThrottle_lock;        // used by Thread start/exit to reduce competition for Threads_lock,
+                                                 // so a VM thread calling a safepoint is prioritized
 extern Monitor* Threads_lock;                    // a lock on the Threads table of active Java threads
                                                  // (also used by Safepoints too to block threads creation/destruction)
 extern Mutex*   NonJavaThreadsList_lock;         // a lock on the NonJavaThreads list


### PR DESCRIPTION
I'd like to backport this fix to fix the issue with starting a lot of threads in a burst. 

Despite the low priority of this issue, some users have found this to be a barrier to migrating from JDK8. 

The backport is not clean as it needs to adjust `globals.hpp` and replace `ConditionalMutexLocker` with classic MutexLocker. The rank `nonleaf` of `UseThreadsLockThrottleLock` has been chosen to be as close as possible to the rank of `Threads_lock` and to not cause a crash in debug mode:
```
#  Internal Error (/home/ubuntu/jdk17u-dev/src/hotspot/share/runtime/mutex.cpp:398), pid=1777, tid=1782
#  assert(false) failed: Attempting to acquire lock Threads_lock/22 out of order with lock ThreadsLockThrottle_lock/22 -- possible deadlock
````

Field `_allow_vm_block` is set to `false` to prevent 
```
#  Internal Error (/home/ubuntu/jdk17u-dev/src/hotspot/share/runtime/thread.cpp:981), pid=56846, tid=56851
#  assert(false) failed: Possible safepoint reached by thread that does not allow it
```

Similar PR is on review at [jdk21](https://github.com/openjdk/jdk21u-dev/pull/1365)
Original fix and discussion are https://github.com/openjdk/jdk/pull/21111

Tested with tier1 (release), tier2(fastdebug), and reproducers from [JDK-8340547](https://bugs.openjdk.org/browse/JDK-8340547), [JDK-8307970](https://bugs.openjdk.org/browse/JDK-8307970)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8340547](https://bugs.openjdk.org/browse/JDK-8340547) needs maintainer approval

### Issue
 * [JDK-8340547](https://bugs.openjdk.org/browse/JDK-8340547): Starting many threads can delay safepoints (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3263/head:pull/3263` \
`$ git checkout pull/3263`

Update a local copy of the PR: \
`$ git checkout pull/3263` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3263`

View PR using the GUI difftool: \
`$ git pr show -t 3263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3263.diff">https://git.openjdk.org/jdk17u-dev/pull/3263.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3263#issuecomment-2630297852)
</details>
