### PR TITLE
8337506: Disable "best-fit" mapping on Windows command line

### DIFF
--- a/src/java.base/share/native/launcher/main.c
+++ b/src/java.base/share/native/launcher/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,7 +150,25 @@ main(int argc, char **argv)
             }
         }
     }
-    JLI_CmdToArgs(GetCommandLine());
+
+    // Obtain the command line in UTF-16, then convert it to ANSI code page
+    // without the "best-fit" option
+    LPWSTR wcCmdline = GetCommandLineW();
+    int mbSize = WideCharToMultiByte(CP_ACP,
+        WC_NO_BEST_FIT_CHARS | WC_COMPOSITECHECK | WC_DEFAULTCHAR,
+        wcCmdline, -1, NULL, 0, NULL, NULL);
+    // If the call to WideCharToMultiByte() fails, it returns 0, which
+    // will then make the following JLI_MemAlloc() to issue exit(1)
+    LPSTR mbCmdline = JLI_MemAlloc(mbSize);
+    if (WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS | WC_COMPOSITECHECK | WC_DEFAULTCHAR,
+        wcCmdline, -1, mbCmdline, mbSize, NULL, NULL) == 0) {
+        perror("command line encoding conversion failure");
+        exit(1);
+    }
+
+    JLI_CmdToArgs(mbCmdline);
+    JLI_MemFree(mbCmdline);
+
     margc = JLI_GetStdArgc();
     // add one more to mark the end
     margv = (char **)JLI_MemAlloc((margc + 1) * (sizeof(char *)));

--- a/test/jdk/tools/launcher/DisableBestFitMappingTest.java
+++ b/test/jdk/tools/launcher/DisableBestFitMappingTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8337506
+ * @summary Verify Command Line arguments are not mapped with
+ *     "best-fit" mappings on Windows
+ * @requires (os.family == "windows")
+ * @library /test/lib
+ * @run junit DisableBestFitMappingTest
+ */
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.util.stream.Stream;
+import jdk.test.lib.process.ProcessTools;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
+public class DisableBestFitMappingTest {
+    private static final CharsetEncoder NATIVE_ENC =
+            Charset.forName(System.getProperty("native.encoding")).newEncoder();
+    private static final String REPLACEMENT =
+            NATIVE_ENC.charset().decode(ByteBuffer.wrap(NATIVE_ENC.replacement())).toString();
+    private static final int EXIT_SUCCESS = 0;
+    private static final int EXIT_FAILURE = -1;
+
+    static Stream<Arguments> CMD_ARGS() {
+        return Stream.of(
+                Arguments.of("aa\uff02 \uff02bb", "aa" + REPLACEMENT + " " + REPLACEMENT + "bb"),
+                Arguments.of("aa\uff01bb", "aa" + REPLACEMENT + "bb"),
+                Arguments.of("aa\u221ebb", "aa" + REPLACEMENT + "bb")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("CMD_ARGS")
+    void testDisableBestFitMapping(String arg, String expected) throws Exception {
+        // Only execute if the arg cannot be encoded
+        assumeFalse(NATIVE_ENC.canEncode(arg),
+                "native.encoding (%s) can encode the argument '%s'. Test ignored."
+                        .formatted(NATIVE_ENC.charset(), arg));
+
+        var result= ProcessTools.executeTestJava(
+                DisableBestFitMappingTest.class.getSimpleName(), arg, expected);
+        result.asLines().forEach(System.out::println);
+        assertEquals(EXIT_SUCCESS, result.getExitValue(),
+                "Disabling best-fit mapping failed");
+    }
+
+    public static void main(String... args) {
+        System.out.println(args[0]);
+        System.out.println(args[1]);
+        System.exit(args[0].equals(args[1]) ? EXIT_SUCCESS : EXIT_FAILURE);
+    }
+}


### PR DESCRIPTION
I'd like to backport this for parity with 17.0.17-oracle.
CSR JDK-8349538 has been approved for 17u.
The patch applies almost cleanly, except for the copyright years.
The new test passes successfully after applying the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8337506](https://bugs.openjdk.org/browse/JDK-8337506) needs maintainer approval
- [x] Change requires CSR request [JDK-8349538](https://bugs.openjdk.org/browse/JDK-8349538) to be approved

### Issues
 * [JDK-8337506](https://bugs.openjdk.org/browse/JDK-8337506): Disable "best-fit" mapping on Windows command line (**Bug** - P4 - Approved)
 * [JDK-8349538](https://bugs.openjdk.org/browse/JDK-8349538): Disable "best-fit" mapping on Windows command line (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3733/head:pull/3733` \
`$ git checkout pull/3733`

Update a local copy of the PR: \
`$ git checkout pull/3733` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3733`

View PR using the GUI difftool: \
`$ git pr show -t 3733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3733.diff">https://git.openjdk.org/jdk17u-dev/pull/3733.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3733#issuecomment-3052898501)
</details>
