### PR TITLE
8354418: Open source Swing tests Batch 4

### DIFF
--- a/test/jdk/com/sun/java/swing/plaf/windows/MenuItem/AcceleratorDelimiter/WindowsLAFMenuAcceleratorDelimiter.java
+++ b/test/jdk/com/sun/java/swing/plaf/windows/MenuItem/AcceleratorDelimiter/WindowsLAFMenuAcceleratorDelimiter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4210461
+ * @requires (os.family == "windows")
+ * @summary Tests that Windows Look & Feel's MenuItem Accelerator Delimiter is
+ * shown properly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual WindowsLAFMenuAcceleratorDelimiter
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.UIManager;
+
+public class WindowsLAFMenuAcceleratorDelimiter {
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel(
+                "com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("The Windows LAF failed to instantiate");
+        }
+
+        String INSTRUCTIONS = """
+            The visual design specification for the Windows LAF asks for
+            a "+" to delimit the other two entities in a menuitem's
+            accelerator.
+
+            As a point of reference, the visual design specifications for the
+            L&Fs are as follows: JLF/Metal = "-", Mac = "-", Motif = "+",
+            Windows = "+".
+
+            Click on "Menu" of "WindowsLAFMenuAcceleratorDelimiter" window,
+            make sure it shows MenuItem with label "Hi There! Ctrl+H".
+
+            If it shows same label test passed otherwise failed.
+            """;
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(50)
+            .testUI(WindowsLAFMenuAcceleratorDelimiter::initialize)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static JFrame initialize() {
+        JFrame fr = new JFrame("WindowsLAFMenuAcceleratorDelimiter");
+        JPanel menuPanel = new JPanel();
+        JMenuBar menuBar = new JMenuBar();
+        menuBar.setOpaque(true);
+        JMenu exampleMenu = new JMenu("Menu");
+        JMenuItem hiMenuItem = new JMenuItem("Hi There!");
+        hiMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H,
+            ActionEvent.CTRL_MASK));
+        exampleMenu.add(hiMenuItem);
+        menuBar.add(exampleMenu);
+        menuPanel.add(menuBar);
+
+        fr.setLayout(new BorderLayout());
+        fr.add(menuPanel, BorderLayout.CENTER);
+        fr.setSize(250, 100);
+        return fr;
+    }
+}

--- a/test/jdk/com/sun/java/swing/plaf/windows/WindowsDesktopManager/4227768/bug4227768.java
+++ b/test/jdk/com/sun/java/swing/plaf/windows/WindowsDesktopManager/4227768/bug4227768.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4227768
+ * @requires (os.family == "windows")
+ * @summary Tests Z-ordering of Windows Look-and-Feel JInternalFrames
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4227768
+ */
+
+import java.awt.Dimension;
+import java.awt.Toolkit;
+import java.beans.PropertyVetoException;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.UIManager;
+
+public class bug4227768 {
+    private static JDesktopPane desktop ;
+    private static JFrame frame;
+    private static int openFrameCount = 0;
+    private static final int xOffset = 30;
+    private static final int yOffset = 30;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel
+                ("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set Windows LAF");
+        }
+
+        String INSTRUCTIONS = """
+            Close the internal frame titled "Document #4". The internal frame
+            titled "Document #3" should get active. Now close the internal
+            frame titled "Document #2". The internal frame titled "Document #3"
+            should remain active. If something is not like this, then test
+            failed. Otherwise test succeeded.
+            """;
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(50)
+            .testUI(bug4227768::initialize)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static JFrame initialize() {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        frame = new JFrame("bug4227768");
+        frame.setSize(screenSize.width / 3, screenSize.height / 3);
+        frame.add(desktop = new JDesktopPane());
+        createFrame();
+        createFrame();
+        createFrame();
+        createFrame();
+        desktop.putClientProperty("JDesktopPane.dragMode", "outline");
+        return frame;
+    }
+
+    protected static void createFrame() {
+        JInternalFrame internalFrame = new JInternalFrame
+            ("Document #" + (++openFrameCount), true, true, true, true);
+        internalFrame.setSize(frame.getWidth() / 2, frame.getHeight() / 2);
+        internalFrame.setLocation(xOffset * openFrameCount,
+            yOffset * openFrameCount);
+        desktop.add(internalFrame);
+        internalFrame.setVisible(true);
+        try {
+            internalFrame.setSelected(true);
+        } catch (PropertyVetoException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/jdk/com/sun/java/swing/plaf/windows/WindowsDesktopManager/4305725/bug4305725.java
+++ b/test/jdk/com/sun/java/swing/plaf/windows/WindowsDesktopManager/4305725/bug4305725.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4305725
+ * @requires (os.family == "windows")
+ * @summary Tests if in Win LAF the JOptionPane.showInternalMessageDialog() is
+ * not maximized to match background maximized internal frame.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4305725
+ */
+
+import java.awt.Dimension;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.JLayeredPane;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.UIManager;
+
+public class bug4305725 implements ActionListener {
+    private static JDesktopPane desktop ;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel
+                ("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set Windows LAF");
+        }
+
+        String INSTRUCTIONS = """
+            Maximize the internal frame, then call Exit from File menu.
+            You will see a message box. If message box is also the size of
+            internal frame, then test failed. If it is of usual size,
+            then test is passed.
+            """;
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(50)
+            .testUI(bug4305725::initialize)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static JFrame initialize() {
+        JFrame frame = new JFrame("bug4305725");
+        frame.add(desktop = new JDesktopPane());
+        JMenuBar mb = new JMenuBar() ;
+        JMenu menu = new JMenu("File");
+        mb.add(menu) ;
+        JMenuItem menuItem = menu.add(new JMenuItem("Exit"));
+        menuItem.addActionListener(new bug4305725()) ;
+        frame.setJMenuBar(mb) ;
+        Dimension sDim = Toolkit.getDefaultToolkit().getScreenSize();
+        frame.setSize(sDim.width / 2, sDim.height / 2) ;
+        JInternalFrame internalFrame = new JInternalFrame
+            ("Internal", true, true, true, true);
+        internalFrame.setSize(frame.getWidth(), frame.getHeight() / 2);
+        internalFrame.setVisible(true);
+        desktop.add(internalFrame, JLayeredPane.FRAME_CONTENT_LAYER);
+        return frame;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent aEvent) {
+        JOptionPane.showInternalMessageDialog(desktop, "Exiting test app");
+    }
+}


### PR DESCRIPTION
Backporting JDK-8354418: Open source Swing tests Batch 4. Adds three windows tests - two for the WindowDesktopManager and one for menu delimiters. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354418](https://bugs.openjdk.org/browse/JDK-8354418) needs maintainer approval

### Issue
 * [JDK-8354418](https://bugs.openjdk.org/browse/JDK-8354418): Open source Swing tests Batch 4 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3888/head:pull/3888` \
`$ git checkout pull/3888`

Update a local copy of the PR: \
`$ git checkout pull/3888` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3888`

View PR using the GUI difftool: \
`$ git pr show -t 3888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3888.diff">https://git.openjdk.org/jdk17u-dev/pull/3888.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3888#issuecomment-3268093871)
</details>
