### PR TITLE
Backport 0f82268134df65bbc65ecda158d25f708f18d150

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -79,7 +79,7 @@ public abstract class PKCS11Test {
 
     // Version of the NSS artifact. This coincides with the version of
     // the NSS version
-    private static final String NSS_BUNDLE_VERSION = "3.101";
+    private static final String NSS_BUNDLE_VERSION = "3.107";
     private static final String NSSLIB = "jpg.tests.jdk.nsslib";
 
     static double nss_version = -1;


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.