### PR TITLE
8288180: C2: VectorPhase must ensure that SafePointNode memory input is a MergeMemNode

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestLoopStoreVector.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestLoopStoreVector.java
@@ -36,6 +36,16 @@ import jdk.incubator.vector.VectorSpecies;
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+OptimizeFill compiler.vectorapi.TestLoopStoreVector
  */
 
+/*
+ * @test
+ * @bug 8288180
+ * @summary VectorPhase must ensure that SafePointNode's memory input is MergeMemNode, required for GraphKit
+ * @modules jdk.incubator.vector
+ *
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+OptimizeFill -XX:+StressReflectiveCode compiler.vectorapi.TestLoopStoreVector
+ */
+
+
 public class TestLoopStoreVector {
     static final VectorSpecies<Integer> SPECIESi = IntVector.SPECIES_PREFERRED;
     static final VectorSpecies<Long> SPECIESl = LongVector.SPECIES_PREFERRED;


### PR DESCRIPTION
I backport this for parity with 17.0.17-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8288180](https://bugs.openjdk.org/browse/JDK-8288180) needs maintainer approval

### Issue
 * [JDK-8288180](https://bugs.openjdk.org/browse/JDK-8288180): C2: VectorPhase must ensure that SafePointNode memory input is a MergeMemNode (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3897/head:pull/3897` \
`$ git checkout pull/3897`

Update a local copy of the PR: \
`$ git checkout pull/3897` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3897`

View PR using the GUI difftool: \
`$ git pr show -t 3897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3897.diff">https://git.openjdk.org/jdk17u-dev/pull/3897.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3897#issuecomment-3276043785)
</details>
