### PR TITLE
8359428: Test 'javax/swing/JTabbedPane/bug4499556.java' failed because after selecting one of L&F items, the test case automatically failed when clicking on L&F Menu button again

### DIFF
--- a/test/jdk/javax/swing/JTabbedPane/bug4499556.java
+++ b/test/jdk/javax/swing/JTabbedPane/bug4499556.java
@@ -89,9 +89,10 @@ public class bug4499556 {
     }
 
     static volatile JTabbedPane pane;
+    static volatile JFrame frame;
 
     static JFrame createUI() {
-        JFrame frame = new JFrame("bug4499556");
+        frame = new JFrame("bug4499556");
         pane = getTabbedPane();
         frame.add(pane);
         frame.add(getRightPanel(), BorderLayout.EAST);
@@ -262,7 +263,7 @@ public class bug4499556 {
             e.printStackTrace();
             return false;
         }
-        SwingUtilities.updateComponentTreeUI(pane);
+        SwingUtilities.updateComponentTreeUI(frame);
         return true;
     }
 


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359428](https://bugs.openjdk.org/browse/JDK-8359428) needs maintainer approval

### Issue
 * [JDK-8359428](https://bugs.openjdk.org/browse/JDK-8359428): Test 'javax/swing/JTabbedPane/bug4499556.java' failed because after selecting one of L&amp;F items, the test case automatically failed when clicking on L&amp;F Menu button again (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3939/head:pull/3939` \
`$ git checkout pull/3939`

Update a local copy of the PR: \
`$ git checkout pull/3939` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3939`

View PR using the GUI difftool: \
`$ git pr show -t 3939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3939.diff">https://git.openjdk.org/jdk17u-dev/pull/3939.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3939#issuecomment-3299177281)
</details>
