### PR TITLE
8342376: More reliable OOM handling in ExceptionDuringDumpAtObjectsInitPhase test

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDumpTransformer.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDumpTransformer.java
@@ -34,7 +34,10 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
     static boolean TEST_WITH_CLEANER = Boolean.getBoolean("test.with.cleaner");
     static boolean TEST_WITH_EXCEPTION = Boolean.getBoolean("test.with.exception");
     static boolean TEST_WITH_OOM = Boolean.getBoolean("test.with.oom");
+
+    static final int WASTE_SIZE = 1024;
     static List<byte[]> waste = new ArrayList();
+    static Object sink;
 
     static Cleaner cleaner;
     static Thread thread;
@@ -59,10 +62,13 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
               return new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
             }
             if (TEST_WITH_OOM) {
-                // fill until OOM
+                // Fill until OOM and fail. This sets up heap for secondary OOM
+                // later on, which should be caught by CDS code. The size of waste
+                // array defines how much max free space would be left for later
+                // code to run with.
                 System.out.println("Fill objects until OOM");
-                for (;;) {
-                    waste.add(new byte[64*1024]);
+                while (true) {
+                    waste.add(new byte[WASTE_SIZE]);
                 }
             }
         }
@@ -104,8 +110,8 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
     }
 
     public static void makeGarbage() {
-        for (int x=0; x<10; x++) {
-            Object[] a = new Object[10000];
+        for (int x = 0; x < 10; x++) {
+            sink = new byte[WASTE_SIZE];
         }
     }
 
@@ -115,7 +121,7 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
         public void run() {
             // Allocate something. This will cause G1 to allocate an EDEN region.
             // See JDK-8245925
-            Object o = new Object();
+            sink = new Object();
             System.out.println("cleaning " + i);
         }
     }


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342376](https://bugs.openjdk.org/browse/JDK-8342376) needs maintainer approval

### Issue
 * [JDK-8342376](https://bugs.openjdk.org/browse/JDK-8342376): More reliable OOM handling in ExceptionDuringDumpAtObjectsInitPhase test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3412/head:pull/3412` \
`$ git checkout pull/3412`

Update a local copy of the PR: \
`$ git checkout pull/3412` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3412`

View PR using the GUI difftool: \
`$ git pr show -t 3412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3412.diff">https://git.openjdk.org/jdk17u-dev/pull/3412.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3412#issuecomment-2766472145)
</details>
