### PR TITLE
8348107: test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java fails intermittently

### DIFF
--- a/test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java
+++ b/test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java
@@ -176,7 +176,8 @@ public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
         try (HttpsTunnelAuthTest test = new HttpsTunnelAuthTest()) {
             test.setUp();
 
-            try (HttpClient client = test.newHttpClient(test.proxySelector)) {
+            {
+                HttpClient client = test.newHttpClient(test.proxySelector);
                 // tests proxy and server authentication through:
                 // - plain proxy connection to plain HTTP/1.1 server,
                 test.test(client, Version.HTTP_1_1, "http", "/foo/http1");
@@ -187,7 +188,8 @@ public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
             // so that is actually somewhat equivalent to the first case:
             // therefore we will use a new client to force re-authentication
             // of the proxy connection.
-            try (HttpClient client = test.newHttpClient(test.proxySelector)) {
+            {
+                HttpClient client = test.newHttpClient(test.proxySelector);
                 test.test(client, Version.HTTP_2, "http", "/foo/http2");
 
                 // - proxy tunnel SSL connection to HTTP/1.1 server


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

HttpClient does not implement AutoClosable in 17, so try-with-resources can not be used here.
This part of the fix is only cleanup, so we can get along without it.
I tried to keep the formatting of the code as close to 21 as possible.

https://bugs.openjdk.org/browse/JDK-8267140 Support closing the HttpClient by making it auto-closable 
came only in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8348107](https://bugs.openjdk.org/browse/JDK-8348107) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8348107](https://bugs.openjdk.org/browse/JDK-8348107): test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java fails intermittently (**Bug** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3372/head:pull/3372` \
`$ git checkout pull/3372`

Update a local copy of the PR: \
`$ git checkout pull/3372` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3372`

View PR using the GUI difftool: \
`$ git pr show -t 3372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3372.diff">https://git.openjdk.org/jdk17u-dev/pull/3372.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3372#issuecomment-2730045244)
</details>
