### PR TITLE
8304163: Move jdk.internal.module.ModuleInfoWriter to the test library

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessModuleLauncher.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/TestProcessModuleLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-import jdk.internal.module.ModuleInfoWriter;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 import java.io.File;
 import java.io.IOException;

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,14 +34,18 @@ import org.testng.annotations.Test;
  * @test
  * @bug 8221730
  * @summary Test of diagnostic command VM.version (tests all DCMD executors)
- * @library /test/lib
- *          /vmTestbase
- * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.module
  *          java.compiler
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @library /test/lib
+ *          /vmTestbase
+ * @requires vm.flagless
  * @run testng/othervm -XX:+UsePerfData VMVersionTest
  */
 public class VMVersionTest {

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
@@ -34,10 +34,8 @@ import org.testng.annotations.Test;
  * @test
  * @bug 8221730
  * @summary Test of diagnostic command VM.version (tests all DCMD executors)
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.misc
  *          java.base/jdk.internal.module
  *          java.compiler

--- a/test/jdk/java/lang/ClassLoader/securityManager/ClassLoaderTest.java
+++ b/test/jdk/java/lang/ClassLoader/securityManager/ClassLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,14 @@
  * @bug 8168423
  * @summary Different types of ClassLoader running with(out) SecurityManager and
  *          (in)valid security policy file.
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.module
  * @library /test/lib
- * @modules java.base/jdk.internal.module
  * @build jdk.test.lib.util.JarUtils
+ *        jdk.test.lib.util.ModuleInfoWriter
  * @build TestClassLoader TestClient
  * @run main ClassLoaderTest -noPolicy
  * @run main ClassLoaderTest -validPolicy
@@ -48,9 +53,9 @@ import java.lang.module.ModuleDescriptor;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import jdk.internal.module.ModuleInfoWriter;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 public class ClassLoaderTest {
 

--- a/test/jdk/java/lang/ClassLoader/securityManager/ClassLoaderTest.java
+++ b/test/jdk/java/lang/ClassLoader/securityManager/ClassLoaderTest.java
@@ -26,10 +26,8 @@
  * @bug 8168423
  * @summary Different types of ClassLoader running with(out) SecurityManager and
  *          (in)valid security policy file.
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils

--- a/test/jdk/java/lang/ModuleTests/AnnotationsTest.java
+++ b/test/jdk/java/lang/ModuleTests/AnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import jdk.internal.module.ModuleInfoWriter;
 import jdk.internal.org.objectweb.asm.AnnotationVisitor;
 import jdk.internal.org.objectweb.asm.Attribute;
 import jdk.internal.org.objectweb.asm.ClassReader;
@@ -44,6 +43,7 @@ import jdk.internal.org.objectweb.asm.ClassVisitor;
 import jdk.internal.org.objectweb.asm.ClassWriter;
 import jdk.internal.org.objectweb.asm.Opcodes;
 import jdk.internal.org.objectweb.asm.commons.ModuleTargetAttribute;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
@@ -52,7 +52,13 @@ import static org.testng.Assert.*;
  * @test
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.org.objectweb.asm.commons
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
  *          java.base/jdk.internal.module
+ * @library /test/lib
+ * @build jdk.test.lib.util.ModuleInfoWriter
  * @run testng AnnotationsTest
  * @summary Basic test of annotations on modules
  */

--- a/test/jdk/java/lang/ModuleTests/AnnotationsTest.java
+++ b/test/jdk/java/lang/ModuleTests/AnnotationsTest.java
@@ -52,10 +52,6 @@ import static org.testng.Assert.*;
  * @test
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.org.objectweb.asm.commons
- *          java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.ModuleInfoWriter

--- a/test/jdk/java/lang/module/ClassFileVersionsTest.java
+++ b/test/jdk/java/lang/module/ClassFileVersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,13 @@
 
 /**
  * @test
- * @modules java.base/jdk.internal.module
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.module
+ * @library /test/lib
+ * @build jdk.test.lib.util.ModuleInfoWriter
  * @run testng ClassFileVersionsTest
  * @summary Test parsing of module-info.class with different class file versions
  */
@@ -36,7 +42,7 @@ import java.util.Set;
 
 import static java.lang.module.ModuleDescriptor.Requires.Modifier.*;
 
-import jdk.internal.module.ModuleInfoWriter;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/test/jdk/java/lang/module/ClassFileVersionsTest.java
+++ b/test/jdk/java/lang/module/ClassFileVersionsTest.java
@@ -23,10 +23,8 @@
 
 /**
  * @test
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.ModuleInfoWriter

--- a/test/jdk/java/lang/module/ConfigurationTest.java
+++ b/test/jdk/java/lang/module/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,15 @@
 
 /**
  * @test
- * @library /test/lib
  * @modules java.base/jdk.internal.access
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
  *          java.base/jdk.internal.module
+ * @library /test/lib
  * @build ConfigurationTest
+ *        jdk.test.lib.util.ModuleInfoWriter
  *        jdk.test.lib.util.ModuleUtils
  * @run testng ConfigurationTest
  * @summary Basic tests for java.lang.module.Configuration
@@ -47,10 +52,10 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 
+import jdk.test.lib.util.ModuleInfoWriter;
 import jdk.test.lib.util.ModuleUtils;
 
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.module.ModuleInfoWriter;
 import jdk.internal.module.ModuleTarget;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/test/jdk/java/lang/module/ConfigurationTest.java
+++ b/test/jdk/java/lang/module/ConfigurationTest.java
@@ -24,10 +24,8 @@
 /**
  * @test
  * @modules java.base/jdk.internal.access
- *          java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build ConfigurationTest

--- a/test/jdk/java/lang/module/ModuleDescriptorTest.java
+++ b/test/jdk/java/lang/module/ModuleDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,10 @@
 /**
  * @test
  * @modules java.base/jdk.internal.access
+ *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.module
+ * @library /test/lib
+ * @build jdk.test.lib.util.ModuleInfoWriter
  * @run testng ModuleDescriptorTest
  * @summary Basic test for java.lang.module.ModuleDescriptor and its builder
  */
@@ -56,7 +59,7 @@ import static java.lang.module.ModuleDescriptor.Requires.Modifier.*;
 
 import jdk.internal.access.JavaLangModuleAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.module.ModuleInfoWriter;
+import jdk.test.lib.util.ModuleInfoWriter;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;

--- a/test/jdk/java/lang/module/ModuleDescriptorTest.java
+++ b/test/jdk/java/lang/module/ModuleDescriptorTest.java
@@ -24,7 +24,8 @@
 /**
  * @test
  * @modules java.base/jdk.internal.access
- *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.ModuleInfoWriter

--- a/test/jdk/java/lang/module/ModuleFinderTest.java
+++ b/test/jdk/java/lang/module/ModuleFinderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,13 @@
 
 /**
  * @test
- * @modules java.base/jdk.internal.module
- * @build ModuleFinderTest
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.module
+ * @library /test/lib
+ * @build ModuleFinderTest jdk.test.lib.util.ModuleInfoWriter
  * @run testng ModuleFinderTest
  * @summary Basic tests for java.lang.module.ModuleFinder
  */
@@ -45,7 +50,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
 
-import jdk.internal.module.ModuleInfoWriter;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;

--- a/test/jdk/java/lang/module/ModuleFinderTest.java
+++ b/test/jdk/java/lang/module/ModuleFinderTest.java
@@ -23,10 +23,8 @@
 
 /**
  * @test
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build ModuleFinderTest jdk.test.lib.util.ModuleInfoWriter

--- a/test/jdk/java/lang/module/ModuleNamesTest.java
+++ b/test/jdk/java/lang/module/ModuleNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,13 @@
 /**
  * @test
  * @modules java.base/jdk.internal.access
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
  *          java.base/jdk.internal.module
+ * @library /test/lib
+ * @build jdk.test.lib.util.ModuleInfoWriter
  * @run testng ModuleNamesTest
  * @summary Basic test of reading a module-info.class with module names that
  *          are legal in class files but not legal in the Java Language
@@ -42,7 +48,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.module.ModuleInfoWriter;
+
+import jdk.test.lib.util.ModuleInfoWriter;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/test/jdk/java/lang/module/ModuleNamesTest.java
+++ b/test/jdk/java/lang/module/ModuleNamesTest.java
@@ -24,10 +24,8 @@
 /**
  * @test
  * @modules java.base/jdk.internal.access
- *          java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.ModuleInfoWriter

--- a/test/jdk/java/lang/module/MultiReleaseJarTest.java
+++ b/test/jdk/java/lang/module/MultiReleaseJarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,15 @@
 
 /**
  * @test
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.module
  * @library /test/lib
- * @modules java.base/jdk.internal.module
- * @build MultiReleaseJarTest jdk.test.lib.util.JarUtils
+ * @build MultiReleaseJarTest
+ *        jdk.test.lib.util.JarUtils
+ *        jdk.test.lib.util.ModuleInfoWriter
  * @run testng MultiReleaseJarTest
  * @run testng/othervm -Djdk.util.jar.enableMultiRelease=false MultiReleaseJarTest
  * @summary Basic test of modular JARs as multi-release JARs
@@ -54,7 +60,7 @@ import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import jdk.internal.module.ModuleInfoWriter;
+import jdk.test.lib.util.ModuleInfoWriter;
 import jdk.test.lib.util.JarUtils;
 
 import org.testng.annotations.Test;

--- a/test/jdk/java/lang/module/MultiReleaseJarTest.java
+++ b/test/jdk/java/lang/module/MultiReleaseJarTest.java
@@ -23,10 +23,8 @@
 
 /**
  * @test
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build MultiReleaseJarTest

--- a/test/jdk/java/security/Provider/SecurityProviderModularTest.java
+++ b/test/jdk/java/security/Provider/SecurityProviderModularTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,19 +38,24 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Builder;
-import jdk.internal.module.ModuleInfoWriter;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
-
+import jdk.test.lib.util.ModuleInfoWriter;
 
 /*
  * @test
  * @bug 8130360 8183310
  * @summary Test security provider in different combination of modular option
  *          defined with(out) service description.
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.module
  * @library /test/lib
- * @modules java.base/jdk.internal.module
- * @build jdk.test.lib.util.JarUtils TestProvider TestClient
+ * @build jdk.test.lib.util.JarUtils
+ *        jdk.test.lib.util.ModuleInfoWriter
+ *        TestProvider TestClient
  * @run main SecurityProviderModularTest CL true
  * @run main SecurityProviderModularTest CL false
  * @run main SecurityProviderModularTest SL true

--- a/test/jdk/java/security/Provider/SecurityProviderModularTest.java
+++ b/test/jdk/java/security/Provider/SecurityProviderModularTest.java
@@ -47,10 +47,8 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @bug 8130360 8183310
  * @summary Test security provider in different combination of modular option
  *          defined with(out) service description.
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils

--- a/test/jdk/javax/security/auth/login/modules/JaasModularClientTest.java
+++ b/test/jdk/javax/security/auth/login/modules/JaasModularClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,19 +33,23 @@ import java.io.File;
 import java.io.OutputStream;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Builder;
-import jdk.internal.module.ModuleInfoWriter;
 import java.util.stream.Stream;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.util.JarUtils;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 /*
  * @test
  * @bug 8078813 8183310
  * @summary Test custom JAAS login module with all possible modular option.
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.module
  * @library /test/lib
- * @modules java.base/jdk.internal.module
- * @build jdk.test.lib.util.JarUtils
+ * @build jdk.test.lib.util.JarUtils jdk.test.lib.util.ModuleInfoWriter
  * @build TestLoginModule JaasClient
  * @run main JaasModularClientTest false
  * @run main JaasModularClientTest true

--- a/test/jdk/javax/security/auth/login/modules/JaasModularClientTest.java
+++ b/test/jdk/javax/security/auth/login/modules/JaasModularClientTest.java
@@ -43,10 +43,8 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @test
  * @bug 8078813 8183310
  * @summary Test custom JAAS login module with all possible modular option.
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils jdk.test.lib.util.ModuleInfoWriter

--- a/test/jdk/javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java
+++ b/test/jdk/javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,19 +32,23 @@ import java.io.File;
 import java.io.OutputStream;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Builder;
-import jdk.internal.module.ModuleInfoWriter;
 import java.util.stream.Stream;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.util.JarUtils;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 /*
  * @test
  * @bug 8151654 8183310
  * @summary Test default callback handler with all possible modular option.
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.module
  * @library /test/lib
- * @modules java.base/jdk.internal.module
- * @build jdk.test.lib.util.JarUtils
+ * @build jdk.test.lib.util.JarUtils jdk.test.lib.util.ModuleInfoWriter
  * @build TestCallbackHandler TestLoginModule JaasClientWithDefaultHandler
  * @run main JaasModularDefaultHandlerTest
  */

--- a/test/jdk/javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java
+++ b/test/jdk/javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java
@@ -42,10 +42,8 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @test
  * @bug 8151654 8183310
  * @summary Test default callback handler with all possible modular option.
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils jdk.test.lib.util.ModuleInfoWriter

--- a/test/jdk/jdk/modules/incubator/ServiceBinding.java
+++ b/test/jdk/jdk/modules/incubator/ServiceBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,13 @@
 /**
  * @test
  * @bug 8233922
- * @modules java.base/jdk.internal.module
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.module
  * @library /test/lib
- * @build ServiceBinding TestBootLayer
+ * @build ServiceBinding TestBootLayer jdk.test.lib.util.ModuleInfoWriter
  * @run testng ServiceBinding
  * @summary Test service binding with incubator modules
  */
@@ -43,17 +47,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.Stream;
 
 import static java.lang.module.ModuleDescriptor.newModule;
 
-import jdk.internal.module.ModuleInfoWriter;
 import jdk.internal.module.ModuleResolution;
 
 import org.testng.annotations.Test;
 
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 @Test
 public class ServiceBinding {

--- a/test/jdk/jdk/modules/incubator/ServiceBinding.java
+++ b/test/jdk/jdk/modules/incubator/ServiceBinding.java
@@ -24,10 +24,8 @@
 /**
  * @test
  * @bug 8233922
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build ServiceBinding TestBootLayer jdk.test.lib.util.ModuleInfoWriter

--- a/test/jdk/sun/tools/jcmd/TestProcessHelper.java
+++ b/test/jdk/sun/tools/jcmd/TestProcessHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,10 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jdk.internal.module.ModuleInfoWriter;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.JarUtils;
+import jdk.test.lib.util.ModuleInfoWriter;
 
 /*
  * @test
@@ -54,10 +54,16 @@ import jdk.test.lib.util.JarUtils;
  *
  * @requires vm.flagless
  * @requires os.family == "linux"
- * @library /test/lib
  * @modules jdk.jcmd/sun.tools.common:+open
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
  *          java.base/jdk.internal.module
+ * @library /test/lib
  * @build test.TestProcess
+ *        jdk.test.lib.util.JarUtils
+ *        jdk.test.lib.util.ModuleInfoWriter
  * @run main/othervm TestProcessHelper
  */
 public class TestProcessHelper {

--- a/test/jdk/sun/tools/jcmd/TestProcessHelper.java
+++ b/test/jdk/sun/tools/jcmd/TestProcessHelper.java
@@ -55,10 +55,8 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @requires vm.flagless
  * @requires os.family == "linux"
  * @modules jdk.jcmd/sun.tools.common:+open
- *          java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build test.TestProcess

--- a/test/jdk/tools/jlink/JLinkNegativeTest.java
+++ b/test/jdk/tools/jlink/JLinkNegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,15 +28,19 @@
  * @bug 8174718
  * @bug 8189671
  * @author Andrei Eremeev
- * @library ../lib
- * @modules java.base/jdk.internal.jimage
+ * @modules java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.java.lang.constant
+ *          java.base/jdk.internal.jimage
  *          java.base/jdk.internal.module
  *          jdk.jdeps/com.sun.tools.classfile
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.compiler
- * @build tests.*
+ * @library /test/lib ../lib
+ * @build tests.* jdk.test.lib.util.ModuleInfoWriter
  * @run testng JLinkNegativeTest
  */
 
@@ -48,17 +52,15 @@ import java.lang.module.ModuleDescriptor;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
-import jdk.internal.module.ModuleInfoWriter;
+import jdk.test.lib.util.ModuleInfoWriter;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/test/jdk/tools/jlink/JLinkNegativeTest.java
+++ b/test/jdk/tools/jlink/JLinkNegativeTest.java
@@ -28,10 +28,8 @@
  * @bug 8174718
  * @bug 8189671
  * @author Andrei Eremeev
- * @modules java.base/jdk.internal.classfile
- *          java.base/jdk.internal.classfile.attribute
- *          java.base/jdk.internal.classfile.constantpool
- *          java.base/jdk.internal.classfile.java.lang.constant
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ *          java.base/jdk.internal.org.objectweb.asm.commons
  *          java.base/jdk.internal.jimage
  *          java.base/jdk.internal.module
  *          jdk.jdeps/com.sun.tools.classfile

--- a/test/lib/jdk/test/lib/util/ModuleInfoWriter.java
+++ b/test/lib/jdk/test/lib/util/ModuleInfoWriter.java
@@ -1,12 +1,10 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -22,7 +20,8 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.internal.module;
+
+package jdk.test.lib.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,6 +36,8 @@ import jdk.internal.org.objectweb.asm.Opcodes;
 import jdk.internal.org.objectweb.asm.commons.ModuleResolutionAttribute;
 import jdk.internal.org.objectweb.asm.commons.ModuleTargetAttribute;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
+import jdk.internal.module.ModuleResolution;
+import jdk.internal.module.ModuleTarget;
 
 /**
  * Utility class to write a ModuleDescriptor as a module-info.class.


### PR DESCRIPTION
I had to resolve three files and adapt the tests to compile (see extra commit)

test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
Resolved test instructions as later change was already backported.

test/jdk/java/lang/module/ModuleDescriptorTest.java
Several resolves. Some previous changes that can not be backported.

test/lib/jdk/test/lib/util/ModuleInfoWriter.java
Resolved

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8304163](https://bugs.openjdk.org/browse/JDK-8304163) needs maintainer approval

### Issue
 * [JDK-8304163](https://bugs.openjdk.org/browse/JDK-8304163): Move jdk.internal.module.ModuleInfoWriter to the test library (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3917/head:pull/3917` \
`$ git checkout pull/3917`

Update a local copy of the PR: \
`$ git checkout pull/3917` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3917`

View PR using the GUI difftool: \
`$ git pr show -t 3917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3917.diff">https://git.openjdk.org/jdk17u-dev/pull/3917.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3917#issuecomment-3284384624)
</details>
