### PR TITLE
8348865: JButton/bug4796987.java never runs because Windows XP is unavailable

### DIFF
--- a/test/jdk/javax/swing/JButton/4796987/bug4796987.java
+++ b/test/jdk/javax/swing/JButton/4796987/bug4796987.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,65 +26,89 @@
  * @bug 4796987
  * @key headful
  * @requires (os.family == "windows")
- * @summary XP Only: JButton.setBorderPainted() does not work with XP L&F
- * @author Alexander Scherbatiy
+ * @summary Verify JButton.setBorderPainted(false) removes border
+ *      for Windows visual styles (Windows XP and later)
  * @library ../../regtesthelpers
- * @library /test/lib
- * @modules java.desktop/com.sun.java.swing.plaf.windows
- *          java.desktop/sun.awt
- * @build jdk.test.lib.OSVersion jdk.test.lib.Platform
  * @build Util
  * @run main bug4796987
  */
 
-import jdk.test.lib.Platform;
-import jdk.test.lib.OSVersion;
-import java.awt.*;
-import javax.swing.*;
-import com.sun.java.swing.plaf.windows.WindowsLookAndFeel;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
 public class bug4796987 {
 
     private static JButton button1;
     private static JButton button2;
     private static JFrame frame;
+    private static JPanel panel;
 
     public static void main(String[] args) throws Exception {
         try {
-            if (Platform.isWindows()
-                && OSVersion.current().equals(OSVersion.WINDOWS_XP)) {
-                UIManager.setLookAndFeel(new WindowsLookAndFeel());
-                testButtonBorder();
-            }
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+            testButtonBorder();
         } finally {
-            if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 
     private static void testButtonBorder() throws Exception {
         Robot robot = new Robot();
-        robot.setAutoDelay(50);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-
-            public void run() {
-                createAndShowGUI();
-            }
-        });
-
+        SwingUtilities.invokeAndWait(bug4796987::createAndShowGUI);
         robot.waitForIdle();
-        Thread.sleep(500);
+        robot.delay(500);
 
-        Point p1 = Util.getCenterPoint(button1);
-        Point p2 = Util.getCenterPoint(button2);
+        // Hover over button1
+        Point b1Center = Util.getCenterPoint(button1);
+        robot.mouseMove(b1Center.x, b1Center.y);
+        robot.waitForIdle();
 
-        Color color = robot.getPixelColor(p1.x, p2.x);
-        for (int dx = p1.x; dx < p2.x - p1.x; dx++) {
-            robot.mouseMove(p1.x + dx, p1.y);
-            if (!color.equals(robot.getPixelColor(p1.x + dx, p1.y))) {
+        Rectangle panelBounds = Util.invokeOnEDT(() ->
+                new Rectangle(panel.getLocationOnScreen(),
+                              panel.getSize()));
+        BufferedImage image = robot.createScreenCapture(panelBounds);
+
+        final Point p1 = Util.invokeOnEDT(() -> getCenterPoint(button1));
+        final Point p2 = Util.invokeOnEDT(() -> getCenterPoint(button2));
+
+        final int color = image.getRGB(p1.x, p1.y);
+        for (int dx = 0; p1.x + dx < p2.x; dx++) {
+            if (color != image.getRGB(p1.x + dx, p1.y)) {
+                System.err.println("Wrong color at " + (p1.x + dx) + ", " + p1.y
+                                   + " - expected " + Integer.toHexString(color));
+                saveImage(image);
                 throw new RuntimeException("Button has border and background!");
             }
         }
+    }
+
+    /**
+     * {@return the center point of a button relative to its parent}
+     * @param button the button to calculate the center point
+     */
+    private static Point getCenterPoint(JButton button) {
+        Point location = button.getLocation();
+        Dimension size = button.getSize();
+        location.translate(size.width / 2, size.height / 2);
+        return location;
     }
 
     private static JButton getButton() {
@@ -95,18 +119,24 @@ public class bug4796987 {
     }
 
     private static void createAndShowGUI() {
-        frame = new JFrame("Test");
+        frame = new JFrame("bug4796987");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setSize(200, 200);
 
-        JButton button = new JButton();
-        button.setBorder(null);
-
-        JPanel panel = new JPanel(new BorderLayout(50, 50));
+        panel = new JPanel(new BorderLayout(50, 50));
         panel.add(getButton(), BorderLayout.CENTER);
         panel.add(button1 = getButton(), BorderLayout.WEST);
         panel.add(button2 = getButton(), BorderLayout.EAST);
         frame.getContentPane().add(panel);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+    }
+
+    private static void saveImage(BufferedImage image) {
+        try {
+            ImageIO.write(image, "png",
+                          new File("frame.png"));
+        } catch (IOException ignored) {
+        }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8348865](https://bugs.openjdk.org/browse/JDK-8348865) needs maintainer approval

### Issue
 * [JDK-8348865](https://bugs.openjdk.org/browse/JDK-8348865): JButton/bug4796987.java never runs because Windows XP is unavailable (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3556/head:pull/3556` \
`$ git checkout pull/3556`

Update a local copy of the PR: \
`$ git checkout pull/3556` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3556`

View PR using the GUI difftool: \
`$ git pr show -t 3556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3556.diff">https://git.openjdk.org/jdk17u-dev/pull/3556.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3556#issuecomment-2854819508)
</details>
