### PR TITLE
8349974: [JMH,17u] MaskQueryOperationsBenchmark fails java.lang.NoClassDefFoundError

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskQueryOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskQueryOperationsBenchmark.java
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskQueryOperationsBenchmark {
     @Param({"128","256","512"})
     int bits;


### PR DESCRIPTION
Hi all,

JMH tests org.openjdk.bench.jdk.incubator.vector.MaskQueryOperationsBenchmark report fails "java.lang.NoClassDefFoundError: jdk/incubator/vector/VectorSpecies" in jdk17u-dev repo.

This failure was fixed by [JDK-8284960](https://bugs.openjdk.org/browse/JDK-8284960) in main-line repo, I think it's not suitable backport [JDK-8284960](https://bugs.openjdk.org/browse/JDK-8284960) to jdk17u-dev. So I create this issue to fix failure.

Change has been verified locally, test-fix only, no risk.

Verify command:

```shell
build/linux-x86_64-server-release/images/jdk/bin/java -Djmh.ignoreLock=true -Djava.library.path=$PWD/build/linux-x86_64-server-release/images/test/micro/native --add-opens=java.base/java.io=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/sun.security.provider=ALL-UNNAMED --add-opens java.base/com.sun.crypto.provider=ALL-UNNAMED -jar $PWD/build/linux-x86_64-server-release/images/test/micro/benchmarks.jar -jvmArgsPrepend -Djava.library.path=$PWD/build/linux-x86_64-server-release/images/test/micro/native -t 1 -f 1 -wi 2 org.openjdk.bench.jdk.incubator.vector.MaskQueryOperationsBenchmark.testFirstTrueByte
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349974](https://bugs.openjdk.org/browse/JDK-8349974) needs maintainer approval

### Issue
 * [JDK-8349974](https://bugs.openjdk.org/browse/JDK-8349974): [JMH,17u] MaskQueryOperationsBenchmark fails java.lang.NoClassDefFoundError (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3277/head:pull/3277` \
`$ git checkout pull/3277`

Update a local copy of the PR: \
`$ git checkout pull/3277` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3277`

View PR using the GUI difftool: \
`$ git pr show -t 3277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3277.diff">https://git.openjdk.org/jdk17u-dev/pull/3277.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3277#issuecomment-2656002193)
</details>
