### PR TITLE
8331231: containers/docker/TestContainerInfo.java fails

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
+++ b/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
@@ -26,6 +26,7 @@
 /*
  * @test
  * @summary Test container info for cgroup v2
+ * @key cgroups
  * @requires docker.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
A small test fix useful in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8331231](https://bugs.openjdk.org/browse/JDK-8331231) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331231](https://bugs.openjdk.org/browse/JDK-8331231): containers/docker/TestContainerInfo.java fails (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3925/head:pull/3925` \
`$ git checkout pull/3925`

Update a local copy of the PR: \
`$ git checkout pull/3925` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3925`

View PR using the GUI difftool: \
`$ git pr show -t 3925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3925.diff">https://git.openjdk.org/jdk17u-dev/pull/3925.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3925#issuecomment-3285009645)
</details>
