### PR TITLE
8316629: j.text.DateFormatSymbols setZoneStrings() exception is unhelpful

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -605,7 +605,8 @@ public class DateFormatSymbols implements Serializable, Cloneable {
         for (int i = 0; i < newZoneStrings.length; ++i) {
             int len = newZoneStrings[i].length;
             if (len < 5) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(String.format(
+                        "Row %s of the input array does not have a length of at least 5", i));
             }
             aCopy[i] = Arrays.copyOf(newZoneStrings[i], len);
         }


### PR DESCRIPTION
Clean backport. This only changes the error string in DateFormatSymbols. Passes GHA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8316629](https://bugs.openjdk.org/browse/JDK-8316629) needs maintainer approval

### Issue
 * [JDK-8316629](https://bugs.openjdk.org/browse/JDK-8316629): j.text.DateFormatSymbols setZoneStrings() exception is unhelpful (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3544/head:pull/3544` \
`$ git checkout pull/3544`

Update a local copy of the PR: \
`$ git checkout pull/3544` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3544`

View PR using the GUI difftool: \
`$ git pr show -t 3544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3544.diff">https://git.openjdk.org/jdk17u-dev/pull/3544.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3544#issuecomment-2859382939)
</details>
