### PR TITLE
8326389: [test] improve assertEquals failure output

### DIFF
--- a/test/lib/jdk/test/lib/Asserts.java
+++ b/test/lib/jdk/test/lib/Asserts.java
@@ -199,10 +199,7 @@ public class Asserts {
      */
     public static void assertEquals(Object lhs, Object rhs, String msg) {
         if ((lhs != rhs) && ((lhs == null) || !(lhs.equals(rhs)))) {
-            msg = Objects.toString(msg, "assertEquals")
-                    + ": expected " + Objects.toString(lhs)
-                    + " to equal " + Objects.toString(rhs);
-            fail(msg);
+            fail((msg == null ? "assertEquals" : msg) + " expected: " + lhs + " but was: " + rhs);
         }
     }
 


### PR DESCRIPTION
Let's backport this to fix the annoying message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8326389](https://bugs.openjdk.org/browse/JDK-8326389) needs maintainer approval

### Issue
 * [JDK-8326389](https://bugs.openjdk.org/browse/JDK-8326389): [test] improve assertEquals failure output (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3574/head:pull/3574` \
`$ git checkout pull/3574`

Update a local copy of the PR: \
`$ git checkout pull/3574` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3574`

View PR using the GUI difftool: \
`$ git pr show -t 3574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3574.diff">https://git.openjdk.org/jdk17u-dev/pull/3574.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3574#issuecomment-2883430530)
</details>
