### PR TITLE
8295804: javax/swing/JFileChooser/JFileChooserSetLocationTest.java failed with "setLocation() is not working properly"

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/JFileChooserSetLocationTest.java
+++ b/test/jdk/javax/swing/JFileChooser/JFileChooserSetLocationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.HeadlessException;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -209,7 +210,11 @@ public class JFileChooserSetLocationTest {
     }
 
     public static void createUI() {
-        frame = new JFrame();
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+
+        int xPos = (int) screenSize.getWidth() / 2;
+        int yPos = (int) screenSize.getHeight() / 2;
+        frame = new JFrame("FileChooser set location test");
         panel = new JPanel();
         btn = new JButton(SHOW_DIALOG_OUTSIDE_THE_PANEL);
         btn1 = new JButton(SHOW_DIALOG_OVER_THE_PANEL);
@@ -238,6 +243,7 @@ public class JFileChooserSetLocationTest {
         frame.setLocationRelativeTo(null);
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         frame.pack();
+        frame.setLocation(xPos, yPos - 200);
         frame.setVisible(true);
     }
 
@@ -280,7 +286,6 @@ public class JFileChooserSetLocationTest {
             System.out.println(
                     "createDialog and set location to (" + x + ", " + y + ")");
             dialog.setLocation(x, y);
-
             return dialog;
         }
 
@@ -289,5 +294,4 @@ public class JFileChooserSetLocationTest {
         }
 
     }
-
 }


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8295804](https://bugs.openjdk.org/browse/JDK-8295804) needs maintainer approval

### Issue
 * [JDK-8295804](https://bugs.openjdk.org/browse/JDK-8295804): javax/swing/JFileChooser/JFileChooserSetLocationTest.java failed with "setLocation() is not working properly" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3477/head:pull/3477` \
`$ git checkout pull/3477`

Update a local copy of the PR: \
`$ git checkout pull/3477` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3477`

View PR using the GUI difftool: \
`$ git pr show -t 3477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3477.diff">https://git.openjdk.org/jdk17u-dev/pull/3477.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3477#issuecomment-2792038011)
</details>
