### PR TITLE
8294509: The sign extension bug applies to 'public static int[] convertSeedBytesToInts(byte[] seed, int n, int z)' in RandomSupport

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -308,7 +308,7 @@ public class RandomSupport {
         final int m = Math.min(seed.length, n << 2);
         // Distribute seed bytes into the words to be formed.
         for (int j = 0; j < m; j++) {
-            result[j>>2] = (result[j>>2] << 8) | seed[j];
+            result[j>>2] = (result[j>>2] << 8) | (seed[j] & 0xFF);
         }
         // If there aren't enough seed bytes for all the words we need,
         // use a SplitMix-style PRNG to fill in the rest.


### PR DESCRIPTION
Backport for RandomSupport issue. There is a loss of information when using `convertSeedBytesToInts()` with a bad seed, causing a lot of the original bytes to be overwritten by 1s. The fix involves using a bitwise AND with the seed before distributing the seed bytes into the result.

Clean backport, ran GHA sanity checks and locally tested tier1, tier2. In tier2, there was 1 failure:
`test/jdk/java/nio/channels/DatagramChannel/SendReceiveMaxSize.java`
However, this fails on master as well.

The backport also updates the test `T8282144.java` to test for ints as well, which passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8294509](https://bugs.openjdk.org/browse/JDK-8294509) needs maintainer approval

### Issue
 * [JDK-8294509](https://bugs.openjdk.org/browse/JDK-8294509): The sign extension bug applies to 'public static int[] convertSeedBytesToInts(byte[] seed, int n, int z)' in RandomSupport (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3722/head:pull/3722` \
`$ git checkout pull/3722`

Update a local copy of the PR: \
`$ git checkout pull/3722` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3722`

View PR using the GUI difftool: \
`$ git pr show -t 3722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3722.diff">https://git.openjdk.org/jdk17u-dev/pull/3722.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3722#issuecomment-3050197253)
</details>
