### PR TITLE
8350224: Test javax/swing/JComboBox/TestComboBoxComponentRendering.java fails in ubuntu 23.x and later

### DIFF
--- a/test/jdk/javax/swing/JComboBox/TestComboBoxComponentRendering.java
+++ b/test/jdk/javax/swing/JComboBox/TestComboBoxComponentRendering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.image.BufferedImage;
+import java.awt.Font;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
@@ -137,6 +138,7 @@ class ComboBoxCustomRenderer extends JLabel
         implements ListCellRenderer {
 
     public ComboBoxCustomRenderer() {
+        setFont(new Font("SansSerif", Font.BOLD, 32));
         setOpaque(true);
         setHorizontalAlignment(CENTER);
         setVerticalAlignment(CENTER);


### PR DESCRIPTION
I would like to fix this in 17 along with 21.

Test not in ProblemList, omitted corresponding hunk.  Making this a backport from 21 should make it clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350224](https://bugs.openjdk.org/browse/JDK-8350224) needs maintainer approval

### Issue
 * [JDK-8350224](https://bugs.openjdk.org/browse/JDK-8350224): Test javax/swing/JComboBox/TestComboBoxComponentRendering.java fails in ubuntu 23.x and later (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3527/head:pull/3527` \
`$ git checkout pull/3527`

Update a local copy of the PR: \
`$ git checkout pull/3527` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3527`

View PR using the GUI difftool: \
`$ git pr show -t 3527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3527.diff">https://git.openjdk.org/jdk17u-dev/pull/3527.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3527#issuecomment-2828269088)
</details>
