### PR TITLE
8277424: javax/net/ssl/TLSCommon/TLSTest.java  fails with connection refused

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/TLSTest.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/TLSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,91 +52,91 @@ import javax.net.ssl.TrustManagerFactory;
  * @test
  * @bug 8205111
  * @summary Test TLS with different types of supported keys.
- * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha1 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha256 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha384 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha512 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 ec_rsa_pkcs1_sha256 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 ecdsa_sha1 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 ecdsa_secp384r1_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pkcs1_sha1 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pkcs1_sha256 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pkcs1_sha384 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pkcs1_sha512 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 ec_rsa_pkcs1_sha256 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 ecdsa_sha1 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 ecdsa_secp384r1_sha384
  *      TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 ecdsa_secp521r1_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 ecdsa_secp521r1_sha512
  *      TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_rsae_sha256 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_rsae_sha384 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_rsae_sha512 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_pss_sha256 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_pss_sha384 TLS_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_pss_sha512 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_rsae_sha256 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_rsae_sha384 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_rsae_sha512 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_pss_sha256 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_pss_sha384 TLS_AES_128_GCM_SHA256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_pss_sha512 TLS_AES_128_GCM_SHA256
  *
- * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha1 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha256 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha384 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha512 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 ec_rsa_pkcs1_sha256 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 ecdsa_sha1 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 ecdsa_secp384r1_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pkcs1_sha1 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pkcs1_sha256 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pkcs1_sha384 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pkcs1_sha512 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 ec_rsa_pkcs1_sha256 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 ecdsa_sha1 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 ecdsa_secp384r1_sha384
  *      TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 ecdsa_secp521r1_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 ecdsa_secp521r1_sha512
  *      TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_rsae_sha256 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_rsae_sha384 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_rsae_sha512 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_pss_sha256 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_pss_sha384 TLS_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.3 rsa_pss_pss_sha512 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_rsae_sha256 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_rsae_sha384 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_rsae_sha512 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_pss_sha256 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_pss_sha384 TLS_AES_256_GCM_SHA384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.3 rsa_pss_pss_sha512 TLS_AES_256_GCM_SHA384
  *
- * @run main/othervm TLSTest TLSv1.2 rsa_pkcs1_sha1 TLS_RSA_WITH_AES_128_CBC_SHA
- * @run main/othervm TLSTest TLSv1.2 rsa_pkcs1_sha256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pkcs1_sha1 TLS_RSA_WITH_AES_128_CBC_SHA
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pkcs1_sha256
  *      TLS_RSA_WITH_AES_128_CBC_SHA
- * @run main/othervm TLSTest TLSv1.2 rsa_pkcs1_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pkcs1_sha384
  *      TLS_RSA_WITH_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.2 rsa_pkcs1_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pkcs1_sha512
  *      TLS_RSA_WITH_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.2 ec_rsa_pkcs1_sha256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 ec_rsa_pkcs1_sha256
  *      TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
- * @run main/othervm TLSTest TLSv1.2 ecdsa_sha1
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 ecdsa_sha1
  *      TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.2 ecdsa_secp384r1_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 ecdsa_secp384r1_sha384
  *      TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
- * @run main/othervm TLSTest TLSv1.2 ecdsa_secp521r1_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 ecdsa_secp521r1_sha512
  *      TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
- * @run main/othervm TLSTest TLSv1.2 rsa_pss_rsae_sha256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pss_rsae_sha256
  *      TLS_RSA_WITH_AES_256_CBC_SHA256
- * @run main/othervm TLSTest TLSv1.2 rsa_pss_rsae_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pss_rsae_sha384
  *      TLS_RSA_WITH_AES_256_CBC_SHA
- * @run main/othervm TLSTest TLSv1.2 rsa_pss_rsae_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pss_rsae_sha512
  *      TLS_RSA_WITH_AES_128_CBC_SHA256
- * @run main/othervm TLSTest TLSv1.2 rsa_pss_pss_sha256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pss_pss_sha256
  *      TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
- * @run main/othervm TLSTest TLSv1.2 rsa_pss_pss_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pss_pss_sha384
  *      TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
- * @run main/othervm TLSTest TLSv1.2 rsa_pss_pss_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.2 rsa_pss_pss_sha512
  *      TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
  *
