### PR TITLE
Backport 9412c0a2caf7d1c279f933e1f767eb3689a2a1ca

### DIFF
--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -90,10 +90,8 @@ LOG_LEVEL_LIST
     if (f != NULL) {
       size_t sz = output.size();
       size_t written = fwrite(output.c_str(), sizeof(char), output.size(), f);
-
-      if (written == sz * sizeof(char)) {
-        return fclose(f) == 0;
-      }
+      // at least see "header"
+      return fclose(f) == 0 && sz == written && sz >= 6;
     }
 
     return false;
@@ -240,38 +238,46 @@ TEST_VM_F(AsyncLogTest, droppingMessage) {
 
 TEST_VM_F(AsyncLogTest, stdoutOutput) {
   testing::internal::CaptureStdout();
+  fprintf(stdout, "header");
   set_log_config("stdout", "logging=debug");
 
   test_asynclog_ls();
   test_asynclog_drop_messages();
 
   AsyncLogWriter::flush();
-  EXPECT_TRUE(write_to_file(testing::internal::GetCapturedStdout()));
+  fflush(nullptr);
 
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+  if (write_to_file(testing::internal::GetCapturedStdout())) {
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
-  if (AsyncLogWriter::instance() != nullptr) {
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+    if (AsyncLogWriter::instance() != nullptr) {
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+    }
   }
 }
 
 TEST_VM_F(AsyncLogTest, stderrOutput) {
   testing::internal::CaptureStderr();
+  fprintf(stderr, "header");
   set_log_config("stderr", "logging=debug");
 
   test_asynclog_ls();
   test_asynclog_drop_messages();
 
   AsyncLogWriter::flush();
-  EXPECT_TRUE(write_to_file(testing::internal::GetCapturedStderr()));
+  fflush(nullptr);
 
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+  if (write_to_file(testing::internal::GetCapturedStderr())) {
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
-  if (AsyncLogWriter::instance() != nullptr) {
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+    if (AsyncLogWriter::instance() != nullptr) {
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+    }
   }
 }


### PR DESCRIPTION
Backport for the fix to `gtest/AsyncLogGtest.java` failing intermittently. Fix involves adding 2 checks in `test/hotspot/gtest/logging/test_asynclog.cpp`: 
1. writing "header" to stdout/stderr and account for this change in `write_to_file()` as a way to check that we at least see a non-empty string from stdout/stderr before running the asserts.
2. flushing all streams before calling GetCapturedStream()