### PR TITLE
8286925: Move JSON parser used in JFR tests to test library

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestPrintJSON.java
+++ b/test/jdk/jdk/jfr/tool/TestPrintJSON.java
@@ -35,7 +35,8 @@ import jdk.jfr.ValueDescriptor;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedObject;
 import jdk.jfr.consumer.RecordingFile;
-import jdk.jfr.tool.JSONValue.JSONArray;
+import jdk.test.lib.json.JSONValue;
+import jdk.test.lib.json.JSONValue.JSONArray;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 

--- a/test/lib/jdk/test/lib/json/JSONValue.java
+++ b/test/lib/jdk/test/lib/json/JSONValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.jfr.tool;
+package jdk.test.lib.json;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
I backport this to simplify later backports that require this file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8286925](https://bugs.openjdk.org/browse/JDK-8286925) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286925](https://bugs.openjdk.org/browse/JDK-8286925): Move JSON parser used in JFR tests to test library (**Enhancement** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3575/head:pull/3575` \
`$ git checkout pull/3575`

Update a local copy of the PR: \
`$ git checkout pull/3575` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3575`

View PR using the GUI difftool: \
`$ git pr show -t 3575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3575.diff">https://git.openjdk.org/jdk17u-dev/pull/3575.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3575#issuecomment-2883648239)
</details>
