### PR TITLE
8353950: Clipboard interaction on Windows is unstable

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/datatransfer/SunClipboard.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/SunClipboard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,8 +204,9 @@ public abstract class SunClipboard extends Clipboard
         byte[] data = null;
         Transferable localeTransferable = null;
 
+        openClipboard(null);
+
         try {
-            openClipboard(null);
 
             long[] formats = getClipboardFormats();
             Long lFormat = DataTransferer.getInstance().
@@ -318,12 +319,7 @@ public abstract class SunClipboard extends Clipboard
      * @since 1.5
      */
     protected long[] getClipboardFormatsOpenClose() {
-        try {
-            openClipboard(null);
-            return getClipboardFormats();
-        } finally {
-            closeClipboard();
-        }
+        return getClipboardFormats();
     }
 
     /**
@@ -356,15 +352,7 @@ public abstract class SunClipboard extends Clipboard
         flavorListeners.add(listener);
 
         if (numberOfFlavorListeners++ == 0) {
-            long[] currentFormats = null;
-            try {
-                openClipboard(null);
-                currentFormats = getClipboardFormats();
-            } catch (final IllegalStateException ignored) {
-            } finally {
-                closeClipboard();
-            }
-            this.currentFormats = currentFormats;
+            this.currentFormats = getClipboardFormats();
 
             registerClipboardViewerChecked();
         }

--- a/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Clipboard.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,9 +69,8 @@ void AwtClipboard::RegisterClipboardViewer(JNIEnv *env, jobject jclipboard) {
         return;
     }
 
-    if (theCurrentClipboard == NULL) {
-        theCurrentClipboard = env->NewGlobalRef(jclipboard);
-    }
+    DASSERT(AwtClipboard::theCurrentClipboard != NULL);
+    DASSERT(env->IsSameObject(AwtClipboard::theCurrentClipboard, jclipboard));
 
     jclass cls = env->GetObjectClass(jclipboard);
     AwtClipboard::handleContentsChangedMID =
@@ -128,11 +127,13 @@ Java_sun_awt_windows_WClipboard_init(JNIEnv *env, jclass cls)
  * Signature: (Lsun/awt/windows/WClipboard;)V
  */
 JNIEXPORT void JNICALL
-Java_sun_awt_windows_WClipboard_openClipboard(JNIEnv *env, jobject self,
+Java_sun_awt_windows_WClipboard_openClipboard0(JNIEnv *env, jobject self,
                                               jobject newOwner)
 {
     TRY;
 
+    DASSERT(AwtClipboard::theCurrentClipboard != NULL);
+    DASSERT(newOwner == NULL || env->IsSameObject(AwtClipboard::theCurrentClipboard, newOwner));
     DASSERT(::GetOpenClipboardWindow() != AwtToolkit::GetInstance().GetHWnd());
 
     if (!::OpenClipboard(AwtToolkit::GetInstance().GetHWnd())) {
@@ -142,10 +143,6 @@ Java_sun_awt_windows_WClipboard_openClipboard(JNIEnv *env, jobject self,
     }
     if (newOwner != NULL) {
         AwtClipboard::GetOwnership();
-        if (AwtClipboard::theCurrentClipboard != NULL) {
-            env->DeleteGlobalRef(AwtClipboard::theCurrentClipboard);
-        }
-        AwtClipboard::theCurrentClipboard = env->NewGlobalRef(newOwner);
     }
 
     CATCH_BAD_ALLOC;
@@ -157,7 +154,7 @@ Java_sun_awt_windows_WClipboard_openClipboard(JNIEnv *env, jobject self,
  * Signature: ()V
  */
 JNIEXPORT void JNICALL
-Java_sun_awt_windows_WClipboard_closeClipboard(JNIEnv *env, jobject self)
+Java_sun_awt_windows_WClipboard_closeClipboard0(JNIEnv *env, jobject self)
 {
     TRY;
 
@@ -297,23 +294,25 @@ Java_sun_awt_windows_WClipboard_getClipboardFormats
 {
     TRY;
 
-    DASSERT(::GetOpenClipboardWindow() == AwtToolkit::GetInstance().GetHWnd());
+    unsigned int cFormats = 128; // Allocate enough space to hold all
+    unsigned int pcFormatsOut = 0;
+    unsigned int lpuiFormats[128] = { 0 };
 
-    jsize nFormats = ::CountClipboardFormats();
-    jlongArray formats = env->NewLongArray(nFormats);
+    VERIFY(::GetUpdatedClipboardFormats(lpuiFormats, 128, &pcFormatsOut));
+
+    jlongArray formats = env->NewLongArray(pcFormatsOut);
     if (formats == NULL) {
         throw std::bad_alloc();
     }
-    if (nFormats == 0) {
+    if (pcFormatsOut == 0) {
         return formats;
     }
     jboolean isCopy;
     jlong *lFormats = env->GetLongArrayElements(formats, &isCopy),
         *saveFormats = lFormats;
-    UINT num = 0;
 
-    for (jsize i = 0; i < nFormats; i++, lFormats++) {
-        *lFormats = num = ::EnumClipboardFormats(num);
+    for (unsigned int i = 0; i < pcFormatsOut; i++, lFormats++) {
+        *lFormats = lpuiFormats[i];
     }
 
     env->ReleaseLongArrayElements(formats, saveFormats, 0);
@@ -476,6 +475,18 @@ Java_sun_awt_windows_WClipboard_getClipboardData
     return bytes;
 
     CATCH_BAD_ALLOC_RET(NULL);
+}
+
+/*
+ * Class:     sun_awt_windows_WClipboard
+ * Method:    registerClipboard
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL
+Java_sun_awt_windows_WClipboard_registerClipboard(JNIEnv *env, jobject self)
+{
+    DASSERT(AwtClipboard::theCurrentClipboard == NULL);
+    AwtClipboard::theCurrentClipboard = env->NewGlobalRef(self);
 }
 
 } /* extern "C" */

--- a/test/jdk/java/awt/Clipboard/ConcurrentClipboardAccessTest.java
+++ b/test/jdk/java/awt/Clipboard/ConcurrentClipboardAccessTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+  @test
+  @bug 8332271
+  @summary tests that concurrent access to the clipboard does not crash the JVM
+  @key headful
+  @requires (os.family == "windows")
+  @run main ConcurrentClipboardAccessTest
+ */
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+
+public class ConcurrentClipboardAccessTest {
+
+    public static void main(String[] args) {
+        Thread clipboardLoader1 = new Thread(new ClipboardLoader());
+        clipboardLoader1.setDaemon(true);
+        clipboardLoader1.start();
+        Thread clipboardLoader2 = new Thread(new ClipboardLoader());
+        clipboardLoader2.setDaemon(true);
+        clipboardLoader2.start();
+        long start = System.currentTimeMillis();
+        while (true) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ignored) {
+            }
+            long now = System.currentTimeMillis();
+            if ((now - start) > (10L * 1000L)) {
+                break;
+            }
+        }
+        // Test is considered successful if the concurrent repeated reading
+        // from clipboard succeeds for the allotted time and the JVM does not
+        // crash.
+        System.out.println("Shutdown normally");
+    }
+
+    public static class ClipboardLoader implements Runnable {
+
+        @Override
+        public void run() {
+            final Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            while (true) {
+                try {
+                    if (systemClipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
+                        systemClipboard.getData(DataFlavor.stringFlavor);
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
8332271: Reading data from the clipboard from multiple threads crashes the JVM

Reviewed-by: abhiscxk, dnguyen

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8353950](https://bugs.openjdk.org/browse/JDK-8353950) needs maintainer approval

### Issue
 * [JDK-8353950](https://bugs.openjdk.org/browse/JDK-8353950): Clipboard interaction on Windows is unstable (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3745/head:pull/3745` \
`$ git checkout pull/3745`

Update a local copy of the PR: \
`$ git checkout pull/3745` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3745`

View PR using the GUI difftool: \
`$ git pr show -t 3745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3745.diff">https://git.openjdk.org/jdk17u-dev/pull/3745.diff</a>

</details>
