### PR TITLE
8339639: Opensource few AWT PopupMenu tests

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -829,6 +829,7 @@ java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.java 8256289 windo
 java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all
 java/awt/Focus/FrameMinimizeTest/FrameMinimizeTest.java 8016266 linux-x64
 java/awt/Frame/SizeMinimizedTest.java 8305915 linux-x64
+java/awt/PopupMenu/PopupHangTest.java 8340022 windows-all
 java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
 
 

--- a/test/jdk/java/awt/PopupMenu/PopupHangTest.java
+++ b/test/jdk/java/awt/PopupMenu/PopupHangTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 4145193
+ * @summary Mouse event activates multiple pull-down menus when testing Oracle app
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PopupHangTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Label;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+
+public class PopupHangTest {
+    private static final String INSTRUCTIONS = """
+         2 areas yellow and red should be seen.
+
+          Clicking in these areas should cause a menu to popup. See if you can
+          get the menu to stay up and grab all input. One way to do this is to
+          click and hold the mouse to popup the menu, move away/outside of the
+          menu and release the mouse. At that point, the input is grabbed and
+          the *only* way out is to hit the escape key. Try this on both areas.
+
+          To make things worse, when the popup menu is up, click repeatedly on
+          the LightWeight component area. Hit escape. Do you see multiple menus appearing ?
+
+          If you do not see either of the two problems above, the problem is fixed.
+          Press pass, else press Fail""";
+
+    static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .title("PopupHangTest")
+                      .instructions(INSTRUCTIONS)
+                      .rows((int) INSTRUCTIONS.lines().count() + 2)
+                      .columns(45)
+                      .testUI(PopupHangTest::createUI)
+                      .logArea()
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        TestMenuButton    m1;
+        TestHeavyButton   m2;
+        frame = new Frame();
+
+        frame.setLayout (new BorderLayout ());
+
+        m1 = new TestMenuButton("LightWeight component");
+        m1.setBackground(Color.yellow);
+
+        m2 = new TestHeavyButton("HeavyWeight component");
+        m2.setBackground(Color.red);
+
+        frame.add("North", m1);
+        frame.add("South", m2);
+
+        m1.requestFocus();
+        frame.setSize(200, 110);
+        return frame;
+    }
+
+}
+
+class TestMenuButton extends Component implements MouseListener,
+                                                MouseMotionListener,
+                                                KeyListener,
+                                                FocusListener  {
+
+    PopupMenu popupMenu = null;
+    String      name;
+
+    TestMenuButton(String name) {
+        PopupMenu menu = popupMenu = new PopupMenu("Popup");
+        menu.add(new MenuItem("item 1"));
+        menu.add(new MenuItem("item 2"));
+        menu.add(new MenuItem("item 3"));
+        this.add(menu);
+        this.name = name;
+        addMouseListener(this);
+        addMouseMotionListener(this);
+        addKeyListener(this);
+        addFocusListener(this);
+    }
+
+    void println(String messageIn) {
+        PassFailJFrame.log(messageIn);
+    }
+
+    public void mouseClicked(MouseEvent event) {
+        /*
+        popupMenu.show(this, event.getX(), event.getY());
+        */
+    }
+    public void mousePressed(MouseEvent event) {
+        println("TestMenuButton.mousePressed() called !!");
+        popupMenu.show(this, event.getX(), event.getY());
+    }
+    public void mouseReleased(MouseEvent event) {
+        println("TestMenuButton.mouseReleased() called !!");
+    }
+    public void mouseEntered(MouseEvent event) {
+        println("TestMenuButton.mouseEntered() called !!");
+        requestFocus();
+    }
+    public void mouseExited(MouseEvent event) {
+    }
+
+    public void mouseDragged(MouseEvent event) {
+        println("TestMenuButton.mouseDragged() called !!");
+    }
+    public void mouseMoved(MouseEvent event) {
+        println("TestMenuButton.mouseMoved() called !!");
+    }
+
+    public void keyPressed(KeyEvent event) {
+        println("TestMenuButton.keyPressed() called !!");
+    }
+    public void keyReleased(KeyEvent event) {
+        println("TestMenuButton.keyReleased() called !!");
+    }
+    public void keyTyped(KeyEvent event) {
+        println("TestMenuButton.keyTyped() called !!");
+    }
+
+
+    public void focusGained(FocusEvent e){
+        println("TestMenuButton.focusGained():" + e);
+    }
+    public void focusLost(FocusEvent e){
+        println("TestMenuButton.focusLost():" + e);
+    }
+
+
+    public void paint(Graphics g)  {
+        Dimension d = getSize();
+
+        g.setColor(getBackground());
+        g.fillRect(0, 0, d.width-1, d.height-1);
+
+        g.setColor(Color.black);
+        g.drawString(name, 15, 15);
+    }
+
+    public Dimension getPreferredSize() {
+        return (new Dimension(200, 50));
+    }
+
+}
+
+class TestHeavyButton extends Label implements MouseListener,
+                                                MouseMotionListener,
+                                                KeyListener,
+                                                FocusListener  {
+
+    PopupMenu popupMenu = null;
+    String      name;
+
+    TestHeavyButton(String name) {
+        super(name);
+        PopupMenu menu = popupMenu = new PopupMenu("Popup");
+        menu.add(new MenuItem("item 1"));
+        menu.add(new MenuItem("item 2"));
+        menu.add(new MenuItem("item 3"));
+        this.add(menu);
+        this.name = name;
+        addMouseListener(this);
+        addMouseMotionListener(this);
+        addKeyListener(this);
+        addFocusListener(this);
+    }
+
+    void println(String messageIn) {
+        PassFailJFrame.log(messageIn);
+    }
+
+    public void mouseClicked(MouseEvent event) {
+        /*
+        popupMenu.show(this, event.getX(), event.getY());
+        */
+    }
+    public void mousePressed(MouseEvent event) {
+        println("TestHeavyButton.mousePressed() called !!");
+        popupMenu.show(this, event.getX(), event.getY());
+    }
+    public void mouseReleased(MouseEvent event) {
+        println("TestHeavyButton.mouseReleased() called !!");
+    }
+    public void mouseEntered(MouseEvent event) {
+        println("TestHeavyButton.mouseEntered() called !!");
+        requestFocus();
+    }
+    public void mouseExited(MouseEvent event) {
+    }
+
+    public void mouseDragged(MouseEvent event) {
+        println("TestHeavyButton.mouseDragged() called !!");
+    }
+    public void mouseMoved(MouseEvent event) {
+        println("TestHeavyButton.mouseMoved() called !!");
+    }
+
+    public void keyPressed(KeyEvent event) {
+        println("TestHeavyButton.keyPressed() called !!");
+    }
+    public void keyReleased(KeyEvent event) {
+        println("TestHeavyButton.keyReleased() called !!");
+    }
+    public void keyTyped(KeyEvent event) {
+        println("TestHeavyButton.keyTyped() called !!");
+    }
+
+    public void focusGained(FocusEvent e){
+        println("TestHeavyButton.focusGained():" + e);
+    }
+    public void focusLost(FocusEvent e){
+        println("TestHeavyButton.focusLost():" + e);
+    }
+
+}
+

