### PR TITLE
8357672: Extreme font sizes can cause font substitution

### DIFF
--- a/src/java.desktop/share/classes/sun/font/FileFontStrike.java
+++ b/src/java.desktop/share/classes/sun/font/FileFontStrike.java
@@ -202,7 +202,6 @@ public class FileFontStrike extends PhysicalStrike {
             this.disposer = new FontStrikeDisposer(fileFont, desc);
             initGlyphCache();
             pScalerContext = NullFontScaler.getNullScalerContext();
-            SunFontManager.getInstance().deRegisterBadFont(fileFont);
             return;
         }
         /* First, see if native code should be used to create the glyph.

--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -500,7 +500,6 @@ Java_sun_font_FreetypeFontScaler_createScalerContextNative(
 
     if (context == NULL) {
         free(context);
-        invalidateJavaScaler(env, scaler, NULL);
         return (jlong) 0;
     }
     (*env)->GetDoubleArrayRegion(env, matrix, 0, 4, dmat);

--- a/test/jdk/java/awt/FontMetrics/ExtremeFontSizeTest.java
+++ b/test/jdk/java/awt/FontMetrics/ExtremeFontSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,16 +24,19 @@
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.util.HashMap;
+import java.util.Map;
 
 /*
  * @test
- * @bug 8328896
+ * @bug 8328896 8357672
  * @summary test that using very large font sizes used don't break later uses
  */
 
@@ -49,34 +52,106 @@ public class ExtremeFontSizeTest {
     static double[] scales = { 1.0, 900.0};
     static boolean[] fms = { false, true };
 
+    static class Key {
+        int fontSize;
+        double scale;
+        boolean fm;
+        String str;
+
+
+        Key(int fs, double sc, boolean f, String s) {
+            fontSize = fs;
+            scale = sc;
+            fm = f;
+            str = s;
+        }
+
+        public boolean equals(Object o) {
+           return
+               (o instanceof Key k) &&
+                this.fontSize == k.fontSize &&
+                this.scale == k.scale &&
+                this.fm == k.fm &&
+                this.str.equals(k.str);
+        }
+
+        public int hashCode() {
+           return fontSize + (int)scale + (fm ? 1 : 0) + str.hashCode();
+        }
+    }
+
+    static class Value {
+        int height;
+        double strBounds;
+        Rectangle pixelBounds;
+        Rectangle2D visualBounds;
+
+        Value(int h, double sb, Rectangle pb, Rectangle2D vb) {
+            height = h;
+            strBounds = sb;
+            pixelBounds = pb;
+            visualBounds = vb;
+        }
+
+        public boolean equals(Object o) {
+           return
+               (o instanceof Value v) &&
+                this.height == v.height &&
+                this.strBounds == v.strBounds &&
+                this.pixelBounds.equals(v.pixelBounds) &&
+                this.visualBounds.equals(v.visualBounds);
+        }
+
+        public int hashCode() {
+           return height + (int)strBounds + pixelBounds.hashCode() + visualBounds.hashCode();
+        }
+    }
+
+    static Map<Key, Value> metricsMap = new HashMap<Key, Value>();
+
     public static void main(String[] args) {
+        Font[] fonts = GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts();
+        for (Font f : fonts) {
+            font = f.deriveFont(Font.PLAIN, 12);
+            System.out.println("Test font : " + font);
+            if (font.canDisplayUpTo(testString) != -1) {
+                System.out.println("Skipping since cannot display test string");
+                continue;
+            }
+            metricsMap = new HashMap<Key, Value>();
+            testFont();
+        }
+    }
+
+    static void testFont() {
 
         /* run tests validating bounds etc are non-zero
          * then run with extreme scales for which zero is allowed - but not required
          * then run the first tests again to be sure they are still reasonable.
         */
-        runTests();
-        test(5_000_000, 10_000, false, testString, false);
-        test(5_000_000, 10_000, true, testString, false);
-        test(0, 0.00000001, false, testString, false);
-        runTests();
+        runTests(true, false);
+        test(5_000_000, 10_000, false, testString, false, false, false);
+        test(5_000_000, 10_000, true, testString, false, false, false);
+        test(0, 0.00000001, false, testString, false, false, false);
+        runTests(false, true);
 
         if (failed) {
             throw new RuntimeException("Test failed. Check stdout log.");
         }
     }
 
-    static void runTests() {
+    static void runTests(boolean add, boolean check) {
         for (int fontSize : fontSizes) {
             for (double scale : scales) {
                 for (boolean fm : fms) {
-                    test(fontSize, scale, fm, testString, true);
+                    test(fontSize, scale, fm, testString, true, add, check);
                 }
             }
         }
     }
 
-    static void test(int size, double scale, boolean fm, String str, boolean checkAll) {
+    static void test(int size, double scale, boolean fm, String str,
+                     boolean checkAll, boolean add, boolean check) {
 
         AffineTransform at = AffineTransform.getScaleInstance(scale, scale);
         FontRenderContext frc = new FontRenderContext(at, false, fm);
@@ -114,5 +189,22 @@ public class ExtremeFontSizeTest {
             System.out.println(" *** RESULTS NOT AS EXPECTED  *** ");
         }
         System.out.println();
+
+        Key k = null;
+        Value v = null;
+        if (add || check) {
+             k = new Key(size, scale, fm, str);
+             v = new Value(height, width, pixelBounds, visualBounds);
+        }
+        if (add) {
+             metricsMap.put(k, v);
+        }
+        if (check) {
+            Value vmap = metricsMap.get(k);
+            if (!v.equals(vmap)) {
+               failed = true;
+               System.out.println("Values differ");
+            }
+        }
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8357672](https://bugs.openjdk.org/browse/JDK-8357672) needs maintainer approval

### Issue
 * [JDK-8357672](https://bugs.openjdk.org/browse/JDK-8357672): Extreme font sizes can cause font substitution (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3776/head:pull/3776` \
`$ git checkout pull/3776`

Update a local copy of the PR: \
`$ git checkout pull/3776` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3776`

View PR using the GUI difftool: \
`$ git pr show -t 3776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3776.diff">https://git.openjdk.org/jdk17u-dev/pull/3776.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3776#issuecomment-3094777793)
</details>
