### PR TITLE
8320682: [AArch64] C1 compilation fails with "Field too big for insn"

### DIFF
--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,9 +287,11 @@
   develop(bool, InstallMethods, true,                                       \
           "Install methods at the end of successful compilations")          \
                                                                             \
+  /* The compiler assumes, in many places, that methods are at most 1MB. */ \
+  /* Therefore, we restrict this flag to at most 1MB.                    */ \
   develop(intx, NMethodSizeLimit, (64*K)*wordSize,                          \
           "Maximum size of a compiled method.")                             \
-          range(0, max_jint)                                                \
+          range(0, 1*M)                                                     \
                                                                             \
   develop(bool, TraceFPUStack, false,                                       \
           "Trace emulation of the FPU stack (intel only)")                  \

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8316653
+ * @requires vm.debug
+ * @summary Test flag with max value.
+ *
+ * @run main/othervm -XX:NMethodSizeLimit=1M
+ *                   compiler.arguments.TestC1Globals
+ */
+
+/**
+ * @test
+ * @bug 8318817
+ * @requires vm.debug
+ * @requires os.family == "linux"
+ * @summary Test flag with max value combined with transparent huge pages on
+ *          Linux.
+ *
+ * @run main/othervm -XX:NMethodSizeLimit=1M
+ *                   -XX:+UseTransparentHugePages
+ *                   compiler.arguments.TestC1Globals
+ */
+
+/**
+ * @test
+ * @bug 8320682
+ * @requires vm.debug
+ * @summary Test flag with max value and specific compilation.
+ *
+ * @run main/othervm -XX:NMethodSizeLimit=1M
+ *                   -XX:CompileOnly=java.util.HashMap::putMapEntries
+ *                   -Xcomp
+ *                   compiler.arguments.TestC1Globals
+ *
+ */
+
+package compiler.arguments;
+
+public class TestC1Globals {
+
+    public static void main(String args[]) {
+        System.out.println("Passed");
+    }
+}


### PR DESCRIPTION
This is a backport from https://github.com/openjdk/jdk/pull/16951 to change the NMethodSizeLimit limit to 1MB to avoid the issue:

```
$ jdk-fastdebug/bin/java -XX:NMethodSizeLimit=10M -version

# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk17u-dev/src/hotspot/cpu/aarch64/assembler_aarch64.hpp:267), pid=334227, tid=334241
#  guarantee(chk == -1 || chk == 0) failed: Field too big for insn
```

The minor merge conflicts have been resolved:
- Copyright year
- TestC1Globals.java in the original fix was an update of an already existing file. Here is is just a new file

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320682](https://bugs.openjdk.org/browse/JDK-8320682) needs maintainer approval

### Issue
 * [JDK-8320682](https://bugs.openjdk.org/browse/JDK-8320682): [AArch64] C1 compilation fails with "Field too big for insn" (**Bug** - P3 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3432/head:pull/3432` \
`$ git checkout pull/3432`

Update a local copy of the PR: \
`$ git checkout pull/3432` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3432`

View PR using the GUI difftool: \
`$ git pr show -t 3432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3432.diff">https://git.openjdk.org/jdk17u-dev/pull/3432.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3432#issuecomment-2775933803)
</details>
