### PR TITLE
8341000: Open source some of the AWT Window tests

### DIFF
--- a/test/jdk/java/awt/Window/BadConfigure/BadConfigure.java
+++ b/test/jdk/java/awt/Window/BadConfigure/BadConfigure.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6261336
+ * @summary Tests that Choice inside ScrollPane opens at the right location
+ *          after resize
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual BadConfigure
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Frame;
+
+public class BadConfigure
+{
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            Please resize the BadConfigure window using the left border.
+            Now click on choice. Its popup will be opened.
+            Please verify that the popup is opened right under the choice.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(35)
+            .testUI(initialize())
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static Frame initialize() {
+        Frame f = new Frame("BadConfigure");
+        f.setLayout(new BorderLayout());
+        Choice ch = new Choice();
+        f.add(ch, BorderLayout.NORTH);
+        ch.add("One");
+        ch.add("One");
+        ch.add("One");
+        ch.add("One");
+        ch.add("One");
+        ch.add("One");
+        f.setSize(200, 200);
+        f.validate();
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Window/InvalidFocusLostEventTest/InvalidFocusLostEventTest.java
+++ b/test/jdk/java/awt/Window/InvalidFocusLostEventTest/InvalidFocusLostEventTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4397883
+ * @summary Tests that non-focusable Window doesn't grab focus
+ * @key headful
+ * @run main InvalidFocusLostEventTest
+ */
+
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+
+public class InvalidFocusLostEventTest implements ActionListener {
+    private static Frame f;
+    private static Button b;
+    private static KeyboardFocusManager fm;
+    private static volatile Point bp;
+    private static volatile int width, height;
+    private static Robot robot;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            InvalidFocusLostEventTest test = new InvalidFocusLostEventTest();
+            EventQueue.invokeAndWait(() -> test.createUI());
+            runTest();
+            // we should check focus after all events are processed,
+            // since focus transfers are asynchronous
+            robot.waitForIdle();
+            if (fm.getFocusOwner() != b) {
+                throw new RuntimeException("Failed: focus was lost");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private void createUI() {
+        f = new Frame("InvalidFocusLostEventTest");
+        b = new Button("Press me");
+        fm = KeyboardFocusManager.getCurrentKeyboardFocusManager();
+        b.addActionListener(this);
+        f.add(b);
+        f.pack();
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+    private static void runTest() throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
+        robot.setAutoWaitForIdle(true);
+        EventQueue.invokeAndWait(() -> {
+            bp = b.getLocationOnScreen();
+            width = b.getWidth();
+            height = b.getHeight();
+        });
+        robot.mouseMove(bp.x + width / 2, bp.y + height / 2 );
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+    }
+
+    public void actionPerformed(ActionEvent ev) {
+        // pop up a non-focusable window
+        Window win = new Window(f);
+        win.setFocusableWindowState(false);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 21.0.8-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341000](https://bugs.openjdk.org/browse/JDK-8341000) needs maintainer approval

### Issue
 * [JDK-8341000](https://bugs.openjdk.org/browse/JDK-8341000): Open source some of the AWT Window tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3385/head:pull/3385` \
`$ git checkout pull/3385`

Update a local copy of the PR: \
`$ git checkout pull/3385` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3385`

View PR using the GUI difftool: \
`$ git pr show -t 3385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3385.diff">https://git.openjdk.org/jdk17u-dev/pull/3385.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3385#issuecomment-2736272302)
</details>
