### PR TITLE
8297936: Use reachabilityFence to manage liveness in ClassUnload tests

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
+import java.lang.ref.Reference;
 public class ConstantPoolDependsTest {
     public static WhiteBox wb = WhiteBox.getWhiteBox();
     public static final String MY_TEST = "ConstantPoolDependsTest$c1c";
@@ -71,8 +72,8 @@ public class ConstantPoolDependsTest {
         ClassUnloadCommon.triggerUnloading();  // should not unload anything
         ClassUnloadCommon.failIf(!wb.isClassAlive(MY_TEST), "should not be unloaded");
         ClassUnloadCommon.failIf(!wb.isClassAlive("p2.c2"), "should not be unloaded");
-        // Unless MyTest_class is referenced here, the compiler can unload it.
-        System.out.println("Should not unload anything before here because " + MyTest_class + " is still alive.");
+        // Should not unload anything before here because MyTest_class is kept alive by the following fence.
+        Reference.reachabilityFence(MyTest_class);
     }
 
     public static void main(String args[]) throws Throwable {

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,20 +36,19 @@
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
+import java.lang.ref.Reference;
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.
  */
 public class KeepAliveObject {
   private static final String className = "test.Empty";
   private static final WhiteBox wb = WhiteBox.getWhiteBox();
-  public static Object escape = null;
 
   public static void main(String... args) throws Exception {
     ClassLoader cl = ClassUnloadCommon.newClassLoader();
     Class<?> c = cl.loadClass(className);
     Object o = c.newInstance();
     cl = null; c = null;
-    escape = o;
 
     {
         boolean isAlive = wb.isClassAlive(className);
@@ -66,8 +65,9 @@ public class KeepAliveObject {
 
         ClassUnloadCommon.failIf(!isAlive, "should be alive");
     }
+    // Don't let `o` get prematurely reclaimed by the GC.
+    Reference.reachabilityFence(o);
     o = null;
-    escape = null;
     ClassUnloadCommon.triggerUnloading();
 
     {


### PR DESCRIPTION
I backport this to make later backports clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297936](https://bugs.openjdk.org/browse/JDK-8297936) needs maintainer approval

### Issue
 * [JDK-8297936](https://bugs.openjdk.org/browse/JDK-8297936): Use reachabilityFence to manage liveness in ClassUnload tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3904/head:pull/3904` \
`$ git checkout pull/3904`

Update a local copy of the PR: \
`$ git checkout pull/3904` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3904`

View PR using the GUI difftool: \
`$ git pr show -t 3904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3904.diff">https://git.openjdk.org/jdk17u-dev/pull/3904.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3904#issuecomment-3281013070)
</details>
