### PR TITLE
8352946: SEGV_BND signal code of SIGSEGV missing from our signal-code table

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -42,6 +42,9 @@
 
 #include <signal.h>
 
+#if !defined(SEGV_BNDERR)
+#define SEGV_BNDERR 3
+#endif
 
 static const char* get_signal_name(int sig, char* out, size_t outlen);
 
@@ -914,6 +917,9 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
     { SIGFPE,  FPE_FLTSUB,   "FPE_FLTSUB",   "Subscript out of range." },
     { SIGSEGV, SEGV_MAPERR,  "SEGV_MAPERR",  "Address not mapped to object." },
     { SIGSEGV, SEGV_ACCERR,  "SEGV_ACCERR",  "Invalid permissions for mapped object." },
+#if defined(LINUX)
+    { SIGSEGV, SEGV_BNDERR,  "SEGV_BNDERR",  "Failed address bound checks." },
+#endif
 #if defined(AIX)
     // no explanation found what keyerr would be
     { SIGSEGV, SEGV_KEYERR,  "SEGV_KEYERR",  "key error" },


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352946](https://bugs.openjdk.org/browse/JDK-8352946) needs maintainer approval

### Issue
 * [JDK-8352946](https://bugs.openjdk.org/browse/JDK-8352946): SEGV_BND signal code of SIGSEGV missing from our signal-code table (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3699/head:pull/3699` \
`$ git checkout pull/3699`

Update a local copy of the PR: \
`$ git checkout pull/3699` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3699`

View PR using the GUI difftool: \
`$ git pr show -t 3699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3699.diff">https://git.openjdk.org/jdk17u-dev/pull/3699.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3699#issuecomment-3032362437)
</details>
