### PR TITLE
8288209: SSL debug message wrong about unsupported authentication scheme

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/CertificateMessage.java
+++ b/src/java.base/share/classes/sun/security/ssl/CertificateMessage.java
@@ -1042,46 +1042,22 @@ final class CertificateMessage {
                 return null;
             }
 
-            Collection<String> checkedKeyTypes = new HashSet<>();
-            List<String> supportedKeyTypes = new ArrayList<>();
-            for (SignatureScheme ss : hc.peerRequestedCertSignSchemes) {
-                if (checkedKeyTypes.contains(ss.keyAlgorithm)) {
-                    if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                        SSLLogger.warning(
-                            "Unsupported authentication scheme: " + ss.name);
-                    }
-                    continue;
-                }
-                checkedKeyTypes.add(ss.keyAlgorithm);
-
-                // Don't select a signature scheme unless we will be able to
-                // produce a CertificateVerify message later
-                if (SignatureScheme.getPreferableAlgorithm(
-                        hc.algorithmConstraints,
-                        hc.peerRequestedSignatureSchemes,
-                        ss, hc.negotiatedProtocol) == null) {
-
-                    if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                        SSLLogger.warning(
-                            "Unable to produce CertificateVerify for " +
-                            "signature scheme: " + ss.name);
-                    }
-                    continue;
-                }
-
-                X509Authentication ka = X509Authentication.valueOf(ss);
-                if (ka == null) {
-                    if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
-                        SSLLogger.warning(
-                            "Unsupported authentication scheme: " + ss.name);
-                    }
-                    continue;
-                }
-                supportedKeyTypes.add(ss.keyAlgorithm);
-            }
+            String[] supportedKeyTypes = hc.peerRequestedCertSignSchemes
+                    .stream()
+                    .map(ss -> ss.keyAlgorithm)
+                    .distinct()
+                    .filter(ka -> SignatureScheme.getPreferableAlgorithm(   // Don't select a signature scheme unless
+                            hc.algorithmConstraints,                        //  we will be able to produce
+                            hc.peerRequestedSignatureSchemes,               //  a CertificateVerify message later
+                            ka, hc.negotiatedProtocol) != null
+                            || SSLLogger.logWarning("ssl,handshake",
+                                    "Unable to produce CertificateVerify for key algorithm: " + ka))
+                    .filter(ka -> X509Authentication.valueOfKeyAlgorithm(ka) != null
+                            || SSLLogger.logWarning("ssl,handshake", "Unsupported key algorithm: " + ka))
+                    .toArray(String[]::new);
 
             SSLPossession pos = X509Authentication
-                    .createPossession(hc, supportedKeyTypes.toArray(String[]::new));
+                    .createPossession(hc, supportedKeyTypes);
             if (pos == null) {
                 if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
                     SSLLogger.warning("No available authentication scheme");

--- a/src/java.base/share/classes/sun/security/ssl/SSLLogger.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLLogger.java
@@ -210,6 +210,15 @@ public final class SSLLogger {
         }
     }
 
+    // Logs a warning message and always returns false. This method
+    // can be used as an OR Predicate to add a log in a stream filter.
+    public static boolean logWarning(String option, String s) {
+        if (SSLLogger.isOn && SSLLogger.isOn(option)) {
+            SSLLogger.warning(s);
+        }
+        return false;
+    }
+
     private static class SSLConsoleLogger implements Logger {
         private final String loggerName;
         private final boolean useCompactFormat;

--- a/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureScheme.java
@@ -455,13 +455,13 @@ enum SignatureScheme {
     static SignatureScheme getPreferableAlgorithm(
             AlgorithmConstraints constraints,
             List<SignatureScheme> schemes,
-            SignatureScheme certScheme,
+            String keyAlgorithm,
             ProtocolVersion version) {
 
         for (SignatureScheme ss : schemes) {
             if (ss.isAvailable &&
                     ss.handshakeSupportedProtocols.contains(version) &&
-                    certScheme.keyAlgorithm.equalsIgnoreCase(ss.keyAlgorithm) &&
+                    keyAlgorithm.equalsIgnoreCase(ss.keyAlgorithm) &&
                     ss.isPermitted(constraints)) {
                 return ss;
             }

--- a/src/java.base/share/classes/sun/security/ssl/X509Authentication.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509Authentication.java
@@ -72,9 +72,9 @@ enum X509Authentication implements SSLAuthentication {
         this.keyTypes = keyTypes;
     }
 
-    static X509Authentication valueOf(SignatureScheme signatureScheme) {
+    static X509Authentication valueOfKeyAlgorithm(String keyAlgorithm) {
         for (X509Authentication au : X509Authentication.values()) {
-            if (au.keyAlgorithm.equals(signatureScheme.keyAlgorithm)) {
+            if (au.keyAlgorithm.equals(keyAlgorithm)) {
                 return au;
             }
         }


### PR DESCRIPTION
I backport this change that does some refactorings to simplify later backports.
It is clean except for Copyrights where the file has already later dates.
This reduces the need for resolving of later backports and thus the chance of errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8288209](https://bugs.openjdk.org/browse/JDK-8288209) needs maintainer approval

### Issue
 * [JDK-8288209](https://bugs.openjdk.org/browse/JDK-8288209): SSL debug message wrong about unsupported authentication scheme (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3791/head:pull/3791` \
`$ git checkout pull/3791`

Update a local copy of the PR: \
`$ git checkout pull/3791` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3791`

View PR using the GUI difftool: \
`$ git pr show -t 3791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3791.diff">https://git.openjdk.org/jdk17u-dev/pull/3791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3791#issuecomment-3144511056)
</details>
