### PR TITLE
8341278: Open source few TrayIcon tests - Set7

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -223,6 +223,8 @@ java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java 8150540 windows-all
 java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java 8150540 windows-all,macosx-all
 java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java 8150540 windows-all
 java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java 8196440 linux-all
+java/awt/TrayIcon/MouseMoveTest.java 8203053 linux-all
+java/awt/TrayIcon/TrayIconKeySelectTest.java 8341557 windows-all
 java/awt/TrayIcon/TrayIconTest.java 8341559 generic-all
 
 java/awt/Window/ShapedAndTranslucentWindows/SetShapeAndClick.java 8197936 macosx-all

--- a/test/jdk/java/awt/TrayIcon/ClearPrevImageTest.java
+++ b/test/jdk/java/awt/TrayIcon/ClearPrevImageTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.RenderingHints;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.image.BufferedImage;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 6267936
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @summary Tests that the previous image in TrayIcon is cleared
+ *          when a new image is set
+ * @run main/manual ClearPrevImageTest
+ */
+
+public class ClearPrevImageTest {
+    private static SystemTray tray;
+    private static TrayIcon icon;
+    private static final String INSTRUCTIONS = """
+            This test checks that the previous image in TrayIcon is cleared
+            when a new image is set.
+
+            When the test starts, a RED square TrayIcon is added
+            to the SystemTray (also, called Taskbar Status Area in MS Windows,
+            Notification Area in, GNOME and System Tray in KDE).
+
+            You should see it change into YELLOW after 5 seconds.
+            If you still see RED TrayIcon after 5 seconds,
+            press FAIL, otherwise press PASS
+            """;
+
+
+    public static void main(String[] args) throws Exception {
+         if (!SystemTray.isSupported()) {
+             throw new SkippedException("Test not applicable as"
+                                        + " System Tray not supported");
+         }
+
+        PassFailJFrame passFailJFrame
+                = PassFailJFrame.builder()
+                                .title("TrayIcon Change Test Instructions")
+                                .instructions(INSTRUCTIONS)
+                                .columns(40)
+                                .build();
+
+        EventQueue.invokeAndWait(ClearPrevImageTest::createAndShowTrayIcon);
+        try {
+            changeTrayIcon();
+            passFailJFrame.awaitAndCheck();
+        } catch (Exception e) {
+            throw new RuntimeException("Test failed: ", e);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (tray != null) {
+                    tray.remove(icon);
+                }
+            });
+        }
+    }
+
+    private static void createAndShowTrayIcon() {
+        Image img1 = createIcon(Color.RED);
+        tray = SystemTray.getSystemTray();
+        icon = new TrayIcon(img1);
+        icon.setImageAutoSize(true);
+
+        try {
+            tray.add(icon);
+        } catch (AWTException e) {
+            throw new RuntimeException("Error while adding"
+                                       + " icon to system tray", e);
+        }
+    }
+
+    private static void changeTrayIcon() {
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        Image img2 = createIcon(Color.YELLOW);
+        icon.setImage(img2);
+    }
+
+    private static Image createIcon(Color color) {
+        BufferedImage image = new BufferedImage(16, 16,
+                                                BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                           RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        g.setColor(color);
+        g.fillRect(0, 0, 16, 16);
+        g.dispose();
+        return image;
+    }
+}

