### PR TITLE
8301989: new javax.swing.text.DefaultCaret().setBlinkRate(N) results in NPE

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1050,7 +1050,7 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
             throw new IllegalArgumentException("Invalid blink rate: " + rate);
         }
         if (rate != 0) {
-            if (component.isEditable()) {
+            if (component != null && component.isEditable()) {
                 if (flasher == null) {
                     flasher = new Timer(rate, handler);
                 }
@@ -1065,7 +1065,7 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
                 flasher.removeActionListener(handler);
                 flasher = null;
             }
-            if (component.isEditable() && isBlinkRateSaved) {
+            if ((component == null || component.isEditable()) && isBlinkRateSaved) {
                 savedBlinkRate = 0;
                 isBlinkRateSaved = false;
             }

--- a/test/jdk/javax/swing/text/DefaultCaret/SetCaretRateTest.java
+++ b/test/jdk/javax/swing/text/DefaultCaret/SetCaretRateTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.swing.text.Caret;
+import javax.swing.text.DefaultCaret;
+
+/*
+ * @test
+ * @bug 8301989
+ * @summary Test checks that there is no exception happens
+ *          when setting blink rate on a javax.swing.DefaultCaret that is not
+ *          associated with any text component
+ * @run main SetCaretRateTest
+ */
+public class SetCaretRateTest {
+    public static void main(String[] args) {
+        Caret caret = new DefaultCaret();
+        caret.setBlinkRate(0);
+        caret.setBlinkRate(100);
+        caret.setBlinkRate(0);
+        caret = new DefaultCaret();
+        caret.setBlinkRate(100);
+        caret.setBlinkRate(0);
+        caret.setBlinkRate(100);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301989](https://bugs.openjdk.org/browse/JDK-8301989) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8301989: new javax.swing.text.DefaultCaret().setBlinkRate(N) results in NPE`

### Issue
 * [JDK-8301989](https://bugs.openjdk.org/browse/JDK-8301989): new javax.swing.text.DefaultCaret().setBlinkRate(N) results in NPE (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3284/head:pull/3284` \
`$ git checkout pull/3284`

Update a local copy of the PR: \
`$ git checkout pull/3284` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3284`

View PR using the GUI difftool: \
`$ git pr show -t 3284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3284.diff">https://git.openjdk.org/jdk17u-dev/pull/3284.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3284#issuecomment-2671504838)
</details>
