### PR TITLE
8341257: Open source few DND tests - Set1

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -203,6 +203,8 @@ java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java 8129778
 java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java 8129778 generic-all
 java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java 8129778 generic-all
 
+java/awt/dnd/DnDCursorCrashTest.java 8242805 macosx-all
+java/awt/dnd/DnDClipboardDeadlockTest.java 8079553 linux-all
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all
 java/awt/Frame/FramesGC/FramesGC.java 8079069 macosx-all
 java/awt/GridLayout/LayoutExtraGaps/LayoutExtraGaps.java 8000171 windows-all

--- a/test/jdk/java/awt/dnd/DnDClipboardDeadlockTest.java
+++ b/test/jdk/java/awt/dnd/DnDClipboardDeadlockTest.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4388802
+ * @summary tests that clipboard operations during drag-and-drop don't deadlock
+ * @key headful
+ * @run main DnDClipboardDeadlockTest
+ */
+
+import java.awt.AWTEvent;
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.AWTEventListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+
+public class DnDClipboardDeadlockTest {
+
+    public static final int CODE_NOT_RETURNED = -1;
+    public static final int CODE_OK = 0;
+    public static final int CODE_FAILURE = 1;
+
+    private int returnCode = CODE_NOT_RETURNED;
+
+    final Frame frame = new Frame();
+    Robot robot = null;
+    Panel panel = null;
+
+    public static void main(String[] args) throws Exception {
+        DnDClipboardDeadlockTest test = new DnDClipboardDeadlockTest();
+        if (args.length == 4) {
+            test.run(args);
+        } else {
+            test.start();
+        }
+    }
+
+    public void run(String[] args) throws InterruptedException, AWTException {
+        try {
+            if (args.length != 4) {
+                throw new RuntimeException("Incorrect command line arguments.");
+            }
+
+            int x = Integer.parseInt(args[0]);
+            int y = Integer.parseInt(args[1]);
+            int w = Integer.parseInt(args[2]);
+            int h = Integer.parseInt(args[3]);
+
+            Transferable t = new StringSelection("TEXT");
+            panel = new DragSourcePanel(t);
+
+            frame.setTitle("DragSource frame");
+            frame.setLocation(300, 200);
+            frame.add(panel);
+            frame.pack();
+            frame.setVisible(true);
+
+            Util.waitForInit();
+
+            Point sourcePoint = panel.getLocationOnScreen();
+            Dimension d = panel.getSize();
+            sourcePoint.translate(d.width / 2, d.height / 2);
+
+            Point targetPoint = new Point(x + w / 2, y + h / 2);
+
+            robot = new Robot();
+
+            if (!Util.pointInComponent(robot, sourcePoint, panel)) {
+                throw new RuntimeException("WARNING: Cannot locate source panel");
+            }
+
+            robot.mouseMove(sourcePoint.x, sourcePoint.y);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (; !sourcePoint.equals(targetPoint);
+                 sourcePoint.translate(sign(targetPoint.x - sourcePoint.x),
+                         sign(targetPoint.y - sourcePoint.y))) {
+                robot.mouseMove(sourcePoint.x, sourcePoint.y);
+                Thread.sleep(10);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            if (frame != null) {
+                frame.dispose();
+            }
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    } // run()
+
+    public static int sign(int n) {
+        return n < 0 ? -1 : n == 0 ? 0 : 1;
+    }
+
+    public void start() {
+        panel = new DropTargetPanel();
+
+        frame.setTitle("DropTarget frame");
+        frame.setLocation(10, 200);
+        frame.add(panel);
+
+        frame.pack();
+        frame.setVisible(true);
+
+        try {
+            Util.waitForInit();
+
+            Point p = panel.getLocationOnScreen();
+            Dimension d = panel.getSize();
+
+            try {
+                Robot robot = new Robot();
+                Point center = new Point(p);
+                center.translate(d.width / 2, d.height / 2);
+                if (!Util.pointInComponent(robot, center, panel)) {
+                    System.err.println("WARNING: Cannot locate target panel");
+                    return;
+                }
+            } catch (AWTException awte) {
+                awte.printStackTrace();
+                return;
+            }
+
+            String javaPath = System.getProperty("java.home", "");
+            String command = javaPath + File.separator + "bin" +
+                    File.separator + "java -cp "
+                    + System.getProperty("java.class.path", ".")
+                    + " DnDClipboardDeadlockTest " +
+                    p.x + " " + p.y + " " + d.width + " " + d.height;
+
+            Process process = Runtime.getRuntime().exec(command);
+            returnCode = process.waitFor();
+
+            InputStream errorStream = process.getErrorStream();
+            int count = errorStream.available();
+            if (count > 0) {
+                byte[] b = new byte[count];
+                errorStream.read(b);
+                System.err.println("========= Child VM System.err ========");
+                System.err.print(new String(b));
+                System.err.println("======================================");
+            }
+
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+        switch (returnCode) {
+            case CODE_NOT_RETURNED:
+                System.err.println("Child VM: failed to start");
+                break;
+            case CODE_OK:
+                System.err.println("Child VM: normal termination");
+                break;
+            case CODE_FAILURE:
+                System.err.println("Child VM: abnormal termination");
+                break;
+        }
+        if (returnCode != CODE_OK) {
+            throw new RuntimeException("The test failed.");
+        }
+        if (frame != null) {
+            frame.dispose();
+        }
+    } // start()
+} // class DnDClipboardDeadlockTest
+
+class Util implements AWTEventListener {
+    private static final Toolkit tk = Toolkit.getDefaultToolkit();
+    private static final Object SYNC_LOCK = new Object();
+    private Component clickedComponent = null;
+    private static final int PAINT_TIMEOUT = 10000;
+    private static final int MOUSE_RELEASE_TIMEOUT = 10000;
+    private static final Util util = new Util();
+
+    static {
+        tk.addAWTEventListener(util, 0xFFFFFFFF);
+    }
+
+    private void reset() {
+        clickedComponent = null;
+    }
+
+    public void eventDispatched(AWTEvent e) {
+        if (e.getID() == MouseEvent.MOUSE_RELEASED) {
+            clickedComponent = (Component) e.getSource();
+            synchronized (SYNC_LOCK) {
+                SYNC_LOCK.notifyAll();
+            }
+        }
+    }
+
+    public static boolean pointInComponent(Robot robot, Point p, Component comp)
+            throws InterruptedException {
+        return util.isPointInComponent(robot, p, comp);
+    }
+
+    private boolean isPointInComponent(Robot robot, Point p, Component comp)
+            throws InterruptedException {
+        tk.sync();
+        robot.waitForIdle();
+        reset();
+        robot.mouseMove(p.x, p.y);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        synchronized (SYNC_LOCK) {
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            SYNC_LOCK.wait(MOUSE_RELEASE_TIMEOUT);
+        }
+
+        Component c = clickedComponent;
+
+        while (c != null && c != comp) {
+            c = c.getParent();
+        }
+
+        return c == comp;
+    }
+
+    public static void waitForInit() throws InterruptedException {
+        final Frame f = new Frame() {
+            public void paint(Graphics g) {
+                dispose();
+                synchronized (SYNC_LOCK) {
+                    SYNC_LOCK.notifyAll();
+                }
+            }
+        };
+        f.setBounds(600, 400, 200, 200);
+        synchronized (SYNC_LOCK) {
+            f.setVisible(true);
+            SYNC_LOCK.wait(PAINT_TIMEOUT);
+        }
+        tk.sync();
+    }
+}
+
+class DragSourceButton extends Button implements Serializable,
+        DragGestureListener,
+        DragSourceListener {
+    static final Clipboard systemClipboard =
+            Toolkit.getDefaultToolkit().getSystemClipboard();
+    final Transferable transferable;
+
+    public DragSourceButton(Transferable t) {
+        super("DragSourceButton");
+
+        this.transferable = t;
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY,
+                this);
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(null, transferable, this);
+    }
+
+    public void dragEnter(DragSourceDragEvent dsde) {
+    }
+
+    public void dragExit(DragSourceEvent dse) {
+    }
+
+    public void dragOver(DragSourceDragEvent dsde) {
+        try {
+            Transferable t = systemClipboard.getContents(null);
+            if (t.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+                String str = (String) t.getTransferData(DataFlavor.stringFlavor);
+            }
+            systemClipboard.setContents(new StringSelection("SOURCE"), null);
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+            if (!ioe.getMessage().equals("Owner failed to convert data")) {
+                throw new RuntimeException("Owner failed to convert data");
+            }
+        } catch (IllegalStateException e) {
+            // IllegalStateExceptions do not indicate a bug in this case.
+            // They result from concurrent modification of system clipboard
+            // contents by the parent and child processes.
+            // These exceptions are numerous, so we avoid dumping their
+            // backtraces to prevent blocking child process io, which
+            // causes test failure on timeout.
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {
+        System.exit(DnDClipboardDeadlockTest.CODE_OK);
+    }
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {
+    }
+}
+
+class DragSourcePanel extends Panel {
+
+    final Dimension preferredDimension = new Dimension(200, 200);
+
+    public DragSourcePanel(Transferable t) {
+        setLayout(new GridLayout(1, 1));
+        add(new DragSourceButton(t));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+}
+
+class DropTargetPanel extends Panel implements DropTargetListener {
+
+    static final Clipboard systemClipboard =
+            Toolkit.getDefaultToolkit().getSystemClipboard();
+    final Dimension preferredDimension = new Dimension(200, 200);
+
+    public DropTargetPanel() {
+        setBackground(Color.green);
+        setDropTarget(new DropTarget(this, this));
+        setLayout(new GridLayout(1, 1));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {
+        dtde.acceptDrag(DnDConstants.ACTION_COPY);
+    }
+
+    public void dragExit(DropTargetEvent dte) {
+    }
+
+    public void dragOver(DropTargetDragEvent dtde) {
+        dtde.acceptDrag(DnDConstants.ACTION_COPY);
+        try {
+            Transferable t = systemClipboard.getContents(null);
+            if (t.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+                String str = (String) t.getTransferData(DataFlavor.stringFlavor);
+            }
+            systemClipboard.setContents(new StringSelection("TARGET"), null);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+            return;
+        }
+
+        removeAll();
+        final List list = new List();
+        add(list);
+
+        Transferable t = dtde.getTransferable();
+        DataFlavor[] dfs = t.getTransferDataFlavors();
+
+        for (int i = 0; i < dfs.length; i++) {
+
+            DataFlavor flavor = dfs[i];
+            String str = null;
+
+            if (DataFlavor.stringFlavor.equals(flavor)) {
+                try {
+                    str = (String) t.getTransferData(flavor);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+            list.add(str + ":" + flavor.getMimeType());
+        }
+
+        dtc.dropComplete(true);
+        validate();
+    }
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {
+    }
+}

--- a/test/jdk/java/awt/dnd/DnDCursorCrashTest.java
+++ b/test/jdk/java/awt/dnd/DnDCursorCrashTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4343300
+ * @summary tests that drag attempt doesn't cause crash when
+ *          custom cursor is used
+ * @key headful
+ * @run main DnDCursorCrashTest
+ */
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+public class DnDCursorCrashTest {
+    static final Frame frame = new Frame();
+    static final DragSourcePanel dragSourcePanel = new DragSourcePanel();
+    static final DropTargetPanel dropTargetPanel = new DropTargetPanel();
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame.setTitle("DnD Cursor Test Frame");
+                frame.setLocation(200, 200);
+                frame.setLayout(new GridLayout(2, 1));
+                frame.add(dragSourcePanel);
+                frame.add(dropTargetPanel);
+                frame.pack();
+                frame.setVisible(true);
+            });
+
+            Robot robot = new Robot();
+            robot.delay(1000);
+            robot.mouseMove(250, 250);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (int y = 250; y < 350; y += 5) {
+                robot.mouseMove(250, y);
+                robot.delay(100);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+}
+
+class DragSourceButton extends Button implements Serializable,
+                                                 Transferable,
+                                                 DragGestureListener,
+                                                 DragSourceListener {
+    private final DataFlavor dataflavor =
+        new DataFlavor(Button.class, "DragSourceButton");
+
+    public DragSourceButton() {
+        this("DragSourceButton");
+    }
+
+    public DragSourceButton(String str) {
+        super(str);
+
+        DragSource ds = DragSource.getDefaultDragSource();
+        ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY,
+                                              this);
+    }
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        dge.startDrag(new Cursor(Cursor.HAND_CURSOR), this, this);
+    }
+
+    public void dragEnter(DragSourceDragEvent dsde) {}
+
+    public void dragExit(DragSourceEvent dse) {}
+
+    public void dragOver(DragSourceDragEvent dsde) {}
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {}
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {}
+
+    public Object getTransferData(DataFlavor flavor)
+      throws UnsupportedFlavorException, IOException {
+
+        if (!isDataFlavorSupported(flavor)) {
+            throw new UnsupportedFlavorException(flavor);
+        }
+
+        Object retObj;
+
+        ByteArrayOutputStream baoStream = new ByteArrayOutputStream();
+        ObjectOutputStream ooStream = new ObjectOutputStream(baoStream);
+        ooStream.writeObject(this);
+
+        ByteArrayInputStream baiStream = new ByteArrayInputStream(baoStream.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(baiStream);
+        try {
+            retObj = ois.readObject();
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e.toString());
+        }
+
+        return retObj;
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[] { dataflavor };
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor dflavor) {
+        return dataflavor.equals(dflavor);
+    }
+}
+
+class DragSourcePanel extends Panel {
+
+    final Dimension preferredDimension = new Dimension(200, 100);
+
+    public DragSourcePanel() {
+        setLayout(new GridLayout(1, 1));
+        add(new DragSourceButton());
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+}
+
+class DropTargetPanel extends Panel implements DropTargetListener {
+
+    final Dimension preferredDimension = new Dimension(200, 100);
+
+    public DropTargetPanel() {
+        setDropTarget(new DropTarget(this, this));
+    }
+
+    public Dimension getPreferredSize() {
+        return preferredDimension;
+    }
+
+    public void dragEnter(DropTargetDragEvent dtde) {}
+
+    public void dragExit(DropTargetEvent dte) {}
+
+    public void dragOver(DropTargetDragEvent dtde) {}
+
+    public void dropActionChanged(DropTargetDragEvent dtde) {}
+
+    public void drop(DropTargetDropEvent dtde) {
+        DropTargetContext dtc = dtde.getDropTargetContext();
+
+        if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+            dtde.acceptDrop(DnDConstants.ACTION_COPY);
+        } else {
+            dtde.rejectDrop();
+        }
+
+        DataFlavor[] dfs = dtde.getCurrentDataFlavors();
+        Component comp = null;
+
+        if (dfs != null && dfs.length >= 1) {
+            Transferable transfer = dtde.getTransferable();
+
+            try {
+                comp = (Component)transfer.getTransferData(dfs[0]);
+            } catch (Throwable e) {
+                e.printStackTrace();
+                dtc.dropComplete(false);
+            }
+        }
+        dtc.dropComplete(true);
+
+        add(comp);
+    }
+}

--- a/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
+++ b/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4357905
+ * @summary Tests that removal of the focus owner component during
+ *          drop processing doesn't cause crash
+ * @key headful
+ * @run main DnDRemoveFocusOwnerCrashTest
+ */
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetContext;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.Serializable;
+
+public class DnDRemoveFocusOwnerCrashTest {
+    public static final int FRAME_ACTIVATION_TIMEOUT = 1000;
+    public static Frame frame;
+    public static Robot robot;
+    public static DragSourceButton dragSourceButton;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame();
+                dragSourceButton = new DragSourceButton();
+                DropTargetPanel dropTargetPanel =
+                        new DropTargetPanel(dragSourceButton);
+                frame.add(new Button("Test"));
+                frame.setTitle("Remove Focus Owner Test Frame");
+                frame.setLocation(200, 200);
+                frame.add(dropTargetPanel);
+                frame.pack();
+                frame.setVisible(true);
+
+                try {
+                    robot.delay(FRAME_ACTIVATION_TIMEOUT);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    throw new RuntimeException("The test failed.");
+                }
+
+                Point p = dragSourceButton.getLocationOnScreen();
+                p.translate(10, 10);
+
+                try {
+                    Robot robot = new Robot();
+                    robot.mouseMove(p.x, p.y);
+                    robot.keyPress(KeyEvent.VK_CONTROL);
+                    robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                    for (int dy = 0; dy < 50; dy++) {
+                        robot.mouseMove(p.x, p.y + dy);
+                        robot.delay(10);
+                    }
+                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                    robot.keyRelease(KeyEvent.VK_CONTROL);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    throw new RuntimeException("The test failed.");
+                }
+            });
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(() -> frame.dispose());
+            }
+        }
+    }
+
+    static class DragSourceButton extends Button implements Serializable,
+            Transferable,
+            DragGestureListener,
+            DragSourceListener {
+
+        private static DataFlavor dataflavor;
+
+        static {
+            try {
+                dataflavor =
+                        new DataFlavor(DataFlavor.javaJVMLocalObjectMimeType);
+                dataflavor.setHumanPresentableName("Local Object Flavor");
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+                throw new ExceptionInInitializerError();
+            }
+        }
+
+        public DragSourceButton() {
+            this("DragSourceButton");
+        }
+
+        public DragSourceButton(String str) {
+            super(str);
+
+            DragSource ds = DragSource.getDefaultDragSource();
+            ds.createDefaultDragGestureRecognizer(this, DnDConstants.ACTION_COPY,
+                    this);
+        }
+
+        public void dragGestureRecognized(DragGestureEvent dge) {
+            dge.startDrag(null, this, this);
+        }
+
+        public void dragEnter(DragSourceDragEvent dsde) {
+        }
+
+        public void dragExit(DragSourceEvent dse) {
+        }
+
+        public void dragOver(DragSourceDragEvent dsde) {
+        }
+
+        public void dragDropEnd(DragSourceDropEvent dsde) {
+        }
+
+        public void dropActionChanged(DragSourceDragEvent dsde) {
+        }
+
+        public Object getTransferData(DataFlavor flavor)
+                throws UnsupportedFlavorException {
+
+            if (!isDataFlavorSupported(flavor)) {
+                throw new UnsupportedFlavorException(flavor);
+            }
+
+            return this;
+        }
+
+        public DataFlavor[] getTransferDataFlavors() {
+            return new DataFlavor[]{dataflavor};
+        }
+
+        public boolean isDataFlavorSupported(DataFlavor dflavor) {
+            return dataflavor.equals(dflavor);
+        }
+    }
+
+    static class DropTargetPanel extends Panel implements DropTargetListener {
+
+        public DropTargetPanel(DragSourceButton button) {
+            setLayout(new FlowLayout(FlowLayout.CENTER, 50, 50));
+            add(button);
+            setDropTarget(new DropTarget(this, this));
+        }
+
+        public void dragEnter(DropTargetDragEvent dtde) {
+        }
+
+        public void dragExit(DropTargetEvent dte) {
+        }
+
+        public void dragOver(DropTargetDragEvent dtde) {
+        }
+
+        public void dropActionChanged(DropTargetDragEvent dtde) {
+        }
+
+        public void drop(DropTargetDropEvent dtde) {
+            removeAll();
+
+            DropTargetContext dtc = dtde.getDropTargetContext();
+
+            if ((dtde.getSourceActions() & DnDConstants.ACTION_COPY) != 0) {
+                dtde.acceptDrop(DnDConstants.ACTION_COPY);
+            } else {
+                dtde.rejectDrop();
+            }
+
+            DataFlavor[] dfs = dtde.getCurrentDataFlavors();
+            Component comp = null;
+
+            if (dfs != null && dfs.length >= 1) {
+                Transferable transfer = dtde.getTransferable();
+
+                try {
+                    comp = (Component) transfer.getTransferData(dfs[0]);
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                    dtc.dropComplete(false);
+                }
+            }
+            dtc.dropComplete(true);
+
+            add(comp);
+            validate();
+        }
+    }
+}

