### PR TITLE
Backport f6e7713bb653811423eeb2515c2f69b437750326

### DIFF
--- a/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
+++ b/test/jdk/javax/net/ssl/SSLSocket/Tls13PacketSize.java
@@ -72,6 +72,10 @@ public class Tls13PacketSize extends SSLSocketTemplate {
 
         sslOS.write(appData);
         sslOS.flush();
+        int drained = 1;
+        while (drained < appData.length) {
+            drained += sslIS.read(appData, drained, appData.length - drained);
+        }
     }
 
     /*


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.