### PR TITLE
8349214: Improve size optimization flags for MSVC builds

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -316,7 +316,7 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_DEBUG="-Od"
     C_O_FLAG_DEBUG_JVM=""
     C_O_FLAG_NONE="-Od"
-    C_O_FLAG_SIZE="-Os"
+    C_O_FLAG_SIZE="-O1"
   fi
 
   # Now copy to C++ flags


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349214](https://bugs.openjdk.org/browse/JDK-8349214) needs maintainer approval

### Issue
 * [JDK-8349214](https://bugs.openjdk.org/browse/JDK-8349214): Improve size optimization flags for MSVC builds (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3789/head:pull/3789` \
`$ git checkout pull/3789`

Update a local copy of the PR: \
`$ git checkout pull/3789` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3789`

View PR using the GUI difftool: \
`$ git pr show -t 3789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3789.diff">https://git.openjdk.org/jdk17u-dev/pull/3789.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3789#issuecomment-3136436972)
</details>
