### PR TITLE
8358617: java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails with 403 due to system proxies

### DIFF
--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java
@@ -429,7 +429,7 @@ public class HttpURLConnectionExpectContinueTest {
                 .port(control.serverSocket.getLocalPort())
                 .toURL();
 
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
         connection.setDoOutput(true);
         connection.setReadTimeout(5000);
         connection.setUseCaches(false);


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358617](https://bugs.openjdk.org/browse/JDK-8358617) needs maintainer approval

### Issue
 * [JDK-8358617](https://bugs.openjdk.org/browse/JDK-8358617): java/net/HttpURLConnection/HttpURLConnectionExpectContinueTest.java fails with 403 due to system proxies (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3737/head:pull/3737` \
`$ git checkout pull/3737`

Update a local copy of the PR: \
`$ git checkout pull/3737` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3737`

View PR using the GUI difftool: \
`$ git pr show -t 3737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3737.diff">https://git.openjdk.org/jdk17u-dev/pull/3737.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3737#issuecomment-3058186880)
</details>
