### PR TITLE
8347995: Race condition in jdk/java/net/httpclient/offline/FixedResponseHttpClient.java

### DIFF
--- a/test/jdk/java/net/httpclient/offline/FixedResponseHttpClient.java
+++ b/test/jdk/java/net/httpclient/offline/FixedResponseHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,8 +189,11 @@ public class FixedResponseHttpClient extends DelegatingHttpClient {
         if (obp.isPresent()) {
             ConsumingSubscriber subscriber = new ConsumingSubscriber();
             obp.get().subscribe(subscriber);
+            // wait for our subscriber to be completed and get the
+            // list of ByteBuffers it received.
+            var buffers = subscriber.getBuffers().join();
             if (responseBodyBytes == ECHO_SENTINAL) {
-                responseBody = subscriber.buffers;
+                responseBody = buffers;
             }
         }
 
@@ -226,6 +229,13 @@ public class FixedResponseHttpClient extends DelegatingHttpClient {
      */
     private static class ConsumingSubscriber implements Flow.Subscriber<ByteBuffer> {
         final List<ByteBuffer> buffers = Collections.synchronizedList(new ArrayList<>());
+        // A CompletableFuture that will be completed with a list of ByteBuffers that the
+        // ConsumingSubscriber has consumed.
+        final CompletableFuture<List<ByteBuffer>> consumed = new CompletableFuture<>();
+
+        public final CompletableFuture<List<ByteBuffer>> getBuffers() {
+            return consumed;
+        }
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
@@ -236,8 +246,8 @@ public class FixedResponseHttpClient extends DelegatingHttpClient {
             buffers.add(item.duplicate());
         }
 
-        @Override public void onError(Throwable throwable) { assert false : "Unexpected"; }
+        @Override public void onError(Throwable throwable) { consumed.completeExceptionally(throwable); }
 
-        @Override public void onComplete() { /* do nothing */ }
+        @Override public void onComplete() { consumed.complete(buffers.stream().toList()); }
     }
 }


### PR DESCRIPTION
Backport for parity with Oracle 21.0.8 (applies also to 17, hence this backport). Clean, low risk: test only, modified test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347995](https://bugs.openjdk.org/browse/JDK-8347995) needs maintainer approval

### Issue
 * [JDK-8347995](https://bugs.openjdk.org/browse/JDK-8347995): Race condition in jdk/java/net/httpclient/offline/FixedResponseHttpClient.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3535/head:pull/3535` \
`$ git checkout pull/3535`

Update a local copy of the PR: \
`$ git checkout pull/3535` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3535`

View PR using the GUI difftool: \
`$ git pr show -t 3535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3535.diff">https://git.openjdk.org/jdk17u-dev/pull/3535.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3535#issuecomment-2831439581)
</details>
