### PR TITLE
8296920: Regression Test DialogOrient.java fails on MacOS

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogOrient.java
+++ b/test/jdk/java/awt/print/Dialog/DialogOrient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,8 +70,8 @@ public class DialogOrient implements Printable {
       Sysout.printInstructions( instructions );
 
         PrinterJob job = PrinterJob.getPrinterJob();
-        job.setPrintable(new DialogOrient());
         PageFormat landscape = job.pageDialog(job.defaultPage());
+        job.setPrintable(new DialogOrient(), landscape);
 
         if (job.printDialog()) {
             job.print();


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8296920](https://bugs.openjdk.org/browse/JDK-8296920) needs maintainer approval

### Issue
 * [JDK-8296920](https://bugs.openjdk.org/browse/JDK-8296920): Regression Test DialogOrient.java fails on MacOS (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3476/head:pull/3476` \
`$ git checkout pull/3476`

Update a local copy of the PR: \
`$ git checkout pull/3476` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3476`

View PR using the GUI difftool: \
`$ git pr show -t 3476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3476.diff">https://git.openjdk.org/jdk17u-dev/pull/3476.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3476#issuecomment-2791935969)
</details>
