### PR TITLE
8318962: Update ProcessTools javadoc with suggestions in 8315097

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -401,12 +401,21 @@ public final class ProcessTools {
     }
 
     /**
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
-     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
-     * <p>
-     * The command line will be like:
-     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     * Create ProcessBuilder using the java launcher from the jdk to
+     * be tested. The default jvm options from jtreg, test.vm.opts and
+     * test.java.opts, are added.
+     *
+     * <p>Unless the "test.noclasspath" property is "true" the
+     * classpath property "java.class.path" is appended to the command
+     * line and the environment of the ProcessBuilder is modified to
+     * remove "CLASSPATH". If the property "test.thread.factory" is
+     * provided the command args are updated and appended to invoke
+     * ProcessTools main() and provide the name of the thread factory.
+     *
+     * <p>The "-Dtest.thread.factory" is appended to the arguments
+     * with the thread factory value. The remaining command args are
+     * scanned for unsupported options and are appended to the
+     * ProcessBuilder.
      *
      * @param command Arguments to pass to the java command.
      * @return The ProcessBuilder instance representing the java command.
@@ -416,12 +425,21 @@ public final class ProcessTools {
     }
 
     /**
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
-     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
-     * <p>
-     * The command line will be like:
-     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     * Create ProcessBuilder using the java launcher from the jdk to
+     * be tested. The default jvm options from jtreg, test.vm.opts and
+     * test.java.opts, are added.
+     *
+     * <p>Unless the "test.noclasspath" property is "true" the
+     * classpath property "java.class.path" is appended to the command
+     * line and the environment of the ProcessBuilder is modified to
+     * remove "CLASSPATH". If the property "test.thread.factory" is
+     * provided the command args are updated and appended to invoke
+     * ProcessTools main() and provide the name of the thread factory.
+     *
+     * <p>The "-Dtest.thread.factory" is appended to the arguments
+     * with the thread factory value. The remaining command args are
+     * scanned for unsupported options and are appended to the
+     * ProcessBuilder.
      *
      * @param command Arguments to pass to the java command.
      * @return The ProcessBuilder instance representing the java command.
@@ -445,6 +463,18 @@ public final class ProcessTools {
      * it in combination with <b>@requires vm.flagless</b> JTREG
      * anotation as to not waste energy and test resources.
      *
+     * <p>Unless the "test.noclasspath" property is "true" the
+     * classpath property "java.class.path" is appended to the command
+     * line and the environment of the ProcessBuilder is modified to
+     * remove "CLASSPATH". If the property "test.thread.factory" is
+     * provided the command args are updated and appended to invoke
+     * ProcessTools main() and provide the name of the thread factory.
+     *
+     * <p>The "-Dtest.thread.factory" is appended to the arguments
+     * with the thread factory value. The remaining command args are
+     * scanned for unsupported options and are appended to the
+     * ProcessBuilder.
+     *
      * @param command Arguments to pass to the java command.
      * @return The ProcessBuilder instance representing the java command.
      */
@@ -467,6 +497,18 @@ public final class ProcessTools {
      * it in combination with <b>@requires vm.flagless</b> JTREG
      * anotation as to not waste energy and test resources.
      *
+     * <p>Unless the "test.noclasspath" property is "true" the
+     * classpath property "java.class.path" is appended to the command
+     * line and the environment of the ProcessBuilder is modified to
+     * remove "CLASSPATH". If the property "test.thread.factory" is
+     * provided the command args are updated and appended to invoke
+     * ProcessTools main() and provide the name of the thread factory.
+     *
+     * <p>The "-Dtest.thread.factory" is appended to the arguments
+     * with the thread factory value. The remaining command args are
+     * scanned for unsupported options and are appended to the
+     * ProcessBuilder.
+     *
      * @param command Arguments to pass to the java command.
      * @return The ProcessBuilder instance representing the java command.
      */
@@ -475,14 +517,12 @@ public final class ProcessTools {
     }
 
     /**
-     * Executes a test jvm process, waits for it to finish and returns the process output.
-     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
-     * The java from the test.jdk is used to execute the command.
-     * <p>
-     * The command line will be like:
-     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
-     * <p>
-     * The jvm process will have exited before this method returns.
+     * Executes a test jvm process, waits for it to finish and returns
+     * the process output.
+     *
+     * <p>The process is created using runtime flags set up by:
+     * {@link #createTestJavaProcessBuilder(String...)}. The
+     * jvm process will have exited before this method returns.
      *
      * @param cmds User specified arguments.
      * @return The output from the process.
@@ -492,14 +532,12 @@ public final class ProcessTools {
     }
 
     /**
-     * Executes a test jvm process, waits for it to finish and returns the process output.
-     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
-     * The java from the test.jdk is used to execute the command.
-     * <p>
-     * The command line will be like:
-     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
-     * <p>
-     * The jvm process will have exited before this method returns.
+     * Executes a test jvm process, waits for it to finish and returns
+     * the process output.
+     *
+     * <p>The process is created using runtime flags set up by:
+     * {@link #createTestJavaProcessBuilder(String...)}. The
+     * jvm process will have exited before this method returns.
      *
      * @param cmds User specified arguments.
      * @return The output from the process.


### PR DESCRIPTION
Backporting doc-only test change as prereq of JDK-8321713.

Needed to resolve trivially.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8318962](https://bugs.openjdk.org/browse/JDK-8318962) needs maintainer approval

### Issue
 * [JDK-8318962](https://bugs.openjdk.org/browse/JDK-8318962): Update ProcessTools javadoc with suggestions in 8315097 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3486/head:pull/3486` \
`$ git checkout pull/3486`

Update a local copy of the PR: \
`$ git checkout pull/3486` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3486`

View PR using the GUI difftool: \
`$ git pr show -t 3486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3486.diff">https://git.openjdk.org/jdk17u-dev/pull/3486.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3486#issuecomment-2796858501)
</details>
