### PR TITLE
8325435: [macos] Menu or JPopupMenu not closed when main window is resized

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1022,7 +1022,11 @@ AWT_ASSERT_APPKIT_THREAD;
             NSRect contentRect = [self.nsWindow contentRectForFrameRect:frame];
 
             // Check if the click happened in the non-client area (title bar)
-            if (p.y >= (frame.origin.y + contentRect.size.height)) {
+            // Also, non-client area includes the edges at left, right and botton of frame
+            if ((p.y >= (frame.origin.y + contentRect.size.height)) ||
+                (p.x >= (frame.origin.x + contentRect.size.width - 3)) ||
+                (fabs(frame.origin.x - p.x) < 3) ||
+                (fabs(frame.origin.y - p.y) < 3)) {
                 JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
                 jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
                 if (platformWindow != NULL) {

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8267374
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies menu closes when main window is resized
+ * @run main TestUngrab
+ */
+
+import java.awt.Point;
+import java.awt.Dimension;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+
+public class TestUngrab {
+    /**
+     * Menu (JMenuBar and JPopupMenu) not hidden when resizing the window.
+     * -> UngrabEvent not sent.
+     */
+    static JMenu menu;
+    static JFrame frame;
+    static volatile Point loc;
+    static volatile Point point;
+    static volatile Dimension dim;
+    static volatile int width;
+    static volatile int height;
+    static volatile boolean popupVisible;
+
+    private static void createAndShowGUI() {
+        frame = new JFrame();
+        JMenuBar mb = new JMenuBar();
+        menu = new JMenu("Menu");
+        menu.add(new JMenuItem("Item 1"));
+        menu.add(new JMenuItem("Item 2"));
+        mb.add(menu);
+
+        frame.setJMenuBar(mb);
+        frame.setSize(300, 300);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                point = menu.getLocationOnScreen();
+                dim = menu.getSize();
+            });
+            robot.mouseMove(point.x + dim.width / 2, point.y + dim.height / 2);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+
+            SwingUtilities.invokeAndWait(() -> {
+                loc = frame.getLocationOnScreen();
+                width = frame.getWidth();
+                height = frame.getHeight();
+            });
+            robot.mouseMove(loc.x + width, loc.y + height);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                popupVisible = menu.isPopupMenuVisible();
+            });
+            System.out.println("isPopupMenuVisible " + popupVisible);
+            if (popupVisible) {
+                throw new RuntimeException("popup menu not closed on resize");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
I would like to fix this mac issue

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325435](https://bugs.openjdk.org/browse/JDK-8325435) needs maintainer approval

### Issue
 * [JDK-8325435](https://bugs.openjdk.org/browse/JDK-8325435): [macos] Menu or JPopupMenu not closed when main window is resized (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3302/head:pull/3302` \
`$ git checkout pull/3302`

Update a local copy of the PR: \
`$ git checkout pull/3302` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3302`

View PR using the GUI difftool: \
`$ git pr show -t 3302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3302.diff">https://git.openjdk.org/jdk17u-dev/pull/3302.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3302#issuecomment-2687257361)
</details>
