### PR TITLE
8331735: UpcallLinker::on_exit races with GC when copying frame anchor

### DIFF
--- a/src/hotspot/share/prims/universalUpcallHandler.cpp
+++ b/src/hotspot/share/prims/universalUpcallHandler.cpp
@@ -131,20 +131,16 @@ void ProgrammableUpcallHandler::on_exit(OptimizedEntryBlob::FrameData* context) 
   // restore previous handle block
   thread->set_active_handles(context->old_handles);
 
-  thread->frame_anchor()->zap();
-
   debug_only(thread->dec_java_call_counter());
+
+  thread->frame_anchor()->copy(&context->jfa);
 
   // Old thread-local info. has been restored. We are now back in native code.
   ThreadStateTransition::transition_from_java(thread, _thread_in_native);
 
-  thread->frame_anchor()->copy(&context->jfa);
-
   // Release handles after we are marked as being in native code again, since this
   // operation might block
   JNIHandleBlock::release_block(context->new_handles, thread);
-
-  assert(!thread->has_pending_exception(), "Upcall can not throw an exception");
 
   if (context->should_detach) {
     detach_current_thread();


### PR DESCRIPTION
Partial backport of a fix for a race condition in code adapted from JavaCallWrapper for the FFM API. This is more visible in 22 and later, where FFM is fully supported and the [OpenType implementation using HarfBuzz](https://bugs.openjdk.org/browse/JDK-8318364) has been ported to use it.

However, the copy in the native state seems to have been introduced as far back as [JDK-8269240](https://bugs.openjdk.org/browse/JDK-8269240) in 17 when the JavaCallWrapper code was ported to what was then universalUpcallHandler.cpp. That fix to `::on_exit` is included here.

The other hunk in the 24 and 21u versions is omitted as the `::on_entry` method has not been modified by [JDK-8272526](https://bugs.openjdk.org/browse/JDK-8272526) which is what moved the thread exception handling to native code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8286875](https://bugs.openjdk.org/browse/JDK-8286875) needs maintainer approval
- [x] [JDK-8331735](https://bugs.openjdk.org/browse/JDK-8331735) needs maintainer approval

### Issues
 * [JDK-8331735](https://bugs.openjdk.org/browse/JDK-8331735): UpcallLinker::on_exit races with GC when copying frame anchor (**Bug** - P3 - Approved)
 * [JDK-8286875](https://bugs.openjdk.org/browse/JDK-8286875): ProgrammableUpcallHandler::on_entry/on_exit access thread fields from native (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3434/head:pull/3434` \
`$ git checkout pull/3434`

Update a local copy of the PR: \
`$ git checkout pull/3434` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3434`

View PR using the GUI difftool: \
`$ git pr show -t 3434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3434.diff">https://git.openjdk.org/jdk17u-dev/pull/3434.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3434#issuecomment-2777130559)
</details>
