### PR TITLE
8330702: Update failure handler to don't generate Error message if cores actions are empty

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/action/ActionSet.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/action/ActionSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,8 +104,11 @@ public class ActionSet implements ProcessInfoGatherer, EnvironmentInfoGatherer, 
 
     private String[] getTools(PrintWriter writer, Properties p, String key) {
         String value = p.getProperty(key);
-        if (value == null || value.isEmpty()) {
-            writer.printf("ERROR: '%s' property is empty%n", key);
+        if (value == null) {
+            writer.printf("ERROR: '%s' property is not set%n", key);
+            return new String[]{};
+        }
+        if (value.isEmpty()) {
             return new String[]{};
         }
         return value.split(" ");

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,8 @@ native.stack.params.repeat=6
 native.core.app=cdb
 native.core.args=-c ".dump /mA core.%p;qd" -p %p
 native.core.params.timeout=600000
+
+cores=
 ################################################################################
 # environment info to gather
 ################################################################################


### PR DESCRIPTION
I backport this for parity with 17.0.13-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8330702](https://bugs.openjdk.org/browse/JDK-8330702) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330702](https://bugs.openjdk.org/browse/JDK-8330702): Update failure handler to don't generate Error message if cores actions are empty (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3265/head:pull/3265` \
`$ git checkout pull/3265`

Update a local copy of the PR: \
`$ git checkout pull/3265` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3265`

View PR using the GUI difftool: \
`$ git pr show -t 3265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3265.diff">https://git.openjdk.org/jdk17u-dev/pull/3265.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3265#issuecomment-2636802067)
</details>
