### PR TITLE
8295210: IR framework should not whitelist -XX:-UseTLAB

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -110,7 +110,6 @@ public class TestFramework {
                     "Trace",
                     "Print",
                     "Verify",
-                    "TLAB",
                     "UseNewCode",
                     "Xmn",
                     "Xms",


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8295210](https://bugs.openjdk.org/browse/JDK-8295210) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295210](https://bugs.openjdk.org/browse/JDK-8295210): IR framework should not whitelist -XX:-UseTLAB (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3636/head:pull/3636` \
`$ git checkout pull/3636`

Update a local copy of the PR: \
`$ git checkout pull/3636` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3636`

View PR using the GUI difftool: \
`$ git pr show -t 3636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3636.diff">https://git.openjdk.org/jdk17u-dev/pull/3636.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3636#issuecomment-2972812727)
</details>
