### PR TITLE
8358764: (sc) SocketChannel.close when thread blocked in read causes connection to be reset (win)

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -70,6 +70,9 @@ public class Net {
     // set to true if the fast tcp loopback should be enabled on Windows
     private static final boolean fastLoopback;
 
+    // set to true if shut down before close should be enabled on Windows
+    private static final boolean shutdown_write_before_close;
+
     // -- Miscellaneous utilities --
 
     private static volatile boolean checkedIPv6;
@@ -104,6 +107,13 @@ public class Net {
      */
     static boolean useExclusiveBind() {
         return exclusiveBind;
+    }
+
+    /**
+     * Tells whether a TCP connection should be shutdown for writing before closing.
+     */
+    static boolean shouldShutdownWriteBeforeClose() {
+        return shutdown_write_before_close;
     }
 
     /**
@@ -506,6 +516,8 @@ public class Net {
      */
     private static native int isExclusiveBindAvailable();
 
+    private static native boolean shouldShutdownWriteBeforeClose0();
+
     private static native boolean shouldSetBothIPv4AndIPv6Options0();
 
     private static native boolean canIPv6SocketJoinIPv4Group0();
@@ -832,5 +844,6 @@ public class Net {
         }
 
         fastLoopback = isFastTcpLoopbackRequested();
+        shutdown_write_before_close = shouldShutdownWriteBeforeClose0();
     }
 }

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -743,7 +743,7 @@ class SocketChannelImpl
     /**
      * Marks the beginning of a connect operation that might block.
      * @param blocking true if configured blocking
-     * @param isa the remote address
+     * @param sa the remote socket address
      * @throws ClosedChannelException if the channel is closed
      * @throws AlreadyConnectedException if already connected
      * @throws ConnectionPendingException is a connection is pending
@@ -970,8 +970,8 @@ class SocketChannelImpl
     }
 
     /**
-     * Closes the socket if there are no I/O operations in progress and the
-     * channel is not registered with a Selector.
+     * Closes the socket if there are no I/O operations in progress (or no I/O
+     * operations tracked), and the channel is not registered with a Selector.
      */
     private boolean tryClose() throws IOException {
         assert Thread.holdsLock(stateLock) && state == ST_CLOSING;
@@ -996,11 +996,16 @@ class SocketChannelImpl
     }
 
     /**
-     * Closes this channel when configured in blocking mode.
+     * Closes this channel when configured in blocking mode. If there are no I/O
+     * operations in progress (or tracked), then the channel's socket is closed. If
+     * there are I/O operations in progress then the behavior is platform specific.
      *
-     * If there is an I/O operation in progress then the socket is pre-closed
-     * and the I/O threads signalled, in which case the final close is deferred
-     * until all I/O operations complete.
+     * On Unix systems, the channel's socket is pre-closed. The socket is dup'ed
+     * and the threads signalled. The final close is deferred until all I/O
+     * operations complete.
+     *
+     * On Windows, the channel's socket is pre-closed. The channel's
+     * socket is closed.
      *
      * Note that a channel configured blocking may be registered with a Selector
      * This arises when a key is canceled and the channel configured to blocking
@@ -1009,7 +1014,20 @@ class SocketChannelImpl
     private void implCloseBlockingMode() throws IOException {
         synchronized (stateLock) {
             assert state < ST_CLOSING;
+            boolean connected = (state == ST_CONNECTED);
+
             state = ST_CLOSING;
+
+            if (connected && Net.shouldShutdownWriteBeforeClose()) {
+                // shutdown output when linger interval not set to 0
+                try {
+                    var SO_LINGER = StandardSocketOptions.SO_LINGER;
+                    if ((int) Net.getSocketOption(fd, SO_LINGER) != 0) {
+                        Net.shutdown(fd, Net.SHUT_WR);
+                    }
+                } catch (IOException ignore) { }
+            }
+
             if (!tryClose()) {
                 long reader = readerThread;
                 long writer = writerThread;

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -201,6 +201,11 @@ Java_sun_nio_ch_Net_isExclusiveBindAvailable(JNIEnv *env, jclass clazz) {
 }
 
 JNIEXPORT jboolean JNICALL
+Java_sun_nio_ch_Net_shouldShutdownWriteBeforeClose0(JNIEnv *env, jclass clazz) {
+    return JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
 Java_sun_nio_ch_Net_shouldSetBothIPv4AndIPv6Options0(JNIEnv* env, jclass cl)
 {
 #if defined(__linux__)

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,6 +115,11 @@ Java_sun_nio_ch_Net_isReusePortAvailable0(JNIEnv* env, jclass c1)
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_Net_isExclusiveBindAvailable(JNIEnv *env, jclass clazz) {
     return 1;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_sun_nio_ch_Net_shouldShutdownWriteBeforeClose0(JNIEnv *env, jclass clazz) {
+    return JNI_TRUE;
 }
 
 JNIEXPORT jboolean JNICALL

--- a/test/jdk/java/nio/channels/SocketChannel/PeerReadsAfterAsyncClose.java
+++ b/test/jdk/java/nio/channels/SocketChannel/PeerReadsAfterAsyncClose.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8358764
+ * @summary Test closing a socket while a thread is blocked in read. The connection
+ *     should be closed gracefuly so that the peer reads EOF.
+ * @run junit PeerReadsAfterAsyncClose
+ */
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SocketChannel;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PeerReadsAfterAsyncClose {
+
+    static Stream<ThreadFactory> factories() {
+        return Stream.of(Executors.defaultThreadFactory());
+    }
+
+    /**
+     * Close SocketChannel while a thread is blocked reading from the channel's socket.
+     */
+    @ParameterizedTest
+    @MethodSource("factories")
+    void testCloseDuringSocketChannelRead(ThreadFactory factory) throws Exception {
+        var loopback = InetAddress.getLoopbackAddress();
+        try (var listener = new ServerSocket()) {
+            listener.bind(new InetSocketAddress(loopback, 0));
+
+            try (SocketChannel sc = SocketChannel.open(listener.getLocalSocketAddress());
+                 Socket peer = listener.accept()) {
+
+                // start thread to read from channel
+                var cceThrown = new AtomicBoolean();
+                Thread thread = factory.newThread(() -> {
+                    try {
+                        sc.read(ByteBuffer.allocate(1));
+                        fail();
+                    } catch (ClosedChannelException e) {
+                        cceThrown.set(true);
+                    } catch (Throwable e) {
+                        e.printStackTrace();
+                    }
+                });
+                thread.start();
+                try {
+                    // close SocketChannel when thread sampled in read()
+                    onReach(thread, "sun.nio.ch.SocketChannelImpl.read", () -> {
+                        try {
+                            sc.close();
+                        } catch (IOException ignore) { }
+                    });
+
+                    // peer should read EOF
+                    int n = peer.getInputStream().read();
+                    assertEquals(-1, n);
+                } finally {
+                    thread.join();
+                }
+                assertEquals(true, cceThrown.get(), "ClosedChannelException not thrown");
+            }
+        }
+    }
+
+    /**
+     * Close Socket while a thread is blocked reading from the socket.
+     */
+    @ParameterizedTest
+    @MethodSource("factories")
+    void testCloseDuringSocketUntimedRead(ThreadFactory factory) throws Exception {
+        testCloseDuringSocketRead(factory, 0);
+    }
+
+    /**
+     * Close Socket while a thread is blocked reading from the socket with a timeout.
+     */
+    @ParameterizedTest
+    @MethodSource("factories")
+    void testCloseDuringSockeTimedRead(ThreadFactory factory) throws Exception {
+        testCloseDuringSocketRead(factory, 60_000);
+    }
+
+    private void testCloseDuringSocketRead(ThreadFactory factory, int timeout) throws Exception {
+        var loopback = InetAddress.getLoopbackAddress();
+        try (var listener = new ServerSocket()) {
+            listener.bind(new InetSocketAddress(loopback, 0));
+
+            try (Socket s = new Socket(loopback, listener.getLocalPort());
+                 Socket peer = listener.accept()) {
+
+                // start thread to read from socket
+                var seThrown = new AtomicBoolean();
+                Thread thread = factory.newThread(() -> {
+                    try {
+                        s.setSoTimeout(timeout);
+                        s.getInputStream().read();
+                        fail();
+                    } catch (SocketException e) {
+                        seThrown.set(true);
+                    } catch (Throwable e) {
+                        e.printStackTrace();
+                    }
+                });
+                thread.start();
+                try {
+                    // close Socket when thread sampled in implRead
+                    onReach(thread, "sun.nio.ch.NioSocketImpl.implRead", () -> {
+                        try {
+                            s.close();
+                        } catch (IOException ignore) { }
+                    });
+
+                    // peer should read EOF
+                    int n = peer.getInputStream().read();
+                    assertEquals(-1, n);
+                } finally {
+                    thread.join();
+                }
+                assertEquals(true, seThrown.get(), "SocketException not thrown");
+            }
+        }
+    }
+
+    /**
+     * Runs the given action when the given target thread is sampled at the given
+     * location. The location takes the form "{@code c.m}" where
+     * {@code c} is the fully qualified class name and {@code m} is the method name.
+     */
+    private void onReach(Thread target, String location, Runnable action) {
+        int index = location.lastIndexOf('.');
+        String className = location.substring(0, index);
+        String methodName = location.substring(index + 1);
+        Thread tDaemon = new Thread(() -> {
+            try {
+                boolean found = false;
+                while (!found) {
+                    found = contains(target.getStackTrace(), className, methodName);
+                    if (!found) {
+                        Thread.sleep(20);
+                    }
+                }
+                action.run();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        tDaemon.setDaemon(true);
+        tDaemon.start();
+    }
+
+    /**
+     * Returns true if the given stack trace contains an element for the given class
+     * and method name.
+     */
+    private boolean contains(StackTraceElement[] stack, String className, String methodName) {
+        return Arrays.stream(stack)
+                .anyMatch(e -> className.equals(e.getClassName())
+                        && methodName.equals(e.getMethodName()));
+    }
+}


### PR DESCRIPTION
Hello,

This is an unclean backport of JDK-8358764 for JDK 17.
I used the following JDK 21 backport as the baseline https://github.com/openjdk/jdk21u-dev/pull/2137

Changes:
* Brought over the Windows socket shutdown on write changes introduced with the virtual threads commit.
* Removed comments related to virtual threads.
* Adapted PeerReadsAfterAsyncClose.java to JDK 17 (removed virtual thread test case/scenario).


Notes:
The fix affects Windows only.
Tested test/jdk/java/nio/ and test/jdk/java/net/ on macOS/ARM and Windows/x64.
The introduced test passed successfully.

OpenJDK GHA Sanity Checks also passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358764](https://bugs.openjdk.org/browse/JDK-8358764) needs maintainer approval

### Issue
 * [JDK-8358764](https://bugs.openjdk.org/browse/JDK-8358764): (sc) SocketChannel.close when thread blocked in read causes connection to be reset (win) (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3936/head:pull/3936` \
`$ git checkout pull/3936`

Update a local copy of the PR: \
`$ git checkout pull/3936` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3936`

View PR using the GUI difftool: \
`$ git pr show -t 3936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3936.diff">https://git.openjdk.org/jdk17u-dev/pull/3936.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3936#issuecomment-3453301203)
</details>
