### PR TITLE
8334560: [PPC64]: postalloc_expand_java_dynamic_call_sched does not copy all fields

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3507,6 +3507,7 @@ encode %{
     call->_oop_map           = _oop_map;
     call->_jvms              = _jvms;
     call->_jvmadj            = _jvmadj;
+    call->_has_ea_local_in_scope = _has_ea_local_in_scope;
     call->_in_rms            = _in_rms;
     call->_nesting           = _nesting;
     call->_override_symbolic_info = _override_symbolic_info;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [13dce296](https://github.com/openjdk/jdk/commit/13dce296fc3924b269757ce1279c57afe18faeeb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Richard Reingruber on 24 Jun 2024 and was reviewed by Matthias Baesken and Martin Doerr.

The fix passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, Renaissance Suite, and SAP specific tests.
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le.

Risk is low. The change affects only PPC64 and the field that is changed is only read in the JVMTI implementation. Also the change includes a regression test.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334560](https://bugs.openjdk.org/browse/JDK-8334560) needs maintainer approval

### Issue
 * [JDK-8334560](https://bugs.openjdk.org/browse/JDK-8334560): [PPC64]: postalloc_expand_java_dynamic_call_sched does not copy all fields (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3301/head:pull/3301` \
`$ git checkout pull/3301`

Update a local copy of the PR: \
`$ git checkout pull/3301` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3301`

View PR using the GUI difftool: \
`$ git pr show -t 3301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3301.diff">https://git.openjdk.org/jdk17u-dev/pull/3301.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3301#issuecomment-2690955408)
</details>
