### PR TITLE
8140527: JInternalFrame has incorrect title button width

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsIconFactory.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsIconFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package com.sun.java.swing.plaf.windows;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
@@ -175,7 +174,7 @@ public class WindowsIconFactory implements Serializable
 
     @SuppressWarnings("serial") // Same-version serialization only
     private static class FrameButtonIcon implements Icon, Serializable {
-        private Part part;
+        private final Part part;
 
         private FrameButtonIcon(Part part) {
             this.part = part;
@@ -286,18 +285,10 @@ public class WindowsIconFactory implements Serializable
             int width;
             if (XPStyle.getXP() != null) {
                 // Fix for XP bug where sometimes these sizes aren't updated properly
-                // Assume for now that height is correct and derive width using the
-                // ratio from the uxtheme part
-                width = UIManager.getInt("InternalFrame.titleButtonHeight") -2;
-                Dimension d = XPStyle.getPartSize(Part.WP_CLOSEBUTTON, State.NORMAL);
-                if (d != null && d.width != 0 && d.height != 0) {
-                    width = (int) ((float) width * d.width / d.height);
-                }
+                // Assume for now that height is correct and derive width from height
+                width = UIManager.getInt("InternalFrame.titleButtonHeight") + 10;
             } else {
-                width = UIManager.getInt("InternalFrame.titleButtonWidth") -2;
-            }
-            if (XPStyle.getXP() != null) {
-                width -= 2;
+                width = UIManager.getInt("InternalFrame.titleButtonHeight") - 2;
             }
             return width;
         }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsInternalFrameTitlePane.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsInternalFrameTitlePane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,46 @@
 
 package com.sun.java.swing.plaf.windows;
 
-import sun.swing.SwingUtilities2;
-
-import javax.swing.*;
-import javax.swing.border.*;
-import javax.swing.UIManager;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.BasicInternalFrameTitlePane;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.LayoutManager;
+import java.awt.Paint;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 
-import static com.sun.java.swing.plaf.windows.TMSchema.*;
+import javax.swing.BorderFactory;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.JInternalFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JSeparator;
+import javax.swing.LookAndFeel;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.border.Border;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicInternalFrameTitlePane;
+
+import sun.swing.SwingUtilities2;
+
+import static com.sun.java.swing.plaf.windows.TMSchema.Part;
+import static com.sun.java.swing.plaf.windows.TMSchema.Prop;
+import static com.sun.java.swing.plaf.windows.TMSchema.State;
 import static com.sun.java.swing.plaf.windows.XPStyle.Skin;
 
 @SuppressWarnings("serial") // Superclass is not serializable across versions
@@ -68,7 +94,6 @@ public class WindowsInternalFrameTitlePane extends BasicInternalFrameTitlePane {
         super.installDefaults();
 
         titlePaneHeight = UIManager.getInt("InternalFrame.titlePaneHeight");
-        buttonWidth     = UIManager.getInt("InternalFrame.titleButtonWidth")  - 4;
         buttonHeight    = UIManager.getInt("InternalFrame.titleButtonHeight") - 4;
 
         Object obj      = UIManager.get("InternalFrame.titleButtonToolTipsOn");
@@ -77,15 +102,10 @@ public class WindowsInternalFrameTitlePane extends BasicInternalFrameTitlePane {
 
         if (XPStyle.getXP() != null) {
             // Fix for XP bug where sometimes these sizes aren't updated properly
-            // Assume for now that height is correct and derive width using the
-            // ratio from the uxtheme part
-            buttonWidth = buttonHeight;
-            Dimension d = XPStyle.getPartSize(Part.WP_CLOSEBUTTON, State.NORMAL);
-            if (d != null && d.width != 0 && d.height != 0) {
-                buttonWidth = (int) ((float) buttonWidth * d.width / d.height);
-            }
+            // Assume for now that height is correct and derive width from height
+            buttonWidth = buttonHeight + 14;
         } else {
-            buttonWidth += 2;
+            buttonWidth = buttonHeight + 2;
             Color activeBorderColor =
                     UIManager.getColor("InternalFrame.activeBorderColor");
             setBorder(BorderFactory.createLineBorder(activeBorderColor, 1));

--- a/test/jdk/javax/swing/JInternalFrame/InternalFrameTitleButtonTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/InternalFrameTitleButtonTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8140527
+ * @key headful
+ * @requires (os.family == "windows")
+ * @summary InternalFrame has incorrect title button width
+ * @run main InternalFrameTitleButtonTest
+ */
+
+import java.awt.Component;
+import java.awt.Robot;
+
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.plaf.basic.BasicInternalFrameUI;
+
+public class InternalFrameTitleButtonTest {
+
+    private static JFrame frame;
+    private static JInternalFrame iframe;
+
+    public static void main(String[] args) throws Exception {
+        String osName = System.getProperty("os.name");
+        if (!osName.toLowerCase().contains("win")) {
+            System.out.println("The test is applicable only for Windows.");
+            return;
+        }
+
+        UIManager.setLookAndFeel(
+                   "com.sun.java.swing.plaf.windows.WindowsClassicLookAndFeel");
+        try {
+            test(2);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+
+        UIManager.setLookAndFeel(
+              "com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        try {
+            test(14);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+
+        System.out.println("ok");
+    }
+
+    private static void test(final int widthAdd) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            frame = new JFrame();
+
+            JDesktopPane pane = new JDesktopPane();
+            frame.setContentPane(pane);
+            frame.setSize(400, 400);
+            frame.setVisible(true);
+
+            iframe = new JInternalFrame("Mail Reader", true,
+                    true, true, true);
+            iframe.setSize(200, 200);
+            pane.add(iframe);
+            iframe.setVisible(true);
+        });
+
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        robot.delay(1000);
+
+        SwingUtilities.invokeAndWait(() -> {
+            JComponent title = ((BasicInternalFrameUI) iframe.getUI()).getNorthPane();
+            for (int i = 0; i < title.getComponentCount(); i++) {
+                Component c = title.getComponent(i);
+                if (c instanceof JButton button
+                    && !testButtonSize(button, widthAdd)) {
+                    throw new RuntimeException("Wrong title icon size");
+                }
+            }
+        });
+    }
+
+    private static boolean testButtonSize(final JButton button,
+                                          final int widthAdd) {
+        int height = UIManager.getInt("InternalFrame.titleButtonHeight") - 4;
+        Icon icon = button.getIcon();
+        return height == button.getHeight()
+               && (height + widthAdd) == button.getWidth()
+               && height == icon.getIconHeight()
+               && (height + widthAdd) == icon.getIconWidth();
+    }
+}
+


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8139392](https://bugs.openjdk.org/browse/JDK-8139392) needs maintainer approval
- [x] [JDK-8140527](https://bugs.openjdk.org/browse/JDK-8140527) needs maintainer approval

### Issues
 * [JDK-8140527](https://bugs.openjdk.org/browse/JDK-8140527): JInternalFrame has incorrect title button width (**Bug** - P3 - Approved)
 * [JDK-8139392](https://bugs.openjdk.org/browse/JDK-8139392): JInternalFrame has incorrect padding (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3866/head:pull/3866` \
`$ git checkout pull/3866`

Update a local copy of the PR: \
`$ git checkout pull/3866` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3866`

View PR using the GUI difftool: \
`$ git pr show -t 3866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3866.diff">https://git.openjdk.org/jdk17u-dev/pull/3866.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3866#issuecomment-3209741444)
</details>
