### PR TITLE
8314236: Overflow in Collections.rotate

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -792,15 +792,16 @@ public class Collections {
         if (distance == 0)
             return;
 
-        for (int cycleStart = 0, nMoved = 0; nMoved != size; cycleStart++) {
+        int bound = size - distance;
+        for (int cycleStart = 0, nMoved = 0; nMoved < size; cycleStart++) {
             T displaced = list.get(cycleStart);
             int i = cycleStart;
             do {
-                i += distance;
-                if (i >= size)
+                if (i >= bound)
                     i -= size;
+                i += distance;
                 displaced = list.set(i, displaced);
-                nMoved ++;
+                nMoved++;
             } while (i != cycleStart);
         }
     }

--- a/test/jdk/java/util/Collections/RotateHuge.java
+++ b/test/jdk/java/util/Collections/RotateHuge.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8314236
+ * @summary Overflow in Collections.rotate
+ */
+
+import java.util.AbstractList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.RandomAccess;
+
+public class RotateHuge {
+
+    private static final class MockList extends AbstractList<Object>
+            implements RandomAccess {
+        private final int size;
+
+        public MockList(final int size) {
+            if (size < 0)
+                throw new IllegalArgumentException("Illegal size: " + size);
+            this.size = size;
+        }
+
+        @Override
+        public Object get(final int index) {
+            Objects.checkIndex(index, size);
+            return null;
+        }
+
+        @Override
+        public Object set(final int index, final Object element) {
+            Objects.checkIndex(index, size);
+            return null;
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+    }
+
+    public static void main(final String[] args) {
+        testRotate((1 << 30) + 1, -(1 << 30) - 2);
+        testRotate((1 << 30) + 1, 1 << 30);
+        testRotate(Integer.MAX_VALUE, Integer.MIN_VALUE);
+        testRotate(Integer.MAX_VALUE, Integer.MIN_VALUE + 3);
+        testRotate(Integer.MAX_VALUE, 2);
+        testRotate(Integer.MAX_VALUE, Integer.MAX_VALUE - 1);
+    }
+
+    /*
+     * This test covers only index computations.
+     * Correctness of elements rotation is not checked.
+     */
+    private static void testRotate(final int size, final int distance) {
+        final List<Object> list = new MockList(size);
+        Collections.rotate(list, distance);
+    }
+}


### PR DESCRIPTION
Clean backport. Fixes bug with Collections.rotate creating overflow on arrays bigger than 2^30 elements. Passes new test on linux x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314236](https://bugs.openjdk.org/browse/JDK-8314236) needs maintainer approval

### Issue
 * [JDK-8314236](https://bugs.openjdk.org/browse/JDK-8314236): Overflow in Collections.rotate (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3530/head:pull/3530` \
`$ git checkout pull/3530`

Update a local copy of the PR: \
`$ git checkout pull/3530` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3530`

View PR using the GUI difftool: \
`$ git pr show -t 3530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3530.diff">https://git.openjdk.org/jdk17u-dev/pull/3530.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3530#issuecomment-2829069040)
</details>
