### PR TITLE
8350412: [21u] AArch64: Ambiguous frame layout leads to incorrect traces in JFR

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1761,8 +1761,8 @@ int MachCallRuntimeNode::ret_addr_offset() {
   // for real runtime callouts it will be six instructions
   // see aarch64_enc_java_to_runtime
   //   adr(rscratch2, retaddr)
+  //   str(rscratch2, Address(rthread, JavaThread::last_Java_pc_offset()));
   //   lea(rscratch1, RuntimeAddress(addr)
-  //   stp(zr, rscratch2, Address(__ pre(sp, -2 * wordSize)))
   //   blr(rscratch1)
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb) {
@@ -3755,13 +3755,12 @@ encode %{
       }
     } else {
       Label retaddr;
+      // Make the anchor frame walkable
       __ adr(rscratch2, retaddr);
+      __ str(rscratch2, Address(rthread, JavaThread::last_Java_pc_offset()));
       __ lea(rscratch1, RuntimeAddress(entry));
-      // Leave a breadcrumb for JavaFrameAnchor::capture_last_Java_pc()
-      __ stp(zr, rscratch2, Address(__ pre(sp, -2 * wordSize)));
       __ blr(rscratch1);
       __ bind(retaddr);
-      __ add(sp, sp, 2 * wordSize);
     }
     if (Compile::current()->max_vector_size() >= 16) {
       __ reinitialize_ptrue();


### PR DESCRIPTION
This tiny change fixes incorrect stack traces sometimes reported by JFR (non-deterministic stack walking). It is a backport from jdk21u. The pach has been manually recreated in 17u context (there are no post_call_nop() calls - a part of Virtual Threads, and max_vector_size comparison is different - a part of SVE support), in principal the patch is the same.

Testing: tier1,2 on linux-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350412](https://bugs.openjdk.org/browse/JDK-8350412) needs maintainer approval

### Issue
 * [JDK-8350412](https://bugs.openjdk.org/browse/JDK-8350412): [21u] AArch64: Ambiguous frame layout leads to incorrect traces in JFR (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3389/head:pull/3389` \
`$ git checkout pull/3389`

Update a local copy of the PR: \
`$ git checkout pull/3389` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3389`

View PR using the GUI difftool: \
`$ git pr show -t 3389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3389.diff">https://git.openjdk.org/jdk17u-dev/pull/3389.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3389#issuecomment-2739680605)
</details>
