### PR TITLE
8282863: java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java fails on Windows 10 with HiDPI screen

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
@@ -47,6 +47,8 @@ import sun.java2d.SunGraphicsEnvironment;
 import sun.java2d.opengl.WGLGraphicsConfig;
 import sun.java2d.windows.WindowsFlags;
 
+import static java.awt.peer.ComponentPeer.SET_BOUNDS;
+
 import static sun.awt.Win32GraphicsEnvironment.debugScaleX;
 import static sun.awt.Win32GraphicsEnvironment.debugScaleY;
 
@@ -443,6 +445,21 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
     protected native void enterFullScreenExclusive(int screen, WindowPeer w);
     protected native void exitFullScreenExclusive(int screen, WindowPeer w);
 
+    /**
+     * Reapplies the size of this graphics device to
+     * the given full-screen window.
+     * @param w a Window that needs resizing
+     * @param b new full-screen window bounds
+     */
+    private static void resizeFSWindow(final Window w, final Rectangle b) {
+        if (w != null) {
+            WindowPeer peer = AWTAccessor.getComponentAccessor().getPeer(w);
+            if (peer != null) {
+                peer.setBounds(b.x, b.y, b.width, b.height, SET_BOUNDS);
+            }
+        }
+    }
+
     @Override
     public boolean isDisplayChangeSupported() {
         return (isFullScreenSupported() && getFullScreenWindow() != null);
@@ -465,13 +482,9 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
             WWindowPeer peer = AWTAccessor.getComponentAccessor().getPeer(w);
             configDisplayMode(screen, peer, dm.getWidth(), dm.getHeight(),
                 dm.getBitDepth(), dm.getRefreshRate());
-            // resize the fullscreen window to the dimensions of the new
-            // display mode
-            Rectangle screenBounds = getDefaultConfiguration().getBounds();
-            w.setBounds(screenBounds.x, screenBounds.y,
-                        screenBounds.width, screenBounds.height);
-            // Note: no call to replaceSurfaceData is required here since
-            // replacement will be caused by an upcoming display change event
+            // Note: the full-screen window will get resized to the dimensions of the new
+            // display mode in the upcoming display change event, when the DPI scales
+            // would already be correctly set etc.
         } else {
             throw new IllegalStateException("Must be in fullscreen mode " +
                                             "in order to set display mode");
@@ -531,6 +544,10 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
         defaultConfig = null;
         configs = null;
         initScaleFactors();
+
+        Rectangle screenBounds = getDefaultConfiguration().getBounds();
+        resizeFSWindow(getFullScreenWindow(), screenBounds);
+
         // pass on to all top-level windows on this display
         topLevels.notifyListeners();
     }

--- a/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
+++ b/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
@@ -32,7 +32,7 @@ import java.awt.Rectangle;
 
 /**
  * @test
- * @bug 8211999
+ * @bug 8211999 8282863
  * @key headful
  * @summary verifies the full-screen window bounds and graphics configuration
  */


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8282863](https://bugs.openjdk.org/browse/JDK-8282863) needs maintainer approval

### Issue
 * [JDK-8282863](https://bugs.openjdk.org/browse/JDK-8282863): java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java fails on Windows 10 with HiDPI screen (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3319/head:pull/3319` \
`$ git checkout pull/3319`

Update a local copy of the PR: \
`$ git checkout pull/3319` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3319`

View PR using the GUI difftool: \
`$ git pr show -t 3319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3319.diff">https://git.openjdk.org/jdk17u-dev/pull/3319.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3319#issuecomment-2707255147)
</details>
