### PR TITLE
8352509: Update jdk.test.lib.SecurityTools jar method to accept List<String> parameter

### DIFF
--- a/test/lib/jdk/test/lib/SecurityTools.java
+++ b/test/lib/jdk/test/lib/SecurityTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,13 +241,36 @@ public class SecurityTools {
     /**
      * Runs jar.
      *
+     * @param args arguments to jar in the list.
+     * @return an {@link OutputAnalyzer} object
+     * @throws Exception if there is an error
+     */
+    public static OutputAnalyzer jar(final List<String> args) throws Exception {
+        return execute(getProcessBuilder("jar", args));
+    }
+
+    /**
+     * Runs jar.
+     *
      * @param args arguments to jar in a single string. The string is
      *             converted to be List with makeList.
      * @return an {@link OutputAnalyzer} object
      * @throws Exception if there is an error
      */
-    public static OutputAnalyzer jar(String args) throws Exception {
-        return execute(getProcessBuilder("jar", makeList(args)));
+    public static OutputAnalyzer jar(final String args) throws Exception {
+        return  jar(makeList(args));
+    }
+
+    /**
+     * Runs jar.
+     *
+     * @param args arguments to jar in multiple strings.
+     *             Converted to be a List with List.of.
+     * @return an {@link OutputAnalyzer} object
+     * @throws Exception if there is an error
+     */
+    public static OutputAnalyzer jar(final String... args) throws Exception {
+        return jar(List.of(args));
     }
 
     /**


### PR DESCRIPTION
backport this for parity with 17.0.17-oracle,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352509](https://bugs.openjdk.org/browse/JDK-8352509) needs maintainer approval

### Issue
 * [JDK-8352509](https://bugs.openjdk.org/browse/JDK-8352509): Update jdk.test.lib.SecurityTools jar method to accept List&lt;String&gt; parameter (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3716/head:pull/3716` \
`$ git checkout pull/3716`

Update a local copy of the PR: \
`$ git checkout pull/3716` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3716`

View PR using the GUI difftool: \
`$ git pr show -t 3716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3716.diff">https://git.openjdk.org/jdk17u-dev/pull/3716.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3716#issuecomment-3045464659)
</details>
