### PR TITLE
8360664: Null pointer dereference in src/hotspot/share/prims/jvmtiTagMap.cpp in IterateOverHeapObjectClosure::do_object()

### DIFF
--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -957,6 +957,7 @@ class IterateOverHeapObjectClosure: public ObjectClosure {
 
 // invoked for each object in the heap
 void IterateOverHeapObjectClosure::do_object(oop o) {
+  assert(o != nullptr, "Heap iteration should never produce null!");
   // check if iteration has been halted
   if (is_iteration_aborted()) return;
 
@@ -966,7 +967,7 @@ void IterateOverHeapObjectClosure::do_object(oop o) {
   }
 
   // skip if object is a dormant shared object whose mirror hasn't been loaded
-  if (o != NULL && o->klass()->java_mirror() == NULL) {
+  if (o->klass()->java_mirror() == NULL) {
     log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s)", p2i(o),
                          o->klass()->external_name());
     return;
@@ -1045,6 +1046,7 @@ class IterateThroughHeapObjectClosure: public ObjectClosure {
 
 // invoked for each object in the heap
 void IterateThroughHeapObjectClosure::do_object(oop obj) {
+  assert(obj != nullptr, "Heap iteration should never produce null!");
   // check if iteration has been halted
   if (is_iteration_aborted()) return;
 
@@ -1052,7 +1054,7 @@ void IterateThroughHeapObjectClosure::do_object(oop obj) {
   if (is_filtered_by_klass_filter(obj, klass())) return;
 
   // skip if object is a dormant shared object whose mirror hasn't been loaded
-  if (obj != NULL &&   obj->klass()->java_mirror() == NULL) {
+  if (obj->klass()->java_mirror() == NULL) {
     log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s)", p2i(obj),
                          obj->klass()->external_name());
     return;


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [e9a43416](https://github.com/openjdk/jdk/commit/e9a434165a6ec07cde0429c7f9823bbc5dab7857) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Artem Semenov on 7 Jul 2025 and was reviewed by Serguei Spitsyn, Alex Menkov and Chris Plummer.

This patch adds an assert that demonstrates that NULL cannot be passed to this function. This change will simplify code analysis during bug hunting and investigation.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] [JDK-8360664](https://bugs.openjdk.org/browse/JDK-8360664) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360664](https://bugs.openjdk.org/browse/JDK-8360664): Null pointer dereference in src/hotspot/share/prims/jvmtiTagMap.cpp in IterateOverHeapObjectClosure::do_object() (**Bug** - P4 - Rejected)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3761/head:pull/3761` \
`$ git checkout pull/3761`

Update a local copy of the PR: \
`$ git checkout pull/3761` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3761`

View PR using the GUI difftool: \
`$ git pr show -t 3761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3761.diff">https://git.openjdk.org/jdk17u-dev/pull/3761.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3761#issuecomment-3078560058)
</details>
