### PR TITLE
8286447: [Linux] AWT should start in Headless mode if headful AWT library not installed

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
+++ b/src/java.desktop/unix/classes/sun/awt/PlatformGraphicsInfo.java
@@ -25,6 +25,7 @@
 
 package sun.awt;
 
+import java.io.File;
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.security.AccessController;
@@ -43,17 +44,42 @@ public class PlatformGraphicsInfo {
     /**
       * Called from java.awt.GraphicsEnvironment when
       * to check if on this platform, the JDK should default to
-      * headless mode, in the case the application did specify
+      * headless mode, in the case the application did not specify
       * a value for the java.awt.headless system property.
       */
     @SuppressWarnings("removal")
     public static boolean getDefaultHeadlessProperty() {
-        return
+        boolean noDisplay =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
 
                final String display = System.getenv("DISPLAY");
-               return  display == null || display.trim().isEmpty();
+               return display == null || display.trim().isEmpty();
             });
+        if (noDisplay) {
+            return true;
+        }
+        /*
+         * If we positively identify a separate headless library support being present
+         * but no corresponding headful library, then we can support headless but
+         * not headful, so report that back to the caller.
+         * This does require duplication of knowing the name of the libraries
+         * also in libawt's OnLoad() but we need to make sure that the Java
+         * code is also set up as headless from the start - it is not so easy
+         * to try headful and then unwind that and then retry as headless.
+         */
+        boolean headless =
+            AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+                String[] libDirs = System.getProperty("sun.boot.library.path", "").split(":");
+                for (String libDir : libDirs) {
+                    File headlessLib = new File(libDir, "libawt_headless.so");
+                    File xawtLib = new File(libDir, "libawt_xawt.so");
+                    if (headlessLib.exists() && !xawtLib.exists()) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+        return headless;
     }
 
     /**
@@ -63,7 +89,11 @@ public class PlatformGraphicsInfo {
       */
     public static String getDefaultHeadlessMessage() {
         return
-            "\nNo X11 DISPLAY variable was set,\n" +
-            "but this program performed an operation which requires it.";
+            """
+
+            No X11 DISPLAY variable was set,
+            or no headful library support was found,
+            but this program performed an operation which requires it,
+            """;
     }
 }


### PR DESCRIPTION
Clean backport to 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8324306](https://bugs.openjdk.org/browse/JDK-8324306) to be approved
- [x] [JDK-8286447](https://bugs.openjdk.org/browse/JDK-8286447) needs maintainer approval

### Issues
 * [JDK-8286447](https://bugs.openjdk.org/browse/JDK-8286447): [Linux] AWT should start in Headless mode if headful AWT library not installed (**Enhancement** - P4 - Approved)
 * [JDK-8324306](https://bugs.openjdk.org/browse/JDK-8324306): [Linux] AWT should start in Headless mode if headful AWT library not installed (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3883/head:pull/3883` \
`$ git checkout pull/3883`

Update a local copy of the PR: \
`$ git checkout pull/3883` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3883`

View PR using the GUI difftool: \
`$ git pr show -t 3883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3883.diff">https://git.openjdk.org/jdk17u-dev/pull/3883.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3883#issuecomment-3250646026)
</details>
