### PR TITLE
8224267: JOptionPane message string with 5000+ newlines produces StackOverflowError

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -89,6 +89,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
     public static final int MinimumHeight = 90;
 
     private static String newline;
+    private static int recursionCount;
 
     /**
      * {@code JOptionPane} that the receiver is providing the
@@ -460,7 +461,7 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                     @SuppressWarnings("serial") // anonymous class
                     JPanel breakPanel = new JPanel() {
                         public Dimension getPreferredSize() {
-                            Font       f = getFont();
+                            Font f = getFont();
 
                             if (f != null) {
                                 return new Dimension(1, f.getSize() + 2);
@@ -475,8 +476,14 @@ public class BasicOptionPaneUI extends OptionPaneUI {
                     addMessageComponents(container, cons, s.substring(0, nl),
                                       maxll, false);
                 }
+                // Prevent recursion of more than
+                // 200 successive newlines in a message
+                if (recursionCount++ > 200) {
+                    recursionCount = 0;
+                    return;
+                }
                 addMessageComponents(container, cons, s.substring(nl + nll), maxll,
-                                  false);
+                                     false);
 
             } else if (len > maxll) {
                 Container c = Box.createVerticalBox();

--- a/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
+++ b/test/jdk/javax/swing/JOptionPane/TestOptionPaneStackOverflow.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8224267
+   @key headful
+   @summary Verifies if StackOverflowError is not thrown for multiple newlines
+   @run main TestOptionPaneStackOverflow
+ */
+
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+public class TestOptionPaneStackOverflow
+{
+    static JFrame frame;
+
+    public static void main(String[] argv) throws Exception
+    {
+        try {
+            String message = java.nio.CharBuffer.allocate(5000).toString().
+                                  replace('\0','\n');
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                JOptionPane optionPane = new JOptionPane();
+                optionPane.createDialog(frame, null);
+                optionPane.setMessage(message);
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8224267](https://bugs.openjdk.org/browse/JDK-8224267) needs maintainer approval

### Issue
 * [JDK-8224267](https://bugs.openjdk.org/browse/JDK-8224267): JOptionPane message string with 5000+ newlines produces StackOverflowError (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3314/head:pull/3314` \
`$ git checkout pull/3314`

Update a local copy of the PR: \
`$ git checkout pull/3314` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3314`

View PR using the GUI difftool: \
`$ git pr show -t 3314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3314.diff">https://git.openjdk.org/jdk17u-dev/pull/3314.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3314#issuecomment-2694897117)
</details>
