### PR TITLE
8347019: Test javax/swing/JRadioButton/8033699/bug8033699.java  still fails:  Focus is not on Radio Button Single as Expected

### DIFF
--- a/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
+++ b/test/jdk/javax/swing/JRadioButton/8033699/bug8033699.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,6 @@ public class bug8033699 {
         });
 
         robot = new Robot();
-        robot.setAutoDelay(100);
         robot.waitForIdle();
         robot.delay(1000);
 


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8347019](https://bugs.openjdk.org/browse/JDK-8347019) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347019](https://bugs.openjdk.org/browse/JDK-8347019): Test javax/swing/JRadioButton/8033699/bug8033699.java  still fails:  Focus is not on Radio Button Single as Expected (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3554/head:pull/3554` \
`$ git checkout pull/3554`

Update a local copy of the PR: \
`$ git checkout pull/3554` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3554`

View PR using the GUI difftool: \
`$ git pr show -t 3554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3554.diff">https://git.openjdk.org/jdk17u-dev/pull/3554.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3554#issuecomment-2854786611)
</details>
