### PR TITLE
8347083: Incomplete logging in nsk/jvmti/ResourceExhausted/resexhausted00* tests

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public class resexhausted001 {
                 makeThread();
             }
 
-            System.out.println("Can't reproduce OOME due to a limit on iterations/execution time. Test was useless."
+            System.out.println("Test resexhausted001: Can't reproduce OOME due to a limit on iterations/execution time. Test was useless."
                     + " threadCount=" + threadCount.get());
             throw new SkippedException("Test did not get an OutOfMemory error");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class resexhausted002 {
                 ++count;
             }
 
-            System.out.println("Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
+            System.out.println("Test resexhausted002: Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
             throw new SkippedException("Test did not get an OutOfMemory error");
 
         } catch (OutOfMemoryError e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,7 +115,7 @@ public class resexhausted003 {
                 ++count;
             }
 
-            System.out.println("Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
+            System.out.println("Test resexhausted003: Can't reproduce OOME due to a limit on iterations/execution time. Test was useless.");
             throw new SkippedException("Test did not get an OutOfMemory error");
 
         } catch (OutOfMemoryError e) {


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347083](https://bugs.openjdk.org/browse/JDK-8347083) needs maintainer approval

### Issue
 * [JDK-8347083](https://bugs.openjdk.org/browse/JDK-8347083): Incomplete logging in nsk/jvmti/ResourceExhausted/resexhausted00* tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3597/head:pull/3597` \
`$ git checkout pull/3597`

Update a local copy of the PR: \
`$ git checkout pull/3597` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3597`

View PR using the GUI difftool: \
`$ git pr show -t 3597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3597.diff">https://git.openjdk.org/jdk17u-dev/pull/3597.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3597#issuecomment-2894584090)
</details>
