### PR TITLE
8314120: Add tests for FileDescriptor.sync

### DIFF
--- a/test/jdk/java/io/FileDescriptor/Sync.java
+++ b/test/jdk/java/io/FileDescriptor/Sync.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8314120
+ * @summary Sanity test for FileDescriptor.sync
+ * @library /test/lib
+ * @run main Sync
+ */
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.SyncFailedException;
+import jdk.test.lib.thread.VThreadRunner;
+
+public class Sync {
+
+    static final String TEST_DIR = System.getProperty("test.dir", ".");
+    static final int TRIES = 10_000;
+
+    public static void testWith(File file) throws Exception {
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            FileDescriptor fd = fos.getFD();
+            for (int t = 0; t < TRIES; t++) {
+                fd.sync();
+            }
+        } catch (SyncFailedException sfe) {
+            // Can happen on some filesystems, print it in the log
+            System.out.println("Sync failed (acceptable)");
+            sfe.printStackTrace();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Run on platform threads
+        System.out.println("With platform threads");
+        run();
+
+        // Run on virtual threads
+        System.out.println("With virtual threads");
+        VThreadRunner.run(Sync::run);
+
+        System.out.println("Complete");
+    }
+
+    private static class AutoDelete implements AutoCloseable {
+        private final File file;
+
+        public AutoDelete(File file) {
+            this.file = file;
+        }
+
+        public File file() {
+            return file;
+        }
+
+        @Override
+        public void close() throws Exception {
+            file.delete();
+        }
+    }
+
+    public static void run() throws Exception {
+        try (var w = new AutoDelete(new File(TEST_DIR, "FileDescriptorSync1"))) {
+            testWith(w.file());
+        }
+
+        try (var w = new AutoDelete(File.createTempFile("FileDescriptorSync2", "tmp"))) {
+            testWith(w.file());
+        }
+    }
+}

--- a/test/jdk/java/io/FileDescriptor/Sync.java
+++ b/test/jdk/java/io/FileDescriptor/Sync.java
@@ -34,7 +34,6 @@ import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.SyncFailedException;
-import jdk.test.lib.thread.VThreadRunner;
 
 public class Sync {
 
@@ -58,10 +57,6 @@ public class Sync {
         // Run on platform threads
         System.out.println("With platform threads");
         run();
-
-        // Run on virtual threads
-        System.out.println("With virtual threads");
-        VThreadRunner.run(Sync::run);
 
         System.out.println("Complete");
     }

--- a/test/micro/org/openjdk/bench/java/io/FileDescriptorSync.java
+++ b/test/micro/org/openjdk/bench/java/io/FileDescriptorSync.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.io;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.SyncFailedException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the cost of FileDescriptor.sync
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class FileDescriptorSync {
+
+    private FileOutputStream fos;
+    private FileDescriptor fd;
+
+    @Setup
+    public void setup() throws IOException {
+        File tmp = File.createTempFile("FileDescriptorSync", "bin");
+        fos = new FileOutputStream(tmp);
+        fd = fos.getFD();
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        fos.close();
+    }
+
+    @Benchmark
+    public void sync() {
+        try {
+            fd.sync();
+        } catch (SyncFailedException e) {
+            // The test assumes the temp filesystem accepts syncs.
+            // Avoid failing if it does not, measure the exceptional path then.
+        }
+    }
+
+}


### PR DESCRIPTION
Backport of JDK-8317788 to add sanity tests for FileDescriptor.Sync. Not clean, but trivial fix to remove case which tested using virtual threads. New tests passing on x64 linux.
```
% make test TEST="micro:java.io.FileDescriptorSync"

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   micro:java.io.FileDescriptorSync                      1     1     0     0   
==============================
TEST SUCCESS

% make test TEST="java/io/FileDescriptor/Sync.java" 
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/java/io/FileDescriptor/Sync.java       1     1     0     0   
==============================
TEST SUCCESS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314120](https://bugs.openjdk.org/browse/JDK-8314120) needs maintainer approval

### Issue
 * [JDK-8314120](https://bugs.openjdk.org/browse/JDK-8314120): Add tests for FileDescriptor.sync (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3516/head:pull/3516` \
`$ git checkout pull/3516`

Update a local copy of the PR: \
`$ git checkout pull/3516` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3516`

View PR using the GUI difftool: \
`$ git pr show -t 3516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3516.diff">https://git.openjdk.org/jdk17u-dev/pull/3516.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3516#issuecomment-2816337525)
</details>