--- a/test/jdk/java/awt/dnd/DnDToWordpadTest.java
+++ b/test/jdk/java/awt/dnd/DnDToWordpadTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6362095
+ * @summary Tests basic DnD functionality to a wordpad
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DnDToWordpadTest
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.Panel;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceDragEvent;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DragSourceEvent;
+import java.awt.dnd.DragSourceListener;
+import java.awt.dnd.InvalidDnDOperationException;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javax.imageio.ImageIO;
+
+import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
+
+public class DnDToWordpadTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                The test window contains a yellow button. Click on the button
+                to copy image into the clipboard or drag the image.
+                Paste or drop the image over Wordpad (when the mouse
+                enters the Wordpad during the drag, the application
+                should change the cursor to indicate that a copy operation is
+                about to happen; release the mouse button).
+                An image of a red rectangle should appear inside the document.
+                You should be able to repeat this operation multiple times.
+                Please, click "Pass" if above conditions are true,
+                otherwise click "Fail".
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(DnDToWordpadTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("DnD To WordPad Test");
+        Panel mainPanel;
+        Component dragSource;
+
+        mainPanel = new Panel();
+        mainPanel.setLayout(null);
+
+        mainPanel.setBackground(Color.black);
+        try {
+            dragSource = new DnDSource("Drag ME!");
+            mainPanel.add(dragSource);
+            f.add(mainPanel);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        f.setSize(200, 200);
+        return f;
+    }
+}
+
+class DnDSource extends Button implements Transferable,
+        DragGestureListener,
+        DragSourceListener {
+    private DataFlavor m_df;
+    private transient int m_dropAction;
+    private Image m_img;
+
+    DnDSource(String label) throws IOException {
+        super(label);
+
+        setBackground(Color.yellow);
+        setForeground(Color.blue);
+        setSize(200, 120);
+
+        m_df = DataFlavor.imageFlavor;
+
+        DragSource dragSource = new DragSource();
+        dragSource.createDefaultDragGestureRecognizer(
+                this,
+                DnDConstants.ACTION_COPY_OR_MOVE,
+                this
+        );
+        dragSource.addDragSourceListener(this);
+
+        // Create test gif image to drag
+        Path p = Path.of(System.getProperty("test.classes", "."));
+        BufferedImage bImg = new BufferedImage(79, 109, TYPE_INT_ARGB);
+        Graphics2D cg = bImg.createGraphics();
+        cg.setColor(Color.RED);
+        cg.fillRect(0, 0, 79, 109);
+        ImageIO.write(bImg, "png", new File(p + java.io.File.separator +
+                "DnDSource_Red.gif"));
+
+        m_img = Toolkit.getDefaultToolkit()
+                .getImage(System.getProperty("test.classes", ".")
+                + java.io.File.separator + "DnDSource_Red.gif");
+
+        addActionListener(
+                ae -> Toolkit.getDefaultToolkit().getSystemClipboard().setContents(
+                        (Transferable) DnDSource.this,
+                        null
+                )
+        );
+    }
+
+    public void paint(Graphics g) {
+        g.drawImage(m_img, 10, 10, null);
+    }
+
+    /**
+     * a Drag gesture has been recognized
+     */
+
+    public void dragGestureRecognized(DragGestureEvent dge) {
+        System.err.println("starting Drag");
+        try {
+            dge.startDrag(null, this, this);
+        } catch (InvalidDnDOperationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * as the hotspot enters a platform dependent drop site
+     */
+
+    public void dragEnter(DragSourceDragEvent dsde) {
+        System.err.println("[Source] dragEnter");
+    }
+
+    /**
+     * as the hotspot moves over a platform dependent drop site
+     */
+
+    public void dragOver(DragSourceDragEvent dsde) {
+        System.err.println("[Source] dragOver");
+        m_dropAction = dsde.getDropAction();
+        System.out.println("m_dropAction = " + m_dropAction);
+    }
+
+    /**
+     * as the operation changes
+     */
+
+    public void dragGestureChanged(DragSourceDragEvent dsde) {
+        System.err.println("[Source] dragGestureChanged");
+        m_dropAction = dsde.getDropAction();
+        System.out.println("m_dropAction = " + m_dropAction);
+    }
+
+    /**
+     * as the hotspot exits a platform dependent drop site
+     */
+
+    public void dragExit(DragSourceEvent dsde) {
+        System.err.println("[Source] dragExit");
+    }
+
+    /**
+     * as the operation completes
+     */
+
+    public void dragDropEnd(DragSourceDropEvent dsde) {
+        System.err.println("[Source] dragDropEnd");
+    }
+
+    public void dropActionChanged(DragSourceDragEvent dsde) {
+        System.err.println("[Source] dropActionChanged");
+        m_dropAction = dsde.getDropAction();
+        System.out.println("m_dropAction = " + m_dropAction);
+    }
+
+    public DataFlavor[] getTransferDataFlavors() {
+        return new DataFlavor[]{m_df};
+    }
+
+    public boolean isDataFlavorSupported(DataFlavor sdf) {
+        System.err.println("[Source] isDataFlavorSupported" + m_df.equals(sdf));
+        return m_df.equals(sdf);
+    }
+
+    public Object getTransferData(DataFlavor tdf) throws UnsupportedFlavorException {
+        if (!m_df.equals(tdf)) {
+            throw new UnsupportedFlavorException(tdf);
+        }
+        System.err.println("[Source] Ok");
+        return m_img;
+    }
+}

--- a/test/jdk/java/awt/dnd/NonAsciiFilenames.java
+++ b/test/jdk/java/awt/dnd/NonAsciiFilenames.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4187490
+ * @summary Verify that Non-ASCII file names can be dragged and dropped
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual NonAsciiFilenames
+ */
+
+import java.awt.Color;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.io.File;
+import java.util.AbstractList;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+
+public class NonAsciiFilenames {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This test must be run on an OS which does not use ISO 8859-1
+                as its default encoding.
+
+                Open a native file browsing application, such as Windows
+                Explorer. Try to find a file whose name uses non-ISO 8859-1
+                characters. Create a file and name it such that it contains
+                non-ISO 8859-1 characters (For ex. é, à, ö, €, ¥). Drag
+                the file from the native application and drop it on the test
+                Frame. If the file name appears normally, then the test passes.
+                If boxes or question marks appear for characters, or if you see
+                the word "Error", then the test fails.
+                """;
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(NonAsciiFilenames::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFrame createUI() {
+        JFrame frame = new JFrame();
+        frame.setTitle("DropLabel test");
+        frame.getContentPane().add(new DropLabel("Drop here"));
+        frame.setSize(300, 100);
+        return frame;
+    }
+}
+
+class DropLabel extends JLabel implements DropTargetListener {
+    public DropLabel(String s) {
+        setText(s);
+        new DropTarget(this, DnDConstants.ACTION_COPY, this, true);
+        showDrop(false);
+    }
+
+    private void showDrop(boolean b) {
+        setForeground(b ? Color.white : Color.black);
+    }
+
+    /**
+     * Configure to desired flavor of dropped data.
+     */
+    private DataFlavor getDesiredFlavor() {
+        return DataFlavor.javaFileListFlavor;
+    }
+
+    /**
+     * Check to make sure that the contains the expected object types.
+     */
+    private void checkDroppedData(Object data) {
+        System.out.println("Got data: " + data.getClass().getName());
+        if (data instanceof AbstractList) {
+            AbstractList files = (AbstractList) data;
+            if (((File) files.get(0)).isFile())
+                setText(((File) files.get(0)).toString());
+            else
+                setText("Error: not valid file: " +
+                        ((File) files.get(0)).toString());
+        } else {
+            System.out.println("Error: wrong type of data dropped");
+        }
+    }
+
+    private boolean isDragOk(DropTargetDragEvent e) {
+        boolean canDrop = false;
+        try {
+            canDrop = e.isDataFlavorSupported(getDesiredFlavor());
+        } catch (Exception ex) {
+        }
+
+        if (canDrop)
+            e.acceptDrag(DnDConstants.ACTION_COPY);
+        else
+            e.rejectDrag();
+        showDrop(canDrop);
+        return canDrop;
+    }
+
+    public void dragEnter(DropTargetDragEvent e) {
+        isDragOk(e);
+    }
+
+
+    public void dragOver(DropTargetDragEvent e) {
+        isDragOk(e);
+    }
+
+    public void dropActionChanged(DropTargetDragEvent e) {
+        isDragOk(e);
+    }
+
+    public void dragExit(DropTargetEvent e) {
+        showDrop(false);
+    }
+
+    public void drop(DropTargetDropEvent e) {
+        try {
+            e.acceptDrop(DnDConstants.ACTION_COPY);
+            checkDroppedData(e.getTransferable().
+                    getTransferData(getDesiredFlavor()));
+        } catch (Exception err) {
+        }
+        e.dropComplete(true);
+        showDrop(false);
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341257](https://bugs.openjdk.org/browse/JDK-8341257) needs maintainer approval

### Issue
 * [JDK-8341257](https://bugs.openjdk.org/browse/JDK-8341257): Open source few DND tests - Set1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3483/head:pull/3483` \
`$ git checkout pull/3483`

Update a local copy of the PR: \
`$ git checkout pull/3483` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3483`

View PR using the GUI difftool: \
`$ git pr show -t 3483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3483.diff">https://git.openjdk.org/jdk17u-dev/pull/3483.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3483#issuecomment-2795137522)
</details>
