### PR TITLE
8356897: Update NSS library to 3.111

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -77,7 +77,7 @@ public abstract class PKCS11Test {
 
     // Version of the NSS artifact. This coincides with the version of
     // the NSS version
-    private static final String NSS_BUNDLE_VERSION = "3.107";
+    private static final String NSS_BUNDLE_VERSION = "3.111";
     private static final String NSSLIB = "jpg.tests.jdk.nsslib";
 
     static double nss_version = -1;


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8356897](https://bugs.openjdk.org/browse/JDK-8356897) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8356897](https://bugs.openjdk.org/browse/JDK-8356897): Update NSS library to 3.111 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3945/head:pull/3945` \
`$ git checkout pull/3945`

Update a local copy of the PR: \
`$ git checkout pull/3945` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3945/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3945`

View PR using the GUI difftool: \
`$ git pr show -t 3945`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3945.diff">https://git.openjdk.org/jdk17u-dev/pull/3945.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3945#issuecomment-3303278585)
</details>
