### PR TITLE
8301255: Http2Connection may send too many GOAWAY frames

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -213,10 +213,10 @@ class Http2ClientImpl {
 
     private EOFException STOPPED;
     void stop() {
-        synchronized (this) {stopping = true;}
         if (debug.on()) debug.log("stopping");
         STOPPED = new EOFException("HTTP/2 client stopped");
         STOPPED.setStackTrace(new StackTraceElement[0]);
+        synchronized (this) {stopping = true;}
         do {
             connections.values().forEach(this::close);
         } while (!connections.isEmpty());

--- a/test/jdk/java/net/httpclient/http2/NoBodyTest.java
+++ b/test/jdk/java/net/httpclient/http2/NoBodyTest.java
@@ -26,7 +26,9 @@
  * @bug 8087112
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.httpclient.test.lib.http2.Http2TestServer
- * @run testng/othervm -Djdk.httpclient.HttpClient.log=ssl,requests,responses,errors NoBodyTest
+ * @run testng/othervm -Djdk.httpclient.HttpClient.log=ssl,requests,responses,errors
+ *                     -Djdk.internal.httpclient.debug=true
+ *                     NoBodyTest
  */
 
 import java.io.IOException;


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

Omitted copyrights as files already have younger ones.

Resolved two chunks in Http2Connection because later change
"8328286: Enhance HTTP client" was already backported.

In shutdown(Throwable) that change added line
        cause.compareAndSet(null, t);
messing up the context.
Also, it removed the line
        if (initialCause == null) this.cause = t;
this change intends to edit, so I omitted this edit.

In protocolError(int, String) "8328286: Enhance HTTP client" added some
code that needs to go into the if() added by this change.
Resolved. so that it is the same as in 21.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8301255](https://bugs.openjdk.org/browse/JDK-8301255) needs maintainer approval

### Issue
 * [JDK-8301255](https://bugs.openjdk.org/browse/JDK-8301255): Http2Connection may send too many GOAWAY frames (**Bug** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3686/head:pull/3686` \
`$ git checkout pull/3686`

Update a local copy of the PR: \
`$ git checkout pull/3686` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3686`

View PR using the GUI difftool: \
`$ git pr show -t 3686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3686.diff">https://git.openjdk.org/jdk17u-dev/pull/3686.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3686#issuecomment-3012614167)
</details>
