### PR TITLE
8352109: java/awt/Desktop/MailTest.java fails in platforms where Action.MAIL is not supported

### DIFF
--- a/test/jdk/java/awt/Desktop/MailTest.java
+++ b/test/jdk/java/awt/Desktop/MailTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,20 +21,22 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 6255196
- * @summary Verifies the function of methods mail() and mail(java.net.URI uri).
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
- * @run main/manual MailTest
- */
-
 import java.awt.Desktop;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import javax.swing.JPanel;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 6255196
+ * @summary Verifies the function of methods mail() and mail(java.net.URI uri).
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @run main/manual MailTest
+ */
 
 public class MailTest extends JPanel {
 
@@ -48,18 +50,7 @@ public class MailTest extends JPanel {
             """;
 
     private MailTest() {
-        if (!Desktop.isDesktopSupported()) {
-            PassFailJFrame.log("Class java.awt.Desktop is not supported on " +
-                    "current platform. Farther testing will not be performed");
-            PassFailJFrame.forcePass();
-        }
-
         Desktop desktop = Desktop.getDesktop();
-        if (!desktop.isSupported(Desktop.Action.MAIL)) {
-            PassFailJFrame.log("Action.MAIL is not supported.");
-            PassFailJFrame.forcePass();
-        }
-
         /*
          * Part 1: launch the mail composing window without a mailto URI.
          */
@@ -103,6 +94,15 @@ public class MailTest extends JPanel {
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
+        if (!Desktop.isDesktopSupported()) {
+            throw new SkippedException("Class java.awt.Desktop is not supported " +
+                    "on current platform. Further testing will not be performed");
+        }
+
+        if (!Desktop.getDesktop().isSupported(Desktop.Action.MAIL)) {
+            throw new SkippedException("Action.MAIL is not supported.");
+        }
+
         PassFailJFrame.builder()
                 .title("Mail Test")
                 .splitUI(MailTest::new)


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352109](https://bugs.openjdk.org/browse/JDK-8352109) needs maintainer approval

### Issue
 * [JDK-8352109](https://bugs.openjdk.org/browse/JDK-8352109): java/awt/Desktop/MailTest.java fails in platforms where Action.MAIL is not supported (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3511/head:pull/3511` \
`$ git checkout pull/3511`

Update a local copy of the PR: \
`$ git checkout pull/3511` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3511`

View PR using the GUI difftool: \
`$ git pr show -t 3511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3511.diff">https://git.openjdk.org/jdk17u-dev/pull/3511.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3511#issuecomment-2813460998)
</details>
