### PR TITLE
8285915: failure_handler: gather the contents of /etc/hosts file

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -80,7 +80,7 @@ environment=\
         memory.vmstat.slabinfo memory.vmstat.disk \
   files \
   locks \
-  net.sockets net.statistics net.ifconfig \
+  net.sockets net.statistics net.ifconfig net.hostsfile \
   screenshot
 ################################################################################
 users.current.app=id
@@ -126,6 +126,9 @@ net.statistics.app=netstat
 net.statistics.args=-sv
 net.ifconfig.app=ifconfig
 net.ifconfig.args=-a
+
+net.hostsfile.app=cat
+net.hostsfile.args=/etc/hosts
 
 screenshot.app=bash
 screenshot.args=-c\0\

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -89,7 +89,7 @@ environment=\
   process.ps process.top \
   memory.vmstat \
   files \
-  net.netstat.av net.netstat.aL net.netstat.m net.netstat.s net.ifconfig \
+  net.netstat.av net.netstat.aL net.netstat.m net.netstat.s net.ifconfig net.hostsfile \
   scutil.nwi scutil.proxy \
   screenshot
 ################################################################################
@@ -130,6 +130,9 @@ net.netstat.m.args=-m
 net.netstat.s.args=-s
 net.ifconfig.app=ifconfig
 net.ifconfig.args=-a
+
+net.hostsfile.app=cat
+net.hostsfile.args=/etc/hosts
 
 scutil.app=scutil
 scutil.nwi.args=--nwi

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -75,7 +75,7 @@ environment=\
   memory.free memory.vmstat.default memory.vmstat.statistics \
         memory.vmstat.slabinfo memory.vmstat.disk \
   files \
-  net.sockets net.statistics net.ipconfig \
+  net.sockets net.statistics net.ipconfig net.hostsfile \
   screenshot
 ################################################################################
 users.current.app=id
@@ -124,6 +124,10 @@ net.statistics.app=netstat
 net.statistics.args=-s -e
 net.ipconfig.app=ipconfig
 net.ipconfig.args=/all
+
+net.hostsfile.app=bash
+net.hostsfile.args.delimiter=\0
+net.hostsfile.args=-c\0cat $WINDIR/System32/drivers/etc/hosts
 
 screenshot.app=bash
 screenshot.args=-c\0\


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8285915](https://bugs.openjdk.org/browse/JDK-8285915) needs maintainer approval

### Issue
 * [JDK-8285915](https://bugs.openjdk.org/browse/JDK-8285915): failure_handler: gather the contents of /etc/hosts file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3929/head:pull/3929` \
`$ git checkout pull/3929`

Update a local copy of the PR: \
`$ git checkout pull/3929` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3929`

View PR using the GUI difftool: \
`$ git pr show -t 3929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3929.diff">https://git.openjdk.org/jdk17u-dev/pull/3929.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3929#issuecomment-3292345123)
</details>
