### PR TITLE
8303549: [AIX] TestNativeStack.java is failing with exit value 1

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/getCreatedJavaVMs/exeGetCreatedJavaVMs.c
+++ b/test/hotspot/jtreg/runtime/jni/getCreatedJavaVMs/exeGetCreatedJavaVMs.c
@@ -89,14 +89,19 @@ void *thread_runner(void *threadid) {
 
 int main (int argc, char* argv[]) {
   pthread_t threads[NUM_THREADS];
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  size_t stack_size = 0x100000;
+  pthread_attr_setstacksize(&attr, stack_size);
   for (int i = 0; i < NUM_THREADS; i++ ) {
     printf("[*] Creating thread %d\n", i);
-    int status = pthread_create(&threads[i], NULL, thread_runner, (void *)(intptr_t)i);
+    int status = pthread_create(&threads[i], &attr, thread_runner, (void *)(intptr_t)i);
     if (status != 0) {
       printf("[*] Error creating thread %d - %d\n", i, status);
       exit(-1);
     }
   }
+  pthread_attr_destroy(&attr);
   for (int i = 0; i < NUM_THREADS; i++ ) {
     pthread_join(threads[i], NULL);
   }

--- a/test/hotspot/jtreg/runtime/jni/nativeStack/libnativeStack.c
+++ b/test/hotspot/jtreg/runtime/jni/nativeStack/libnativeStack.c
@@ -109,10 +109,17 @@ Java_TestNativeStack_triggerJNIStackTrace
 
   warning = warn;
 
-  if ((res = pthread_create(&thread, NULL, thread_start, NULL)) != 0) {
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  size_t stack_size = 0x100000;
+  pthread_attr_setstacksize(&attr, stack_size);
+
+  if ((res = pthread_create(&thread, &attr, thread_start, NULL)) != 0) {
     fprintf(stderr, "TEST ERROR: pthread_create failed: %s (%d)\n", strerror(res), res);
     exit(1);
   }
+
+  pthread_attr_destroy(&attr);
 
   if ((res = pthread_join(thread, NULL)) != 0) {
     fprintf(stderr, "TEST ERROR: pthread_join failed: %s (%d)\n", strerror(res), res);


### PR DESCRIPTION
I backport this as we see failures in these tests on AIX even in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8303549](https://bugs.openjdk.org/browse/JDK-8303549) needs maintainer approval

### Issue
 * [JDK-8303549](https://bugs.openjdk.org/browse/JDK-8303549): [AIX] TestNativeStack.java is failing with exit value 1 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3547/head:pull/3547` \
`$ git checkout pull/3547`

Update a local copy of the PR: \
`$ git checkout pull/3547` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3547`

View PR using the GUI difftool: \
`$ git pr show -t 3547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3547.diff">https://git.openjdk.org/jdk17u-dev/pull/3547.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3547#issuecomment-2853768166)
</details>
