### PR TITLE
8361478: GHA: Use MSYS2 from GHA runners

### DIFF
--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -30,15 +30,15 @@ runs:
   using: composite
   steps:
     - name: 'Install MSYS2'
-      uses: msys2/setup-msys2@v2.22.0
+      id: msys2
+      uses: msys2/setup-msys2@v2.28.0
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal
-        location: ${{ runner.tool_cache }}/msys2
+        release: false
 
       # We can't run bash until this is completed, so stick with pwsh
     - name: 'Set MSYS2 path'
       run: |
-        # Prepend msys2/msys64/usr/bin to the PATH
-        echo "$env:RUNNER_TOOL_CACHE/msys2/msys64/usr/bin" >> $env:GITHUB_PATH
+        echo "${{ steps.msys2.outputs.msys2-location }}/usr/bin" >> $env:GITHUB_PATH
       shell: pwsh


### PR DESCRIPTION
Improves GHA performance.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8361478](https://bugs.openjdk.org/browse/JDK-8361478) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361478](https://bugs.openjdk.org/browse/JDK-8361478): GHA: Use MSYS2 from GHA runners (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3872/head:pull/3872` \
`$ git checkout pull/3872`

Update a local copy of the PR: \
`$ git checkout pull/3872` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3872`

View PR using the GUI difftool: \
`$ git pr show -t 3872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3872.diff">https://git.openjdk.org/jdk17u-dev/pull/3872.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3872#issuecomment-3219550829)
</details>
