### PR TITLE
8340015: Open source several AWT focus tests - series 7

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -848,6 +848,6 @@ java/awt/Checkbox/CheckboxBoxSizeTest.java 8340870 windows-all
 java/awt/Checkbox/CheckboxIndicatorSizeTest.java 8340870 windows-all
 java/awt/Checkbox/CheckboxNullLabelTest.java 8340870 windows-all
 java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
-
+java/awt/Focus/MinimizeNonfocusableWindowTest.java 8024487 windows-all
 
 ############################################################################

--- a/test/jdk/java/awt/Focus/MinimizeNonfocusableWindowTest.java
+++ b/test/jdk/java/awt/Focus/MinimizeNonfocusableWindowTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6399659
+ * @summary   When minimizing non-focusable window focus shouldn't jump out of the focused window.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MinimizeNonfocusableWindowTest
+*/
+
+import java.awt.Frame;
+import java.awt.Window;
+import java.util.List;
+
+public class MinimizeNonfocusableWindowTest {
+
+    private static final String INSTRUCTIONS = """
+
+             You should see three frames: Frame-1, Frame-2 and Unfocusable.
+
+             1. Click Frame-1 to make it focused window, then click Frame-2.
+                Minimize Unfocusable frame with the mouse. If Frame-2 is still
+                the focused window continue testing, otherwise press FAIL.
+
+             2. Restore Unfocusable frame to normal state. Try to resize by dragging
+                its edge with left mouse button. It should be resizable. If not press
+                FAIL. Try the same with right mouse button. It shouldn't resize.
+                If it does, press FAIL, otherwise press PASS.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("MinimizeNonfocusableWindowTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(40)
+                .testUI(MinimizeNonfocusableWindowTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static List<Window> createTestUI() {
+        Frame frame1 = new Frame("Frame-1");
+        Frame frame2 = new Frame("Frame-2");
+        Frame frame3 = new Frame("Unfocusable");
+        frame1.setBounds(100, 0, 200, 100);
+        frame2.setBounds(100, 150, 200, 100);
+        frame3.setBounds(100, 300, 200, 100);
+
+        frame3.setFocusableWindowState(false);
+
+        return List.of(frame1, frame2, frame3);
+    }
+}
+

--- a/test/jdk/java/awt/Focus/WindowDisposeFocusTest.java
+++ b/test/jdk/java/awt/Focus/WindowDisposeFocusTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4257071 4228379
+ * @summary Ensures that focus lost is delivered to a lightweight component
+            in a disposed window
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual WindowDisposeFocusTest
+*/
+
+import java.awt.Window;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+
+public class WindowDisposeFocusTest {
+
+    private static final String INSTRUCTIONS = """
+         Click on "Second"
+         Click on close box
+         When dialog pops up, "Second" should no longer have focus.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("WindowDisposeFocusTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(WindowDisposeFocusTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Window createTestUI() {
+        return JFCFocusBug2.test(new String[]{});
+    }
+}
+
+class JFCFocusBug2 extends JPanel {
+
+    static public Window test(String[] args) {
+        final JFrame frame = new JFrame("WindowDisposeFrame");
+        frame.setSize(100, 100);
+        frame.setVisible(true);
+
+        final JFCFocusBug2 bug = new JFCFocusBug2();
+        final JDialog dialog = new JDialog(frame, false);
+        dialog.addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                dialog.dispose();
+                JDialog dialog2 = new JDialog(frame, false);
+                dialog2.setContentPane(bug);
+                dialog2.pack();
+                dialog2.setVisible(true);
+            }
+        });
+        dialog.setContentPane(bug);
+        dialog.pack();
+        dialog.setVisible(true);
+        return frame;
+    }
+
+    public JFCFocusBug2() {
+        _first = new JButton("First");
+        _second = new JButton("Second");
+        add(_first);
+        add(_second);
+    }
+
+    private JButton _first;
+    private JButton _second;
+}

--- a/test/jdk/java/awt/Focus/bug6435715.java
+++ b/test/jdk/java/awt/Focus/bug6435715.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6435715
+ * @summary JButton stops receiving the focusGained event and eventually focus is lost altogether
+ * @modules java.desktop/sun.awt
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug6435715
+ */
+
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+
+public class bug6435715 {
+
+    private static final String INSTRUCTIONS = """
+            1. after test started you will see frame with three buttons. Notice that focus is on Button2.
+            2. Click on Button 3. Focus goes to Button3.
+            3. Click on Button1 and quickly switch to another window. Via either alt/tab or
+            clicking another window with the mouse.
+            4. After a few seconds, come back to the frame. Notice that focus is around Button2
+            5. Click at Button3. If focus remains at Button2 test failed, if focus is on Button3 - test passed.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("bug6435715 Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 5)
+                .columns(35)
+                .testUI(bug6435715::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame fr = new JFrame("FocusIssue");
+        sun.awt.SunToolkit.setLWRequestStatus(fr, true);
+
+        JPanel panel = new JPanel();
+        final JButton b1 = new JButton("Button 1");
+        final JButton b2 = new JButton("Button 2");
+        final JButton b3 = new JButton("Button 3");
+
+        panel.add(b1);
+        panel.add(b2);
+        panel.add(b3);
+
+        b1.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent event) {
+                synchronized (this) {
+                    try {
+                        wait(1000);
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                    }
+                    b2.requestFocus();
+                }
+            }
+        });
+        fr.getContentPane().add(panel);
+        fr.pack();
+        return fr;
+    }
+
+}


### PR DESCRIPTION
Backporting JDK-8340015: Open source several AWT focus tests - series 7. Adds three window focus event tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is almost clean - had to manually address trivial conflicts with ProblemList.txt. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8340015](https://bugs.openjdk.org/browse/JDK-8340015) needs maintainer approval

### Issue
 * [JDK-8340015](https://bugs.openjdk.org/browse/JDK-8340015): Open source several AWT focus tests - series 7 (**Bug** - P4 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3878/head:pull/3878` \
`$ git checkout pull/3878`

Update a local copy of the PR: \
`$ git checkout pull/3878` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3878`

View PR using the GUI difftool: \
`$ git pr show -t 3878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3878.diff">https://git.openjdk.org/jdk17u-dev/pull/3878.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3878#issuecomment-3229715732)
</details>
