### PR TITLE
Backport 83b15da2eb3cb6c8937f517c9b75eaa9eeece314

### DIFF
--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -1136,6 +1136,7 @@ void TemplateTable::aastore() {
   // Get the value we will store
   __ ldr(r0, at_tos());
   // Now store using the appropriate barrier
+  // Clobbers: r10, r11, r3
   do_oop_store(_masm, element_address, r0, IS_ARRAY);
   __ b(done);
 
@@ -1144,6 +1145,7 @@ void TemplateTable::aastore() {
   __ profile_null_seen(r2);
 
   // Store a NULL
+  // Clobbers: r10, r11, r3
   do_oop_store(_masm, element_address, noreg, IS_ARRAY);
 
   // Pop stack arguments
@@ -2706,6 +2708,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
     __ pop(atos);
     if (!is_static) pop_and_check_object(obj);
     // Store into the field
+    // Clobbers: r10, r11, r3
     do_oop_store(_masm, field, r0, IN_HEAP);
     if (rc == may_rewrite) {
       patch_bytecode(Bytecodes::_fast_aputfield, bc, r1, true, byte_no);
@@ -2905,8 +2908,8 @@ void TemplateTable::fast_storefield(TosState state)
   // Must prevent reordering of the following cp cache loads with bytecode load
   __ membar(MacroAssembler::LoadLoad);
 
-  // test for volatile with r3
-  __ ldrw(r3, Address(r2, in_bytes(base +
+  // test for volatile with r5
+  __ ldrw(r5, Address(r2, in_bytes(base +
                                    ConstantPoolCacheEntry::flags_offset())));
 
   // replace index with field offset from cache entry
@@ -2914,7 +2917,7 @@ void TemplateTable::fast_storefield(TosState state)
 
   {
     Label notVolatile;
-    __ tbz(r3, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
+    __ tbz(r5, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
     __ membar(MacroAssembler::StoreStore | MacroAssembler::LoadStore);
     __ bind(notVolatile);
   }
@@ -2930,6 +2933,7 @@ void TemplateTable::fast_storefield(TosState state)
   // access field
   switch (bytecode()) {
   case Bytecodes::_fast_aputfield:
+    // Clobbers: r10, r11, r3
     do_oop_store(_masm, field, r0, IN_HEAP);
     break;
   case Bytecodes::_fast_lputfield:
@@ -2962,7 +2966,7 @@ void TemplateTable::fast_storefield(TosState state)
 
   {
     Label notVolatile;
-    __ tbz(r3, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
+    __ tbz(r5, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
     __ membar(MacroAssembler::StoreLoad | MacroAssembler::StoreStore);
     __ bind(notVolatile);
   }


### PR DESCRIPTION
Fixes AArch64 memory ordering problem. Readily manifests in new jcstress tests; there are sightings of related problems in JSR 133 tests. The patch is not clean, because [JDK-8301996](https://bugs.openjdk.org/browse/JDK-8301996) is in the way, and it is IMO too risky to backport. I resolved some hunks to match the intended behavior, after checking `do_oop_store` clobbers the same `r3` as in mainline.

Additional testing:
 - [x] Linux AArch64 server release, jcstress `RefDekker` test now passes
 - [x] Linux AArch64 server release, jcstress `seqcst.volatiles.ref` tests now pass
 - [x] Linux AArch64 server release, jcstress `all` tests now pass
 - [x] Linux AArch64 server fastdebug, `all`