### PR TITLE
8274039: codestrings gtest fails when hsdis is present

### DIFF
--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -37,10 +37,13 @@ static const char* replace_addr_expr(const char* str)
 {
     // Remove any address expression "0x0123456789abcdef" found in order to
     // aid string comparison. Also remove any trailing printout from a padded
-    // buffer.
+    // buffer (too brittle?).
 
-    std::basic_string<char> tmp = std::regex_replace(str, std::regex("0x[0-9a-fA-F]+"), "<addr>");
-    std::basic_string<char> red = std::regex_replace(tmp, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
+    std::basic_string<char> tmp1 = std::regex_replace(str, std::regex("0x[0-9a-fA-F]+"), "<addr>");
+    // Padding: aarch64
+    std::basic_string<char> tmp2 = std::regex_replace(tmp1, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
+    // Padding: x64
+    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
 
     return os::strdup(red.c_str());
 }


### PR DESCRIPTION
I backport this as follow up of [JDK-8264207](https://bugs.openjdk.org/browse/JDK-8264207)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8274039](https://bugs.openjdk.org/browse/JDK-8274039) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8274039: codestrings gtest fails when hsdis is present`

### Issue
 * [JDK-8274039](https://bugs.openjdk.org/browse/JDK-8274039): codestrings gtest fails when hsdis is present (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3750/head:pull/3750` \
`$ git checkout pull/3750`

Update a local copy of the PR: \
`$ git checkout pull/3750` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3750`

View PR using the GUI difftool: \
`$ git pr show -t 3750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3750.diff">https://git.openjdk.org/jdk17u-dev/pull/3750.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3750#issuecomment-3073044280)
</details>
