### PR TITLE
8347126: gc/stress/TestStressG1Uncommit.java gets OOM-killed

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressG1Uncommit.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Uncommit.java
@@ -57,6 +57,7 @@ public class TestStressG1Uncommit {
         Collections.addAll(options,
             "-Xlog:gc,gc+heap+region=debug",
             "-XX:+UseG1GC",
+            "-Xmx1g",
             StressUncommit.class.getName()
         );
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(options);
@@ -80,9 +81,9 @@ class StressUncommit {
         // Leave 20% head room to try to avoid Full GCs.
         long allocationSize = (long) (Runtime.getRuntime().maxMemory() * 0.8);
 
-        // Figure out suitable number of workers (~1 per gig).
-        int gigsOfAllocation = (int) Math.ceil((double) allocationSize / G);
-        int numWorkers = Math.min(gigsOfAllocation, Runtime.getRuntime().availableProcessors());
+        // Figure out suitable number of workers (~1 per 100M).
+        int allocationChunks = (int) Math.ceil((double) allocationSize / (100 * M));
+        int numWorkers = Math.min(allocationChunks, Runtime.getRuntime().availableProcessors());
         long workerAllocation = allocationSize / numWorkers;
 
         log("Using " + numWorkers + " workers, each allocating: ~" + (workerAllocation / M) + "M");


### PR DESCRIPTION
Backporting JDK-8347126: gc/stress/TestStressG1Uncommit.java gets OOM-killed. Minor change that reduces the memory usage in the gc/stress/TestStressG1Uncommit.java test. Ran GHA Sanity Checks, local Tier 1 and Tier 2 tests, and gc/stress/TestStressG1Uncommit.java. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347126](https://bugs.openjdk.org/browse/JDK-8347126) needs maintainer approval

### Issue
 * [JDK-8347126](https://bugs.openjdk.org/browse/JDK-8347126): gc/stress/TestStressG1Uncommit.java gets OOM-killed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3329/head:pull/3329` \
`$ git checkout pull/3329`

Update a local copy of the PR: \
`$ git checkout pull/3329` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3329`

View PR using the GUI difftool: \
`$ git pr show -t 3329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3329.diff">https://git.openjdk.org/jdk17u-dev/pull/3329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3329#issuecomment-2704412242)
</details>
