### PR TITLE
8321204: C2: assert(false) failed: node should be in igvn hash table

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4610,7 +4610,7 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
         const Type* t_no_spec = t->remove_speculative();
         if (t_no_spec != t) {
           bool in_hash = igvn.hash_delete(n);
-          assert(in_hash, "node should be in igvn hash table");
+          assert(in_hash || n->hash() == Node::NO_HASH, "node should be in igvn hash table");
           tn->set_type(t_no_spec);
           igvn.hash_insert(n);
           igvn._worklist.push(n); // give it a chance to go away


### PR DESCRIPTION
Backporting JDK-8321204: C2: assert(false) failed: node should be in igvn hash table. Adjusts assert added by [JDK-8024070](https://bugs.openjdk.org/browse/JDK-8024070) and adds additional condition that `Node::hash` is non zero. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is not clean due to skipping the [JDK-8312218](https://bugs.openjdk.org/browse/JDK-8312218) (which is reverted by this commit anyway).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321204](https://bugs.openjdk.org/browse/JDK-8321204) needs maintainer approval

### Issue
 * [JDK-8321204](https://bugs.openjdk.org/browse/JDK-8321204): C2: assert(false) failed: node should be in igvn hash table (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3520/head:pull/3520` \
`$ git checkout pull/3520`

Update a local copy of the PR: \
`$ git checkout pull/3520` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3520`

View PR using the GUI difftool: \
`$ git pr show -t 3520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3520.diff">https://git.openjdk.org/jdk17u-dev/pull/3520.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3520#issuecomment-2822250794)
</details>
