### PR TITLE
8341972: java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java timed out after JDK-8341257

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -203,6 +203,7 @@ java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java 8129778
 java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java 8129778 generic-all
 java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java 8129778 generic-all
 
+java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java 8242805 macosx-all
 java/awt/dnd/DnDCursorCrashTest.java 8242805 macosx-all
 java/awt/dnd/DnDClipboardDeadlockTest.java 8079553 linux-all
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all

--- a/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
+++ b/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
@@ -64,10 +64,13 @@ public class DnDRemoveFocusOwnerCrashTest {
     public static Frame frame;
     public static Robot robot;
     public static DragSourceButton dragSourceButton;
+    static volatile Point p;
 
     public static void main(String[] args) throws Exception {
         try {
             robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
             EventQueue.invokeAndWait(() -> {
                 frame = new Frame();
                 dragSourceButton = new DragSourceButton();
@@ -79,37 +82,33 @@ public class DnDRemoveFocusOwnerCrashTest {
                 frame.add(dropTargetPanel);
                 frame.pack();
                 frame.setVisible(true);
+            });
 
-                try {
-                    robot.delay(FRAME_ACTIVATION_TIMEOUT);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    throw new RuntimeException("The test failed.");
-                }
+            robot.waitForIdle();
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
 
-                Point p = dragSourceButton.getLocationOnScreen();
+            EventQueue.invokeAndWait(() -> {
+                p = dragSourceButton.getLocationOnScreen();
                 p.translate(10, 10);
+            });
 
-                try {
-                    Robot robot = new Robot();
-                    robot.mouseMove(p.x, p.y);
-                    robot.keyPress(KeyEvent.VK_CONTROL);
-                    robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-                    for (int dy = 0; dy < 50; dy++) {
-                        robot.mouseMove(p.x, p.y + dy);
-                        robot.delay(10);
-                    }
-                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-                    robot.keyRelease(KeyEvent.VK_CONTROL);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    throw new RuntimeException("The test failed.");
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+            robot.mouseMove(p.x, p.y);
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (int dy = 0; dy < 50; dy++) {
+                robot.mouseMove(p.x, p.y + dy);
+                robot.delay(10);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
                 }
             });
-        } finally {
-            if (frame != null) {
-                EventQueue.invokeAndWait(() -> frame.dispose());
-            }
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341972](https://bugs.openjdk.org/browse/JDK-8341972) needs maintainer approval

### Issue
 * [JDK-8341972](https://bugs.openjdk.org/browse/JDK-8341972): java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java timed out after JDK-8341257 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3488/head:pull/3488` \
`$ git checkout pull/3488`

Update a local copy of the PR: \
`$ git checkout pull/3488` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3488`

View PR using the GUI difftool: \
`$ git pr show -t 3488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3488.diff">https://git.openjdk.org/jdk17u-dev/pull/3488.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3488#issuecomment-2797182134)
</details>
