### PR TITLE
Backport 5f38d1bb94d008c33c1a7af12c81ee0e15371e13

### DIFF
--- a/make/modules/jdk.jdwp.agent/Lib.gmk
+++ b/make/modules/jdk.jdwp.agent/Lib.gmk
@@ -55,6 +55,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     DISABLED_WARNINGS_gcc := unused-function, \
     DISABLED_WARNINGS_clang := sometimes-uninitialized format-nonliteral \
         self-assign, \
+    DISABLED_WARNINGS_microsoft_debugInit.c := 5287, \
     EXTRA_HEADER_DIRS := \
       include \
       libjdwp/export, \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e225254f](https://github.com/openjdk/jdk21u-dev/commit/e225254fbdb4a164bf5f2eeaccddf08fd4f3fd22) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

The commit being backported was authored by Sergey Bylokhov on 22 May 2025 and had no reviewers.

Thanks!