### PR TITLE
8352719: Add an equals sign to the modules statement

### DIFF
--- a/test/jdk/sun/security/krb5/auto/TEST.properties
+++ b/test/jdk/sun/security/krb5/auto/TEST.properties
@@ -1,12 +1,12 @@
-modules java.base/jdk.internal.misc \
-        java.base/sun.security.util \
-        java.security.jgss/sun.security.jgss \
-        java.security.jgss/sun.security.jgss.krb5 \
-        java.security.jgss/sun.security.krb5:+open \
-        java.security.jgss/sun.security.krb5.internal:+open \
-        java.security.jgss/sun.security.krb5.internal.ccache \
-        java.security.jgss/sun.security.krb5.internal.rcache \
-        java.security.jgss/sun.security.krb5.internal.crypto \
-        java.security.jgss/sun.security.krb5.internal.ktab \
-        jdk.security.auth \
-        jdk.security.jgss
+modules = java.base/jdk.internal.misc \
+          java.base/sun.security.util \
+          java.security.jgss/sun.security.jgss \
+          java.security.jgss/sun.security.jgss.krb5 \
+          java.security.jgss/sun.security.krb5:+open \
+          java.security.jgss/sun.security.krb5.internal:+open \
+          java.security.jgss/sun.security.krb5.internal.ccache \
+          java.security.jgss/sun.security.krb5.internal.rcache \
+          java.security.jgss/sun.security.krb5.internal.crypto \
+          java.security.jgss/sun.security.krb5.internal.ktab \
+          jdk.security.auth \
+          jdk.security.jgss


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352719](https://bugs.openjdk.org/browse/JDK-8352719) needs maintainer approval

### Issue
 * [JDK-8352719](https://bugs.openjdk.org/browse/JDK-8352719): Add an equals sign to the modules statement (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3729/head:pull/3729` \
`$ git checkout pull/3729`

Update a local copy of the PR: \
`$ git checkout pull/3729` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3729`

View PR using the GUI difftool: \
`$ git pr show -t 3729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3729.diff">https://git.openjdk.org/jdk17u-dev/pull/3729.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3729#issuecomment-3052427297)
</details>
