### PR TITLE
8236907: JTable added to nested panels does not paint last visible row

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/TablePrintable.java
+++ b/src/java.desktop/share/classes/javax/swing/TablePrintable.java
@@ -395,11 +395,14 @@ class TablePrintable implements Printable {
         // draw a box around the table
         g2d.setColor(Color.BLACK);
 
+        Rectangle bounds = table.getBounds();
+        bounds.x = bounds.y = 0;
+
         // compute the visible portion of table and draw the rect around it
-        Rectangle visibleBounds = clip.intersection(table.getBounds());
+        Rectangle visibleBounds = clip.intersection(bounds);
         Point upperLeft = visibleBounds.getLocation();
-        Point lowerRight = new Point(visibleBounds.x + visibleBounds.width,
-                                     visibleBounds.y + visibleBounds.height);
+        Point lowerRight = new Point(visibleBounds.x + visibleBounds.width - 1,
+                                     visibleBounds.y + visibleBounds.height - 1);
 
         int rMin = table.rowAtPoint(upperLeft);
         int rMax = table.rowAtPoint(lowerRight);
@@ -410,7 +413,7 @@ class TablePrintable implements Printable {
             rMax = table.getRowCount();
         }
         int rowHeight = 0;
-        for(int visrow = rMin; visrow < rMax; visrow++) {
+        for(int visrow = rMin; visrow <= rMax; visrow++) {
             rowHeight += table.getRowHeight(visrow);
         }
         // If PrintMode is FIT_WIDTH, then draw rect for entire column width while

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTableUI.java
@@ -1884,23 +1884,6 @@ public class BasicTableUI extends TableUI
             comp = comp.getParent();
         }
 
-        if (comp != null && !(comp instanceof JViewport) && !(comp instanceof JScrollPane)) {
-            // We did rMax-1 to paint the same number of rows that are drawn on console
-            // otherwise 1 extra row is printed per page than that are displayed
-            // when there is no scrollPane and we do printing of table
-            // but not when rmax is already pointing to index of last row
-            // and if there is any selected rows
-            if (rMax != (table.getRowCount() - 1) &&
-                    (table.getSelectedRow() == -1)) {
-                // Do not decrement rMax if rMax becomes
-                // less than or equal to rMin
-                // else cells will not be painted
-                if (rMax - rMin > 1) {
-                    rMax = rMax - 1;
-                }
-            }
-        }
-
         // Paint the grid.
         paintGrid(g, rMin, rMax, cMin, cMax);
 

--- a/test/jdk/javax/swing/JTable/8236907/LastVisibleRow.java
+++ b/test/jdk/javax/swing/JTable/8236907/LastVisibleRow.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @key headful
+ * @bug 8236907
+ * @summary  Verifies if JTable last row is visible.
+ * @run main LastVisibleRow
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.event.InputEvent;
+import java.awt.image.BufferedImage;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+
+import javax.swing.BorderFactory;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+
+public class LastVisibleRow {
+    static JFrame frame;
+    static JTable table;
+    static Robot testRobot;
+
+    public static void main(String[] args) throws Exception {
+        Point clkPoint;
+        try {
+            testRobot = new Robot();
+
+            SwingUtilities.invokeAndWait(new Runnable() {
+
+                public void run() {
+                    createAndShowGUI();
+                }
+            });
+            testRobot.delay(1000);
+            testRobot.waitForIdle();
+            BufferedImage bufferedImageBefore = testRobot.createScreenCapture(getCaptureRect());
+            testRobot.delay(1000);
+            testRobot.waitForIdle();
+            clkPoint = getMousePosition();
+            mouseEvents(clkPoint);
+            testRobot.waitForIdle();
+            clearSelect();
+            testRobot.waitForIdle();
+            BufferedImage bufferedImageAfter = testRobot.createScreenCapture(getCaptureRect());
+            testRobot.delay(1000);
+
+            if (!compare(bufferedImageBefore, bufferedImageAfter)) {
+                throw new RuntimeException("Test Case Failed!!");
+            }
+        } finally {
+            if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
+        }
+    }
+
+    /*
+     *
+     * Get clickable screen point for particular row and column of a table
+     * param row   Row Number
+     * param column    Column Number
+     * return Point
+     */
+    private static Point getCellClickPoint(final int row, final int column) {
+        Point result;
+
+        Rectangle rect = table.getCellRect(row, column, false);
+        Point point = new Point(rect.x + rect.width / 2,
+                rect.y + rect.height / 2);
+        SwingUtilities.convertPointToScreen(point, table);
+        result = point;
+
+        return result;
+    }
+
+    private static void createAndShowGUI() {
+        final PrintRequestAttributeSet printReqAttr = new HashPrintRequestAttributeSet();
+        printReqAttr.add(javax.print.attribute.standard.OrientationRequested.LANDSCAPE);
+        frame = new JFrame();
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        Container contentPane = frame.getContentPane();
+        JPanel centerPane = new JPanel(new BorderLayout());
+        centerPane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        JPanel tablePaneContainer = new JPanel(new BorderLayout());
+        JPanel tablePane = new JPanel(new BorderLayout());
+        table = new JTable(new Object[][]{{"row_1_col_1", "row_1_col_2", "row_1_col_3"}, {"row_2_col_1", "row_2_col_2", "row_2_col_3"}, {"row_3_col_1", "row_3_col_2", "row_3_col_3"}, {"row_4_col_1", "row_4_col_2", "row_4_col_3"}}, new String[]{"Col1", "Col2", "Col3"});
+        table.setPreferredSize(new Dimension(0, (table.getRowHeight() * 3)));
+
+        tablePane.add(table.getTableHeader(), BorderLayout.NORTH);
+        tablePane.add(table, BorderLayout.CENTER);
+        tablePaneContainer.add(tablePane, BorderLayout.CENTER);
+        centerPane.add(tablePaneContainer, BorderLayout.NORTH);
+        contentPane.add(centerPane, BorderLayout.CENTER);
+        frame.setSize(400, 120);
+        frame.setVisible(true);
+        frame.setLocationRelativeTo(null);
+
+    }
+
+    /*
+     *
+     * mouseEvents for last row click
+     */
+
+    private static void mouseEvents(Point clkPnt)  {
+        testRobot.mouseMove(clkPnt.x, clkPnt.y);
+        testRobot.delay(50);
+        testRobot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        testRobot.delay(50);
+        testRobot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        testRobot.delay(50);
+    }
+    /*
+     *
+     * getMousePosition Actions for last row click
+     * returns Point
+     * throws Exception
+     */
+
+    private static Point getMousePosition() throws Exception {
+        final Point[] clickPoint = new Point[1];
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                clickPoint[0] = getCellClickPoint(2, 0);
+            }
+        });
+        return clickPoint[0];
+    }
+
+    /*
+     *
+     * Clears the selected table row
+     * throws Exception
+     */
+
+    private static void clearSelect() throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                table.getSelectionModel().clearSelection();
+                table.setFocusable(false);
+            }
+        });
+    }
+
+    /*
+     * getCaptureRect Method - To Compute the Rectangle for
+     * Screen Capturing the Last Row for comparison
+     * return Rectangle
+     */
+
+    private static Rectangle getCaptureRect() throws InterruptedException, InvocationTargetException {
+        final Rectangle[] captureRect = new Rectangle[1];
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                Rectangle cellRect = table.getCellRect(2, 0, true);
+                Point point = new Point(cellRect.x, cellRect.y);
+                SwingUtilities.convertPointToScreen(point, table);
+
+                captureRect[0] = new Rectangle(point.x, point.y, table.getColumnCount() * cellRect.width, cellRect.height);
+            }
+        });
+        return captureRect[0];
+    }
+
+    /*
+     * Compare method - to compare two images.
+     * param bufferedImage1    Buffered Image Before click
+     * param bufferedImage2    Buffered Image After click
+     * return Boolean
+     */
+
+    static Boolean compare(BufferedImage bufferedImage1, BufferedImage bufferedImage2) {
+        if (bufferedImage1.getWidth() == bufferedImage2.getWidth()
+                && bufferedImage1.getHeight() == bufferedImage2.getHeight()) {
+            for (int x = 0; x < bufferedImage1.getWidth(); x++) {
+                for (int y = 0; y < bufferedImage1.getHeight(); y++) {
+                    if (bufferedImage1.getRGB(x, y) != bufferedImage2.getRGB(x, y)) {
+                        return false;
+                    }
+                }
+            }
+        } else {
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
I would like to fix this small, well testable issue in 17.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8236907](https://bugs.openjdk.org/browse/JDK-8236907) needs maintainer approval

### Issue
 * [JDK-8236907](https://bugs.openjdk.org/browse/JDK-8236907): JTable added to nested panels does not paint last visible row (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3928/head:pull/3928` \
`$ git checkout pull/3928`

Update a local copy of the PR: \
`$ git checkout pull/3928` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3928`

View PR using the GUI difftool: \
`$ git pr show -t 3928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3928.diff">https://git.openjdk.org/jdk17u-dev/pull/3928.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3928#issuecomment-3287724316)
</details>
