### PR TITLE
8339984: Open source AWT MenuItem related tests

### DIFF
--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+/*
+ * @test
+ * @bug 4700350
+ * @requires os.family != "mac"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests menu item font is big
+ * @run main/manual GiantFontTest
+ */
+
+public class GiantFontTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                        A frame with one menu will appear.
+                        On Linux, the menu's (present on menu bar) font should
+                        be quite large (48 point).
+                        If not, test fails.
+
+                        On Windows, the menu's (present on menu bar) font
+                        should be normal size.
+                        If the menu text is clipped by the title bar, or is painted over
+                        the title bar or client area, the test fails.
+
+                        On both Windows and Linux, the menu items in the popup
+                        menu should be large.
+
+                        If so, test passes.""";
+
+        PassFailJFrame.builder()
+                .title("GiantFontTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(GiantFontTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Font giantFont = new Font("Dialog", Font.PLAIN, 48);
+        Frame f = new Frame("GiantFontTest");
+        MenuBar mb = new MenuBar();
+        Menu m = new Menu("My font is too big!");
+        m.setFont(giantFont);
+        for (int i = 0; i < 5; i++) {
+            m.add(new MenuItem("Some MenuItems"));
+        }
+        mb.add(m);
+        f.setMenuBar(mb);
+        f.setSize(450, 400);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+
+/*
+ * @test
+ * @bug 4175790
+ * @requires os.family == "windows"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Win32: Running out of command ids for menu items
+ * @run main/manual LotsOfMenuItemsTest
+ */
+
+public class LotsOfMenuItemsTest extends ComponentAdapter {
+    private static final int NUM_WINDOWS = 400;
+    private static TestFrame firstFrame;
+
+    public static void main(String[] args) throws Exception {
+        LotsOfMenuItemsTest obj = new LotsOfMenuItemsTest();
+        String INSTRUCTIONS = """
+                This test creates lots of frames with menu bars.
+                When it's done you will see two frames.
+                Try to select menu items from each of them.
+
+                If everything seems to work - test passed.
+                Click "Pass" button in the test harness window.
+
+                If test crashes on you - test failed.""";
+
+        PassFailJFrame.builder()
+                .title("LotsOfMenuItemsTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(obj::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private Frame createAndShowUI() {
+        firstFrame = new TestFrame("First frame");
+        firstFrame.addComponentListener(this);
+        return firstFrame;
+    }
+
+    @Override
+    public void componentShown(ComponentEvent e) {
+        final int x = firstFrame.getX();
+        final int y = firstFrame.getY() + firstFrame.getHeight() + 8;
+        TestFrame testFrame;
+        for (int i = 1; i < NUM_WINDOWS - 1; ++i) {
+            testFrame = new TestFrame("Running(" + i + ")...", x, y);
+            testFrame.setVisible(false);
+            testFrame.dispose();
+        }
+        testFrame = new TestFrame("Last Frame", x, y);
+        PassFailJFrame.addTestWindow(testFrame);
+    }
+
+    private static class TestFrame extends Frame {
+        static int n = 0;
+
+        public TestFrame(String title) {
+            this(title, 0, 0, false);
+        }
+
+        public TestFrame(String s, int x, int y) {
+            this(s, x, y, true);
+        }
+
+        private TestFrame(String title, int x, int y, boolean visible) {
+            super(title);
+            MenuBar mb = new MenuBar();
+            for (int i = 0; i < 10; ++i) {
+                Menu m = new Menu("Menu_" + (i + 1));
+                for (int j = 0; j < 20; ++j) {
+                    MenuItem mi = new MenuItem("Menu item " + ++n);
+                    m.add(mi);
+                }
+                mb.add(m);
+            }
+            setMenuBar(mb);
+            setLocation(x, y);
+            setSize(450, 150);
+            if (visible) {
+                setVisible(true);
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/MenuItem/MenuSetFontTest.java
+++ b/test/jdk/java/awt/MenuItem/MenuSetFontTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+/*
+ * @test
+ * @bug 4066657 8009454
+ * @requires os.family != "mac"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests that setting a font on the Menu with MenuItem takes effect.
+ * @run main/manual MenuSetFontTest
+ */
+
+public class MenuSetFontTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                    Look at the menu in the upper left corner of the 'SetFont Test' frame.
+                    Click on the "File" menu. You will see "menu item" item.
+                    Press Pass if menu item is displayed using bold and large font,
+                    otherwise press Fail.
+                    If you do not see menu at all, press Fail.""";
+
+        PassFailJFrame.builder()
+                .title("MenuSetFontTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(MenuSetFontTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Frame frame = new Frame("SetFont Test");
+        MenuBar menuBar = new MenuBar();
+        Menu menu = new Menu("File");
+        MenuItem item = new MenuItem("menu item");
+        menu.add(item);
+        menuBar.add(menu);
+        menuBar.setFont(new Font(Font.MONOSPACED, Font.BOLD, 24));
+        frame.setMenuBar(menuBar);
+        frame.setSize(300, 200);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/MenuItem/NullOrEmptyStringLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/NullOrEmptyStringLabelTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4251036
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary MenuItem setLabel(null/"") behaves differently under Win32 and Solaris
+ * @run main/manual NullOrEmptyStringLabelTest
+ */
+
+public class NullOrEmptyStringLabelTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                The bug is reproducible under Win32 and Solaris.
+                Setting 'null' and "" as a label of menu item
+                should set blank label on all platforms according to the specification.
+                But under Solaris setting "" as a label of menu item used to
+                cause some garbage to be set as label.
+                Under Win32 setting 'null' as a label used to result in
+                throwing NullPointerException.
+
+                If you see any of these things happen test fails otherwise
+                it passes.""";
+
+        PassFailJFrame.builder()
+                .title("NullOrEmptyStringLabelTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(NullOrEmptyStringLabelTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Frame frame = new Frame("Null Or Empty String Label Test");
+        Menu menu = new Menu("Menu");
+        MenuItem mi = new MenuItem("Item");
+        MenuBar mb = new MenuBar();
+        Button button1 = new Button("Set MenuItem label to 'null'");
+        Button button2 = new Button("Set MenuItem label to \"\"");
+        Button button3 = new Button("Set MenuItem label to 'text'");
+        button1.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ev) {
+                System.out.println("Setting MenuItem label to null");
+                mi.setLabel(null);
+            }
+        });
+        button2.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ev) {
+                System.out.println("Setting MenuItem label to \"\"");
+                mi.setLabel("");
+            }
+        });
+        button3.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ev) {
+                System.out.println("Setting MenuItem label to 'text'");
+                mi.setLabel("text");
+            }
+        });
+        menu.add(mi);
+        mb.add(menu);
+        frame.add(button1, BorderLayout.NORTH);
+        frame.add(button2, BorderLayout.CENTER);
+        frame.add(button3, BorderLayout.SOUTH);
+        frame.setMenuBar(mb);
+        frame.setSize(200, 135);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/MenuItem/UnicodeMenuItemTest.java
+++ b/test/jdk/java/awt/MenuItem/UnicodeMenuItemTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+/*
+ * @test
+ * @bug 4099695
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary menu items with Unicode labels treated as separators
+ * @run main/manual UnicodeMenuItemTest
+ */
+
+public class UnicodeMenuItemTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Click on the "Menu" on the top-left corner of frame.
+
+                The menu should have four entries:
+                1) a row of five unicode characters: \u00c4\u00cb\u00cf\u00d6\u00dc
+                2) a menu separator
+                3) a unicode character:  \u012d
+                4) a unicode character:  \u022d
+
+                If the menu items look like the list above, the test passes.
+                It is okay if the unicode characters look like empty boxes
+                or something - as long as they are not separators.
+
+                If either of the last two menu items show up as separators,
+                the test FAILS.
+
+                Press 'Pass' if above instructions hold good else press 'Fail'.""";
+
+        PassFailJFrame.builder()
+                .title("UnicodeMenuItemTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testUI(UnicodeMenuItemTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+    private static Frame createAndShowUI() {
+        Frame frame = new Frame("Unicode MenuItem Test");
+        MenuBar mb = new MenuBar();
+        Menu m = new Menu("Menu");
+
+        MenuItem mi1 = new MenuItem("\u00c4\u00cb\u00cf\u00d6\u00dc");
+        m.add(mi1);
+
+        MenuItem separator = new MenuItem("-");
+        m.add(separator);
+
+        MenuItem mi2 = new MenuItem("\u012d");
+        m.add(mi2);
+
+        MenuItem mi3 = new MenuItem("\u022d");
+        m.add(mi3);
+
+        mb.add(m);
+
+        frame.setMenuBar(mb);
+        frame.setSize(450, 150);
+        return frame;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339984](https://bugs.openjdk.org/browse/JDK-8339984) needs maintainer approval

### Issue
 * [JDK-8339984](https://bugs.openjdk.org/browse/JDK-8339984): Open source AWT MenuItem related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3347/head:pull/3347` \
`$ git checkout pull/3347`

Update a local copy of the PR: \
`$ git checkout pull/3347` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3347`

View PR using the GUI difftool: \
`$ git pr show -t 3347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3347.diff">https://git.openjdk.org/jdk17u-dev/pull/3347.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3347#issuecomment-2718290519)
</details>
