### PR TITLE
8280991: [XWayland] No displayChanged event after setDisplayMode call

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,15 @@ public final class X11GraphicsDevice extends GraphicsDevice
     private boolean shutdownHookRegistered;
     private int scale;
 
+    // Wayland clients are by design not allowed to change the resolution in Wayland.
+    // XRandR in Xwayland is just an emulation, it doesn't actually change the resolution.
+    // This emulation is per window/x11 client, so different clients can have
+    // different emulated resolutions at the same time.
+    // So any request to get the current display mode will always return
+    // the original screen resolution, even if we are in emulated resolution.
+    // To handle this situation, we store the last set display mode in this variable.
+    private volatile DisplayMode xwlCurrentDisplayMode;
+
     public X11GraphicsDevice(int screennum) {
         this.screen = screennum;
         this.scale = initScaleFactor();
@@ -125,6 +134,20 @@ public final class X11GraphicsDevice extends GraphicsDevice
 
     private Rectangle getBoundsImpl() {
         Rectangle rect = pGetBounds(getScreen());
+
+        if (XToolkit.isOnWayland() && xwlCurrentDisplayMode != null) {
+            // XRandR resolution change in Xwayland is an emulation,
+            // and implemented in such a way that multiple display modes
+            // for a device are only available in a single screen scenario,
+            // if we have multiple screens they will each have a single display mode
+            // (no emulated resolution change is available).
+            // So we don't have to worry about x and y for a screen here.
+            rect.setSize(
+                    xwlCurrentDisplayMode.getWidth(),
+                    xwlCurrentDisplayMode.getHeight()
+            );
+        }
+
         if (getScaleFactor() != 1) {
             rect.x = scaleDown(rect.x);
             rect.y = scaleDown(rect.y);
@@ -424,10 +447,19 @@ public final class X11GraphicsDevice extends GraphicsDevice
     @Override
     public synchronized DisplayMode getDisplayMode() {
         if (isFullScreenSupported()) {
+            if (XToolkit.isOnWayland() && xwlCurrentDisplayMode != null) {
+                return xwlCurrentDisplayMode;
+            }
+
             DisplayMode mode = getCurrentDisplayMode(screen);
             if (mode == null) {
                 mode = getDefaultDisplayMode();
             }
+
+            if (XToolkit.isOnWayland()) {
+                xwlCurrentDisplayMode = mode;
+            }
+
             return mode;
         } else {
             if (origDisplayMode == null) {
@@ -502,6 +534,10 @@ public final class X11GraphicsDevice extends GraphicsDevice
         configDisplayMode(screen,
                           dm.getWidth(), dm.getHeight(),
                           dm.getRefreshRate());
+
+        if (XToolkit.isOnWayland()) {
+            xwlCurrentDisplayMode = dm;
+        }
 
         // update bounds of the fullscreen window
         w.setBounds(0, 0, dm.getWidth(), dm.getHeight());

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -489,7 +489,6 @@ java/awt/Dialog/ChoiceModalDialogTest.java 8161475 macosx-all
 
 # Wayland related
 
-java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java 8280991 linux-x64
 
 ############################################################################
 

--- a/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
+++ b/test/jdk/java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,10 @@ public final class FullscreenWindowProps {
                 super.paint(g);
                 g.setColor(Color.GREEN);
                 g.fillRect(0, 0, getWidth(), getHeight());
+                g.setColor(Color.RED);
+                DisplayMode displayMode =
+                        getGraphicsConfiguration().getDevice().getDisplayMode();
+                g.drawString(displayMode.toString(), 100, 100);
             }
         };
         try {


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

Resolved Copyright, ProblemList, probably clean anyways.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8280991](https://bugs.openjdk.org/browse/JDK-8280991) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280991](https://bugs.openjdk.org/browse/JDK-8280991): [XWayland] No displayChanged event after setDisplayMode call (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3365/head:pull/3365` \
`$ git checkout pull/3365`

Update a local copy of the PR: \
`$ git checkout pull/3365` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3365`

View PR using the GUI difftool: \
`$ git pr show -t 3365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3365.diff">https://git.openjdk.org/jdk17u-dev/pull/3365.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3365#issuecomment-2728943021)
</details>
