### PR TITLE
8363965: GHA: Switch cross-compiling sysroots to Debian bookworm

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -60,26 +60,26 @@ jobs:
             gnu-arch: aarch64
             debian-arch: arm64
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             tolerate-sysroot-errors: false
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             tolerate-sysroot-errors: false
             gnu-abi: eabihf
           - target-cpu: s390x
             gnu-arch: s390x
             debian-arch: s390x
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             tolerate-sysroot-errors: false
           - target-cpu: ppc64le
             gnu-arch: powerpc64le
             debian-arch: ppc64el
             debian-repository: https://httpredir.debian.org/debian/
-            debian-version: bullseye
+            debian-version: bookworm
             tolerate-sysroot-errors: false
           - target-cpu: riscv64
             gnu-arch: riscv64


### PR DESCRIPTION
Fixes GHA cross-compilation jobs.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8363965](https://bugs.openjdk.org/browse/JDK-8363965) needs maintainer approval

### Issue
 * [JDK-8363965](https://bugs.openjdk.org/browse/JDK-8363965): GHA: Switch cross-compiling sysroots to Debian bookworm (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3785/head:pull/3785` \
`$ git checkout pull/3785`

Update a local copy of the PR: \
`$ git checkout pull/3785` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3785`

View PR using the GUI difftool: \
`$ git pr show -t 3785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3785.diff">https://git.openjdk.org/jdk17u-dev/pull/3785.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3785#issuecomment-3133169144)
</details>
