### PR TITLE
8348675: TrayIcon tests fail in Ubuntu 24.10 Wayland

### DIFF
--- a/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
+++ b/test/jdk/java/awt/TrayIcon/ActionCommand/ActionCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,14 @@
  * questions.
  */
 
-import java.awt.*;
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
+
+import java.awt.AWTException;
+import java.awt.EventQueue;
+import java.awt.Point;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
 import java.awt.image.BufferedImage;
 
 /*
@@ -30,12 +37,18 @@ import java.awt.image.BufferedImage;
  * @summary Check the return value of the getActionCommand method
  *          of the ActionEvent triggered when TrayIcon is double clicked
  *          (single clicked, on Mac)
- * @author Dmitriy Ermashov (dmitriy.ermashov@oracle.com)
  * @modules java.desktop/java.awt:open
- * @library /lib/client ../
- * @library /java/awt/patchlib
- * @build java.desktop/java.awt.Helper
- * @build ExtendedRobot SystemTrayIconHelper
+ * @library
+ *          /java/awt/patchlib
+ *          /java/awt/TrayIcon
+ *          /lib/client
+ *          /test/lib
+ * @build
+ *          java.desktop/java.awt.Helper
+ *          jdk.test.lib.Platform
+ *          jtreg.SkippedException
+ *          ExtendedRobot
+ *          SystemTrayIconHelper
  * @run main ActionCommand
  */
 
@@ -44,32 +57,38 @@ public class ActionCommand {
     TrayIcon icon;
     ExtendedRobot robot;
 
-    boolean actionPerformed = false;
-    Object actionLock = new Object();
-    String actionCommand = null;
+    volatile boolean actionPerformed = false;
+    volatile String actionCommand = null;
+    final Object actionLock = new Object();
+
     static boolean isMacOS = false;
 
     public static void main(String[] args) throws Exception {
-        if (! SystemTray.isSupported()) {
-            System.out.println("SystemTray not supported on the platform under test. " +
-                    "Marking the test passed");
-        } else {
-            if (System.getProperty("os.name").toLowerCase().startsWith("win")) {
-                System.err.println("Test can fail if the icon hides to a tray icons pool " +
-                        "in Windows 7, which is behavior by default.\n" +
-                        "Set \"Right mouse click\" -> \"Customize notification icons\" -> " +
-                        "\"Always show all icons and notifications on the taskbar\" true to " +
-                        "avoid this problem. Or change behavior only for Java SE tray icon " +
-                        "and rerun test.");
-            } else  if (System.getProperty("os.name").toLowerCase().startsWith("mac")){
-                isMacOS = true;
-            } else if (SystemTrayIconHelper.isOel7orLater()) {
-                System.out.println("OEL 7 doesn't support double click in " +
-                        "systray. Skipped");
-                return;
-            }
-            new ActionCommand().doTest();
+        if (Platform.isOnWayland()) {
+            // The current robot implementation does not support
+            // clicking in the system tray area.
+            throw new SkippedException("Skipped on Wayland");
         }
+
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("SystemTray is not supported on this platform.");
+        }
+
+        if (Platform.isWindows()) {
+            System.err.println("Test can fail if the icon hides to a tray icons pool " +
+                    "in Windows 7, which is behavior by default.\n" +
+                    "Set \"Right mouse click\" -> \"Customize notification icons\" -> " +
+                    "\"Always show all icons and notifications on the taskbar\" true to " +
+                    "avoid this problem. Or change behavior only for Java SE tray icon " +
+                    "and rerun test.");
+        } else if (Platform.isOSX()){
+            isMacOS = true;
+        } else if (SystemTrayIconHelper.isOel7orLater()) {
+            System.out.println("OEL 7 doesn't support double click in " +
+                    "systray. Skipped");
+            throw new SkippedException("Skipped on OEL 7+");
+        }
+        new ActionCommand().doTest();
     }
 
     void doTest() throws Exception {
@@ -95,7 +114,7 @@ public class ActionCommand {
 
             icon.setActionCommand("Sample Command");
 
-            if (! "Sample Command".equals(icon.getActionCommand()))
+            if (!"Sample Command".equals(icon.getActionCommand()))
                 throw new RuntimeException("FAIL: getActionCommand did not return the correct value. " +
                         icon.getActionCommand() + " Expected: Sample Command");
 
@@ -117,7 +136,7 @@ public class ActionCommand {
         actionPerformed = false;
         SystemTrayIconHelper.doubleClick(robot);
 
-        if (! actionPerformed) {
+        if (!actionPerformed) {
             synchronized (actionLock) {
                 try {
                     actionLock.wait(3000);
@@ -125,7 +144,7 @@ public class ActionCommand {
                 }
             }
         }
-        if (! actionPerformed) {
+        if (!actionPerformed) {
             throw new RuntimeException("FAIL: ActionEvent not triggered when TrayIcon is "+(isMacOS? "" : "double ")+"clicked");
         } else if (! "Sample Command".equals(actionCommand)) {
             throw new RuntimeException("FAIL: ActionEvent.getActionCommand did not return the correct " +
@@ -140,7 +159,7 @@ public class ActionCommand {
             }
         });
 
-        robot.mouseMove(0, 0);
+        robot.mouseMove(100, 0);
         robot.waitForIdle();
         robot.mouseMove(iconPosition.x, iconPosition.y);
         robot.waitForIdle();
@@ -149,7 +168,7 @@ public class ActionCommand {
         actionCommand = null;
         SystemTrayIconHelper.doubleClick(robot);
 
-        if (! actionPerformed) {
+        if (!actionPerformed) {
             synchronized (actionLock) {
                 try {
                     actionLock.wait(3000);
@@ -157,7 +176,7 @@ public class ActionCommand {
                 }
             }
         }
-        if (! actionPerformed) {
+        if (!actionPerformed) {
             throw new RuntimeException("FAIL: ActionEvent not triggered when ActionCommand set to " +
                     "null and then TrayIcon is "+(isMacOS? "" : "double ")+ "clicked");
         } else if (actionCommand != null) {


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8348675](https://bugs.openjdk.org/browse/JDK-8348675) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348675](https://bugs.openjdk.org/browse/JDK-8348675): TrayIcon tests fail in Ubuntu 24.10 Wayland (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3289/head:pull/3289` \
`$ git checkout pull/3289`

Update a local copy of the PR: \
`$ git checkout pull/3289` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3289`

View PR using the GUI difftool: \
`$ git pr show -t 3289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3289.diff">https://git.openjdk.org/jdk17u-dev/pull/3289.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3289#issuecomment-2671741942)
</details>
