### PR TITLE
8329261: G1: interpreter post-barrier x86 code asserts index size of wrong buffer

### DIFF
--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -265,8 +265,6 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
                                                   Register thread,
                                                   Register tmp,
                                                   Register tmp2) {
-  // Generated code assumes that buffer index is pointer sized.
-  STATIC_ASSERT(in_bytes(SATBMarkQueue::byte_width_of_index()) == sizeof(intptr_t));
 #ifdef _LP64
   assert(thread == r15_thread, "must be");
 #endif // _LP64
@@ -316,6 +314,9 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
   // dirty card and log.
 
   __ movb(Address(card_addr, 0), (int)G1CardTable::dirty_card_val());
+
+  // The code below assumes that buffer index is pointer sized.
+  STATIC_ASSERT(in_bytes(G1DirtyCardQueue::byte_width_of_index()) == sizeof(intptr_t));
 
   __ movptr(tmp2, queue_index);
   __ testptr(tmp2, tmp2);


### PR DESCRIPTION
Backporting JDK-8329261: G1: interpreter post-barrier x86 code asserts index size of wrong buffer. This changeset updates an assert in G1's interpreter x86 post-barrier logic so that it refers to the right queue (G1DirtyCardQueue rather than pre-barrier's SATBMarkQueue) and moves the assert closer to the logic that exploits it. Doesn't change functionality.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8329261](https://bugs.openjdk.org/browse/JDK-8329261) needs maintainer approval

### Issue
 * [JDK-8329261](https://bugs.openjdk.org/browse/JDK-8329261): G1: interpreter post-barrier x86 code asserts index size of wrong buffer (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3443/head:pull/3443` \
`$ git checkout pull/3443`

Update a local copy of the PR: \
`$ git checkout pull/3443` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3443`

View PR using the GUI difftool: \
`$ git pr show -t 3443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3443.diff">https://git.openjdk.org/jdk17u-dev/pull/3443.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3443#issuecomment-2779567841)
</details>
