### PR TITLE
8297242: Use-after-free during library unloading on Linux

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -698,9 +698,20 @@ void* os::dll_lookup(void* handle, const char* name) {
 }
 
 void os::dll_unload(void *lib) {
-  const char* l_path = LINUX_ONLY(os::Linux::dll_path(lib))
-                       NOT_LINUX("<not available>");
-  if (l_path == NULL) l_path = "<not available>";
+  // os::Linux::dll_path returns a pointer to a string that is owned by the dynamic loader. Upon
+  // calling dlclose the dynamic loader may free the memory containing the string, thus we need to
+  // copy the string to be able to reference it after dlclose.
+  const char* l_path = NULL;
+#ifdef LINUX
+  char* l_pathdup = NULL;
+  l_path = os::Linux::dll_path(lib);
+  if (l_path != NULL) {
+    l_path = l_pathdup = os::strdup(l_path);
+  }
+#endif  // LINUX
+  if (l_path == NULL) {
+    l_path = "<not available>";
+  }
   int res = ::dlclose(lib);
 
   if (res == 0) {
@@ -718,6 +729,7 @@ void os::dll_unload(void *lib) {
     log_info(os)("Attempt to unload shared library \"%s\" [" INTPTR_FORMAT "] failed, %s",
                   l_path, p2i(lib), error_report);
   }
+  LINUX_ONLY(os::free(l_pathdup));
 }
 
 jlong os::lseek(int fd, jlong offset, int whence) {


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297242](https://bugs.openjdk.org/browse/JDK-8297242) needs maintainer approval

### Issue
 * [JDK-8297242](https://bugs.openjdk.org/browse/JDK-8297242): Use-after-free during library unloading on Linux (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3602/head:pull/3602` \
`$ git checkout pull/3602`

Update a local copy of the PR: \
`$ git checkout pull/3602` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3602`

View PR using the GUI difftool: \
`$ git pr show -t 3602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3602.diff">https://git.openjdk.org/jdk17u-dev/pull/3602.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3602#issuecomment-2897814400)
</details>
