### PR TITLE
8317804: com/sun/jdi/JdwpAllowTest.java fails on Alpine 3.17 / 3.18

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -755,7 +755,7 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
 
         if (isEqualIPv6Addr(listenAddr, mappedAny)) {
             for (ai = addrInfo; ai != NULL; ai = ai->ai_next) {
-                if (isEqualIPv6Addr(listenAddr, in6addr_any)) {
+                if (isEqualIPv6Addr(ai, in6addr_any)) {
                     listenAddr = ai;
                     break;
                 }


### PR DESCRIPTION
Clean backport. Testing with tier 1 on alpine 3.17 in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8317804](https://bugs.openjdk.org/browse/JDK-8317804) needs maintainer approval

### Issue
 * [JDK-8317804](https://bugs.openjdk.org/browse/JDK-8317804): com/sun/jdi/JdwpAllowTest.java fails on Alpine 3.17 / 3.18 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3568/head:pull/3568` \
`$ git checkout pull/3568`

Update a local copy of the PR: \
`$ git checkout pull/3568` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3568`

View PR using the GUI difftool: \
`$ git pr show -t 3568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3568.diff">https://git.openjdk.org/jdk17u-dev/pull/3568.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3568#issuecomment-2874339657)
</details>
