### PR TITLE
8285032: vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy008/ fails with "eventSet.suspendPolicy() != policyExpected"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy008.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy008.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -247,8 +247,8 @@ public class suspendpolicy008 extends JDIBase {
         getEventSet();
         cpRequest.disable();
 
-        ClassPrepareEvent event = (ClassPrepareEvent) eventIterator.next();
-        debuggeeClass = event.referenceType();
+        ClassPrepareEvent cpEvent = (ClassPrepareEvent) eventIterator.next();
+        debuggeeClass = cpEvent.referenceType();
 
         if (!debuggeeClass.name().equals(debuggeeName))
            throw new JDITestRuntimeException("** Unexpected ClassName for ClassPrepareEvent **");
@@ -371,13 +371,14 @@ public class suspendpolicy008 extends JDIBase {
             }
 
             mainThread.resume();
-            getEventSet();
+            getEventSetForThreadStartDeath("thread" + i);
 
-            if ( !(eventIterator.nextEvent() instanceof ThreadStartEvent)) {
-                 log3("ERROR: new event is not ThreadStartEvent");
+            Event event = eventIterator.nextEvent();
+            if (!(event instanceof ThreadStartEvent)) {
+                log3("ERROR: new event is not ThreadStartEvent: " + event);
                  testExitCode = FAILED;
             } else {
-                log2("......got : instanceof ThreadStartEvent");
+                log2("......got : instanceof ThreadStartEvent: " + event);
                 policy = eventSet.suspendPolicy();
                 if (policy != policyExpected[i]) {
                     log3("ERROR: eventSet.suspendPolicy() != policyExpected");
@@ -418,8 +419,6 @@ public class suspendpolicy008 extends JDIBase {
             throws JDITestRuntimeException {
         try {
             ThreadStartRequest tsr = eventRManager.createThreadStartRequest();
-//            tsr.addThreadFilter(mainThread);
-            tsr.addCountFilter(1);
             tsr.setSuspendPolicy(suspendPolicy);
             tsr.putProperty("number", property);
             return tsr;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/EventFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -335,6 +335,10 @@ public class EventFilters
             return true;
 
         if (event.toString().contains("JFR request timer"))
+            return true;
+
+        // Filter out any carrier thread that starts while running the test.
+        if (event.toString().contains("ForkJoinPool"))
             return true;
 
         return false;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,18 +165,21 @@ public class JDIBase {
             Event event = eventIterator.nextEvent();
             if (event instanceof ThreadStartEvent evt) {
                 if (evt.thread().name().equals(threadName)) {
+                    log2("Got ThreadStartEvent for '" + evt.thread().name());
                     break;
                 }
                 log2("Got ThreadStartEvent for '" + evt.thread().name()
                         + "' instead of '" + threadName + "', skipping");
             } else if (event instanceof ThreadDeathEvent evt) {
                 if (evt.thread().name().equals(threadName)) {
+                    log2("Got ThreadDeathEvent for '" + evt.thread().name());
                     break;
                 }
                 log2("Got ThreadDeathEvent for '" + evt.thread().name()
                         + "' instead of '" + threadName + "', skipping");
             } else {
                 // not ThreadStartEvent nor ThreadDeathEvent
+                log2("Did't get ThreadStartEvent or ThreadDeathEvent: " + event);
                 break;
             }
             eventSet.resume();
@@ -188,15 +191,22 @@ public class JDIBase {
     protected void breakpointForCommunication() throws JDITestRuntimeException {
 
         log2("breakpointForCommunication");
-        getEventSet();
+        while (true) {
+            getEventSet();
 
-        Event event = eventIterator.nextEvent();
-        if (event instanceof BreakpointEvent) {
-            bpEvent = (BreakpointEvent) event;
-            return;
+            Event event = eventIterator.nextEvent();
+            if (event instanceof BreakpointEvent) {
+                bpEvent = (BreakpointEvent) event;
+                return;
+            }
+
+            if (EventFilters.filtered(event)) {
+                // We filter out spurious ThreadStartEvents
+                continue;
+            }
+
+            throw new JDITestRuntimeException("** event '" + event + "' IS NOT a breakpoint **");
         }
-
-        throw new JDITestRuntimeException("** event '" + event + "' IS NOT a breakpoint **");
     }
 
     // Similar to breakpointForCommunication, but skips Locatable events from unexpected locations.


### PR DESCRIPTION
I backport this to make later backorts clean.

A useful fix anyways.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8285032](https://bugs.openjdk.org/browse/JDK-8285032) needs maintainer approval

### Issue
 * [JDK-8285032](https://bugs.openjdk.org/browse/JDK-8285032): vmTestbase/nsk/jdi/EventSet/suspendPolicy/suspendpolicy008/ fails with "eventSet.suspendPolicy() != policyExpected" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3644/head:pull/3644` \
`$ git checkout pull/3644`

Update a local copy of the PR: \
`$ git checkout pull/3644` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3644`

View PR using the GUI difftool: \
`$ git pr show -t 3644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3644.diff">https://git.openjdk.org/jdk17u-dev/pull/3644.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3644#issuecomment-2977070494)
</details>
