### PR TITLE
8337299: vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java failure goes undetected

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,6 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+//    THIS TEST IS LINE NUMBER SENSITIVE
 
 package nsk.jdb.stop_at.stop_at002;
 
@@ -59,7 +61,7 @@ public class stop_at002a {
         class DeeperNested {
             class  DeepestNested {
                 public void foo(boolean input) {
-                    flag = input; /* <--------  This is line number 43 */
+                    flag = input; /* <--------  This is line number 64 */
                 }
             }
         }
@@ -73,7 +75,7 @@ public class stop_at002a {
                 content = "";
             }
             public void foo(String input) {
-                content += input; /* <--------  This is line number 57 */
+                content += input; /* <--------  This is line number 78 */
             }
         }
     }


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337299](https://bugs.openjdk.org/browse/JDK-8337299) needs maintainer approval

### Issue
 * [JDK-8337299](https://bugs.openjdk.org/browse/JDK-8337299): vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java failure goes undetected (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3392/head:pull/3392` \
`$ git checkout pull/3392`

Update a local copy of the PR: \
`$ git checkout pull/3392` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3392`

View PR using the GUI difftool: \
`$ git pr show -t 3392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3392.diff">https://git.openjdk.org/jdk17u-dev/pull/3392.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3392#issuecomment-2741558622)
</details>
