### PR TITLE
8296072: CertAttrSet::encode and DerEncoder::derEncode should write into DerOutputStream

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attribute.java
@@ -26,7 +26,6 @@
 package sun.security.pkcs;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.util.Date;
 import sun.security.x509.CertificateExtensions;
@@ -527,7 +526,7 @@ public class PKCS9Attribute implements DerEncoder {
      * should be encoded as <code>T61String</code>s.
      */
     @Override
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream temp = new DerOutputStream();
         temp.putOID(oid);
         switch (index) {
@@ -648,11 +647,7 @@ public class PKCS9Attribute implements DerEncoder {
         default: // can't happen
         }
 
-        DerOutputStream derOut = new DerOutputStream();
-        derOut.write(DerValue.tag_Sequence, temp.toByteArray());
-
-        out.write(derOut.toByteArray());
-
+        out.write(DerValue.tag_Sequence, temp.toByteArray());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
+++ b/src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
@@ -25,7 +25,6 @@
 
 package sun.security.pkcs;
 
-import java.io.OutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.CertPathValidatorException;
@@ -236,7 +235,7 @@ public class SignerInfo implements DerEncoder {
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream seq = new DerOutputStream();
         seq.putInteger(version);
         DerOutputStream issuerAndSerialNumber = new DerOutputStream();
@@ -258,10 +257,7 @@ public class SignerInfo implements DerEncoder {
         if (unauthenticatedAttributes != null)
             unauthenticatedAttributes.encode((byte)0xA1, seq);
 
-        DerOutputStream tmp = new DerOutputStream();
-        tmp.write(DerValue.tag_Sequence, seq);
-
-        out.write(tmp.toByteArray());
+        out.write(DerValue.tag_Sequence, seq);
     }
 
     /*

--- a/src/java.base/share/classes/sun/security/pkcs10/PKCS10Attribute.java
+++ b/src/java.base/share/classes/sun/security/pkcs10/PKCS10Attribute.java
@@ -25,7 +25,6 @@
 
 package sun.security.pkcs10;
 
-import java.io.OutputStream;
 import java.io.IOException;
 
 import sun.security.pkcs.PKCS9Attribute;
@@ -108,7 +107,7 @@ public class PKCS10Attribute implements DerEncoder {
      *
      * @exception IOException on encoding errors.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         PKCS9Attribute attr = new PKCS9Attribute(attributeId, attributeValue);
         attr.derEncode(out);
     }

--- a/src/java.base/share/classes/sun/security/pkcs10/PKCS10Attributes.java
+++ b/src/java.base/share/classes/sun/security/pkcs10/PKCS10Attributes.java
@@ -26,7 +26,6 @@
 package sun.security.pkcs10;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.util.Collection;
 import java.util.Collections;
@@ -92,7 +91,7 @@ public class PKCS10Attributes implements DerEncoder {
      * @param out the OutputStream to marshal the contents to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    public void encode(DerOutputStream out) throws IOException {
         derEncode(out);
     }
 
@@ -103,17 +102,14 @@ public class PKCS10Attributes implements DerEncoder {
      * @param out the OutputStream to marshal the contents to.
      * @exception IOException on encoding errors.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         // first copy the elements into an array
         Collection<PKCS10Attribute> allAttrs = map.values();
         PKCS10Attribute[] attribs =
                 allAttrs.toArray(new PKCS10Attribute[map.size()]);
 
-        DerOutputStream attrOut = new DerOutputStream();
-        attrOut.putOrderedSetOf(DerValue.createTag(DerValue.TAG_CONTEXT,
-                                                   true, (byte)0),
-                                attribs);
-        out.write(attrOut.toByteArray());
+        out.putOrderedSetOf(
+                DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0), attribs);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/util/DerEncoder.java
+++ b/src/java.base/share/classes/sun/security/util/DerEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2099, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/DerEncoder.java
+++ b/src/java.base/share/classes/sun/security/util/DerEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1999, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2099, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.util;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 /**
  * Interface to an object that knows how to write its own DER
@@ -41,7 +40,7 @@ public interface DerEncoder {
      *
      * @param out  the stream on which the DER encoding is written.
      */
-    public void derEncode(OutputStream out)
+    public void derEncode(DerOutputStream out)
         throws IOException;
 
 }

--- a/src/java.base/share/classes/sun/security/util/DerOutputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerOutputStream.java
@@ -26,7 +26,6 @@
 package sun.security.util;
 
 import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
@@ -583,7 +582,7 @@ extends ByteArrayOutputStream implements DerEncoder {
      *
      *  @exception IOException on output error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         out.write(toByteArray());
     }
 

--- a/src/java.base/share/classes/sun/security/x509/AVA.java
+++ b/src/java.base/share/classes/sun/security/x509/AVA.java
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.Reader;
 import java.text.Normalizer;
 import java.util.*;
@@ -638,14 +637,12 @@ public class AVA implements DerEncoder {
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         DerOutputStream         tmp = new DerOutputStream();
-        DerOutputStream         tmp2 = new DerOutputStream();
 
         tmp.putOID(oid);
         value.encode(tmp);
-        tmp2.write(DerValue.tag_Sequence, tmp);
-        out.write(tmp2.toByteArray());
+        out.write(DerValue.tag_Sequence, tmp);
     }
 
     private String toKeyword(int format, Map<String, String> oidMap) {

--- a/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/AlgorithmId.java
@@ -164,9 +164,8 @@ public class AlgorithmId implements Serializable, DerEncoder {
      * @exception IOException on encoding error.
      */
     @Override
-    public void derEncode (OutputStream out) throws IOException {
+    public void derEncode (DerOutputStream out) throws IOException {
         DerOutputStream bytes = new DerOutputStream();
-        DerOutputStream tmp = new DerOutputStream();
 
         bytes.putOID(algid);
 
@@ -230,8 +229,7 @@ public class AlgorithmId implements Serializable, DerEncoder {
         } else {
             bytes.write(encodedParams);
         }
-        tmp.write(DerValue.tag_Sequence, bytes);
-        out.write(tmp.toByteArray());
+        out.write(DerValue.tag_Sequence, bytes);
     }
 
 

--- a/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityInfoAccessExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 
@@ -149,15 +148,14 @@ public class AuthorityInfoAccessExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.AuthInfoAccess_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/AuthorityKeyIdentifierExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -215,18 +214,17 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             extensionId = PKIXExtensions.AuthorityKey_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -190,7 +189,8 @@ implements CertAttrSet<String> {
       *
       * @param out the DerOutputStream to encode the extension to.
       */
-     public void encode(OutputStream out) throws IOException {
+     @Override
+     public void encode(DerOutputStream out) throws IOException {
          DerOutputStream tmp = new DerOutputStream();
          if (extensionValue == null) {
              this.extensionId = PKIXExtensions.BasicConstraints_Id;
@@ -201,9 +201,7 @@ implements CertAttrSet<String> {
              }
              encodeThis();
          }
-         super.encode(tmp);
-
-         out.write(tmp.toByteArray());
+         super.encode(out);
      }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLDistributionPointsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 import java.util.Collections;
@@ -199,7 +198,8 @@ public class CRLDistributionPointsExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         encode(out, PKIXExtensions.CRLDistributionPoints_Id, false);
     }
 
@@ -207,17 +207,15 @@ public class CRLDistributionPointsExtension extends Extension
      * Write the extension to the DerOutputStream.
      * (Also called by the subclass)
      */
-    protected void encode(OutputStream out, ObjectIdentifier extensionId,
-        boolean isCritical) throws IOException {
+    protected void encode(DerOutputStream out, ObjectIdentifier extensionId,
+            boolean isCritical) throws IOException {
 
-        DerOutputStream tmp = new DerOutputStream();
         if (this.extensionValue == null) {
             this.extensionId = extensionId;
             this.critical = isCritical;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLExtensions.java
@@ -30,7 +30,6 @@ import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.cert.CRLException;
-import java.security.cert.CertificateException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -145,16 +144,8 @@ public class CRLExtensions {
     throws CRLException {
         try {
             DerOutputStream extOut = new DerOutputStream();
-            Collection<Extension> allExts = map.values();
-            Object[] objs = allExts.toArray();
-
-            for (int i = 0; i < objs.length; i++) {
-                if (objs[i] instanceof CertAttrSet)
-                    ((CertAttrSet)objs[i]).encode(extOut);
-                else if (objs[i] instanceof Extension)
-                    ((Extension)objs[i]).encode(extOut);
-                else
-                    throw new CRLException("Illegal extension object");
+            for (Extension ext : map.values()) {
+                ext.encode(extOut);
             }
 
             DerOutputStream seq = new DerOutputStream();
@@ -169,8 +160,6 @@ public class CRLExtensions {
 
             out.write(tmp.toByteArray());
         } catch (IOException e) {
-            throw new CRLException("Encoding error: " + e.toString());
-        } catch (CertificateException e) {
             throw new CRLException("Encoding error: " + e.toString());
         }
     }

--- a/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.Enumeration;
 
@@ -198,7 +197,8 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         DerOutputStream tmp = new DerOutputStream();
         encode(out, PKIXExtensions.CRLNumber_Id, true);
     }
@@ -207,18 +207,15 @@ implements CertAttrSet<String> {
      * Write the extension to the DerOutputStream.
      * (Also called by the subclass)
      */
-    protected void encode(OutputStream out, ObjectIdentifier extensionId,
-        boolean isCritical) throws IOException {
-
-       DerOutputStream  tmp = new DerOutputStream();
+    protected void encode(DerOutputStream out, ObjectIdentifier extensionId,
+            boolean isCritical) throws IOException {
 
        if (this.extensionValue == null) {
            this.extensionId = extensionId;
            this.critical = isCritical;
            encodeThis();
        }
-       super.encode(tmp);
-       out.write(tmp.toByteArray());
+       super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CRLReasonCodeExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CRLReason;
 import java.util.Enumeration;
 
@@ -158,16 +157,14 @@ public class CRLReasonCodeExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.ReasonCode_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertAttrSet.java
+++ b/src/java.base/share/classes/sun/security/x509/CertAttrSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
 
 package sun.security.x509;
 
+import sun.security.util.DerOutputStream;
+
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.util.Enumeration;
 
@@ -58,12 +59,12 @@ public interface CertAttrSet<T> {
      * Encodes the attribute to the output stream in a format
      * that can be parsed by the <code>decode</code> method.
      *
-     * @param out the OutputStream to encode the attribute to.
+     * @param out the DerOutputStream to encode the attribute to.
      *
      * @exception CertificateException on encoding or validity errors.
      * @exception IOException on other errors.
      */
-    void encode(OutputStream out)
+    void encode(DerOutputStream out)
         throws CertificateException, IOException;
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateAlgorithmId.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateAlgorithmId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -105,11 +104,9 @@ public class CertificateAlgorithmId implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        algId.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        algId.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateExtensions.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateExtensions.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -152,8 +151,9 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out)
-    throws CertificateException, IOException {
+    @Override
+    public void encode(DerOutputStream out)
+            throws CertificateException, IOException {
         encode(out, false);
     }
 
@@ -165,33 +165,21 @@ public class CertificateExtensions implements CertAttrSet<Extension> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out, boolean isCertReq)
+    public void encode(DerOutputStream out, boolean isCertReq)
     throws CertificateException, IOException {
         DerOutputStream extOut = new DerOutputStream();
-        Collection<Extension> allExts = map.values();
-        Object[] objs = allExts.toArray();
-
-        for (int i = 0; i < objs.length; i++) {
-            if (objs[i] instanceof CertAttrSet)
-                ((CertAttrSet)objs[i]).encode(extOut);
-            else if (objs[i] instanceof Extension)
-                ((Extension)objs[i]).encode(extOut);
-            else
-                throw new CertificateException("Illegal extension object");
+        for (Extension ext : map.values()) {
+            ext.encode(extOut);
         }
 
-        DerOutputStream seq = new DerOutputStream();
-        seq.write(DerValue.tag_Sequence, extOut);
-
-        DerOutputStream tmp;
         if (!isCertReq) { // certificate
-            tmp = new DerOutputStream();
-            tmp.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)3),
+            DerOutputStream seq = new DerOutputStream();
+            seq.write(DerValue.tag_Sequence, extOut);
+            out.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)3),
                     seq);
-        } else
-            tmp = seq; // pkcs#10 certificateRequest
-
-        out.write(tmp.toByteArray());
+        } else {
+            out.write(DerValue.tag_Sequence, extOut);
+        }
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.DerValue;
@@ -176,18 +175,17 @@ public class CertificateIssuerExtension extends Extension
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to
+     * @param out the DerOutputStream to write the extension to
      * @exception IOException on encoding errors
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.CertificateIssuer_Id;
             critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateIssuerName.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateIssuerName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import javax.security.auth.x500.X500Principal;
@@ -107,11 +106,9 @@ public class CertificateIssuerName implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        dnName.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        dnName.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificatePoliciesExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import sun.security.util.DerValue;
@@ -177,15 +176,14 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.CertificatePolicies_Id;
           critical = false;
           encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateSerialNumber.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateSerialNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.Enumeration;
 import java.util.Random;
@@ -117,11 +116,9 @@ public class CertificateSerialNumber implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        serial.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        serial.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateSubjectName.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateSubjectName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import javax.security.auth.x500.X500Principal;
@@ -107,11 +106,9 @@ public class CertificateSubjectName implements CertAttrSet<String> {
      * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        dnName.encode(tmp);
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        dnName.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateValidity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.*;
 import java.util.Date;
 import java.util.Enumeration;
@@ -144,10 +143,11 @@ public class CertificateValidity implements CertAttrSet<String> {
     /**
      * Encode the CertificateValidity period in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
 
         // in cases where default constructor is used check for
         // null values
@@ -167,10 +167,7 @@ public class CertificateValidity implements CertAttrSet<String> {
         } else {
             pair.putGeneralizedTime(notAfter);
         }
-        DerOutputStream seq = new DerOutputStream();
-        seq.write(DerValue.tag_Sequence, pair);
-
-        out.write(seq.toByteArray());
+        out.write(DerValue.tag_Sequence, pair);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package sun.security.x509;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -155,10 +154,11 @@ public class CertificateVersion implements CertAttrSet<String> {
     /**
      * Encode the CertificateVersion period in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         // Nothing for default
         if (version == V1) {
             return;
@@ -166,11 +166,8 @@ public class CertificateVersion implements CertAttrSet<String> {
         DerOutputStream tmp = new DerOutputStream();
         tmp.putInteger(version);
 
-        DerOutputStream seq = new DerOutputStream();
-        seq.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0),
+        out.write(DerValue.createTag(DerValue.TAG_CONTEXT, true, (byte)0),
                   tmp);
-
-        out.write(seq.toByteArray());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/CertificateX509Key.java
+++ b/src/java.base/share/classes/sun/security/x509/CertificateX509Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.security.x509;
 import java.security.PublicKey;
 import java.io.InputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -97,14 +96,12 @@ public class CertificateX509Key implements CertAttrSet<String> {
     /**
      * Encode the key in DER form to the stream.
      *
-     * @param out the OutputStream to marshal the contents to.
+     * @param out the DerOutputStream to marshal the contents to.
      * @exception IOException on errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
-        tmp.write(key.getEncoded());
-
-        out.write(tmp.toByteArray());
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
+        out.write(key.getEncoded());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
 
 package sun.security.x509;
 
+import sun.security.util.DerOutputStream;
+
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.Enumeration;
 
@@ -109,7 +110,8 @@ public class DeltaCRLIndicatorExtension extends CRLNumberExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
        DerOutputStream  tmp = new DerOutputStream();
         super.encode(out, PKIXExtensions.DeltaCRLIndicator_Id, true);
     }

--- a/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/ExtendedKeyUsageExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -197,15 +196,14 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.ExtendedKeyUsage_Id;
           critical = false;
           encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/Extension.java
+++ b/src/java.base/share/classes/sun/security/x509/Extension.java
@@ -141,22 +141,28 @@ public class Extension implements java.security.cert.Extension {
         return ext;
     }
 
-    public void encode(OutputStream out) throws IOException {
+    /**
+     * Implementing {@link java.security.cert.Extension#encode(OutputStream)}.
+     * This implementation is made final to make sure all {@code encode()}
+     * methods in child classes are actually implementations of
+     * {@link #encode(DerOutputStream)} below.
+     *
+     * @param out the output stream
+     * @throws IOException
+     */
+    @Override
+    public final void encode(OutputStream out) throws IOException {
         if (out == null) {
             throw new NullPointerException();
         }
 
-        DerOutputStream dos1 = new DerOutputStream();
-        DerOutputStream dos2 = new DerOutputStream();
-
-        dos1.putOID(extensionId);
-        if (critical) {
-            dos1.putBoolean(critical);
+        if (out instanceof DerOutputStream dos) {
+            encode(dos);
+        } else {
+            DerOutputStream dos = new DerOutputStream();
+            encode(dos);
+            out.write(dos.toByteArray());
         }
-        dos1.putOctetString(extensionValue);
-
-        dos2.write(DerValue.tag_Sequence, dos1);
-        out.write(dos2.toByteArray());
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
@@ -25,8 +25,9 @@
 
 package sun.security.x509;
 
+import sun.security.util.DerOutputStream;
+
 import java.io.IOException;
-import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.Enumeration;
 import java.util.List;
@@ -93,7 +94,8 @@ public class FreshestCRLExtension extends CRLDistributionPointsExtension {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         super.encode(out, PKIXExtensions.FreshestCRL_Id, false);
     }
 }

--- a/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InhibitAnyPolicyExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -160,16 +159,14 @@ implements CertAttrSet<String> {
       *
       * @param out the DerOutputStream to encode the extension to.
       */
-     public void encode(OutputStream out) throws IOException {
-         DerOutputStream tmp = new DerOutputStream();
+     @Override
+     public void encode(DerOutputStream out) throws IOException {
          if (extensionValue == null) {
              this.extensionId = PKIXExtensions.InhibitAnyPolicy_Id;
              critical = true;
              encodeThis();
          }
-         super.encode(tmp);
-
-         out.write(tmp.toByteArray());
+         super.encode(out);
      }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Date;
 import java.util.Enumeration;
 
@@ -177,16 +176,14 @@ public class InvalidityDateExtension extends Extension
      * @param out the DerOutputStream to write the extension to
      * @exception IOException on encoding errors
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.InvalidityDate_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuerAlternativeNameExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -159,18 +158,17 @@ extends Extension implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.IssuerAlternativeName_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.*;
 
@@ -234,15 +233,14 @@ public class IssuingDistributionPointExtension extends Extension
      * @param out the output stream.
      * @exception IOException on encoding error.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.IssuingDistributionPoint_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/KeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/KeyUsageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -318,16 +317,14 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-       DerOutputStream  tmp = new DerOutputStream();
-
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
        if (this.extensionValue == null) {
            this.extensionId = PKIXExtensions.KeyUsage_Id;
            this.critical = true;
            encodeThis();
        }
-       super.encode(tmp);
-       out.write(tmp.toByteArray());
+       super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NameConstraintsExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.*;
@@ -233,18 +232,17 @@ implements CertAttrSet<String>, Cloneable {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.NameConstraints_Id;
             this.critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/NetscapeCertTypeExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import sun.security.util.*;
@@ -264,16 +263,14 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream  tmp = new DerOutputStream();
-
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = NetscapeCertType_Id;
             this.critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyConstraintsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -201,15 +200,14 @@ implements CertAttrSet<String> {
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
           extensionId = PKIXExtensions.PolicyConstraints_Id;
           critical = true;
           encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PolicyMappingsExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 import sun.security.util.*;
@@ -146,18 +145,17 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PolicyMappings_Id;
             critical = true;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/PrivateKeyUsageExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.CertificateExpiredException;
@@ -237,18 +236,17 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.PrivateKeyUsage_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectAlternativeNameExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -161,18 +160,17 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectAlternativeName_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectInfoAccessExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.util.Collections;
 import java.util.*;
@@ -154,15 +153,14 @@ public class SubjectInfoAccessExtension extends Extension
      * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (this.extensionValue == null) {
             this.extensionId = PKIXExtensions.SubjectInfoAccess_Id;
             this.critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
+++ b/src/java.base/share/classes/sun/security/x509/SubjectKeyIdentifierExtension.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Enumeration;
 
 import sun.security.util.*;
@@ -122,18 +121,17 @@ implements CertAttrSet<String> {
     /**
      * Write the extension to the OutputStream.
      *
-     * @param out the OutputStream to write the extension to.
+     * @param out the DerOutputStream to write the extension to.
      * @exception IOException on encoding errors.
      */
-    public void encode(OutputStream out) throws IOException {
-        DerOutputStream tmp = new DerOutputStream();
+    @Override
+    public void encode(DerOutputStream out) throws IOException {
         if (extensionValue == null) {
             extensionId = PKIXExtensions.SubjectKey_Id;
             critical = false;
             encodeThis();
         }
-        super.encode(tmp);
-        out.write(tmp.toByteArray());
+        super.encode(out);
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1260,7 +1260,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
     }
 
     @Override
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         if (signedCRL == null)
             throw new IOException("Null CRL to encode");
         out.write(signedCRL.clone());

--- a/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertImpl.java
@@ -332,7 +332,7 @@ public class X509CertImpl extends X509Certificate implements DerEncoder {
      *
      * @exception IOException on encoding error.
      */
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         if (signedCert == null)
             throw new IOException("Null certificate to encode");
         out.write(signedCert.clone());

--- a/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CertInfo.java
@@ -26,7 +26,6 @@
 package sun.security.x509;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import java.security.cert.*;
 import java.util.*;
@@ -179,14 +178,15 @@ public class X509CertInfo implements CertAttrSet<String> {
      * @exception CertificateException on encoding errors.
      * @exception IOException on other errors.
      */
-    public void encode(OutputStream out)
-    throws CertificateException, IOException {
+    @Override
+    public void encode(DerOutputStream out)
+            throws CertificateException, IOException {
         if (rawCertInfo == null) {
-            DerOutputStream tmp = new DerOutputStream();
-            emit(tmp);
-            rawCertInfo = tmp.toByteArray();
+            emit(out);
+            rawCertInfo = out.toByteArray();
+        } else {
+            out.write(rawCertInfo.clone());
         }
-        out.write(rawCertInfo.clone());
     }
 
     /**

--- a/test/jdk/sun/security/pkcs/pkcs7/SignerOrder.java
+++ b/test/jdk/sun/security/pkcs/pkcs7/SignerOrder.java
@@ -32,7 +32,6 @@
  * @run main SignerOrder default 1024
  * @run main SignerOrder Sha256 2048
  */
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.KeyPair;
@@ -117,7 +116,7 @@ public class SignerOrder {
     }
 
     static void printSignerInfos(SignerInfo signerInfo) throws IOException {
-        ByteArrayOutputStream strm = new ByteArrayOutputStream();
+        DerOutputStream strm = new DerOutputStream();
         signerInfo.derEncode(strm);
         System.out.println("SignerInfo, length: "
                 + strm.toByteArray().length);
@@ -127,7 +126,7 @@ public class SignerOrder {
     }
 
     static void printSignerInfos(SignerInfo[] signerInfos) throws IOException {
-        ByteArrayOutputStream strm = new ByteArrayOutputStream();
+        DerOutputStream strm = new DerOutputStream();
         for (int i = 0; i < signerInfos.length; i++) {
             signerInfos[i].derEncode(strm);
             System.out.println("SignerInfo[" + i + "], length: "

--- a/test/jdk/sun/security/pkcs/pkcs9/UnknownAttribute.java
+++ b/test/jdk/sun/security/pkcs/pkcs9/UnknownAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,10 @@
  *          java.base/sun.security.util
  */
 
-import java.io.*;
 import java.util.Arrays;
 
 import sun.security.pkcs.PKCS9Attribute;
+import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.util.ObjectIdentifier;
 import jdk.test.lib.hexdump.HexPrinter;
@@ -57,10 +57,10 @@ public class UnknownAttribute {
         if (p2.isKnown()) {
             throw new Exception();
         }
-        ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        p2.derEncode(bout);
-        HexPrinter.simple().dest(System.err).format(bout.toByteArray());
-        if (!Arrays.equals(data, bout.toByteArray())) {
+        DerOutputStream dout = new DerOutputStream();
+        p2.derEncode(dout);
+        HexPrinter.simple().dest(System.err).format(dout.toByteArray());
+        if (!Arrays.equals(data, dout.toByteArray())) {
             throw new Exception();
         }
         // Unknown attr from value
@@ -75,9 +75,9 @@ public class UnknownAttribute {
         if (p3.isKnown()) {
             throw new Exception();
         }
-        bout = new ByteArrayOutputStream();
-        p3.derEncode(bout);
-        if (!Arrays.equals(data, bout.toByteArray())) {
+        dout = new DerOutputStream();
+        p3.derEncode(dout);
+        if (!Arrays.equals(data, dout.toByteArray())) {
             throw new Exception();
         }
     }

--- a/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
+++ b/test/jdk/sun/security/tools/keytool/ExtOptionCamelCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@
  */
 
 import sun.security.tools.keytool.Main;
+import sun.security.util.DerOutputStream;
 import sun.security.util.DerValue;
 import sun.security.x509.BasicConstraintsExtension;
 import sun.security.x509.CertificateExtensions;
@@ -41,7 +42,6 @@ import sun.security.x509.Extension;
 import sun.security.x509.KeyIdentifier;
 import sun.security.x509.KeyUsageExtension;
 
-import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -203,9 +203,9 @@ public class ExtOptionCamelCase {
             // ATTENTION: the extensions created above might contain raw
             // extensions (not of a subtype) and we need to store and reload
             // it to resolve them to subtypes.
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            exts.encode(bout);
-            exts = new CertificateExtensions(new DerValue(bout.toByteArray()).data);
+            DerOutputStream dout = new DerOutputStream();
+            exts.encode(dout);
+            exts = new CertificateExtensions(new DerValue(dout.toByteArray()).data);
 
             if (clazz == null) {
                 throw new Exception("Should fail");

--- a/test/jdk/sun/security/util/asn1StringTypes/StringTypes.java
+++ b/test/jdk/sun/security/util/asn1StringTypes/StringTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class StringTypes {
         derOut.putT61String(s);
         derOut.putBMPString(s);
 
-        derOut.derEncode(fout);
+        fout.write(derOut.toByteArray());
         fout.close();
 
         FileInputStream fis = new FileInputStream(fileName);

--- a/test/langtools/tools/jdeps/jdkinternals/src/q/NoRepl.java
+++ b/test/langtools/tools/jdeps/jdkinternals/src/q/NoRepl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,11 @@
 package q;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import sun.security.util.DerEncoder;
+import sun.security.util.DerOutputStream;
 
 public class NoRepl implements DerEncoder {
-    public void derEncode(OutputStream out) throws IOException {
+    public void derEncode(DerOutputStream out) throws IOException {
         throw new IOException();
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

I had to resolve a hand full of files, but the conflicts are all
trivial. Wasn't there the copyright change in SignerOrder.java
I think it would be clean.

src/java.base/share/classes/sun/security/pkcs/SignerInfo.java
src/java.base/share/classes/sun/security/pkcs10/PKCS10Attributes.java
Removed import by hand.

src/java.base/share/classes/sun/security/util/DerEncoder.java
Trivial resolve due to context

src/java.base/share/classes/sun/security/util/DerOutputStream.java
Removed import by hand.

src/java.base/share/classes/sun/security/x509/BasicConstraintsExtension.java
Resolved due to context.

src/java.base/share/classes/sun/security/x509/CRLExtensions.java
Code formatted differently.

src/java.base/share/classes/sun/security/x509/CRLNumberExtension.java
There is a dead variable in the context.

src/java.base/share/classes/sun/security/x509/CertificateIssuerExtension.java
Copyright.

src/java.base/share/classes/sun/security/x509/DeltaCRLIndicatorExtension.java
There is a dead variable in the context.

src/java.base/share/classes/sun/security/x509/Extension.java
A bit more complex, but straight forward to resolve.

src/java.base/share/classes/sun/security/x509/FreshestCRLExtension.java
Resolve imports.

src/java.base/share/classes/sun/security/x509/InvalidityDateExtension.java
src/java.base/share/classes/sun/security/x509/IssuingDistributionPointExtension.java
test/jdk/sun/security/pkcs/pkcs7/SignerOrder.java
Copyright

A follow up is needed: [JDK-8296167](https://bugs.openjdk.org/browse/JDK-8296167). It is included
here.

I ran all of the following tests, and they pass:
test/jdk/sun/security/

I had a look at the related issues.
All of them were pushed after this change.
Some are clear cleanups, marked as enhancements. Others
are labeled as bug, but as I understand they are not
caused by this change, so they aren't required follow ups.
They rather are deficiencies of the previous implementation
and fixing them depended on this change, so they could all
be finished after pushing this.  In detail:

Bug JDK-8297723 asn1Encode methods in Kerberos throw IOException and Asn1Exception
 Cleanup of exceptions. Not yet fixed. No issue for 17, omit.
Bug JDK-8296736 Some PKCS9Attribute can be created but cannot be encoded
  This looks like a useful bugfix, but I don't think it is directly related.
  It was opened and fixed right after this change here.
Bug JDK-8296741 Illegal X400Address and EDIPartyName should not be created
  Another bugfix filed and fixed right after this change here.
Bug JDK-8296742 Illegal X509 Extension should not be created
  A large change, also a bugfix filed and fixed right after this change here.
Bug JDK-8297065 DerOutputStream operations should not throw IOExceptions
  Rather an enhancement coming after this here.  Don't backport.
Enhancement JDK-8296142 CertAttrSet::(getName|getElements|delete) are mostly useless
Enhancement JDK-8296143 CertAttrSet's set/get mechanism is not type-safe
Enhancement JDK-8296612 CertAttrSet is useless
  These three enhancements are cleanups. Huge. Don't backport.
Bug JDK-8296442 EncryptedPrivateKeyInfo can be created with an uninitialized AlgorithmParameters
Bug JDK-8296900 CertificateValidity fields are not optional
Bug JDK-8296901 Do not create unsigned certificate and CRL
  These three also came after this here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296072](https://bugs.openjdk.org/browse/JDK-8296072) needs maintainer approval
- [x] [JDK-8296167](https://bugs.openjdk.org/browse/JDK-8296167) needs maintainer approval

### Issues
 * [JDK-8296072](https://bugs.openjdk.org/browse/JDK-8296072): CertAttrSet::encode and DerEncoder::derEncode should write into DerOutputStream (**Enhancement** - P4 - Approved)
 * [JDK-8296167](https://bugs.openjdk.org/browse/JDK-8296167): test/langtools/tools/jdeps/jdkinternals/ShowReplacement.java failing after JDK-8296072 (**Bug** - P2 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3313/head:pull/3313` \
`$ git checkout pull/3313`

Update a local copy of the PR: \
`$ git checkout pull/3313` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3313`

View PR using the GUI difftool: \
`$ git pr show -t 3313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3313.diff">https://git.openjdk.org/jdk17u-dev/pull/3313.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3313#issuecomment-2697326787)
</details>
