### PR TITLE
8355779: When no "signature_algorithms_cert" extension is present we do not apply certificate scope constraints to algorithms in "signature_algorithms" extension

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SignatureAlgorithmsExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SignatureAlgorithmsExtension.java
@@ -25,6 +25,7 @@
 
 package sun.security.ssl;
 
+import static sun.security.ssl.SignatureScheme.CERTIFICATE_SCOPE;
 import static sun.security.ssl.SignatureScheme.HANDSHAKE_SCOPE;
 
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLProtocolException;
 import sun.security.ssl.SSLExtension.ExtensionConsumer;
 import sun.security.ssl.SSLExtension.SSLExtensionSpec;
@@ -276,30 +278,8 @@ final class SignatureAlgorithmsExtension {
                 return;
             }
 
-            // update the context
-            List<SignatureScheme> sss =
-                    SignatureScheme.getSupportedAlgorithms(
-                            shc.sslConfig,
-                            shc.algorithmConstraints, shc.negotiatedProtocol,
-                            spec.signatureSchemes,
-                            HANDSHAKE_SCOPE);
-
-            if (sss == null || sss.isEmpty()) {
-                throw shc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
-                        "No supported signature algorithm");
-            }
-            shc.peerRequestedSignatureSchemes = sss;
-
-            // If no "signature_algorithms_cert" extension is present, then
-            // the "signature_algorithms" extension also applies to
-            // signatures appearing in certificates.
-            SignatureSchemesSpec certSpec =
-                    (SignatureSchemesSpec)shc.handshakeExtensions.get(
-                            SSLExtension.CH_SIGNATURE_ALGORITHMS_CERT);
-            if (certSpec == null) {
-                shc.peerRequestedCertSignSchemes = sss;
-                shc.handshakeSession.setPeerSupportedSignatureAlgorithms(sss);
-            }
+            updateHandshakeContext(shc, spec.signatureSchemes,
+                    SSLExtension.CH_SIGNATURE_ALGORITHMS_CERT);
 
             if (!shc.isResumption &&
                     shc.negotiatedProtocol.useTLS13PlusSpec()) {
@@ -507,30 +487,8 @@ final class SignatureAlgorithmsExtension {
                 return;
             }
 
-            // update the context
-            List<SignatureScheme> sss =
-                    SignatureScheme.getSupportedAlgorithms(
-                            chc.sslConfig,
-                            chc.algorithmConstraints, chc.negotiatedProtocol,
-                            spec.signatureSchemes,
-                            HANDSHAKE_SCOPE);
-
-            if (sss == null || sss.isEmpty()) {
-                throw chc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
-                        "No supported signature algorithm");
-            }
-            chc.peerRequestedSignatureSchemes = sss;
-
-            // If no "signature_algorithms_cert" extension is present, then
-            // the "signature_algorithms" extension also applies to
-            // signatures appearing in certificates.
-            SignatureSchemesSpec certSpec =
-                    (SignatureSchemesSpec)chc.handshakeExtensions.get(
-                            SSLExtension.CR_SIGNATURE_ALGORITHMS_CERT);
-            if (certSpec == null) {
-                chc.peerRequestedCertSignSchemes = sss;
-                chc.handshakeSession.setPeerSupportedSignatureAlgorithms(sss);
-            }
+            updateHandshakeContext(chc, spec.signatureSchemes,
+                    SSLExtension.CR_SIGNATURE_ALGORITHMS_CERT);
         }
     }
 
@@ -551,6 +509,51 @@ final class SignatureAlgorithmsExtension {
             throw chc.conContext.fatal(Alert.MISSING_EXTENSION,
                     "No mandatory signature_algorithms extension in the " +
                     "received CertificateRequest handshake message");
+        }
+    }
+
+    // Updates given HandshakeContext with peer signature schemes.
+    private static void updateHandshakeContext(HandshakeContext hc,
+            int[] signatureSchemes, SSLExtension signatureAlgorithmsCertExt)
+            throws SSLException {
+        List<SignatureScheme> handshakeSS =
+                SignatureScheme.getSupportedAlgorithms(
+                        hc.sslConfig,
+                        hc.algorithmConstraints,
+                        hc.negotiatedProtocol,
+                        signatureSchemes,
+                        HANDSHAKE_SCOPE);
+
+        if (handshakeSS.isEmpty()) {
+            throw hc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
+                    "No supported signature algorithm");
+        }
+
+        hc.peerRequestedSignatureSchemes = handshakeSS;
+
+        // If no "signature_algorithms_cert" extension is present, then
+        // the "signature_algorithms" extension also applies to
+        // signatures appearing in certificates.
+        SignatureSchemesSpec certSpec =
+                (SignatureSchemesSpec) hc.handshakeExtensions.get(
+                        signatureAlgorithmsCertExt);
+
+        if (certSpec == null) {
+            List<SignatureScheme> certSS =
+                    SignatureScheme.getSupportedAlgorithms(
+                            hc.sslConfig,
+                            hc.algorithmConstraints,
+                            hc.negotiatedProtocol,
+                            signatureSchemes,
+                            CERTIFICATE_SCOPE);
+
+            if (certSS.isEmpty()) {
+                throw hc.conContext.fatal(Alert.HANDSHAKE_FAILURE,
+                        "No supported signature algorithm");
+            }
+
+            hc.peerRequestedCertSignSchemes = certSS;
+            hc.handshakeSession.setPeerSupportedSignatureAlgorithms(certSS);
         }
     }
 }


### PR DESCRIPTION
I backport this as follow-up to JDK-8349583. This needs to go along with this change and is independent of Java version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8355779](https://bugs.openjdk.org/browse/JDK-8355779) needs maintainer approval

### Issue
 * [JDK-8355779](https://bugs.openjdk.org/browse/JDK-8355779): When no "signature_algorithms_cert" extension is present we do not apply certificate scope constraints to algorithms in "signature_algorithms" extension (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3820/head:pull/3820` \
`$ git checkout pull/3820`

Update a local copy of the PR: \
`$ git checkout pull/3820` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3820`

View PR using the GUI difftool: \
`$ git pr show -t 3820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3820.diff">https://git.openjdk.org/jdk17u-dev/pull/3820.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3820#issuecomment-3156613905)
</details>
