### PR TITLE
8201183: sjavac build failures: "Connection attempt failed: Connection refused"

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/sjavac/server/PortFile.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/sjavac/server/PortFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,17 +59,16 @@ public class PortFile {
     // Followed by a 4 byte int, with the port nr.
     // Followed by a 8 byte long, with cookie nr.
 
-    private String filename;
-    private File file;
-    private File stopFile;
+    private final String filename;
+    private final File file;
+    private final File stopFile;
     private RandomAccessFile rwfile;
-    private FileChannel channel;
 
     // FileLock used to solve inter JVM synchronization, lockSem used to avoid
     // JVM internal OverlappingFileLockExceptions.
     // Class invariant: lock.isValid() <-> lockSem.availablePermits() == 0
     private FileLock lock;
-    private Semaphore lockSem = new Semaphore(1);
+    private final Semaphore lockSem = new Semaphore(1);
 
     private boolean containsPortInfo;
     private int serverPort;
@@ -98,17 +97,18 @@ public class PortFile {
         }
         // The rwfile should only be readable by the owner of the process
         // and no other! How do we do that on a RandomAccessFile?
-        channel = rwfile.getChannel();
     }
 
     /**
      * Lock the port file.
      */
     public void lock() throws IOException, InterruptedException {
-        if (channel == null) {
-            initializeChannel();
-        }
         lockSem.acquire();
+        if (rwfile != null) {
+            throw new IllegalStateException("rwfile not null");
+        }
+        initializeChannel();
+        FileChannel channel = rwfile.getChannel();
         lock = channel.lock();
     }
 
@@ -119,8 +119,7 @@ public class PortFile {
     public void getValues()  {
         containsPortInfo = false;
         if (lock == null) {
-            // Not locked, remain ignorant about port file contents.
-            return;
+            throw new IllegalStateException("Must lock before calling getValues");
         }
         try {
             if (rwfile.length()>0) {
@@ -167,6 +166,9 @@ public class PortFile {
      * Store the values into the locked port file.
      */
     public void setValues(int port, long cookie) throws IOException {
+        if (lock == null) {
+            throw new IllegalStateException("Must lock before calling setValues");
+        }
         Assert.check(lock != null);
         rwfile.seek(0);
         // Write the magic nr that identifies a port file.
@@ -181,19 +183,19 @@ public class PortFile {
      * Delete the port file.
      */
     public void delete() throws IOException, InterruptedException {
-        // Access to file must be closed before deleting.
-        rwfile.close();
-
-        file.delete();
-
-        // Wait until file has been deleted (deletes are asynchronous on Windows!) otherwise we
+        if (!file.exists()) { // file deleted already
+            return;
+        }
+        // Keep trying until file has been deleted, otherwise we
         // might shutdown the server and prevent another one from starting.
-        for (int i = 0; i < 10 && file.exists(); i++) {
+        for (int i = 0; i < 10 && file.exists() && !file.delete(); i++) {
             Thread.sleep(1000);
         }
         if (file.exists()) {
             throw new IOException("Failed to delete file.");
         }
+        // allow some time for late clients to connect
+        Thread.sleep(1000);
     }
 
     /**
@@ -222,10 +224,12 @@ public class PortFile {
      */
     public void unlock() throws IOException {
         if (lock == null) {
-            return;
+            throw new IllegalStateException("Not locked");
         }
         lock.release();
         lock = null;
+        rwfile.close();
+        rwfile = null;
         lockSem.release();
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

File was moved two times between 17 and 21, and it needed simple resolve (there is an assert)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8201183](https://bugs.openjdk.org/browse/JDK-8201183) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8201183: sjavac build failures: "Connection attempt failed: Connection refused"`

### Issue
 * [JDK-8201183](https://bugs.openjdk.org/browse/JDK-8201183): sjavac build failures: "Connection attempt failed: Connection refused" (**Bug** - P4 - Approved)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3918/head:pull/3918` \
`$ git checkout pull/3918`

Update a local copy of the PR: \
`$ git checkout pull/3918` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3918`

View PR using the GUI difftool: \
`$ git pr show -t 3918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3918.diff">https://git.openjdk.org/jdk17u-dev/pull/3918.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3918#issuecomment-3284695147)
</details>
