### PR TITLE
Backport 21a6cf848da00c795d833f926f831c7aea05dfa3

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,9 @@ native.core.args=-ABRT %p
 cores=native.lldb
 native.lldb.app=lldb
 native.lldb.delimiter=\0
+# Core files can be very big and take a long time to load on macosx-aarch64.
+# The 20 seconds default timeout is not nearly enough.
+native.lldb.timeout=120000
 # Assume that java standard laucher has been used
 native.lldb.args=--core\0%p\0%java\0-o\0thread backtrace all\0-o\0quit
 


### PR DESCRIPTION
I backport this test change as it also goes to 17.0.17-oracle.