### PR TITLE
8334016: Make PrintNullString.java automatic

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,164 +21,113 @@
  * questions.
  */
 
-import java.awt.Button;
-import java.awt.Dimension;
-import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.Panel;
 import java.awt.print.PageFormat;
 import java.awt.print.Printable;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
+import java.io.File;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
 
-import javax.swing.JOptionPane;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.Destination;
 
 /*
  * @test
  * @bug 4223328
- * @summary Printer graphics must behave the same as screen graphics
+ * @summary Printer graphics must throw expected exceptions
  * @key printer
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
- * @run main/manual PrintNullString
+ * @run main PrintNullString
  */
-public class PrintNullString extends Frame {
-    private static final String INSTRUCTIONS =
-            "This test should print a page which contains the same\n" +
-            "text messages as in the test window on the screen.\n" +
-            "\n" +
-            "The messages should contain only 'OK' and 'expected' messages.\n" +
-            "Press Pass if it's the case; otherwise press Fail.\n" +
-            "\n" +
-            "If the page fails to print, but there were no exceptions\n" +
-            "then the problem is likely elsewhere (i.e. your printer)";
+public class PrintNullString implements Printable {
+    private final String nullStr = null;
+    private final String emptyStr = "";
+    private final AttributedString emptyAttStr = new AttributedString(emptyStr);
+    private final AttributedCharacterIterator nullIterator = null;
+    private final AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
 
     public static void main(String[] args) throws Exception {
         if (PrinterJob.lookupPrintServices().length == 0) {
             throw new RuntimeException("Printer not configured or available.");
         }
 
-        PassFailJFrame.builder()
-                .instructions(INSTRUCTIONS)
-                .testUI(PrintNullString::new)
-                .rows((int) INSTRUCTIONS.lines().count() + 1)
-                .columns(45)
-                .build()
-                .awaitAndCheck();
+        new PrintNullString();
     }
 
-    public PrintNullString() {
-        super("PrintNullString");
-
-        TextCanvas c = new TextCanvas();
-        add("Center", c);
-
-        Button b = new Button("Print");
-        add("South", b);
-        b.addActionListener(e -> {
-            PrinterJob pj = PrinterJob.getPrinterJob();
-            if (pj.printDialog()) {
-                pj.setPrintable(c);
-                try {
-                    pj.print();
-                } catch (PrinterException ex) {
-                    ex.printStackTrace();
-                    String msg = "PrinterException: " + ex.getMessage();
-                    JOptionPane.showMessageDialog(b, msg, "Error occurred",
-                            JOptionPane.ERROR_MESSAGE);
-                    PassFailJFrame.forceFail(msg);
-                }
-            }
-        });
-        pack();
+    public PrintNullString() throws PrinterException {
+        PrinterJob pj = PrinterJob.getPrinterJob();
+        pj.setPrintable(this, new PageFormat());
+        PrintRequestAttributeSet pSet = new HashPrintRequestAttributeSet();
+        File file = new File("out.prn");
+        file.deleteOnExit();
+        pSet.add(new Destination(file.toURI()));
+        pj.print(pSet);
     }
 
-    private static class TextCanvas extends Panel implements Printable {
-        private final String nullStr = null;
-        private final String emptyStr = "";
-        private final AttributedString emptyAttStr = new AttributedString(emptyStr);
-        private final AttributedCharacterIterator nullIterator = null;
-        private final AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
-
-        @Override
-        public void paint(Graphics g) {
-            Graphics2D g2d = (Graphics2D) g;
-            paint(g2d);
+    @Override
+    public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
+        if (pgIndex > 0) {
+            return NO_SUCH_PAGE;
         }
 
-        @Override
-        public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-            if (pgIndex > 0) {
-                return NO_SUCH_PAGE;
-            }
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
 
-            Graphics2D g2d = (Graphics2D) g;
-            g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-            paint(g2d);
-
-            return PAGE_EXISTS;
+        // API 1: null & empty drawString(String, int, int);
+        try {
+            g2d.drawString(nullStr, 20, 40);
+            throw new RuntimeException("FAILURE: No NPE for null String, int");
+        } catch (NullPointerException e) {
+            g2d.drawString("caught expected NPE for null String, int", 20, 40);
         }
 
-        private void paint(Graphics2D g2d) {
-            // API 1: null & empty drawString(String, int, int);
-            try {
-                g2d.drawString(nullStr, 20, 40);
-                g2d.drawString("FAILURE: No NPE for null String, int", 20, 40);
-            } catch (NullPointerException e) {
-                g2d.drawString("caught expected NPE for null String, int", 20, 40);
-            }
+        g2d.drawString(emptyStr, 20, 60);
+        g2d.drawString("OK for empty String, int", 20, 60);
 
-            g2d.drawString(emptyStr, 20, 60);
-            g2d.drawString("OK for empty String, int", 20, 60);
-
-            // API 2: null & empty drawString(String, float, float);
-            try {
-                g2d.drawString(nullStr, 20.0f, 80.0f);
-                g2d.drawString("FAILURE: No NPE for null String, float", 20, 80);
-            } catch (NullPointerException e) {
-                g2d.drawString("caught expected NPE for null String, float", 20, 80);
-            }
-
-            g2d.drawString(emptyStr, 20.0f, 100.0f);
-            g2d.drawString("OK for empty String, float", 20.0f, 100.f);
-
-            // API 3: null & empty drawString(Iterator, int, int);
-            try {
-                g2d.drawString(nullIterator, 20, 120);
-                g2d.drawString("FAILURE: No NPE for null iterator, int", 20, 120);
-            } catch (NullPointerException e) {
-                g2d.drawString("caught expected NPE for null iterator, int", 20, 120);
-            }
-
-            try {
-                g2d.drawString(emptyIterator, 20, 140);
-                g2d.drawString("FAILURE: No IAE for empty iterator, int", 20, 140);
-            } catch (IllegalArgumentException e) {
-                g2d.drawString("caught expected IAE for empty iterator, int", 20, 140);
-            }
-
-            // API 4: null & empty drawString(Iterator, float, int);
-            try {
-                g2d.drawString(nullIterator, 20.0f, 160.0f);
-                g2d.drawString("FAILURE: No NPE for null iterator, float", 20, 160);
-            } catch (NullPointerException e) {
-                g2d.drawString("caught expected NPE for null iterator, float", 20, 160);
-            }
-
-            try {
-                g2d.drawString(emptyIterator, 20.0f, 180.0f);
-                g2d.drawString("FAILURE: No IAE for empty iterator, float", 20, 180);
-            } catch (IllegalArgumentException e) {
-                g2d.drawString("caught expected IAE for empty iterator, float", 20, 180);
-            }
+        // API 2: null & empty drawString(String, float, float);
+        try {
+            g2d.drawString(nullStr, 20.0f, 80.0f);
+            throw new RuntimeException("FAILURE: No NPE for null String, float");
+        } catch (NullPointerException e) {
+            g2d.drawString("caught expected NPE for null String, float", 20, 80);
         }
 
-        @Override
-        public Dimension getPreferredSize() {
-            return new Dimension(450, 250);
+        g2d.drawString(emptyStr, 20.0f, 100.0f);
+        g2d.drawString("OK for empty String, float", 20.0f, 100.f);
+
+        // API 3: null & empty drawString(Iterator, int, int);
+        try {
+            g2d.drawString(nullIterator, 20, 120);
+            throw new RuntimeException("FAILURE: No NPE for null iterator, int");
+        } catch (NullPointerException e) {
+            g2d.drawString("caught expected NPE for null iterator, int", 20, 120);
         }
+
+        try {
+            g2d.drawString(emptyIterator, 20, 140);
+            throw new RuntimeException("FAILURE: No IAE for empty iterator, int");
+        } catch (IllegalArgumentException e) {
+            g2d.drawString("caught expected IAE for empty iterator, int", 20, 140);
+        }
+
+        // API 4: null & empty drawString(Iterator, float, int);
+        try {
+            g2d.drawString(nullIterator, 20.0f, 160.0f);
+            throw new RuntimeException("FAILURE: No NPE for null iterator, float");
+        } catch (NullPointerException e) {
+            g2d.drawString("caught expected NPE for null iterator, float", 20, 160);
+        }
+
+        try {
+            g2d.drawString(emptyIterator, 20.0f, 180.0f);
+            throw new RuntimeException("FAILURE: No IAE for empty iterator, float");
+        } catch (IllegalArgumentException e) {
+            g2d.drawString("caught expected IAE for empty iterator, float", 20, 180);
+        }
+
+        return PAGE_EXISTS;
     }
 }


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8334016](https://bugs.openjdk.org/browse/JDK-8334016) needs maintainer approval

### Issue
 * [JDK-8334016](https://bugs.openjdk.org/browse/JDK-8334016): Make PrintNullString.java automatic (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3807/head:pull/3807` \
`$ git checkout pull/3807`

Update a local copy of the PR: \
`$ git checkout pull/3807` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3807/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3807`

View PR using the GUI difftool: \
`$ git pr show -t 3807`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3807.diff">https://git.openjdk.org/jdk17u-dev/pull/3807.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3807#issuecomment-3148642639)
</details>
