### PR TITLE
8340176: Replace usage of -noclassgc with -Xnoclassgc in test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.java

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
  * @bug     4982128
  * @summary Test low memory detection of non-heap memory pool
  *
- * @run main/othervm/timeout=600 -noclassgc -XX:MaxMetaspaceSize=32m
+ * @run main/othervm/timeout=600 -Xnoclassgc -XX:MaxMetaspaceSize=32m
  * LowMemoryTest2
  */
 
@@ -45,7 +45,7 @@
  * @bug     4982128
  * @summary Test low memory detection of non-heap memory pool
  *
- * @run main/othervm/timeout=600 -noclassgc -XX:MaxMetaspaceSize=16m
+ * @run main/othervm/timeout=600 -Xnoclassgc -XX:MaxMetaspaceSize=16m
  * -XX:CompressedClassSpaceSize=4m LowMemoryTest2
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340176](https://bugs.openjdk.org/browse/JDK-8340176) needs maintainer approval

### Issue
 * [JDK-8340176](https://bugs.openjdk.org/browse/JDK-8340176): Replace usage of -noclassgc with -Xnoclassgc in test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3525/head:pull/3525` \
`$ git checkout pull/3525`

Update a local copy of the PR: \
`$ git checkout pull/3525` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3525`

View PR using the GUI difftool: \
`$ git pr show -t 3525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3525.diff">https://git.openjdk.org/jdk17u-dev/pull/3525.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3525#issuecomment-2827677734)
</details>
