### PR TITLE
Backport b8ac0d20ceec26b3a1dd0b9577817fa6320ea9ef

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/AnimationController.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/AnimationController.java
@@ -59,7 +59,7 @@ import sun.awt.AppContext;
  *   <li> It tracks the animation state for every UI component involved in the
  *        animation and paints {@code Skin} in new {@code State} over the
  *        {@code Skin} in last {@code State} using
- *        {@code AlphaComposite.SrcOver.derive(alpha)} where {code alpha}
+ *        {@code AlphaComposite.SrcOver.derive(alpha)} where {@code alpha}
  *        depends on the state of animation
  * </ul>
  *

--- a/src/java.management/share/classes/javax/management/modelmbean/RequiredModelMBean.java
+++ b/src/java.management/share/classes/javax/management/modelmbean/RequiredModelMBean.java
@@ -192,7 +192,7 @@ public class RequiredModelMBean
      *
      * @exception MBeanException Wraps a distributed communication Exception.
      * @exception RuntimeOperationsException Wraps an
-     *    {link java.lang.IllegalArgumentException}:
+     *    {@link java.lang.IllegalArgumentException}:
      *          The MBeanInfo passed in parameter is null.
      *
      **/

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -1090,7 +1090,7 @@ public class ResponseSubscribers {
      * Invokes bs::getBody using the provided executor.
      * If invoking bs::getBody requires an executor, and the given executor
      * is a {@link HttpClientImpl.DelegatingExecutor}, then the executor's
-     * delegate is used. If an error occurs anywhere then the given {code cf}
+     * delegate is used. If an error occurs anywhere then the given {@code cf}
      * is completed exceptionally (this method does not throw).
      * @param e   The executor that should be used to call bs::getBody
      * @param bs  The BodySubscriber

--- a/src/java.rmi/share/classes/java/rmi/server/RemoteObject.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RemoteObject.java
@@ -251,7 +251,7 @@ public abstract class RemoteObject implements Remote, java.io.Serializable {
      * written by {@link java.io.ObjectOutput#writeInt(int)}
      *
      * <li>the data written as a result of calling
-     * {link java.rmi.server.ObjID#write(java.io.ObjectOutput)}
+     * {@link java.rmi.server.ObjID#write(java.io.ObjectOutput)}
      * on the <code>ObjID</code> instance contained in the reference
      *
      * <li>the boolean value <code>false</code>,
@@ -275,7 +275,7 @@ public abstract class RemoteObject implements Remote, java.io.Serializable {
      * written by {@link java.io.ObjectOutput#writeInt(int)}
      *
      * <li>the data written as a result of calling
-     * {link java.rmi.server.ObjID#write(java.io.ObjectOutput)}
+     * {@link java.rmi.server.ObjID#write(java.io.ObjectOutput)}
      * on the <code>ObjID</code> instance contained in the reference
      *
      * <li>the boolean value <code>false</code>,
@@ -304,7 +304,7 @@ public abstract class RemoteObject implements Remote, java.io.Serializable {
      * <code>writeObject</code> on the stream instance
      *
      * <li>the data written as a result of calling
-     * {link java.rmi.server.ObjID#write(java.io.ObjectOutput)}
+     * {@link java.rmi.server.ObjID#write(java.io.ObjectOutput)}
      * on the <code>ObjID</code> instance contained in the reference
      *
      * <li>the boolean value <code>false</code>,

--- a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/SignatureProperties.java
+++ b/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/SignatureProperties.java
@@ -88,7 +88,7 @@ public class SignatureProperties extends SignatureElementProxy {
 
     /**
      * Return the <i>i</i><sup>th</sup> SignatureProperty. Valid {@code i}
-     * values are 0 to {@code {link@ getSize}-1}.
+     * values are 0 to {@code {@link getSize}-1}.
      *
      * @param i Index of the requested {@link SignatureProperty}
      * @return the <i>i</i><sup>th</sup> SignatureProperty

--- a/src/jdk.compiler/share/classes/com/sun/source/util/Trees.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/Trees.java
@@ -72,7 +72,7 @@ public abstract class Trees {
     }
 
     /**
-     * Returns a Trees object for a given ProcessingEnvironment.
+     * Returns a {@code Trees} object for a given ProcessingEnvironment.
      * @param env the processing environment for which to get the Trees object
      * @throws IllegalArgumentException if the env does not support the Trees API.
      * @return the Trees object

--- a/test/jdk/java/awt/Desktop/DesktopEventsExceptions/DesktopEventsExceptions.java
+++ b/test/jdk/java/awt/Desktop/DesktopEventsExceptions/DesktopEventsExceptions.java
@@ -45,7 +45,7 @@ import java.util.List;
  * @test
  * @bug 8203224
  * @summary tests that the correct exceptions are thrown by the events classes
- *          in {code java.awt.desktop} package
+ *          in {@code java.awt.desktop} package
  * @run main/othervm DesktopEventsExceptions
  * @run main/othervm -Djava.awt.headless=true DesktopEventsExceptions
  */

--- a/test/jdk/java/awt/regtesthelpers/process/ProcessCommunicator.java
+++ b/test/jdk/java/awt/regtesthelpers/process/ProcessCommunicator.java
@@ -76,7 +76,7 @@ public class ProcessCommunicator {
     }
 
     /**
-     * Executes child {code Process}
+     * Executes child {@code Process}
      *
      * @param classToExecute class to be executed as a child java process
      * @param args args to be passed in to the child process


### PR DESCRIPTION
I backport this to make later backports clean

Resolved src/jdk.compiler/share/classes/com/sun/source/util/Trees.java
"8271227: Missing {@code } in com.sun.source.*", which is not in 17, added a wrong tag.
I added the correct one.

Omitted PublisherVerificationRules.java
8297645: Drop the test/jdk/java/net/httpclient/reactivestreams-tck-tests/TckDriver.java test
which deleted this test already backported.