### PR TITLE
8342635: javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java creates tmp file in src dir

### DIFF
--- a/test/jdk/javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java
+++ b/test/jdk/javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,9 +46,6 @@ public class WBMPStreamTruncateTest
     static final int height = 100;
     public static void main(String[] args) throws IOException
     {
-        String sep = System.getProperty("file.separator");
-        String dir = System.getProperty("test.src", ".");
-        String filePath = dir+sep;
         BufferedImage srcImage = new
                 BufferedImage(width, height, BufferedImage.TYPE_BYTE_BINARY);
         Graphics2D g = (Graphics2D) srcImage.getGraphics();
@@ -57,7 +54,7 @@ public class WBMPStreamTruncateTest
         g.dispose();
         // create WBMP image
         File imageFile = File.
-                createTempFile("test", ".wbmp", new File(filePath));
+                createTempFile("test", ".wbmp", new File("./"));
         imageFile.deleteOnExit();
         ImageIO.write(srcImage, "wbmp", imageFile);
         BufferedImage testImg =

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,18 +44,16 @@ public class WindowsDefaultIconSizeTest {
     }
 
     public void test() {
-        String sep = System.getProperty("file.separator");
-        String dir = System.getProperty("test.src", ".");
         String filename = "test.not";
 
-        File testFile = new File(dir + sep + filename);
+        File testFile = new File(filename);
         try {
             if (!testFile.exists()) {
                 testFile.createNewFile();
                 testFile.deleteOnExit();
             }
             FileSystemView fsv = FileSystemView.getFileSystemView();
-            Icon icon = fsv.getSystemIcon(new File(dir + sep + filename));
+            Icon icon = fsv.getSystemIcon(new File(filename));
             if (icon instanceof ImageIcon) {
                 Image image = ((ImageIcon) icon).getImage();
                 if (image instanceof MultiResolutionImage) {


### PR DESCRIPTION
I backport this for parity with 21.0.7-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8342634](https://bugs.openjdk.org/browse/JDK-8342634) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] [JDK-8342635](https://bugs.openjdk.org/browse/JDK-8342635) needs maintainer approval

### Issues
 * [JDK-8342635](https://bugs.openjdk.org/browse/JDK-8342635): javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java creates tmp file in src dir (**Bug** - P3 - Approved)
 * [JDK-8342634](https://bugs.openjdk.org/browse/JDK-8342634): javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java creates temp file in src dir (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3294/head:pull/3294` \
`$ git checkout pull/3294`

Update a local copy of the PR: \
`$ git checkout pull/3294` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3294`

View PR using the GUI difftool: \
`$ git pr show -t 3294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3294.diff">https://git.openjdk.org/jdk17u-dev/pull/3294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3294#issuecomment-2678348215)
</details>
