### PR TITLE
8312475: org.jline.util.PumpReader signed byte problem

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/PumpReader.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/PumpReader.java
@@ -413,7 +413,7 @@ public class PumpReader extends Reader {
                 return EOF;
             }
 
-            return buffer.get();
+            return buffer.get() & 0xFF;
         }
 
         private boolean readUsingBuffer() throws IOException {


### PR DESCRIPTION
Clean Backport JDK-8312475: SonarCloud reports a possible issue in `read` method

* `buffer.get()` reads a signed byte so it has a range of -128-127
* When end of file is reached the read method returns -1 signed integer

When the `buffer.get()` reads -1 => it returns 0xFF as a signed byte value, this causes the SonarCloud to confuse the possibility that the -1 byte value (0xFF), equals the -1 EOF value (0xFFFFFFFF)

This simply added a casting to & 0xFF to avoid this confusion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8312475](https://bugs.openjdk.org/browse/JDK-8312475) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312475](https://bugs.openjdk.org/browse/JDK-8312475): org.jline.util.PumpReader signed byte problem (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3536/head:pull/3536` \
`$ git checkout pull/3536`

Update a local copy of the PR: \
`$ git checkout pull/3536` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3536`

View PR using the GUI difftool: \
`$ git pr show -t 3536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3536.diff">https://git.openjdk.org/jdk17u-dev/pull/3536.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3536#issuecomment-2837737613)
</details>
