### PR TITLE
8320276: Improve class initialization barrier in TemplateTable::_new

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3473,11 +3473,9 @@ void TemplateTable::_new() {
   // get InstanceKlass
   __ load_resolved_klass_at_offset(r4, r3, r4, rscratch1);
 
-  // make sure klass is initialized & doesn't have finalizer
-  // make sure klass is fully initialized
-  __ ldrb(rscratch1, Address(r4, InstanceKlass::init_state_offset()));
-  __ cmp(rscratch1, (u1)InstanceKlass::fully_initialized);
-  __ br(Assembler::NE, slow_case);
+  // make sure klass is initialized
+  assert(VM_Version::supports_fast_class_init_checks(), "Optimization requires support for fast class initialization checks");
+  __ clinit_barrier(r4, rscratch1, nullptr /*L_fast_path*/, &slow_case);
 
   // get instance_size in InstanceKlass (scaled to a count of bytes)
   __ ldrw(r3,

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -156,6 +156,7 @@ public:
   static int dcache_line_size() { return _dcache_line_size; }
   static int get_initial_sve_vector_length()  { return _initial_sve_vector_length; };
 
+  // Aarch64 supports fast class initialization checks
   static bool supports_fast_class_init_checks() { return true; }
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 

--- a/src/hotspot/cpu/ppc/vm_version_ppc.hpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.hpp
@@ -131,6 +131,8 @@ public:
 
   // POWER 8: DSCR current value.
   static uint64_t _dscr_val;
+
+  static void initialize_cpu_information(void);
 };
 
 #endif // CPU_PPC_VM_VERSION_PPC_HPP

--- a/src/hotspot/cpu/s390/vm_version_s390.hpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.hpp
@@ -386,7 +386,7 @@ class VM_Version: public Abstract_VM_Version {
   // Override Abstract_VM_Version implementation
   static void print_platform_virtualization_info(outputStream*);
 
-  // s390 supports fast class initialization checks for static methods.
+  // s390 supports fast class initialization checks
   static bool supports_fast_class_init_checks() { return true; }
 
   // CPU feature query functions

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -3936,11 +3936,16 @@ void TemplateTable::_new() {
   __ load_resolved_klass_at_index(rcx, rcx, rdx);
   __ push(rcx);  // save the contexts of klass for initializing the header
 
-  // make sure klass is initialized & doesn't have finalizer
-  // make sure klass is fully initialized
+  // make sure klass is initialized
+#ifdef _LP64
+  assert(VM_Version::supports_fast_class_init_checks(), "must support fast class initialization checks");
+  __ clinit_barrier(rcx, r15_thread, nullptr /*L_fast_path*/, &slow_case);
+#else
   __ cmpb(Address(rcx, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
   __ jcc(Assembler::notEqual, slow_case);
+#endif
 
+  // make sure klass doesn't have finalizer
   // get instance_size in InstanceKlass (scaled to a count of bytes)
   __ movl(rdx, Address(rcx, Klass::layout_helper_offset()));
   // test to see if it has a finalizer or is malformed in some way

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -1003,7 +1003,7 @@ public:
   // the intrinsic for java.lang.Thread.onSpinWait()
   static bool supports_on_spin_wait() { return supports_sse2(); }
 
-  // x86_64 supports fast class initialization checks for static methods.
+  // x86_64 supports fast class initialization checks
   static bool supports_fast_class_init_checks() {
     return LP64_ONLY(true) NOT_LP64(false); // not implemented on x86_32
   }


### PR DESCRIPTION
This PR backports 8320276 to support backporting 8338379, see the comment thread linked below. This was a clean backport, though reviewers may want to confirm that the decision to include [this function](https://github.com/openjdk/jdk17u-dev/blob/f19121cc65199f2052c69747dfa7ae8d209596f4/src/hotspot/cpu/ppc/vm_version_ppc.hpp#L135) was correct. 

---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8320276](https://bugs.openjdk.org/browse/JDK-8320276) needs maintainer approval

### Issue
 * [JDK-8320276](https://bugs.openjdk.org/browse/JDK-8320276): Improve class initialization barrier in TemplateTable::_new (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3508/head:pull/3508` \
`$ git checkout pull/3508`

Update a local copy of the PR: \
`$ git checkout pull/3508` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3508`

View PR using the GUI difftool: \
`$ git pr show -t 3508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3508.diff">https://git.openjdk.org/jdk17u-dev/pull/3508.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8320276](https://bugs.openjdk.org/browse/JDK-8320276) needs maintainer approval

### Issue
 * [JDK-8320276](https://bugs.openjdk.org/browse/JDK-8320276): Improve class initialization barrier in TemplateTable::_new (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3508/head:pull/3508` \
`$ git checkout pull/3508`

Update a local copy of the PR: \
`$ git checkout pull/3508` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3508`

View PR using the GUI difftool: \
`$ git pr show -t 3508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3508.diff">https://git.openjdk.org/jdk17u-dev/pull/3508.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3508#issuecomment-2812624861)
</details>
