### PR TITLE
8353309: Open source several Swing text tests

### DIFF
--- a/test/jdk/javax/swing/text/BoxView/BaselineTest.java
+++ b/test/jdk/javax/swing/text/BoxView/BaselineTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4519537 4522866
+ * @summary Tests that text and components in paragraph views line up at their baselines.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual BaselineTest
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.GridLayout;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextPane;
+
+import javax.swing.text.ComponentView;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledEditorKit;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+
+public class BaselineTest {
+
+    static final String INSTRUCTIONS = """
+        Test that components displayed in a JTextPane properly respect their vertical alignment.
+        There are two text panes, stacked vertically with similar content except the bottom components are taller.
+        The content consists of a leading and trailing text string, with pink coloured components between.
+        The text string content means the strings 'Default Size Text' and 'Large Size Text'.
+        Text content baseline is at the bottom of CAPITAL letters in the text.
+        Each pink component has a string displaying its alignment setting in the range 0.0 to 1.0
+        NB: The position of the strings "align = 0.0" etc is not important, it is the component position that matters.
+        0.0 means it should be aligned with its top at the text content baseline,
+        1.0 means it should be aligned with its bottom at the text content baseline.
+        A value in between will be a proportional alignment, eg 0.5 is centered on the text content baseline
+        If the content displays as described, the test PASSES.
+    """;
+
+    public static void main(String[] args) throws Exception {
+       PassFailJFrame.builder()
+            .title("BaselineTest Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .rows(12)
+            .testUI(BaselineTest::createUI)
+            .positionTestUIBottomRowCentered()
+            .build()
+            .awaitAndCheck();
+    }
+
+    public static JFrame createUI() {
+        JFrame frame = new JFrame("BaselineTest");
+        frame.setLayout(new GridLayout(2, 1));
+
+        JTextPane prefPane = new JTextPane();
+        initJTextPane(prefPane);
+        frame.add(new JScrollPane(prefPane));
+
+        JTextPane variablePane = new JTextPane();
+        variablePane.setEditorKit(new CustomEditorKit());
+        initJTextPane(variablePane);
+        frame.add(new JScrollPane(variablePane));
+        frame.setSize(800, 400);
+        return frame;
+    }
+
+    static void initJTextPane(JTextPane tp) {
+
+        try {
+            Document doc = tp.getDocument();
+
+            doc.insertString(0, " Default Size Text ", null);
+            tp.setCaretPosition(doc.getLength());
+            tp.insertComponent(new PaintLabel(0.0f));
+            tp.insertComponent(new PaintLabel(0.2f));
+            tp.insertComponent(new PaintLabel(0.5f));
+            tp.insertComponent(new PaintLabel(0.7f));
+            tp.insertComponent(new PaintLabel(1.0f));
+            SimpleAttributeSet set = new SimpleAttributeSet();
+            StyleConstants.setFontSize(set, 20);
+            tp.setCaretPosition(doc.getLength());
+            doc.insertString(doc.getLength(), " Large Size Text ", set);
+        } catch (BadLocationException ble) {
+            throw new RuntimeException(ble);
+        }
+    }
+
+    static class PaintLabel extends JLabel {
+
+        private int pref = 40;
+        private int min = pref - 30;
+        private int max = pref + 30;
+
+        public PaintLabel(float align) {
+
+            setAlignmentY(align);
+            String alignStr = String.valueOf(align);
+
+            setText("align = " + alignStr);
+            setOpaque(true);
+            setBackground(Color.PINK);
+        }
+
+        public Dimension getMinimumSize() {
+            return new Dimension(super.getMinimumSize().width, min);
+        }
+
+        public Dimension getPreferredSize() {
+            return new Dimension(super.getPreferredSize().width, pref);
+        }
+
+        public Dimension getMaximumSize() {
+            return new Dimension(super.getMaximumSize().width, max);
+        }
+
+        public void paintComponent(Graphics g) {
+            g.setColor(Color.PINK);
+            g.fillRect(0, 0, getWidth(), getHeight());
+            int y = (int)(getAlignmentY() * getHeight());
+            g.setColor(Color.BLACK);
+            g.drawLine(0, y, getWidth(), y);
+            g.drawString(getText(), 0, 10);
+        }
+    }
+
+    static class CustomComponentView extends ComponentView {
+
+        public CustomComponentView(Element elem) {
+            super(elem);
+        }
+
+        public int getResizeWeight(int axis) {
+            return 1;
+        }
+}
+
+    static class CustomEditorKit extends StyledEditorKit implements ViewFactory {
+
+        public View create(Element elem) {
+            if (StyleConstants.ComponentElementName.equals(elem.getName())) {
+                return new CustomComponentView(elem);
+            } else {
+                return super.getViewFactory().create(elem);
+            }
+        }
+
+        public ViewFactory getViewFactory() {
+            return this;
+        }
+}
+
+}

--- a/test/jdk/javax/swing/text/GlyphView/bug4188841.java
+++ b/test/jdk/javax/swing/text/GlyphView/bug4188841.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4188841
+ * @summary Tests a JTextPane wrapping issue
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4188841
+*/
+
+import java.awt.Dimension;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextPane;
+
+public class bug4188841 {
+
+    static final String INSTRUCTIONS = """
+        The text pane contains the phrase "the quick brown fox jumps over the lazy dog",
+        all the words are separated by tabs. When the test starts, the whole phrase should
+        appear on one line. If it is wrapped along two or more lines, the test FAILS.
+
+        Otherwise, place the text caret in the very end of the line (e.g. by clicking
+        in the line and hitting End). Press Enter twice. The text should appear as one
+        line at all times. If the text wraps when you press Enter, the test FAILS.
+    """;
+
+    static class NoWrapTextPane extends JTextPane {
+
+        public boolean getScrollableTracksViewportWidth() {
+           //should not allow text to be wrapped
+           return false;
+        }
+
+        public void setSize(Dimension d) {
+           // don't let the Textpane get sized smaller than its parent
+           if (d.width < getParent().getSize().width) {
+              super.setSize(getParent().getSize());
+           }
+           else {
+              super.setSize(d);
+           }
+        }
+    }
+
+    static JFrame createUI() {
+
+        JFrame frame = new JFrame("bug4188841");
+
+        NoWrapTextPane nwp = new NoWrapTextPane();
+        nwp.setText("the\tslow\tbrown\tfox\tjumps\tover\tthe\tlazy\tdog!");
+        nwp.setCaretPosition(nwp.getText().length());
+
+        JScrollPane scrollPane = new JScrollPane(nwp,
+            JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+            JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
+
+        frame.add(scrollPane);
+        frame.setSize(400, 300);
+        return frame;
+    }
+
+    public static void main(String args[]) throws Exception {
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .testUI(bug4188841::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/GlyphView/bug4188841.java
+++ b/test/jdk/javax/swing/text/GlyphView/bug4188841.java
@@ -69,7 +69,7 @@ public class bug4188841 {
         JFrame frame = new JFrame("bug4188841");
 
         NoWrapTextPane nwp = new NoWrapTextPane();
-        nwp.setText("the\tslow\tbrown\tfox\tjumps\tover\tthe\tlazy\tdog!");
+        nwp.setText("the\tquick\tbrown\tfox\tjumps\tover\tthe\tlazy\tdog!");
         nwp.setCaretPosition(nwp.getText().length());
 
         JScrollPane scrollPane = new JScrollPane(nwp,

--- a/test/jdk/javax/swing/text/html/FormView/4473401/bug4473401.java
+++ b/test/jdk/javax/swing/text/html/FormView/4473401/bug4473401.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4473401
+ * @summary Tests if FormSubmitEvent is submitted correctly.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4473401
+*/
+
+import java.io.File;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+import javax.swing.text.html.FormSubmitEvent;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4473401 implements HyperlinkListener {
+
+    static final String INSTRUCTIONS = """
+        The test window displays an HTML frameset with a frame
+        on the left and another to the right.
+        Push the 'Submit Query' button in the left frame to perform testing.
+        The window should be updated to have only one frame with the
+        message 'If you see this page the test PASSED'.
+        If it appears, PASS the test, otherwise FAIL the test.
+    """;
+
+    static JEditorPane jep;
+    static JFrame createUI() {
+
+        JFrame frame = new JFrame("bug4473401");
+        jep = new JEditorPane();
+        jep.addHyperlinkListener(new bug4473401());
+        HTMLEditorKit kit = new HTMLEditorKit();
+        kit.setAutoFormSubmission(false);
+        jep.setEditorKit(kit);
+        jep.setEditable(false);
+
+        try {
+            File file = new File(System.getProperty("test.src", "."), "frameset.html");
+            System.out.println(file.toURI().toURL());
+            jep.setPage(file.toURL());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        frame.add(jep);
+        frame.setSize(500, 500);
+        return frame;
+    }
+
+    public void hyperlinkUpdate(HyperlinkEvent e) {
+        if (e instanceof FormSubmitEvent) {
+            jep.setText("If you see this page the test<font color=green> PASSED</font></CENTER>");
+        }
+    }
+
+    public static void main(String args[]) throws Exception {
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(bug4473401::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/html/FormView/4473401/frame1.html
+++ b/test/jdk/javax/swing/text/html/FormView/4473401/frame1.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+Push the <span style="color:blue">Submit query</span> button
+<FORM ACTION="./frameresult.html" METHOD=post  TARGET="main" >
+<input type="text" name="Selection"><BR>
+<INPUT type="submit">
+</FORM>
+</body>
+</html>

--- a/test/jdk/javax/swing/text/html/FormView/4473401/frame2.html
+++ b/test/jdk/javax/swing/text/html/FormView/4473401/frame2.html
@@ -1,0 +1,4 @@
+<HTML>
+<BODY>
+</BODY>
+</HTML>

--- a/test/jdk/javax/swing/text/html/FormView/4473401/frameresult.html
+++ b/test/jdk/javax/swing/text/html/FormView/4473401/frameresult.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+If you see this page the test <font color=red>FAILED</font>.
+</body>
+</html>

--- a/test/jdk/javax/swing/text/html/FormView/4473401/frameset.html
+++ b/test/jdk/javax/swing/text/html/FormView/4473401/frameset.html
@@ -1,0 +1,11 @@
+<HTML>
+ <HEAD>
+   <TITLE>
+     Manual test for bug 4463014
+   </TITLE>
+ </HEAD>
+ <FRAMESET COLS="150,*">
+  <FRAME SRC="frame1.html">
+  <FRAME name="main" SRC="frame2.html">
+ </FRAMESET>
+</HTML>

--- a/test/jdk/javax/swing/text/html/FormView/bug4529702.java
+++ b/test/jdk/javax/swing/text/html/FormView/bug4529702.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4529702
+ * @summary Test that radio buttons with different names should be selectable at the same time
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4529702
+*/
+
+import javax.swing.JFrame;
+import javax.swing.JTextPane;
+
+public class bug4529702 {
+
+    static final String INSTRUCTIONS = """
+        There are two rows of radio buttons, each row having two buttons.
+        If you can select radio buttons from the first and the second rows
+        at the same time the test PASSES otherwise the test FAILS.
+    """;
+
+    static JFrame createUI() {
+        JFrame frame = new JFrame("bug4529702");
+        JTextPane jtp = new JTextPane();
+        jtp.setContentType("text/html");
+        jtp.setText("<html><body><form><input type=radio name=a><input type=radio name=a><br>" +
+                    "<input type=radio name=b><input type=radio name=b></form></body></html>");
+        frame.add(jtp);
+        frame.setSize(200, 200);
+        return frame;
+    }
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(bug4529702::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/html/FrameSetView/4890934/bug4890934.java
+++ b/test/jdk/javax/swing/text/html/FrameSetView/4890934/bug4890934.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4890934
+ * @summary Tests if JEditor Pane updates the correct frame when using <BASE target="xxxx">
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4890934
+*/
+
+import java.io.File;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.HTMLFrameHyperlinkEvent;
+
+public class bug4890934 implements HyperlinkListener {
+
+    static final String INSTRUCTIONS = """
+        The test window displays an HTML frameset with a frame
+        on the left and another to the right.
+        Click the link in the left frame which should change the view.
+        The resulting page will tell you if the test PASSED or FAILED.
+    """;
+
+    static JFrame createUI() {
+
+        JFrame frame = new JFrame("bug4890934");
+        JEditorPane jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+        jep.addHyperlinkListener(new bug4890934());
+
+        try {
+            File file = new File(System.getProperty("test.src", "."), "frameset.html");
+            System.out.println(file.toURI().toURL());
+            jep.setPage(file.toURL());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        frame.add(jep);
+        frame.setSize(600, 300);
+        return frame;
+    }
+
+    public void hyperlinkUpdate(HyperlinkEvent e) {
+        if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+            JEditorPane pane = (JEditorPane) e.getSource();
+            if (e instanceof HTMLFrameHyperlinkEvent) {
+                HTMLFrameHyperlinkEvent  evt = (HTMLFrameHyperlinkEvent)e;
+                HTMLDocument doc = (HTMLDocument)pane.getDocument();
+                doc.processHTMLFrameHyperlinkEvent(evt);
+            }
+        }
+    }
+
+    public static void main(String args[]) throws Exception {
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(bug4890934::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/text/html/FrameSetView/4890934/frame1.html
+++ b/test/jdk/javax/swing/text/html/FrameSetView/4890934/frame1.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<base TARGET="main">
+</head>
+<body>
+<a href="./frameresult.html"> a link </a>
+</body>
+</html>

--- a/test/jdk/javax/swing/text/html/FrameSetView/4890934/frame2.html
+++ b/test/jdk/javax/swing/text/html/FrameSetView/4890934/frame2.html
@@ -1,0 +1,4 @@
+<HTML>
+<BODY>
+</BODY>
+</HTML>

--- a/test/jdk/javax/swing/text/html/FrameSetView/4890934/frameresult.html
+++ b/test/jdk/javax/swing/text/html/FrameSetView/4890934/frameresult.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+If you see this text in the <span style="color:green">RIGHT</span> frame the test <span style="color:green">PASSED</span>.
+<p>If you see this text in the <span style="color:red">LEFT</span> frame the test <span style="color:red">FAILED</span>.
+
+</body>
+</html>

--- a/test/jdk/javax/swing/text/html/FrameSetView/4890934/frameset.html
+++ b/test/jdk/javax/swing/text/html/FrameSetView/4890934/frameset.html
@@ -1,0 +1,11 @@
+<HTML>
+ <HEAD>
+   <TITLE>
+     Manual test for bug 4463014
+   </TITLE>
+ </HEAD>
+ <FRAMESET COLS="150,*">
+  <FRAME SRC="frame1.html">
+  <FRAME name="main" SRC="frame2.html">
+ </FRAMESET>
+</HTML>


### PR DESCRIPTION
Backporting JDK-8353309: Open source several Swing text tests. Adds five swing text related tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is not clean, but trivial fix: there's a typo in one of the tests addressed by [JDK-8359418](https://bugs.openjdk.org/browse/JDK-8359418) that I've included here. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359418](https://bugs.openjdk.org/browse/JDK-8359418) needs maintainer approval
- [x] [JDK-8353309](https://bugs.openjdk.org/browse/JDK-8353309) needs maintainer approval

### Issues
 * [JDK-8353309](https://bugs.openjdk.org/browse/JDK-8353309): Open source several Swing text tests (**Bug** - P4 - Approved)
 * [JDK-8359418](https://bugs.openjdk.org/browse/JDK-8359418): Test "javax/swing/text/GlyphView/bug4188841.java" failed because the phrase of text pane does not match the instructions (**Bug** - P5 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3916/head:pull/3916` \
`$ git checkout pull/3916`

Update a local copy of the PR: \
`$ git checkout pull/3916` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3916`

View PR using the GUI difftool: \
`$ git pr show -t 3916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3916.diff">https://git.openjdk.org/jdk17u-dev/pull/3916.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3916#issuecomment-3283017700)
</details>
