### PR TITLE
8292214: Memory leak in getAllConfigs of awt_GraphicsEnv.c:386

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -386,7 +386,7 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
          */
         screenDataPtr->defaultConfig = makeDefaultConfig(env, screen);
         if (screenDataPtr->defaultConfig == NULL) {
-            return;
+            goto cleanup;
         }
     }
 
@@ -575,6 +575,9 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
 
 cleanup:
     if (success != JNI_TRUE) {
+        for (i = 0; i < nConfig; i++) {
+            free(graphicsConfigs[i]);
+        }
         free(graphicsConfigs);
     }
     if (n8p != 0)


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8292214](https://bugs.openjdk.org/browse/JDK-8292214) needs maintainer approval

### Issue
 * [JDK-8292214](https://bugs.openjdk.org/browse/JDK-8292214): Memory leak in getAllConfigs of awt_GraphicsEnv.c:386 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3919/head:pull/3919` \
`$ git checkout pull/3919`

Update a local copy of the PR: \
`$ git checkout pull/3919` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3919`

View PR using the GUI difftool: \
`$ git pr show -t 3919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3919.diff">https://git.openjdk.org/jdk17u-dev/pull/3919.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3919#issuecomment-3284694193)
</details>
