### PR TITLE
8314975: JavadocTester should set source path if not specified

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
+++ b/test/langtools/jdk/javadoc/doclet/testCopyFiles/TestCopyFiles.java
@@ -259,6 +259,7 @@ public class TestCopyFiles extends JavadocTester {
     public void testDocFilesInPackagesSource7UsingClassPath() {
         javadoc("-d", "packages-out-src7-cp",
                 "-source", "7",
+                "-sourcepath", testSrc("packages"),
                 "-classpath", testSrc("packages"),
                 "p1");
         checkExit(Exit.OK);

--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
@@ -422,12 +422,14 @@ public abstract class JavadocTester {
         String charsetArg = null;
         String docencodingArg = null;
         String encodingArg = null;
+        boolean haveSourcePath = false;
         for (int i = 0; i < args.length - 2; i++) {
             switch (args[i]) {
                 case "-d" -> outputDir = Path.of(args[++i]);
                 case "-charset" -> charsetArg = args[++i];
                 case "-docencoding" -> docencodingArg = args[++i];
                 case "-encoding" -> encodingArg = args[++i];
+                case "-sourcepath", "--source-path", "--module-source-path" -> haveSourcePath = true;
             }
         }
 
@@ -447,6 +449,16 @@ public abstract class JavadocTester {
             charset = Charset.forName(cs);
         } catch (UnsupportedCharsetException e) {
             charset = Charset.defaultCharset();
+        }
+
+        // explicitly set the source path if none specified
+        // to override the javadoc tool default to use the classpath
+        if (!haveSourcePath) {
+            var newArgs = new String[args.length + 2];
+            newArgs[0] = "-sourcepath";
+            newArgs[1] = testSrc;
+            System.arraycopy(args, 0, newArgs, 2, args.length);
+            args = newArgs;
         }
 
         out.println("args: " + Arrays.toString(args));


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

Add-on:

Our nightly testing found that TestCopyFiles.java is failing with this patch.
This concerns only the subtest  testDocFilesInPackagesSource7UsingClassPath().

This test is removed in later jdks by [JDK-8173605](https://bugs.openjdk.org/browse/JDK-8173605): Remove support for source and target 1.7 option in javac.

The test sets "-source 7" for the test run.  It tests that -classpath can 
be given to javadoc instead of -sourcepath.  This feature still exists in higher jdks,
I verified that the test is passing if either using "-source 8/9" or removing this flag (and undoing the edits of this change).

The edits of this change affect that -sourcepath is added to the javadoc command line, but the 
path used (testSrc) does not point to the proper sources. Thus the test fails.

I see several ways to repair this:
* add proper -sourcepath to the test.  This contradicts the purpose of this test, but makes it pass. See second commit.
* remove the test altogether as it is the case in later jdks.
* somehow implement a special case to avoid that JavadocTester adds -sourcepath to this test.

A somewhat bigger fix would be to add "-classpath" to the check for sourcepath in JavadocTester and add the testDocFilesInPackagesSource7UsingClassPath back again, but remove the -source setting from that test. I guess this should be done in head and backported to 24, 21 and 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314975](https://bugs.openjdk.org/browse/JDK-8314975) needs maintainer approval

### Issue
 * [JDK-8314975](https://bugs.openjdk.org/browse/JDK-8314975): JavadocTester should set source path if not specified (**Bug** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3266/head:pull/3266` \
`$ git checkout pull/3266`

Update a local copy of the PR: \
`$ git checkout pull/3266` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3266`

View PR using the GUI difftool: \
`$ git pr show -t 3266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3266.diff">https://git.openjdk.org/jdk17u-dev/pull/3266.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3266#issuecomment-2636822091)
</details>
