### PR TITLE
Backport bc441e39dbcbc9114dfb8cf7da06b65ff5b7a5bb

### DIFF
--- a/make/Bundles.gmk
+++ b/make/Bundles.gmk
@@ -242,7 +242,10 @@ ifneq ($(filter product-bundles% legacy-bundles, $(MAKECMDGOALS)), )
       )
 
   JDK_SYMBOLS_BUNDLE_FILES := \
-      $(call FindFiles, $(SYMBOLS_IMAGE_DIR))
+      $(filter-out \
+          %.stripped.pdb, \
+          $(call FindFiles, $(SYMBOLS_IMAGE_DIR)) \
+      )
 
   TEST_DEMOS_BUNDLE_FILES := $(filter $(JDK_DEMOS_IMAGE_HOMEDIR)/demo/%, \
       $(ALL_JDK_DEMOS_FILES))


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8353709](https://bugs.openjdk.org/browse/JDK-8353709), commit [bc441e39](https://github.com/openjdk/jdk21u-dev/commit/bc441e39dbcbc9114dfb8cf7da06b65ff5b7a5bb) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by Christoph Langer on 14 Apr 2025 and had no reviewers.

Thanks!