### PR TITLE
8310525: DynamicLauncher for JDP test needs to try harder to find a free port

### DIFF
--- a/test/jdk/sun/management/jdp/DynamicLauncher.java
+++ b/test/jdk/sun/management/jdp/DynamicLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ import java.util.UUID;
  */
 public abstract class DynamicLauncher {
 
+    private static final int MAX_RETRY_ATTEMPTS = 10;
+
     final String jdpName = UUID.randomUUID().toString();
     OutputAnalyzer output;
     int jmxPort;
@@ -52,7 +54,7 @@ public abstract class DynamicLauncher {
             try {
                 output.shouldNotContain("Port already in use");
             } catch (RuntimeException e) {
-                if (retries < 3) {
+                if (retries < MAX_RETRY_ATTEMPTS) {
                     retries++;
                     tryAgain = true;
                 }

--- a/test/jdk/sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java
@@ -52,7 +52,7 @@ public class JMXInterfaceBindingTest {
     public static final int JMX_PORT_RANGE_UPPER = 9200;
     public static final int JMX_PORT_RANGE_LOWER_SSL = 9201; // 9200 might be RMI Port
     public static final int JMX_PORT_RANGE_UPPER_SSL = 9300;
-    private static final int MAX_RETRY_ATTEMTS = 10;
+    private static final int MAX_RETRY_ATTEMPTS = 10;
     public static final String READY_MSG = "MainThread: Ready for connections";
     public static final String TEST_CLASS = JMXAgentInterfaceBinding.class.getSimpleName();
     public static final String KEYSTORE_LOC = System.getProperty("test.src", ".") +
@@ -159,7 +159,7 @@ public class JMXInterfaceBindingTest {
                     System.err.println("Retrying the test for " + name);
                 }
                 needRetry = runTest();
-            } while (needRetry && (attempts++ < MAX_RETRY_ATTEMTS));
+            } while (needRetry && (attempts++ < MAX_RETRY_ATTEMPTS));
 
             if (testFailed) {
                 int exitValue = output.getExitValue();


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8310525](https://bugs.openjdk.org/browse/JDK-8310525) needs maintainer approval

### Issue
 * [JDK-8310525](https://bugs.openjdk.org/browse/JDK-8310525): DynamicLauncher for JDP test needs to try harder to find a free port (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3580/head:pull/3580` \
`$ git checkout pull/3580`

Update a local copy of the PR: \
`$ git checkout pull/3580` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3580`

View PR using the GUI difftool: \
`$ git pr show -t 3580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3580.diff">https://git.openjdk.org/jdk17u-dev/pull/3580.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3580#issuecomment-2886470424)
</details>
