### PR TITLE
8352879: TestPeriod.java and TestGetContentType.java run wrong test class

### DIFF
--- a/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
+++ b/test/jdk/jdk/jfr/api/metadata/annotations/TestPeriod.java
@@ -35,7 +35,7 @@ import jdk.test.lib.jfr.Events;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
- * @run main/othervm jdk.jfr.api.metadata.annotations.TestLabel
+ * @run main/othervm jdk.jfr.api.metadata.annotations.TestPeriod
  */
 public class TestPeriod {
 

--- a/test/jdk/jdk/jfr/api/metadata/settingdescriptor/TestGetContentType.java
+++ b/test/jdk/jdk/jfr/api/metadata/settingdescriptor/TestGetContentType.java
@@ -38,7 +38,7 @@ import jdk.test.lib.jfr.Events;
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
- * @run main/othervm jdk.jfr.api.metadata.settingdescriptor.TestGetDescription
+ * @run main/othervm jdk.jfr.api.metadata.settingdescriptor.TestGetContentType
  */
 public class TestGetContentType {
 
@@ -49,7 +49,7 @@ public class TestGetContentType {
         Asserts.assertNull(plain.getContentType());
 
         SettingDescriptor annotatedType = Events.getSetting(type, "annotatedType");
-        Asserts.assertNull(annotatedType.getContentType(), Timestamp.class.getName());
+        Asserts.assertEquals(annotatedType.getContentType(), Timestamp.class.getName());
 
         SettingDescriptor newName = Events.getSetting(type, "newName");
         Asserts.assertEquals(newName.getContentType(), Timespan.class.getName());
@@ -58,7 +58,7 @@ public class TestGetContentType {
         Asserts.assertNull(overridden.getContentType());
 
         SettingDescriptor protectedBase = Events.getSetting(type, "protectedBase");
-        Asserts.assertEquals(protectedBase.getContentType(), Frequency.class);
+        Asserts.assertEquals(protectedBase.getContentType(), Frequency.class.getName());
 
         SettingDescriptor publicBase = Events.getSetting(type, "publicBase");
         Asserts.assertEquals(publicBase.getContentType(), Timestamp.class.getName());


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352879](https://bugs.openjdk.org/browse/JDK-8352879) needs maintainer approval

### Issue
 * [JDK-8352879](https://bugs.openjdk.org/browse/JDK-8352879): TestPeriod.java and TestGetContentType.java run wrong test class (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3728/head:pull/3728` \
`$ git checkout pull/3728`

Update a local copy of the PR: \
`$ git checkout pull/3728` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3728`

View PR using the GUI difftool: \
`$ git pr show -t 3728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3728.diff">https://git.openjdk.org/jdk17u-dev/pull/3728.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3728#issuecomment-3052408458)
</details>
