### PR TITLE
8353070: Clean up and open source couple AWT Graphics related tests (Part 1)

### DIFF
--- a/test/jdk/java/awt/Graphics/LineLocationTest.java
+++ b/test/jdk/java/awt/Graphics/LineLocationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4094059
+ * @summary drawing to a subclass of canvas didn't draw to the correct location.
+ * @key headful
+ * @run main LineLocationTest
+ */
+
+import java.awt.AWTException;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.InvocationTargetException;
+
+public class LineLocationTest extends Frame {
+    private DrawScreen screen;
+
+    public void initialize() {
+        setSize(400, 400);
+        setLocationRelativeTo(null);
+        setTitle("Line Location Test");
+        Panel p = new Panel();
+        screen = new DrawScreen();
+        p.add(screen);
+        p.setLocation(50, 50);
+        p.setSize(300, 300);
+        add(p);
+        setBackground(Color.white);
+        setForeground(Color.blue);
+        setVisible(true);
+    }
+
+    public void requestCoordinates(Rectangle r) {
+        Point location = screen.getLocationOnScreen();
+        Dimension size = screen.getSize();
+        r.setBounds(location.x, location.y, size.width, size.height);
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        LineLocationTest me = new LineLocationTest();
+        EventQueue.invokeAndWait(me::initialize);
+        try {
+            Robot robot = new Robot();
+            robot.delay(1000);
+            Rectangle coords = new Rectangle();
+            EventQueue.invokeAndWait(() -> {
+                me.requestCoordinates(coords);
+            });
+            BufferedImage capture = robot.createScreenCapture(coords);
+            robot.delay(2000);
+            for (int y = 0; y < capture.getHeight(); y++) {
+                for (int x = 0; x < capture.getWidth(); x++) {
+                    int blue = Color.blue.getRGB();
+                    if (capture.getRGB(x, y) == blue) {
+                        throw new RuntimeException("Blue detected at " + x + ", " + y);
+                    }
+                }
+            }
+        } finally {
+            EventQueue.invokeAndWait(me::dispose);
+        }
+    }
+}
+
+class DrawScreen extends Canvas {
+    public Dimension getPreferredSize() {
+        return new Dimension(300, 300);
+    }
+
+    public void paint(Graphics g) {
+        g.setColor(Color.blue);
+        g.drawLine(5, -3145583, 50, -3145583);
+    }
+}

