### PR TITLE
8340228: Open source couple more miscellaneous AWT tests

### DIFF
--- a/test/jdk/java/awt/Desktop/EditAndPrintTest/EditAndPrintTest.java
+++ b/test/jdk/java/awt/Desktop/EditAndPrintTest/EditAndPrintTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key printer
+ * @bug 6255196
+ * @summary  Verifies the function of methods edit(java.io.File file) and
+ *           print(java.io.File file)
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual EditAndPrintTest
+ */
+
+import java.awt.Desktop;
+import java.awt.Desktop.Action;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.JPanel;
+
+public class EditAndPrintTest extends JPanel {
+
+    static final String INSTRUCTIONS = """
+            This test tries to edit and print a directory, which will expectedly raise IOException.
+            Then this test would edit and print a .txt file, which should be successful.
+            After test execution close the editor if it was launched by test.
+            If you see any EXCEPTION messages in the output press FAIL.
+            """;
+
+    public EditAndPrintTest() {
+        if (!Desktop.isDesktopSupported()) {
+            PassFailJFrame.log("Class java.awt.Desktop is not supported on " +
+                    "current platform. Further testing will not be performed");
+            PassFailJFrame.forcePass();
+        }
+
+        Desktop desktop = Desktop.getDesktop();
+
+        if (!desktop.isSupported(Action.PRINT) && !desktop.isSupported(Action.EDIT)) {
+            PassFailJFrame.log("Neither EDIT nor PRINT actions are supported. Nothing to test.");
+            PassFailJFrame.forcePass();
+        }
+
+        /*
+         * Part 1: print or edit a directory, which should throw an IOException.
+         */
+        File userHome = new File(System.getProperty("user.home"));
+        try {
+            if (desktop.isSupported(Action.EDIT)) {
+                PassFailJFrame.log("Trying to edit " + userHome);
+                desktop.edit(userHome);
+                PassFailJFrame.log("No exception has been thrown for editing " +
+                        "directory " + userHome.getPath());
+                PassFailJFrame.log("Test failed.");
+            } else {
+                PassFailJFrame.log("Action EDIT is unsupported.");
+            }
+        } catch (IOException e) {
+            PassFailJFrame.log("Expected IOException is caught.");
+        }
+
+        try {
+            if (desktop.isSupported(Action.PRINT)) {
+                PassFailJFrame.log("Trying to print " + userHome);
+                desktop.print(userHome);
+                PassFailJFrame.log("No exception has been thrown for printing " +
+                        "directory " + userHome.getPath());
+                PassFailJFrame.log("Test failed.");
+            } else {
+                PassFailJFrame.log("Action PRINT is unsupported.\n");
+            }
+        } catch (IOException e) {
+            PassFailJFrame.log("Expected IOException is caught.");
+        }
+
+        /*
+         * Part 2: print or edit a normal .txt file, which may succeed if there
+         * is associated application to print or edit the given file. It fails
+         * otherwise.
+         */
+        // Create a temp .txt file for test.
+        String testFilePath = System.getProperty("java.io.tmpdir") + File.separator + "JDIC-test.txt";
+        File testFile = null;
+        try {
+            PassFailJFrame.log("Creating temporary file.");
+            testFile = File.createTempFile("JDIC-test", ".txt", new File(System.getProperty("java.io.tmpdir")));
+            testFile.deleteOnExit();
+            FileWriter writer = new FileWriter(testFile);
+            writer.write("This is a temp file used to test print() method of Desktop.");
+            writer.flush();
+            writer.close();
+        } catch (java.io.IOException ioe){
+            PassFailJFrame.log("EXCEPTION: " + ioe.getMessage());
+            PassFailJFrame.forceFail("Failed to create temp file for testing.");
+        }
+
+        try {
+            if (desktop.isSupported(Action.EDIT)) {
+                PassFailJFrame.log("Try to edit " + testFile);
+                desktop.edit(testFile);
+                PassFailJFrame.log("Succeed.");
+            }
+        } catch (IOException e) {
+            PassFailJFrame.log("EXCEPTION: " + e.getMessage());
+        }
+
+        try {
+            if (desktop.isSupported(Action.PRINT)) {
+                PassFailJFrame.log("Trying to print " + testFile);
+                desktop.print(testFile);
+                PassFailJFrame.log("Succeed.");
+            }
+        } catch (IOException e) {
+            PassFailJFrame.log("EXCEPTION: " + e.getMessage());
+        }
+    }
+
+    public static void main(String args[]) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Edit and Print test")
+                .splitUI(EditAndPrintTest::new)
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(60)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/TextField/GetTextTest/GetTextTest.java
+++ b/test/jdk/java/awt/TextField/GetTextTest/GetTextTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4100188
+ * @key headful
+ * @summary Make sure that TextFields contain all of,
+ * and exactly, the text that was entered into them.
+ * @run main GetTextTest
+ */
+
+import java.awt.AWTException;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.lang.reflect.InvocationTargetException;
+
+public class GetTextTest extends Frame implements ActionListener {
+    private final String s = "test string";
+    private volatile String ac;
+    private TextField t;
+    private Point location;
+    private Dimension size;
+
+    public void setupGUI() {
+        setLayout(new FlowLayout(FlowLayout.LEFT));
+
+        t = new TextField(s, 32);
+        add(new Label("Hit <CR> after text"));
+        add(t);
+        t.addActionListener(this);
+        setLocationRelativeTo(null);
+        pack();
+        setVisible(true);
+    }
+
+    public void actionPerformed(ActionEvent evt) {
+        ac = evt.getActionCommand();
+    }
+
+    public void performTest() throws AWTException, InterruptedException,
+            InvocationTargetException {
+        EventQueue.invokeAndWait(() -> {
+            location = t.getLocationOnScreen();
+            size = t.getSize();
+        });
+        Robot robot = new Robot();
+        robot.setAutoDelay(50);
+        robot.delay(1000);
+        robot.waitForIdle();
+        robot.mouseMove(location.x + size.width - 3, location.y + (size.height / 2));
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(1000);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_ENTER);
+        robot.keyRelease(KeyEvent.VK_ENTER);
+        robot.delay(1000);
+        if (!s.equals(ac)) {
+            throw new RuntimeException("Action command should be the same as text field content");
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        GetTextTest test = new GetTextTest();
+        EventQueue.invokeAndWait(test::setupGUI);
+        try {
+            test.performTest();
+        } finally {
+            EventQueue.invokeAndWait(test::dispose);
+        }
+    }
+}

--- a/test/jdk/java/awt/TextField/SetEchoCharTest3/SetEchoCharTest3.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharTest3/SetEchoCharTest3.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4222122
+ * @summary TextField.setEchoCharacter() seems to be broken
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetEchoCharTest3
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.TextField;
+import java.lang.reflect.InvocationTargetException;
+
+public class SetEchoCharTest3 extends Frame {
+    static String INSTRUCTIONS = """
+             Type in the text field and "*" characters should echo.
+             If only one "*" echoes and then the system beeps after
+             the second character is typed, then press Fail, otherwise press Pass.
+             """;
+    public SetEchoCharTest3() {
+        setLayout(new FlowLayout());
+        add(new Label("Enter text:"));
+        TextField tf = new TextField(15);
+        tf.setEchoChar('*');
+        add(tf);
+        pack();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Set Echo Char Test 3")
+                .testUI(SetEchoCharTest3::new)
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340228](https://bugs.openjdk.org/browse/JDK-8340228) needs maintainer approval

### Issue
 * [JDK-8340228](https://bugs.openjdk.org/browse/JDK-8340228): Open source couple more miscellaneous AWT tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3404/head:pull/3404` \
`$ git checkout pull/3404`

Update a local copy of the PR: \
`$ git checkout pull/3404` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3404`

View PR using the GUI difftool: \
`$ git pr show -t 3404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3404.diff">https://git.openjdk.org/jdk17u-dev/pull/3404.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3404#issuecomment-2749017528)
</details>
