### PR TITLE
8340432: Open source some MenuBar tests - Set2

### DIFF
--- a/test/jdk/java/awt/MenuBar/MenuBarAddRemoveTest/MenuBarAddRemoveTest.java
+++ b/test/jdk/java/awt/MenuBar/MenuBarAddRemoveTest/MenuBarAddRemoveTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4028130 4112308
+ * @summary Test for location of Frame/MenuBar when MenuBar is re-added
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuBarAddRemoveTest
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+
+public class MenuBarAddRemoveTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Click the left mouse button on the "Re-Add MenuBar"
+                button several times.
+                3. The Frame/MenuBar may repaint or flash, but the location
+                of its upper left corner should never change.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(MenuBarAddRemoveTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("Re-Add MenuBar Test Frame");
+        Button b = new Button("Re-Add MenuBar");
+        b.addActionListener(e -> f.setMenuBar(createMenuBar()));
+        f.setMenuBar(createMenuBar());
+        f.add(b);
+        f.pack();
+        return f;
+    }
+
+    private static MenuBar createMenuBar() {
+        MenuBar bar = new MenuBar();
+        bar.add(new Menu("foo"));
+        return bar;
+    }
+}

--- a/test/jdk/java/awt/MenuBar/MenuBarOnDisabledFrame/MenuBarOnDisabledFrame.java
+++ b/test/jdk/java/awt/MenuBar/MenuBarOnDisabledFrame/MenuBarOnDisabledFrame.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6185057
+ * @summary Disabling a frame does not disable the menus on the frame, on
+ *      solaris/linux
+ * @requires os.family != "mac"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuBarOnDisabledFrame
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+public class MenuBarOnDisabledFrame {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Check if MenuBar is disabled on 'Disabled frame'
+                Press pass if menu bar is disabled, fail otherwise
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(MenuBarOnDisabledFrame::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("Disabled frame");
+        MenuBar mb = new MenuBar();
+        Menu m1 = new Menu("Disabled Menu 1");
+        Menu m2 = new Menu("Disabled Menu 2");
+        MenuItem m11 = new MenuItem("MenuItem 1.1");
+        MenuItem m21 = new MenuItem("MenuItem 2.1");
+        Button b = new Button("Disabled button");
+
+        m1.add(m11);
+        m2.add(m21);
+        mb.add(m1);
+        mb.add(m2);
+        f.setMenuBar(mb);
+        f.add(b);
+        f.setEnabled(false);
+        f.setSize(300, 300);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/MenuBar/MenuBarVisuals/MenuBarVisuals.java
+++ b/test/jdk/java/awt/MenuBar/MenuBarVisuals/MenuBarVisuals.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6180416
+ * @summary Tests MenuBar and drop down menu visuals
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuBarVisuals
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.MenuShortcut;
+import java.awt.event.KeyEvent;
+
+public class MenuBarVisuals {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Look at the MenuBar and traverse the menus using mouse and
+                keyboard. Then check if following is showing correctly:
+                1. Mnemonic label Ctrl+A is NOT drawn for Menu 1/Submenu 1.1
+                2. Mnemonic label Ctrl+B is drawn for
+                    Menu 1/Submenu 1.1/Item 1.1.1
+                3. Mnemonic label Ctrl+C is drawn for Menu1/Item 1.2
+                Press PASS if Menu is drawing correctly, FAIL otherwise.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(MenuBarVisuals::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("MenuBar Visuals Test");
+        MenuBar mb = new MenuBar();
+        Menu menu1 = new Menu("Menu 1");
+        Menu submenu11 = new Menu("Submenu 1.1");
+        MenuItem item111 = new MenuItem("Item 1.1.1");
+        MenuItem item112 = new MenuItem("Item 1.1.2");
+        MenuItem item12 = new MenuItem("Item 1.2");
+        Menu menu2 = new Menu("Menu 2");
+        MenuItem item21 = new MenuItem("Item 2.1");
+        MenuItem item22 = new MenuItem("Item 2.2");
+        item111.setShortcut(new MenuShortcut(KeyEvent.VK_B, false));
+        submenu11.add(item111);
+        submenu11.add(item112);
+        submenu11.setShortcut(new MenuShortcut(KeyEvent.VK_A, false));
+        menu1.add(submenu11);
+        item12.setShortcut(new MenuShortcut(KeyEvent.VK_C, false));
+        menu1.add(item12);
+        mb.add(menu1);
+        menu2.add(item21);
+        menu2.add(item22);
+        mb.add(menu2);
+        f.setMenuBar(mb);
+        f.setSize(300, 300);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/MenuBar/SetHelpMenuTest/SetHelpMenuTest.java
+++ b/test/jdk/java/awt/MenuBar/SetHelpMenuTest/SetHelpMenuTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4275843
+ * @summary MenuBar doesn't display all of its Menus correctly on Windows
+ * @requires os.family == "windows"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetHelpMenuTest
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+public class SetHelpMenuTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                An empty frame should be visible. When focused, the MenuBar
+                should have 5 menus ("one", "two", "three", "Help 2",
+                "four"). If so, then the test passed. Otherwise, the test
+                failed.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(SetHelpMenuTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("Help MenuBar Test");
+        f.setSize(100, 100);
+
+        MenuBar mb = new MenuBar();
+        Menu h1, h2;
+
+        f.setMenuBar(mb);
+        mb.add(createMenu("one", false));
+        mb.add(createMenu("two", false));
+        mb.add(createMenu("three", true));
+
+        mb.add(h1 = createMenu("Help 1", false));  // h1 is HelpMenu
+        mb.setHelpMenu(h1);
+
+        mb.add(h2 = createMenu("Help 2", false));  // h2 replaced h1
+        mb.setHelpMenu(h2);
+
+        mb.add(createMenu("four", false));
+
+        return f;
+    }
+
+    private static Menu createMenu(String name, boolean tearOff) {
+        Menu m = new Menu(name, tearOff);
+        m.add(new MenuItem(name + " item 1"));
+        m.add(new MenuItem(name + " item 2"));
+        m.add(new MenuItem(name + " item 3"));
+        return m;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8340432](https://bugs.openjdk.org/browse/JDK-8340432) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340432](https://bugs.openjdk.org/browse/JDK-8340432): Open source some MenuBar tests - Set2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3451/head:pull/3451` \
`$ git checkout pull/3451`

Update a local copy of the PR: \
`$ git checkout pull/3451` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3451`

View PR using the GUI difftool: \
`$ git pr show -t 3451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3451.diff">https://git.openjdk.org/jdk17u-dev/pull/3451.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3451#issuecomment-2786308595)
</details>
