### PR TITLE
8340143: Open source several Java2D rendering loop tests.

### DIFF
--- a/test/jdk/sun/java2d/loops/ARGBBgToRGB.java
+++ b/test/jdk/sun/java2d/loops/ARGBBgToRGB.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4238978
+ * @summary This test verifies that the correct blitting loop is being used.
+ *          The correct output should have a yellow border on the top and
+ *          left sides of a red box.  The incorrect output would have only
+ *          a red box -- no yellow border."
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+public class ARGBBgToRGB {
+
+    public static void main(String[] argv) {
+        BufferedImage bi = new BufferedImage(256, 256, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D big = bi.createGraphics();
+        big.setColor(Color.red);
+        big.fillRect(30, 30, 150, 150);
+
+        BufferedImage bi2 = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D big2 = bi2.createGraphics();
+        big2.drawImage(bi, 0, 0, Color.yellow, null);
+
+        int expectYellowPix = bi2.getRGB(0, 0);
+        int expectRedPix = bi2.getRGB(50, 50);
+        if ((expectYellowPix != Color.yellow.getRGB()) ||
+            (expectRedPix != Color.red.getRGB()))
+        {
+           throw new RuntimeException("Unexpected colors " + expectYellowPix + " " + expectRedPix);
+        }
+    }
+}

--- a/test/jdk/sun/java2d/loops/CopyNegative.java
+++ b/test/jdk/sun/java2d/loops/CopyNegative.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4188744
+ * @summary This test verifies that copyArea performs correctly for negative offset values.
+ *          The correct output shows that the text area is moved to the left and down,
+ *          leaving some garbage on the right and the top.
+ *          The incorrect copy would show the text area garbled and no text is legible.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CopyNegative
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.Panel;
+
+public class CopyNegative extends Panel {
+
+   private static final String INSTRUCTIONS = """
+       This test verifies that copyArea performs correctly for negative offset values.
+       The test draws text in an image, then copies the contents repeatedly.
+       The correct output shows that the text is moved to the left and down,
+       leaving some garbage on the top / right and some legible text at the bottom left.
+       The incorrect copy would show the whole text area garbled and no text is legible.
+       """;
+
+    public static void main(String[] argv) throws Exception {
+       PassFailJFrame.builder()
+            .title("CopyNegativeTest")
+            .instructions(INSTRUCTIONS)
+            .testUI(CopyNegative::createUI)
+            .testTimeOut(5)
+            .rows(10)
+            .columns(50)
+            .build()
+            .awaitAndCheck();
+    }
+
+    Image img;
+
+    static final int W = 200, H = 200;
+
+    static Frame createUI() {
+        Frame f = new Frame("CopyNegative");
+        f.add(new CopyNegative());
+        f.pack();
+        return f;
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(W, H);
+    }
+
+    private void doCopy() {
+        Graphics g = img.getGraphics();
+        g.setColor(Color.white);
+        g.fillRect(0, 0, W, H);
+        g.setColor(Color.black);
+        String text = "Some Text To Display, it is long enough to fill the entire display line.";
+        StringBuffer sb = new StringBuffer(text);
+
+        for (int i = 1; i < 50; i++) {
+            g.drawString(sb.toString(), 5,20 * i - 10);
+            sb.insert(0, Integer.toString(i));
+        }
+        for (int i = 0 ; i < 20 ; i++ ) {
+            g.copyArea(0, 0, W, H, -3, 3);
+        }
+    }
+
+    public void paint(Graphics g) {
+        img = createImage(W, H);
+        doCopy();
+        g.drawImage(img, 0, 0, this);
+    }
+
+}

--- a/test/jdk/sun/java2d/loops/DitheredSolidFill.java
+++ b/test/jdk/sun/java2d/loops/DitheredSolidFill.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 4181172
+ * @summary Confirm that solid white fill is not dithered on an 8-bit indexed surface.
+ *          The test draws two areas filled with white solid color.
+ *          The upper left square is filled in aliasing mode and
+ *          the lower right square is filled in anti-aliasing mode.
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+
+public class DitheredSolidFill {
+
+    public static void main(String args[]) {
+       BufferedImage bi = new BufferedImage(120, 120, BufferedImage.TYPE_BYTE_INDEXED);
+       Graphics2D g2D = bi.createGraphics();
+
+        g2D.setColor(Color.black);
+        g2D.fillRect(0, 0, 100, 100);
+
+        g2D.setColor(Color.white);
+        g2D.fillRect(5, 5, 40, 40);
+        checkPixels(bi, 5, 5, 40, 40);
+
+        g2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2D.fillRect(55, 55, 40, 40);
+        checkPixels(bi, 55, 55, 40, 40);
+    }
+
+    static void checkPixels(BufferedImage bi, int x, int y, int w, int h) {
+       // pixel can be off white, but must be the same in all cases.
+       int expectedPix = bi.getRGB(x, y);
+       for (int x0 = x; x0 < x + w; x0++) {
+           for (int y0 = y; y0 < y + h; y0++) {
+              if (bi.getRGB(x0, y0) != expectedPix) {
+                  try {
+                      javax.imageio.ImageIO.write(bi, "png", new java.io.File("failed.png"));
+                  } catch (Exception e) {
+                  }
+                  throw new RuntimeException("Not expected pix : " +
+                                             Integer.toHexString(bi.getRGB(x0, y0)) +
+                                             " at " + x0 + "," + y0);
+              }
+           }
+       }
+   }
+}

--- a/test/jdk/sun/java2d/loops/OffsetCalculationTest.java
+++ b/test/jdk/sun/java2d/loops/OffsetCalculationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+  @test
+  @bug 4236576
+  @summary tests that a BufferedImage in TYPE_3BYTE_BGR format is correctly
+           drawn when there is an offset between the Graphics clip bounds
+           and the clip box of the underlying device context.
+  @run main OffsetCalculationTest
+*/
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+
+public class OffsetCalculationTest {
+
+    public static void main(String[] args) {
+        BufferedImage srcImage = new BufferedImage(500, 500, BufferedImage.TYPE_3BYTE_BGR);
+
+        DataBuffer buffer = srcImage.getRaster().getDataBuffer();
+        for (int i = 2; i < buffer.getSize(); i+=3) {
+            // setting each pixel to blue via the data buffer elements.
+            buffer.setElem(i - 2, 0xff);
+            buffer.setElem(i - 1, 0);
+            buffer.setElem(i, 0);
+        }
+
+        int w = 200, h = 200;
+        BufferedImage destImage = new BufferedImage(w, h, BufferedImage.TYPE_3BYTE_BGR);
+        Graphics2D g = destImage.createGraphics();
+        Rectangle r = new Rectangle(0, 0, w, h);
+        g.setClip(r.x - 1, r.y, r.width + 1, r.height);
+        g.drawImage(srcImage, 0, 0, null);
+
+        int bluepix = Color.blue.getRGB();
+        for (int y = 0; y < w; y++) {
+            for (int x = 0; x < h; x++) {
+                if (destImage.getRGB(x, y) != bluepix) {
+                     throw new RuntimeException("Not Blue");
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/sun/java2d/loops/XORClearRect.java
+++ b/test/jdk/sun/java2d/loops/XORClearRect.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4088173
+ * @summary This interactive test verifies that the XOR mode is not affecting
+ *          the clearRect() call. The correct output looks like:
+ *
+ *          \      /
+ *           \    /
+ *                     The backgound is blue.
+ *                     The lines outside the central rectangle are green.
+ *                     The central rectangle is also blue (the result of clearRect())
+ *           /    \
+ *          /      \
+ *
+ * @key headful
+ * @run main XORClearRect
+ */
+
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Graphics;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+
+public class XORClearRect extends Panel {
+
+    public static void main(String args[]) throws Exception {
+        EventQueue.invokeAndWait(XORClearRect::createUI);
+        try {
+             Robot robot = new Robot();
+             robot.waitForIdle();
+             robot.delay(2000);
+             Point p = frame.getLocationOnScreen();
+             int pix = robot.getPixelColor(p.x + 100, p.y + 100).getRGB();
+             if (pix != Color.blue.getRGB()) {
+                 throw new RuntimeException("Not blue");
+             }
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+    }
+
+    static volatile Frame frame;
+
+    static void createUI() {
+        frame = new Frame("XORClearRect");
+        frame.setBackground(Color.blue);
+        XORClearRect xor = new XORClearRect();
+        frame.add(xor);
+        frame.setSize(200,200);
+        frame.setVisible(true);
+    }
+
+    public XORClearRect() {
+       setBackground(Color.blue);
+    }
+
+    public void paint(Graphics g) {
+        g.setColor(Color.green);
+        g.drawLine(0,0,200,200);
+        g.drawLine(0,200,200,0);
+        g.setXORMode(Color.blue);
+        g.clearRect(50,50,100,100); //expecting the rectangle to be filled
+                                    // with the background color (blue)
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8340143](https://bugs.openjdk.org/browse/JDK-8340143) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8340143: Open source several Java2D rendering loop tests.`

### Issue
 * [JDK-8340143](https://bugs.openjdk.org/browse/JDK-8340143): Open source several Java2D rendering loop tests. (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3421/head:pull/3421` \
`$ git checkout pull/3421`

Update a local copy of the PR: \
`$ git checkout pull/3421` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3421`

View PR using the GUI difftool: \
`$ git pr show -t 3421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3421.diff">https://git.openjdk.org/jdk17u-dev/pull/3421.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3421#issuecomment-2768338948)
</details>
