### PR TITLE
8353446: Open source several AWT Menu tests - Batch 2

### DIFF
--- a/test/jdk/java/awt/Menu/DestroyMenuTest/DestroyMenuTest.java
+++ b/test/jdk/java/awt/Menu/DestroyMenuTest/DestroyMenuTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4209511
+ * @summary Regression test DestroyMenuTest.java Failing
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DestroyMenuTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Canvas;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.Scrollbar;
+import java.awt.TextField;
+
+public class DestroyMenuTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Create many windows by randomly clicking 'Show Menu Test 1',
+                  'Show Menu Test 2', 'Show Menu Test 3' buttons.
+                2. Ignore the contents of the windows.
+                   Go to the windows created and select menu items inside the menus.
+                3. Close the windows by selecting menu item File--> Quit.
+                4. Do the above menu item selections as quickly as possible.
+                   If the program crashes when you select File--> Quit,
+                   then the test FAILS. Otherwise the test is PASS.
+                      """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(38)
+                .testUI(DestroyMenuTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame f = new Frame("Destroy Menu Test");
+        Button launchButton = new Button("Show Menu Test 1...");
+        Button launchButton2 = new Button("Show Menu Test 2...");
+        Button launchButton3 = new Button("Show Menu Test 3...");
+        f.setLayout(new FlowLayout());
+        f.add(launchButton);
+        f.add(launchButton2);
+        f.add(launchButton3);
+
+        launchButton.addActionListener(event -> {
+            MenuTest frame = new MenuTest("Menu Test 1");
+            frame.setBounds(300, 300, 300, 300);
+            frame.setVisible(true);
+        });
+
+        launchButton2.addActionListener(event -> {
+            MenuTest frame = new MenuTest("Menu Test 2");
+
+            Button closeButton = new Button("Close");
+
+            Panel X = new Panel();
+            X.setLayout(new BorderLayout());
+
+            Panel topPanel = new Panel();
+            Panel bottomPanel = new Panel();
+
+            bottomPanel.add(closeButton);
+
+            Scrollbar vScrollbar = new Scrollbar(Scrollbar.VERTICAL);
+            Scrollbar hScrollbar = new Scrollbar(Scrollbar.HORIZONTAL);
+            hScrollbar.setValues(hScrollbar.getValue(), 0, 0, 50);
+            vScrollbar.setValues(vScrollbar.getValue(), 0, 0, 50);
+            topPanel.setLayout(new BorderLayout());
+            topPanel.add(vScrollbar, BorderLayout.EAST);
+            topPanel.add(hScrollbar, BorderLayout.SOUTH);
+
+            X.add(topPanel, BorderLayout.NORTH);
+            X.add(bottomPanel, BorderLayout.SOUTH);
+            frame.add(X, BorderLayout.SOUTH);
+            frame.setBounds(350, 350, 300, 250);
+            frame.setVisible(true);
+        });
+
+        launchButton3.addActionListener(event -> {
+            MenuTest frame = new MenuTest("Menu Test 3");
+            frame.setBounds(400, 400, 300, 300);
+
+            mySimpleCanvas clock = new mySimpleCanvas();
+            frame.add(clock, BorderLayout.CENTER);
+
+            Panel p = new Panel();
+            Button closeButton = new Button("Close");
+            p.add(closeButton);
+
+            p.add(new Label("Label"));
+            TextField textField = new TextField(8);
+            p.add(textField);
+            f.add(p, BorderLayout.EAST);
+
+            frame.add(p, BorderLayout.SOUTH);
+            frame.setVisible(true);
+        });
+        f.pack();
+        return f;
+    }
+
+    static class mySimpleCanvas extends Canvas {
+        @Override
+        public void paint(Graphics g) {
+            g.drawOval(0, 0, 100, 100);
+            g.drawOval(2, 2, 100, 100);
+            g.drawOval(4, 4, 100, 100);
+        }
+    }
+}

--- a/test/jdk/java/awt/Menu/DestroyMenuTest/MenuTest.java
+++ b/test/jdk/java/awt/Menu/DestroyMenuTest/MenuTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Canvas;
+import java.awt.CardLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Label;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Panel;
+
+public class MenuTest extends Frame {
+    private MenuItem quitItem;
+    private final Panel cards;
+    private final CardLayout layout;
+
+    public MenuTest(String s) {
+        super(s);
+        MenuBar mbar = new MenuBar();
+        createMenus(mbar);
+        setMenuBar(mbar);
+
+        cards = new Panel();
+        layout = new CardLayout();
+        cards.setLayout(layout);
+
+        cards.add(new MyPanelOne("Options"), "Options");
+        cards.add(new MyRectCanvas(), "MyRectCanvas");
+        cards.add(new MycircleCanvas(), "MyCircleCanvas");
+
+        add(cards, "Center");
+    }
+
+    public void createMenus(MenuBar mbar) {
+        mbar.add(createFileMenu());
+        mbar.add(createEditMenu());
+        mbar.add(createOptionMenu1());
+        mbar.add(createOptionMenu2());
+        mbar.add(createOptionMenu3());
+        mbar.add(createOptionMenu4());
+    }
+
+    private Menu createFileMenu() {
+        Menu fileMenu = new Menu("File");
+        fileMenu.add(quitItem = new MenuItem("Quit"));
+
+        quitItem.addActionListener(event -> {
+            MenuItem item = (MenuItem) event.getSource();
+            if (item == quitItem) {
+                dispose();
+            }
+        });
+        return fileMenu;
+    }
+
+    private Menu createEditMenu() {
+        Menu editMenu = new Menu("Edit");
+
+        editMenu.add("Cut");
+        editMenu.add("Copy");
+        editMenu.add("Paste");
+        editMenu.addSeparator();
+        editMenu.add("Select all");
+        editMenu.addSeparator();
+        editMenu.add("Find");
+        editMenu.add("Find again");
+
+        return editMenu;
+    }
+
+    private Menu createOptionMenu1() {
+        Menu optionMenu1 = new Menu("Option1");
+        MenuItem item1, item2, item3;
+        optionMenu1.add(item1 = new MenuItem("Item1"));
+        optionMenu1.add(item2 = new MenuItem("Item2"));
+        optionMenu1.add(item3 = new MenuItem("Item3"));
+
+        item1.addActionListener(event -> {
+            MenuItem mItem = (MenuItem) event.getSource();
+            if (mItem == item1) {
+                layout.show(cards, "Options");
+            }
+        });
+        item2.addActionListener(event -> {
+            MenuItem mItem = (MenuItem) event.getSource();
+            if (mItem == item2) {
+                layout.show(cards, "MyRectCanvas");
+            }
+        });
+        item3.addActionListener(event -> {
+            MenuItem mItem = (MenuItem) event.getSource();
+            if (mItem == item3) {
+                layout.show(cards, "MyCircleCanvas");
+            }
+        });
+        return optionMenu1;
+    }
+
+    private Menu createOptionMenu2() {
+        Menu optionMenu2 = new Menu("Option2");
+
+        optionMenu2.add("Item1");
+        optionMenu2.add("Item2");
+
+        return optionMenu2;
+    }
+
+    private Menu createOptionMenu3() {
+        Menu optionMenu3 = new Menu("Option3");
+
+        optionMenu3.add("Item1");
+        optionMenu3.add("Item2");
+        optionMenu3.add("Item3");
+        optionMenu3.add("Item4");
+
+        return optionMenu3;
+    }
+
+    private Menu createOptionMenu4() {
+        Menu optionMenu4 = new Menu("Option3");
+
+        optionMenu4.add("Item1");
+        optionMenu4.add("Item2");
+        optionMenu4.add("Item3");
+
+        return optionMenu4;
+    }
+}
+
+class MyRectCanvas extends Canvas {
+    @Override
+    public void paint(Graphics g) {
+        g.drawRect(0, 0, 100, 100);
+    }
+}
+
+class MyPanelOne extends Panel {
+    MyPanelOne(String name) {
+        add(new Label(name + " panel goes here"));
+    }
+}
+
+class MycircleCanvas extends Canvas {
+    @Override
+    public void paint(Graphics g) {
+        g.drawOval(0, 0, 100, 100);
+        g.drawOval(2, 2, 100, 100);
+        g.drawOval(4, 4, 100, 100);
+    }
+}

--- a/test/jdk/java/awt/Menu/MenuAddRemoveCrash.java
+++ b/test/jdk/java/awt/Menu/MenuAddRemoveCrash.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4410477
+ * @summary Tests that menu does not crash during simultaneous drawing
+ *          and removal of items.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuAddRemoveCrash
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+public class MenuAddRemoveCrash {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Move and resize the frame.
+                2. If the test crashes the test is FAILED.
+                   Otherwise it is PASSED.
+                    """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(MenuAddRemoveCrash::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame initialize() {
+        final TestGui myTestGui = new TestGui();
+        Thread test = new Thread() {
+            public void run() {
+                while (!Thread.interrupted()) {
+                    myTestGui.changeMenuItems();
+                }
+            }
+        };
+        test.setDaemon(true);
+        test.start();
+        return myTestGui;
+    }
+}
+
+class TestGui extends Frame {
+    Menu myMenu1;
+    Menu myMenu2;
+
+    public TestGui() {
+        this.setTitle("Try to resize this frame!");
+
+        this.setSize(300, 300);
+        this.setVisible(true);
+
+        MenuBar myMenuBar = new MenuBar();
+        myMenu1 = new Menu("DemoMenu1");
+        myMenu2 = new Menu("DemoMenu2");
+
+        myMenuBar.add(myMenu1);
+        myMenuBar.add(myMenu2);
+
+        this.setMenuBar(myMenuBar);
+    }
+
+    public void changeMenuItems() {
+        myMenu1.removeAll();
+
+        for (int i = 0; i < 10; i++) {
+            MenuItem myMenuItem1 = new MenuItem("DemoMenuItem" + i);
+            myMenu1.add(myMenuItem1);
+        }
+        try {
+            Thread.sleep(100);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed :" + e);
+        }
+    }
+}

