### PR TITLE
8340874: Open source some of the AWT Geometry/Button tests

### DIFF
--- a/test/jdk/java/awt/Button/BadActionEventTest/BadActionEventTest.java
+++ b/test/jdk/java/awt/Button/BadActionEventTest/BadActionEventTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4530087
+ * @summary Test if double-clicking causes ActionEvent on underlying button
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual BadActionEventTest
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class BadActionEventTest implements ActionListener {
+    private static Button showBtn;
+    private static Button listBtn;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            1) Click on 'Show File Dialog' to bring up the FileDialog window.
+            (If necessary, change to a directory with files (not just directories) in it.)
+            2) Move the FileDialog so that one of the file names (again, a file, NOT a directory) in the list is
+            directly over the 'ActionListener' button.
+            3) Double-click on the file name over the button. The FileDialog will disappear.
+            4) If the 'ActionListener' button receives an ActionEvent, the test fails and a
+            message to that effect will be printed.
+            Otherwise, the test passes.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(45)
+            .testUI(BadActionEventTest::createUI)
+            .logArea(2)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame frame = new Frame("BadActionEventTest");
+        frame.setLayout(new GridLayout(1, 2));
+        frame.setSize(400, 200);
+        showBtn = new Button("Show File Dialog");
+        listBtn = new Button("ActionListener");
+        showBtn.setSize(200, 200);
+        listBtn.setSize(200, 200);
+        showBtn.addActionListener(new BadActionEventTest());
+        listBtn.addActionListener(new BadActionEventTest());
+        frame.add(showBtn);
+        frame.add(listBtn);
+        return frame;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (e.getSource() == showBtn) {
+            FileDialog fd = new FileDialog(new Frame());
+            fd.setVisible(true);
+        } else if (e.getSource() == listBtn) {
+            listBtn.setBackground(Color.red);
+            listBtn.setLabel("TEST FAILS!");
+            PassFailJFrame.log("*TEST FAILS!* ActionListener got ActionEvent! *TEST FAILS!*");
+        }
+    }
+}

--- a/test/jdk/java/awt/geom/Arc2D/Arc2DHitTest.java
+++ b/test/jdk/java/awt/geom/Arc2D/Arc2DHitTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4178123
+ * @summary Verifies that the Arc2D.contains(point) methods work correctly.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual Arc2DHitTest
+ */
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.geom.Arc2D;
+
+public class Arc2DHitTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            This test displays an arc figure and lets the user click on it.
+            The arc will initially be drawn in red and only when the user clicks
+            within the arc in the window it will be redrawn into green otherwise
+            it should stay red.
+
+            For convenience, the point being tested is drawn in black.  Note
+            that rounding in the arc rendering routines may cause points near
+            the boundary of the arc to render incorrectly.  Allow for a pixel
+            or two of leeway near the boundary.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(initialize())
+            .build()
+            .awaitAndCheck();
+    }
+    private static Frame initialize() {
+        Frame f = new Frame("Arc2DHitTest");
+        ArcHitPanel panel = new ArcHitPanel();
+        f.add(panel);
+        f.setSize(300, 250);
+        return f;
+    }
+}
+
+class ArcHitPanel extends Panel {
+    private Arc2D arc;
+    private Point hit;
+    public ArcHitPanel() {
+        arc = new Arc2D.Float(10, 10, 100, 100, 0, 120, Arc2D.PIE);
+        this.addMouseListener(new MouseAdapter() {
+            public void mouseClicked(MouseEvent e) {
+                hit = e.getPoint();
+                repaint();
+            }
+        });
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        Graphics2D g2 = (Graphics2D) g;
+        g2.setColor(Color.white);
+        g2.fill(g2.getClipBounds());
+        g2.setColor((hit != null && arc.contains(hit))
+            ? Color.green : Color.red);
+        g2.fill(arc);
+        if (hit != null) {
+            g2.setColor(Color.black);
+            g2.fillRect(hit.x, hit.y, 1, 1);
+        }
+    }
+}

