### PR TITLE
8315721: CloseRace.java#id0 fails transiently on libgraal

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/CloseRace.java
+++ b/test/jdk/java/lang/ProcessBuilder/CloseRace.java
@@ -23,10 +23,12 @@
 
 /**
  * @test
- * @bug 8024521
+ * @bug 8024521 8315721
  * @summary Closing ProcessPipeInputStream at the time the process exits is racy
  *          and leads to data corruption. Run this test manually (as
  *          an ordinary java program) with  -Xmx8M  to repro bug 8024521.
+ * @comment Don't allow -Xcomp, it disturbs the timing
+ * @requires (vm.compMode != "Xcomp")
  * @run main/othervm -Xmx8M -Dtest.duration=2 CloseRace
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle

Needed to resolve as generational ZGC is not in 17, which added a second test case that is adapted by the original change as well.  Original commit: https://github.com/openjdk/jdk/commit/1be355734da94243e29f0899b53aa1ebdf3bcb79

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8315721](https://bugs.openjdk.org/browse/JDK-8315721) needs maintainer approval

### Issue
 * [JDK-8315721](https://bugs.openjdk.org/browse/JDK-8315721): CloseRace.java#id0 fails transiently on libgraal (**Bug** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3485/head:pull/3485` \
`$ git checkout pull/3485`

Update a local copy of the PR: \
`$ git checkout pull/3485` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3485`

View PR using the GUI difftool: \
`$ git pr show -t 3485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3485.diff">https://git.openjdk.org/jdk17u-dev/pull/3485.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3485#issuecomment-2796007890)
</details>
