### PR TITLE
8266247: Swing test bug7154030.java sometimes fails on macOS 11 ARM

### DIFF
--- a/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
+++ b/test/jdk/javax/swing/JComponent/7154030/bug7154030.java
@@ -74,6 +74,8 @@ public class bug7154030 {
                 @Override
                 public void run() {
                     JDesktopPane desktop = new JDesktopPane();
+                    desktop.setBackground(Color.WHITE);
+                    desktop.setForeground(Color.BLACK);
                     button = new JButton("button");
                     frame = new JFrame();
                     frame.setUndecorated(true);


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8266247](https://bugs.openjdk.org/browse/JDK-8266247) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266247](https://bugs.openjdk.org/browse/JDK-8266247): Swing test bug7154030.java sometimes fails on macOS 11 ARM (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3840/head:pull/3840` \
`$ git checkout pull/3840`

Update a local copy of the PR: \
`$ git checkout pull/3840` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3840`

View PR using the GUI difftool: \
`$ git pr show -t 3840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3840.diff">https://git.openjdk.org/jdk17u-dev/pull/3840.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3840#issuecomment-3179346880)
</details>
