### PR TITLE
8338595: Add more linesize for MIME decoder in macro bench test Base64Decode

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/Base64Decode.java
+++ b/test/micro/org/openjdk/bench/java/util/Base64Decode.java
@@ -47,7 +47,7 @@ public class Base64Decode {
             "112", "512", "1000", "20000", "50000"})
     private int maxNumBytes;
 
-    @Param({"4"})
+    @Param({"4", "32", "76", "128"})
     private int lineSize;
 
     private byte[] lineSeparator = {'\r', '\n'};


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338595](https://bugs.openjdk.org/browse/JDK-8338595) needs maintainer approval

### Issue
 * [JDK-8338595](https://bugs.openjdk.org/browse/JDK-8338595): Add more linesize for MIME decoder in macro bench test Base64Decode (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3286/head:pull/3286` \
`$ git checkout pull/3286`

Update a local copy of the PR: \
`$ git checkout pull/3286` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3286`

View PR using the GUI difftool: \
`$ git pr show -t 3286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3286.diff">https://git.openjdk.org/jdk17u-dev/pull/3286.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3286#issuecomment-2671580730)
</details>
