### PR TITLE
8325647: [IR framework] Only prints stdout if exitCode is 134

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -244,7 +244,9 @@ public class TestVMProcess {
         int exitCode = oa.getExitValue();
         String stdErr = oa.getStderr();
         String stdOut = "";
-        if (exitCode == 134) {
+        boolean osIsWindows = Platform.isWindows();
+        boolean JVMHadError = (!osIsWindows && exitCode == 134) || (osIsWindows && exitCode == -1);
+        if (JVMHadError) {
             // Also dump the stdout if we experience a JVM error (e.g. to show hit assertions etc.).
             stdOut = System.lineSeparator() + System.lineSeparator() + "Standard Output" + System.lineSeparator()
                      + "---------------" + System.lineSeparator() + oa.getOutput();


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8325647](https://bugs.openjdk.org/browse/JDK-8325647) needs maintainer approval

### Issue
 * [JDK-8325647](https://bugs.openjdk.org/browse/JDK-8325647): [IR framework] Only prints stdout if exitCode is 134 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3912/head:pull/3912` \
`$ git checkout pull/3912`

Update a local copy of the PR: \
`$ git checkout pull/3912` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3912`

View PR using the GUI difftool: \
`$ git pr show -t 3912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3912.diff">https://git.openjdk.org/jdk17u-dev/pull/3912.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3912#issuecomment-3287610652)
</details>
