### PR TITLE
Backport 2c4e8d211a030c85488e656a9a851d10dd0f9c11

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -1,5 +1,11 @@
 /*
+<<<<<<< HEAD
  * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
+=======
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
+>>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +43,16 @@ import java.util.Arrays;
 import sun.nio.cs.UTF_8;
 
 /**
+<<<<<<< HEAD
  * Utility class for zipfile name and comment decoding and encoding
+||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
+ * Utility class for ZIP file entry name and comment decoding and encoding
+=======
+ * Utility class for ZIP file entry name and comment decoding and encoding.
+ * <p>
+ * The {@code ZipCoder} for UTF-8 charset is thread safe, {@code ZipCoder}
+ * for other charsets require external synchronization.
+>>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
  */
 class ZipCoder {
 
@@ -155,6 +170,13 @@ class ZipCoder {
               .onUnmappableCharacter(CodingErrorAction.REPORT);
         }
         return dec;
+    }
+
+    /**
+     * {@return the {@link Charset} used by this {@code ZipCoder}}
+     */
+    final Charset charset() {
+        return this.cs;
     }
 
     private CharsetEncoder encoder() {

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -1,11 +1,5 @@
 /*
-<<<<<<< HEAD
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
- * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
-=======
  * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,16 +37,10 @@ import java.util.Arrays;
 import sun.nio.cs.UTF_8;
 
 /**
-<<<<<<< HEAD
- * Utility class for zipfile name and comment decoding and encoding
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
- * Utility class for ZIP file entry name and comment decoding and encoding
-=======
  * Utility class for ZIP file entry name and comment decoding and encoding.
  * <p>
  * The {@code ZipCoder} for UTF-8 charset is thread safe, {@code ZipCoder}
  * for other charsets require external synchronization.
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
  */
 class ZipCoder {
 

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1,11 +1,5 @@
 /*
-<<<<<<< HEAD
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
-=======
  * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,17 +95,9 @@ import static java.util.zip.ZipUtils.*;
  */
 public class ZipFile implements ZipConstants, Closeable {
 
-<<<<<<< HEAD
     private final String name;     // zip file name
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-    private final String filePath;     // ZIP file path
-    private final String fileName;     // name of the file
-=======
-    private final String filePath;     // ZIP file path
-    private final String fileName;     // name of the file
     // Used when decoding entry names and comments
     private final ZipCoder zipCoder;
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
     private volatile boolean closeRequested;
 
     // The "resource" used by this zip file that needs to be
@@ -336,25 +322,7 @@ public class ZipFile implements ZipConstants, Closeable {
             if (res.zsrc.comment == null) {
                 return null;
             }
-<<<<<<< HEAD
-            return res.zsrc.zc.toString(res.zsrc.comment);
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-            // If there is a problem decoding the byte array which represents
-            // the ZIP file comment, return null;
-            try {
-                return res.zsrc.zc.toString(res.zsrc.comment);
-            } catch (IllegalArgumentException iae) {
-                return null;
-            }
-=======
-            // If there is a problem decoding the byte array which represents
-            // the ZIP file comment, return null;
-            try {
-                return zipCoder.toString(res.zsrc.comment);
-            } catch (IllegalArgumentException iae) {
-                return null;
-            }
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
+            return zipCoder.toString(res.zsrc.comment);
         }
     }
 
@@ -371,25 +339,12 @@ public class ZipFile implements ZipConstants, Closeable {
         ZipEntry entry = null;
         synchronized (this) {
             ensureOpen();
-<<<<<<< HEAD
-            int pos = res.zsrc.getEntryPos(name, true);
+            // Look up the name and CEN header position of the entry.
+            // The resolved name may include a trailing slash.
+            // See Source::getEntryPos for details.
+            int pos = res.zsrc.getEntryPos(name, true, zipCoder);
             if (pos != -1) {
                 entry = getZipEntry(name, pos);
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-            // Look up the name and CEN header position of the entry.
-            // The resolved name may include a trailing slash.
-            // See Source::getEntryPos for details.
-            EntryPos pos = res.zsrc.getEntryPos(name, true);
-            if (pos != null) {
-                entry = getZipEntry(pos.name, pos.pos);
-=======
-            // Look up the name and CEN header position of the entry.
-            // The resolved name may include a trailing slash.
-            // See Source::getEntryPos for details.
-            EntryPos pos = res.zsrc.getEntryPos(name, true, zipCoder);
-            if (pos != null) {
-                entry = getZipEntry(pos.name, pos.pos);
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
             }
         }
         return entry;
@@ -420,23 +375,7 @@ public class ZipFile implements ZipConstants, Closeable {
             if (Objects.equals(lastEntryName, entry.name)) {
                 pos = lastEntryPos;
             } else {
-<<<<<<< HEAD
-                pos = zsrc.getEntryPos(entry.name, false);
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-                EntryPos entryPos = zsrc.getEntryPos(entry.name, false);
-                if (entryPos != null) {
-                    pos = entryPos.pos;
-                } else {
-                    pos = -1;
-                }
-=======
-                EntryPos entryPos = zsrc.getEntryPos(entry.name, false, zipCoder);
-                if (entryPos != null) {
-                    pos = entryPos.pos;
-                } else {
-                    pos = -1;
-                }
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
+                pos = zsrc.getEntryPos(entry.name, false, zipCoder);
             }
             if (pos == -1) {
                 return null;
@@ -738,7 +677,7 @@ public class ZipFile implements ZipConstants, Closeable {
         int elen = CENEXT(cen, pos);
         int clen = CENCOM(cen, pos);
 
-        ZipCoder zc = res.zsrc.zipCoderForPos(pos);
+        ZipCoder zc = zipCoderFor(cen, pos, zipCoder);
         if (name != null) {
             // only need to check for mismatch of trailing slash
             if (nlen > 0 &&
@@ -775,12 +714,6 @@ public class ZipFile implements ZipConstants, Closeable {
         }
         if (clen != 0) {
             int start = pos + CENHDR + nlen + elen;
-<<<<<<< HEAD
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-            ZipCoder zc = res.zsrc.zipCoderForPos(pos);
-=======
-            ZipCoder zc = zipCoderFor(cen, pos, zipCoder);
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
             e.comment = zc.toString(cen, start, clen);
         }
         lastEntryName = e.name;
@@ -1265,12 +1198,6 @@ public class ZipFile implements ZipConstants, Closeable {
         private static final int[] EMPTY_META_VERSIONS = new int[0];
 
         private final Key key;               // the key in files
-<<<<<<< HEAD
-        private final @Stable ZipCoder zc;   // zip coder used to decode/encode
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-        private final @Stable ZipCoder zc;   // ZIP coder used to decode/encode
-=======
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
 
         private int refs = 1;
 
@@ -1344,33 +1271,9 @@ public class ZipFile implements ZipConstants, Closeable {
                 int next = table[hsh];
                 table[hsh] = index;
                 // Record the CEN offset and the name hash in our hash cell.
-<<<<<<< HEAD
-                entries[index++] = hash;
-                entries[index++] = next;
-                entries[index  ] = pos;
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-                entries[index++] = hash;
-                entries[index++] = next;
-                entries[index  ] = pos;
-                // Validate comment if it exists.
-                // If the bytes representing the comment cannot be converted to
-                // a String via zcp.toString, an Exception will be thrown
-                if (clen > 0) {
-                    int start = entryPos + nlen + elen;
-                    zcp.toString(cen, start, clen);
-                }
-=======
                 entries[index] = hash;
                 entries[index + 1] = next;
                 entries[index + 2] = pos;
-                // Validate comment if it exists.
-                // If the bytes representing the comment cannot be converted to
-                // a String via zcp.toString, an Exception will be thrown
-                if (clen > 0) {
-                    int start = entryPos + nlen + elen;
-                    zipCoder.toString(cen, start, clen);
-                }
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
             } catch (Exception e) {
                 zerror("invalid CEN header (bad entry name)");
             }
@@ -1515,16 +1418,6 @@ public class ZipFile implements ZipConstants, Closeable {
         private int[] table;                 // Hash chain heads: indexes into entries
         private int tablelen;                // number of hash heads
 
-<<<<<<< HEAD
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-        /**
-         * A class representing a key to a ZIP file. A key is based
-         * on the file key if available, or the path value if the
-         * file key is not available. The key is also based on the
-         * file's last modified time to allow for cases where a ZIP
-         * file is re-opened after it has been modified.
-         */
-=======
         /**
          * A class representing a key to the Source of a ZipFile.
          * The Key is composed of:
@@ -1535,7 +1428,6 @@ public class ZipFile implements ZipConstants, Closeable {
          * - The Charset that was provided when constructing the ZipFile instance.
          * The unique combination of these components identifies a Source of a ZipFile.
          */
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
         private static class Key {
             private final BasicFileAttributes attrs;
             private final File file;
@@ -1800,16 +1692,8 @@ public class ZipFile implements ZipConstants, Closeable {
             throw new ZipException("zip END header not found");
         }
 
-<<<<<<< HEAD
-        // Reads zip file central directory.
-        private void initCEN(int knownTotal) throws IOException {
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-        // Reads ZIP file central directory.
-        private void initCEN(int knownTotal) throws IOException {
-=======
         // Reads ZIP file central directory.
         private void initCEN(final int knownTotal, final ZipCoder zipCoder) throws IOException {
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
             // Prefer locals for better performance during startup
             byte[] cen;
             if (knownTotal == -1) {
@@ -1871,24 +1755,12 @@ public class ZipFile implements ZipConstants, Closeable {
                     // This will only happen if the zip file has an incorrect
                     // ENDTOT field, which usually means it contains more than
                     // 65535 entries.
-<<<<<<< HEAD
-                    initCEN(countCENHeaders(cen, limit));
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-                    initCEN(countCENHeaders(cen));
-=======
-                    initCEN(countCENHeaders(cen), zipCoder);
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
+                    initCEN(countCENHeaders(cen, limit), zipCoder);
                     return;
                 }
 
-<<<<<<< HEAD
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-                int entryPos = pos + CENHDR;
-=======
-                int entryPos = pos + CENHDR;
                 // the ZipCoder for any non-UTF8 entries
                 final ZipCoder entryZipCoder = zipCoderFor(cen, pos, zipCoder);
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
                 // Checks the entry and adds values to entries[idx ... idx+2]
                 int nlen = checkAndAddEntry(pos, idx, entryZipCoder);
                 idx += 3;
@@ -1911,39 +1783,9 @@ public class ZipFile implements ZipConstants, Closeable {
                         // performance in multi-release jar files
                         int version = getMetaVersion(entryPos + META_INF_LEN, nlen - META_INF_LEN);
                         if (version > 0) {
-<<<<<<< HEAD
                             if (metaVersionsSet == null)
                                 metaVersionsSet = new TreeSet<>();
                             metaVersionsSet.add(version);
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-                            try {
-                                // Compute hash code of name from "META-INF/versions/{version)/{name}
-                                int prefixLen = META_INF_VERSIONS_LEN + DecimalDigits.stringSize(version);
-                                int hashCode = zipCoderForPos(pos).checkedHash(cen,
-                                        entryPos + prefixLen,
-                                        nlen - prefixLen);
-                                // Register version for this hash code
-                                if (metaVersions == null)
-                                    metaVersions = new HashMap<>();
-                                metaVersions.computeIfAbsent(hashCode, _ -> new BitSet()).set(version);
-                            } catch (Exception e) {
-                                zerror("invalid CEN header (bad entry name or comment)");
-                            }
-=======
-                            try {
-                                // Compute hash code of name from "META-INF/versions/{version)/{name}
-                                int prefixLen = META_INF_VERSIONS_LEN + DecimalDigits.stringSize(version);
-                                int hashCode = entryZipCoder.checkedHash(cen,
-                                        entryPos + prefixLen,
-                                        nlen - prefixLen);
-                                // Register version for this hash code
-                                if (metaVersions == null)
-                                    metaVersions = new HashMap<>();
-                                metaVersions.computeIfAbsent(hashCode, _ -> new BitSet()).set(version);
-                            } catch (Exception e) {
-                                zerror("invalid CEN header (bad entry name or comment)");
-                            }
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
                         }
                     }
                 }
@@ -1985,25 +1827,11 @@ public class ZipFile implements ZipConstants, Closeable {
         }
 
         /*
-<<<<<<< HEAD
-         * Returns the {@code pos} of the zip cen entry corresponding to the
-         * specified entry name, or -1 if not found.
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-         * Returns the resolved name and position of the ZIP cen entry corresponding
-         *  to the specified entry name, or {@code null} if not found.
-=======
          * Returns the resolved name and position of the ZIP cen entry corresponding
          * to the specified entry name, or {@code null} if not found.
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
          */
-<<<<<<< HEAD
-        private int getEntryPos(String name, boolean addSlash) {
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-        private EntryPos getEntryPos(String name, boolean addSlash) {
-=======
-        private EntryPos getEntryPos(final String name, final boolean addSlash,
-                                     final ZipCoder zipCoder) {
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
+        private int getEntryPos(final String name, final boolean addSlash,
+                                final ZipCoder zipCoder) {
             if (total == 0) {
                 return -1;
             }
@@ -2018,9 +1846,8 @@ public class ZipFile implements ZipConstants, Closeable {
                     // The CEN name must match the specfied one
                     int pos = getEntryPos(idx);
 
-<<<<<<< HEAD
                     try {
-                        ZipCoder zc = zipCoderForPos(pos);
+                        final ZipCoder zc = zipCoderFor(cen, pos, zipCoder);
                         String entry = zc.toString(cen, pos + CENHDR, CENNAM(cen, pos));
 
                         // If addSlash is true we'll test for name+/ in addition to
@@ -2037,41 +1864,11 @@ public class ZipFile implements ZipConstants, Closeable {
                                 && entry.startsWith(name) &&
                                 entry.charAt(entryLen - 1) == '/') {
                             // Found the entry "name+/", now find the CEN entry pos
-                            int exactPos = getEntryPos(name, false);
+                            int exactPos = getEntryPos(name, false, zipCoder);
                             return exactPos == -1 ? pos : exactPos;
                         }
                     } catch (IllegalArgumentException iae) {
                         // Ignore
-||||||| parent of 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
-                    ZipCoder zc = zipCoderForPos(pos);
-
-                    // Compare the lookup name with the name encoded in the CEN
-                    switch (zc.compare(name, cen, noff, nlen, addSlash)) {
-                        case ZipCoder.EXACT_MATCH:
-                            // We found an exact match for "name"
-                            return new EntryPos(name, pos);
-                        case ZipCoder.DIRECTORY_MATCH:
-                            // We found the directory "name/"
-                            // Track its position, then continue the search for "name"
-                            dirPos = pos;
-                            break;
-                        case ZipCoder.NO_MATCH:
-                            // Hash collision, continue searching
-=======
-                    final ZipCoder zc = zipCoderFor(cen, pos, zipCoder);
-                    // Compare the lookup name with the name encoded in the CEN
-                    switch (zc.compare(name, cen, noff, nlen, addSlash)) {
-                        case ZipCoder.EXACT_MATCH:
-                            // We found an exact match for "name"
-                            return new EntryPos(name, pos);
-                        case ZipCoder.DIRECTORY_MATCH:
-                            // We found the directory "name/"
-                            // Track its position, then continue the search for "name"
-                            dirPos = pos;
-                            break;
-                        case ZipCoder.NO_MATCH:
-                            // Hash collision, continue searching
->>>>>>> 2c4e8d211a0 (8347712: IllegalStateException on multithreaded ZipFile access with non-UTF8 charset)
                     }
                 }
                 idx = getEntryNext(idx);

--- a/test/jdk/java/util/zip/ZipFile/ZipFileCharsetTest.java
+++ b/test/jdk/java/util/zip/ZipFile/ZipFileCharsetTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.api.Test;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/*
+ * @test
+ * @bug 8355975
+ * @summary verify that the internal ZIP structure caching in java.util.zip.ZipFile
+ *          uses the correct Charset when parsing the ZIP structure of a ZIP file
+ * @run junit ZipFileCharsetTest
+ */
+public class ZipFileCharsetTest {
+
+    private static final String ISO_8859_15_NAME = "ISO-8859-15";
+
+    /**
+     * The internal implementation of java.util.zip.ZipFile maintains a cache
+     * of the ZIP structure of each ZIP file that's currently open. This cache
+     * helps prevent repeat parsing of the ZIP structure of the same underlying
+     * ZIP file, every time a ZipFile instance is created for the same ZIP file.
+     * The cache uses an internal key to map a ZIP file to the corresponding
+     * ZIP structure that's cached.
+     * A ZipFile can be constructed by passing a Charset which will be used to
+     * decode the entry names (and comment) in a ZIP file.
+     * The test verifies that when multiple ZipFile instances are
+     * constructed using different Charsets but the same underlying ZIP file,
+     * then the internal caching implementation of ZipFile doesn't end up using
+     * a wrong Charset for parsing the ZIP structure of the ZIP file.
+     */
+    @Test
+    void testCachedZipFileSource() throws Exception {
+        // ISO-8859-15 is not a standard charset in Java. We skip this test
+        // when it is unavailable
+        assumeTrue(Charset.availableCharsets().containsKey(ISO_8859_15_NAME),
+                "skipping test since " + ISO_8859_15_NAME + " charset isn't available");
+
+        // We choose the byte 0xA4 for entry name in the ZIP file.
+        // 0xA4 is "Euro sign" in ISO-8859-15 charset and
+        // "Currency sign (generic)" in ISO-8859-1 charset.
+        final byte[] entryNameBytes = new byte[]{(byte) 0xA4}; // intentional cast
+        final Charset euroSignCharset = Charset.forName(ISO_8859_15_NAME);
+        final Charset currencySignCharset = ISO_8859_1;
+
+        final String euroSign = new String(entryNameBytes, euroSignCharset);
+        final String currencySign = new String(entryNameBytes, currencySignCharset);
+
+        // create a ZIP file whose entry name is encoded using ISO-8859-15 charset
+        final Path zip = createZIP("euro", euroSignCharset, entryNameBytes);
+
+        // Construct a ZipFile instance using the (incorrect) charset ISO-8859-1.
+        // While that ZipFile instance is still open (and the ZIP file structure
+        // still cached), construct another instance for the same ZIP file, using
+        // the (correct) charset ISO-8859-15.
+        try (ZipFile incorrect = new ZipFile(zip.toFile(), currencySignCharset);
+             ZipFile correct = new ZipFile(zip.toFile(), euroSignCharset)) {
+
+            // correct encoding should resolve the entry name to euro sign
+            // and the entry should be thus be located
+            assertNotNull(correct.getEntry(euroSign), "euro sign entry missing in " + correct);
+            // correct encoding should not be able to find an entry name
+            // with the currency sign
+            assertNull(correct.getEntry(currencySign), "currency sign entry unexpectedly found in "
+                    + correct);
+
+            // incorrect encoding should resolve the entry name to currency sign
+            // and the entry should be thus be located by the currency sign name
+            assertNotNull(incorrect.getEntry(currencySign), "currency sign entry missing in "
+                    + incorrect);
+            // incorrect encoding should not be able to find an entry name
+            // with the euro sign
+            assertNull(incorrect.getEntry(euroSign), "euro sign entry unexpectedly found in "
+                    + incorrect);
+        }
+    }
+
+    /**
+     * Creates and return ZIP file whose entry names are encoded using the given {@code charset}
+     */
+    private static Path createZIP(final String fileNamePrefix, final Charset charset,
+                                  final byte[] entryNameBytes) throws IOException {
+        final Path zip = Files.createTempFile(Path.of("."), fileNamePrefix, ".zip");
+        // create a ZIP file whose entry name(s) use the given charset
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip), charset)) {
+            zos.putNextEntry(new ZipEntry(new String(entryNameBytes, charset)));
+            final byte[] entryContent = "doesnotmatter".getBytes(US_ASCII);
+            zos.write(entryContent);
+            zos.closeEntry();
+        }
+        return zip;
+    }
+}

--- a/test/jdk/java/util/zip/ZipFile/ZipFileSharedSourceTest.java
+++ b/test/jdk/java/util/zip/ZipFile/ZipFileSharedSourceTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+/*
+ * @test
+ * @bug 8347712
+ * @summary verify that different instances of java.util.zip.ZipFile do not share
+ *          the same instance of (non-thread-safe) java.nio.charset.CharsetEncoder/CharsetDecoder
+ * @run junit ZipFileSharedSourceTest
+ */
+public class ZipFileSharedSourceTest {
+
+    static Path createZipFile(final Charset charset) throws Exception {
+        final Path zipFilePath = Files.createTempFile(Path.of("."), "8347712", ".zip");
+        try (OutputStream os = Files.newOutputStream(zipFilePath);
+             ZipOutputStream zos = new ZipOutputStream(os, charset)) {
+            final int numEntries = 10240;
+            for (int i = 1; i <= numEntries; i++) {
+                final ZipEntry entry = new ZipEntry("entry-" + i);
+                zos.putNextEntry(entry);
+                zos.write("foo bar".getBytes(US_ASCII));
+                zos.closeEntry();
+            }
+        }
+        return zipFilePath;
+    }
+
+    static List<Arguments> charsets() {
+        return List.of(
+                Arguments.of(StandardCharsets.UTF_8),
+                Arguments.of(StandardCharsets.ISO_8859_1),
+                Arguments.of(US_ASCII)
+        );
+    }
+
+    /**
+     * In this test, multiple concurrent threads each create an instance of java.util.zip.ZipFile
+     * with the given {@code charset} for the same underlying ZIP file. Each of the threads
+     * then iterate over the entries of their ZipFile instance. The test verifies that such access,
+     * where each thread is accessing an independent ZipFile instance corresponding to the same
+     * underlying ZIP file, doesn't lead to unexpected failures contributed by concurrent
+     * threads.
+     */
+    @ParameterizedTest
+    @MethodSource("charsets")
+    void testMultipleZipFileInstances(final Charset charset) throws Exception {
+        final Path zipFilePath = createZipFile(charset);
+        final int numTasks = 200;
+        final CountDownLatch startLatch = new CountDownLatch(numTasks);
+        final List<Future<Void>> results = new ArrayList<>();
+        try (final ExecutorService executor =
+                     Executors.newThreadPerTaskExecutor(Thread.ofPlatform().factory())) {
+            for (int i = 0; i < numTasks; i++) {
+                final var task = new ZipEntryIteratingTask(zipFilePath, charset,
+                        startLatch);
+                results.add(executor.submit(task));
+            }
+            System.out.println(numTasks + " tasks submitted, waiting for them to complete");
+            for (final Future<Void> f : results) {
+                f.get();
+            }
+        }
+        System.out.println("All " + numTasks + " tasks completed successfully");
+    }
+
+    private static final class ZipEntryIteratingTask implements Callable<Void> {
+        private final Path file;
+        private final Charset charset;
+        private final CountDownLatch startLatch;
+
+        private ZipEntryIteratingTask(final Path file, final Charset charset,
+                                      final CountDownLatch startLatch) {
+            this.file = file;
+            this.charset = charset;
+            this.startLatch = startLatch;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            // let other tasks know we are ready to run
+            this.startLatch.countDown();
+            // wait for other tasks to be ready to run
+            this.startLatch.await();
+            // create a new instance of ZipFile and iterate over the entries
+            try (final ZipFile zf = new ZipFile(this.file.toFile(), this.charset)) {
+                final var entries = zf.entries();
+                while (entries.hasMoreElements()) {
+                    final ZipEntry ze = entries.nextElement();
+                    // additionally exercise the ZipFile.getEntry() method
+                    zf.getEntry(ze.getName());
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Multithreaded handling of ZIP files can throw an exception.

This backport is far from clean. The last commit resolves the conflicts.

The backport would be a little cleaner if there was backported as a pre-requisite JDK-8321156. But given there is [a backward compatibility concern](https://bugs.openjdk.org/browse/JDK-8321156?focusedId=14630523&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14630523) I have not backported it.
