### PR TITLE
Backport 73f06468ae7f9eebb8e37f2a534d2c19a8dac60d

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemoveEmptyLoop.java
@@ -28,6 +28,7 @@
  * @summary Unexpected test result caused by C2 IdealLoopTree::do_remove_empty_loop
  *
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation
+ *      -XX:StressLongCountedLoop=0
  *      compiler.loopopts.TestRemoveEmptyLoop
  */
 


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.