### PR TITLE
8340393: Open source closed choice tests #2

### DIFF
--- a/test/jdk/java/awt/Choice/CheckChoiceTest.java
+++ b/test/jdk/java/awt/Choice/CheckChoiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Frame;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4151949
+ * @summary Verifies that Components are reshaped to their preferred size
+ *          when their Container is packed.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CheckChoiceTest
+ */
+
+public class CheckChoiceTest {
+
+    private static JComponent componentToFocus;
+
+    private static final String INSTRUCTIONS = """
+            Verify that the widths of the Choice components are all the same
+            and that none is the minimum possible size.
+            (The Choices should be at least as wide as the Frame.)
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .title("CheckChoiceTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 3)
+                .columns(45)
+                .testUI(CheckChoiceTest::createAndShowUI)
+                .splitUIBottom(CheckChoiceTest::createComponentToFocus)
+                .build();
+
+        // focus away from the window with choices
+        Thread.sleep(300);
+        SwingUtilities.invokeAndWait(() -> componentToFocus.requestFocus());
+
+        passFailJFrame.awaitAndCheck();
+    }
+
+    private static JComponent createComponentToFocus() {
+        componentToFocus = new JPanel();
+        return componentToFocus;
+    }
+
+    private static Frame createAndShowUI() {
+        Frame f = new Frame("Check Choice");
+        f.setLayout(new BorderLayout());
+
+        Choice choice1 = new Choice();
+        Choice choice2 = new Choice();
+        Choice choice3 = new Choice();
+
+        f.add(choice1, BorderLayout.NORTH);
+        f.add(choice3, BorderLayout.CENTER);
+        f.add(choice2, BorderLayout.SOUTH);
+        f.pack();
+
+        choice1.add("I am Choice, yes I am : 0");
+        choice2.add("I am the same, yes I am : 0");
+        choice3.add("I am the same, yes I am : 0");
+
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceBigTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceBigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Choice;
+import java.awt.Frame;
+import java.awt.FlowLayout;
+import java.awt.Window;
+
+/*
+ * @test
+ * @bug 4288285
+ * @summary Verifies choice works with many items
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ChoiceBigTest
+ */
+
+public class ChoiceBigTest {
+    private static final String INSTRUCTIONS = """
+            Click the Choice button, press Pass if:
+
+            - all looks good.
+            - if you can select the item 1000
+
+            Otherwise press Fail.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ChoiceBigTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 3)
+                .columns(45)
+                .testUI(ChoiceBigTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Window createAndShowUI() {
+        Frame frame = new Frame("Check Choice");
+        frame.setLayout(new FlowLayout());
+        Choice choice = new Choice();
+        frame.setSize(400, 200);
+        for (int i = 1; i < 1001; ++i) {
+            choice.add("I am Choice, yes I am : " + i);
+        }
+        frame.add(choice);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Choice/ChoiceFocusTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceFocusTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Window;
+
+/*
+ * @test
+ * @bug 4927930
+ * @summary Verify that the focus is set to the selected item after calling the java.awt.Choice.select() method
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ChoiceFocusTest
+ */
+
+public class ChoiceFocusTest {
+
+    private static final String INSTRUCTIONS = """
+            1. Use the mouse to select Item 5 in the Choice list.
+            2. Click on the Choice. Item5 is now selected and highlighted. This is the correct behavior.
+            3. Select Item 1 in the Choice list.
+            4. Click the "choice.select(5)" button. This causes a call to Choice.select(5). Item 5 is now selected.
+            5. Click on the Choice.
+            6. If the cursor and focus are on item 5, the test passes. Otherwise, it fails.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ChoiceFocusTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 3)
+                .columns(50)
+                .testUI(ChoiceFocusTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Window createAndShowUI() {
+        Panel panel = new Panel();
+        Choice choice = new Choice();
+        Button button = new Button("choice.select(5);");
+
+        for (int i = 0; i < 10; i++) {
+            choice.add(String.valueOf(i));
+        }
+
+        button.addActionListener(e -> choice.select(5));
+
+        panel.add(button);
+        panel.add(choice);
+
+        Frame frame = new Frame("ChoiceFocusTest");
+        frame.add(panel);
+        frame.pack();
+
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Choice/DisabledList.java
+++ b/test/jdk/java/awt/Choice/DisabledList.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Checkbox;
+import java.awt.Choice;
+import java.awt.Frame;
+import java.awt.Window;
+import java.awt.event.ItemEvent;
+
+/*
+ * @test
+ * @bug 6476183
+ * @summary Drop down of a Choice changed to enabled state has a disabled like appearance
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DisabledList
+ */
+
+public class DisabledList {
+
+    private static final String INSTRUCTIONS = """
+            1) Select the checkbox
+            2) Open Choice
+            3) Drag mouse over the scrollbar or drag out it the choice
+            4) If choice's items become disabled press fail, otherwise pass
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("DisabledList Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 3)
+                .columns(45)
+                .testUI(DisabledList::createAndShowUI)
+                .logArea(4)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Window createAndShowUI() {
+        Frame frame = new Frame("DisabledList");
+        frame.setSize(200, 200);
+        frame.validate();
+        Checkbox checkbox = new Checkbox("checkbox");
+        final Choice choice = new Choice();
+        choice.setEnabled(false);
+        for (int i = 0; i < 15; i++) {
+            choice.addItem("Item" + i);
+        }
+        checkbox.addItemListener(event -> {
+            PassFailJFrame.log("CheckBox.itemStateChanged occurred");
+            choice.setEnabled(event.getStateChange() == ItemEvent.SELECTED);
+        });
+        frame.add(BorderLayout.NORTH, checkbox);
+        frame.add(BorderLayout.CENTER, choice);
+        return frame;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340393](https://bugs.openjdk.org/browse/JDK-8340393) needs maintainer approval

### Issue
 * [JDK-8340393](https://bugs.openjdk.org/browse/JDK-8340393): Open source closed choice tests #2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3348/head:pull/3348` \
`$ git checkout pull/3348`

Update a local copy of the PR: \
`$ git checkout pull/3348` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3348`

View PR using the GUI difftool: \
`$ git pr show -t 3348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3348.diff">https://git.openjdk.org/jdk17u-dev/pull/3348.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3348#issuecomment-2719171858)
</details>
