### PR TITLE
8350540: [17u,11u] B8312065.java fails Network is unreachable

### DIFF
--- a/test/jdk/java/net/Socket/B8312065.java
+++ b/test/jdk/java/net/Socket/B8312065.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2023, 2025, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
  * @bug 8312065
  * @summary Socket.connect does not timeout as expected when profiling (i.e. keep receiving signal)
  * @requires (os.family != "windows")
+ * @library /test/lib
+ * @build jtreg.SkippedException
  * @compile NativeThread.java
  * @run main/othervm/native/timeout=120 -Djdk.net.usePlainSocketImpl B8312065
  */
@@ -36,6 +38,8 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
+
+import jtreg.SkippedException;
 
 public class B8312065 {
     public static void main(String[] args) throws Exception {
@@ -83,6 +87,8 @@ public class B8312065 {
                 System.out.println("Test FAILED: duration " + duration + " ms, expected >= " + timeoutMillis + " ms");
                 System.exit(1);
             }
+        } catch (java.net.ConnectException e) {
+            throw new SkippedException("Network setup issue, skip this test", e);
         }
     }
 }


### PR DESCRIPTION
Hi all,

Test test/jdk/java/net/Socket/B8312065.java fails on some machines. Test assume 192.168.255.255 is not in use, but on some machines linux command `ping 192.168.255.255` will report "ping: connect: Network is unreachable" failure, so this test will report "java.net.ConnectException: Network is unreachable (connect failed)" failure. And this failure is not caused by JDK bug, so I think it's better throw `jtreg.SkippedException` when this failure reported.

Change has been verified locally, test-fix only to make test more robustness, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8350540](https://bugs.openjdk.org/browse/JDK-8350540) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350540](https://bugs.openjdk.org/browse/JDK-8350540): [17u,11u] B8312065.java fails Network is unreachable (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3293/head:pull/3293` \
`$ git checkout pull/3293`

Update a local copy of the PR: \
`$ git checkout pull/3293` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3293`

View PR using the GUI difftool: \
`$ git pr show -t 3293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3293.diff">https://git.openjdk.org/jdk17u-dev/pull/3293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3293#issuecomment-2676738625)
</details>
