### PR TITLE
8316451: 6 java/lang/instrument/PremainClass tests ignore VM flags

### DIFF
--- a/test/jdk/java/lang/instrument/NegativeAgentRunner.java
+++ b/test/jdk/java/lang/instrument/NegativeAgentRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ public class NegativeAgentRunner {
         }
         String agentClassName = argv[0];
         String excepClassName = argv[1];
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 "-javaagent:" + agentClassName + ".jar", "-Xmx128m", "-XX:-CreateCoredumpOnCrash",
                 agentClassName);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/jdk/java/lang/instrument/PremainClass/PremainClassTest.java
+++ b/test/jdk/java/lang/instrument/PremainClass/PremainClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,10 @@ public class PremainClassTest {
     // a non ascii character.
     // Verify that the premain() function is executed correctly.
     public static void main(String[] a) throws Exception {
-        String testArgs = String.format(
-                "-javaagent:%s/Agent.jar -classpath %s DummyMain",
-                System.getProperty("test.src"),
-                System.getProperty("test.classes", "."));
+        String testArgs = String.format("-javaagent:%s/Agent.jar",
+                System.getProperty("test.src"));
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-                Utils.addTestJavaOpts(testArgs.split("\\s+")));
-        System.out.println("testjvm.cmd:" + Utils.getCommandLine(pb));
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(testArgs, "DummyMain");
 
         OutputAnalyzer output = ProcessTools.executeProcess(pb);
         System.out.println("testjvm.stdout:" + output.getStdout());


### PR DESCRIPTION
I backport this to keep the tests up-to-date. Many similar changes have been backported. Let's do this, too, to complete the job. This will simplify later backports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316451](https://bugs.openjdk.org/browse/JDK-8316451) needs maintainer approval

### Issue
 * [JDK-8316451](https://bugs.openjdk.org/browse/JDK-8316451): 6 java/lang/instrument/PremainClass tests ignore VM flags (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3465/head:pull/3465` \
`$ git checkout pull/3465`

Update a local copy of the PR: \
`$ git checkout pull/3465` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3465`

View PR using the GUI difftool: \
`$ git pr show -t 3465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3465.diff">https://git.openjdk.org/jdk17u-dev/pull/3465.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3465#issuecomment-2789624324)
</details>