--- a/test/jdk/java/awt/PopupMenu/PopupMenuVisuals.java
+++ b/test/jdk/java/awt/PopupMenu/PopupMenuVisuals.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 6180413 6184485 6267144
+ * @summary test for popup menu visual bugs in XAWT
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PopupMenuVisuals
+*/
+
+import java.awt.Button;
+import java.awt.CheckboxMenuItem;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.PopupMenu;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+
+public class PopupMenuVisuals {
+    private static final String INSTRUCTIONS = """
+         This test should show a button 'Popup'.
+         Click on the button. A popup menu should be shown.
+         If following conditions are met:
+          - Menu is disabled
+          - Menu has caption 'Popup menu' (only applicable for linux)
+          - Menu items don't show shortcuts
+
+         Click Pass else click Fail.""";
+
+    static PopupMenu pm;
+    static Frame frame;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("PopupMenu Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(PopupMenuVisuals::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static class Listener implements ActionListener {
+        public void actionPerformed(ActionEvent e) {
+            pm.show(frame, 0, 0);
+        }
+    }
+
+    private static Frame createTestUI() {
+        Button b = new Button("Popup");
+        pm = new PopupMenu("Popup menu");
+        MenuItem mi1 = new MenuItem("Item 1");
+        CheckboxMenuItem mi2 = new CheckboxMenuItem("Item 2");
+        CheckboxMenuItem mi3 = new CheckboxMenuItem("Item 3");
+        Menu sm = new Menu("Submenu");
+
+        //Get things going.  Request focus, set size, et cetera
+        frame = new Frame("PopupMenuVisuals");
+        frame.setSize (200,200);
+        frame.validate();
+
+        frame.add(b);
+        b.addActionListener(new Listener());
+        mi1.setShortcut(new MenuShortcut(KeyEvent.VK_A));
+        pm.add(mi1);
+        pm.add(mi2);
+        pm.add(mi3);
+        pm.add(sm);
+        sm.add(new MenuItem("Item"));
+        pm.setEnabled(false);
+        mi3.setState(true);
+        frame.add(pm);
+        return frame;
+    }
+
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

Resolved ProblemList, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8339639](https://bugs.openjdk.org/browse/JDK-8339639) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339639](https://bugs.openjdk.org/browse/JDK-8339639): Opensource few AWT PopupMenu tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3418/head:pull/3418` \
`$ git checkout pull/3418`

Update a local copy of the PR: \
`$ git checkout pull/3418` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3418`

View PR using the GUI difftool: \
`$ git pr show -t 3418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3418.diff">https://git.openjdk.org/jdk17u-dev/pull/3418.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3418#issuecomment-2768320981)
</details>
