### PR TITLE
Backport 9a0e6f338f34fb5da16d5f9eb710cdddd4302945

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -299,7 +299,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBLCMS, \
         common/awt/debug \
         libawt/java2d, \
     HEADERS_FROM_SRC := $(LIBLCMS_HEADERS_FROM_SRC), \
-    DISABLED_WARNINGS_gcc := format-nonliteral type-limits \
+    DISABLED_WARNINGS_gcc := format-nonliteral \
         misleading-indentation undef unused-function stringop-truncation, \
     DISABLED_WARNINGS_clang := tautological-compare format-nonliteral undef, \
     DISABLED_WARNINGS_microsoft := 4819, \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9a0e6f33](https://github.com/openjdk/jdk/commit/9a0e6f338f34fb5da16d5f9eb710cdddd4302945) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 9 May 2025 and was reviewed by Julian Waters and Phil Race.

The change is the same as in mainline, but a different makefile is updated because [JDK-8330107](https://bugs.openjdk.org/browse/JDK-8330107) has not been backported to JDK 17.

Thanks!