### PR TITLE
8347286: (fs) Remove some extensions from java/nio/file/Files/probeContentType/Basic.java

### DIFF
--- a/test/jdk/java/nio/file/Files/probeContentType/Basic.java
+++ b/test/jdk/java/nio/file/Files/probeContentType/Basic.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import jdk.test.lib.Platform;
-import jdk.test.lib.OSVersion;
 import jdk.internal.util.StaticProperty;
 
 /**
@@ -188,18 +187,8 @@ public class Basic {
         exTypes.add(new ExType("xlsx", List.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")));
         // exTypes.add(new ExType("wasm", List.of("application/wasm")));  Note. "wasm" is added via JDK-8297609 (Java 20) which not exist in current java version yet
 
-        // extensions with content type that differs on Windows 11+ and
-        // Windows Server 2025
-        if (Platform.isWindows() &&
-            (System.getProperty("os.name").matches("^.*[11|2025]$") ||
-                new OSVersion(10, 0).compareTo(OSVersion.current()) > 0)) {
-            System.out.println("Windows 11+ detected: using different types");
-            exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip", "application/x-compressed")));
-            exTypes.add(new ExType("csv", List.of("text/csv", "application/vnd.ms-excel")));
-            exTypes.add(new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed", "application/x-compressed")));
-            exTypes.add(new ExType("rtf", List.of("application/rtf", "text/rtf", "application/msword")));
-            exTypes.add(new ExType("7z", List.of("application/x-7z-compressed", "application/x-compressed")));
-        } else {
+        // extensions with consistent content type on Unix (but not on Windows)
+        if (!Platform.isWindows()) {
             exTypes.add(new ExType("bz2", List.of("application/bz2", "application/x-bzip2", "application/x-bzip")));
             exTypes.add(new ExType("csv", List.of("text/csv")));
             exTypes.add(new ExType("rar", List.of("application/rar", "application/vnd.rar", "application/x-rar", "application/x-rar-compressed")));


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle

I had to resolve.
OperatingSystem.isWindows() is not in 17.
Also, two changes are missing in 17:

[8287237: (fs) Files.probeContentType returns null if filename contains hash mark on Linux](https://github.com/openjdk/jdk/commit/8071b2311caaacd714d74f12aee6cb7c2fe700fa)
[8297609: Add application/wasm MIME type for wasm file extension](https://github.com/openjdk/jdk/commit/914ef07fed960f940e1591318b9f00938b37bf09)

I don't think these should be backported as prereq.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347286](https://bugs.openjdk.org/browse/JDK-8347286) needs maintainer approval

### Issue
 * [JDK-8347286](https://bugs.openjdk.org/browse/JDK-8347286): (fs) Remove some extensions from java/nio/file/Files/probeContentType/Basic.java (**Enhancement** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3362/head:pull/3362` \
`$ git checkout pull/3362`

Update a local copy of the PR: \
`$ git checkout pull/3362` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3362`

View PR using the GUI difftool: \
`$ git pr show -t 3362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3362.diff">https://git.openjdk.org/jdk17u-dev/pull/3362.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3362#issuecomment-2727011171)
</details>