--- a/test/jdk/java/awt/TrayIcon/FocusLostAfterTrayTest.java
+++ b/test/jdk/java/awt/TrayIcon/FocusLostAfterTrayTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.SystemTray;
+import java.awt.TextArea;
+import java.awt.TrayIcon;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.image.BufferedImage;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 6269309
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @summary Tests that focus is transferred properly back
+ *          to toplevel after clicking on a tray icon.
+ * @run main/manual FocusLostAfterTrayTest
+ */
+
+public class FocusLostAfterTrayTest {
+    private static SystemTray tray;
+    private static TrayIcon icon;
+
+    private static final String INSTRUCTIONS = """
+            This test checks that focus is transferred properly back
+            to top-level after clicking on a tray icon.
+
+            When the test starts, a Frame with a text area & a RED tray icon
+            are shown. If you don't see a tray icon please make sure that
+            the tray area (also called Taskbar Status Area on MS Windows
+            Notification Area on Gnome or System Tray on KDE) is visible.
+
+            Click with a mouse inside a text area and make sure that it has
+            received input focus. Then click on the tray icon and then back
+            on the text area and verify that it has input focus again. Repeat
+            the last step several times. Ensure that the text area always
+            has the input focus and there are no "FOCUS LOST" event
+            for text area in the log section.
+
+            If above is true, Press PASS, else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("Test not applicable as"
+                                       + " System Tray not supported");
+        }
+
+        try {
+            PassFailJFrame.builder()
+                          .title("FocusLostAfterTrayTest Instructions")
+                          .instructions(INSTRUCTIONS)
+                          .columns(40)
+                          .testUI(FocusLostAfterTrayTest::createAndShowTrayIcon)
+                          .logArea()
+                          .build()
+                          .awaitAndCheck();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (tray != null) {
+                    tray.remove(icon);
+                }
+            });
+        }
+    }
+
+    private static Frame createAndShowTrayIcon() {
+        Frame frame = new Frame("FocusLostAfterTrayTest");
+        frame.setBounds(100, 300, 200, 200);
+        frame.setLayout(new BorderLayout());
+        TextArea ta = new TextArea();
+        ta.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusGained(FocusEvent e) {
+                PassFailJFrame.log("FOCUS GAINED: "
+                                   + e.getComponent().getClass().toString());
+            }
+            @Override
+            public void focusLost(FocusEvent e) {
+                PassFailJFrame.log("FOCUS LOST !! "
+                                   + e.getComponent().getClass().toString());
+            }
+        });
+        frame.add(ta);
+
+        BufferedImage image = new BufferedImage(16, 16,
+                                                BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = image.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                           RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        g.setColor(Color.RED);
+        g.fillRect(0, 0, 16, 16);
+        g.dispose();
+        tray = SystemTray.getSystemTray();
+        icon = new TrayIcon(image);
+        icon.setImageAutoSize(true);
+
+        try {
+            tray.add(icon);
+        } catch (AWTException e) {
+            throw new RuntimeException("Error while adding"
+                                       + " icon to system tray", e);
+        }
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/TrayIcon/MouseMoveTest.java
+++ b/test/jdk/java/awt/TrayIcon/MouseMoveTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Graphics;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.awt.image.BufferedImage;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 6267980
+ * @summary PIT:Spurious MouseMoved events are triggered by Tray Icon
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @run main/manual MouseMoveTest
+ */
+
+public class MouseMoveTest {
+    private static SystemTray tray;
+    private static TrayIcon icon;
+    private static final String INSTRUCTIONS = """
+            1) You will see a tray icon (white square) in notification area,
+            2) Move mouse pointer to the icon and leave it somewhere inside the icon,
+            3) Verify that MOUSE_MOVE events are NOT triggered after you have STOPPED
+               moving mouse.
+            4) If events are still triggered Press FAIL else PASS.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("Test not applicable as"
+                                       + " System Tray not supported");
+        }
+
+        PassFailJFrame passFailJFrame
+                = PassFailJFrame.builder()
+                                .title("TrayIcon Change Test Instructions")
+                                .instructions(INSTRUCTIONS)
+                                .columns(45)
+                                .logArea()
+                                .build();
+
+        try {
+            EventQueue.invokeAndWait(MouseMoveTest::createAndShowTrayIcon);
+            passFailJFrame.awaitAndCheck();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (tray != null) {
+                    tray.remove(icon);
+                }
+            });
+        }
+    }
+
+    private static void createAndShowTrayIcon() {
+        BufferedImage img = new BufferedImage(32, 32,
+                                              BufferedImage.TYPE_INT_ARGB);
+        Graphics g = img.createGraphics();
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, 32, 32);
+        g.dispose();
+
+        tray = SystemTray.getSystemTray();
+        icon = new TrayIcon(img);
+        icon.setImageAutoSize(true);
+
+        icon.addMouseMotionListener(new MouseMotionAdapter() {
+                public void mouseMoved(MouseEvent me){
+                    PassFailJFrame.log(me.toString());
+                }
+        });
+
+        try {
+            tray.add(icon);
+        } catch (AWTException e) {
+            throw new RuntimeException("Error while adding"
+                                       + " icon to system tray", e);
+        }
+    }
+}

