### PR TITLE
8328570: Convert closed JViewport manual applet tests to main

### DIFF
--- a/test/jdk/javax/swing/JViewport/bug4137282.java
+++ b/test/jdk/javax/swing/JViewport/bug4137282.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4137282
+ * @summary Tests that scrollbars appear automatically when the enclosed
+ *          component is enlarged
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4137282
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Dimension;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class bug4137282 {
+
+    private static final String INSTRUCTIONS = """
+        Press the "resize" button. Two scrollbars should appear.
+        Press Pass if they appear and Fail otherwise.""";
+
+    static volatile JPanel pane;
+
+    public static void main(String[] args) throws Exception {
+
+         PassFailJFrame.builder()
+                .title("JViewport Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(5)
+                .columns(30)
+                .testUI(bug4137282::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        pane = new JPanel();
+
+        pane.setBackground(Color.blue);
+        setPaneSize(100, 100);
+        JFrame frame = new JFrame("bug4137282");
+        JScrollPane sp = new JScrollPane(pane);
+
+        JButton b = new JButton("resize");
+        b.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent ev) {
+                    setPaneSize(300, 300);
+                }
+            });
+
+        frame.add(b, BorderLayout.NORTH);
+        frame.add(sp, BorderLayout.CENTER);
+        frame.pack();
+        return frame;
+    }
+
+    static void setPaneSize(int w, int h) {
+        pane.setPreferredSize(new Dimension(w, h));
+        pane.setSize(w, h);
+    }
+}

--- a/test/jdk/javax/swing/JViewport/bug4217252.java
+++ b/test/jdk/javax/swing/JViewport/bug4217252.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4217252
+ * @summary Tests
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4217252
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.Rectangle;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.AbstractTableModel;
+
+public class bug4217252 {
+
+    private static final String INSTRUCTIONS = """
+        Click on the 'Scroll' button and then click it again.
+        If you see row 98 and 99 twice, then test failed, otherwise it passed.""";
+
+    static class TestModel extends AbstractTableModel {
+
+        public String getColumnName(int column) {
+            return Integer.toString(column);
+        }
+
+        public int getRowCount() {
+                return 100;
+        }
+
+        public int getColumnCount() {
+                return 5;
+        }
+
+        public Object getValueAt(int row, int col) {
+                return row + " x " + col;
+        }
+
+        public boolean isCellEditable(int row, int column) { return false; }
+
+        public void setValueAt(Object value, int row, int col) { }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+         PassFailJFrame.builder()
+                .title("JViewport Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(5)
+                .columns(30)
+                .testUI(bug4217252::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI(){
+        JFrame frame = new JFrame("bug4217252");
+        final JTable table = new JTable(new TestModel());
+        JButton scrollButton = new JButton("Scroll");
+        scrollButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ae) {
+                Rectangle bounds = table.getBounds();
+                bounds.y = bounds.height + table.getRowHeight();
+                bounds.height = table.getRowHeight();
+                table.scrollRectToVisible(bounds);
+            }
+        });
+        frame.getContentPane().add(new JScrollPane(table),
+                                   BorderLayout.CENTER);
+        frame.getContentPane().add(scrollButton, BorderLayout.SOUTH);
+        frame.pack();
+        return frame;
+    }
+
+}

