### PR TITLE
Backport 88fa3b2fe9bccf9cd4a4041732e2f6d425c19244

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/ResourceExhausted/resexhausted003/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,10 +39,7 @@
  *          /test/lib
  * @run main/othervm/native
  *      -agentlib:resexhausted=-waittime=5
- *      -Xms64m
- *      -Xmx64m
- *      -XX:MaxMetaspaceSize=9m
- *      -XX:-UseGCOverheadLimit
+ *      -XX:MaxMetaspaceSize=20m
  *      nsk.jvmti.ResourceExhausted.resexhausted003
  */
 


### PR DESCRIPTION
I backport this for parity with 21.0.9-oracle.