### PR TITLE
8362839: [21u] Problem list more tests that fail in 21 and would be fixed by 8309622

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -80,10 +80,17 @@ gc/g1/logging/TestG1LoggingFailure.java 8169634 generic-all
 gc/g1/humongousObjects/TestHeapCounters.java 8178918 generic-all
 gc/shenandoah/TestAllocIntArrays.java#aggressive 8309622 generic-all
 gc/shenandoah/TestAllocIntArrays.java#iu-aggressive 8309622 generic-all
+gc/shenandoah/TestAllocObjectArrays.java#aggressive 8309622 generic-all
+gc/shenandoah/TestAllocObjectArrays.java#iu-aggressive 8309622 generic-all
+gc/shenandoah/TestJcmdHeapDump.java#aggressive 8309622 generic-all
+gc/shenandoah/TestJcmdHeapDump.java#iu-aggressive 8309622 generic-all
+gc/shenandoah/TestSieveObjects.java#aggressive 8309622 generic-all
+gc/shenandoah/TestSieveObjects.java#iu-aggressive 8309622 generic-all
 gc/stress/CriticalNativeStress.java#id1 8312028 generic-all
 gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
 gc/stress/gclocker/TestGCLockerWithParallel.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithG1.java 8180622 generic-all
+gc/stress/gcold/TestGCOldWithShenandoah.java#aggressive 8309622 generic-all
 gc/stress/gcold/TestGCOldWithShenandoah.java#iu-aggressive 8309622 generic-all
 gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java 8192647 generic-all
 


### PR DESCRIPTION
I backport this as we see the same issues in 17.

Resolved Problemlist, probably clean anyways.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362839](https://bugs.openjdk.org/browse/JDK-8362839) needs maintainer approval

### Issue
 * [JDK-8362839](https://bugs.openjdk.org/browse/JDK-8362839): [21u] Problem list more tests that fail in 21 and would be fixed by 8309622 (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3782/head:pull/3782` \
`$ git checkout pull/3782`

Update a local copy of the PR: \
`$ git checkout pull/3782` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3782`

View PR using the GUI difftool: \
`$ git pr show -t 3782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3782.diff">https://git.openjdk.org/jdk17u-dev/pull/3782.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3782#issuecomment-3102371785)
</details>
