### PR TITLE
8320858: Move jpackage tests to tier3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -84,10 +84,12 @@ tier2_part3 = \
 tier3 = \
     :build \
     :jdk_vector \
+    -:jdk_vector_sanity \
     :jdk_rmi \
     :jdk_svc \
-   -:jdk_svc_sanity \
-   -:svc_tools
+    -:jdk_svc_sanity \
+    -:svc_tools \
+    :jdk_jpackage
 
 # Everything not in other tiers
 tier4 = \
@@ -278,10 +280,11 @@ jdk_launcher = \
     sun/tools
 
 #
-# Tool (and tool API) tests are split into core and svc groups
+# Tool (and tool API) tests are mostly split into core and svc groups
 #
 core_tools = \
     tools \
+    -tools/jpackage \
     jdk/internal/jrtfs \
     sun/tools/jrunscript
 
@@ -293,10 +296,14 @@ svc_tools = \
 
 jdk_tools = \
     :core_tools \
-    :svc_tools
+    :svc_tools \
+    :jdk_jpackage
 
 jdk_jfr = \
     jdk/jfr
+
+jdk_jpackage = \
+    tools/jpackage
 
 #
 # Catch-all for other areas with a small number of tests


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

Trivial resolves needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8320858](https://bugs.openjdk.org/browse/JDK-8320858) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320858](https://bugs.openjdk.org/browse/JDK-8320858): Move jpackage tests to tier3 (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3637/head:pull/3637` \
`$ git checkout pull/3637`

Update a local copy of the PR: \
`$ git checkout pull/3637` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3637`

View PR using the GUI difftool: \
`$ git pr show -t 3637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3637.diff">https://git.openjdk.org/jdk17u-dev/pull/3637.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3637#issuecomment-2972858242)
</details>
