### PR TITLE
8345173: BlockLocationPrinter::print_location misses a ResourceMark

### DIFF
--- a/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
+++ b/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/shared/locationPrinter.hpp"
 
+#include "memory/resourceArea.inline.hpp"
 #include "oops/compressedOops.inline.hpp"
 #include "oops/oopsHierarchy.hpp"
 
@@ -51,6 +52,7 @@ oop BlockLocationPrinter<CollectedHeapT>::base_oop_or_null(void* addr) {
 
 template <typename CollectedHeapT>
 bool BlockLocationPrinter<CollectedHeapT>::print_location(outputStream* st, void* addr) {
+  ResourceMark rm;
   // Check if addr points into Java heap.
   if (CollectedHeapT::heap()->is_in(addr)) {
     oop o = base_oop_or_null(addr);


### PR DESCRIPTION
Backporting JDK-8345173: BlockLocationPrinter::print_location misses a ResourceMark. Since BlockLocationPrinter can be called at any point (e.g. the stop() method of MacroAssembler), it may currently fail with a "Missing ResourceMark error - possible memory leak" error instead of providing the stop() output (and then failing). Ran GHA Sanity Checks and local Tier 1 and 2. Patch is clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8345173](https://bugs.openjdk.org/browse/JDK-8345173) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345173](https://bugs.openjdk.org/browse/JDK-8345173): BlockLocationPrinter::print_location misses a ResourceMark (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3665/head:pull/3665` \
`$ git checkout pull/3665`

Update a local copy of the PR: \
`$ git checkout pull/3665` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3665`

View PR using the GUI difftool: \
`$ git pr show -t 3665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3665.diff">https://git.openjdk.org/jdk17u-dev/pull/3665.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3665#issuecomment-2981248213)
</details>
