### PR TITLE
8350964: Add an ArtifactResolver.fetch(clazz) method

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -31,7 +31,6 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
@@ -60,7 +59,6 @@ import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
-import jdk.test.lib.artifacts.ArtifactResolverException;
 import jtreg.SkippedException;
 
 public abstract class PKCS11Test {
@@ -240,10 +238,6 @@ public abstract class PKCS11Test {
 
     static String getNSSLibDir(String library) throws Exception {
         Path libPath = getNSSLibPath(library);
-        if (libPath == null) {
-            return null;
-        }
-
         String libDir = String.valueOf(libPath.getParent()) + File.separatorChar;
         System.out.println("nssLibDir: " + libDir);
         System.setProperty("pkcs11test.nss.libdir", libDir);
@@ -257,12 +251,7 @@ public abstract class PKCS11Test {
     static Path getNSSLibPath(String library) throws Exception {
         String osid = getOsId();
         Path libraryName = Path.of(System.mapLibraryName(library));
-        Path nssLibPath = fetchNssLib(osid, libraryName);
-        if (nssLibPath == null) {
-            throw new SkippedException("Warning: unsupported OS: " + osid
-                    + ", please initialize NSS library location, skipping test");
-        }
-        return nssLibPath;
+        return fetchNssLib(osid, libraryName);
     }
 
     private static String getOsId() {
@@ -667,7 +656,7 @@ public abstract class PKCS11Test {
         return data;
     }
 
-    private static Path fetchNssLib(String osId, Path libraryName) {
+    private static Path fetchNssLib(String osId, Path libraryName) throws IOException {
         switch (osId) {
             case "Windows-amd64-64":
                 return fetchNssLib(WINDOWS_X64.class, libraryName);
@@ -692,28 +681,13 @@ public abstract class PKCS11Test {
                     return fetchNssLib(LINUX_AARCH64.class, libraryName);
                 }
             default:
-                return null;
+                throw new SkippedException("Unsupported OS: " + osId);
         }
     }
 
-    private static Path fetchNssLib(Class<?> clazz, Path libraryName) {
-        Path path = null;
-        try {
-            Path p = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue();
-            path = findNSSLibrary(p, libraryName);
-        } catch (ArtifactResolverException | IOException e) {
-            Throwable cause = e.getCause();
-            if (cause == null) {
-                System.out.println("Cannot resolve artifact, "
-                        + "please check if JIB jar is present in classpath.");
-            } else {
-                throw new RuntimeException("Fetch artifact failed: " + clazz
-                        + "\nPlease make sure the artifact is available.", e);
-            }
-        }
-        Policy.setPolicy(null); // Clear the policy created by JIB if any
-        return path;
+    private static Path fetchNssLib(Class<?> clazz, Path libraryName) throws IOException {
+        Path p = ArtifactResolver.fetchOne(clazz);
+        return findNSSLibrary(p, libraryName);
     }
 
     private static Path findNSSLibrary(Path path, Path libraryName) throws IOException {

--- a/test/jdk/sun/security/pkcs11/SecmodTest.java
+++ b/test/jdk/sun/security/pkcs11/SecmodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ public class SecmodTest extends PKCS11Test {
         useNSS();
         LIBPATH = getNSSLibDir();
         // load all the libraries except libnss3 into memory
-        if ((LIBPATH == null) || (!loadNSPR(LIBPATH))) {
+        if (!loadNSPR(LIBPATH)) {
             throw new SkippedException("Failed to load NSS libraries");
         }
 

--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -56,7 +56,6 @@ import jdk.test.lib.SecurityTools;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.security.OpensslArtifactFetcher;
-import jtreg.SkippedException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -82,19 +81,9 @@ public class KeytoolOpensslInteropTest {
         boolean generatePKCS12 = Boolean.parseBoolean(args[0]);
         if (generatePKCS12) {
             String opensslPath = OpensslArtifactFetcher.getOpensslPath();
-            if (opensslPath != null) {
-                // if the current version of openssl is available, perform all
-                // keytool <-> openssl interop tests
-                generateInitialKeystores(opensslPath);
-                testWithJavaCommands();
-                testWithOpensslCommands(opensslPath);
-            } else {
-                String exMsg = "Can't find the version: "
-                        + OpensslArtifactFetcher.getTestOpensslBundleVersion()
-                        + " of openssl binary on this machine, please install"
-                        + " and set openssl path with property 'test.openssl.path'";
-                throw new SkippedException(exMsg);
-            }
+            generateInitialKeystores(opensslPath);
+            testWithJavaCommands();
+            testWithOpensslCommands(opensslPath);
         } else {
             // since this scenario is using preexisting PKCS12, skip all
             // openssl command dependent tests

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
@@ -23,6 +23,8 @@
 
 package jdk.test.lib.artifacts;
 
+import jtreg.SkippedException;
+
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,6 +59,38 @@ public class ArtifactResolver {
         }
 
         return locations;
+    }
+
+    /**
+     * Retrieve an artifact/library/file from a repository or local file system.
+     * <p>
+     * Artifacts are defined with the {@link jdk.test.lib.artifacts.Artifact}
+     * annotation.
+     * <p>
+     * If you have a local version of a dependency that you want to use, you can
+     * specify that by setting the system property:
+     * <code>jdk.test.lib.artifacts.ARTIFACT_NAME</code>. Where ARTIFACT_NAME
+     * is the name field of the Artifact annotation.
+     * <p>
+     * Generally, tests that use this method should be run with <code>make test</code>.
+     * However, tests can also be run with <code>jtreg</code> but you must have a
+     * local copy of the artifact and the system property must be set as specified
+     * above.
+     *
+     * @param klass a class annotated with {@link jdk.test.lib.artifacts.Artifact}
+     * @return the local path to the artifact. If the artifact is a compressed
+     * file that gets unpacked, this path will point to the root
+     * directory of the uncompressed file(s).
+     * @throws SkippedException thrown if the artifact cannot be found
+     */
+    public static Path fetchOne(Class<?> klass) {
+        try {
+            return ArtifactResolver.resolve(klass).entrySet().stream()
+                    .findAny().get().getValue();
+        } catch (ArtifactResolverException e) {
+            Artifact artifact = klass.getAnnotation(Artifact.class);
+            throw new SkippedException("Cannot find the artifact " + artifact.name(), e);
+        }
     }
 
     private static String artifactName(Artifact artifact) {

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -23,14 +23,12 @@
 
 package jdk.test.lib.security;
 
-import java.io.File;
-
 import java.nio.file.Path;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.artifacts.Artifact;
 import jdk.test.lib.artifacts.ArtifactResolver;
-import jdk.test.lib.artifacts.ArtifactResolverException;
+import jtreg.SkippedException;
 
 public class OpensslArtifactFetcher {
 
@@ -50,6 +48,7 @@ public class OpensslArtifactFetcher {
            and return that path, if download fails then return null.
      *
      * @return openssl binary path of the current version
+     * @throws SkippedException if a valid version of OpenSSL cannot be found
      */
     public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
@@ -76,7 +75,16 @@ public class OpensslArtifactFetcher {
                 path = fetchOpenssl(MACOSX_AARCH64.class);
             }
         }
-        return verifyOpensslVersion(path, OPENSSL_BUNDLE_VERSION) ? path : null;
+
+        if (!verifyOpensslVersion(path, OPENSSL_BUNDLE_VERSION)) {
+            String exMsg = "Can't find the version: "
+                    + OpensslArtifactFetcher.getTestOpensslBundleVersion()
+                    + " of openssl binary on this machine, please install"
+                    + " and set openssl path with property 'test.openssl.path'";
+            throw new SkippedException(exMsg);
+        } else {
+            return path;
+        }
     }
 
     private static String getOpensslFromSystemProp(String version) {
@@ -112,23 +120,9 @@ public class OpensslArtifactFetcher {
     }
 
     private static String fetchOpenssl(Class<?> clazz) {
-        String path = null;
-        try {
-            path = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue() + File.separator + "openssl"
-                    + File.separator + "bin" + File.separator + "openssl";
-            System.out.println("path: " + path);
-        } catch (ArtifactResolverException e) {
-            Throwable cause = e.getCause();
-            if (cause == null) {
-                System.out.println("Cannot resolve artifact, "
-                        + "please check if JIB jar is present in classpath.");
-            } else {
-                throw new RuntimeException("Fetch artifact failed: " + clazz
-                        + "\nPlease make sure the artifact is available.", e);
-            }
-        }
-        return path;
+        return ArtifactResolver.fetchOne(clazz)
+            .resolve("openssl").resolve("bin").resolve("openssl")
+                .toString();
     }
 
     // retrieve the provider directory path from <OPENSSL_HOME>/bin/openssl


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

Clean backport, although skara would not grok it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350964](https://bugs.openjdk.org/browse/JDK-8350964) needs maintainer approval

### Issue
 * [JDK-8350964](https://bugs.openjdk.org/browse/JDK-8350964): Add an ArtifactResolver.fetch(clazz) method (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3788/head:pull/3788` \
`$ git checkout pull/3788`

Update a local copy of the PR: \
`$ git checkout pull/3788` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3788`

View PR using the GUI difftool: \
`$ git pr show -t 3788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3788.diff">https://git.openjdk.org/jdk17u-dev/pull/3788.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3788#issuecomment-3133334264)
</details>
