### PR TITLE
Goetz backport 8299338

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -209,24 +209,12 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
         }
 
         @Override
-        protected void onSubscribed() {
+        protected void register() {
             exchange.registerResponseSubscriber(this);
         }
 
         @Override
-        protected void complete(Throwable t) {
-            try {
-                exchange.unregisterResponseSubscriber(this);
-            } finally {
-                super.complete(t);
-            }
-        }
-
-        @Override
-        protected void onCancel() {
-            // If the subscription is cancelled the
-            // subscriber may or may not get completed.
-            // Therefore we need to unregister it
+        protected void unregister() {
             exchange.unregisterResponseSubscriber(this);
         }
     }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1Exchange.java
@@ -266,7 +266,7 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
     // The Http1ResponseBodySubscriber is registered with the HttpClient
     // to ensure that it gets completed if the SelectorManager aborts due
     // to unexpected exceptions.
-    private void registerResponseSubscriber(Http1ResponseBodySubscriber<T> subscriber) {
+    private boolean registerResponseSubscriber(Http1ResponseBodySubscriber<T> subscriber) {
         Throwable failed = null;
         synchronized (lock) {
             failed = this.failed;
@@ -276,13 +276,14 @@ class Http1Exchange<T> extends ExchangeImpl<T> {
         }
         if (failed != null) {
             subscriber.onError(failed);
+            return false;
         } else {
-            client.registerSubscriber(subscriber);
+            return client.registerSubscriber(subscriber);
         }
     }
 
-    private void unregisterResponseSubscriber(Http1ResponseBodySubscriber<T> subscriber) {
-        client.unregisterSubscriber(subscriber);
+    private boolean unregisterResponseSubscriber(Http1ResponseBodySubscriber<T> subscriber) {
+        return client.unregisterSubscriber(subscriber);
     }
 
     @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -542,7 +542,14 @@ final class HttpClientImpl extends HttpClient implements Trackable {
         client.subscribers.forEach(s -> s.onError(t));
     }
 
-    public void registerSubscriber(HttpBodySubscriberWrapper<?> subscriber) {
+    /**
+     * Adds the given subscriber to the subscribers list, or call
+     * its {@linkplain HttpBodySubscriberWrapper#onError onError}
+     * method if the client is shutting down.
+     * @param subscriber the subscriber
+     * @return true if the subscriber was added to the list.
+     */
+    public boolean registerSubscriber(HttpBodySubscriberWrapper<?> subscriber) {
         if (!selmgr.isClosed()) {
             synchronized (selmgr) {
                 if (!selmgr.isClosed()) {
@@ -552,20 +559,28 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                             debug.log("body subscriber registered: " + count);
                         }
                     }
-                    return;
+                    return true;
                 }
             }
         }
         subscriber.onError(selmgr.selectorClosedException());
+        return false;
     }
 
-    public void unregisterSubscriber(HttpBodySubscriberWrapper<?> subscriber) {
+    /**
+     * Remove the given subscriber from the subscribers list.
+     * @param subscriber the subscriber
+     * @return true if the subscriber was found and removed from the list.
+     */
+    public boolean unregisterSubscriber(HttpBodySubscriberWrapper<?> subscriber) {
         if (subscribers.remove(subscriber)) {
             long count = pendingSubscribersCount.decrementAndGet();
             if (debug.on()) {
                 debug.log("body subscriber unregistered: " + count);
             }
+            return true;
         }
+        return false;
     }
 
     private void closeConnection(HttpConnection conn) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -540,7 +540,7 @@ public class ResponseSubscribers {
         @Override
         public void onSubscribe(Flow.Subscription s) {
             Objects.requireNonNull(s);
-            if (debug.on()) debug.log("onSubscribed called");
+            if (debug.on()) debug.log("onSubscribe called");
             try {
                 if (!subscribed.compareAndSet(false, true)) {
                     if (debug.on()) debug.log("Already subscribed: canceling");
@@ -554,10 +554,12 @@ public class ResponseSubscribers {
                         closed = this.closed;
                         if (!closed) {
                             this.subscription = s;
-                            // should contain at least 2
-                            assert buffers.remainingCapacity() > 1
+                            // should contain at least 2, unless closed or failed.
+                            assert buffers.remainingCapacity() > 1 || failed != null
                                     : "buffers capacity: " + buffers.remainingCapacity()
-                                    + " closed: " + closed + " failed: " + failed;
+                                    + ", closed: " + closed + ", terminated: "
+                                    + buffers.contains(LAST_LIST)
+                                    + ", failed: " + failed;
                         }
                     }
                     if (closed) {
@@ -573,7 +575,7 @@ public class ResponseSubscribers {
             } catch (Throwable t) {
                 failed = t;
                 if (debug.on())
-                    debug.log("onSubscribed failed", t);
+                    debug.log("onSubscribe failed", t);
                 try {
                     close();
                 } catch (IOException x) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -1692,21 +1692,12 @@ class Stream<T> extends ExchangeImpl<T> {
         }
 
         @Override
-        protected void onSubscribed() {
+        protected void register() {
             registerResponseSubscriber(this);
         }
 
         @Override
-        protected void complete(Throwable t) {
-            try {
-                unregisterResponseSubscriber(this);
-            } finally {
-                super.complete(t);
-            }
-        }
-
-        @Override
-        protected void onCancel() {
+        protected void unregister() {
             unregisterResponseSubscriber(this);
         }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -352,12 +352,12 @@ class Stream<T> extends ExchangeImpl<T> {
     // The Http2StreamResponseSubscriber is registered with the HttpClient
     // to ensure that it gets completed if the SelectorManager aborts due
     // to unexpected exceptions.
-    private void registerResponseSubscriber(Http2StreamResponseSubscriber<?> subscriber) {
-        client().registerSubscriber(subscriber);
+    private boolean registerResponseSubscriber(Http2StreamResponseSubscriber<?> subscriber) {
+        return client().registerSubscriber(subscriber);
     }
 
-    private void unregisterResponseSubscriber(Http2StreamResponseSubscriber<?> subscriber) {
-        client().unregisterSubscriber(subscriber);
+    private boolean unregisterResponseSubscriber(Http2StreamResponseSubscriber<?> subscriber) {
+        return client().unregisterSubscriber(subscriber);
     }
 
     @Override

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
@@ -275,21 +275,6 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
     }
 
     /**
-     * Called right before the userSubscriber::onSubscribe is called.
-     * @apiNote
-     * This method may be used by subclasses to perform cleanup
-     * related actions after a subscription has been successfully
-     * accepted.
-     * This method is called while holding a subscription
-     * lock.
-     * @implSpec
-     * This method calls {@link #tryRegister()}
-     */
-    protected void onSubscribed() {
-        tryRegister();
-    }
-
-    /**
      * Complete the subscriber, either normally or exceptionally
      * ensure that the subscriber is completed only once.
      * @param t a throwable, or {@code null}
@@ -381,8 +366,8 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
         // subscription is finished before calling onError;
         subscriptionLock.lock();
         try {
+            tryRegister();
             if (markSubscribed()) {
-                onSubscribed();
                 SubscriptionWrapper wrapped = new SubscriptionWrapper(subscription);
                 userSubscriber.onSubscribe(this.subscription = wrapped);
             } else {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/HttpBodySubscriberWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,11 +58,16 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
         public void cancel() { }
     };
 
+    static final int SUBSCRIBED = 1;
+    static final int REGISTERED = 2;
+    static final int COMPLETED = 4;
+    static final int CANCELLED = 8;
+    static final int UNREGISTERED = 16;
+
     static final AtomicLong IDS = new AtomicLong();
     final long id = IDS.incrementAndGet();
     final BodySubscriber<T> userSubscriber;
-    final AtomicBoolean completed = new AtomicBoolean();
-    final AtomicBoolean subscribed = new AtomicBoolean();
+    private volatile int state;
     final ReentrantLock subscriptionLock = new ReentrantLock();
     volatile SubscriptionWrapper subscription;
     volatile Throwable withError;
@@ -83,12 +88,53 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
         @Override
         public void cancel() {
             try {
-                subscription.cancel();
-                onCancel();
+                try {
+                    subscription.cancel();
+                } finally {
+                    if (markCancelled()) {
+                        onCancel();
+                    }
+                }
             } catch (Throwable t) {
                 onError(t);
             }
         }
+    }
+
+    private final boolean markState(final int flag) {
+        int state = this.state;
+        if ((state & flag) == flag) {
+            return false;
+        }
+        synchronized (this) {
+            state = this.state;
+            if ((state & flag) == flag) {
+                return false;
+            }
+            state = this.state = (state | flag);
+        }
+        assert (state & flag) == flag;
+        return true;
+    }
+
+    private boolean markSubscribed() {
+        return markState(SUBSCRIBED);
+    }
+
+    private boolean markCancelled() {
+        return markState(CANCELLED);
+    }
+
+    private boolean markCompleted() {
+        return markState(COMPLETED);
+    }
+
+    private boolean markRegistered() {
+        return markState(REGISTERED);
+    }
+
+    private boolean markUnregistered() {
+        return markState(UNREGISTERED);
     }
 
     final long id() { return id; }
@@ -101,8 +147,9 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
     // propagate the error to the user subscriber, even if not
     // subscribed yet.
     private void propagateError(Throwable t) {
+        var state = this.state;
         assert t != null;
-        assert completed.get();
+        assert (state & COMPLETED) != 0;
         try {
             // if unsubscribed at this point, it will not
             // get subscribed later - so do it now and
@@ -111,7 +158,7 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
             // subscription is finished before calling onError;
             subscriptionLock.lock();
             try {
-                if (subscribed.compareAndSet(false, true)) {
+                if (markSubscribed()) {
                     userSubscriber.onSubscribe(NOP);
                 }
             } finally {
@@ -126,33 +173,138 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
     }
 
     /**
+     * This method attempts to mark the state of this
+     * object as registered, and then call the
+     * {@link #register()} method.
+     * <p>
+     * The state will be marked as registered, and the
+     * {@code register()} method will be called only
+     * if not already registered or unregistered,
+     * or cancelled, or completed.
+     *
+     * @return {@code true} if {@link #register()} was called,
+     * false otherwise.
+     */
+    protected final boolean tryRegister() {
+        subscriptionLock.lock();
+        try {
+            int state = this.state;
+            if ((state & (REGISTERED | UNREGISTERED | CANCELLED | COMPLETED)) != 0) return false;
+            if (markRegistered()) {
+                register();
+                return true;
+            }
+        } finally {
+            subscriptionLock.unlock();
+        }
+        return false;
+    }
+
+    /**
+     * This method attempts to mark the state of this
+     * object as unregistered, and then call the
+     * {@link #unregister()} method.
+     * <p>
+     * The {@code unregister()} method will be called only
+     * if already registered and not yet unregistered.
+     * Whether {@code unregister()} is called or not,
+     * the state is marked as unregistered, to prevent
+     * {@link #tryRegister()} from calling {@link #register()}
+     * after {@link #tryUnregister()} has been called.
+     *
+     * @return {@code true} if {@link #unregister()} was called,
+     * false otherwise.
+     */
+    protected final boolean tryUnregister() {
+        subscriptionLock.lock();
+        try {
+            int state = this.state;
+            if ((state & REGISTERED) == 0) {
+                markUnregistered();
+                return false;
+            }
+            if (markUnregistered()) {
+                unregister();
+                return true;
+            }
+        } finally {
+            subscriptionLock.unlock();
+        }
+        return false;
+    }
+
+    /**
+     * This method can be implemented by subclasses
+     * to perform registration actions. It will not be
+     * called if already registered or unregistered.
+     * @apiNote
+     * This method is called while holding a subscription
+     * lock.
+     * @see #tryRegister()
+     */
+    protected void register() {
+        assert subscriptionLock.isHeldByCurrentThread();
+    }
+
+    /**
+     * This method can be implemented by subclasses
+     * to perform unregistration actions. It will not be
+     * called if not already registered, or already unregistered.
+     * @apiNote
+     * This method is called while holding a subscription
+     * lock.
+     * @see #tryUnregister()
+     */
+    protected void unregister() {
+        assert subscriptionLock.isHeldByCurrentThread();
+    }
+
+    /**
      * Called when the subscriber cancels its subscription.
      * @apiNote
      * This method may be used by subclasses to perform cleanup
      * actions after a subscription has been cancelled.
+     * @implSpec
+     * This method calls {@link #tryUnregister()}
      */
-    protected void onCancel() { }
+    protected void onCancel() {
+        // If the subscription is cancelled the
+        // subscriber may or may not get completed.
+        // Therefore we need to unregister it
+        tryUnregister();
+    }
 
     /**
      * Called right before the userSubscriber::onSubscribe is called.
      * @apiNote
      * This method may be used by subclasses to perform cleanup
-     * related actions after a subscription has been succesfully
+     * related actions after a subscription has been successfully
      * accepted.
+     * This method is called while holding a subscription
+     * lock.
+     * @implSpec
+     * This method calls {@link #tryRegister()}
      */
-    protected void onSubscribed() { }
+    protected void onSubscribed() {
+        tryRegister();
+    }
 
     /**
      * Complete the subscriber, either normally or exceptionally
      * ensure that the subscriber is completed only once.
      * @param t a throwable, or {@code null}
+     * @implSpec
+     * If not {@linkplain #completed()} yet, this method
+     * calls {@link #tryUnregister()}
      */
-    protected void complete(Throwable t) {
-        if (completed.compareAndSet(false, true)) {
+    public final void complete(Throwable t) {
+        if (markCompleted()) {
+            tryUnregister();
             t  = withError = Utils.getCompletionCause(t);
             if (t == null) {
                 try {
-                    assert subscribed.get();
+                    var state = this.state;
+                    assert (state & SUBSCRIBED) != 0;
                     userSubscriber.onComplete();
                 } catch (Throwable x) {
                     // Simply propagate the error by calling
@@ -179,9 +331,44 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
      * {@return true if this subscriber has already completed, either normally
      * or abnormally}
      */
-    public boolean completed() {
-        return completed.get();
+    public final boolean completed() {
+        int state = this.state;
+        return (state & COMPLETED) != 0;
     }
+
+    /**
+     * {@return true if this subscriber has already subscribed}
+     */
+    public final boolean subscribed() {
+        int state = this.state;
+        return (state & SUBSCRIBED) != 0;
+    }
+
+    /**
+     * {@return true if this subscriber has already been registered}
+     */
+    public final boolean registered() {
+        int state = this.state;
+        return (state & REGISTERED) != 0;
+    }
+
+    /**
+     * {@return true if this subscriber has already been unregistered}
+     */
+    public final boolean unregistered() {
+        int state = this.state;
+        return (state & UNREGISTERED) != 0;
+    }
+
+    /**
+     * {@return true if this subscriber's subscription has already
+     * been cancelled}
+     */
+    public final boolean cancelled() {
+        int state = this.state;
+        return (state & CANCELLED) != 0;
+    }
+
 
     @Override
     public CompletionStage<T> getBody() {
@@ -194,7 +381,7 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
         // subscription is finished before calling onError;
         subscriptionLock.lock();
         try {
-            if (subscribed.compareAndSet(false, true)) {
+            if (markSubscribed()) {
                 onSubscribed();
                 SubscriptionWrapper wrapped = new SubscriptionWrapper(subscription);
                 userSubscriber.onSubscribe(this.subscription = wrapped);
@@ -208,8 +395,9 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
 
     @Override
     public void onNext(List<ByteBuffer> item) {
-        assert subscribed.get();
-        if (completed.get()) {
+        var state = this.state;
+        assert (state & SUBSCRIBED) != 0;
+        if ((state & COMPLETED) != 0) {
             SubscriptionWrapper subscription = this.subscription;
             if (subscription != null) {
                 subscription.subscription.cancel();
@@ -222,6 +410,7 @@ public class HttpBodySubscriberWrapper<T> implements TrustedSubscriber<T> {
     public void onError(Throwable throwable) {
         complete(throwable);
     }
+
     @Override
     public void onComplete() {
         complete(null);

--- a/test/jdk/java/net/httpclient/AsyncExecutorShutdown.java
+++ b/test/jdk/java/net/httpclient/AsyncExecutorShutdown.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8277969
+ * @bug 8277969 8299338
  * @summary Test for edge case where the executor is not accepting
  *          new tasks while the client is still running
  * @library /test/lib /test/jdk/java/net/httpclient/lib

--- a/test/jdk/java/net/httpclient/CancelRequestTest.java
+++ b/test/jdk/java/net/httpclient/CancelRequestTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8245462 8229822 8254786 8297075 8297149 8298340
+ * @bug 8245462 8229822 8254786 8297075 8297149 8298340 8302635
  * @summary Tests cancelling the request.
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @key randomness


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3691/head:pull/3691` \
`$ git checkout pull/3691`

Update a local copy of the PR: \
`$ git checkout pull/3691` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3691`

View PR using the GUI difftool: \
`$ git pr show -t 3691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3691.diff">https://git.openjdk.org/jdk17u-dev/pull/3691.diff</a>

</details>
