### PR TITLE
8338154: Fix -Wzero-as-null-pointer-constant warnings in gtest framework

### DIFF
--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -49,7 +49,8 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
         $(GTEST_FRAMEWORK_SRC)/googletest/src \
         $(GTEST_FRAMEWORK_SRC)/googlemock/src, \
     INCLUDE_FILES := gtest-all.cc gmock-all.cc, \
-    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral maybe-uninitialized, \
+    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral \
+        maybe-uninitialized zero-as-null-pointer-constant, \
     DISABLED_WARNINGS_clang := undef unused-result format-nonliteral, \
     CFLAGS := $(JVM_CFLAGS) \
         -I$(GTEST_FRAMEWORK_SRC)/googletest \

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -334,7 +334,7 @@ static void run_in_new_thread(const args_t* args) {
 extern "C" void* thread_wrapper(void* p) {
   const args_t* const p_args = (const args_t*) p;
   runUnitTestsInner(p_args->argc, p_args->argv);
-  return 0;
+  return nullptr;
 }
 
 static void run_in_new_thread(const args_t* args) {


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8338154](https://bugs.openjdk.org/browse/JDK-8338154) needs maintainer approval

### Issue
 * [JDK-8338154](https://bugs.openjdk.org/browse/JDK-8338154): Fix -Wzero-as-null-pointer-constant warnings in gtest framework (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3551/head:pull/3551` \
`$ git checkout pull/3551`

Update a local copy of the PR: \
`$ git checkout pull/3551` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3551`

View PR using the GUI difftool: \
`$ git pr show -t 3551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3551.diff">https://git.openjdk.org/jdk17u-dev/pull/3551.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3551#issuecomment-2854613087)
</details>
