### PR TITLE
8319932: [JVMCI] class unloading related tests can fail on libgraal

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassInitErrors/InitExceptionUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/InitExceptionUnloadTest.java
@@ -37,6 +37,8 @@
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Set;
+import java.util.List;
 
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
@@ -122,10 +124,9 @@ public class InitExceptionUnloadTest {
             }
         }
         cl = null;
-        ClassUnloadCommon.triggerUnloading();  // should unload these classes
-        for (String className : classNames) {
-          ClassUnloadCommon.failIf(wb.isClassAlive(className), "should be unloaded");
-        }
+
+        Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(classNames));
+        ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should be unloaded: " + aliveClasses);
     }
     public static void main(java.lang.String[] unused) throws Throwable {
         test();


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8319932](https://bugs.openjdk.org/browse/JDK-8319932) needs maintainer approval

### Issue
 * [JDK-8319932](https://bugs.openjdk.org/browse/JDK-8319932): [JVMCI] class unloading related tests can fail on libgraal (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3766/head:pull/3766` \
`$ git checkout pull/3766`

Update a local copy of the PR: \
`$ git checkout pull/3766` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3766`

View PR using the GUI difftool: \
`$ git pr show -t 3766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3766.diff">https://git.openjdk.org/jdk17u-dev/pull/3766.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3766#issuecomment-3082878542)
</details>
