### PR TITLE
8297173: usageTicks and totalTicks should be volatile to ensure that different threads get the latest ticks

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -49,8 +49,8 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     private ContainerCpuTicks processLoadTicks = new ProcessCpuTicks();
 
     private abstract class ContainerCpuTicks {
-        private long usageTicks = 0;
-        private long totalTicks = 0;
+        private volatile long usageTicks;
+        private volatile long totalTicks;
 
         private double getUsageDividesTotal(long usageTicks, long totalTicks) {
             // If cpu quota or cpu shares are in effect. Calculate the cpu load


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8297173](https://bugs.openjdk.org/browse/JDK-8297173) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297173](https://bugs.openjdk.org/browse/JDK-8297173): usageTicks and totalTicks should be volatile to ensure that different threads get the latest ticks (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3320/head:pull/3320` \
`$ git checkout pull/3320`

Update a local copy of the PR: \
`$ git checkout pull/3320` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3320`

View PR using the GUI difftool: \
`$ git pr show -t 3320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3320.diff">https://git.openjdk.org/jdk17u-dev/pull/3320.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3320#issuecomment-2698388686)
</details>
