### PR TITLE
8330535: Update nsk/jdb tests to use driver instead of othervm

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/caught_exception/caught_exception002/caught_exception002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.caught_exception.caught_exception002.caught_exception002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.caught_exception.caught_exception002.caught_exception002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -69,14 +69,10 @@ import java.util.*;
 public class caught_exception002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new caught_exception002().runTest(argv, out);
+        new caught_exception002().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.caught_exception.caught_exception002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classes/classes001/classes001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.classes.classes001.classes001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.classes.classes001.classes001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -60,14 +60,10 @@ import java.util.*;
 public class classes001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new classes001().runTest(argv, out);
+        new classes001().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.classes.classes001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/classpath/classpath001/classpath001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.classpath.classpath001.classpath001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.classpath.classpath001.classpath001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -59,14 +59,10 @@ import java.util.*;
 public class classpath001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new classpath001().runTest(argv, out);
+        new classpath001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.classpath.classpath001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear002/clear002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.clear.clear002.clear002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.clear.clear002.clear002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -61,14 +61,10 @@ import java.util.*;
 public class clear002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new clear002().runTest(argv, out);
+        new clear002().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.clear.clear002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear003/clear003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.clear.clear003.clear003a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.clear.clear003.clear003
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -62,14 +62,10 @@ import java.util.*;
 public class clear003 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new clear003().runTest(argv, out);
+        new clear003().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.clear.clear003";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/clear/clear004/clear004.java
@@ -40,7 +40,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.clear.clear004.clear004a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.clear.clear004.clear004
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -63,14 +63,10 @@ import java.util.*;
 public class clear004 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new clear004().runTest(argv, out);
+        new clear004().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.clear.clear004";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/down/down002/down002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.down.down002.down002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.down.down002.down002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -66,14 +66,10 @@ import java.util.*;
 public class down002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new down002().runTest(argv, out);
+        new down002().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.down.down002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/dump/dump002/dump002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.dump.dump002.dump002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.dump.dump002.dump002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -70,15 +70,11 @@ import java.util.*;
 public class dump002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
-        return new dump002().runTest(argv, out);
+        new dump002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.dump.dump002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/eval/eval001/eval001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@
  * @clean nsk.jdb.eval.eval001.eval001a
  * @compile -g:lines,source,vars eval001a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.eval.eval001.eval001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -75,14 +75,10 @@ import java.util.*;
 public class eval001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new eval001().runTest(argv, out);
+        new eval001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.eval.eval001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/exclude/exclude001/exclude001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.exclude.exclude001.exclude001a
- * @run main/othervm/timeout=600
+ * @run driver/timeout=600
  *      nsk.jdb.exclude.exclude001.exclude001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=10
@@ -82,14 +82,10 @@ import java.util.*;
 public class exclude001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new exclude001().runTest(argv, out);
+        new exclude001().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.exclude.exclude001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/fields/fields001/fields001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.fields.fields001.fields001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.fields.fields001.fields001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -64,14 +64,10 @@ import java.util.*;
 public class fields001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new fields001().runTest(argv, out);
