### PR TITLE
8297424: java/net/httpclient/AsyncExecutorShutdown.java fails in AssertionError due to misplaced assert

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -552,13 +552,13 @@ public class ResponseSubscribers {
                         closed = this.closed;
                         if (!closed) {
                             this.subscription = s;
+                            assert buffers.remainingCapacity() > 1; // should contain at least 2
                         }
                     }
                     if (closed) {
                         s.cancel();
                         return;
                     }
-                    assert buffers.remainingCapacity() > 1; // should contain at least 2
                     if (debug.on())
                         debug.log("onSubscribe: requesting "
                                   + Math.max(1, buffers.remainingCapacity() - 1));

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -184,10 +184,9 @@ class Stream<T> extends ExchangeImpl<T> {
                 if (subscriber == null) {
                     // can't process anything yet
                     return;
-                } else {
-                    if (debug.on()) debug.log("subscribing user subscriber");
-                    subscriber.onSubscribe(userSubscription);
                 }
+                if (debug.on()) debug.log("subscribing user subscriber");
+                subscriber.onSubscribe(userSubscription);
             }
             while (!inputQ.isEmpty()) {
                 Http2Frame frame = inputQ.peek();
@@ -420,7 +419,7 @@ class Stream<T> extends ExchangeImpl<T> {
             responseBodyCF.completeExceptionally(t);
         }
 
-        // ensure that the body subscriber will be subsribed and onError() is
+        // ensure that the body subscriber will be subscribed and onError() is
         // invoked
         pendingResponseSubscriber = bodySubscriber;
         sched.runOrSchedule(); // in case data waiting already to be processed, or error
@@ -600,9 +599,9 @@ class Stream<T> extends ExchangeImpl<T> {
             Flow.Subscriber<?> subscriber =
                     responseSubscriber == null ? pendingResponseSubscriber : responseSubscriber;
             if (response == null && subscriber == null) {
-                // we haven't receive the headers yet, and won't receive any!
+                // we haven't received the headers yet, and won't receive any!
                 // handle reset now.
-                handleReset(frame, subscriber);
+                handleReset(frame, null);
             } else {
                 // put it in the input queue in order to read all
                 // pending data frames first. Indeed, a server may send


### PR DESCRIPTION
I backport this to make later changes clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297424](https://bugs.openjdk.org/browse/JDK-8297424) needs maintainer approval

### Issue
 * [JDK-8297424](https://bugs.openjdk.org/browse/JDK-8297424): java/net/httpclient/AsyncExecutorShutdown.java fails in AssertionError due to misplaced assert (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3684/head:pull/3684` \
`$ git checkout pull/3684`

Update a local copy of the PR: \
`$ git checkout pull/3684` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3684`

View PR using the GUI difftool: \
`$ git pr show -t 3684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3684.diff">https://git.openjdk.org/jdk17u-dev/pull/3684.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3684#issuecomment-3012442221)
</details>
