### PR TITLE
8355558: SJIS.java test is always ignored

### DIFF
--- a/test/jdk/java/io/pathNames/win32/SJIS.java
+++ b/test/jdk/java/io/pathNames/win32/SJIS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,15 @@
    @summary Check that pathnames containing double-byte characters are not
             corrupted by win32 path processing
    @author Mark Reinhold
+   @library /test/lib
 */
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import jtreg.SkippedException;
 
 
 public class SJIS {
@@ -47,8 +53,11 @@ public class SJIS {
         /* This test is only valid on win32 systems
            that use the SJIS encoding */
         if (File.separatorChar != '\\') return;
-        String enc = System.getProperty("file.encoding");
-        if ((enc == null) || !enc.equals("SJIS")) return;
+        String enc = System.getProperty("native.encoding");
+        if ((enc == null) || !enc.equals("MS932")) {
+            throw new SkippedException(
+                "native.encoding(%s) is not MS932".formatted(enc));
+        }
 
         File f = new File("\u30BD");
         if (f.exists()) rm(f);


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8355558](https://bugs.openjdk.org/browse/JDK-8355558) needs maintainer approval

### Issue
 * [JDK-8355558](https://bugs.openjdk.org/browse/JDK-8355558): SJIS.java test is always ignored (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3909/head:pull/3909` \
`$ git checkout pull/3909`

Update a local copy of the PR: \
`$ git checkout pull/3909` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3909`

View PR using the GUI difftool: \
`$ git pr show -t 3909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3909.diff">https://git.openjdk.org/jdk17u-dev/pull/3909.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3909#issuecomment-3281225520)
</details>
