### PR TITLE
8346929: runtime/ClassUnload/DictionaryDependsTest.java fails with "Test failed: should be unloaded"

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassUnload/DictionaryDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/DictionaryDependsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@
 import jdk.test.whitebox.WhiteBox;
 import java.lang.reflect.Method;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
+import java.util.Set;
 
 public class DictionaryDependsTest {
     public static WhiteBox wb = WhiteBox.getWhiteBox();
@@ -82,9 +84,9 @@ public class DictionaryDependsTest {
     public static void main(String args[]) throws Throwable {
         DictionaryDependsTest d = new DictionaryDependsTest();
         d.test();
-        ClassUnloadCommon.triggerUnloading();  // should not unload anything
-        System.out.println("Should unload MyTest and p2.c2 just now");
-        ClassUnloadCommon.failIf(wb.isClassAlive(MY_TEST), "should be unloaded");
-        ClassUnloadCommon.failIf(wb.isClassAlive("p2.c2"), "should be unloaded");
+
+        // Now unload MY_TEST and p2.c2
+        Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(MY_TEST, "p2.c2"));
+        ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should be unloaded: " + aliveClasses);
     }
 }

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveClass.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@
 import java.lang.ref.SoftReference;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.
@@ -60,7 +62,6 @@ public class KeepAliveClass {
     }
 
     ClassUnloadCommon.triggerUnloading();
-
     {
         boolean isAlive = wb.isClassAlive(className);
         System.out.println("testClass (2) alive: " + isAlive);
@@ -69,13 +70,8 @@ public class KeepAliveClass {
     }
     c = null;
     escape = null;
-    ClassUnloadCommon.triggerUnloading();
 
-    {
-        boolean isAlive = wb.isClassAlive(className);
-        System.out.println("testClass (3) alive: " + isAlive);
-        ClassUnloadCommon.failIf(isAlive, "should be unloaded");
-    }
-
+    Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(className));
+    ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "testClass (3) should be unloaded: " + aliveClasses);
   }
 }

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveClassLoader.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@
 
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.
@@ -68,13 +70,8 @@ public class KeepAliveClassLoader {
     }
     cl = null;
     escape = null;
-    ClassUnloadCommon.triggerUnloading();
 
