### PR TITLE
8353320: Open source more Swing text tests

### DIFF
--- a/test/jdk/javax/swing/text/html/FrameView/4463014/bug4463014.java
+++ b/test/jdk/javax/swing/text/html/FrameView/4463014/bug4463014.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4463014
+ * @summary  Tests if JEditorPane updates the correct frame when using <FORM target="xxxx">
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4463014
+ */
+
+import java.io.File;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4463014 {
+
+    static final String INSTRUCTIONS = """
+        The test window displays an HTML frameset with a frame
+        on the left and another to the right.
+        Follow the instructions displayed in the left frame to perform testing.
+        The test PASSES only if the test behaves as per instructions.
+    """;
+
+    static JFrame createUI() {
+        JFrame frame = new JFrame("bug4463014");
+        JEditorPane jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        try {
+            File file = new File(System.getProperty("test.src", "."), "frameset.html");
+            System.out.println(file.toURL());
+            jep.setPage(file.toURL());
+        } catch (Exception e) {
+        }
+
+        frame.add(jep);
+        frame.setSize(500,500);
+        return frame;
+    }
+
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(bug4463014::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/html/FrameView/4463014/frame1.html
+++ b/test/jdk/javax/swing/text/html/FrameView/4463014/frame1.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+Push the <span style="color:blue">Submit query</span> button
+<FORM ACTION="./frameresult.html" METHOD=post  TARGET="main" >
+<input type="text" name="Selection"><BR>
+<INPUT type="submit">
+</FORM>
+</body>
+</html>

--- a/test/jdk/javax/swing/text/html/FrameView/4463014/frame2.html
+++ b/test/jdk/javax/swing/text/html/FrameView/4463014/frame2.html
@@ -1,0 +1,4 @@
+<HTML>
+<BODY>
+</BODY>
+</HTML>

--- a/test/jdk/javax/swing/text/html/FrameView/4463014/frameresult.html
+++ b/test/jdk/javax/swing/text/html/FrameView/4463014/frameresult.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+If you see this text in the <span style="color:green">RIGHT</span> frame the test <span style="color:green">PASSED</span>.
+<p>If you see this text in the <span style="color:red">LEFT</span> frame the test <span style="color:red">FAILED</span>.
+
+</body>
+</html>

--- a/test/jdk/javax/swing/text/html/FrameView/4463014/frameset.html
+++ b/test/jdk/javax/swing/text/html/FrameView/4463014/frameset.html
@@ -1,0 +1,11 @@
+<HTML>
+ <HEAD>
+   <TITLE>
+     Manual test for bug 4463014
+   </TITLE>
+ </HEAD>
+ <FRAMESET COLS="150,*">
+  <FRAME SRC="frame1.html">
+  <FRAME name="main" SRC="frame2.html">
+ </FRAMESET>
+</HTML>

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4102068.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4102068.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4102068
+ * @summary Tests HTML editor JEditorPane change mouse icon over the link
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4102068
+ */
+
+import java.awt.Cursor;
+import javax.swing.JFrame;
+import javax.swing.JTextPane;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4102068 {
+
+    static final String INSTRUCTIONS = """
+        The test window contains an HTML frame containing a string with one hyperlink.
+        Move the mouse pointer over this hyperlink.
+        If the pointer over the hyperlink became a HAND cursor then the test PASSES,
+        otherwise the test FAILS.
+    """;
+
+    static JFrame createUI() {
+
+        JFrame frame = new JFrame("bug4102068");
+        JTextPane ep = new JTextPane();
+        ep.setContentType("text/html");
+        HTMLEditorKit ek = new HTMLEditorKit();
+        ep.setEditorKit(ek);
+        ep.setText("<html><body>Here is a <a href=''>HyperLink Cursor Test</a></body></html>");
+        ek.setDefaultCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+        Cursor ct = ek.getDefaultCursor();
+        ek.setLinkCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        Cursor cl = ek.getLinkCursor();
+        if (ct.getType() != Cursor.DEFAULT_CURSOR || cl.getType() != Cursor.HAND_CURSOR) {
+             throw new RuntimeException("Error with cursor settings...");
+        }
+        ep.setEditable(false);
+
+        frame.add(ep);
+        frame.setSize(300, 300);
+        return frame;
+    }
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(50)
+            .testUI(bug4102068::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4198022.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4198022.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4198022
+ * @summary Tests if HTML tags <sup>, <sub> and <nobr> are supported in JEditorPane
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4198022
+ */
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4198022 {
+
+    static final String INSTRUCTIONS = """
+    There are two "lines" of text in the displayed HTML window
+    The first line/string contains <sub> and <sup> HTML elements.
+    The word "subscript" should be subscripted (placed lower than the word "Testing"),
+    and the word "superscript" should be superscripted (placed higher than "Testing").
+    If instead these words are placed on the same level then the test FAILS.
+
+    The second line/string contains a sentence marked with <nobr> tag.
+    It should be presented as one long line without breaks.
+    It is OK for the line to extend past the end of the window and not be all visible.
+    If the line is broken up so you see multiple lines the test FAILS.
+
+    If all behaves as expected, the test PASSES.
+    """;
+
+    static JFrame createUI() {
+
+        JFrame frame = new JFrame("bug4198022");
+        JEditorPane ep = new JEditorPane();
+        HTMLEditorKit ek = new HTMLEditorKit();
+        ep.setEditorKit(ek);
+        ep.setText(
+            "<html><body>Testing <sub>subscript</sub> and <sup>superscript</sup>.<br>" +
+            "<nobr>This text is intended to be presented as a single line without " +
+            "any word wrapping, regardless of whether it fits the viewable area of " +
+            "the editor pane or not.</nobr></body></html>");
+
+        ep.setEditable(false);
+
+        frame.add(ep);
+        frame.setSize(500, 300);
+        return frame;
+    }
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .testUI(bug4198022::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4245401.java
+++ b/test/jdk/javax/swing/text/html/HTMLEditorKit/bug4245401.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4245401
+ * @summary Tests that JTextPane with HTMLEditorKit handles the HEAD tag properly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4245401
+ */
+
+import java.io.StringReader;
+import javax.swing.JFrame;
+import javax.swing.JTextPane;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4245401 {
+
+    static final String INSTRUCTIONS = """
+        Place the cursor before the "H" in the word "HTML"
+        Then press <Up-arrow> and <Enter>.
+        If an extra HEAD tag appear, the test FAILS, otherwise it PASSES.
+    """;
+
+    static JFrame createUI() {
+
+        JFrame frame = new JFrame("bug4245401");
+        JTextPane ep = new JTextPane();
+        ep.setEditable(true);
+        ep.setContentType("text/html");
+        HTMLEditorKit kit = (HTMLEditorKit) ep.getEditorKit();
+        ep.setEditorKit(kit);
+        HTMLDocument doc = (HTMLDocument) kit.createDefaultDocument();
+        ep.setDocument(doc);
+
+        try {
+            String text = "HTML Test... Test is a test...";
+            kit.read(new StringReader(text), doc, 0);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        frame.add(ep);
+        frame.setSize(300, 300);
+        return frame;
+    }
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(bug4245401::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/html/StyleSheet/bug4619595.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/bug4619595.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4619595
+ * @summary Tests that embedded list items do not inherit the 'value'
+ *          property from their parent list item
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4619595
+ */
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+
+public class bug4619595 {
+
+    static final String INSTRUCTIONS = """
+        The test window contains numbered lists.
+        Look at the three indented/embedded list items (the ones that are bold).
+        If they are not numbered 1, 2 and 3, then press FAIL.
+
+        Below the lists there should also be a line saying: "The quick brown fox".
+        If you don't see this, press FAIL.
+
+        If all is as expected, PASS the test.
+    """;
+
+    final static String HTML = "<html><body>" +
+        "<ol>  <li>Let's start  <li value=4>Look @ inner list" +
+        "    <ol> <li><b>Inner list starts</b>  <li><b>Second inner item</b>" +
+        "         <li><b>Inner list ends</b>  </ol>" +
+        "    <li>That's all </ol>" +
+        " <p style='background-color:'>The quick brown fox</p>" +
+        "</body> </html>";
+
+    static JFrame createUI() {
+
+        JFrame frame = new JFrame("bug4619595");
+        JEditorPane pane = new JEditorPane();
+        pane.setContentType("text/html");
+        pane.setText(HTML);
+        frame.add(pane);
+        frame.setSize(400, 400);
+        return frame;
+    }
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(bug4619595::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353320](https://bugs.openjdk.org/browse/JDK-8353320) needs maintainer approval

### Issue
 * [JDK-8353320](https://bugs.openjdk.org/browse/JDK-8353320): Open source more Swing text tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3581/head:pull/3581` \
`$ git checkout pull/3581`

Update a local copy of the PR: \
`$ git checkout pull/3581` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3581`

View PR using the GUI difftool: \
`$ git pr show -t 3581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3581.diff">https://git.openjdk.org/jdk17u-dev/pull/3581.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3581#issuecomment-2886509481)
</details>