--- a/test/jdk/java/awt/TrayIcon/TrayIconKeySelectTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconKeySelectTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTException;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Graphics;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
+import java.awt.image.BufferedImage;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 6267943
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @summary Tests the possibility of selecting a tray icon with the keyboard.
+ * @run main/manual TrayIconKeySelectTest
+ */
+
+public class TrayIconKeySelectTest {
+    private static SystemTray tray;
+    private static TrayIcon icon;
+    private static final String INSTRUCTIONS = """
+            Tests that TrayIcon is selectable with the keyboard
+            When the test is started you will see three-color icon
+            in the system tray.
+
+            1. Bring the focus to the icon with TAB. Press ENTER key.
+            - One or more ActionEvent should be generated
+               (see the output area of the test)
+
+            2. Bring the focus again to the icon. Press SPACE key twice.
+            - One or more ActionEvent should be generated.
+
+            3. Bring the focus again to the icon. Click on the icon with
+            the LEFT mouse button twice.
+            - One or more ActionEvent should be generated.
+
+            4. Again bring the focus to the icon. Click on the icon with
+            the LEFT mouse button just once.
+            - NO ActionEvent should be generated.
+
+            5. Repeat the 4th step with other mouse buttons.
+
+            If all the above are true press PASS, else FAIL
+            """;
+
+    public static void main(String[] args) throws Exception {
+        if (!SystemTray.isSupported()) {
+            throw new SkippedException("Test not applicable as"
+                                       + " System Tray not supported");
+        }
+        PassFailJFrame passFailJFrame;
+        try {
+            passFailJFrame
+                    = PassFailJFrame.builder()
+                                    .title("TrayIconKeySelectTest Instructions")
+                                    .instructions(INSTRUCTIONS)
+                                    .columns(40)
+                                    .logArea()
+                                    .build();
+
+            EventQueue.invokeAndWait(TrayIconKeySelectTest::createAndShowTrayIcon);
+            passFailJFrame.awaitAndCheck();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (tray != null) {
+                    tray.remove(icon);
+                }
+            });
+        }
+    }
+
+    private static void createAndShowTrayIcon() {
+        BufferedImage im = new BufferedImage(16, 16,
+                                             BufferedImage.TYPE_INT_ARGB);
+        Graphics gr = im.createGraphics();
+        gr.setColor(Color.white);
+        gr.fillRect(0, 0, 16, 5);
+        gr.setColor(Color.blue);
+        gr.fillRect(0, 5, 16, 10);
+        gr.setColor(Color.red);
+        gr.fillRect(0, 10, 16, 16);
+        gr.dispose();
+
+        tray = SystemTray.getSystemTray();
+        icon = new TrayIcon(im);
+        icon.setImageAutoSize(true);
+        icon.addActionListener(e -> PassFailJFrame.log(e.toString()));
+
+        try {
+            tray.add(icon);
+        } catch (AWTException e) {
+            throw new RuntimeException("Error while adding"
+                                       + " icon to system tray", e);
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8341278](https://bugs.openjdk.org/browse/JDK-8341278) needs maintainer approval

### Issue
 * [JDK-8341278](https://bugs.openjdk.org/browse/JDK-8341278): Open source few TrayIcon tests - Set7 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3497/head:pull/3497` \
`$ git checkout pull/3497`

Update a local copy of the PR: \
`$ git checkout pull/3497` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3497`

View PR using the GUI difftool: \
`$ git pr show -t 3497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3497.diff">https://git.openjdk.org/jdk17u-dev/pull/3497.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3497#issuecomment-2805155671)
</details>
