### PR TITLE
8313804: JDWP support for -Djava.net.preferIPv6Addresses=system

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -727,11 +727,13 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
         return err;
     }
 
-    // Try to find bind address of preferred address family first.
-    for (ai = addrInfo; ai != NULL; ai = ai->ai_next) {
-        if (ai->ai_family == preferredAddressFamily) {
-            listenAddr = ai;
-            break;
+    // Try to find bind address of preferred address family first (if java.net.preferIPv6Addresses != "system").
+    if (preferredAddressFamily != AF_UNSPEC) {
+        for (ai = addrInfo; ai != NULL; ai = ai->ai_next) {
+            if (ai->ai_family == preferredAddressFamily) {
+                listenAddr = ai;
+                break;
+            }
         }
     }
 
@@ -748,9 +750,9 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
     // Binding to IN6ADDR_ANY allows to serve both IPv4 and IPv6 connections,
     // but binding to mapped INADDR_ANY (::ffff:0.0.0.0) allows to serve IPv4
     // connections only. Make sure that IN6ADDR_ANY is preferred over
-    // mapped INADDR_ANY if preferredAddressFamily is AF_INET6 or not set.
+    // mapped INADDR_ANY if preferIPv4Stack is false.
 
-    if (preferredAddressFamily != AF_INET) {
+    if (!allowOnlyIPv4) {
         inet_pton(AF_INET6, "::ffff:0.0.0.0", &mappedAny);
 
         if (isEqualIPv6Addr(listenAddr, mappedAny)) {
@@ -972,8 +974,10 @@ socketTransport_attach(jdwpTransportEnv* env, const char* addressString, jlong a
         return err;
     }
 
-    /* 1st pass - preferredAddressFamily (by default IPv4), 2nd pass - the rest */
-    for (pass = 0; pass < 2 && socketFD < 0; pass++) {
+    // 1st pass - preferredAddressFamily (by default IPv4), 2nd pass - the rest;
+    // if java.net.preferIPv6Addresses == "system", only 2nd pass is needed
+    pass = preferredAddressFamily != AF_UNSPEC ? 0 : 1;
+    for (; pass < 2 && socketFD < 0; pass++) {
         for (ai = addrInfo; ai != NULL; ai = ai->ai_next) {
             if ((pass == 0 && ai->ai_family == preferredAddressFamily) ||
                 (pass == 1 && ai->ai_family != preferredAddressFamily))
@@ -1310,6 +1314,43 @@ static int readBooleanSysProp(int *result, int trueValue, int falseValue,
     return JNI_OK;
 }
 
+/*
+ * Reads java.net.preferIPv6Addresses system value, sets preferredAddressFamily to
+ *  - AF_INET6 if the property is "true";
+ *  - AF_INET if the property is "false".
+ *  - AF_UNSPEC if the property is "system".
+ * Doesn't change preferredAddressFamily if the property is not set or failed to read.
+ */
+static int readPreferIPv6Addresses(JNIEnv* jniEnv,
+    jclass sysClass, jmethodID getPropMethod, const char *propName)
+{
+    jstring value;
+    jstring name = (*jniEnv)->NewStringUTF(jniEnv, propName);
+
+    if (name == NULL) {
+        return JNI_ERR;
+    }
+    value = (jstring)(*jniEnv)->CallStaticObjectMethod(jniEnv, sysClass, getPropMethod, name);
+    if ((*jniEnv)->ExceptionCheck(jniEnv)) {
+        return JNI_ERR;
+    }
+    if (value != NULL) {
+        const char *theValue = (*jniEnv)->GetStringUTFChars(jniEnv, value, NULL);
+        if (theValue == NULL) {
+            return JNI_ERR;
+        }
+        if (strcmp(theValue, "true") == 0) {
+            preferredAddressFamily = AF_INET6;
+        } else if (strcmp(theValue, "false") == 0) {
+            preferredAddressFamily = AF_INET;
+        } else if (strcmp(theValue, "system") == 0) {
+            preferredAddressFamily = AF_UNSPEC;
+        }
+        (*jniEnv)->ReleaseStringUTFChars(jniEnv, value, theValue);
+    }
+    return JNI_OK;
+}
+
 JNIEXPORT jint JNICALL
 jdwpTransport_OnLoad(JavaVM *vm, jdwpTransportCallback* cbTablePtr,
                      jint version, jdwpTransportEnv** env)
@@ -1367,7 +1408,7 @@ jdwpTransport_OnLoad(JavaVM *vm, jdwpTransportCallback* cbTablePtr,
         }
         readBooleanSysProp(&allowOnlyIPv4, 1, 0,
             jniEnv, sysClass, getPropMethod, "java.net.preferIPv4Stack");
-        readBooleanSysProp(&preferredAddressFamily, AF_INET6, AF_INET,
+        readPreferIPv6Addresses(
             jniEnv, sysClass, getPropMethod, "java.net.preferIPv6Addresses");
     } while (0);
 


### PR DESCRIPTION
Clean backport. Testing with tier1 in progress on alpine linux and mac os.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8313804](https://bugs.openjdk.org/browse/JDK-8313804) needs maintainer approval

### Issue
 * [JDK-8313804](https://bugs.openjdk.org/browse/JDK-8313804): JDWP support for -Djava.net.preferIPv6Addresses=system (**Bug** - P4 - Requested)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3567/head:pull/3567` \
`$ git checkout pull/3567`

Update a local copy of the PR: \
`$ git checkout pull/3567` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3567`

View PR using the GUI difftool: \
`$ git pr show -t 3567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3567.diff">https://git.openjdk.org/jdk17u-dev/pull/3567.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3567#issuecomment-2874330898)
</details>
