### PR TITLE
8293713: java/net/httpclient/BufferingSubscriberTest.java fails in timeout, blocked in submission publisher

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/SubmissionPublisher.java
+++ b/src/java.base/share/classes/java/util/concurrent/SubmissionPublisher.java
@@ -1059,7 +1059,7 @@ public class SubmissionPublisher<T> implements Publisher<T>,
         final Subscriber<? super T> subscriber;
         final BiConsumer<? super Subscriber<? super T>, ? super Throwable> onNextHandler;
         Executor executor;                 // null on error
-        Thread waiter;                     // blocked producer thread
+        volatile Thread waiter;            // blocked producer thread
         Throwable pendingError;            // holds until onError issued
         BufferedSubscription<T> next;      // used only by publisher
         BufferedSubscription<T> nextRetry; // used only by publisher


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle, but to 17.0.17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8293713](https://bugs.openjdk.org/browse/JDK-8293713) needs maintainer approval

### Issue
 * [JDK-8293713](https://bugs.openjdk.org/browse/JDK-8293713): java/net/httpclient/BufferingSubscriberTest.java fails in timeout, blocked in submission publisher (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3858/head:pull/3858` \
`$ git checkout pull/3858`

Update a local copy of the PR: \
`$ git checkout pull/3858` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3858`

View PR using the GUI difftool: \
`$ git pr show -t 3858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3858.diff">https://git.openjdk.org/jdk17u-dev/pull/3858.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3858#issuecomment-3190883067)
</details>
