### PR TITLE
Backport f3f078846feae66d3504d50081353f74bd4891d7

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -226,6 +226,7 @@ module java.base {
         jdk.jfr;
     exports jdk.internal.ref to
         java.desktop,
+        java.net.http,
         jdk.incubator.foreign;
     exports jdk.internal.reflect to
         java.logging,

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -19,6 +19,7 @@ grant codeBase "jrt:/java.net.http" {
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.util";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.net.www";
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.ref";
     permission java.lang.RuntimePermission "modifyThread";
     permission java.net.SocketPermission "*","connect,resolve";
     permission java.net.URLPermission "http:*","*:*";

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientFacade.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package jdk.internal.net.http;
 
 import java.io.IOException;
+import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
 import java.net.Authenticator;
 import java.net.CookieHandler;
@@ -44,12 +45,19 @@ import java.net.http.HttpResponse.PushPromiseHandler;
 import java.net.http.WebSocket;
 import jdk.internal.net.http.common.OperationTrackers.Trackable;
 import jdk.internal.net.http.common.OperationTrackers.Tracker;
+import jdk.internal.ref.CleanerFactory;
 
 /**
  * An HttpClientFacade is a simple class that wraps an HttpClient implementation
  * and delegates everything to its implementation delegate.
+ * @implSpec
+ * Though the facade strongly reference its implementation, the
+ * implementation MUST NOT strongly reference the facade.
+ * It MAY use weak references if needed.
  */
 public final class HttpClientFacade extends HttpClient implements Trackable {
+
+    static final Cleaner cleaner = CleanerFactory.cleaner();
 
     final HttpClientImpl impl;
 
@@ -58,6 +66,8 @@ public final class HttpClientFacade extends HttpClient implements Trackable {
      */
     HttpClientFacade(HttpClientImpl impl) {
         this.impl = impl;
+        // wakeup the impl when the facade is gc'ed
+        cleaner.register(this, impl::facadeCleanup);
     }
 
     @Override // for tests

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -491,6 +491,13 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         assert facadeRef.get() != null;
     }
 
+    // called when the facade is GC'ed.
+    // Just wakes up the selector to cleanup...
+    void facadeCleanup() {
+        SelectorManager selmgr = this.selmgr;
+        if (selmgr != null) selmgr.wakeupSelector();
+    }
+
     void onSubmitFailure(Runnable command, Throwable failure) {
         selmgr.abort(failure);
     }
@@ -723,7 +730,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         }
         @Override
         public boolean isFacadeReferenced() {
-            return reference.get() != null;
+            return !reference.refersTo(null);
         }
         @Override
         public boolean isSelectorAlive() { return isAlive.get(); }
@@ -749,8 +756,7 @@ final class HttpClientImpl extends HttpClient implements Trackable {
     // Called by the SelectorManager thread to figure out whether it's time
     // to terminate.
     boolean isReferenced() {
-        HttpClient facade = facade();
-        return facade != null || referenceCount() > 0;
+        return !facadeRef.refersTo(null) || referenceCount() > 0;
     }
 
     /**

--- a/test/jdk/java/net/httpclient/ReferenceTracker.java
+++ b/test/jdk/java/net/httpclient/ReferenceTracker.java
@@ -179,13 +179,15 @@ public class ReferenceTracker {
                                 boolean printThreads) {
         AssertionError fail = null;
         graceDelayMs = Math.max(graceDelayMs, 100);
-        long delay = Math.min(graceDelayMs, 500);
+        long delay = Math.min(graceDelayMs, 10);
         var count = delay > 0 ? graceDelayMs / delay : 1;
         for (int i = 0; i < count; i++) {
             if (TRACKERS.stream().anyMatch(hasOutstanding)) {
                 System.gc();
                 try {
-                    System.out.println("Waiting for HTTP operations to terminate...");
+                    if (i == 0) {
+                        System.out.println("Waiting for HTTP operations to terminate...");
+                    }
                     Thread.sleep(Math.min(graceDelayMs, Math.max(delay, 1)));
                 } catch (InterruptedException x) {
                     // OK

--- a/test/jdk/java/net/httpclient/ResponseBodyBeforeError.java
+++ b/test/jdk/java/net/httpclient/ResponseBodyBeforeError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @summary Tests that all response body is delivered to the BodySubscriber
  *          before an abortive error terminates the flow
+ * @modules java.net.http/jdk.internal.net.http.common
  * @library /test/lib
  * @build jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm ResponseBodyBeforeError
@@ -59,6 +60,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocketFactory;
+
+import static java.lang.System.err;
 import static java.lang.System.out;
 import static java.net.http.HttpClient.Builder.NO_PROXY;
 import static java.net.http.HttpResponse.BodyHandlers.ofString;
@@ -177,6 +180,7 @@ public class ResponseBodyBeforeError {
     }
 
     static final int ITERATION_COUNT = 3;
+    static final ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
 
     @Test(dataProvider = "uris")
     void testSynchronousAllRequestBody(String url,
@@ -186,24 +190,34 @@ public class ResponseBodyBeforeError {
     {
         out.print("---\n");
         HttpClient client = null;
-        for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = HttpClient.newBuilder()
-                        .proxy(NO_PROXY)
-                        .sslContext(sslContext)
-                        .build();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
-            CustomBodySubscriber bs = new CustomBodySubscriber();
-            try {
-                HttpResponse<String> response = client.send(request, r -> bs);
-                String body = response.body();
-                out.println(response + ": " + body);
-                fail("UNEXPECTED RESPONSE: " + response);
-            } catch (IOException expected) {
-                String pm = bs.receivedAsString();
-                out.println("partial body received: " + pm);
-                assertEquals(pm, expectedPatrialBody);
+        try {
+            for (int i = 0; i < ITERATION_COUNT; i++) {
+                if (!sameClient || client == null) {
+                    client = HttpClient.newBuilder()
+                            .proxy(NO_PROXY)
+                            .sslContext(sslContext)
+                            .build();
+                    TRACKER.track(client);
+                    System.gc();
+                }
+                HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
+                CustomBodySubscriber bs = new CustomBodySubscriber();
+                try {
+                    HttpResponse<String> response = client.send(request, r -> bs);
+                    String body = response.body();
+                    out.println(response + ": " + body);
+                    fail("UNEXPECTED RESPONSE: " + response);
+                } catch (IOException expected) {
+                    String pm = bs.receivedAsString();
+                    out.println("partial body received: " + pm);
+                    assertEquals(pm, expectedPatrialBody);
+                }
             }
+        } finally {
+            client = null;
+            System.gc();
+            var error = TRACKER.checkShutdown(1000);
+            if (error != null) throw error;
         }
     }
 
@@ -215,28 +229,38 @@ public class ResponseBodyBeforeError {
     {
         out.print("---\n");
         HttpClient client = null;
-        for (int i=0; i< ITERATION_COUNT; i++) {
-            if (!sameClient || client == null)
-                client = HttpClient.newBuilder()
-                        .proxy(NO_PROXY)
-                        .sslContext(sslContext)
-                        .build();
-            HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
-            CustomBodySubscriber bs = new CustomBodySubscriber();
-            try {
-                HttpResponse<String> response = client.sendAsync(request, r -> bs).get();
-                String body = response.body();
-                out.println(response + ": " + body);
-                fail("UNEXPECTED RESPONSE: " + response);
-            } catch (ExecutionException ee) {
-                if (ee.getCause() instanceof IOException) {
-                    String pm = bs.receivedAsString();
-                    out.println("partial body received: " + pm);
-                    assertEquals(pm, expectedPatrialBody);
-                } else {
-                    throw ee;
+        try {
+            for (int i = 0; i < ITERATION_COUNT; i++) {
+                if (!sameClient || client == null) {
+                    client = HttpClient.newBuilder()
+                            .proxy(NO_PROXY)
+                            .sslContext(sslContext)
+                            .build();
+                    System.gc();
+                    TRACKER.track(client);
+                }
+                HttpRequest request = HttpRequest.newBuilder(URI.create(url)).build();
+                CustomBodySubscriber bs = new CustomBodySubscriber();
+                try {
+                    HttpResponse<String> response = client.sendAsync(request, r -> bs).get();
+                    String body = response.body();
+                    out.println(response + ": " + body);
+                    fail("UNEXPECTED RESPONSE: " + response);
+                } catch (ExecutionException ee) {
+                    if (ee.getCause() instanceof IOException) {
+                        String pm = bs.receivedAsString();
+                        out.println("partial body received: " + pm);
+                        assertEquals(pm, expectedPatrialBody);
+                    } else {
+                        throw ee;
+                    }
                 }
             }
+        } finally {
+            client = null;
+            System.gc();
+            var error = TRACKER.checkShutdown(1000);
+            if (error != null) throw error;
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

Some trivial resolves were needed.

Resolved module-info.java due to context.

Resolved test/jdk/java/net/httpclient/AsFileDownloadTest.java
as several later changes have been backported already. 

Resolved Copyright in test/jdk/java/net/httpclient/DigestEchoClient.java.
