### PR TITLE
8345566: Deproblemlist test/jdk/javax/swing/JComboBox/6559152/bug6559152.java

### DIFF
--- a/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
+++ b/test/jdk/javax/swing/JComboBox/6559152/bug6559152.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,8 @@ public class bug6559152 {
     private static JFrame frame;
     private static JComboBox cb;
     private static Robot robot;
-    private static Point p = null;
-    private static Dimension d;
+    private static volatile Point p = null;
+    private static volatile Dimension d;
 
     public static void main(String[] args) throws Exception {
         robot = new Robot();
@@ -84,7 +84,7 @@ public class bug6559152 {
     }
 
     private static void setupUI() {
-        frame = new JFrame();
+        frame = new JFrame("bug6559152");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         DefaultTableModel model = new DefaultTableModel(1, 1);


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8345566](https://bugs.openjdk.org/browse/JDK-8345566) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345566](https://bugs.openjdk.org/browse/JDK-8345566): Deproblemlist test/jdk/javax/swing/JComboBox/6559152/bug6559152.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3648/head:pull/3648` \
`$ git checkout pull/3648`

Update a local copy of the PR: \
`$ git checkout pull/3648` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3648`

View PR using the GUI difftool: \
`$ git pr show -t 3648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3648.diff">https://git.openjdk.org/jdk17u-dev/pull/3648.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3648#issuecomment-2977392766)
</details>
