### PR TITLE
8301004: httpclient: Add more debug to HttpResponseInputStream

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -540,8 +540,10 @@ public class ResponseSubscribers {
         @Override
         public void onSubscribe(Flow.Subscription s) {
             Objects.requireNonNull(s);
+            if (debug.on()) debug.log("onSubscribed called");
             try {
                 if (!subscribed.compareAndSet(false, true)) {
+                    if (debug.on()) debug.log("Already subscribed: canceling");
                     s.cancel();
                 } else {
                     // check whether the stream is already closed.
@@ -552,10 +554,14 @@ public class ResponseSubscribers {
                         closed = this.closed;
                         if (!closed) {
                             this.subscription = s;
-                            assert buffers.remainingCapacity() > 1; // should contain at least 2
+                            // should contain at least 2
+                            assert buffers.remainingCapacity() > 1
+                                    : "buffers capacity: " + buffers.remainingCapacity()
+                                    + " closed: " + closed + " failed: " + failed;
                         }
                     }
                     if (closed) {
+                        if (debug.on()) debug.log("Already closed: canceling");
                         s.cancel();
                         return;
                     }
@@ -566,6 +572,8 @@ public class ResponseSubscribers {
                 }
             } catch (Throwable t) {
                 failed = t;
+                if (debug.on())
+                    debug.log("onSubscribed failed", t);
                 try {
                     close();
                 } catch (IOException x) {
@@ -599,6 +607,8 @@ public class ResponseSubscribers {
 
         @Override
         public void onError(Throwable thrwbl) {
+            if (debug.on())
+                debug.log("onError called: " + thrwbl);
             subscription = null;
             failed = Objects.requireNonNull(thrwbl);
             // The client process that reads the input stream might
@@ -613,6 +623,8 @@ public class ResponseSubscribers {
 
         @Override
         public void onComplete() {
+            if (debug.on())
+                debug.log("onComplete called");
             subscription = null;
             onNext(LAST_LIST);
         }
@@ -626,6 +638,8 @@ public class ResponseSubscribers {
                 s = subscription;
                 subscription = null;
             }
+            if (debug.on())
+                debug.log("close called");
             // s will be null if already completed
             try {
                 if (s != null) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -552,13 +552,13 @@ public class ResponseSubscribers {
                         closed = this.closed;
                         if (!closed) {
                             this.subscription = s;
+                            assert buffers.remainingCapacity() > 1; // should contain at least 2
                         }
                     }
                     if (closed) {
                         s.cancel();
                         return;
                     }
-                    assert buffers.remainingCapacity() > 1; // should contain at least 2
                     if (debug.on())
                         debug.log("onSubscribe: requesting "
                                   + Math.max(1, buffers.remainingCapacity() - 1));

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -184,10 +184,9 @@ class Stream<T> extends ExchangeImpl<T> {
                 if (subscriber == null) {
                     // can't process anything yet
                     return;
-                } else {
-                    if (debug.on()) debug.log("subscribing user subscriber");
-                    subscriber.onSubscribe(userSubscription);
                 }
+                if (debug.on()) debug.log("subscribing user subscriber");
+                subscriber.onSubscribe(userSubscription);
             }
             while (!inputQ.isEmpty()) {
                 Http2Frame frame = inputQ.peek();
@@ -420,7 +419,7 @@ class Stream<T> extends ExchangeImpl<T> {
             responseBodyCF.completeExceptionally(t);
         }
 
-        // ensure that the body subscriber will be subsribed and onError() is
+        // ensure that the body subscriber will be subscribed and onError() is
         // invoked
         pendingResponseSubscriber = bodySubscriber;
         sched.runOrSchedule(); // in case data waiting already to be processed, or error
@@ -600,9 +599,9 @@ class Stream<T> extends ExchangeImpl<T> {
             Flow.Subscriber<?> subscriber =
                     responseSubscriber == null ? pendingResponseSubscriber : responseSubscriber;
             if (response == null && subscriber == null) {
-                // we haven't receive the headers yet, and won't receive any!
+                // we haven't received the headers yet, and won't receive any!
                 // handle reset now.
-                handleReset(frame, subscriber);
+                handleReset(frame, null);
             } else {
                 // put it in the input queue in order to read all
                 // pending data frames first. Indeed, a server may send


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8301004](https://bugs.openjdk.org/browse/JDK-8301004) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301004](https://bugs.openjdk.org/browse/JDK-8301004): httpclient: Add more debug to HttpResponseInputStream (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3685/head:pull/3685` \
`$ git checkout pull/3685`

Update a local copy of the PR: \
`$ git checkout pull/3685` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3685`

View PR using the GUI difftool: \
`$ git pr show -t 3685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3685.diff">https://git.openjdk.org/jdk17u-dev/pull/3685.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3685#issuecomment-3012473970)
</details>
