### PR TITLE
8355077: Compiler error at splashscreen_gif.c due to unterminated string initialization

### DIFF
--- a/src/java.desktop/share/native/libsplashscreen/splashscreen_gif.c
+++ b/src/java.desktop/share/native/libsplashscreen/splashscreen_gif.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@
                                 // restore the area overwritten by the graphic with
                                 // what was there prior to rendering the graphic.
 
-static const char szNetscape20ext[11] = "NETSCAPE2.0";
+static const char szNetscape20ext[] = "NETSCAPE2.0";
 
 #define NSEXT_LOOP      0x01    // Loop Count field code
 
@@ -181,7 +181,7 @@ SplashDecodeGif(Splash * splash, GifFileType * gif)
                 }
             case APPLICATION_EXT_FUNC_CODE:
                 {
-                    if (size == sizeof(szNetscape20ext)
+                    if (size == strlen(szNetscape20ext)
                         && memcmp(pExtension, szNetscape20ext, size) == 0) {
                         int iSubCode;
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8355077](https://bugs.openjdk.org/browse/JDK-8355077) needs maintainer approval

### Issue
 * [JDK-8355077](https://bugs.openjdk.org/browse/JDK-8355077): Compiler error at splashscreen_gif.c due to unterminated string initialization (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3611/head:pull/3611` \
`$ git checkout pull/3611`

Update a local copy of the PR: \
`$ git checkout pull/3611` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3611`

View PR using the GUI difftool: \
`$ git pr show -t 3611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3611.diff">https://git.openjdk.org/jdk17u-dev/pull/3611.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3611#issuecomment-2907543163)
</details>
