### PR TITLE
8298061: vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java failed with "fatal error: refcount has gone to zero"

### DIFF
--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -326,7 +326,12 @@ void PlaceholderTable::find_and_remove(unsigned int hash,
     PlaceholderEntry *probe = get_entry(hash, name, loader_data);
     if (probe != NULL) {
        log(probe, "find_and_remove", action);
-       probe->remove_seen_thread(thread, action);
+
+       bool empty = probe->remove_seen_thread(thread, action);
+       if (empty && action == LOAD_SUPER) {
+          probe->set_supername(NULL);
+       }
+
        // If no other threads using this entry, and this thread is not using this entry for other states
        if ((probe->superThreadQ() == NULL) && (probe->loadInstanceThreadQ() == NULL)
           && (probe->defineThreadQ() == NULL) && (probe->definer() == NULL)) {

--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -142,8 +142,12 @@ class PlaceholderEntry : public HashtableEntry<Symbol*, mtClass> {
 
   Symbol*            supername()           const { return _supername; }
   void               set_supername(Symbol* supername) {
-    _supername = supername;
-    if (_supername != NULL) _supername->increment_refcount();
+    if (supername != _supername) {
+      _supername = supername;
+      if (_supername != NULL) {
+        _supername->increment_refcount();
+      }
+    }
   }
 
   Thread*            definer()             const {return _definer; }


### PR DESCRIPTION
Please review the backport of the fix for JDK-8298061 to jdk17u. The bug leads to rare crashes. For instance, they cause the Spring Boot build to fail under certain circumstances. In particular on AMD EPYC 7R13 and Ubuntu 24.04.1.

Original patch doesn't apply cleanly. First, technically clear_supername() was only added by JDK-8292286 in JDK 20 and Symbol::maybe_increment/decrement_refcount were added by JDK-8291457 also in JDK 20, all before the original patch. 
Second, PlaceholderTable::find_and_remove() actually needs what clear_supername() call does in 20 to make the fix complete (and to match find_and_add()). That second part was later reworked in JDK 21 (JDK-8302108) and after.

PlaceholderEntry::set_supername() was modified to perform same work as before under the same condition as in the original patch.

The early version of the original change by @coleenp had an implementation of the second part which is suitable for 17u so it was made a part of this backport. See https://github.com/openjdk/jdk/pull/11726

Without that second part part we did observe assert failures.

Testing: jtreg tier 1-3 on linux-amd64, dedicated stress test of the Spring Boot build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8298061](https://bugs.openjdk.org/browse/JDK-8298061) needs maintainer approval

### Issue
 * [JDK-8298061](https://bugs.openjdk.org/browse/JDK-8298061): vmTestbase/nsk/sysdict/vm/stress/btree/btree012/btree012.java failed with "fatal error: refcount has gone to zero" (**Bug** - P3 - Approved)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3328/head:pull/3328` \
`$ git checkout pull/3328`

Update a local copy of the PR: \
`$ git checkout pull/3328` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3328`

View PR using the GUI difftool: \
`$ git pr show -t 3328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3328.diff">https://git.openjdk.org/jdk17u-dev/pull/3328.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3328#issuecomment-2701838743)
</details>
