### PR TITLE
8346285: Update jarsigner compatibility test for change in default digest algorithm

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,7 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import jdk.security.jarsigner.JarSigner;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
@@ -1430,7 +1431,9 @@ public class Compatibility {
         String expectedDigestAlg() {
             return digestAlgorithm != null
                     ? digestAlgorithm
-                    : jdkInfo.majorVersion >= 20 ? "SHA-384" : "SHA-256";
+                    : jdkInfo.majorVersion >= 20
+                        ? JarSigner.Builder.getDefaultDigestAlgorithm()
+                        : "SHA-256";
         }
 
         private SignItem tsaDigestAlgorithm(String tsaDigestAlgorithm) {
@@ -1439,7 +1442,11 @@ public class Compatibility {
         }
 
         String expectedTsaDigestAlg() {
-            return tsaDigestAlgorithm != null ? tsaDigestAlgorithm : "SHA-256";
+            return tsaDigestAlgorithm != null
+                    ? tsaDigestAlgorithm
+                    : jdkInfo.majorVersion >= 20
+                        ? JarSigner.Builder.getDefaultDigestAlgorithm()
+                        : "SHA-256";
         }
 
         private SignItem tsaIndex(int tsaIndex) {


### PR DESCRIPTION
Backport for Oracle 17.0.16 parity. Clean backport, test only, modified test passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346285](https://bugs.openjdk.org/browse/JDK-8346285) needs maintainer approval

### Issue
 * [JDK-8346285](https://bugs.openjdk.org/browse/JDK-8346285): Update jarsigner compatibility test for change in default digest algorithm (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3613/head:pull/3613` \
`$ git checkout pull/3613`

Update a local copy of the PR: \
`$ git checkout pull/3613` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3613`

View PR using the GUI difftool: \
`$ git pr show -t 3613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3613.diff">https://git.openjdk.org/jdk17u-dev/pull/3613.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3613#issuecomment-2917406625)
</details>
