### PR TITLE
8287352: DockerTestUtils::execute shows incorrect elapsed time

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -275,7 +275,6 @@ public class DockerTestUtils {
      * @throws Exception
      */
     public static OutputAnalyzer execute(String... command) throws Exception {
-
         ProcessBuilder pb = new ProcessBuilder(command);
         System.out.println("[COMMAND]\n" + Utils.getCommandLine(pb));
 
@@ -284,14 +283,19 @@ public class DockerTestUtils {
         long pid = p.pid();
         OutputAnalyzer output = new OutputAnalyzer(p);
 
-        String stdoutLogFile = String.format("docker-stdout-%d.log", pid);
+        int max = MAX_LINES_TO_COPY_FOR_CHILD_STDOUT;
+        String stdout = output.getStdout();
+        String stdoutLimited = limitLines(stdout, max);
         System.out.println("[ELAPSED: " + (System.currentTimeMillis() - started) + " ms]");
         System.out.println("[STDERR]\n" + output.getStderr());
-        System.out.println("[STDOUT]\n" +
-                           trimLines(output.getStdout(),MAX_LINES_TO_COPY_FOR_CHILD_STDOUT));
-        System.out.printf("Child process STDOUT is trimmed to %d lines \n",
-                           MAX_LINES_TO_COPY_FOR_CHILD_STDOUT);
-        writeOutputToFile(output.getStdout(), stdoutLogFile);
+        System.out.println("[STDOUT]\n" + stdoutLimited);
+        if (stdout != stdoutLimited) {
+            System.out.printf("Child process STDOUT is limited to %d lines\n",
+                              max);
+        }
+
+        String stdoutLogFile = String.format("docker-stdout-%d.log", pid);
+        writeOutputToFile(stdout, stdoutLogFile);
         System.out.println("Full child process STDOUT was saved to " + stdoutLogFile);
 
         return output;
@@ -305,7 +309,7 @@ public class DockerTestUtils {
     }
 
 
-    private static String trimLines(String buffer, int nrOfLines) {
+    private static String limitLines(String buffer, int nrOfLines) {
         List<String> l = Arrays.asList(buffer.split("\\R"));
         if (l.size() < nrOfLines) {
             return buffer;


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8287352](https://bugs.openjdk.org/browse/JDK-8287352) needs maintainer approval

### Issue
 * [JDK-8287352](https://bugs.openjdk.org/browse/JDK-8287352): DockerTestUtils::execute shows incorrect elapsed time (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3570/head:pull/3570` \
`$ git checkout pull/3570`

Update a local copy of the PR: \
`$ git checkout pull/3570` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3570`

View PR using the GUI difftool: \
`$ git pr show -t 3570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3570.diff">https://git.openjdk.org/jdk17u-dev/pull/3570.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3570#issuecomment-2883287861)
</details>
