### PR TITLE
8342988: GHA: Build JTReg in single step

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+name: 'Build JTReg'
+description: 'Build JTReg'
+
+runs:
+  using: composite
+  steps:
+    - name: 'Get JTReg version configuration'
+      id: version
+      uses: ./.github/actions/config
+      with:
+        var: JTREG_VERSION
+
+    - name: 'Check cache for already built JTReg'
+      id: get-cached
+      uses: actions/cache@v4
+      with:
+        path: jtreg/installed
+        key: jtreg-${{ steps.version.outputs.value }}
+
+    - name: 'Checkout the JTReg source'
+      uses: actions/checkout@v4
+      with:
+        repository: openjdk/jtreg
+        ref: jtreg-${{ steps.version.outputs.value }}
+        path: jtreg/src
+      if: (steps.get-cached.outputs.cache-hit != 'true')
+
+    - name: 'Build JTReg'
+      run: |
+        # Build JTReg and move files to the proper locations
+        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
+        mkdir ../installed
+        mv build/images/jtreg/* ../installed
+      working-directory: jtreg/src
+      shell: bash
+      if: (steps.get-cached.outputs.cache-hit != 'true')
+
+    - name: 'Upload JTReg artifact'
+      uses: actions/upload-artifact@v4
+      with:
+        name: bundles-jtreg-${{ steps.version.outputs.value }}
+        path: jtreg/installed
+        retention-days: 1

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -24,7 +24,7 @@
 #
 
 name: 'Get JTReg'
-description: 'Download JTReg from cache or source location'
+description: 'Get JTReg'
 outputs:
   path:
     description: 'Path to the installed JTReg'
@@ -39,36 +39,12 @@ runs:
       with:
         var: JTREG_VERSION
 
-    - name: 'Check cache for JTReg'
-      id: get-cached-jtreg
-      uses: actions/cache@v4
+    - name: 'Download JTReg artifact'
+      id: download-jtreg
+      uses: actions/download-artifact@v4
       with:
+        name: bundles-jtreg-${{ steps.version.outputs.value }}
         path: jtreg/installed
-        key: jtreg-${{ steps.version.outputs.value }}
-
-    - name: 'Checkout the JTReg source'
-      uses: actions/checkout@v4
-      with:
-        repository: openjdk/jtreg
-        ref: jtreg-${{ steps.version.outputs.value }}
-        path: jtreg/src
-      if: steps.get-cached-jtreg.outputs.cache-hit != 'true'
-
-    - name: 'Build JTReg'
-      run: |
-        # If runner architecture is x64 set JAVA_HOME_17_X64 otherwise set to JAVA_HOME_17_arm64
-        if [[ '${{ runner.arch }}' == 'X64' ]]; then
-          JDK="$JAVA_HOME_17_X64"
-        else
-          JDK="$JAVA_HOME_17_arm64"
-        fi
-        # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$JDK"
-        mkdir ../installed
-        mv build/images/jtreg/* ../installed
-      working-directory: jtreg/src
-      shell: bash
-      if: steps.get-cached-jtreg.outputs.cache-hit != 'true'
 
     - name: 'Export path to where JTReg is installed'
       id: path-name

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,8 @@ jobs:
   ### Determine platforms to include
   ###
 
-  select:
-    name: 'Select platforms'
+  prepare:
+    name: 'Prepare the run'
     runs-on: ubuntu-22.04
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
@@ -67,7 +67,19 @@ jobs:
       windows-aarch64: ${{ steps.include.outputs.windows-aarch64 }}
 
     steps:
-        # This function must be inlined in main.yml, or we'd be forced to checkout the repo
+      - name: 'Checkout the scripts'
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            make/conf/github-actions.conf
+
+      - name: 'Build JTReg'
+        id: jtreg
+        uses: ./.github/actions/build-jtreg
+
+      # TODO: Now that we are checking out the repo scripts, we can put the following code
+      # into a separate file
       - name: 'Check what jobs to run'
         id: include
         run: |
@@ -123,18 +135,18 @@ jobs:
 
   build-linux-x64:
     name: linux-x64
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
       gcc-major-version: '10'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-x64 == 'true'
+    if: needs.prepare.outputs.linux-x64 == 'true'
 
   build-linux-x86-hs:
     name: linux-x86-hs
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x86
@@ -148,11 +160,11 @@ jobs:
       extra-conf-options: '--with-target-bits=32'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-x86-hs == 'true'
+    if: needs.prepare.outputs.linux-x86-hs == 'true'
 
   build-linux-x64-hs-nopch:
     name: linux-x64-hs-nopch
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
@@ -162,11 +174,11 @@ jobs:
       extra-conf-options: '--disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-x64-variants == 'true'
+    if: needs.prepare.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-zero:
     name: linux-x64-hs-zero
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
@@ -176,11 +188,11 @@ jobs:
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-x64-variants == 'true'
+    if: needs.prepare.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-minimal:
     name: linux-x64-hs-minimal
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
@@ -190,11 +202,11 @@ jobs:
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-x64-variants == 'true'
+    if: needs.prepare.outputs.linux-x64-variants == 'true'
 
   build-linux-x64-hs-optimized:
     name: linux-x64-hs-optimized
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-linux.yml
     with:
       platform: linux-x64
@@ -205,22 +217,21 @@ jobs:
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-x64-variants == 'true'
+    if: needs.prepare.outputs.linux-x64-variants == 'true'
 
   build-linux-cross-compile:
     name: linux-cross-compile
-    needs:
-      - select
+    needs: prepare
     uses: ./.github/workflows/build-cross-compile.yml
     with:
       gcc-major-version: '10'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.linux-cross-compile == 'true'
+    if: needs.prepare.outputs.linux-cross-compile == 'true'
 
   build-macos-x64:
     name: macos-x64
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-x64
@@ -228,11 +239,11 @@ jobs:
       xcode-toolset-version: '14.3.1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.macos-x64 == 'true'
+    if: needs.prepare.outputs.macos-x64 == 'true'
 
   build-macos-aarch64:
     name: macos-aarch64
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-macos.yml
     with:
       platform: macos-aarch64
@@ -240,11 +251,11 @@ jobs:
       xcode-toolset-version: '15.4'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.macos-aarch64 == 'true'
+    if: needs.prepare.outputs.macos-aarch64 == 'true'
 
   build-windows-x64:
     name: windows-x64
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-x64
@@ -252,11 +263,11 @@ jobs:
       msvc-toolset-architecture: 'x86.x64'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.windows-x64 == 'true'
+    if: needs.prepare.outputs.windows-x64 == 'true'
 
   build-windows-aarch64:
     name: windows-aarch64
-    needs: select
+    needs: prepare
     uses: ./.github/workflows/build-windows.yml
     with:
       platform: windows-aarch64
@@ -266,7 +277,7 @@ jobs:
       extra-conf-options: '--openjdk-target=aarch64-unknown-cygwin'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.windows-aarch64 == 'true'
+    if: needs.prepare.outputs.windows-aarch64 == 'true'
 
   ###
   ### Test jobs


### PR DESCRIPTION
I want to backport this to reduce errors in gha runs.  The backport is based on the commit to 21.

I had to resolve becasue 8297984: Turn on warnings as errors for javadoc
is not in 17.
Omitted the edits in the code added by JDK-8297984.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342988](https://bugs.openjdk.org/browse/JDK-8342988) needs maintainer approval

### Issue
 * [JDK-8342988](https://bugs.openjdk.org/browse/JDK-8342988): GHA: Build JTReg in single step (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) Review applies to [48710d9a](https://git.openjdk.org/jdk17u-dev/pull/3264/files/48710d9a45716c90e168b04646ef26fdb0fee946)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3264/head:pull/3264` \
`$ git checkout pull/3264`

Update a local copy of the PR: \
`$ git checkout pull/3264` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3264`

View PR using the GUI difftool: \
`$ git pr show -t 3264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3264.diff">https://git.openjdk.org/jdk17u-dev/pull/3264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3264#issuecomment-2639962524)
</details>
