### PR TITLE
8321931: memory_swap_current_in_bytes reports 0 as "unlimited"

### DIFF
--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -138,7 +138,7 @@ jlong OSContainer::pids_current() {
 
 void OSContainer::print_container_helper(outputStream* st, jlong j, const char* metrics) {
   st->print("%s: ", metrics);
-  if (j > 0) {
+  if (j >= 0) {
     if (j >= 1024) {
       st->print_cr(UINT64_FORMAT " k", uint64_t(j) / 1024);
     } else {

--- a/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
+++ b/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @summary Test container info for cgroup v2
+ * @requires docker.support
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *          jdk.jartool/sun.tools.jar
+ * @build CheckContainerized jdk.test.whitebox.WhiteBox PrintContainerInfo
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox
+ * @run driver TestContainerInfo
+ */
+import jtreg.SkippedException;
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+import jdk.test.lib.containers.docker.DockerRunOptions;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+
+public class TestContainerInfo {
+    private static final String imageName = Common.imageName("container-info");
+
+    public static void main(String[] args) throws Exception {
+        if (!DockerTestUtils.canTestDocker()) {
+            return;
+        }
+
+        Common.prepareWhiteBox();
+        DockerTestUtils.buildJdkContainerImage(imageName);
+
+        try {
+            testPrintContainerInfoWithoutSwap();
+        } finally {
+            DockerTestUtils.removeDockerImage(imageName);
+        }
+    }
+
+    private static void testPrintContainerInfoWithoutSwap() throws Exception {
+        Common.logNewTestCase("Test print_container_info() - without swap");
+
+        DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo")
+                      .addDockerOpts("--memory=500m")
+                      .addDockerOpts("--memory-swap=500m"); // no swap
+        Common.addWhiteBoxOpts(opts);
+
+        OutputAnalyzer out = Common.run(opts);
+        checkContainerInfo(out);
+    }
+
+    private static void shouldMatchWithValue(OutputAnalyzer output, String match, String value) {
+        output.shouldContain(match);
+        String str = output.getOutput();
+        for (String s : str.split(System.lineSeparator())) {
+            if (s.contains(match)) {
+                if (!s.contains(value)) {
+                    throw new RuntimeException("memory_swap_current_in_bytes NOT " + value + "! Line was : " + s);
+                }
+            }
+        }
+    }
+
+    private static void checkContainerInfo(OutputAnalyzer out) throws Exception {
+        String str = out.getOutput();
+        if (str.contains("cgroupv2")) {
+            shouldMatchWithValue(out, "memory_swap_max_limit_in_bytes", "0");
+            shouldMatchWithValue(out, "memory_swap_current_in_bytes", "0");
+        } else {
+            throw new SkippedException("This test is cgroups v2 specific, skipped on cgroups v1");
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321931](https://bugs.openjdk.org/browse/JDK-8321931) needs maintainer approval

### Issue
 * [JDK-8321931](https://bugs.openjdk.org/browse/JDK-8321931): memory_swap_current_in_bytes reports 0 as "unlimited" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3423/head:pull/3423` \
`$ git checkout pull/3423`

Update a local copy of the PR: \
`$ git checkout pull/3423` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3423`

View PR using the GUI difftool: \
`$ git pr show -t 3423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3423.diff">https://git.openjdk.org/jdk17u-dev/pull/3423.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3423#issuecomment-2772610911)
</details>
