### PR TITLE
8350386: Test TestCodeCacheFull.java fails with option -XX:-UseCodeCacheFlushing

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCodeCacheFull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import jdk.test.whitebox.code.BlobType;
 /**
  * @test TestCodeCacheFull
  * @requires vm.hasJFR
+ * @requires vm.opt.UseCodeCacheFlushing == null | vm.opt.UseCodeCacheFlushing == true
  *
  * @library /test/lib
  * @modules jdk.jfr


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c2ba777e](https://github.com/openjdk/jdk21u-dev/commit/c2ba777e0b2524359b23481f2c31afdcd5568827) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by SendaoYan on 23 Apr 2025 and had no reviewers.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350386](https://bugs.openjdk.org/browse/JDK-8350386) needs maintainer approval

### Issue
 * [JDK-8350386](https://bugs.openjdk.org/browse/JDK-8350386): Test TestCodeCacheFull.java fails with option -XX:-UseCodeCacheFlushing (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3524/head:pull/3524` \
`$ git checkout pull/3524`

Update a local copy of the PR: \
`$ git checkout pull/3524` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3524`

View PR using the GUI difftool: \
`$ git pr show -t 3524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3524.diff">https://git.openjdk.org/jdk17u-dev/pull/3524.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3524#issuecomment-2824745891)
</details>
