### PR TITLE
8353486: Open source Swing Tests - Set 4

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/bug4464774.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4464774.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4464774
+ * @requires (os.family == "windows")
+ * @summary JFileChooser: selection of left-side folder buttons shown incorrectly
+            in Windows L&F
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4464774
+ */
+
+import javax.swing.JFileChooser;
+import javax.swing.UIManager;
+
+public class bug4464774 {
+    private static final String INSTRUCTIONS = """
+            Click any button from the buttons to the left
+            ("Documents", "Desktop", "My Computer" etc.) in FileChooser dialog.
+            When the button is toggled, it should be lowered and
+            should NOT have focus painted inside it (black dotted frame).
+
+            If the above is true, press PASS else FAIL.
+            """;
+
+    public static void main(String[] argv) throws Exception {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(65)
+                .rows(10)
+                .testUI(() -> {
+                    JFileChooser jfc = new JFileChooser();
+                    jfc.setControlButtonsAreShown(false);
+                    return jfc;
+                })
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4522756.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4522756.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4522756
+ * @requires (os.family == "windows")
+ * @summary Verifies that the Desktop icon is not missing when
+            JFileChooser is opened for the first time.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4522756
+ */
+
+import javax.swing.JFileChooser;
+import javax.swing.UIManager;
+
+public class bug4522756 {
+    private static final String INSTRUCTIONS = """
+            Verify the following:
+
+            1. If Desktop icon image is present on the Desktop button
+               on the left panel of JFileChooser.
+            2. Press Desktop button. Check that you actually
+               go up to the desktop.
+
+            If the above is true, press PASS else FAIL.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(50)
+                .rows(12)
+                .testUI(() -> {
+                    JFileChooser jfc = new JFileChooser();
+                    jfc.setControlButtonsAreShown(false);
+                    return jfc;
+                })
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4759934.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4759934.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 4759934
+ * @summary windows activation problem
+ * @library /javax/swing/regtesthelpers
+ * @build Util
+ * @run main bug4759934
+ */
+
+import java.awt.Dialog;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4759934 {
+    private static JFrame fr;
+    private static Dialog dlg;
+    private static JFileChooser jfc;
+
+    private static JButton frameBtn;
+    private static JButton dialogBtn;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+
+            SwingUtilities.invokeAndWait(bug4759934::createTestUI);
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            Point frameBtnLoc = Util.getCenterPoint(frameBtn);
+            robot.mouseMove(frameBtnLoc.x, frameBtnLoc.y);
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.delay(500);
+
+            Point dlgBtnLoc = Util.getCenterPoint(dialogBtn);
+            robot.mouseMove(dlgBtnLoc.x , dlgBtnLoc.y);
+            robot.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
+            robot.delay(500);
+
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+            robot.delay(500);
+
+            SwingUtilities.invokeAndWait(() -> {
+                if (frameBtn.hasFocus() && !dialogBtn.hasFocus()) {
+                    throw new RuntimeException("Test failed! Focus was passed back" +
+                            " to Frame instead of Dialog");
+                }
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (dlg != null) {
+                    dlg.dispose();
+                }
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createTestUI() {
+        fr = new JFrame("bug4759934 - JFrame");
+
+        frameBtn = new JButton("Show Dialog");
+        frameBtn.addActionListener(e -> createDialog());
+        fr.add(frameBtn);
+
+        fr.setSize(300, 200);
+        fr.setLocationRelativeTo(null);
+        fr.setVisible(true);
+    }
+
+    private static void createDialog() {
+        dlg = new JDialog(fr, "bug4759934 - JDialog");
+
+        dialogBtn = new JButton("Show FileChooser");
+        dlg.add(dialogBtn);
+
+        dialogBtn.addActionListener(e -> {
+            jfc = new JFileChooser();
+            jfc.showOpenDialog(dlg);
+        });
+
+        dlg.setSize(300, 200);
+        dlg.setLocation(fr.getX() + fr.getWidth() + 10, fr.getY());
+        dlg.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/bug4943900.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4943900.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4943900
+ * @summary Tests that FileFilter combo box is shown in FileChooser
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4943900
+ */
+
+import java.io.File;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.UIManager;
+import javax.swing.filechooser.FileFilter;
+
+public class bug4943900 {
+    private static final String INSTRUCTIONS = """
+        <html>
+        <ol>
+        <li>When the test runs, a <code>JFileChooser</code> will be displayed.
+        <li>Ensure that there is a filter combo box with these two items:
+          <ul>
+          <li><b>Text Files (*.txt)</b>
+              &mdash; <em>[must be selected when the dialog opens]</em>
+          <li><b>All Files</b>
+          </ul>
+        <li>Leave the <b>Text files</b> item selected and check that the
+        filter works: only <code>*.txt</code> files can appear in the file list.
+        You can navigate directories in the file chooser and find one
+        that contains some <code>*.txt</code> files to ensure they are shown in
+        the file list. On macOS when the text filter is applied verify
+        that the non-text files are greyed out.
+        <li>Try switching the filters and ensure that the file list
+        is updated properly.
+        <li>If the <code>FileFilter</code> works correctly,
+            press <b>Pass</b> else press <b>Fail</b>.
+        </ol>
+        </html>
+        """;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+
+        PassFailJFrame.builder()
+                .title("bug4943900 Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(14)
+                .columns(50)
+                .testUI(bug4943900::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFrame createAndShowUI() {
+        JFileChooser fc = new JFileChooser();
+        fc.setControlButtonsAreShown(false);
+        TextFileFilter filter = new TextFileFilter();
+        fc.setFileFilter(filter);
+
+        JFrame frame = new JFrame("bug4943900 - JFileChooser");
+        frame.add(fc);
+        frame.pack();
+        return frame;
+    }
+
+    private static final class TextFileFilter extends FileFilter {
+        @Override
+        public boolean accept(File f) {
+            if (f != null) {
+                if (f.isDirectory()) {
+                    return true;
+                }
+                String extension = getExtension(f);
+                return extension != null && extension.equals("txt");
+            }
+            return false;
+        }
+
+        @Override
+        public String getDescription() {
+            return "Text Files (*.txt)";
+        }
+
+        private static String getExtension(File f) {
+            if (f != null) {
+                String filename = f.getName();
+                int i = filename.lastIndexOf('.');
+                if (i > 0 && i < filename.length() - 1) {
+                    return filename.substring(i + 1).toLowerCase();
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JOptionPane/bug4194862.java
+++ b/test/jdk/javax/swing/JOptionPane/bug4194862.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4194862
+ * @summary Tests that internal frame-based dialogs are centered relative
+            to their parents
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4194862
+ */
+
+import javax.swing.JButton;
+import javax.swing.JDesktopPane;
+import javax.swing.JFrame;
+import javax.swing.JInternalFrame;
+import javax.swing.JOptionPane;
+
+public class bug4194862 {
+    private static final String INSTRUCTIONS = """
+            In the internal frame titled "Main",
+            click the "Show JOptionPane Dialog" button.
+            A dialog will appear. It should be centered with
+            respect to the JInternalFrame - "Main".
+
+            If the above is true then click on JOptionPane's "YES" button
+            to PASS else click JOptionPane's "NO" button to FAIL the test.
+            """;
+
+    public static void main(String[] args) throws Exception{
+        PassFailJFrame.builder()
+                .title("Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(bug4194862::createAndShowUI)
+                .screenCapture()
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        JFrame frame = new JFrame("bug4194862 - JInternalFrame JOptionPane");
+        JDesktopPane desktop = new JDesktopPane();
+        frame.add(desktop);
+        JInternalFrame jInternalFrame = new JInternalFrame("Main", true);
+        desktop.add(jInternalFrame);
+        jInternalFrame.setBounds(5, 30, 390, 240);
+        jInternalFrame.setVisible(true);
+
+        JButton b = new JButton("Show JOptionPane Dialog");
+        b.addActionListener(e -> {
+            int retVal = JOptionPane.showInternalConfirmDialog(
+                                      jInternalFrame, "Am I centered?",
+                                      "bug4194862 JOptionPane", JOptionPane.YES_NO_OPTION);
+            switch (retVal) {
+                case JOptionPane.YES_OPTION -> PassFailJFrame.forcePass();
+                case JOptionPane.NO_OPTION ->
+                        PassFailJFrame.forceFail("JOptionPane isn't centered"
+                                + " within JInternalFrame \"Main\"");
+            }
+        });
+        jInternalFrame.add(b);
+
+        for (int i = 0; i < 4; i++) {
+            JInternalFrame f = new JInternalFrame("JIF: "+ i);
+            f.setBounds(i * 50, i * 33, 120, 120);
+            f.setVisible(true);
+            desktop.add(f);
+        }
+        frame.setSize(450, 400);
+        return frame;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353486: Open source Swing Tests - Set 4. Adds four file selection and one option pane related swing tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353486](https://bugs.openjdk.org/browse/JDK-8353486) needs maintainer approval

### Issue
 * [JDK-8353486](https://bugs.openjdk.org/browse/JDK-8353486): Open source Swing Tests - Set 4 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3892/head:pull/3892` \
`$ git checkout pull/3892`

Update a local copy of the PR: \
`$ git checkout pull/3892` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3892`

View PR using the GUI difftool: \
`$ git pr show -t 3892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3892.diff">https://git.openjdk.org/jdk17u-dev/pull/3892.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3892#issuecomment-3272498038)
</details>
