### PR TITLE
8346049: jdk/test/lib/security/timestamp/TsaServer.java warnings

### DIFF
--- a/test/lib/jdk/test/lib/security/timestamp/TsaServer.java
+++ b/test/lib/jdk/test/lib/security/timestamp/TsaServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class TsaServer implements AutoCloseable {
      *
      * @param handler a {@link TsaHandler}
      */
-    public void setHandler(TsaHandler handler) {
+    public final void setHandler(TsaHandler handler) {
         server.createContext("/", handler);
     }
 
@@ -113,7 +113,7 @@ public class TsaServer implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         stop();
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

verified with 
test/jdk/sun/security/tools/jarsigner/TsacertOptionTest.java
test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
which use this class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8346049](https://bugs.openjdk.org/browse/JDK-8346049) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346049](https://bugs.openjdk.org/browse/JDK-8346049): jdk/test/lib/security/timestamp/TsaServer.java warnings (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3447/head:pull/3447` \
`$ git checkout pull/3447`

Update a local copy of the PR: \
`$ git checkout pull/3447` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3447`

View PR using the GUI difftool: \
`$ git pr show -t 3447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3447.diff">https://git.openjdk.org/jdk17u-dev/pull/3447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3447#issuecomment-2781369773)
</details>
