### PR TITLE
8340966: Open source few Checkbox and Cursor tests - Set1

### DIFF
--- a/test/jdk/java/awt/Checkbox/DynamicChangeTest/DynamicChangeTest.java
+++ b/test/jdk/java/awt/Checkbox/DynamicChangeTest/DynamicChangeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6225679
+ * @summary Tests that checkbox changes into radiobutton dynamically
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DynamicChangeTest
+ */
+
+import java.awt.Checkbox;
+import java.awt.CheckboxGroup;
+import java.awt.Frame;
+import java.awt.GridLayout;
+
+public class DynamicChangeTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This test is primarily for Windows platform, but should pass
+                on other platforms as well. Ensure that 'This is checkbox' is
+                checkbox, and 'This is radiobutton' is radiobutton.
+                If it is so, press pass else fail.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(DynamicChangeTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("Dynamic Change Checkbox Test");
+        f.setSize(200, 200);
+
+        f.setLayout(new GridLayout(2, 1));
+        Checkbox ch1 = new Checkbox("This is checkbox",
+                new CheckboxGroup(), true);
+        f.add(ch1);
+        Checkbox ch2 = new Checkbox("This is radiobutton", null, true);
+        f.add(ch2);
+
+        ch1.setCheckboxGroup(null);
+        ch2.setCheckboxGroup(new CheckboxGroup());
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Cursor/CursorDragTest/ListDragCursor.java
+++ b/test/jdk/java/awt/Cursor/CursorDragTest/ListDragCursor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4313052
+ * @summary Test cursor changes after mouse dragging ends
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ListDragCursor
+ */
+
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.TextArea;
+
+public class ListDragCursor {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Move mouse to the TextArea.
+                2. Press the left mouse button.
+                3. Drag mouse to the list.
+                4. Release the left mouse button.
+
+                If the mouse cursor starts as a Text Line Cursor and changes
+                to a regular Pointer Cursor, then Hand Cursor when hovering
+                the list, pass the test. This test fails if the cursor does
+                not update at all when pointing over the different components.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(ListDragCursor::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame frame = new Frame("Cursor change after drag");
+        Panel panel = new Panel();
+
+        List list = new List(2);
+        list.add("List1");
+        list.add("List2");
+        list.add("List3");
+        list.add("List4");
+        list.setCursor(new Cursor(Cursor.HAND_CURSOR));
+
+        TextArea textArea = new TextArea(3, 5);
+        textArea.setCursor(new Cursor(Cursor.TEXT_CURSOR));
+
+        panel.add(textArea);
+        panel.add(list);
+
+        frame.add(panel);
+        frame.setBounds(300, 100, 300, 150);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Cursor/HiddenDialogParentTest/HiddenDialogParentTest.java
+++ b/test/jdk/java/awt/Cursor/HiddenDialogParentTest/HiddenDialogParentTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5079694
+ * @summary Test if JDialog respects setCursor
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual HiddenDialogParentTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.border.LineBorder;
+
+public class HiddenDialogParentTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                 You can see a label area in the center of JDialog.
+                 Verify that the cursor is a hand cursor in this area.
+                 If so, press pass, else press fail.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(HiddenDialogParentTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JDialog createUI() {
+        JDialog dialog = new JDialog();
+        dialog.setTitle("JDialog Cursor Test");
+        dialog.setLayout(new BorderLayout());
+        JLabel centerLabel = new JLabel("Cursor should be a hand in this " +
+                "label area");
+        centerLabel.setBorder(new LineBorder(Color.BLACK));
+        centerLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        dialog.add(centerLabel, BorderLayout.CENTER);
+        dialog.setSize(300, 200);
+
+        return dialog;
+    }
+}

--- a/test/jdk/java/awt/Cursor/InvalidImageCustomCursorTest/InvalidImageCustomCursorTest.java
+++ b/test/jdk/java/awt/Cursor/InvalidImageCustomCursorTest/InvalidImageCustomCursorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4212593
+ * @summary The Toolkit.createCustomCursor does not check absence of the
+ *          image of cursor
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual InvalidImageCustomCursorTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.Image;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Toolkit;
+
+public class InvalidImageCustomCursorTest {
+    static Cursor cursor;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Press 'Hide' button to hide (set transparent) cursor for the
+                green panel. Move the pointer over the green panel - pointer
+                should disappear. Press 'Default' button to set default cursor
+                for the green panel.
+
+                If you see any exceptions or cursor is not transparent,
+                test failed, otherwise it passed.
+                """;
+
+        Toolkit tk = Toolkit.getDefaultToolkit();
+        Image image = tk.getImage("NON_EXISTING_FILE.gif");
+        Point p = new Point(0, 0);
+
+        cursor = tk.createCustomCursor(image, p, "Test");
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(InvalidImageCustomCursorTest::createUI)
+                .logArea(5)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("Invalid Cursor Image Test");
+        f.setLayout(new BorderLayout());
+        f.setSize(200, 200);
+
+        Button def = new Button("Default");
+        Button hide = new Button("Hide");
+        Panel panel = new Panel();
+
+        def.addActionListener(e -> panel.setCursor(Cursor.getDefaultCursor()));
+        hide.addActionListener(e -> panel.setCursor(cursor));
+
+        panel.setBackground(Color.green);
+        panel.setSize(100, 100);
+        f.add("Center", panel);
+        f.add("North", hide);
+        f.add("South", def);
+
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Cursor/NullCursorTest/NullCursorTest.java
+++ b/test/jdk/java/awt/Cursor/NullCursorTest/NullCursorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4111379
+ * @summary Test for setting cursor to null for lightweight components
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual NullCursorTest
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class NullCursorTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                 1. Hover over each colored area as described:
+                        Green area shows a CrossCursor.
+                        Red area shows a TextCursor.
+                        Yellow area shows a HandCursor.
+                 2. Click once in red area, then:
+                        Green area shows a HandCursor.
+                        Red area shows a BusyCursor.
+                        Yellow area shows a HandCursor.
+                 3. Click again in red area, then:
+                        Green area shows a CrossCursor.
+                        Red area shows a HandCursor.
+                        Yellow area shows a HandCursor.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(NullCursorTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("Null Cursor Test Frame");
+        f.setSize(200, 200);
+        final Container p = f;
+        p.setName("parent");
+        p.setLayout(null);
+
+        final Component green = p.add(new Component() {
+            public void paint(Graphics g) {
+                Rectangle r = getBounds();
+                g.setColor(Color.green);
+                g.fillRect(0, 0, r.width, r.height);
+            }
+        });
+        green.setName("green");
+        green.setBackground(Color.red);
+        green.setBounds(50, 50, 75, 75);
+        green.setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
+
+        Container h = new Container() {
+            public void paint(Graphics g) {
+                Rectangle r = getBounds();
+                g.setColor(Color.yellow);
+                g.fillRect(0, 0, r.width, r.height);
+                super.paint(g);
+            }
+        };
+        h.setBounds(15, 25, 150, 150);
+        h.setName("container");
+        h.setBackground(Color.yellow);
+        h.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        final Component red = new Component() {
+            public void paint(Graphics g) {
+                Rectangle r = getBounds();
+                Color c = getBackground();
+                g.setColor(c);
+                g.fillRect(0, 0, r.width, r.height);
+                super.paint(g);
+            }
+        };
+        red.setName("red");
+        red.setBackground(Color.red);
+        red.setBounds(10, 10, 120, 120);
+        red.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
+
+        final Button b = (Button)h.add(new Button("Test"));
+        b.setBounds(10, 10, 40, 20);
+        h.add(red);
+        p.add(h);
+
+        b.addActionListener(new ActionListener() {
+            boolean f = false;
+            public void actionPerformed(ActionEvent e) {
+                if (f) {
+                    b.setCursor(null);
+                } else {
+                    b.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+                }
+                f = !f;
+            }
+        });
+        red.addMouseListener(new MouseAdapter() {
+            boolean f = true;
+
+            public void mouseClicked(MouseEvent e) {
+                Component c = (Component)e.getSource();
+                if (f) {
+                    c.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+                    p.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
+                    green.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+                    f = false;
+                } else {
+                    c.setCursor(null);
+                    p.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+                    green.setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
+                    f = true;
+                }
+            }
+        });
+        return f;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340966](https://bugs.openjdk.org/browse/JDK-8340966) needs maintainer approval

### Issue
 * [JDK-8340966](https://bugs.openjdk.org/browse/JDK-8340966): Open source few Checkbox and Cursor tests - Set1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3353/head:pull/3353` \
`$ git checkout pull/3353`

Update a local copy of the PR: \
`$ git checkout pull/3353` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3353`

View PR using the GUI difftool: \
`$ git pr show -t 3353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3353.diff">https://git.openjdk.org/jdk17u-dev/pull/3353.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3353#issuecomment-2721503929)
</details>
