### PR TITLE
8254786: java/net/httpclient/CancelRequestTest.java failing intermittently

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1073,6 +1073,10 @@ class Http2Connection  {
         }
     }
 
+    boolean isOpen() {
+        return !closed && connection.channel().isOpen();
+    }
+
     void resetStream(int streamid, int code) {
         try {
             if (connection.channel().isOpen()) {

--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8245462 8229822
+ * @bug 8245462 8229822 8254786
  * @summary Tests cancelling the request.
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @key randomness


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

The original change was pushed in jdk19.
Several later changes were already backported causing conflicts.

src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java
Three later patches were applied. Resolve trivial.

src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
Two later patches were applied. The conflict of hunk 3 is caused by the change of
8328286: Enhance HTTP client in line 103. Resolved.

These and two more files had Copyright conflicts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8254786](https://bugs.openjdk.org/browse/JDK-8254786) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254786](https://bugs.openjdk.org/browse/JDK-8254786): java/net/httpclient/CancelRequestTest.java failing intermittently (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3334/head:pull/3334` \
`$ git checkout pull/3334`

Update a local copy of the PR: \
`$ git checkout pull/3334` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3334`

View PR using the GUI difftool: \
`$ git pr show -t 3334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3334.diff">https://git.openjdk.org/jdk17u-dev/pull/3334.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3334#issuecomment-2711014542)
</details>
