### PR TITLE
8351086: (fc) Make java/nio/channels/FileChannel/BlockDeviceSize.java test manual

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,10 @@
  * @bug 8054029
  * @requires (os.family == "linux")
  * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
+ * @comment The test must be launched with sudo or the block devices listed in
+ * the BLK_FNAMES array must be readable by the user running the test.
  * @library /test/lib
+ * @run main/manual BlockDeviceSize
  */
 
 import java.io.RandomAccessFile;


### PR DESCRIPTION
I backport this for parity with 17.0.16-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351086](https://bugs.openjdk.org/browse/JDK-8351086) needs maintainer approval

### Issue
 * [JDK-8351086](https://bugs.openjdk.org/browse/JDK-8351086): (fc) Make java/nio/channels/FileChannel/BlockDeviceSize.java test manual (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3528/head:pull/3528` \
`$ git checkout pull/3528`

Update a local copy of the PR: \
`$ git checkout pull/3528` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3528`

View PR using the GUI difftool: \
`$ git pr show -t 3528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3528.diff">https://git.openjdk.org/jdk17u-dev/pull/3528.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3528#issuecomment-2828316852)
</details>
