### PR TITLE
8347302: Mark test tools/jimage/JImageToolTest.java as flagless

### DIFF
--- a/test/jdk/tools/jimage/JImageToolTest.java
+++ b/test/jdk/tools/jimage/JImageToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 /*
  * @test
  * @library /test/lib
+ * @requires vm.flagless
  * @build jdk.test.lib.process.ProcessTools
  * @summary Test to check if jimage tool exists and is working
  * @run main/timeout=360 JImageToolTest


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347302](https://bugs.openjdk.org/browse/JDK-8347302) needs maintainer approval

### Issue
 * [JDK-8347302](https://bugs.openjdk.org/browse/JDK-8347302): Mark test tools/jimage/JImageToolTest.java as flagless (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3725/head:pull/3725` \
`$ git checkout pull/3725`

Update a local copy of the PR: \
`$ git checkout pull/3725` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3725`

View PR using the GUI difftool: \
`$ git pr show -t 3725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3725.diff">https://git.openjdk.org/jdk17u-dev/pull/3725.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3725#issuecomment-3052356972)
</details>
