### PR TITLE
8313367: SunMSCAPI cannot read Local Computer certs w/o Windows elevation

### DIFF
--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -444,7 +444,7 @@ JNIEXPORT void JNICALL Java_sun_security_mscapi_CKeyStore_loadKeysOrCertificateC
         }
         else if (jCertStoreLocation == KEYSTORE_LOCATION_LOCALMACHINE) {
             hCertStore = ::CertOpenStore(CERT_STORE_PROV_SYSTEM_A, 0, NULL,
-                CERT_SYSTEM_STORE_LOCAL_MACHINE, pszCertStoreName);
+                CERT_SYSTEM_STORE_LOCAL_MACHINE | CERT_STORE_MAXIMUM_ALLOWED_FLAG, pszCertStoreName);
         }
         else {
             PP("jCertStoreLocation is not a valid value");
@@ -792,11 +792,15 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_mscapi_CSignature_signHash
             ::CryptGetProvParam((HCRYPTPROV)hCryptProv, PP_CONTAINER, //deprecated
                 (BYTE *)pbData, &cbData, 0);
 
+            DWORD keysetType = 0;
+            DWORD keysetTypeLen = sizeof(keysetType);
+            ::CryptGetProvParam((HCRYPTPROV)hCryptProv, PP_KEYSET_TYPE, //deprecated
+                (BYTE*)&keysetType, &keysetTypeLen, 0);
+
             // Acquire an alternative CSP handle
             if (::CryptAcquireContext(&hCryptProvAlt, LPCSTR(pbData), NULL, //deprecated
-                PROV_RSA_AES, 0) == FALSE)
+                PROV_RSA_AES, 0 | keysetType) == FALSE)
             {
-
                 ThrowException(env, SIGNATURE_EXCEPTION, GetLastError());
                 __leave;
             }

--- a/test/jdk/sun/security/mscapi/AllTypes.java
+++ b/test/jdk/sun/security/mscapi/AllTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,31 +45,10 @@ public class AllTypes {
         var nr = test("windows-root");
         var nmu = test("windows-my-currentuser");
         var nru = test("windows-root-currentuser");
-        var hasAdminPrivileges = detectIfRunningWithAdminPrivileges();
-        var nmm = adminTest("windows-my-localmachine", hasAdminPrivileges);
-        var nrm = adminTest("windows-root-localmachine", hasAdminPrivileges);
+        var nmm = test("windows-my-localmachine");
+        var nrm = test("windows-root-localmachine");
         Asserts.assertEQ(nm, nmu);
         Asserts.assertEQ(nr, nru);
-    }
-
-    private static boolean detectIfRunningWithAdminPrivileges() {
-        try {
-            Process p = Runtime.getRuntime().exec("reg query \"HKU\\S-1-5-19\"");
-            p.waitFor();
-            return (p.exitValue() == 0);
-        }
-        catch (Exception ex) {
-            System.out.println("Warning: unable to detect admin privileges, assuming none");
-            return false;
-        }
-    }
-
-    private static List<String> adminTest(String type, boolean hasAdminPrivileges) throws Exception {
-        if (hasAdminPrivileges) {
-            return test(type);
-        }
-        System.out.println("Ignoring: " + type + " as it requires admin privileges");
-        return null;
     }
 
     private static List<String> test(String type) throws Exception {


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

Resolved Copyright, probably clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8313367](https://bugs.openjdk.org/browse/JDK-8313367) needs maintainer approval

### Issue
 * [JDK-8313367](https://bugs.openjdk.org/browse/JDK-8313367): SunMSCAPI cannot read Local Computer certs w/o Windows elevation (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3647/head:pull/3647` \
`$ git checkout pull/3647`

Update a local copy of the PR: \
`$ git checkout pull/3647` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3647`

View PR using the GUI difftool: \
`$ git pr show -t 3647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3647.diff">https://git.openjdk.org/jdk17u-dev/pull/3647.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3647#issuecomment-2977203165)
</details>
