### PR TITLE
8328673: Convert closed text/html/CSS manual applet test to main

### DIFF
--- a/test/jdk/javax/swing/text/html/CSS/bug4271058.java
+++ b/test/jdk/javax/swing/text/html/CSS/bug4271058.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4270889 4271058 4285098
+ * @summary Tests that <table border>, <table align> and <td width> tags work
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4271058
+*/
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+
+public class bug4271058 {
+
+    private static String INSTRUCTIONS = """
+        What should be seen is three 2x2 tables.
+
+        The first table should have borders and lines distinguishing
+        table cells. If they are not shown, test fails (bug 4271058).
+
+        In the second table, the first (left) column should be about
+        four times as wide as the second (right) column.
+        If this is not so, test fails (bug 4270889).
+
+        The third table should be right aligned, i.e. its right edge
+        should be close to the right edge of the viewable area.
+        Otherwise test fails (bug 4285098).
+        """;
+
+    public static void main(String[] args) throws Exception {
+         PassFailJFrame.builder()
+                .title("CSS html tag verification Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(15)
+                .columns(30)
+                .testUI(bug4271058::createTestUI)
+                .screenCapture()
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        String htmlText =
+            "<html><table border width=300 height=200>" +
+            "<tr><th>col A</th><th>col B</th></tr>" +
+            "<tr>" +
+            "<td>aaaaaa</td>" +
+            "<td>bbbbbbb</td>" +
+            "</tr></table>" +
+            "<table border width=300>" +
+            "<tr><th>A</th><th>B</th></tr>" +
+            "<tr>" +
+            "<td width=\"80%\">a</td>" +
+            "<td width=\"20%\">b</td>" +
+            "</tr></table>" +
+            "<table align=right border width=200>" +
+            "<tr><th>col A</th><th>col B</th></tr>" +
+            "<tr>" +
+            "<td>aaaaaa</td>" +
+            "<td>bbbbbbb</td>" +
+            "</tr></table></html>";
+
+        JEditorPane lbl = new JEditorPane("text/html", htmlText);
+        JFrame frame = new JFrame("bug4271058");
+        frame.add(lbl);
+        frame.pack();
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/text/html/CSS/bug4286458.java
+++ b/test/jdk/javax/swing/text/html/CSS/bug4286458.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4286458
+ * @summary  Tests if cellpadding in tables is non-negative number
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4286458
+*/
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4286458 {
+
+    private static String INSTRUCTIONS = """
+        If you can clearly read the line of text in the appeared frame
+        press PASS. Otherwise test fails.""";
+
+    public static void main(String[] args) throws Exception {
+         PassFailJFrame.builder()
+                .title("CSS tag Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(5)
+                .columns(30)
+                .testUI(bug4286458::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+
+        String text =
+            "<html><body><table border=\"1\" cellpadding=\"-10\">" +
+            "<tr><td>This line should be clearly readable</td></tr>" +
+            "</table></body></html>";
+
+        JFrame f = new JFrame("bug4286458");
+        JEditorPane jep = new JEditorPane("text/html", text);
+        jep.setEditable(false);
+
+        f.add(jep);
+        f.pack();
+        return f;
+    }
+}


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328673](https://bugs.openjdk.org/browse/JDK-8328673) needs maintainer approval

### Issue
 * [JDK-8328673](https://bugs.openjdk.org/browse/JDK-8328673): Convert closed text/html/CSS manual applet test to main (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3571/head:pull/3571` \
`$ git checkout pull/3571`

Update a local copy of the PR: \
`$ git checkout pull/3571` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3571`

View PR using the GUI difftool: \
`$ git pr show -t 3571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3571.diff">https://git.openjdk.org/jdk17u-dev/pull/3571.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3571#issuecomment-2883303445)
</details>