--- a/test/jdk/java/awt/Menu/MenuZOrderTest.java
+++ b/test/jdk/java/awt/Menu/MenuZOrderTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6267182
+ * @summary Menu is not visible after showing and disposing a file dialog.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuZOrderTest
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class MenuZOrderTest {
+    static class Listener implements ActionListener {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            Frame f = new Frame("Menu Z order test frame");
+            f.setBounds(200, 200, 200, 200);
+            f.setVisible(true);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Choose Menu 1 --> Menu Item 1 several times.
+                2. If menu window is shown correctly and each click
+                   creates new frame - press PASS.
+                3. If menu window is obscured by frame - press FAIL.
+                    """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(MenuZOrderTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame mf = new Frame("Menu Z order test");
+        Listener l = new Listener();
+        MenuBar mb = new MenuBar();
+        Menu m1 = new Menu("Menu 1");
+        MenuItem mi1 = new MenuItem("Menu Item 1");
+
+        mf.setSize(200, 200);
+        mi1.addActionListener(l);
+        m1.add(mi1);
+        mb.add(m1);
+        mf.setMenuBar(mb);
+        mf.setVisible(true);
+        return mf;
+    }
+}

--- a/test/jdk/java/awt/Menu/OnFlyRepaintMenuTest.java
+++ b/test/jdk/java/awt/Menu/OnFlyRepaintMenuTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5024051
+ * @summary Tests if menu is repainted in enabling/disabling it and
+ *          changing its label while it is visible, either on MenuBar
+ *          or in other Menu. Menu items are covered as well
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual OnFlyRepaintMenuTest
+ */
+
+import java.awt.Button;
+import java.awt.CheckboxMenuItem;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+public class OnFlyRepaintMenuTest {
+    static boolean menuEnabled = true;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Click the button 'Change state' and wait for 5 secs.
+                2. If menu is repainted correctly after its setLabel()
+                   and setEnabled() methods called test PASSED, else FAILED.
+                   (During a 5 secs delay you may select the menu to see
+                   the effect for menu items and submenu)
+                         """;
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(OnFlyRepaintMenuTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame f = new Frame("OnFly Menu Repaint Test");
+
+        f.setSize(200, 100);
+
+        MenuBar mb = new MenuBar();
+        Menu menu = new Menu("Menu");
+        MenuItem menuItem = new MenuItem("MenuItem");
+        menu.add(menuItem);
+        Menu submenu = new Menu("SubMenu");
+        MenuItem submenuItem = new MenuItem("SubmenuItem");
+        submenu.add(submenuItem);
+        CheckboxMenuItem checkMenuItem = new CheckboxMenuItem("CheckboxmenuItem");
+        checkMenuItem.setState(true);
+        menu.add(checkMenuItem);
+        menu.add(submenu);
+        mb.add(menu);
+        f.setMenuBar(mb);
+
+        Button b = new Button("Change state");
+        b.addActionListener(ev -> new Thread(() -> {
+            try {
+                Thread.sleep(5000);
+            } catch (Exception e) {
+            }
+            menuEnabled = !menuEnabled;
+            String label = menuEnabled ? "Enabled" : "Disabled";
+            menu.setLabel(label);
+            menuItem.setLabel(label);
+            submenu.setLabel(label);
+            submenuItem.setLabel(label);
+            checkMenuItem.setLabel(label);
+            checkMenuItem.setEnabled(menuEnabled);
+            checkMenuItem.setState(menuEnabled);
+            submenuItem.setEnabled(menuEnabled);
+            submenu.setEnabled(menuEnabled);
+            menuItem.setEnabled(menuEnabled);
+            menu.setEnabled(menuEnabled);
+        }).start());
+        f.add(b);
+        return f;
+    }
+}


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353446](https://bugs.openjdk.org/browse/JDK-8353446) needs maintainer approval

### Issue
 * [JDK-8353446](https://bugs.openjdk.org/browse/JDK-8353446): Open source several AWT Menu tests - Batch 2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3588/head:pull/3588` \
`$ git checkout pull/3588`

Update a local copy of the PR: \
`$ git checkout pull/3588` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3588`

View PR using the GUI difftool: \
`$ git pr show -t 3588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3588.diff">https://git.openjdk.org/jdk17u-dev/pull/3588.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3588#issuecomment-2891498941)
</details>