+        new fields001().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.fields.fields001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/hidden_class/hc001/hc001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          jdk.jdwp.agent
  * @build nsk.jdb.hidden_class.hc001.hc001a
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.hidden_class.hc001.hc001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -60,13 +60,9 @@ public class hc001 extends JdbTest {
     static final int    MAX_SLEEP_CNT     = 3;
 
     public static void main(String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass = DEBUGGEE_CLASS; // needed for JdbTest.runTest
         firstBreak = MAIN_METHOD_NAME;  // needed for JdbTest.runTest
-        return new hc001().runTest(argv, out);
+        new hc001().runTest(argv);
     }
 
     static boolean checkPattern(String[] arr, String pattern) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/ignore/ignore001/ignore001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.ignore.ignore001.ignore001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.ignore.ignore001.ignore001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -63,14 +63,10 @@ import java.util.*;
 public class ignore001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new ignore001().runTest(argv, out);
+        new ignore001().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.ignore.ignore001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/interrupt/interrupt001/interrupt001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.interrupt.interrupt001.interrupt001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.interrupt.interrupt001.interrupt001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -73,13 +73,9 @@ import java.util.stream.Collectors;
 public class interrupt001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
-        return new interrupt001().runTest(argv, out);
+        new interrupt001().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.interrupt.interrupt001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.kill.kill001.kill001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.kill.kill001.kill001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -70,13 +70,9 @@ import java.util.*;
 public class kill001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
-        return new kill001().runTest(argv, out);
+        new kill001().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.kill.kill001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill002/kill002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.kill.kill002.kill002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.kill.kill002.kill002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -66,13 +66,9 @@ import java.util.*;
 public class kill002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
-        return new kill002().runTest(argv, out);
+        new kill002().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.kill.kill002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/klass/class001/class001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.klass.class001.class001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.klass.class001.class001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -63,14 +63,10 @@ import java.util.*;
 public class class001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new class001().runTest(argv, out);
+        new class001().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.klass.class001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list002/list002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  *          /test/lib
  * @build nsk.jdb.list.list002.list002a
  * @run driver jdk.test.lib.FileInstaller list002a.java src/nsk/jdb/list/list002/list002a.java
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.list.list002.list002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -68,14 +68,10 @@ import java.util.*;
 public class list002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new list002().runTest(argv, out);
+        new list002().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.list.list002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/locals/locals002/locals002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@
  * @clean nsk.jdb.locals.locals002.locals002a
  * @compile -g:lines,source,vars locals002a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.locals.locals002.locals002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -75,15 +75,11 @@ import java.util.*;
 public class locals002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
-        return new locals002().runTest(argv, out);
+        new locals002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.locals.locals002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/methods/methods002/methods002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.methods.methods002.methods002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.methods.methods002.methods002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -73,14 +73,10 @@ import java.util.*;
 public class methods002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new methods002().runTest(argv, out);
+        new methods002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.methods.methods002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.monitor.monitor001.monitor001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.monitor.monitor001.monitor001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -69,14 +69,10 @@ import java.util.*;
 public class monitor001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new monitor001().runTest(argv, out);
+        new monitor001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.monitor.monitor001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor002/monitor002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.monitor.monitor002.monitor002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.monitor.monitor002.monitor002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -65,14 +65,10 @@ import java.util.*;
 public class monitor002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new monitor002().runTest(argv, out);
+        new monitor002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.monitor.monitor002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/next/next001/next001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.next.next001.next001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.next.next001.next001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -69,14 +69,10 @@ import java.util.*;
 public class next001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new next001().runTest(argv, out);
+        new next001().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.next.next001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect001/connect001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.options.connect.connect001.connect001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.options.connect.connect001.connect001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -71,14 +71,10 @@ import java.util.*;
 public class connect001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new connect001().runTest(argv, out);
+        new connect001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect002/connect002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.options.connect.connect002.connect002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.options.connect.connect002.connect002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -71,14 +71,10 @@ import java.util.*;
 public class connect002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new connect002().runTest(argv, out);
+        new connect002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect003/connect003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.options.connect.connect003.connect003a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.options.connect.connect003.connect003
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -71,14 +71,10 @@ import java.util.*;
 public class connect003 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new connect003().runTest(argv, out);
+        new connect003().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect003";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect004/connect004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.options.connect.connect004.connect004a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.options.connect.connect004.connect004
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -71,14 +71,10 @@ import java.util.*;
 public class connect004 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new connect004().runTest(argv, out);
+        new connect004().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect004";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/connect/connect005/connect005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.options.connect.connect005.connect005a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.options.connect.connect005.connect005
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -70,15 +70,10 @@ import java.util.*;
 
 public class connect005 extends JdbTest {
 
-    public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
-        debuggeeClass =  DEBUGGEE_CLASS;
+    public static void main (String argv[]) {    debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new connect005().runTest(argv, out);
+        new connect005().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.options.connect.connect005";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/options/listconnectors/listconnectors001/listconnectors001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.options.listconnectors.listconnectors001.listconnectors001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -75,14 +75,10 @@ import java.util.*;
 public class listconnectors001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new listconnectors001().runTest(argv, out);
+        new listconnectors001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.options.connect";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop/pop001/pop001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.pop.pop001.pop001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.pop.pop001.pop001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -70,14 +70,10 @@ import java.util.*;
 public class pop001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new pop001().runTest(argv, out);
+        new pop001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.pop.pop001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/pop_exception/pop_exception001/pop_exception001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.pop_exception.pop_exception001.pop_exception001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.pop_exception.pop_exception001.pop_exception001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -63,14 +63,10 @@ public class pop_exception001 extends JdbTest {
     static final String LAST_BREAK      = DEBUGGEE_CLASS + ".lastBreak";
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new pop_exception001().runTest(argv, out);
+        new pop_exception001().runTest(argv);
     }
 
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/print/print002/print002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@
  * @clean nsk.jdb.print.print002.print002a
  * @compile -g:lines,source,vars print002a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.print.print002.print002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -75,14 +75,10 @@ import java.util.*;
 public class print002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new print002().runTest(argv, out);
+        new print002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.print.print002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/read/read001/read001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@
  * @clean nsk.jdb.read.read001.read001a
  * @compile -g:lines,source,vars read001a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.read.read001.read001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -76,14 +76,10 @@ import java.util.*;
 public class read001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new read001().runTest(argv, out);
+        new read001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.read.read001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/redefine/redefine001/redefine001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@
  *      -cp ${test.class.path}
  *      ${test.src}/newclass_g/RedefinedClass.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.redefine.redefine001.redefine001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -80,14 +80,10 @@ import java.util.*;
 public class redefine001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new redefine001().runTest(argv, out);
+        new redefine001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.redefine.redefine001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/reenter/reenter001/reenter001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.reenter.reenter001.reenter001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.reenter.reenter001.reenter001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -69,14 +69,10 @@ import java.util.*;
 public class reenter001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new reenter001().runTest(argv, out);
+        new reenter001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.reenter.reenter001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/regression/b4689395/b4689395.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@
  *      -cp ${test.class.path}
  *      ${test.src}/newclass/b4689395a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.regression.b4689395.b4689395
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -131,13 +131,9 @@ public class b4689395 extends JdbTest {
         private String classFile;
 
         public static void main (String argv[]) {
-                System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-        }
-
-        public static int run(String argv[], PrintStream out) {
                 debuggeeClass =  DEBUGGEE_CLASS;
                 firstBreak = FIRST_BREAK;
-                return new b4689395().runTest(argv, out);
+                new b4689395().runTest(argv);
         }
 
         public b4689395() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.resume.resume002.resume002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.resume.resume002.resume002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -73,14 +73,10 @@ import java.util.*;
 public class resume002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new resume002().runTest(argv, out);
+        new resume002().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.resume.resume002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/run/run002/run002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.run.run002.run002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.run.run002.run002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -67,14 +67,10 @@ import java.util.*;
 public class run002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new run002().runTest(argv, out);
+        new run002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.run.run002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set001/set001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@
  * @clean nsk.jdb.set.set001.set001a
  * @compile -g:lines,source,vars set001a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.set.set001.set001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -76,14 +76,10 @@ import java.util.*;
 public class set001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new set001().runTest(argv, out);
+        new set001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.set.set001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/set/set002/set002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@
  * @clean nsk.jdb.set.set002.set002a
  * @compile -g:lines,source,vars set002a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.set.set002.set002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -76,15 +76,11 @@ import java.util.*;
 public class set002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
 
-        return new set002().runTest(argv, out);
+        new set002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.set.set002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step/step002/step002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@
  * @clean nsk.jdb.step.step002.step002a
  * @compile -g:lines,source,vars step002a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.step.step002.step002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -79,14 +79,10 @@ import java.util.*;
 public class step002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new step002().runTest(argv, out);
+        new step002().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.step.step002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/step_up/step_up001/step_up001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.step_up.step_up001.step_up001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.step_up.step_up001.step_up001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -68,14 +68,10 @@ import java.util.*;
 public class step_up001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new step_up001().runTest(argv, out);
+        new step_up001().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.step_up.step_up001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at002/stop_at002.java
@@ -37,7 +37,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.stop_at.stop_at002.stop_at002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.stop_at.stop_at002.stop_at002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -67,14 +67,10 @@ import java.util.*;
 public class stop_at002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new stop_at002().runTest(argv, out);
+        new stop_at002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.stop_at.stop_at002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_at/stop_at003/stop_at003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.stop_at.stop_at003.stop_at003a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.stop_at.stop_at003.stop_at003
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -79,14 +79,10 @@ import java.util.*;
 public class stop_at003 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new stop_at003().runTest(argv, out);
+        new stop_at003().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.stop_at.stop_at003";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/stop_in/stop_in002/stop_in002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.stop_in.stop_in002.stop_in002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.stop_in.stop_in002.stop_in002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -80,14 +80,10 @@ import java.util.*;
 public class stop_in002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new stop_in002().runTest(argv, out);
+        new stop_in002().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.stop_in.stop_in002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/suspend/suspend001/suspend001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.suspend.suspend001.suspend001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.suspend.suspend001.suspend001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -69,14 +69,10 @@ import java.util.*;
 public class suspend001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new suspend001().runTest(argv, out);
+        new suspend001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.suspend.suspend001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/thread/thread002/thread002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.thread.thread002.thread002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.thread.thread002.thread002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -66,14 +66,10 @@ import java.util.*;
 public class thread002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new thread002().runTest(argv, out);
+        new thread002().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.thread.thread002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.threadgroup.threadgroup002.threadgroup002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.threadgroup.threadgroup002.threadgroup002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -64,14 +64,10 @@ import java.util.*;
 public class threadgroup002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new threadgroup002().runTest(argv, out);
+        new threadgroup002().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.threadgroup.threadgroup002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroups/threadgroups002/threadgroups002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.threadgroups.threadgroups002.threadgroups002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.threadgroups.threadgroups002.threadgroups002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -64,14 +64,10 @@ import java.util.*;
 public class threadgroups002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new threadgroups002().runTest(argv, out);
+        new threadgroups002().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.threadgroups.threadgroups002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.threads.threads002.threads002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.threads.threads002.threads002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -63,14 +63,10 @@ import java.util.*;
 public class threads002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new threads002().runTest(argv, out);
+        new threads002().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.threads.threads002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.trace.trace001.trace001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.trace.trace001.trace001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -70,14 +70,10 @@ import java.util.*;
 public class trace001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new trace001().runTest(argv, out);
+        new trace001().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.trace.trace001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/uncaught_exception/uncaught_exception002/uncaught_exception002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@
  * @clean nsk.jdb.uncaught_exception.uncaught_exception002.uncaught_exception002a
  * @compile -g:lines,source,vars uncaught_exception002a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.uncaught_exception.uncaught_exception002.uncaught_exception002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -75,14 +75,10 @@ import java.util.*;
 public class uncaught_exception002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new uncaught_exception002(true).runTest(argv, out);
+        new uncaught_exception002(true).runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.uncaught_exception.uncaught_exception002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@
  * @clean nsk.jdb.unmonitor.unmonitor001.unmonitor001a
  * @compile -g:lines,source,vars unmonitor001a.java
  *
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.unmonitor.unmonitor001.unmonitor001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -79,14 +79,10 @@ import java.util.*;
 public class unmonitor001 extends JdbTest {
 
     public static void main (String argv[])  {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new unmonitor001().runTest(argv, out);
+        new unmonitor001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.unmonitor.unmonitor001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/untrace/untrace001/untrace001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.untrace.untrace001.untrace001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.untrace.untrace001.untrace001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -77,14 +77,10 @@ import java.util.*;
 public class untrace001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new untrace001().runTest(argv, out);
+        new untrace001().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.untrace.untrace001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch001/unwatch001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.unwatch.unwatch001.unwatch001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.unwatch.unwatch001.unwatch001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -73,14 +73,10 @@ import java.util.*;
 public class unwatch001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new unwatch001().runTest(argv, out);
+        new unwatch001().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.unwatch.unwatch001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unwatch/unwatch002/unwatch002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.unwatch.unwatch002.unwatch002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.unwatch.unwatch002.unwatch002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -74,14 +74,10 @@ import java.util.*;
 public class unwatch002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new unwatch002().runTest(argv, out);
+        new unwatch002().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.unwatch.unwatch002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/up/up002/up002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.up.up002.up002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.up.up002.up002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -66,14 +66,10 @@ import java.util.*;
 public class up002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new up002().runTest(argv, out);
+        new up002().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.up.up002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/use/use001/use001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.use.use001.use001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.use.use001.use001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -67,14 +67,10 @@ import java.util.*;
 public class use001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new use001().runTest(argv, out);
+        new use001().runTest(argv);
     }
 
     static final String PACKAGE_NAME = "nsk.jdb.use.use001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch001/watch001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.watch.watch001.watch001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.watch.watch001.watch001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -71,15 +71,11 @@ import java.util.*;
 public class watch001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
-        return new watch001().runTest(argv, out);
+        new watch001().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.watch.watch001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/watch/watch002/watch002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.watch.watch002.watch002a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.watch.watch002.watch002
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -71,15 +71,11 @@ import java.util.*;
 public class watch002 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
         compoundPromptIdent = COMPOUND_PROMPT_IDENT;
-        return new watch002().runTest(argv, out);
+        new watch002().runTest(argv);
     }
 
     static final String PACKAGE_NAME       = "nsk.jdb.watch.watch002";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where004/where004.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.where.where004.where004a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.where.where004.where004
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -64,14 +64,10 @@ import java.util.*;
 public class where004 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new where004().runTest(argv, out);
+        new where004().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.where.where004";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where005/where005.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.where.where005.where005a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.where.where005.where005
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -65,14 +65,10 @@ import java.util.*;
 public class where005 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new where005(true).runTest(argv, out);
+        new where005(true).runTest(argv);
     }
 
     public where005 (boolean debuggeeShouldFail) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/where/where006/where006.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.where.where006.where006a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.where.where006.where006
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -65,14 +65,10 @@ import java.util.*;
 public class where006 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new where006().runTest(argv, out);
+        new where006().runTest(argv);
     }
 
     static final String PACKAGE_NAME     = "nsk.jdb.where.where006";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/wherei/wherei001/wherei001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  * @library /vmTestbase
  *          /test/lib
  * @build nsk.jdb.wherei.wherei001.wherei001a
- * @run main/othervm
+ * @run driver
  *      nsk.jdb.wherei.wherei001.wherei001
  *      -arch=${os.family}-${os.simpleArch}
  *      -waittime=5
@@ -60,14 +60,10 @@ import java.util.*;
 public class wherei001 extends JdbTest {
 
     public static void main (String argv[]) {
-        System.exit(run(argv, System.out) + JCK_STATUS_BASE);
-    }
-
-    public static int run(String argv[], PrintStream out) {
         debuggeeClass =  DEBUGGEE_CLASS;
         firstBreak = FIRST_BREAK;
         lastBreak = LAST_BREAK;
-        return new wherei001().runTest(argv, out);
+        new wherei001().runTest(argv);
     }
 
     static final String PACKAGE_NAME    = "nsk.jdb.wherei.wherei001";

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
@@ -127,14 +127,15 @@ public abstract class JdbTest {
     protected void afterJdbExit() {
     }
 
-    protected int runTest(String argv[], PrintStream out) {
+    protected void runTest(String argv[]) {
+        PrintStream out = System.out;
         try {
             argumentHandler = new JdbArgumentHandler(argv);
             log = new Log(out, argumentHandler);
 
             if (shouldPass()) {
                 log.println("TEST PASSED");
-                return PASSED;
+                return;
             }
 
             try {
@@ -223,16 +224,14 @@ public abstract class JdbTest {
 
             if (!success) {
                 log.complain("TEST FAILED");
-                return FAILED;
+                throw new RuntimeException("TEST FAILED");
             }
 
         } catch (Exception e) {
             out.println("Caught unexpected exception while starting the test: " + e);
             e.printStackTrace(out);
-            out.println("TEST FAILED");
-            return FAILED;
+            throw new RuntimeException("TEST FAILED", e);
         }
         out.println("TEST PASSED");
-        return PASSED;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
@@ -171,10 +171,12 @@ public class Launcher extends DebugeeBinder {
             } else /* LaunchingConnector or DefaultConnector */ {
 
                 connect.append("vmexec=" + argumentHandler.getLaunchExecName().trim());
+                connect.append(",options=");
+                connect.append(" \"-cp\"");
+                connect.append(" \"" + System.getProperty("test.class.path") + "\"");
+
                 String debuggeeOpts = argumentHandler.getDebuggeeOptions();
                 if (debuggeeOpts.trim().length() > 0) {
-                    //connect.append(",options=" + debuggeeOpts.trim());
-                    connect.append(",options=");
                     for (String arg : debuggeeOpts.split("\\s+")) {
                        connect.append(" \"");
                        connect.append(arg);


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

Three adapted tests are not in 17.
Others don't apply clean because mostly the copyright was changed
in 21.  Only JdbTest needed a trivial resolve of code.


test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001.java
Resolved Copyright. 21 has several virtual thread changes.

test/hotspot/jtreg/vmTestbase/nsk/jdb/list/list003/list003.java
Added by new feature "8271356: Modify jdb to treat an empty command as a repeat of the previous command". Skipped.

test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
Resolved Copyright. 21 has a virtual thread change.

test/hotspot/jtreg/vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java
Added by new feature "8271356: Modify jdb to treat an empty command as a repeat of the previous command". Skipped.

test/hotspot/jtreg/vmTestbase/nsk/jdb/resume/resume002/resume002.java
Resolved Copyright because "8284191: Replace usages of 'a the' in hotspot and java.base" is not in 17.

test/hotspot/jtreg/vmTestbase/nsk/jdb/threadgroup/threadgroup002/threadgroup002.java
Resolved Copyright because new feature "8282641: Make jdb "threadgroup" command with no args reset the current threadgroup back to the default" was added in 19.

test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads002/threads002.java
Resolved Copyright because 21 has virtual thread changes.

test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
Was added by virtual threads change. Skipped.

test/hotspot/jtreg/vmTestbase/nsk/jdb/trace/trace001/trace001.java
Resolved Copyright because 21 has virtual thread changes.

test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
Resolved Copyright because 21 has virtual thread changes.

test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
Resolved one chunk due to context because 21 has changes as "8332641: Update nsk.share.jpda.Jdb to don't use finalization"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8330535](https://bugs.openjdk.org/browse/JDK-8330535) needs maintainer approval

### Issue
 * [JDK-8330535](https://bugs.openjdk.org/browse/JDK-8330535): Update nsk/jdb tests to use driver instead of othervm (**Sub-task** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3709/head:pull/3709` \
`$ git checkout pull/3709`

Update a local copy of the PR: \
`$ git checkout pull/3709` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3709`

View PR using the GUI difftool: \
`$ git pr show -t 3709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3709.diff">https://git.openjdk.org/jdk17u-dev/pull/3709.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3709#issuecomment-3044514342)
</details>