- * @run main/othervm TLSTest TLSv1.1 rsa_pkcs1_sha1 TLS_RSA_WITH_AES_128_CBC_SHA
- * @run main/othervm TLSTest TLSv1.1 rsa_pkcs1_sha256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.1 rsa_pkcs1_sha1 TLS_RSA_WITH_AES_128_CBC_SHA
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.1 rsa_pkcs1_sha256
  *      TLS_RSA_WITH_AES_256_CBC_SHA
- * @run main/othervm TLSTest TLSv1.1 rsa_pkcs1_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.1 rsa_pkcs1_sha384
  *      TLS_RSA_WITH_AES_128_CBC_SHA
- * @run main/othervm TLSTest TLSv1.1 rsa_pkcs1_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.1 rsa_pkcs1_sha512
  *      TLS_RSA_WITH_AES_256_CBC_SHA
- * @run main/othervm TLSTest TLSv1.1 rsa_pss_rsae_sha256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.1 rsa_pss_rsae_sha256
  *      TLS_RSA_WITH_AES_128_CBC_SHA
- * @run main/othervm TLSTest TLSv1.1 rsa_pss_rsae_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.1 rsa_pss_rsae_sha384
  *      TLS_RSA_WITH_AES_256_CBC_SHA
- * @run main/othervm TLSTest TLSv1.1 rsa_pss_rsae_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1.1 rsa_pss_rsae_sha512
  *      TLS_RSA_WITH_AES_128_CBC_SHA
  *
- * @run main/othervm TLSTest TLSv1 rsa_pkcs1_sha1 TLS_RSA_WITH_AES_128_CBC_SHA
- * @run main/othervm TLSTest TLSv1 rsa_pkcs1_sha256 TLS_RSA_WITH_AES_256_CBC_SHA
- * @run main/othervm TLSTest TLSv1 rsa_pkcs1_sha384 TLS_RSA_WITH_AES_128_CBC_SHA
- * @run main/othervm TLSTest TLSv1 rsa_pkcs1_sha512 TLS_RSA_WITH_AES_256_CBC_SHA
- * @run main/othervm TLSTest TLSv1 rsa_pss_rsae_sha256
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1 rsa_pkcs1_sha1 TLS_RSA_WITH_AES_128_CBC_SHA
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1 rsa_pkcs1_sha256 TLS_RSA_WITH_AES_256_CBC_SHA
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1 rsa_pkcs1_sha384 TLS_RSA_WITH_AES_128_CBC_SHA
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1 rsa_pkcs1_sha512 TLS_RSA_WITH_AES_256_CBC_SHA
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1 rsa_pss_rsae_sha256
  *      TLS_RSA_WITH_AES_128_CBC_SHA
- * @run main/othervm TLSTest TLSv1 rsa_pss_rsae_sha384
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1 rsa_pss_rsae_sha384
  *      TLS_RSA_WITH_AES_256_CBC_SHA
- * @run main/othervm TLSTest TLSv1 rsa_pss_rsae_sha512
+ * @run main/othervm -Djavax.net.debug=ssl,handshake TLSTest TLSv1 rsa_pss_rsae_sha512
  *      TLS_RSA_WITH_AES_128_CBC_SHA
  */
 public class TLSTest {
@@ -281,7 +281,7 @@ public class TLSTest {
                     keyType.getTrustedCert(), null, null, keyType.getKeyType());
             SSLSocketFactory sslsf = ctx.getSocketFactory();
             try (SSLSocket sslSocket
-                    = (SSLSocket) sslsf.createSocket("localhost", serverPort)) {
+                    = (SSLSocket) sslsf.createSocket(InetAddress.getLoopbackAddress(), serverPort)) {
                 // Specify the client cipher suites
                 sslSocket.setEnabledCipherSuites(new String[]{this.cipher});
                 sslSocket.setEnabledProtocols(new String[]{this.tlsProtocol});


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8277424](https://bugs.openjdk.org/browse/JDK-8277424) needs maintainer approval

### Issue
 * [JDK-8277424](https://bugs.openjdk.org/browse/JDK-8277424): javax/net/ssl/TLSCommon/TLSTest.java  fails with connection refused (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3931/head:pull/3931` \
`$ git checkout pull/3931`

Update a local copy of the PR: \
`$ git checkout pull/3931` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3931`

View PR using the GUI difftool: \
`$ git pr show -t 3931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3931.diff">https://git.openjdk.org/jdk17u-dev/pull/3931.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3931#issuecomment-3292398615)
</details>
