### PR TITLE
8315951: Open source several Swing HTMLEditorKit related tests

### DIFF
--- a/test/jdk/java/awt/event/PaintEvent/RepaintTest.java
+++ b/test/jdk/java/awt/event/PaintEvent/RepaintTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FontMetrics;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/*
+ * @test
+ * @bug 4394287
+ * @key headful
+ * @summary Paint pending on heavyweight component move
+ */
+
+public class RepaintTest {
+    private static Frame frame;
+    private static Panel panel;
+    private static volatile IncrementComponent counter;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            EventQueue.invokeAndWait(RepaintTest::createAndShowUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            EventQueue.invokeAndWait(() -> panel.setLocation(panel.getX() + 10,
+                                                             panel.getY() + 10));
+            robot.waitForIdle();
+            robot.delay(500);
+
+            int count = counter.getCount().get();
+
+            EventQueue.invokeAndWait(panel::repaint);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            if (counter.getCount().get() == count) {
+                throw new RuntimeException("Failed");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new MyFrame("Repaint Test");
+        frame.setLayout(null);
+
+        counter = new IncrementComponent();
+        panel = new Panel();
+        panel.add(counter);
+        frame.add(panel);
+        panel.setBounds(0, 0, 100, 100);
+        frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static class MyFrame extends Frame {
+
+         public MyFrame(String title) {
+            super(title);
+        }
+
+        public void update(Graphics g) {
+            System.out.println("UPDATE: " + g.getClipBounds());
+            super.update(g);
+        }
+
+        public void paint(Graphics g) {
+            System.out.println("PAINT: " + g.getClipBounds());
+            super.paint(g);
+        }
+    }
+
+    // Subclass of Component, everytime paint is invoked a counter
+    // is incremented, this counter is displayed in the component.
+    private static class IncrementComponent extends Component {
+        private static final AtomicInteger paintCount = new AtomicInteger(0);
+
+        public Dimension getPreferredSize() {
+            return new Dimension(100, 100);
+        }
+
+        public AtomicInteger getCount() {
+            return paintCount;
+        }
+
+        public void paint(Graphics g) {
+            g.setColor(Color.red);
+            g.fillRect(0, 0, getWidth(), getHeight());
+            g.setColor(Color.white);
+
+            String string = Integer.toString(paintCount.getAndIncrement());
+            FontMetrics metrics = g.getFontMetrics();
+            int x = (getWidth() - metrics.stringWidth(string)) / 2;
+            int y = (getHeight() + metrics.getHeight()) / 2;
+            g.drawString(string, x, y);
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4214848.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4214848.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import javax.swing.text.Document;
+import javax.swing.text.html.HTMLEditorKit;
+
+/*
+ * @test
+ * @bug 4214848
+ * @summary Tests whether  HTMLEditorKit.read(...)
+ *          creates Document for html with empty BODY
+ */
+
+public class bug4214848 {
+    public static void main (String[] args) throws Exception {
+        StringWriter sw = new StringWriter();
+        String test = "<HTML><BODY></BODY></HTML>";
+        HTMLEditorKit kit = new HTMLEditorKit();
+        Document doc = kit.createDefaultDocument();
+        kit.read(new StringReader(test), doc, 0); // prepare test document
+        kit.write(sw, doc, 0, 10);
+        String out = sw.toString().toLowerCase();
+        if (out.indexOf("<body>") != out.lastIndexOf("<body>")) {
+            throw new RuntimeException("Test failed: extra <body> section generated");
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4230197.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4230197.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.StringWriter;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+
+/*
+ * @test
+ * @bug 4230197
+ * @summary Tests if HTMLEditorKit.insertHTML() works for font/phrase tags
+ */
+
+public class bug4230197 {
+
+    public static void main(String[] args) throws Exception {
+        HTMLEditorKit kit = new HTMLEditorKit();
+        StringWriter sw = new StringWriter();
+        HTMLDocument doc = (HTMLDocument) kit.createDefaultDocument();
+        kit.insertHTML(doc, doc.getLength(), "<sub>0</sub>", 0, 0, HTML.Tag.SUB);
+        kit.insertHTML(doc, doc.getLength(), "<sup>0</sup>", 0, 0, HTML.Tag.SUP);
+        kit.insertHTML(doc, doc.getLength(), "<b>0</b>", 0, 0, HTML.Tag.B);
+        kit.insertHTML(doc, doc.getLength(), "<i>0</i>", 0, 0, HTML.Tag.I);
+        kit.insertHTML(doc, doc.getLength(), "<code>0</code>", 0, 0, HTML.Tag.CODE);
+        kit.write(sw, doc, 0, doc.getLength());
+
+        String out = sw.toString().toLowerCase();
+        if ((!out.contains("<sub>0</sub>"))
+                || (!out.contains("<sup>0</sup>"))
+                || (!out.contains("<code>0</code>"))
+                || (!out.contains("<b>0</b>"))
+                || (!out.contains("<i>0</i>"))) {
+            throw new RuntimeException("Test failed: HTMLEditorKit.insertHTML()" +
+                    " doesn't work for font/phrase tags");
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4238223.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4238223.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.Reader;
+import java.io.StringReader;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.parser.ParserDelegator;
+
+/*
+ * @test
+ * @bug 4238223
+ * @summary Tests that HTMLEditorKit.ParserCallback methods receive
+ *          correct 'pos' argument.
+ */
+
+public class bug4238223 {
+
+    public static void main(String[] argv) throws Exception {
+        TestParser parser = new TestParser();
+        String testHTML = "<HTML><HEAD><TITLE>Text</TITLE></HEAD>" +
+                "<BODY><WRONGTAG>Simple text<!--comment--></BODY></HTML>";
+        parser.parse(testHTML);
+    }
+
+    static class TestCallback extends HTMLEditorKit.ParserCallback {
+        String commentData = "comment";
+        int commentIndex = 65;
+
+        public void handleComment(char[] data, int pos) {
+            if (!(new String(data)).equals(commentData)
+                    || pos != commentIndex) {
+
+                throw new RuntimeException("handleComment failed");
+            }
+        }
+
+        HTML.Tag[] endTags = {HTML.Tag.TITLE, HTML.Tag.HEAD,
+                HTML.Tag.BODY, HTML.Tag.HTML};
+        int[] endTagPositions = {23, 31, 79, 86};
+        int endTagIndex = 0;
+        public void handleEndTag(HTML.Tag tag, int pos) {
+            if (!tag.equals(endTags[endTagIndex])
+                    || pos != endTagPositions[endTagIndex]) {
+
+                throw new RuntimeException("handleEndTag failed");
+            } else {
+                endTagIndex++;
+            }
+        }
+
+        int errorIndex = 54;
+        public void handleError(String errorMsg, int pos) {
+            if (pos != errorIndex) {
+                throw new RuntimeException("handleError failed");
+            }
+        }
+
+        int[] simpleTagPositions = {44, 93};
+        int simpleTagIndex = 0;
+        public void handleSimpleTag(HTML.Tag tag, MutableAttributeSet attr,
+                                    int pos) {
+            if (pos != simpleTagPositions[simpleTagIndex++]) {
+                throw new RuntimeException("handleSimpleTag failed");
+            }
+        }
+
+        HTML.Tag[] startTags = {HTML.Tag.HTML, HTML.Tag.HEAD,
+                HTML.Tag.TITLE, HTML.Tag.BODY};
+        int[] startTagPositions = {0, 6, 12, 38};
+        int startTagIndex = 0;
+        public void handleStartTag(HTML.Tag tag, MutableAttributeSet attr,
+                                   int pos) {
+            if (!tag.equals(startTags[startTagIndex])
+                    || pos != startTagPositions[startTagIndex]) {
+
+                throw new RuntimeException("handleStartTag failed");
+            } else {
+                startTagIndex++;
+            }
+        }
+
+        String[] textData = {"Text", "Simple text"};
+        int[] textPositions = {19, 54};
+        int textIndex = 0;
+        public void handleText(char[] data, int pos) {
+            if (!textData[textIndex].equals(new String(data))
+                    || pos != textPositions[textIndex]) {
+
+                throw new RuntimeException("handleText failed");
+            } else {
+                textIndex++;
+            }
+        }
+    }
+
+    static class TestParser extends ParserDelegator {
+        public void parse(String html) throws Exception {
+            Reader r = new StringReader(html);
+            super.parse(r, new TestCallback(), false);
+            r.close();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8315951](https://bugs.openjdk.org/browse/JDK-8315951) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315951](https://bugs.openjdk.org/browse/JDK-8315951): Open source several Swing HTMLEditorKit related tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3416/head:pull/3416` \
`$ git checkout pull/3416`

Update a local copy of the PR: \
`$ git checkout pull/3416` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3416`

View PR using the GUI difftool: \
`$ git pr show -t 3416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3416.diff">https://git.openjdk.org/jdk17u-dev/pull/3416.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3416#issuecomment-2768308790)
</details>
