### PR TITLE
8353714: [17u] Backport of 8347740 incomplete

### DIFF
--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -117,10 +117,6 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        boolean exceptionExpected =
-            !(System.getProperty("os.name").matches("^.*[11|2025]$") ||
-              new OSVersion(10, 0).compareTo(OSVersion.current()) > 0);
-        test("ReservedName", resvPre, resvSuf, exceptionExpected);
 
         System.out.println("OS name:    " + System.getProperty("os.name") + "\n" +
                            "OS version: " + OSVersion.current());


### PR DESCRIPTION
Fix test issue.   The old call to the test should have been removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353714](https://bugs.openjdk.org/browse/JDK-8353714) needs maintainer approval

### Issue
 * [JDK-8353714](https://bugs.openjdk.org/browse/JDK-8353714): [17u] Backport of 8347740 incomplete (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3435/head:pull/3435` \
`$ git checkout pull/3435`

Update a local copy of the PR: \
`$ git checkout pull/3435` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3435`

View PR using the GUI difftool: \
`$ git pr show -t 3435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3435.diff">https://git.openjdk.org/jdk17u-dev/pull/3435.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3435#issuecomment-2778113790)
</details>
