### PR TITLE
8340092: [Linux] containers/systemd/SystemdMemoryAwarenessTest.java failing on some systems

### DIFF
--- a/test/hotspot/jtreg/containers/systemd/TEST.properties
+++ b/test/hotspot/jtreg/containers/systemd/TEST.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+exclusiveAccess.dirs=.


### PR DESCRIPTION
Follow up for JDK-8333446.  Clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8340092](https://bugs.openjdk.org/browse/JDK-8340092) needs maintainer approval

### Integration blocker
&nbsp;⚠️ Dependency #3926 must be integrated first

### Issue
 * [JDK-8340092](https://bugs.openjdk.org/browse/JDK-8340092): [Linux] containers/systemd/SystemdMemoryAwarenessTest.java failing on some systems (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3927/head:pull/3927` \
`$ git checkout pull/3927`

Update a local copy of the PR: \
`$ git checkout pull/3927` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3927`

View PR using the GUI difftool: \
`$ git pr show -t 3927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3927.diff">https://git.openjdk.org/jdk17u-dev/pull/3927.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3927#issuecomment-3285119182)
</details>
