### PR TITLE
8358701: Remove misleading javax.management.remote API doc wording about JMX spec, and historic link to JMXMP

### DIFF
--- a/src/java.management/share/classes/javax/management/remote/package.html
+++ b/src/java.management/share/classes/javax/management/remote/package.html
@@ -2,7 +2,7 @@
 <head>
     <title>JMX Remote API.</title>
 <!--
-Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -30,12 +30,9 @@ questions.
       <p>Interfaces for remote access to
 	JMX MBean servers.
 	This package defines the essential interfaces for making a JMX
-	MBean server manageable remotely. The specification of this 
-        functionality is completed by Part III of the 
-       <a href="https://jcp.org/aboutJava/communityprocess/mrel/jsr160/index2.html">
-	JMX Specification, version 1.4</a></p>
+	MBean server manageable remotely.</p>
 
-      <p>The JMX specification defines the notion of <b>connectors</b>.
+      <p>JMX defines the notion of <b>connectors</b>.
 	A connector is attached to a JMX API MBean server and makes it
 	accessible to remote Java clients. The client end of a
 	connector exports essentially the same interface as the MBean
@@ -44,32 +41,17 @@ questions.
 	interface.</p>
 
       <p>A connector makes an MBean server remotely accessible through
-	a given protocol. The JMX Remote API allows the use of different 
-        type of connectors:
+	a given protocol.
 
       <ul>
        <li>The JMX Remote API defines a standard connector,
 	the <b>RMI Connector</b>, which provides remote access to an
         MBeanServer through RMI.
 
-       <li>The JMX Remote API also defines an optional connector called 
-        <b>JMXMP Connector</b> implementing the JMX Message Protocol 
-	(JMXMP). As it is optional, it is not part of this bundle (see
-	note below).
-
-       <li>User-defined connector protocols are also possible using the 
+       <li>Other connector protocols are also possible using the
 	{@link javax.management.remote.JMXConnectorFactory
-	JMXConnectorFactory} and, optionally, the Generic Connector
-	(not part of this bundle, see note below).
+	JMXConnectorFactory}
       </ul>
-
-      <p><u>Note</u>: the optional packages implementing
-        the optional part of the <em>JMX Remote API</em>
-        are not included in the <em>Java SE Platform</em> 
-        but are available from the <em>JMX Remote API 
-	<a href="https://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-java-plat-419418.html">
-	Reference Implementation</a></em>.</p>
-
 
       <h2>Connector addresses</h2>
 


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8358701](https://bugs.openjdk.org/browse/JDK-8358701) needs maintainer approval
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8360041](https://bugs.openjdk.org/browse/JDK-8360041) to be approved

### Issues
 * [JDK-8358701](https://bugs.openjdk.org/browse/JDK-8358701): Remove misleading javax.management.remote API doc wording about JMX spec, and historic link to JMXMP (**Enhancement** - P3 - Approved)
 * [JDK-8360041](https://bugs.openjdk.org/browse/JDK-8360041): Remove misleading javax.management.remote API doc wording about JMX spec, and historic link to JMXMP (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3934/head:pull/3934` \
`$ git checkout pull/3934`

Update a local copy of the PR: \
`$ git checkout pull/3934` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3934`

View PR using the GUI difftool: \
`$ git pr show -t 3934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3934.diff">https://git.openjdk.org/jdk17u-dev/pull/3934.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3934#issuecomment-3292603808)
</details>
