### PR TITLE
Backport 7af46a6b424cadfe298958d774da0f21db58ecd3

### DIFF
--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1637,7 +1637,7 @@ public class MessageFormat extends Format {
 
         // Check the correctness of arguments and offsets
         if (isValid) {
-            int lastOffset = patt.length() + 1;
+            int lastOffset = patt.length();
             for (int i = maxOff; i >= 0; --i) {
                 if (argNums[i] < 0 || argNums[i] >= MAX_ARGUMENT_INDEX
                         || offs[i] < 0 || offs[i] > lastOffset) {

--- a/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8331446
+ * @bug 8331446 8340554
  * @summary Check correctness of deserialization
  * @run junit SerializationTest
  */
@@ -70,7 +70,13 @@ public class SerializationTest {
                 // With null locale. (NPE not thrown, if no format defined)
                 new MessageFormat("{1} {0} foo", null),
                 // With formats
-                new MessageFormat("{0,number,short} {0} {1,date,long} foo")
+                new MessageFormat("{0,number,short} {0} {1,date,long} foo"),
+                // Offset equal to pattern length (0)
+                new MessageFormat("{0}"),
+                // Offset equal to pattern length (1)
+                new MessageFormat("X{0}"),
+                // Offset 1 under pattern length
+                new MessageFormat("X{0}X")
         );
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.