### PR TITLE
8328670: Automate and open source few closed manual applet test

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/Ctrli.java
+++ b/test/jdk/javax/swing/JInternalFrame/Ctrli.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+import javax.swing.JFrame;
+import javax.swing.JComponent;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4199401
+ * @summary DefaultFocusManager interferes with comps that
+ *          return true to isManagingFocus().
+ * @key headful
+ * @run main Ctrli
+ */
+
+public class Ctrli {
+    private static JFrame frame;
+    private static JComponent keyecho;
+    private static volatile boolean iPressed = false;
+    private static volatile Point compLoc;
+    private static volatile int compWidth;
+    private static volatile int compHeight;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.setAutoWaitForIdle(true);
+        try {
+            SwingUtilities.invokeAndWait(Ctrli::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                compLoc = keyecho.getLocationOnScreen();
+                compWidth = keyecho.getWidth();
+                compHeight = keyecho.getHeight();
+            });
+
+            robot.mouseMove(compLoc.x + compWidth / 2, compLoc.y + compHeight / 2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_I);
+            robot.waitForIdle();
+            robot.keyRelease(KeyEvent.VK_I);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.waitForIdle();
+
+            if (!iPressed) {
+                throw new RuntimeException("Test failed: CTRL+I not pressed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new JFrame("Test Ctrl+I operation");
+        keyecho = new JComponent() {
+            public boolean isManagingFocus() {
+                return true;
+            }
+        };
+        KeyListener keyListener = new KeyAdapter() {
+            public void keyPressed(KeyEvent e) {
+                if (((e.getModifiers() & ActionEvent.CTRL_MASK) == ActionEvent.CTRL_MASK)
+                        && (e.getKeyCode() == 73))
+                    iPressed = true;
+            }
+
+            public void keyTyped(KeyEvent e) {
+                if (!iPressed) {
+                    throw new RuntimeException("Test failed: CTRL+I not pressed.");
+                }
+            }
+        };
+
+        MouseListener mouseListener = new MouseAdapter() {
+            public void mousePressed(MouseEvent e) {
+                keyecho.requestFocus();
+            }
+        };
+
+        keyecho.addKeyListener(keyListener);
+        keyecho.addMouseListener(mouseListener);
+        frame.setLayout(new BorderLayout());
+        frame.add(keyecho);
+        frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JMenuItem/JActionCommandTest.java
+++ b/test/jdk/javax/swing/JMenuItem/JActionCommandTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4159610
+ * @key headful
+ * @summary Verifies that JMenuItem's shortcuts are not inserted in JTextField
+ * @run main JActionCommandTest
+ */
+
+public class JActionCommandTest {
+
+    private static Robot robot;
+    private static JMenu m;
+    private static JMenuItem mi;
+    private static JFrame f;
+    private static JTextField tf;
+    private static volatile Point menuLoc;
+    private static volatile Point menuItemLoc;
+    private static volatile Point textFieldLoc;
+    private static volatile int menuWidth;
+    private static volatile int menuHeight;
+    private static volatile int menuItemWidth;
+    private static volatile int menuItemHeight;
+    private static volatile int textFieldWidth;
+    private static volatile int textFieldHeight;
+    private static volatile boolean passed = false;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.setAutoWaitForIdle(true);
+        try {
+            SwingUtilities.invokeAndWait(JActionCommandTest::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                menuLoc = m.getLocationOnScreen();
+                menuWidth = m.getWidth();
+                menuHeight = m.getHeight();
+
+                textFieldLoc = tf.getLocationOnScreen();
+                textFieldWidth = tf.getWidth();
+                textFieldHeight = tf.getHeight();
+            });
+            moveAndPressMouse(menuLoc.x, menuLoc.y, menuWidth, menuHeight);
+
+            SwingUtilities.invokeAndWait(() -> {
+                menuItemLoc = mi.getLocationOnScreen();
+                menuItemWidth = mi.getWidth();
+                menuItemHeight = mi.getHeight();
+            });
+            moveAndPressMouse(menuItemLoc.x, menuItemLoc.y, menuItemWidth, menuItemHeight);
+            System.out.println("passed is: "+passed);
+            if (!passed) {
+                throw new RuntimeException("Test Failed: JMenuItem label is not" +
+                        " equals to 'Testitem'.");
+            }
+            passed = false;
+            moveAndPressMouse(textFieldLoc.x, textFieldLoc.y, textFieldWidth, textFieldHeight);
+            robot.keyPress(KeyEvent.VK_ALT);
+            robot.keyPress(KeyEvent.VK_T);
+            robot.keyRelease(KeyEvent.VK_T);
+            robot.keyRelease(KeyEvent.VK_ALT);
+            robot.waitForIdle();
+
+            System.out.println("passed is: "+passed);
+            System.out.println("tf.getText() is: "+tf.getText());
+            if (!passed && tf.getText().equals("t")) {
+                throw new RuntimeException("Test Failed: Either JMenuItem label is not" +
+                        " equal to 'Testitem' or JTextField contains text 't'. ");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        CustomActionListener customListener = new CustomActionListener();
+        f = new JFrame("Test JMenuItem Shortcut");
+        f.setLayout(new BorderLayout());
+        tf = new JTextField(12);
+        tf.addActionListener(customListener);
+        JMenuBar mb = new JMenuBar();
+        m = new JMenu("Test");
+        mi = new JMenuItem("Testitem");
+        KeyStroke ks = KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_T,
+                java.awt.Event.ALT_MASK, false);
+        mi.setAccelerator(ks);
+        mi.addActionListener(customListener);
+        m.add(mi);
+        mb.add(m);
+        f.setJMenuBar(mb);
+        f.add("South", tf);
+        f.setSize(200, 200);
+        f.setLocationRelativeTo(null);
+        f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        f.setVisible(true);
+    }
+
+    public static void moveAndPressMouse(int x, int y, int width, int height) {
+        robot.mouseMove(x + width / 2, y + height / 2);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+    }
+
+    static class CustomActionListener implements ActionListener {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (e.getSource() == mi && e.getActionCommand().equals("Testitem")) {
+                System.out.println("MenuItem's label: " + e.getActionCommand());
+                passed = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328670](https://bugs.openjdk.org/browse/JDK-8328670) needs maintainer approval

### Issue
 * [JDK-8328670](https://bugs.openjdk.org/browse/JDK-8328670): Automate and open source few closed manual applet test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3339/head:pull/3339` \
`$ git checkout pull/3339`

Update a local copy of the PR: \
`$ git checkout pull/3339` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3339`

View PR using the GUI difftool: \
`$ git pr show -t 3339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3339.diff">https://git.openjdk.org/jdk17u-dev/pull/3339.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3339#issuecomment-2714788435)
</details>
