### PR TITLE
8315981: Opensource five more random Swing tests

### DIFF
--- a/test/jdk/javax/swing/DefaultListCellRenderer/4180943/bug4180943.java
+++ b/test/jdk/javax/swing/DefaultListCellRenderer/4180943/bug4180943.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4180943
+ * @summary Extra borders created by DefaultListCellRenderer
+ * @run main bug4180943
+ */
+
+import javax.swing.DefaultListCellRenderer;
+
+public class bug4180943 {
+    public static void main(String[] argv) {
+        DefaultListCellRenderer lcr1 = new DefaultListCellRenderer();
+        DefaultListCellRenderer lcr2 = new DefaultListCellRenderer();
+        if (lcr1.getBorder() != lcr2.getBorder()) {
+            throw new RuntimeException("Extra borders created by DefaultListCellRenderer");
+        }
+    }
+}

--- a/test/jdk/javax/swing/DefaultListModel/4466250/bug4466250.java
+++ b/test/jdk/javax/swing/DefaultListModel/4466250/bug4466250.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4466250
+ * @summary DefaultListModel.removeRange does not throw IllegalArgumentException
+ * @run main bug4466250
+*/
+
+import javax.swing.DefaultListModel;
+import javax.swing.JLabel;
+
+public class bug4466250 {
+    public static void main(String[] args) {
+        DefaultListModel model = new DefaultListModel();
+        int size = 16;
+        for (int i = 0; i < size; i++ ) {
+            model.addElement(new JLabel("wow"));
+        }
+
+        try {
+            model.removeRange(3, 1);
+            throw new RuntimeException("IllegalArgumentException has not been thrown");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+}

--- a/test/jdk/javax/swing/DefaultListSelectionModel/4140619/bug4140619.java
+++ b/test/jdk/javax/swing/DefaultListSelectionModel/4140619/bug4140619.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4140619
+ * @summary Breaks SINGLE_SELECTION in DefaultListSelectionModel.setLeadSelectionIndex()
+ * @run main bug4140619
+ */
+
+import javax.swing.DefaultListSelectionModel;
+import javax.swing.ListSelectionModel;
+
+public class bug4140619 {
+    public static void main(String[] args) {
+        DefaultListSelectionModel selection = new DefaultListSelectionModel();
+        selection.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        selection.setSelectionInterval(10, 10);
+        selection.removeSelectionInterval(10, 10);
+        selection.setLeadSelectionIndex(2);
+        selection.setLeadSelectionIndex(30);
+        selection.setLeadSelectionIndex(5);
+
+        if (selection.getMinSelectionIndex()!=5
+                || selection.getMaxSelectionIndex()!=5) {
+            throw new RuntimeException("DefaultListSelectionModel: breaks SINGLE_SELECTION "
+                    + "in setLeadSelectionIndex()");
+        }
+    }
+}

--- a/test/jdk/javax/swing/DefaultListSelectionModel/4177723/bug4177723.java
+++ b/test/jdk/javax/swing/DefaultListSelectionModel/4177723/bug4177723.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4177723
+ * @summary ListSelectionEvents fired on model changes affecting JList selection
+ * @run main bug4177723
+ */
+
+import javax.swing.DefaultListModel;
+import javax.swing.JList;
+
+public class bug4177723 {
+    static int count = 0;
+
+    public static void main (String[] args) {
+        DefaultListModel model = new DefaultListModel();
+        for (int i = 0; i < 10; i++) {
+            model.addElement("item " + i);
+        }
+
+        JList list = new JList(model);
+        list.addListSelectionListener(e -> count++);
+
+        list.getSelectionModel().setSelectionInterval(3, 8);
+        model.removeRange(4, 7);
+        if (count != 2) {
+            throw new RuntimeException("ListSelectionEvent wasn't generated");
+        }
+    }
+}

--- a/test/jdk/javax/swing/ImageIcon/4827074/bug4827074.java
+++ b/test/jdk/javax/swing/ImageIcon/4827074/bug4827074.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4827074
+ * @summary ImageIcon serialization does not preload restored images
+ * @run main bug4827074
+ */
+
+import javax.swing.ImageIcon;
+import java.awt.Image;
+import java.awt.Panel;
+import java.awt.image.MemoryImageSource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class bug4827074 extends Panel {
+
+    static ImageIcon testIcon = null;
+    private volatile static boolean passed = false;
+
+    public void init() {
+        testIcon = new TestImageIcon();
+        ImageIcon icon = saveAndLoad(testIcon);
+
+        if (!passed) {
+            throw new RuntimeException("Image was not loaded properly");
+        }
+    }
+
+    synchronized static void setPassed(boolean p) {
+        passed = p;
+    }
+
+    static ImageIcon saveAndLoad(ImageIcon ii) {
+        ImageIcon _ii = null;
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream out = new ObjectOutputStream(baos);
+            out.writeObject(ii);
+            out.flush();
+            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+            ObjectInputStream in = new ObjectInputStream(bais);
+            _ii = (ImageIcon)in.readObject();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return _ii;
+    }
+
+    class TestImageIcon extends ImageIcon {
+        public TestImageIcon() {
+            super();
+            setImage(buildImage());
+        }
+
+        private Image buildImage() {
+            int w = 32, h = 32;
+            float halfW = w / 2 , halfH = h / 2;
+            int col = 0xff0000;
+            int[] pixels = new int[w * h];
+            for(int y = 0; y < h; y++) {
+                for(int x = 0; x < w; x++) {
+                    float cx = 1f - (float)x / halfW;
+                    float cy = 1f - (float)y / halfH;
+                    double ray = Math.sqrt(cx * cx + cy * cy);
+                    pixels[y * w + x] = ray < 1 ? col | (255 - (int)(ray * 255)) << 24:0;
+                }
+            }
+            MemoryImageSource mis = new MemoryImageSource(w, h, pixels, 0, w);
+            Image image = createImage(mis);
+            return image;
+        }
+
+        protected void loadImage(Image image) {
+            super.loadImage(image);
+            if (testIcon != null && image != testIcon.getImage()) {
+                setPassed(true);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        bug4827074 bug = new bug4827074();
+        bug.init();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315981](https://bugs.openjdk.org/browse/JDK-8315981) needs maintainer approval

### Issue
 * [JDK-8315981](https://bugs.openjdk.org/browse/JDK-8315981): Opensource five more random Swing tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3401/head:pull/3401` \
`$ git checkout pull/3401`

Update a local copy of the PR: \
`$ git checkout pull/3401` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3401`

View PR using the GUI difftool: \
`$ git pr show -t 3401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3401.diff">https://git.openjdk.org/jdk17u-dev/pull/3401.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3401#issuecomment-2748976173)
</details>
