### PR TITLE
8343936: Adjust timeout in test javax/management/monitor/DerivedGaugeMonitorTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -526,8 +526,6 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-all
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all
 
-javax/management/monitor/DerivedGaugeMonitorTest.java         8042211 generic-all
-
 ############################################################################
 
 # jdk_io

--- a/test/jdk/javax/management/monitor/DerivedGaugeMonitorTest.java
+++ b/test/jdk/javax/management/monitor/DerivedGaugeMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@
  * @summary Test that the initial derived gauge is (Integer)0
  * @author Daniel Fuchs
  *
+ * @library /test/lib
+ *
  * @run clean DerivedGaugeMonitorTest
  * @run build DerivedGaugeMonitorTest
  * @run main DerivedGaugeMonitorTest
@@ -40,8 +42,11 @@ import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
 import javax.management.monitor.CounterMonitor;
 import javax.management.monitor.GaugeMonitor;
+import jdk.test.lib.Utils;
 
 public class DerivedGaugeMonitorTest {
+
+    public static final int WAIT_TIME = 1000;
 
     public static interface Things {
         public long getALong();
@@ -239,7 +244,7 @@ public class DerivedGaugeMonitorTest {
             mon1.setGranularityPeriod(5);
             mon2.setGranularityPeriod(5);
 
-            my.cdl.await(1000, TimeUnit.MILLISECONDS);
+            my.cdl.await(Utils.adjustTimeout(WAIT_TIME), TimeUnit.MILLISECONDS);
             if (my.cdl.getCount() > 0)
                 throw new Exception(attr+": Count down not reached!");
 


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle

Resolved ProblemList, probably clean.
Update: it's not clean because the removed ProblemList line differs in whitespace.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8343936](https://bugs.openjdk.org/browse/JDK-8343936) needs maintainer approval

### Issue
 * [JDK-8343936](https://bugs.openjdk.org/browse/JDK-8343936): Adjust timeout in test javax/management/monitor/DerivedGaugeMonitorTest.java (**Bug** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3378/head:pull/3378` \
`$ git checkout pull/3378`

Update a local copy of the PR: \
`$ git checkout pull/3378` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3378`

View PR using the GUI difftool: \
`$ git pr show -t 3378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3378.diff">https://git.openjdk.org/jdk17u-dev/pull/3378.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3378#issuecomment-2732943225)
</details>
