### PR TITLE
8316460: 4 javax/management tests ignore VM flags

### DIFF
--- a/test/jdk/javax/management/ImplementationVersion/ImplVersionTest.java
+++ b/test/jdk/javax/management/ImplementationVersion/ImplVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,70 +30,48 @@
  * system property.
  * @author Luis-Miguel Alventosa
  *
- * @run clean ImplVersionTest ImplVersionCommand
+ * @library /test/lib
  * @run build ImplVersionTest ImplVersionCommand ImplVersionReader
  * @run main ImplVersionTest
  */
+
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 
 public class ImplVersionTest {
 
-    public static void main(String[] args) {
-        try {
-            // Get OS name
-            //
-            String osName = System.getProperty("os.name");
-            System.out.println("osName = " + osName);
-            if ("Windows 98".equals(osName)) {
-                // Disable this test on Win98 due to parsing
-                // errors (bad handling of white spaces) when
-                // J2SE is installed under "Program Files".
-                //
-                System.out.println("This test is disabled on Windows 98.");
-                System.out.println("Bye! Bye!");
-                return;
-            }
-            // Get Java Home
-            //
-            String javaHome = System.getProperty("java.home");
-            System.out.println("javaHome = " + javaHome);
-            // Get test src
-            //
-            String testSrc = System.getProperty("test.src");
-            System.out.println("testSrc = " + testSrc);
-            // Get test classes
-            //
-            String testClasses = System.getProperty("test.classes");
-            System.out.println("testClasses = " + testClasses);
-            // Get boot class path
-            //
-            String command =
-                javaHome + File.separator + "bin" + File.separator + "java " +
-                " -classpath " + testClasses +
-                " -Djava.security.manager -Djava.security.policy==" + testSrc +
-                File.separator + "policy -Dtest.classes=" + testClasses +
-                " ImplVersionCommand " +
-                System.getProperty("java.runtime.version");
-            System.out.println("ImplVersionCommand Exec Command = " +command);
-            Process proc = Runtime.getRuntime().exec(command);
-            new ImplVersionReader(proc, proc.getInputStream()).start();
-            new ImplVersionReader(proc, proc.getErrorStream()).start();
-            int exitValue = proc.waitFor();
-            System.out.println("ImplVersionCommand Exit Value = " +
-                               exitValue);
-            if (exitValue != 0) {
-                System.out.println("TEST FAILED: Incorrect exit value " +
-                                   "from ImplVersionCommand");
-                System.exit(exitValue);
-            }
-            // Test OK!
-            //
-            System.out.println("Bye! Bye!");
-        } catch (Exception e) {
-            System.out.println("Unexpected exception caught = " + e);
-            e.printStackTrace();
-            System.exit(1);
+    public static void main(String[] args) throws Exception {
+        // Get test src
+        //
+        String testSrc = System.getProperty("test.src");
+        System.out.println("testSrc = " + testSrc);
+        // Get test classes
+        //
+        String testClasses = System.getProperty("test.classes");
+        System.out.println("testClasses = " + testClasses);
+        // Get boot class path
+        //
+        String[] command = new String[] {
+            "-Djava.security.manager",
+            "-Djava.security.policy==" + testSrc + File.separator + "policy",
+            "-Dtest.classes=" + testClasses,
+            "ImplVersionCommand",
+            System.getProperty("java.runtime.version")
+        };
+
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(command);
+        Process proc = pb.start();
+        new ImplVersionReader(proc, proc.getInputStream()).start();
+        new ImplVersionReader(proc, proc.getErrorStream()).start();
+        int exitValue = proc.waitFor();
+        System.out.println("ImplVersionCommand Exit Value = " + exitValue);
+        if (exitValue != 0) {
+            throw new RuntimeException("TEST FAILED: Incorrect exit value " +
+                                       "from ImplVersionCommand " + exitValue);
         }
+        // Test OK!
+        //
+        System.out.println("Bye! Bye!");
     }
 }

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -189,11 +189,9 @@ public class DefaultAgentFilterTest {
 
     private static void testDefaultAgent(String propertyFile, int port) throws Exception {
         String propFile = System.getProperty("test.src") + File.separator + propertyFile;
-        List<String> pbArgs = new ArrayList<>(Arrays.asList(
-                "-cp",
-                System.getProperty("test.class.path"),
-                "-XX:+UsePerfData"
-        ));
+        List<String> pbArgs = new ArrayList<>();
+        pbArgs.add("-XX:+UsePerfData");
+
         String[] args = new String[]{
             "-Dcom.sun.management.jmxremote.port=" + port,
             "-Dcom.sun.management.jmxremote.authenticate=false",
@@ -203,7 +201,7 @@ public class DefaultAgentFilterTest {
         pbArgs.addAll(Arrays.asList(args));
         pbArgs.add(TEST_APP_NAME);
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 pbArgs.toArray(new String[pbArgs.size()])
         );
 

--- a/test/jdk/javax/management/remote/mandatory/version/ImplVersionTest.java
+++ b/test/jdk/javax/management/remote/mandatory/version/ImplVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,69 +30,48 @@
  * system property.
  * @author Luis-Miguel Alventosa, Joel Feraud
  *
- * @run clean ImplVersionTest ImplVersionCommand
+ * @library /test/lib
  * @run build ImplVersionTest ImplVersionCommand ImplVersionReader
  * @run main ImplVersionTest
  */
+
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 
 public class ImplVersionTest {
 
-    public static void main(String[] args) {
-        try {
-            // Get OS name
-            //
-            String osName = System.getProperty("os.name");
-            System.out.println("osName = " + osName);
-            if ("Windows 98".equals(osName)) {
-                // Disable this test on Win98 due to parsing
-                // errors (bad handling of white spaces) when
-                // J2SE is installed under "Program Files".
-                //
-                System.out.println("This test is disabled on Windows 98.");
-                System.out.println("Bye! Bye!");
-                return;
-            }
+    public static void main(String[] args) throws Exception {
 
-            // Get Java Home
-            String javaHome = System.getProperty("java.home");
+        // Get test src
+        //
+        String testSrc = System.getProperty("test.src");
 
-            // Get test src
-            //
-            String testSrc = System.getProperty("test.src");
+        // Get test classes
+        String testClasses = System.getProperty("test.classes");
 
-            // Get test classes
-            String testClasses = System.getProperty("test.classes");
+        // Build command string
 
-            // Build command string
-            String command =
-                javaHome + File.separator + "bin" + File.separator + "java " +
-                " -classpath " + testClasses +
-                " -Djava.security.manager -Djava.security.policy==" + testSrc +
-                File.separator + "policy -Dtest.classes=" + testClasses +
-                " ImplVersionCommand " + System.getProperty("java.runtime.version");
-            System.out.println("ImplVersionCommand Exec Command = " + command);
+        String[] command = new String[] {
+            "-Djava.security.manager",
+            "-Djava.security.policy==" + testSrc + File.separator + "policy",
+            "-Dtest.classes=" + testClasses,
+            "ImplVersionCommand",
+            System.getProperty("java.runtime.version")
+        };
 
-            // Exec command
-            Process proc = Runtime.getRuntime().exec(command);
-            new ImplVersionReader(proc, proc.getInputStream()).start();
-            new ImplVersionReader(proc, proc.getErrorStream()).start();
-            int exitValue = proc.waitFor();
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(command);
+        Process proc = pb.start();
+        new ImplVersionReader(proc, proc.getInputStream()).start();
+        new ImplVersionReader(proc, proc.getErrorStream()).start();
+        int exitValue = proc.waitFor();
 
-            System.out.println("ImplVersionCommand Exit Value = " +
-                               exitValue);
-            if (exitValue != 0) {
-                System.out.println("TEST FAILED: Incorrect exit value " +
-                                   "from ImplVersionCommand");
-                System.exit(exitValue);
-            }
-            // Test OK!
-            System.out.println("Bye! Bye!");
-        } catch (Exception e) {
-            System.out.println("Unexpected exception caught = " + e);
-            e.printStackTrace();
-            System.exit(1);
+        System.out.println("ImplVersionCommand Exit Value = " + exitValue);
+        if (exitValue != 0) {
+            throw new RuntimeException("TEST FAILED: Incorrect exit value " +
+                                       "from ImplVersionCommand " + exitValue);
         }
+        // Test OK!
+        System.out.println("Bye! Bye!");
     }
 }

--- a/test/jdk/javax/management/security/HashedPasswordFileTest.java
+++ b/test/jdk/javax/management/security/HashedPasswordFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -468,10 +468,6 @@ public class HashedPasswordFileTest {
         perms.add(PosixFilePermission.OWNER_READ);
         perms.add(PosixFilePermission.OWNER_WRITE);
         Files.setPosixFilePermissions(file.toPath(), perms);
-
-        pbArgs.add("-cp");
-        pbArgs.add(System.getProperty("test.class.path"));
-
         pbArgs.add("-Dcom.sun.management.jmxremote.port=0");
         pbArgs.add("-Dcom.sun.management.jmxremote.authenticate=true");
         pbArgs.add("-Dcom.sun.management.jmxremote.password.file=" + file.getAbsolutePath());
@@ -481,7 +477,7 @@ public class HashedPasswordFileTest {
         pbArgs.add("jdk.management.agent/jdk.internal.agent=ALL-UNNAMED");
         pbArgs.add(TestApp.class.getSimpleName());
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 pbArgs.toArray(new String[0]));
         Process process = ProcessTools.startProcess(
                 TestApp.class.getSimpleName(),


### PR DESCRIPTION
I backport this to keep the tests up-to-date. Many similar changes have been backported. Let's do this, too, to complete the job. This will simplify later backports.

I had to resolve DefaultAgentFilterTest.java as 8299891: JMX ObjectInputFilter additional classes needed is not in 17.

Further the -virtual ProblemList is not in 17. Omitted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316460](https://bugs.openjdk.org/browse/JDK-8316460) needs maintainer approval

### Issue
 * [JDK-8316460](https://bugs.openjdk.org/browse/JDK-8316460): 4 javax/management tests ignore VM flags (**Sub-task** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3463/head:pull/3463` \
`$ git checkout pull/3463`

Update a local copy of the PR: \
`$ git checkout pull/3463` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3463`

View PR using the GUI difftool: \
`$ git pr show -t 3463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3463.diff">https://git.openjdk.org/jdk17u-dev/pull/3463.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3463#issuecomment-2789598284)
</details>
