### PR TITLE
8332494: java/util/zip/EntryCount64k.java failing with java.lang.RuntimeException: '\\A\\Z' missing from stderr

### DIFF
--- a/test/jdk/java/util/zip/EntryCount64k.java
+++ b/test/jdk/java/util/zip/EntryCount64k.java
@@ -163,6 +163,6 @@ public class EntryCount64k {
         OutputAnalyzer a = ProcessTools.executeTestJava("-jar", zipFile.getName());
         a.shouldHaveExitValue(0);
         a.stdoutShouldMatch("\\AMain\\Z");
-        a.stderrShouldMatch("\\A\\Z");
+        a.stderrShouldMatchIgnoreDeprecatedWarnings("\\A\\Z");
     }
 }

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -641,7 +641,7 @@ public final class OutputAnalyzer {
 
     /**
      * Verify that the stderr contents of output buffer matches the pattern,
-     * after filtering out the Hotespot warning messages
+     * after filtering out the Hotspot warning messages
      *
      * @param pattern
      * @throws RuntimeException If the pattern was not found
@@ -653,6 +653,24 @@ public final class OutputAnalyzer {
             reportDiagnosticSummary();
             throw new RuntimeException("'" + pattern
                   + "' missing from stderr \n");
+        }
+        return this;
+    }
+
+    /**
+     * Verify that the stderr contents of output buffer matches the pattern,
+     * after filtering out the Hotspot deprecation warning messages
+     *
+     * @param pattern
+     * @throws RuntimeException If the pattern was not found
+     */
+    public OutputAnalyzer stderrShouldMatchIgnoreDeprecatedWarnings(String pattern) {
+        String stderr = getStderr().replaceAll(deprecatedmsg + "\\R", "");
+        Matcher matcher = Pattern.compile(pattern, Pattern.MULTILINE).matcher(stderr);
+        if (!matcher.find()) {
+            reportDiagnosticSummary();
+            throw new RuntimeException("'" + pattern
+                  + "' missing from stderr");
         }
         return this;
     }


### PR DESCRIPTION
I backport this to make later backorts clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8332494](https://bugs.openjdk.org/browse/JDK-8332494) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332494](https://bugs.openjdk.org/browse/JDK-8332494): java/util/zip/EntryCount64k.java failing with java.lang.RuntimeException: '\\A\\Z' missing from stderr (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3649/head:pull/3649` \
`$ git checkout pull/3649`

Update a local copy of the PR: \
`$ git checkout pull/3649` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3649`

View PR using the GUI difftool: \
`$ git pr show -t 3649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3649.diff">https://git.openjdk.org/jdk17u-dev/pull/3649.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3649#issuecomment-2977462757)
</details>
