### PR TITLE
8334895: OpenJDK fails to configure on linux aarch64 when CDS is disabled after JDK-8331942

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -211,9 +211,8 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
   # three different page sizes: 4K, 64K, and if run on Mac m1 hardware, 16K.
   COMPATIBLE_CDS_ALIGNMENT_DEFAULT=false
   if test "x$OPENJDK_TARGET_OS" = "xlinux" && test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
-    COMPATIBLE_CDS_ALIGNMENT_DEFAULT=true
+    COMPATIBLE_CDS_ALIGNMENT_DEFAULT=auto
   fi
-  AC_SUBST(COMPATIBLE_CDS_ALIGNMENT_DEFAULT)
 
   # Compress jars
   COMPRESS_JARS=false
@@ -596,7 +595,7 @@ AC_DEFUN([JDKOPT_ENABLE_DISABLE_COMPATIBLE_CDS_ALIGNMENT],
   UTIL_ARG_ENABLE(NAME: compatible-cds-alignment, DEFAULT: $COMPATIBLE_CDS_ALIGNMENT_DEFAULT,
       RESULT: ENABLE_COMPATIBLE_CDS_ALIGNMENT,
       DESC: [enable use alternative compatible cds core region alignment],
-      DEFAULT_DESC: [disabled],
+      DEFAULT_DESC: [disabled except on linux-aarch64],
       CHECKING_MSG: [if compatible cds region alignment enabled],
       CHECK_AVAILABLE: [
         AC_MSG_CHECKING([if CDS archive is available])


### PR DESCRIPTION
Backporting JDK-8334895: OpenJDK fails to configure on linux aarch64 when CDS is disabled after JDK-8331942. Sets COMPATIBLE_CDS_ALIGNMENT_DEFAULT to auto for aarch64 to address configure failure when building on linux aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334895](https://bugs.openjdk.org/browse/JDK-8334895) needs maintainer approval

### Issue
 * [JDK-8334895](https://bugs.openjdk.org/browse/JDK-8334895): OpenJDK fails to configure on linux aarch64 when CDS is disabled after JDK-8331942 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3398/head:pull/3398` \
`$ git checkout pull/3398`

Update a local copy of the PR: \
`$ git checkout pull/3398` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3398`

View PR using the GUI difftool: \
`$ git pr show -t 3398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3398.diff">https://git.openjdk.org/jdk17u-dev/pull/3398.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3398#issuecomment-2743881226)
</details>
