### PR TITLE
Backport 4669e7b7b02636a8bd7381a9d401aaaf0c1d7294

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/conf/default.properties
+++ b/test/hotspot/jtreg/testlibrary/jittester/conf/default.properties
@@ -8,6 +8,6 @@ classes-file=conf/classes.lst
 exclude-methods-file=conf/exclude.methods.lst
 print-complexity=true
 print-hierarchy=true
-disable-static=true
+disable-static=false
 generatorsFactories=jdk.test.lib.jittester.TestGeneratorsFactory
 generators=JavaCode,ByteCode

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/StaticConstructorDefinitionFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/StaticConstructorDefinitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ class StaticConstructorDefinitionFactory extends Factory<StaticConstructorDefini
                     .setOperatorLimit(operatorLimit)
                     .setLevel(level)
                     .setSubBlock(true)
-                    .setCanHaveBreaks(true)
+                    .setCanHaveBreaks(false)
                     .setCanHaveContinues(false)
                     .setCanHaveReturn(false)
                     .getBlockFactory()


### PR DESCRIPTION
The backport verified on MacOS/Linux/Windows by manually running JITTester.

Verification involved modifying JITTester code to terminate with non-zero exit code when encountering specific compilation error (a break statement in a static initializer) in the generated code and enabling static initializer generation in configuration file in non-fixed version.

Without the fix typically the error reproduces during the first generation round.
With the fix, there is no error for 10s of rounds.