### PR TITLE
8279894: javax/swing/JInternalFrame/8020708/bug8020708.java timeouts on Windows 11

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/8020708/bug8020708.java
+++ b/test/jdk/javax/swing/JInternalFrame/8020708/bug8020708.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import javax.swing.UIManager;
  * @summary NLS: mnemonics missing in SwingSet2/JInternalFrame demo
  * @library ../../regtesthelpers
  * @build Util
- * @run main bug8020708
+ * @run main/timeout=300 bug8020708
  */
 public class bug8020708 {
 
@@ -68,6 +68,7 @@ public class bug8020708 {
 
     public static void main(String[] args) throws Exception {
         for (Locale locale : SUPPORTED_LOCALES) {
+            System.out.println("locale: " + locale);
             for (String laf : LOOK_AND_FEELS) {
                 Locale.setDefault(locale);
                 if (!installLookAndFeel(laf)) {
@@ -80,7 +81,7 @@ public class bug8020708 {
 
     static void testInternalFrameMnemonic(Locale locale) throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(250);
+        robot.setAutoDelay(100);
         robot.setAutoWaitForIdle(true);
 
         SwingUtilities.invokeAndWait(new Runnable() {
@@ -142,6 +143,7 @@ public class bug8020708 {
         UIManager.LookAndFeelInfo[] infos = UIManager.getInstalledLookAndFeels();
         for (UIManager.LookAndFeelInfo info : infos) {
             if (info.getClassName().contains(lafName)) {
+                System.out.println("LookAndFeel: " + info.getClassName());
                 UIManager.setLookAndFeel(info.getClassName());
                 return true;
             }


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8279894](https://bugs.openjdk.org/browse/JDK-8279894) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279894](https://bugs.openjdk.org/browse/JDK-8279894): javax/swing/JInternalFrame/8020708/bug8020708.java timeouts on Windows 11 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3307/head:pull/3307` \
`$ git checkout pull/3307`

Update a local copy of the PR: \
`$ git checkout pull/3307` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3307`

View PR using the GUI difftool: \
`$ git pr show -t 3307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3307.diff">https://git.openjdk.org/jdk17u-dev/pull/3307.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3307#issuecomment-2687981152)
</details>
