### PR TITLE
Backport cd3a607576bede17f48c3d5ebde2bf05f3b615ba

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/ProviderList.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderList.java
@@ -366,17 +366,19 @@ public final class ProviderList {
         int i;
 
         // Preferred provider list
-        if (preferredPropList != null &&
-                (pList = preferredPropList.getAll(type, name)) != null) {
+        if (preferredPropList != null) {
+            pList = preferredPropList.getAll(type, name);
             for (i = 0; i < pList.size(); i++) {
                 Provider p = getProvider(pList.get(i).provider);
+                if (p == null) {
+                    continue;
+                }
                 Service s = p.getService(type, name);
                 if (s != null) {
                     return s;
                 }
             }
         }
-
         for (i = 0; i < configs.length; i++) {
             Provider p = getProvider(i);
             Service s = p.getService(type, name);

--- a/test/jdk/sun/security/jca/NullPreferredList.java
+++ b/test/jdk/sun/security/jca/NullPreferredList.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.*;
+
+/**
+ * @test
+ * @bug 8328864
+ * @summary Test that ProviderList.getService checks configs when
+ * ProviderList.getProvider fails for preferred providers.
+ * @run main/othervm
+ *  -Djava.security.properties=${test.src}/app-security.properties NullPreferredList
+ */
+
+public class NullPreferredList {
+
+    public static void main(final String[] args) throws Exception {
+        final KeyStore ks = KeyStore.getInstance("PKCS12");
+        System.out.println("Got keystore " + ks);
+    }
+}

--- a/test/jdk/sun/security/jca/app-security.properties
+++ b/test/jdk/sun/security/jca/app-security.properties
@@ -1,0 +1,1 @@
+jdk.security.provider.preferred=KeyStore.PKCS12:NonExistingProvider


### PR DESCRIPTION
Backporting JDK-8328864: NullPointerException in sun.security.jca.ProviderList.getService(). Updated `getService` to check whether `getProvider` returns null when checking for preferred providers, continuing the loop if so. Added NullPreferredList test. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.