--- a/test/jdk/javax/swing/JViewport/bug4237176.java
+++ b/test/jdk/javax/swing/JViewport/bug4237176.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4237176
+ * @summary Tests that background color is set properly for JViewport
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4237176
+ */
+
+import java.awt.Color;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JViewport;
+
+public class bug4237176 {
+
+    private static final String INSTRUCTIONS = """
+        Look at the empty space below the table. It should be blue.
+        If it is, test passes, otherwise it fails.""";
+
+    public static void main(String[] args) throws Exception {
+
+         PassFailJFrame.builder()
+                .title("JViewport Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(5)
+                .columns(30)
+                .testUI(bug4237176::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("Color Demo");
+        JTable table = new JTable(new Object[][]{{"one", "two"}}, new Object[]{"A", "B"});
+        JScrollPane sp = new JScrollPane(table);
+        JViewport vp = sp.getViewport();
+        vp.setBackground(Color.blue);
+        vp.setOpaque(true);
+
+        frame.getContentPane().add(sp);
+        frame.pack();
+        return frame;
+    }
+
+}

--- a/test/jdk/javax/swing/JViewport/bug4243479.java
+++ b/test/jdk/javax/swing/JViewport/bug4243479.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4243479
+ * @summary Tests that JViewport do not blit when not visible
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4243479
+ */
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.FlowLayout;
+import java.awt.Point;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTextArea;
+import javax.swing.JViewport;
+
+public class bug4243479 {
+    private static final String INSTRUCTIONS = """
+        The tabbed pane contains two tabs: "button" and "scrollpane".
+        The second contains some text inserted into a scrollpane.
+        Press the "Press here" button.
+        If a piece of scrollpane appears, press Fail else press Pass.""";
+
+    private static JFrame createTestUI() {
+        char[] text = new char[20000];
+        for (int counter = 0; counter < text.length; counter++) {
+            if (counter % 80 == 0) {
+                text[counter] = '\n';
+            }
+            else {
+                text[counter] = 'a';
+            }
+        }
+        JScrollPane sp = new JScrollPane(new JTextArea
+                                               (new String(text)));
+        final JViewport vp = sp.getViewport();
+        vp.putClientProperty("EnableWindowBlit", Boolean.TRUE);
+        JTabbedPane tp = new JTabbedPane();
+        JPanel panel = new JPanel(new FlowLayout());
+        JButton button = new JButton("Press here");
+        button.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ae) {
+                Point location = vp.getViewPosition();
+                location.y += 100;
+                vp.setViewPosition(location);
+            }
+        });
+        panel.add(button);
+        tp.add("button", panel);
+        tp.add("scrollpane", sp);
+        JFrame frame = new JFrame("4243479 Test");
+        frame.getContentPane().add(tp);
+        frame.pack();
+        return frame;
+    }
+
+    public static void main(String[] argv) throws Exception {
+         PassFailJFrame.builder()
+                .title("JViewport Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(5)
+                .columns(30)
+                .position(PassFailJFrame.Position.TOP_LEFT_CORNER)
+                .testUI(bug4243479::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/JViewport/bug4750421.java
+++ b/test/jdk/javax/swing/JViewport/bug4750421.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4750421
+ * @summary 4143833 - regression in 1.4.x
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4750421
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JViewport;
+
+public class bug4750421 {
+
+    private static final String INSTRUCTIONS = """
+        A table will be shown.
+        Select the third row of the table.
+        Then press down arrow button of vertical scrollbar to scroll down.
+            (in macos drag the vertical scrollbar down via mouse just enough
+            to scroll by 1 unit as there is no arrow button in scrollbar)
+        If the selection disappears press Fail else press Pass.""";
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("bug4750421");
+        JTable table = new JTable(30, 10);
+        table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+        JScrollPane pane = new JScrollPane(table);
+        frame.getContentPane().add(pane);
+        pane.getViewport().setScrollMode(JViewport.BACKINGSTORE_SCROLL_MODE);
+        frame.pack();
+        return frame;
+    }
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("JViewport Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(7)
+                .columns(35)
+                .testUI(bug4750421::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8328570](https://bugs.openjdk.org/browse/JDK-8328570) needs maintainer approval

### Issue
 * [JDK-8328570](https://bugs.openjdk.org/browse/JDK-8328570): Convert closed JViewport manual applet tests to main (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3828/head:pull/3828` \
`$ git checkout pull/3828`

Update a local copy of the PR: \
`$ git checkout pull/3828` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3828`

View PR using the GUI difftool: \
`$ git pr show -t 3828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3828.diff">https://git.openjdk.org/jdk17u-dev/pull/3828.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3828#issuecomment-3167128273)
</details>
