### PR TITLE
8312246: NPE when HSDB visits bad oop

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HSDB.java
@@ -1087,7 +1087,9 @@ public class HSDB implements ObjectHistogramPanel.Listener, SAListener {
                           G1CollectedHeap heap = (G1CollectedHeap)collHeap;
                           HeapRegion region = heap.hrm().getByAddress(handle);
 
-                          if (region.isFree()) {
+                          if (region == null) {
+                            // intentionally skip
+                          } else if (region.isFree()) {
                             anno = "Free ";
                             bad = false;
                           } else if (region.isYoung()) {


### PR DESCRIPTION
Backporting JDK-8312246: NPE when HSDB visits bad oop. Minor HSDB fix: corrects printing "bad oop" with throwing a NPE message to the console when a corrupted object is found. Ran GHA Sanity Checks, local Tier 1 and 2 tests. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8312246](https://bugs.openjdk.org/browse/JDK-8312246) needs maintainer approval

### Issue
 * [JDK-8312246](https://bugs.openjdk.org/browse/JDK-8312246): NPE when HSDB visits bad oop (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3546/head:pull/3546` \
`$ git checkout pull/3546`

Update a local copy of the PR: \
`$ git checkout pull/3546` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3546`

View PR using the GUI difftool: \
`$ git pr show -t 3546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3546.diff">https://git.openjdk.org/jdk17u-dev/pull/3546.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3546#issuecomment-2852069917)
</details>
