### PR TITLE
8345133: Test sun/security/tools/jarsigner/TsacertOptionTest.java failed: Warning found in stdout

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/TsacertOptionTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/TsacertOptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,6 +103,7 @@ public class TsacertOptionTest extends Test {
                 "-alias", CA_KEY_ALIAS,
                 "-keystore", KEYSTORE,
                 "-storepass", PASSWORD,
+                "-startdate", "-1M",
                 "-keypass", PASSWORD,
                 "-validity", Integer.toString(VALIDITY),
                 "-infile", "certreq",


### PR DESCRIPTION
Backport for parity with Oracle 17.0.16. Clean, low risk: test only, modified test passes, eliminates warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345133](https://bugs.openjdk.org/browse/JDK-8345133) needs maintainer approval

### Issue
 * [JDK-8345133](https://bugs.openjdk.org/browse/JDK-8345133): Test sun/security/tools/jarsigner/TsacertOptionTest.java failed: Warning found in stdout (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3444/head:pull/3444` \
`$ git checkout pull/3444`

Update a local copy of the PR: \
`$ git checkout pull/3444` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3444`

View PR using the GUI difftool: \
`$ git pr show -t 3444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3444.diff">https://git.openjdk.org/jdk17u-dev/pull/3444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3444#issuecomment-2779854893)
</details>
