### PR TITLE
8316452: java/lang/instrument/modules/AppendToClassPathModuleTest.java ignores VM flags

### DIFF
--- a/test/jdk/java/lang/instrument/modules/AppendToClassPathModuleTest.java
+++ b/test/jdk/java/lang/instrument/modules/AppendToClassPathModuleTest.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8169909
+ * @requires vm.flagless
  * @library src /test/lib
  * @build test/*
  * @run shell AppendToClassPathModuleTest.sh


### PR DESCRIPTION
I backport this to keep the tests up-to-date. Many similar changes have been backported. Let's do this, too, to complete the job. This will simplify later backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316452](https://bugs.openjdk.org/browse/JDK-8316452) needs maintainer approval

### Issue
 * [JDK-8316452](https://bugs.openjdk.org/browse/JDK-8316452): java/lang/instrument/modules/AppendToClassPathModuleTest.java ignores VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3464/head:pull/3464` \
`$ git checkout pull/3464`

Update a local copy of the PR: \
`$ git checkout pull/3464` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3464`

View PR using the GUI difftool: \
`$ git pr show -t 3464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3464.diff">https://git.openjdk.org/jdk17u-dev/pull/3464.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3464#issuecomment-2789616897)
</details>
