### PR TITLE
8340967: Open source few Cursor tests - Set2

### DIFF
--- a/test/jdk/java/awt/Cursor/BlockedWindowTest/BlockedWindowTest.java
+++ b/test/jdk/java/awt/Cursor/BlockedWindowTest/BlockedWindowTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6391547
+ * @summary Test if the JTextField's cursor is changed when there is a modal dialog
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual BlockedWindowTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Cursor;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+class MyDialog extends Dialog implements ActionListener {
+    MyDialog(Frame owner) {
+        super(owner, "Modal dialog", true);
+        setBounds(owner.getX() + 150, owner.getY() + 150, 100, 100);
+        setLayout(new BorderLayout());
+        Button b = new Button("Close");
+        add(b, "South");
+        b.addActionListener(this);
+        setVisible(true);
+    }
+
+    public void actionPerformed(ActionEvent ae) {
+        setVisible(false);
+        this.dispose();
+    }
+}
+
+class MyFrame extends Frame implements ActionListener {
+    Dialog d;
+
+    public MyFrame() {
+        super("ManualYesNoTest");
+        Button b = new Button("Click here");
+        TextField tf = new TextField("A text field");
+        b.addActionListener(this);
+        setLayout(new BorderLayout());
+        setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        add(b, "South");
+        add(tf, "North");
+        setSize(300, 300);
+    }
+
+    public void actionPerformed(ActionEvent ae) {
+        d = new MyDialog(this);
+    }
+}
+
+public class BlockedWindowTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Verify that the hand cursor is displayed over the window and
+                text cursor over TextField.
+                Click the button in the window to display a modal dialog.
+                Verify that default cursor is displayed over the window
+                and over TextField now.
+                Then close modal dialog and verify that hand cursor is
+                displayed over window and text cursor over TextField.
+                If so, press PASS, else press FAIL.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(BlockedWindowTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static MyFrame createUI() {
+        MyFrame f = new MyFrame();
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Cursor/CursorUpdateTest/CursorUpdateTest.java
+++ b/test/jdk/java/awt/Cursor/CursorUpdateTest/CursorUpdateTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5097531
+ * @summary Make sure the cursor updates correctly under certain
+ *          circumstances even when the EDT is busy
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CursorUpdateTest
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+
+public class CursorUpdateTest {
+    final static String progress = "|/-\\";
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Check the following:
+                1. Cursor must be crosshair when hovering the mouse over the
+                    blue square.
+                2. Crosshair cursor must not flicker.
+                3. The cursor must be "I-beam" when hovering the mouse over the
+                    button.
+                4. Click the button - it will display "Busy" message and a
+                    rotating bar for 5 seconds. The cursor must change to
+                    hourglass.
+                5. (Windows only) While the cursor is on the button, press Alt.
+                    The cursor must change to normal shape. Pressing Alt again
+                    must revert it back to I-beam.
+                6. Move the mouse out of the button and back onto it. The cursor
+                    must update correctly (hourglass over the button, normal
+                    over the frame) even when the button displays "busy".
+                    Do not try to check (1) or (5) when the button displays
+                    "Busy" - this is not required.
+                Pass if all the steps are as behave as described. Otherwise,
+                fail this test.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(CursorUpdateTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame();
+        f.setLayout(new FlowLayout());
+        Button b = new Button("Button");
+        f.add(b);
+        b.setCursor(new Cursor(Cursor.TEXT_CURSOR));
+        Component c = new MyComponent();
+        f.add(c);
+        c.setCursor(new Cursor(Cursor.CROSSHAIR_CURSOR));
+        b.addActionListener(e -> {
+            String oldLabel = b.getLabel();
+            Cursor oldCursor = b.getCursor();
+            b.setCursor(new Cursor(Cursor.WAIT_CURSOR));
+            try {
+                for (int i = 0; i < 50; i++) {
+                    b.setLabel("Busy " + progress.charAt(i % 4));
+                    Thread.sleep(100);
+                }
+            } catch (InterruptedException ex) {
+            }
+            b.setCursor(oldCursor);
+            b.setLabel(oldLabel);
+        });
+        return f;
+    }
+}
+
+class MyComponent extends Component {
+    public void paint(Graphics g) {
+        g.setColor(getBackground());
+        g.fillRect(0, 0, getSize().width, getSize().height);
+    }
+
+    public MyComponent() {
+        setBackground(Color.blue);
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(100, 100);
+    }
+}

--- a/test/jdk/java/awt/Cursor/CustomCursorTest/CustomCursorTest.java
+++ b/test/jdk/java/awt/Cursor/CustomCursorTest/CustomCursorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4174035 4106384 4205805
+ * @summary Test for functionality of Custom Cursor
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual CustomCursorTest
+ */
+
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Frame;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Toolkit;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+
+import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
+
+public class CustomCursorTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This test is for switching between a custom cursor and the
+                system cursor.
+
+                1. Click on the test window panel to change from the default
+                    system cursor to the custom red square cursor
+                2. Verify that the square cursor shows when the panel is clicked
+                3. Verify that the square cursor is colored red
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(CustomCursorTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        JFrame f = new JFrame("Custom Cursor Test");
+        CustomCursorPanel c = null;
+        try {
+            c = new CustomCursorPanel();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        f.setIconImage(c.getImage());
+        f.getContentPane().add(c);
+        f.setSize(400, 400);
+        return f;
+    }
+}
+
+class CustomCursorPanel extends Panel {
+    Toolkit toolkit = Toolkit.getDefaultToolkit();
+    Image image;
+    Cursor cursor;
+    boolean flip = false;
+
+    public CustomCursorPanel() throws IOException {
+        generateRedSquareCursor();
+
+        image = toolkit.getImage(System.getProperty("test.classes", ".")
+                + java.io.File.separator + "square_cursor.gif");
+
+        setBackground(Color.green);
+        cursor = toolkit.createCustomCursor(image, new Point(0, 0), "custom");
+
+        JLabel c = (JLabel) add(new JLabel("click to switch between " +
+                "red square and default cursors"));
+        c.setBackground(Color.white);
+        c.setForeground(Color.red);
+
+        addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent me) {
+                if (!flip) {
+                    setCursor(cursor);
+                    flip = true;
+                } else {
+                    setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+                    flip = false;
+                }
+            }
+        });
+    }
+
+    public Image getImage() {
+        return image;
+    }
+
+    private static void generateRedSquareCursor() throws IOException {
+        Path p = Path.of(System.getProperty("test.classes", "."));
+        BufferedImage bImg = new BufferedImage(35, 34, TYPE_INT_ARGB);
+        Graphics2D cg = bImg.createGraphics();
+        cg.setColor(Color.RED);
+        cg.fillRect(0, 0, 35, 34);
+        ImageIO.write(bImg, "png", new File(p + java.io.File.separator +
+                "square_cursor.gif"));
+    }
+}

