### PR TITLE
Backport 315d051f6842120f233bb5b7dd488cabcd2e968d

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
  * @summary Test of diagnostic command help (tests all DCMD executors)
  * @library /test/lib
  *          /vmTestbase
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
  * @summary Test of invalid diagnostic command (tests all DCMD executors)
  * @library /test/lib
  *          /vmTestbase
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
@@ -27,7 +27,6 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.dcmd.MainClassJcmdExecutor;
 import jdk.test.lib.dcmd.FileJcmdExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
-import nsk.share.jdi.ArgumentHandler;
 
 import org.testng.annotations.Test;
 
@@ -37,6 +36,7 @@ import org.testng.annotations.Test;
  * @summary Test of diagnostic command VM.version (tests all DCMD executors)
  * @library /test/lib
  *          /vmTestbase
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.module
  *          java.compiler


### PR DESCRIPTION
I backport this to keep the tests up-to-date. Many similar changes have been backported. Let's do this, too, to complete the job. This will simplify later backports.

Backport from 21 including follow-up.

Trivial resolve, probably clean.