### PR TITLE
8357173: Split jtreg test group jdk tier3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -1,4 +1,4 @@
-#  Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 #  This code is free software; you can redistribute it and/or modify it
@@ -81,14 +81,24 @@ tier2_part2 = \
 tier2_part3 = \
     :jdk_net
 
+# These sub groups of tier3 allow for running certain tests separately from the
+# rest. When adding tests to tier3, in most cases they should be added to
+# tier3_part1.
 tier3 = \
+    :tier3_part1 \
+    :tier3_jpackage
+
+tier3_part1 = \
     :build \
     :jdk_vector \
     -:jdk_vector_sanity \
     :jdk_rmi \
     :jdk_svc \
     -:jdk_svc_sanity \
-    -:svc_tools \
+    -:svc_tools
+
+# The jpackage tests on Windows require permissions that aren't always present
+tier3_jpackage = \
     :jdk_jpackage
 
 # Everything not in other tiers


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

Resolved copyright, probably clean anyways.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8357173](https://bugs.openjdk.org/browse/JDK-8357173) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357173](https://bugs.openjdk.org/browse/JDK-8357173): Split jtreg test group jdk tier3 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3806/head:pull/3806` \
`$ git checkout pull/3806`

Update a local copy of the PR: \
`$ git checkout pull/3806` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3806`

View PR using the GUI difftool: \
`$ git pr show -t 3806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3806.diff">https://git.openjdk.org/jdk17u-dev/pull/3806.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3806#issuecomment-3148634448)
</details>