--- a/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
+++ b/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4114073
+ * @summary Test for setCursor in a JPanel when added to a JFrame's contentPane
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual JPanelCursorTest
+ */
+
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Graphics;
+
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JSplitPane;
+import javax.swing.border.BevelBorder;
+
+public class JPanelCursorTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This test checks for setCursor in a JPanel when added to a
+                JFrame's contentPane.
+
+                1. Verify that the cursor in the left side of the test window
+                    is a default cursor.
+                2. Verify that the cursor changes to the crosshair cursor when
+                    pointing over the button.
+                3. Verify that the cursor changes to the hand cursor when in
+                    the right side of the splitpane (and not on the button).
+
+                If true, then pass the test. Otherwise, fail this test.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(JPanelCursorTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFrame createUI() {
+        JFrame frame = new JFrame();
+
+        JSplitPane j = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+        ExtJComponent pane = new ExtJComponent();
+
+        CursorBugPanel panel = new CursorBugPanel();
+
+        j.setLeftComponent(pane);
+        j.setRightComponent(panel);
+        j.setContinuousLayout(true);
+
+        frame.getContentPane().add("Center", j);
+        pane.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
+        frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        frame.pack();
+        return frame;
+    }
+}
+
+class ExtJComponent extends JComponent {
+    public ExtJComponent() {
+        super();
+        setOpaque(true);
+        setBackground(Color.green);
+        setForeground(Color.red);
+        setBorder(new BevelBorder(BevelBorder.RAISED));
+    }
+    public void paintComponent(Graphics g) {
+        g.drawString("Default", 20, 30);
+    }
+    public Dimension getPreferredSize() {
+        return new Dimension(100, 100);
+    }
+}
+
+class CursorBugPanel extends JPanel {
+    public CursorBugPanel () {
+        // BUG: fails to set cursor for panel
+        setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+
+        // Create a button
+        JButton button = new JButton("Crosshair");
+
+        // Sets cursor for button, no problem
+        button.setCursor(Cursor.getPredefinedCursor(Cursor.CROSSHAIR_CURSOR));
+        add(button);
+    }
+
+    public void paintComponent(Graphics g) {
+        g.drawString("Hand", 20, 60);
+    }
+}

--- a/test/jdk/java/awt/Cursor/SetCursorTest/SetCursorTest.java
+++ b/test/jdk/java/awt/Cursor/SetCursorTest/SetCursorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4160080
+ * @summary Test setCursor() on lightweight components when event is generated
+ *          by a button
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetCursorTest
+ */
+
+import java.awt.Cursor;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+
+
+public class SetCursorTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This test checks for the behavior of setCursor() when called in
+                a JFrame's JButton action event.
+
+                1. Click the "OK" button in the test window.
+                2. Verify that the cursor changes to the waiting cursor instead
+                    of the default system cursor.
+
+                If true, then pass the test. Otherwise, fail this test.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(SetCursorTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static myFrame createUI() {
+        myFrame f = new myFrame();
+        return f;
+    }
+}
+
+class myFrame extends JFrame {
+    public myFrame() {
+        super("SetCursor With Button Test");
+        setSize(200, 200);
+
+        final JPanel p = new JPanel();
+        final JButton okButton = new JButton("OK");
+        okButton.addActionListener(e ->
+                setCursor(new Cursor(Cursor.WAIT_CURSOR)));
+
+        p.add(okButton);
+        getContentPane().add(p);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340967](https://bugs.openjdk.org/browse/JDK-8340967) needs maintainer approval

### Issue
 * [JDK-8340967](https://bugs.openjdk.org/browse/JDK-8340967): Open source few Cursor tests - Set2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3429/head:pull/3429` \
`$ git checkout pull/3429`

Update a local copy of the PR: \
`$ git checkout pull/3429` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3429`

View PR using the GUI difftool: \
`$ git pr show -t 3429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3429.diff">https://git.openjdk.org/jdk17u-dev/pull/3429.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3429#issuecomment-2773532182)
</details>
