### PR TITLE
Backport f529bf712d8946584999dfc98abea60c22c97167

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -157,6 +157,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
       FLAG_SET_DEFAULT(OnSpinWaitInstCount, 2);
     }
+    if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
+      FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
+    }
   }
 
   // ThunderX


### PR DESCRIPTION
Backport the commit to set -XX:+UseSignumIntrinsic by default for Ampere CPUs. It is to fix performance problem observed on JMH cases `vm.compiler.Signum|java.lang.*MathBench.sig[nN]um*`.  For example, `vm.compiler.Signum._1_signumFloatTest` thrpt score becomes 30x better on both jdk mainline and jdk17u-dev. The backporting can be very safe as it is limited to Ampere CPUs only and well verified on Ampere-1A with related jmh and jtreg tier1 tests.