### PR TITLE
8316156: ByteArrayInputStream.transferTo causes MaxDirectMemorySize overflow

### DIFF
--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -44,6 +44,7 @@ import java.util.Objects;
  * @since   1.0
  */
 public class ByteArrayInputStream extends InputStream {
+    private static final int MAX_TRANSFER_SIZE = 128*1024;
 
     /**
      * An array of bytes that was provided
@@ -205,8 +206,16 @@ public class ByteArrayInputStream extends InputStream {
 
     public synchronized long transferTo(OutputStream out) throws IOException {
         int len = count - pos;
-        out.write(buf, pos, len);
-        pos = count;
+        if (len > 0) {
+            int nwritten = 0;
+            while (nwritten < len) {
+                int nbyte = Integer.min(len - nwritten, MAX_TRANSFER_SIZE);
+                out.write(buf, pos, nbyte);
+                pos += nbyte;
+                nwritten += nbyte;
+            }
+            assert pos == count;
+        }
         return len;
     }
 

--- a/test/jdk/java/io/ByteArrayInputStream/ChunkedTransferTo.java
+++ b/test/jdk/java/io/ByteArrayInputStream/ChunkedTransferTo.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8316156
+ * @summary Ensure ByteArrayInputStream.transferTo does not cause direct memory
+ *          to overflow MaxDirectMemorySize
+ * @run junit/othervm -XX:MaxDirectMemorySize=5M ChunkedTransferTo
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Random;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardOpenOption.*;
+
+import org.junit.jupiter.api.Test;
+
+public class ChunkedTransferTo {
+    // this value must exceed MaxDirectMemorySize
+    private static final int SIZE = 10_000_000;
+
+    @Test
+    public void byteArrayInputStream() throws IOException {
+        byte[] src = new byte[SIZE];
+        Random rnd = new Random(System.nanoTime());
+        rnd.nextBytes(src);
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(src)) {
+            Path target = Files.createTempFile("SNA", "FU");
+            FileChannel fc = FileChannel.open(target, CREATE, WRITE);
+            bais.transferTo(Channels.newOutputStream(fc));
+            byte[] dst = new byte[SIZE + 1];
+            try (FileInputStream fis = new FileInputStream(target.toFile())) {
+                int n = -1;
+                if ((n = fis.read(dst)) != SIZE)
+                    throw new RuntimeException(n + " != " + SIZE);
+            }
+            Files.delete(target);
+            if (!Arrays.equals(src, 0, SIZE, dst, 0, SIZE))
+                throw new RuntimeException("Arrays are not equal");
+        } catch (OutOfMemoryError oome) {
+            throw new RuntimeException(oome);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport. Fixes bug with ByteArrayInputStream.transferTo causing overflow. Change passes added test on linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316156](https://bugs.openjdk.org/browse/JDK-8316156) needs maintainer approval

### Issue
 * [JDK-8316156](https://bugs.openjdk.org/browse/JDK-8316156): ByteArrayInputStream.transferTo causes MaxDirectMemorySize overflow (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3507/head:pull/3507` \
`$ git checkout pull/3507`

Update a local copy of the PR: \
`$ git checkout pull/3507` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3507`

View PR using the GUI difftool: \
`$ git pr show -t 3507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3507.diff">https://git.openjdk.org/jdk17u-dev/pull/3507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3507#issuecomment-2811375056)
</details>