-    {
-        boolean isAlive = wb.isClassAlive(className);
-        System.out.println("testClassLoader (3) alive: " + isAlive);
-        ClassUnloadCommon.failIf(isAlive, "should be unloaded");
-    }
-
+    Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(className));
+    ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "testClassLoader (3) should be unloaded: " + aliveClasses);
   }
 }

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@
 
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
+import java.util.Set;
 
 import java.lang.ref.Reference;
 /**
@@ -68,13 +70,8 @@ public class KeepAliveObject {
     // Don't let `o` get prematurely reclaimed by the GC.
     Reference.reachabilityFence(o);
     o = null;
-    ClassUnloadCommon.triggerUnloading();
 
-    {
-        boolean isAlive = wb.isClassAlive(className);
-        System.out.println("testObject (3) alive: " + isAlive);
-        ClassUnloadCommon.failIf(isAlive, "should be unloaded");
-    }
-
+    Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(className));
+    ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "testObject (3) should be unloaded: " + aliveClasses);
   }
 }

--- a/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/KeepAliveSoftReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@
 import java.lang.ref.SoftReference;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
 
 /**
  * Test that verifies that classes are not unloaded when specific types of references are kept to them.
@@ -69,8 +70,7 @@ public class KeepAliveSoftReference {
         ClassUnloadCommon.failIf(isAlive != shouldBeAlive, "" + isAlive + " != " + shouldBeAlive);
     }
     sr.clear();
-    ClassUnloadCommon.triggerUnloading();
-
+    ClassUnloadCommon.triggerUnloading(List.of(className));
     {
         boolean isAlive = wb.isClassAlive(className);
         System.out.println("testSoftReference (3) alive: " + isAlive);

--- a/test/hotspot/jtreg/runtime/ClassUnload/SuperDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/SuperDependsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@
 import jdk.test.whitebox.WhiteBox;
 import p2.*;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
+import java.util.Set;
 
 public class SuperDependsTest {
     public static WhiteBox wb = WhiteBox.getWhiteBox();
@@ -75,9 +77,7 @@ public class SuperDependsTest {
     public static void main(String args[]) throws Throwable {
         SuperDependsTest d = new SuperDependsTest();
         d.test();
-        ClassUnloadCommon.triggerUnloading();  // should not unload anything
-        System.out.println("Should unload MyTest and p2.c2 just now");
-        ClassUnloadCommon.failIf(wb.isClassAlive(MY_TEST), "should be unloaded");
-        ClassUnloadCommon.failIf(wb.isClassAlive("p2.c2"), "should be unloaded");
+        Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(MY_TEST, "p2.c2"));
+        ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should be unloaded: " + aliveClasses);
     }
 }

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadInterfaceTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadInterfaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ import jdk.test.whitebox.WhiteBox;
 import test.Interface;
 import java.lang.ClassLoader;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Test that verifies that class unloaded removes the implementor from its the interface that it implements
@@ -86,8 +88,11 @@ public class UnloadInterfaceTest {
         ClassUnloadCommon.failIf(!wb.isClassAlive(interfaceName), "should be live here");
 
         cl = null; c = null; o = null;
-        ClassUnloadCommon.triggerUnloading();
-        ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
+
+        // Now unload className. This calls triggerUnloading but we only pass the class we expect to be unloaded
+        // otherwise the test will take too long.
+        Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(className));
+        ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should be unloaded: " + aliveClasses);
         ClassUnloadCommon.failIf(!wb.isClassAlive(interfaceName), "should be live here");
         System.out.println("We still have Interface referenced" + ic);
     }

--- a/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/UnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ import jdk.test.lib.classloader.ClassUnloadCommon;
 
 import java.lang.reflect.Array;
 import java.lang.ref.Reference;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Test that verifies that liveness of classes is correctly tracked.
@@ -108,9 +110,9 @@ public class UnloadTest {
         // Don't let `o` get prematurely reclaimed by the GC.
         Reference.reachabilityFence(o);
         o = null;
-        ClassUnloadCommon.triggerUnloading();
 
-        ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
+        Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(className));
+        ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should have been unloaded: " + aliveClasses);
 
         int unloadedRefcount = wb.getSymbolRefcount(loaderName);
         System.out.println("Refcount of symbol " + loaderName + " is " + unloadedRefcount);

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/HelloUnload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
+import java.util.Set;
 
 public class HelloUnload {
     private static String className = "CustomLoadee";
@@ -87,9 +89,9 @@ public class HelloUnload {
 
         if (doUnload) {
             urlClassLoader = null; c = null; o = null;
-            ClassUnloadCommon.triggerUnloading();
+            Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(className));
             System.out.println("Is CustomLoadee alive? " + wb.isClassAlive(className));
-            ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
+            ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should have been unloaded: " + aliveClasses);
 
         }
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/UnloadUnregisteredLoader.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/test-classes/UnloadUnregisteredLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
+import java.util.List;
+import java.util.Set;
 
 public class UnloadUnregisteredLoader {
     public static void main(String args[]) throws Exception {
@@ -39,8 +41,8 @@ public class UnloadUnregisteredLoader {
         for (int i=0; i<5; i++) {
             doit(urls, className, (i == 0));
 
-            ClassUnloadCommon.triggerUnloading();
-            ClassUnloadCommon.failIf(wb.isClassAlive(className), "should have been unloaded");
+            Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(className));
+            ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should have been unloaded: " + aliveClasses);
         }
     }
 

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class ClassLoadUnloadTest {
             ClassLoader cl = ClassUnloadCommon.newClassLoader();
             Class<?> c = cl.loadClass(className);
             cl = null; c = null;
-            ClassUnloadCommon.triggerUnloading();
+            ClassUnloadCommon.triggerUnloading(List.of(className));
         }
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8346929](https://bugs.openjdk.org/browse/JDK-8346929) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346929](https://bugs.openjdk.org/browse/JDK-8346929): runtime/ClassUnload/DictionaryDependsTest.java fails with "Test failed: should be unloaded" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3921/head:pull/3921` \
`$ git checkout pull/3921`

Update a local copy of the PR: \
`$ git checkout pull/3921` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3921`

View PR using the GUI difftool: \
`$ git pr show -t 3921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3921.diff">https://git.openjdk.org/jdk17u-dev/pull/3921.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3921#issuecomment-3284762515)
</details>
