### PR TITLE
8352649: [17u] guarantee(is_result_safe || is_in_asgct()) failed inside AsyncGetCallTrace

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1008,7 +1008,6 @@ void JavaThread::check_for_valid_safepoint_state() {
 JavaThread::JavaThread() :
   // Initialize fields
 
-  _in_asgct(false),
   _on_thread_list(false),
   DEBUG_ONLY(_java_call_counter(0) COMMA)
   _entry_point(nullptr),

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -715,7 +715,6 @@ class JavaThread: public Thread {
   friend class ThreadsSMRSupport; // to access _threadObj for exiting_threads_oops_do
   friend class HandshakeState;
  private:
-  bool           _in_asgct;                      // Is set when this JavaThread is handling ASGCT call
   bool           _on_thread_list;                // Is set when this JavaThread is added to the Threads list
   OopHandle      _threadObj;                     // The Java level thread object
 
@@ -1640,10 +1639,6 @@ public:
   // Helper function to do vm_exit_on_initialization for osthread
   // resource allocation failure.
   static void vm_exit_on_osthread_failure(JavaThread* thread);
-
-  // AsyncGetCallTrace support
-  inline bool in_asgct(void) {return _in_asgct;}
-  inline void set_in_asgct(bool value) {_in_asgct = value;}
 };
 
 // Inline implementation of JavaThread::current


### PR DESCRIPTION
This PR fixes intermittent JVM crash at `guarantee(is_result_safe || is_in_asgct()) failed: unsafe access to zombie method` when running profiler.

This guarantee was changed in [JDK-8283849](https://bugs.openjdk.org/browse/JDK-8283849) to avoid failing in AsyncGetCallTrace context. However, after [JDK-8304725](https://bugs.openjdk.org/browse/JDK-8304725) and [JDK-8325585](https://bugs.openjdk.org/browse/JDK-8325585) it started failing again. This is because JDK-8304725 introduced another copy of `_in_asgct` field in Thread class, whereas JDK-8325585 removed setting of `_in_asgct` in JavaThread class. In this way, `AsyncGetCallTrace` sets `Thread::_in_asgct` field, but the above guarantee checks a different `JavaThread::_in_asgct` field.

This PR resolves confusion by removing redundant `_in_asgct` field declared in `JavaThread`. Now, all code consistently sets and reads the only `_in_asgct` field declared in `Thread` class. This matches existing logic in jdk tip and jdk21u.

**Low risk:** straightforward removal of redundant code related to AsyncGetCallTrace.

**Testing:** tier1, runnining Renaissance and DaCapo with async-profiler enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8352649](https://bugs.openjdk.org/browse/JDK-8352649) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352649](https://bugs.openjdk.org/browse/JDK-8352649): [17u] guarantee(is_result_safe || is_in_asgct()) failed inside AsyncGetCallTrace (**Bug** - P4 - Approved)


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.org/census#jbachorik) (@jbachorik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3400/head:pull/3400` \
`$ git checkout pull/3400`

Update a local copy of the PR: \
`$ git checkout pull/3400` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3400`

View PR using the GUI difftool: \
`$ git pr show -t 3400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3400.diff">https://git.openjdk.org/jdk17u-dev/pull/3400.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3400#issuecomment-2746520013)
</details>
