### PR TITLE
Backport bc269de452ba2c6072529c3201059b2039210238

### DIFF
--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -31,9 +31,7 @@
 static bool zero_page_read_protected() { return true; }
 
 class Linux {
-  friend class CgroupSubsystem;
   friend class os;
-  friend class OSContainer;
   friend class TestReserveMemorySpecial;
 
   static int (*_pthread_getcpuclockid)(pthread_t, clockid_t *);
@@ -57,7 +55,6 @@ class Linux {
   static int _page_size;
 
   static julong available_memory();
-  static int active_processor_count();
 
   static void initialize_system_info();
 
@@ -106,6 +103,8 @@ class Linux {
     uint64_t steal;
     bool     has_steal_ticks;
   };
+
+  static int active_processor_count();
 
   // which_logical_cpu=-1 returns accumulated ticks for all cpus.
   static bool get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu);


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

Resolved, but probably clean anyways.