--- a/test/jdk/java/awt/Graphics/NativeWin32Clear.java
+++ b/test/jdk/java/awt/Graphics/NativeWin32Clear.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4216180
+ * @summary This test verifies that Graphics2D.setBackground and clearRect
+ *   performs correctly regardless of antialiasing hint.
+ * @key headful
+ * @run main NativeWin32Clear
+ */
+
+import java.awt.AWTException;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.InvocationTargetException;
+
+public class NativeWin32Clear extends Frame {
+
+    public void initialize() {
+        setLocationRelativeTo(null);
+        setSize(300, 200);
+        setBackground(Color.red);
+        setVisible(true);
+    }
+
+    public void paint(Graphics g) {
+        Graphics2D g2 = (Graphics2D) g;
+        Dimension d = getSize();
+        g2.setBackground(Color.green);
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                            RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.clearRect(0, 0, d.width / 2, d.height);
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                            RenderingHints.VALUE_ANTIALIAS_OFF);
+        g2.clearRect(d.width / 2, 0, d.width / 2, d.height);
+        g2.setColor(Color.black);
+    }
+
+    public void cleanup() {
+        setVisible(false);
+        dispose();
+    }
+
+    public void requestCoordinates(Rectangle r) {
+        Insets insets = getInsets();
+        Point location = getLocationOnScreen();
+        Dimension size = getSize();
+        r.x = location.x + insets.left + 5;
+        r.y = location.y + insets.top + 5;
+        r.width = size.width - (insets.left + insets.right + 10);
+        r.height = size.height - (insets.top + insets.bottom + 10);
+    }
+
+    /*
+     * Check color match within allowed deviation.
+     * Prints first non-matching pixel coordinates and actual and expected values.
+     * Returns true if image is filled with the provided color, false otherwise.
+     */
+    private boolean checkColor(BufferedImage img, Color c, int delta) {
+        int cRed = c.getRed();
+        int cGreen = c.getGreen();
+        int cBlue = c.getBlue();
+        for (int y = 0; y < img.getHeight(); y++) {
+            for (int x = 0; x < img.getWidth(); x++) {
+                int rgb = img.getRGB(x, y);
+                int red = (rgb & 0x00ff0000) >> 16;
+                int green = (rgb & 0x0000ff00) >> 8;
+                int blue = rgb & 0x000000ff;
+                if (cRed > (red + delta) || cRed < (red - delta)
+                 || cGreen > (green + delta) || cGreen < (green - delta)
+                 || cBlue > (blue + delta) || cBlue < (blue - delta)) {
+                    System.err.println("Color at coordinates (" + x + ", " + y + ") does not match");
+                    System.err.println("Expected color: " + c.getRGB());
+                    System.err.println("Actual color: " + rgb);
+                    System.err.println("Allowed deviation: " + delta);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException, AWTException {
+        NativeWin32Clear test = new NativeWin32Clear();
+        try {
+            EventQueue.invokeAndWait(test::initialize);
+            Robot robot = new Robot();
+            Rectangle coords = new Rectangle();
+            EventQueue.invokeAndWait(() -> {
+                test.requestCoordinates(coords);
+            });
+            robot.delay(2000);
+            robot.mouseMove(coords.x - 50, coords.y - 50);
+            robot.waitForIdle();
+            BufferedImage capture = robot.createScreenCapture(coords);
+            robot.delay(2000);
+            if (!test.checkColor(capture, Color.green, 5)) {
+                throw new RuntimeException("Incorrect color encountered, check error log for details");
+            }
+        } finally {
+            EventQueue.invokeAndWait(test::cleanup);
+        }
+    }
+}

--- a/test/jdk/java/awt/Graphics/PolygonFillTest.java
+++ b/test/jdk/java/awt/Graphics/PolygonFillTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4465509 4453725 4489667
+ * @summary verify that fillPolygon completely fills area defined by drawPolygon
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PolygonFillTest
+*/
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.awt.Polygon;
+import java.lang.reflect.InvocationTargetException;
+
+public class PolygonFillTest extends Frame {
+    Polygon poly;
+    static String INSTRUCTIONS = """
+                There should be two hourglass shapes drawn inside the window
+                called "Polygon Fill Test". The outline should be blue
+                and the interior should be green and there should be no gaps
+                between the filled interior and the outline nor should the green
+                filler spill outside the blue outline. You may need
+                to use a screen magnifier to inspect the smaller shape
+                on the left to verify that there are no gaps.
+
+                If both polygons painted correctly press "Pass" otherwise press "Fail".
+                """;
+
+    public PolygonFillTest() {
+        poly = new Polygon();
+        poly.addPoint(0, 0);
+        poly.addPoint(10, 10);
+        poly.addPoint(0, 10);
+        poly.addPoint(10, 0);
+        setSize(300, 300);
+        setTitle("Polygon Fill Test");
+    }
+
+    public void paint(Graphics g) {
+        int w = getWidth();
+        int h = getHeight();
+        Image img = createImage(20, 20);
+        Graphics g2 = img.getGraphics();
+        drawPolys(g2, 20, 20, 5, 5);
+        g2.dispose();
+        drawPolys(g, w, h, (w / 4) - 5, (h / 2) - 5);
+        g.drawImage(img, (3 * w / 4) - 40, (h / 2) - 40, 80, 80, null);
+    }
+
+    public void drawPolys(Graphics g, int w, int h, int x, int y) {
+        g.setColor(Color.white);
+        g.fillRect(0, 0, w, h);
+        g.translate(x, y);
+        g.setColor(Color.green);
+        g.fillPolygon(poly);
+        g.setColor(Color.blue);
+        g.drawPolygon(poly);
+        g.translate(-x, -y);
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Polygon Fill Instructions")
+                .instructions(INSTRUCTIONS)
+                .testUI(PolygonFillTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/Graphics/TallText.java
+++ b/test/jdk/java/awt/Graphics/TallText.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4844952
+ * @summary test large text draws properly to the screen
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TallText
+ */
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.lang.reflect.InvocationTargetException;
+
+public class TallText extends Frame {
+    static String INSTRUCTIONS = """
+            There should be a window called "Tall Text Test" that contains text "ABCDEFGHIJ".
+            Test should be properly displayed: no missing letters
+            and all letters fit within the frame without overlapping.
+            If all letters are properly displayed press "Pass", otherwise press "Fail".
+            """;
+
+    public TallText() {
+        setSize(800, 200);
+        setTitle("Tall Text Test");
+    }
+
+    public void paint(Graphics g) {
+        Font font = new Font("dialog", Font.PLAIN, 99);
+        g.setFont(font);
+        g.setColor(Color.black);
+        g.drawString("ABCDEFGHIJ", 10, 150);
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Tall Text Instructions")
+                .instructions(INSTRUCTIONS)
+                .testUI(TallText::new)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353070](https://bugs.openjdk.org/browse/JDK-8353070) needs maintainer approval

### Issue
 * [JDK-8353070](https://bugs.openjdk.org/browse/JDK-8353070): Clean up and open source couple AWT Graphics related tests (Part 1) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3586/head:pull/3586` \
`$ git checkout pull/3586`

Update a local copy of the PR: \
`$ git checkout pull/3586` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3586`

View PR using the GUI difftool: \
`$ git pr show -t 3586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3586.diff">https://git.openjdk.org/jdk17u-dev/pull/3586.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3586#issuecomment-2891439154)
</details>
