### PR TITLE
8339300: CollectorPolicy.young_scaled_initial_ergo_vm gtest fails on ppc64 based platforms

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -69,7 +69,7 @@ class TestGenCollectorPolicy {
       FLAG_SET_ERGO(InitialHeapSize, 100 * M);
       FLAG_SET_ERGO(OldSize, 4 * M);
       FLAG_SET_ERGO(NewSize, 1 * M);
-      FLAG_SET_ERGO(MaxNewSize, 80 * M);
+      FLAG_SET_ERGO(MaxNewSize, 40 * M);
 
       ASSERT_NO_FATAL_FAILURE(setter1->execute());
 
@@ -212,6 +212,9 @@ class TestGenCollectorPolicy {
 // depends on so many other configurable variables. These tests only try to
 // verify that there are some basic rules for NewSize honored by the policies.
 
+// Tests require at least 128M of MaxHeap
+// otherwise ergonomic is different and generation sizes might be changed.
+
 // If NewSize has been ergonomically set, the collector policy
 // should use it for min
 TEST_VM(CollectorPolicy, young_min_ergo) {
@@ -225,6 +228,9 @@ TEST_VM(CollectorPolicy, young_min_ergo) {
 // should use it for min but calculate the initial young size
 // using NewRatio.
 TEST_VM(CollectorPolicy, young_scaled_initial_ergo) {
+  if (MaxHeapSize < 128 * M) {
+      return;
+  }
   TestGenCollectorPolicy::SetNewSizeErgo setter(20 * M);
   TestGenCollectorPolicy::CheckScaledYoungInitial checker;
 
@@ -237,6 +243,9 @@ TEST_VM(CollectorPolicy, young_scaled_initial_ergo) {
 // the rest of the VM lifetime. This is an irreversible change and
 // could impact other tests so we use TEST_OTHER_VM
 TEST_OTHER_VM(CollectorPolicy, young_cmd) {
+  if (MaxHeapSize < 128 * M) {
+    return;
+  }
   // If NewSize is set on the command line, it should be used
   // for both min and initial young size if less than min heap.
   TestGenCollectorPolicy::SetNewSizeCmd setter(20 * M);
@@ -249,8 +258,8 @@ TEST_OTHER_VM(CollectorPolicy, young_cmd) {
 
   // If NewSize is set on command line, but is larger than the min
   // heap size, it should only be used for initial young size.
-  TestGenCollectorPolicy::SetNewSizeCmd setter_large(80 * M);
-  TestGenCollectorPolicy::CheckYoungInitial checker_large(80 * M);
+  TestGenCollectorPolicy::SetNewSizeCmd setter_large(40 * M);
+  TestGenCollectorPolicy::CheckYoungInitial checker_large(40 * M);
   TestGenCollectorPolicy::TestWrapper::test(&setter_large, &checker_large);
 }
 

--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -69,7 +69,7 @@ class TestGenCollectorPolicy {
       FLAG_SET_ERGO(InitialHeapSize, 100 * M);
       FLAG_SET_ERGO(OldSize, 4 * M);
       FLAG_SET_ERGO(NewSize, 1 * M);
-      FLAG_SET_ERGO(MaxNewSize, 40 * M);
+      FLAG_SET_ERGO(MaxNewSize, 50 * M);
 
       ASSERT_NO_FATAL_FAILURE(setter1->execute());
 
@@ -258,8 +258,8 @@ TEST_OTHER_VM(CollectorPolicy, young_cmd) {
 
   // If NewSize is set on command line, but is larger than the min
   // heap size, it should only be used for initial young size.
-  TestGenCollectorPolicy::SetNewSizeCmd setter_large(40 * M);
-  TestGenCollectorPolicy::CheckYoungInitial checker_large(40 * M);
+  TestGenCollectorPolicy::SetNewSizeCmd setter_large(50 * M);
+  TestGenCollectorPolicy::CheckYoungInitial checker_large(50 * M);
   TestGenCollectorPolicy::TestWrapper::test(&setter_large, &checker_large);
 }
 


### PR DESCRIPTION
Follow up to 8258483 to fix PPC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339300](https://bugs.openjdk.org/browse/JDK-8339300) needs maintainer approval

### Issue
 * [JDK-8339300](https://bugs.openjdk.org/browse/JDK-8339300): CollectorPolicy.young_scaled_initial_ergo_vm gtest fails on ppc64 based platforms (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3438/head:pull/3438` \
`$ git checkout pull/3438`

Update a local copy of the PR: \
`$ git checkout pull/3438` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3438`

View PR using the GUI difftool: \
`$ git pr show -t 3438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3438.diff">https://git.openjdk.org/jdk17u-dev/pull/3438.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3438#issuecomment-2778796127)
</details>
