### PR TITLE
8297740: runtime/ClassUnload/UnloadTest.java failed with "Test failed: should still be live"

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -168,10 +168,12 @@ inline void ParCompactionManager::follow_class_loader(ClassLoaderData* cld) {
 
 inline void ParCompactionManager::follow_contents(oop obj) {
   assert(PSParallelCompact::mark_bitmap()->is_marked(obj), "should be marked");
+  PCIterateMarkAndPushClosure cl(this, PSParallelCompact::ref_processor());
+
   if (obj->is_objArray()) {
+    cl.do_klass(obj->klass());
     follow_array(objArrayOop(obj), 0);
   } else {
-    PCIterateMarkAndPushClosure cl(this, PSParallelCompact::ref_processor());
     obj->oop_iterate(&cl);
   }
 }

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
@@ -35,29 +35,33 @@
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
+import java.lang.reflect.Array;
+
 /**
- * Test that verifies that classes are unloaded when they are no longer reachable.
+ * Test that verifies that liveness of classes is correctly tracked.
  *
- * The test creates a class loader, uses the loader to load a class and creates an instance
- * of that class. The it nulls out all the references to the instance, class and class loader
- * and tries to trigger class unloading. Then it verifies that the class is no longer
- * loaded by the VM.
+ * The test creates a class loader, uses the loader to load a class and creates
+ * an instance related to that class.
+ * 1. Then, it nulls out references to the class loader, triggers class
+ *    unloading and verifies the class is *not* unloaded.
+ * 2. Next, it nulls out references to the instance, triggers class unloading
+ *    and verifies the class is unloaded.
  */
 public class UnloadTest {
-    private static String className = "test.Empty";
 
     public static void main(String... args) throws Exception {
-       run();
+       test_unload_instance_klass();
+       test_unload_obj_array_klass();
     }
 
-    private static void run() throws Exception {
+    private static void test_unload_instance_klass() throws Exception {
+        final String className = "test.Empty";
         final WhiteBox wb = WhiteBox.getWhiteBox();
 
         ClassUnloadCommon.failIf(wb.isClassAlive(className), "is not expected to be alive yet");
 
         ClassLoader cl = ClassUnloadCommon.newClassLoader();
-        Class<?> c = cl.loadClass(className);
-        Object o = c.newInstance();
+        Object o = cl.loadClass(className).newInstance();
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
 
@@ -65,8 +69,42 @@ public class UnloadTest {
         int loadedRefcount = wb.getSymbolRefcount(loaderName);
         System.out.println("Refcount of symbol " + loaderName + " is " + loadedRefcount);
 
-        cl = null; c = null; o = null;
+        cl = null;
         ClassUnloadCommon.triggerUnloading();
+
+        ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
+
+        o = null;
+        ClassUnloadCommon.triggerUnloading();
+
+
+        ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
+
+        int unloadedRefcount = wb.getSymbolRefcount(loaderName);
+        System.out.println("Refcount of symbol " + loaderName + " is " + unloadedRefcount);
+        ClassUnloadCommon.failIf(unloadedRefcount != (loadedRefcount - 1), "Refcount must be decremented");
+    }
+
+    private static void test_unload_obj_array_klass() throws Exception {
+        final WhiteBox wb = WhiteBox.getWhiteBox();
+
+        ClassLoader cl = ClassUnloadCommon.newClassLoader();
+        Object o = Array.newInstance(cl.loadClass("test.Empty"), 1);
+        final String className = o.getClass().getName();
+
+        ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
+
+        String loaderName = cl.getName();
+        int loadedRefcount = wb.getSymbolRefcount(loaderName);
+        System.out.println("Refcount of symbol " + loaderName + " is " + loadedRefcount);
+
+        cl = null;
+        ClassUnloadCommon.triggerUnloading();
+        ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should still be live");
+
+        o = null;
+        ClassUnloadCommon.triggerUnloading();
+
         ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
 
         int unloadedRefcount = wb.getSymbolRefcount(loaderName);

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test UnloadTest
- * @bug 8210559
+ * @bug 8210559 8297740
  * @requires vm.opt.final.ClassUnloading
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
@@ -48,6 +48,8 @@ import java.lang.reflect.Array;
  *    and verifies the class is unloaded.
  */
 public class UnloadTest {
+    // Using a global static field to keep the object live in -Xcomp mode.
+    private static Object o;
 
     public static void main(String... args) throws Exception {
        test_unload_instance_klass();
@@ -61,7 +63,7 @@ public class UnloadTest {
         ClassUnloadCommon.failIf(wb.isClassAlive(className), "is not expected to be alive yet");
 
         ClassLoader cl = ClassUnloadCommon.newClassLoader();
-        Object o = cl.loadClass(className).newInstance();
+        o = cl.loadClass(className).newInstance();
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");
 
@@ -89,7 +91,7 @@ public class UnloadTest {
         final WhiteBox wb = WhiteBox.getWhiteBox();
 
         ClassLoader cl = ClassUnloadCommon.newClassLoader();
-        Object o = Array.newInstance(cl.loadClass("test.Empty"), 1);
+        o = Array.newInstance(cl.loadClass("test.Empty"), 1);
         final String className = o.getClass().getName();
 
         ClassUnloadCommon.failIf(!wb.isClassAlive(className), "should be live here");


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297740](https://bugs.openjdk.org/browse/JDK-8297740) needs maintainer approval

### Issue
 * [JDK-8297740](https://bugs.openjdk.org/browse/JDK-8297740): runtime/ClassUnload/UnloadTest.java failed with "Test failed: should still be live" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3702/head:pull/3702` \
`$ git checkout pull/3702`

Update a local copy of the PR: \
`$ git checkout pull/3702` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3702`

View PR using the GUI difftool: \
`$ git pr show -t 3702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3702.diff">https://git.openjdk.org/jdk17u-dev/pull/3702.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3702#issuecomment-3032513786)
</details>
