### PR TITLE
Backport b6935dfb86a1c011355d2dfb2140be26ec536351

### DIFF
--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -256,7 +256,7 @@ class nmethod : public CompiledMethod {
   // stack.  An not_entrant method can be removed when there are no
   // more activations, i.e., when the _stack_traversal_mark is less than
   // current sweep traversal index.
-  volatile long _stack_traversal_mark;
+  volatile int64_t _stack_traversal_mark;
 
   // The _hotness_counter indicates the hotness of a method. The higher
   // the value the hotter the method. The hotness counter of a nmethod is
@@ -546,8 +546,8 @@ public:
   void fix_oop_relocations()                           { fix_oop_relocations(NULL, NULL, false); }
 
   // Sweeper support
-  long  stack_traversal_mark()                    { return _stack_traversal_mark; }
-  void  set_stack_traversal_mark(long l)          { _stack_traversal_mark = l; }
+  int64_t stack_traversal_mark()                  { return _stack_traversal_mark; }
+  void    set_stack_traversal_mark(int64_t l)     { _stack_traversal_mark = l; }
 
   // On-stack replacement support
   int   osr_entry_bci() const                     { assert(is_osr_method(), "wrong kind of nmethod"); return _entry_bci; }

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -185,7 +185,7 @@ int CompileBroker::_sum_standard_bytes_compiled    = 0;
 int CompileBroker::_sum_nmethod_size               = 0;
 int CompileBroker::_sum_nmethod_code_size          = 0;
 
-long CompileBroker::_peak_compilation_time         = 0;
+jlong CompileBroker::_peak_compilation_time        = 0;
 
 CompilerStatistics CompileBroker::_stats_per_level[CompLevel_full_optimization];
 

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -223,7 +223,7 @@ class CompileBroker: AllStatic {
   static int _sum_standard_bytes_compiled;
   static int _sum_nmethod_size;
   static int _sum_nmethod_code_size;
-  static long _peak_compilation_time;
+  static jlong _peak_compilation_time;
 
   static CompilerStatistics _stats_per_level[];
 
@@ -416,8 +416,8 @@ public:
   static int get_sum_standard_bytes_compiled() {    return _sum_standard_bytes_compiled; }
   static int get_sum_nmethod_size() {               return _sum_nmethod_size;}
   static int get_sum_nmethod_code_size() {          return _sum_nmethod_code_size; }
-  static long get_peak_compilation_time() {         return _peak_compilation_time; }
-  static long get_total_compilation_time() {        return _t_total_compilation.milliseconds(); }
+  static jlong get_peak_compilation_time() {        return _peak_compilation_time; }
+  static jlong get_total_compilation_time() {       return _t_total_compilation.milliseconds(); }
 
   // Log that compilation profiling is skipped because metaspace is full.
   static void log_metaspace_failure();

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -569,7 +569,7 @@ void JVMCIEnv::put_int_at(JVMCIPrimitiveArray array, int index, jint value) {
   }
 }
 
-long JVMCIEnv::get_long_at(JVMCIPrimitiveArray array, int index) {
+jlong JVMCIEnv::get_long_at(JVMCIPrimitiveArray array, int index) {
   if (is_hotspot()) {
     return HotSpotJVMCI::resolve(array)->long_at(index);
   } else {

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -251,7 +251,7 @@ public:
   jint get_int_at(JVMCIPrimitiveArray array, int index);
   void put_int_at(JVMCIPrimitiveArray array, int index, jint value);
 
-  long get_long_at(JVMCIPrimitiveArray array, int index);
+  jlong get_long_at(JVMCIPrimitiveArray array, int index);
   void put_long_at(JVMCIPrimitiveArray array, int index, jlong value);
 
   void copy_bytes_to(JVMCIPrimitiveArray src, jbyte* dest, int offset, jsize length);

--- a/src/hotspot/share/runtime/interfaceSupport.cpp
+++ b/src/hotspot/share/runtime/interfaceSupport.cpp
@@ -78,7 +78,7 @@ VMNativeEntryWrapper::~VMNativeEntryWrapper() {
 
 unsigned int InterfaceSupport::_scavenge_alot_counter = 1;
 unsigned int InterfaceSupport::_fullgc_alot_counter   = 1;
-int InterfaceSupport::_fullgc_alot_invocation = 0;
+intx InterfaceSupport::_fullgc_alot_invocation = 0;
 
 void InterfaceSupport::gc_alot() {
   Thread *thread = Thread::current();

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -54,7 +54,7 @@ class InterfaceSupport: AllStatic {
  public:
   static unsigned int _scavenge_alot_counter;
   static unsigned int _fullgc_alot_counter;
-  static int _fullgc_alot_invocation;
+  static intx _fullgc_alot_invocation;
 
   // Helper methods used to implement +ScavengeALot and +FullGCALot
   static void check_gc_alot() { if (ScavengeALot || FullGCALot) gc_alot(); }

--- a/src/hotspot/share/runtime/sweeper.cpp
+++ b/src/hotspot/share/runtime/sweeper.cpp
@@ -55,9 +55,9 @@
 // Sweeper logging code
 class SweeperRecord {
  public:
-  int traversal;
+  int64_t traversal;
   int compile_id;
-  long traversal_mark;
+  int64_t traversal_mark;
   int state;
   const char* kind;
   address vep;
@@ -65,8 +65,8 @@ class SweeperRecord {
   int line;
 
   void print() {
-      tty->print_cr("traversal = %d compile_id = %d %s uep = " PTR_FORMAT " vep = "
-                    PTR_FORMAT " state = %d traversal_mark %ld line = %d",
+      tty->print_cr("traversal = " INT64_FORMAT " compile_id = %d %s uep = " PTR_FORMAT " vep = "
+                    PTR_FORMAT " state = %d traversal_mark " INT64_FORMAT " line = %d",
                     traversal,
                     compile_id,
                     kind == NULL ? "" : kind,
@@ -107,8 +107,8 @@ void NMethodSweeper::init_sweeper_log() {
 #endif
 
 CompiledMethodIterator NMethodSweeper::_current(CompiledMethodIterator::all_blobs); // Current compiled method
-long     NMethodSweeper::_traversals                   = 0;    // Stack scan count, also sweep ID.
-long     NMethodSweeper::_total_nof_code_cache_sweeps  = 0;    // Total number of full sweeps of the code cache
+int64_t  NMethodSweeper::_traversals                   = 0;    // Stack scan count, also sweep ID.
+int64_t  NMethodSweeper::_total_nof_code_cache_sweeps  = 0;    // Total number of full sweeps of the code cache
 int      NMethodSweeper::_seen                         = 0;    // Nof. nmethod we have currently processed in current pass of CodeCache
 size_t   NMethodSweeper::_sweep_threshold_bytes        = 0;    // Threshold for when to sweep. Updated after ergonomics
 
@@ -119,8 +119,8 @@ volatile size_t NMethodSweeper::_bytes_changed         = 0;    // Counts the tot
                                                                //   2) not_entrant -> zombie
 int    NMethodSweeper::_hotness_counter_reset_val       = 0;
 
-long   NMethodSweeper::_total_nof_methods_reclaimed     = 0;   // Accumulated nof methods flushed
-long   NMethodSweeper::_total_nof_c2_methods_reclaimed  = 0;   // Accumulated nof methods flushed
+int64_t NMethodSweeper::_total_nof_methods_reclaimed    = 0;   // Accumulated nof methods flushed
+int64_t NMethodSweeper::_total_nof_c2_methods_reclaimed = 0;   // Accumulated nof methods flushed
 size_t NMethodSweeper::_total_flushed_size              = 0;   // Total number of bytes flushed from the code cache
 Tickspan NMethodSweeper::_total_time_sweeping;                 // Accumulated time sweeping
 Tickspan NMethodSweeper::_total_time_this_sweep;               // Total time this sweep
@@ -187,7 +187,7 @@ CodeBlobClosure* NMethodSweeper::prepare_mark_active_nmethods() {
   _total_time_this_sweep = Tickspan();
 
   if (PrintMethodFlushing) {
-    tty->print_cr("### Sweep: stack traversal %ld", _traversals);
+    tty->print_cr("### Sweep: stack traversal " INT64_FORMAT, _traversals);
   }
   return &mark_activation_closure;
 }
@@ -217,7 +217,7 @@ void NMethodSweeper::sweeper_loop() {
     {
       ThreadBlockInVM tbivm(JavaThread::current());
       MonitorLocker waiter(CodeSweeper_lock, Mutex::_no_safepoint_check_flag);
-      const long wait_time = 60*60*24 * 1000;
+      const int64_t wait_time = 60*60*24 * 1000;
       timeout = waiter.wait(wait_time);
     }
     if (!timeout && (_should_sweep || _force_sweep)) {
@@ -649,7 +649,7 @@ void NMethodSweeper::log_sweep(const char* msg, const char* format, ...) {
     CodeCache::log_state(&s);
 
     ttyLocker ttyl;
-    xtty->begin_elem("sweeper state='%s' traversals='" INTX_FORMAT "' ", msg, (intx)traversal_count());
+    xtty->begin_elem("sweeper state='%s' traversals='" INT64_FORMAT "' ", msg, traversal_count());
     if (format != NULL) {
       va_list ap;
       va_start(ap, format);
@@ -667,8 +667,9 @@ void NMethodSweeper::print(outputStream* out) {
   out = (out == NULL) ? tty : out;
   out->print_cr("Code cache sweeper statistics:");
   out->print_cr("  Total sweep time:                %1.0lf ms", (double)_total_time_sweeping.value()/1000000);
-  out->print_cr("  Total number of full sweeps:     %ld", _total_nof_code_cache_sweeps);
-  out->print_cr("  Total number of flushed methods: %ld (thereof %ld C2 methods)", _total_nof_methods_reclaimed,
+  out->print_cr("  Total number of full sweeps:     " INT64_FORMAT, _total_nof_code_cache_sweeps);
+  out->print_cr("  Total number of flushed methods: " INT64_FORMAT " (thereof " INT64_FORMAT " C2 methods)",
+                                                    _total_nof_methods_reclaimed,
                                                     _total_nof_c2_methods_reclaimed);
   out->print_cr("  Total size of flushed methods:   " SIZE_FORMAT " kB", _total_flushed_size/K);
 }

--- a/src/hotspot/share/runtime/sweeper.hpp
+++ b/src/hotspot/share/runtime/sweeper.hpp
@@ -66,8 +66,8 @@ class NMethodSweeper : public AllStatic {
     MadeZombie,
     Flushed
   };
-  static long      _traversals;                   // Stack scan count, also sweep ID.
-  static long      _total_nof_code_cache_sweeps;  // Total number of full sweeps of the code cache
+  static int64_t   _traversals;                   // Stack scan count, also sweep ID.
+  static int64_t   _total_nof_code_cache_sweeps;  // Total number of full sweeps of the code cache
   static CompiledMethodIterator _current;         // Current compiled method
   static int       _seen;                         // Nof. nmethod we have currently processed in current pass of CodeCache
   static size_t    _sweep_threshold_bytes;        // The threshold for when to invoke sweeps
@@ -78,8 +78,8 @@ class NMethodSweeper : public AllStatic {
                                                   //   1) alive       -> not_entrant
                                                   //   2) not_entrant -> zombie
   // Stat counters
-  static long      _total_nof_methods_reclaimed;    // Accumulated nof methods flushed
-  static long      _total_nof_c2_methods_reclaimed; // Accumulated nof C2-compiled methods flushed
+  static int64_t   _total_nof_methods_reclaimed;    // Accumulated nof methods flushed
+  static int64_t   _total_nof_c2_methods_reclaimed; // Accumulated nof C2-compiled methods flushed
   static size_t    _total_flushed_size;             // Total size of flushed methods
   static int       _hotness_counter_reset_val;
 
@@ -97,10 +97,10 @@ class NMethodSweeper : public AllStatic {
   static void do_stack_scanning();
   static void sweep();
  public:
-  static long traversal_count()                    { return _traversals; }
+  static int64_t traversal_count()                 { return _traversals; }
   static size_t sweep_threshold_bytes()              { return _sweep_threshold_bytes; }
   static void set_sweep_threshold_bytes(size_t threshold) { _sweep_threshold_bytes = threshold; }
-  static int  total_nof_methods_reclaimed()        { return _total_nof_methods_reclaimed; }
+  static int64_t total_nof_methods_reclaimed()     { return _total_nof_methods_reclaimed; }
   static const Tickspan total_time_sweeping()      { return _total_time_sweeping; }
   static const Tickspan peak_sweep_time()          { return _peak_sweep_time; }
   static const Tickspan peak_sweep_fraction_time() { return _peak_sweep_fraction_time; }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -687,7 +687,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   nonstatic_field(nmethod,                     _verified_entry_point,                         address)                               \
   nonstatic_field(nmethod,                     _osr_entry_point,                              address)                               \
   volatile_nonstatic_field(nmethod,            _lock_count,                                   jint)                                  \
-  volatile_nonstatic_field(nmethod,            _stack_traversal_mark,                         long)                                  \
+  volatile_nonstatic_field(nmethod,            _stack_traversal_mark,                         int64_t)                               \
   nonstatic_field(nmethod,                     _compile_id,                                   int)                                   \
   nonstatic_field(nmethod,                     _comp_level,                                   int)                                   \
                                                                                                                                      \
@@ -1224,6 +1224,7 @@ typedef HashtableEntry<InstanceKlass*, mtClass>  KlassHashtableEntry;
   declare_integer_type(ssize_t)                                           \
   declare_integer_type(intx)                                              \
   declare_integer_type(intptr_t)                                          \
+  declare_integer_type(int64_t)                                           \
   declare_unsigned_integer_type(uintx)                                    \
   declare_unsigned_integer_type(uintptr_t)                                \
   declare_unsigned_integer_type(uint8_t)                                  \


### PR DESCRIPTION
Backporting JDK-8251505: Use of types in compiler shared code should be consistent. Cleans up mixed types and usage of 'long' type. Ran GHA Sanity Checks, local Tier 1 and Tier 2 tests, and jdk/jfr and java/lang/management explicitly. Patch is clean.