--- a/test/jdk/java/awt/geom/Arc2D/BoundsBug.java
+++ b/test/jdk/java/awt/geom/Arc2D/BoundsBug.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4197746
+ * @summary Verifies that the getBounds2D method of Arc2D returns the
+ *          correct result.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual BoundsBug
+ */
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.Arc2D;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.GeneralPath;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+
+public class BoundsBug {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            This test displays three figures and draws the outline of their
+            bounding boxes. The bounding boxes should correctly encompass
+            the 3 figures.
+
+            This test also paints two highlight rectangles at the ends of the
+            angular extents of the arc. The two highlights should correctly
+            appear at the outer circumference of the arc where the radii lines
+            from its center intersect that circumference.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(initialize())
+            .build()
+            .awaitAndCheck();
+    }
+    private static Frame initialize() {
+        Frame f = new Frame("BoundsBug");
+        ArcPanel panel = new ArcPanel();
+        f.add(panel);
+        f.setSize(300, 250);
+        return f;
+    }
+}
+
+class ArcPanel extends Panel {
+    protected void drawPoint(Graphics2D g2, Point2D p) {
+        g2.setColor(Color.green);
+        g2.fill(new Rectangle2D.Double(p.getX() - 5, p.getY() - 5, 10, 10));
+    }
+
+    protected void drawShapeAndBounds(Graphics2D g2, Shape s) {
+        g2.setColor(Color.orange);
+        g2.fill(s);
+        g2.setColor(Color.black);
+        g2.draw(s);
+
+        Rectangle2D r = s.getBounds2D();
+        g2.setColor(Color.gray);
+        g2.draw(r);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        Graphics2D g2 = (Graphics2D)g;
+        g2.setColor(Color.white);
+        g2.fill(g.getClipBounds());
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+            RenderingHints.VALUE_ANTIALIAS_ON);
+
+        // Create some interesting shapes.
+        Ellipse2D ellipse = new Ellipse2D.Float(20, 40, 60, 80);
+        Arc2D arc = new Arc2D.Float(60, 40, 100, 120,
+            -30, -40, Arc2D.PIE);
+        GeneralPath path = new GeneralPath(GeneralPath.WIND_EVEN_ODD);
+        path.moveTo(0, 0);
+        path.lineTo(75, -25);
+        path.lineTo(25, 75);
+        path.lineTo(0, 25);
+        path.lineTo(100, 50);
+        path.lineTo(50, 0);
+        path.lineTo(25, 50);
+        path.closePath();
+        // Now draw them and their bounds rectangles.
+        drawShapeAndBounds(g2, ellipse);
+        drawShapeAndBounds(g2, arc);
+        drawPoint(g2, arc.getStartPoint());
+        drawPoint(g2, arc.getEndPoint());
+        g2.translate(180, 65);
+        drawShapeAndBounds(g2, path);
+    }
+}

--- a/test/jdk/java/awt/geom/Area/Translate.java
+++ b/test/jdk/java/awt/geom/Area/Translate.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4183373
+ * @summary Verifies that the translated Area objects display correctly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual Translate
+ */
+
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Panel;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
+import java.awt.geom.Rectangle2D;
+
+public class Translate {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            This test displays two sets of rectangular figures. The two sets
+            should be displayed one on top of the other and should be lined
+            up vertically with each other. If the two sets of figures are
+            not directly above and below each other then the test fails
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(35)
+            .testUI(initialize())
+            .build()
+            .awaitAndCheck();
+    }
+    private static Frame initialize() {
+        Frame f = new Frame("Translate");
+        TranslatePanel panel = new TranslatePanel();
+        f.add(panel);
+        f.setSize(300, 250);
+        return f;
+    }
+}
+
+class TranslatePanel extends Panel {
+    private static Image bufferedImage;
+    private static Area a1, a2, a3;
+
+    public TranslatePanel() {
+        a1 = new Area(new Rectangle2D.Double(20.0, 20.0, 60.0, 60.0));
+
+        a2 = new Area((Area) a1.clone());
+        a2.subtract(new Area(new Rectangle2D.Double(30.0, 30.0, 40.0, 40.0)));
+
+        a3 = new Area((Area) a2.clone());
+        a3.add(new Area(new Rectangle2D.Double(40.0, 40.0, 20.0, 20.0)));
+
+        AffineTransform at2 = new AffineTransform();
+        at2.translate(100.0, 0.0);
+        a2.transform(at2);
+
+        AffineTransform at3 = new AffineTransform();
+        at3.translate(200.0, 0.0);
+        a3.transform(at3);
+    }
+    private void paintRects(Graphics2D g2) {
+        Rectangle clip = g2.getClipBounds();
+        g2.setColor(Color.white);
+        g2.fillRect(clip.x, clip.y, clip.width, clip.height);
+        g2.setPaint(Color.red);
+        g2.fill(a1);
+        g2.setPaint(Color.yellow);
+        g2.fill(a2);
+        g2.setPaint(Color.blue);
+        g2.fill(a3);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        if (bufferedImage == null) {
+            bufferedImage = createImage(300, 100);
+            Graphics big = bufferedImage.getGraphics();
+            // Notice that if you remove the translate() call, it works fine.
+            big.translate(-1, -1);
+            big.setClip(1, 1, 300, 100);
+            paintRects((Graphics2D)big);
+            big.translate(1, 1);
+        }
+        paintRects((Graphics2D)g);
+        g.drawImage(bufferedImage, 1, 100, this);
+        g.setColor(Color.black);
+        g.drawString("From offscreen image (with translate):", 10, 95);
+        g.drawString(" (should line up with rectangles above)", 10, 110);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340874](https://bugs.openjdk.org/browse/JDK-8340874) needs maintainer approval

### Issue
 * [JDK-8340874](https://bugs.openjdk.org/browse/JDK-8340874): Open source some of the AWT Geometry/Button tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3424/head:pull/3424` \
`$ git checkout pull/3424`

Update a local copy of the PR: \
`$ git checkout pull/3424` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3424`

View PR using the GUI difftool: \
`$ git pr show -t 3424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3424.diff">https://git.openjdk.org/jdk17u-dev/pull/3424.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3424#issuecomment-2772613361)
</details>
