### PR TITLE
Backport e47e9ec05b630c82182c7843365dfd90fdaa18a0

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -114,6 +114,7 @@ class CgroupV1Subsystem: public CgroupSubsystem {
     char * pids_max_val();
 
     jlong read_mem_swappiness();
+    jlong read_mem_swap();
 
   public:
     CgroupV1Subsystem(CgroupV1Controller* cpuset,

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -152,6 +152,12 @@ char* CgroupV2Subsystem::mem_soft_limit_val() {
 // without also setting a memory limit is not allowed.
 jlong CgroupV2Subsystem::memory_and_swap_limit_in_bytes() {
   char* mem_swp_limit_str = mem_swp_limit_val();
+  if (mem_swp_limit_str == nullptr) {
+    // Some container tests rely on this trace logging to happen.
+    log_trace(os, container)("Memory and Swap Limit is: %d", OSCONTAINER_ERROR);
+    // swap disabled at kernel level, treat it as no swap
+    return read_memory_limit_in_bytes();
+  }
   jlong swap_limit = limit_from_str(mem_swp_limit_str);
   if (swap_limit >= 0) {
     jlong memory_limit = read_memory_limit_in_bytes();

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -86,8 +86,8 @@ public class TestMemoryWithCgroupV1 {
         // capabilities or the cgroup is not mounted. Memory limited without swap."
         // we only have 'Memory and Swap Limit is: -2' in the output
         try {
-            if (out.getOutput().contains("memory_and_swap_limit_in_bytes: not supported")) {
-                System.out.println("memory_and_swap_limit_in_bytes not supported, avoiding Memory and Swap Limit check");
+            if (out.getOutput().contains("Memory and Swap Limit is: -2")) {
+                System.out.println("System doesn't seem to allow swap, avoiding Memory and Swap Limit check");
             } else {
                 out.shouldContain("Memory and Swap Limit is: " + expectedReadLimit)
                     .shouldContain(


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.