### PR TITLE
Backport b7ca76ef4bfc640668492e655acc6d755411a92f

### DIFF
--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
@@ -26,6 +26,7 @@ package jdk.jfr.api.metadata.annotations;
 import jdk.jfr.Event;
 import jdk.jfr.EventType;
 import jdk.jfr.Period;
+import jdk.jfr.FlightRecorder;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.Events;
 
@@ -44,6 +45,7 @@ public class TestPeriod {
 
     public static void main(String[] args) throws Exception {
         EventType periodicEvent = EventType.getEventType(PeriodicEvent.class);
+        FlightRecorder.addPeriodicEvent(PeriodicEvent.class, () -> {});
         String defaultValue = Events.getSetting(periodicEvent, Period.NAME).getDefaultValue();
         Asserts.assertEQ(defaultValue, "47 s", "Incorrect default value for period");
     }


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.