### PR TITLE
8354285: Open source Swing tests Batch 3

### DIFF
--- a/test/jdk/com/sun/java/swing/plaf/motif/MenuItem/AcceleratorDelimiter/MotifLAFMenuAcceleratorDelimiter.java
+++ b/test/jdk/com/sun/java/swing/plaf/motif/MenuItem/AcceleratorDelimiter/MotifLAFMenuAcceleratorDelimiter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4210461
+ * @summary Tests that Motif Look & Feel's MenuItem Accelerator Delimiter is
+ * shown properly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MotifLAFMenuAcceleratorDelimiter
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.UIManager;
+
+public class MotifLAFMenuAcceleratorDelimiter {
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel(
+                "com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("The Motif LAF failed to instantiate");
+        }
+
+        String INSTRUCTIONS = """
+            The visual design specification for the Motif LAF asks for
+            a "+" to delimit the other two entities in a menu item's
+            accelerator.
+
+            As a point of reference, the visual design specifications for the
+            L&Fs are as follows: JLF/Metal = "-", Mac = "-", Motif = "+",
+            Windows = "+".
+
+            Click on "Menu" of "MotifLAFMenuAcceleratorDelimiter" window,
+            make sure it shows MenuItem with label "Hi There! ^+H" or
+            "Hi There! Ctrl+H".
+
+            If it shows same label test passed otherwise failed.
+            """;
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(50)
+            .testUI(MotifLAFMenuAcceleratorDelimiter::initialize)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static JFrame initialize() {
+        JFrame fr = new JFrame("MotifLAFMenuAcceleratorDelimiter");
+        JPanel menuPanel = new JPanel();
+        JMenuBar menuBar = new JMenuBar();
+        menuBar.setOpaque(true);
+        JMenu exampleMenu = new JMenu("Menu");
+        JMenuItem hiMenuItem = new JMenuItem("Hi There!");
+        hiMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H,
+            ActionEvent.CTRL_MASK));
+        exampleMenu.add(hiMenuItem);
+        menuBar.add(exampleMenu);
+        menuPanel.add(menuBar);
+
+        fr.setLayout(new BorderLayout());
+        fr.add(menuPanel, BorderLayout.CENTER);
+        fr.setSize(250,100);
+        return fr;
+    }
+}

--- a/test/jdk/com/sun/java/swing/plaf/motif/SplitPane/4141400/bug4141400.java
+++ b/test/jdk/com/sun/java/swing/plaf/motif/SplitPane/4141400/bug4141400.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4141400
+ * @summary Tests that the divider of JSplitPane can be moved only by
+ * dragging its thumb under Motif LAF
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4141400
+ */
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JSplitPane;
+import javax.swing.UIManager;
+
+public class bug4141400 {
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel(
+                "com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set Motif LAF");
+        }
+
+        String INSTRUCTIONS = """
+            Place mouse cursor somewhere on the split pane divider, but outside
+            its thumb. Then try to move the divider. It should not move. If it
+            does not move, the test passes, otherwise it fails.
+            """;
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(70)
+            .testUI(bug4141400::initialize)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static JFrame initialize() {
+        JFrame fr = new JFrame("bug4141400");
+        JSplitPane pane = new JSplitPane(JSplitPane.VERTICAL_SPLIT,
+            true,
+            new JButton("Button 1"),
+            new JButton("Button 2"));
+        fr.add(pane);
+        fr.setSize(250, 300);
+        return fr;
+    }
+}

--- a/test/jdk/com/sun/java/swing/plaf/windows/MenuItem/4685843/bug4685843.java
+++ b/test/jdk/com/sun/java/swing/plaf/windows/MenuItem/4685843/bug4685843.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4685843
+ * @requires (os.family == "windows")
+ * @summary Tests that disabled JCheckBoxMenuItem's are drawn properly in
+ * Windows LAF
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4685843
+ */
+
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JRadioButtonMenuItem;
+import javax.swing.UIManager;
+
+public class bug4685843 {
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel (
+                "com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set Windows LAF");
+        }
+
+        String INSTRUCTIONS = """
+            In the window named "bug4685843" open File menu.
+            If all three disabled items are drawn properly press "Pass".
+            Otherwise press "Fail".
+            """;
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(35)
+            .testUI(bug4685843::initialize)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static JFrame initialize() {
+        JMenuBar jMenuBar = new JMenuBar();
+        JMenu jMenu = new JMenu("File");
+        JMenuItem jMenuItem = new JMenuItem("JMenuItem");
+        JCheckBoxMenuItem jCheckBoxMenuItem =
+            new JCheckBoxMenuItem("JCheckBoxMenuItem");
+        JRadioButtonMenuItem jRadioButtonMenuItem =
+            new JRadioButtonMenuItem("JRadioButtonMenuItem");
+
+        jMenuItem.setEnabled(false);
+        jMenu.add(jMenuItem);
+        jCheckBoxMenuItem.setEnabled(false);
+        jMenu.add(jCheckBoxMenuItem);
+        jRadioButtonMenuItem.setEnabled(false);
+        jMenu.add(jRadioButtonMenuItem);
+        jMenuBar.add(jMenu);
+
+        JFrame mainFrame = new JFrame("bug4685843");
+        mainFrame.setJMenuBar(jMenuBar);
+        mainFrame.setSize(200, 200);
+        return mainFrame;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8354285: Open source Swing tests Batch 3. Adds three UI tests (split pane, deliminators, checkbox menu items). Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354285](https://bugs.openjdk.org/browse/JDK-8354285) needs maintainer approval

### Issue
 * [JDK-8354285](https://bugs.openjdk.org/browse/JDK-8354285): Open source Swing tests Batch 3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3873/head:pull/3873` \
`$ git checkout pull/3873`

Update a local copy of the PR: \
`$ git checkout pull/3873` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3873`

View PR using the GUI difftool: \
`$ git pr show -t 3873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3873.diff">https://git.openjdk.org/jdk17u-dev/pull/3873.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3873#issuecomment-3221092403)
</details>
