### PR TITLE
8314611: Provide more explicative error message parsing Currencies

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -314,7 +314,8 @@ public final class Currency implements Serializable {
             // or in the list of other currencies.
             boolean found = false;
             if (currencyCode.length() != 3) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("The input currency code must " +
+                        "have a length of 3 characters");
             }
             char char1 = currencyCode.charAt(0);
             char char2 = currencyCode.charAt(1);
@@ -337,7 +338,8 @@ public final class Currency implements Serializable {
             if (!found) {
                 OtherCurrencyEntry ocEntry = OtherCurrencyEntry.findEntry(currencyCode);
                 if (ocEntry == null) {
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("The input currency code" +
+                            " is not a valid ISO 4217 code");
                 }
                 defaultFractionDigits = ocEntry.fraction;
                 numericCode = ocEntry.numericCode;
@@ -392,7 +394,8 @@ public final class Currency implements Serializable {
         String country = CalendarDataUtility.findRegionOverride(locale).getCountry();
 
         if (country == null || !country.matches("^[a-zA-Z]{2}$")) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("The country of the input locale" +
+                    " is not a valid ISO 3166 country code");
         }
 
         char char1 = country.charAt(0);
@@ -409,7 +412,8 @@ public final class Currency implements Serializable {
         } else {
             // special cases
             if (tableEntry == INVALID_COUNTRY_ENTRY) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("The country of the input locale" +
+                        " is not a valid ISO 3166 country code");
             }
             if (tableEntry == COUNTRY_WITHOUT_CURRENCY_ENTRY) {
                 return null;
@@ -674,7 +678,8 @@ public final class Currency implements Serializable {
      */
     private static int getMainTableEntry(char char1, char char2) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("The country code is not a " +
+                    "valid ISO 3166 code");
         }
         return mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')];
     }
@@ -685,7 +690,8 @@ public final class Currency implements Serializable {
      */
     private static void setMainTableEntry(char char1, char char2, int entry) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("The country code is not a " +
+                    "valid ISO 3166 code");
         }
         mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')] = entry;
     }

--- a/test/jdk/java/util/Currency/CurrencyTest.java
+++ b/test/jdk/java/util/Currency/CurrencyTest.java
@@ -80,14 +80,31 @@ public class CurrencyTest {
 
         // Calling getInstance() with an invalid currency code should throw an IAE
         @ParameterizedTest
-        @MethodSource("invalidCurrencies")
+        @MethodSource("non4217Currencies")
         public void invalidCurrencyTest(String currencyCode) {
-            assertThrows(IllegalArgumentException.class, () ->
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
                     Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
+            assertEquals("The input currency code is not a" +
+                    " valid ISO 4217 code", ex.getMessage());
         }
 
-        private static Stream<String> invalidCurrencies() {
-            return Stream.of("AQD", "US$", "\u20AC");
+        private static Stream<String> non4217Currencies() {
+            return Stream.of("AQD", "US$");
+        }
+
+        // Calling getInstance() with a currency code not 3 characters long should throw
+        // an IAE
+        @ParameterizedTest
+        @MethodSource("invalidLengthCurrencies")
+        public void invalidCurrencyLengthTest(String currencyCode) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                    Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
+            assertEquals("The input currency code must have a length of 3" +
+                    " characters", ex.getMessage());
+        }
+
+        private static Stream<String> invalidLengthCurrencies() {
+            return Stream.of("\u20AC", "", "12345");
         }
     }
 
@@ -144,7 +161,10 @@ public class CurrencyTest {
                         ctryLength == 3 || // UN M.49 code
                         ctryCode.matches("AA|Q[M-Z]|X[A-JL-Z]|ZZ" + // user defined codes, excluding "XK" (Kosovo)
                                 "AC|CP|DG|EA|EU|FX|IC|SU|TA|UK")) { // exceptional reservation codes
-                    assertThrows(IllegalArgumentException.class, () -> Currency.getInstance(locale), "Did not throw IAE");
+                    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                            () -> Currency.getInstance(locale), "Did not throw IAE");
+                    assertEquals("The country of the input locale is not a" +
+                            " valid ISO 3166 country code", ex.getMessage());
                 } else {
                     goodCountries++;
                     Currency currency = Currency.getInstance(locale);
@@ -163,8 +183,11 @@ public class CurrencyTest {
         // Check an invalid country code
         @Test
         public void invalidCountryTest() {
-            assertThrows(IllegalArgumentException.class, ()->
-                    Currency.getInstance(new Locale("", "EU")), "Did not throw IAE");
+            Locale l = new Locale("", "EU");
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    ()-> Currency.getInstance(l), "Did not throw IAE");
+            assertEquals("The country of the input locale is not a valid" +
+                    " ISO 3166 country code", ex.getMessage());
         }
 
         // Ensure a selection of countries have the expected currency


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

The changes to the lib code applied clean. 
In the test I resolved one chunk and replace Locale.of() which is not available in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8314611](https://bugs.openjdk.org/browse/JDK-8314611) needs maintainer approval

### Issue
 * [JDK-8314611](https://bugs.openjdk.org/browse/JDK-8314611): Provide more explicative error message parsing Currencies (**Enhancement** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3734/head:pull/3734` \
`$ git checkout pull/3734`

Update a local copy of the PR: \
`$ git checkout pull/3734` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3734`

View PR using the GUI difftool: \
`$ git pr show -t 3734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3734.diff">https://git.openjdk.org/jdk17u-dev/pull/3734.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3734#issuecomment-3057899521)
</details>
