### PR TITLE
8344581: [TESTBUG] java/awt/Robot/ScreenCaptureRobotTest.java failing on macOS

### DIFF
--- a/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
+++ b/test/jdk/java/awt/Robot/ScreenCaptureRobotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,17 @@ import javax.imageio.ImageIO;
  * @bug 8342098
  * @summary Verify that the image captured from the screen using a Robot
  * and the source image are same.
+ * @requires os.family == "mac"
+ * @run main/othervm ScreenCaptureRobotTest
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8342098
+ * @summary Verify that the image captured from the screen using a Robot
+ * and the source image are same.
+ * @requires os.family != "mac"
  * @run main/othervm -Dsun.java2d.uiScale=1 ScreenCaptureRobotTest
  */
 public class ScreenCaptureRobotTest {
@@ -96,6 +107,7 @@ public class ScreenCaptureRobotTest {
 
     private static void doTest() throws Exception {
         Robot robot = new Robot();
+        robot.mouseMove(0, 0);
         robot.waitForIdle();
         robot.delay(500);
 


### PR DESCRIPTION
I backport this for parity with 17.0.15-oracle.

Not problem listed in 17, thus omitted PL change.
I will make this depend on 21 once pushed, and I assume it will turn out clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8344581](https://bugs.openjdk.org/browse/JDK-8344581) needs maintainer approval

### Issue
 * [JDK-8344581](https://bugs.openjdk.org/browse/JDK-8344581): [TESTBUG] java/awt/Robot/ScreenCaptureRobotTest.java failing on macOS (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3297/head:pull/3297` \
`$ git checkout pull/3297`

Update a local copy of the PR: \
`$ git checkout pull/3297` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3297`

View PR using the GUI difftool: \
`$ git pr show -t 3297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3297.diff">https://git.openjdk.org/jdk17u-dev/pull/3297.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3297#issuecomment-2678916745)
</details>
