### PR TITLE
8196465: javax/swing/JComboBox/8182031/ComboPopupTest.java fails on Linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -694,7 +694,6 @@ javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all
 javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
 javax/swing/JFileChooser/6798062/bug6798062.java 8146446 windows-all
-javax/swing/JComboBox/8182031/ComboPopupTest.java 8196465 linux-all,macosx-all
 javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
 javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all

--- a/test/jdk/javax/swing/JComboBox/8182031/ComboPopupTest.java
+++ b/test/jdk/javax/swing/JComboBox/8182031/ComboPopupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,22 +46,6 @@ public class ComboPopupTest {
     private volatile Point p = null;
     private volatile Dimension d = null;
 
-    void blockTillDisplayed(JComponent comp) throws Exception {
-        while (p == null) {
-            try {
-                SwingUtilities.invokeAndWait(() -> {
-                    p = comp.getLocationOnScreen();
-                    d = comboBox.getSize();
-                });
-            } catch (IllegalStateException e) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException ie) {
-                }
-            }
-        }
-    }
-
     public static void main(String[] args) throws Exception {
         new ComboPopupTest();
     }
@@ -69,13 +53,18 @@ public class ComboPopupTest {
     public ComboPopupTest() throws Exception {
         try {
             Robot robot = new Robot();
-            robot.setAutoDelay(200);
+            robot.setAutoDelay(100);
             SwingUtilities.invokeAndWait(() -> start());
-            blockTillDisplayed(comboBox);
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                p = comboBox.getLocationOnScreen();
+                d = comboBox.getSize();
+            });
             robot.waitForIdle();
-            robot.mouseMove(p.x + d.width-1, p.y + d.height/2);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseMove(p.x + d.width - 1, p.y + d.height/2);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
             System.out.println("popmenu visible " + comboBox.isPopupVisible());


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8196465](https://bugs.openjdk.org/browse/JDK-8196465) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8196465](https://bugs.openjdk.org/browse/JDK-8196465): javax/swing/JComboBox/8182031/ComboPopupTest.java fails on Linux (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3455/head:pull/3455` \
`$ git checkout pull/3455`

Update a local copy of the PR: \
`$ git checkout pull/3455` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3455`

View PR using the GUI difftool: \
`$ git pr show -t 3455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3455.diff">https://git.openjdk.org/jdk17u-dev/pull/3455.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3455#issuecomment-2786641262)
</details>
