### PR TITLE
8286660: codestrings gtest fails on AArch64: "udf" in padding

### DIFF
--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -37,10 +37,13 @@ static const char* replace_addr_expr(const char* str)
 {
     // Remove any address expression "0x0123456789abcdef" found in order to
     // aid string comparison. Also remove any trailing printout from a padded
-    // buffer.
+    // buffer (too brittle?).
 
-    std::basic_string<char> tmp = std::regex_replace(str, std::regex("0x[0-9a-fA-F]+"), "<addr>");
-    std::basic_string<char> red = std::regex_replace(tmp, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
+    std::basic_string<char> tmp1 = std::regex_replace(str, std::regex("0x[0-9a-fA-F]+"), "<addr>");
+    // Padding: aarch64
+    std::basic_string<char> tmp2 = std::regex_replace(tmp1, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
+    // Padding: x64
+    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
 
     return os::strdup(red.c_str());
 }

--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -42,8 +42,9 @@ static const char* replace_addr_expr(const char* str)
     std::basic_string<char> tmp1 = std::regex_replace(str, std::regex("0x[0-9a-fA-F]+"), "<addr>");
     // Padding: aarch64
     std::basic_string<char> tmp2 = std::regex_replace(tmp1, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
+    std::basic_string<char> tmp3 = std::regex_replace(tmp2, std::regex("\\s+<addr>:\\s+udf\\t#0"), "");
     // Padding: x64
-    std::basic_string<char> red  = std::regex_replace(tmp2, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
+    std::basic_string<char> red  = std::regex_replace(tmp3, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
 
     return os::strdup(red.c_str());
 }

--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -44,6 +44,7 @@ static const char* replace_addr_expr(const char* str)
     std::basic_string<char> tmp2 = std::regex_replace(tmp1, std::regex("\\s+<addr>:\\s+\\.inst\\t<addr> ; undefined"), "");
     std::basic_string<char> tmp3 = std::regex_replace(tmp2, std::regex("\\s+<addr>:\\s+udf\\t#0"), "");
     // Padding: x64
+    std::basic_string<char> red  = std::regex_replace(tmp3, std::regex("\\s+<addr>:\\s+hlt[ \\t]+(?!\\n\\s+;;)"), "");
 
     return os::strdup(red.c_str());
 }


### PR DESCRIPTION
I backport this as follow up of [JDK-8264207](https://bugs.openjdk.org/browse/JDK-8264207)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8286660](https://bugs.openjdk.org/browse/JDK-8286660) needs maintainer approval
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8286660: codestrings gtest fails on AArch64: "udf" in padding`

### Issue
 * [JDK-8286660](https://bugs.openjdk.org/browse/JDK-8286660): codestrings gtest fails on AArch64: "udf" in padding (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3752/head:pull/3752` \
`$ git checkout pull/3752`

Update a local copy of the PR: \
`$ git checkout pull/3752` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3752`

View PR using the GUI difftool: \
`$ git pr show -t 3752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3752.diff">https://git.openjdk.org/jdk17u-dev/pull/3752.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3752#issuecomment-3073086911)
</details>
