### PR TITLE
8345547: test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java fails in ubuntu22.04

### DIFF
--- a/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
+++ b/test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,17 +26,22 @@
  * @key headful
  * @bug 4278839 8233634
  * @summary Incorrect cursor movement between words at the end of line
- * @author Anton Nashatyrev
  * @library ../../../regtesthelpers
  * @build Util
  * @run main bug4278839
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.InputEvent;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
-public class bug4278839 extends JFrame {
+public class bug4278839 {
 
     private static boolean passed = true;
     private static JTextArea area;
@@ -47,16 +52,12 @@ public class bug4278839 extends JFrame {
         try {
 
             robo = new Robot();
-            robo.setAutoDelay(200);
+            robo.setAutoDelay(100);
 
-            SwingUtilities.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    createAndShowGUI();
-                }
-            });
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
 
             robo.waitForIdle();
+            robo.delay(1000);
 
             clickMouse();
             robo.waitForIdle();
@@ -100,33 +101,27 @@ public class bug4278839 extends JFrame {
 
         final int[] result = new int[1];
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-
-            @Override
-            public void run() {
-                result[0] = area.getCaretPosition();
-            }
+        SwingUtilities.invokeAndWait(() -> {
+            result[0] = area.getCaretPosition();
         });
 
-        int pos = result[0];
-        return pos;
+        return result[0];
     }
 
     private static void clickMouse() throws Exception {
         final Rectangle result[] = new Rectangle[1];
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                result[0] = new Rectangle(area.getLocationOnScreen(), area.getSize());
-            }
+        SwingUtilities.invokeAndWait(() -> {
+            result[0] = new Rectangle(area.getLocationOnScreen(), area.getSize());
         });
 
         Rectangle rect = result[0];
 
         robo.mouseMove(rect.x + rect.width / 2, rect.y + rect.width / 2);
-        robo.mousePress(InputEvent.BUTTON1_MASK);
-        robo.mouseRelease(InputEvent.BUTTON1_MASK);
+        robo.waitForIdle();
+        robo.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robo.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robo.waitForIdle();
     }
 
     /**


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8345547](https://bugs.openjdk.org/browse/JDK-8345547) needs maintainer approval

### Issue
 * [JDK-8345547](https://bugs.openjdk.org/browse/JDK-8345547): test/jdk/javax/swing/text/DefaultEditorKit/4278839/bug4278839.java fails in ubuntu22.04 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3573/head:pull/3573` \
`$ git checkout pull/3573`

Update a local copy of the PR: \
`$ git checkout pull/3573` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3573`

View PR using the GUI difftool: \
`$ git pr show -t 3573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3573.diff">https://git.openjdk.org/jdk17u-dev/pull/3573.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3573#issuecomment-2883369350)
</details>
