### PR TITLE
8352865: Open source several AWT TextComponent tests - Batch 2

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -840,6 +840,8 @@ java/awt/TrayIcon/DragEventSource/DragEventSource.java 8252242 macosx-all
 java/awt/FileDialog/DefaultFocusOwner/DefaultFocusOwner.java 7187728 macosx-all,linux-all
 java/awt/print/PageFormat/Orient.java 8016055 macosx-all
 java/awt/TextArea/TextAreaCursorTest/HoveringAndDraggingTest.java 8024986 macosx-all,linux-all
+java/awt/TextComponent/CorrectTextComponentSelectionTest.java 8237220 macosx-all
+java/awt/TextComponent/SelectionAndCaretColor.java 7017622 linux-all
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter.java 8254841 macosx-all
 java/awt/Focus/AppletInitialFocusTest/AppletInitialFocusTest1.java 8256289 windows-x64
 java/awt/FullScreen/TranslucentWindow/TranslucentWindow.java 8258103 linux-all

--- a/test/jdk/java/awt/TextComponent/AltPlusNumberKeyCombinationsTest.java
+++ b/test/jdk/java/awt/TextComponent/AltPlusNumberKeyCombinationsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4737679 4623376 4501485 4740906 4708221
+ * @requires (os.family == "windows")
+ * @summary Alt+Left/right/up/down generate characters in JTextArea
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AltPlusNumberKeyCombinationsTest
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.TextArea;
+import java.awt.TextField;
+
+public class AltPlusNumberKeyCombinationsTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                [WINDOWS PLATFORM ONLY]
+                Please do the following steps for both TextField and TextArea:
+                1. Hold down ALT and press a NON-NUMPAD right arrow, then release
+                   ALT key. If any symbol is typed the test failed.
+                2. Hold down ALT and press one after another the following
+                   NUMPAD keys: 0, 1, 2, 8. Release ALT key. If the Euro symbol
+                   is not typed the test failed
+                3. Hold down ALT and press one after another the following
+                   NUMPAD keys: 0, 2, 2, 7. Release ALT key. If nothing or
+                   the blank symbol is typed the test failed
+                 If all the steps are done successfully the test PASSed,
+                 else test FAILS.
+                """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(initialize())
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame initialize() {
+        Frame f = new Frame("key combination test");
+        f.setLayout(new FlowLayout());
+        TextField tf = new TextField("TextField");
+        f.add(tf);
+        TextArea ta = new TextArea("TextArea");
+        f.add(ta);
+        f.setSize(200, 200);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/TextComponent/CorrectTextComponentSelectionTest.java
+++ b/test/jdk/java/awt/TextComponent/CorrectTextComponentSelectionTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5100806
+ * @summary TextArea.select(0,0) does not de-select the selected text properly
+ * @key headful
+ * @run main CorrectTextComponentSelectionTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.TextComponent;
+import java.awt.TextField;
+import java.lang.reflect.InvocationTargetException;
+
+public class CorrectTextComponentSelectionTest {
+    static TextField tf = new TextField("TextField");
+    static TextArea ta = new TextArea("TextArea");
+    static Robot r;
+    static Frame frame;
+    static volatile Color color_center;
+    static volatile Point loc;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            r = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                initialize();
+            });
+            r.waitForIdle();
+            r.delay(1000);
+
+            test(tf);
+            test(ta);
+            System.out.println("Test Passed!");
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public static void initialize() {
+        frame = new Frame("TextComponent Selection Test");
+        frame.setLayout(new BorderLayout());
+
+        // We should place to the text components the long strings in order to
+        // cover the components by the selection completely
+        String sf = "";
+        for (int i = 0; i < 50; i++) {
+            sf = sf + " ";
+        }
+        tf.setText(sf);
+        // We check the color of the text component in order to find out the
+        // bug reproducible situation
+        tf.setForeground(Color.WHITE);
+        tf.setBackground(Color.WHITE);
+
+        String sa = "";
+        for (int i = 0; i < 50; i++) {
+            for (int j = 0; j < 50; j++) {
+                sa = sa + " ";
+            }
+            sa = sa + "\n";
+        }
+        ta.setText(sa);
+        ta.setForeground(Color.WHITE);
+        ta.setBackground(Color.WHITE);
+
+        frame.add(tf, "North");
+        frame.add(ta, "South");
+        frame.setSize(200, 200);
+        frame.setVisible(true);
+    }
+
+    private static void test(TextComponent tc) throws Exception {
+        if (tc instanceof TextField) {
+            System.out.println("TextField testing ...");
+        } else if (tc instanceof TextArea) {
+            System.out.println("TextArea testing ...");
+        }
+
+        r.waitForIdle();
+        r.delay(100);
+        EventQueue.invokeAndWait(() -> {
+            tc.requestFocus();
+            tc.selectAll();
+            tc.select(0, 0);
+        });
+
+        r.waitForIdle();
+        r.delay(100);
+        EventQueue.invokeAndWait(() -> {
+            loc = tc.getLocationOnScreen();
+        });
+        r.waitForIdle();
+        r.delay(100);
+
+        EventQueue.invokeAndWait(() -> {
+            color_center = r.getPixelColor(loc.x + tc.getWidth() / 2, loc.y + tc.getHeight() / 2);
+        });
+
+        System.out.println("Color of the text component (CENTER) =" + color_center);
+        System.out.println("White color=" + Color.WHITE);
+
+        if (color_center.getRGB() != Color.WHITE.getRGB()) {
+            throw new RuntimeException("Test Failed");
+        }
+    }
+}

--- a/test/jdk/java/awt/TextComponent/SelectionAndCaretColor.java
+++ b/test/jdk/java/awt/TextComponent/SelectionAndCaretColor.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6287895
+ * @requires (os.family == "linux")
+ * @summary Test cursor and selected text incorrectly colored in TextField
+ * @key headful
+ * @run main SelectionAndCaretColor
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.TextComponent;
+import java.awt.TextField;
+import java.awt.image.BufferedImage;
+
+public class SelectionAndCaretColor {
+    static TextField tf = new TextField(20);
+    static TextArea ta = new TextArea("", 1, 20, TextArea.SCROLLBARS_NONE);
+    static Robot r;
+    static Frame frame;
+    static volatile int flips;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            frame = new Frame("Selection and Caret color test");
+            r = new Robot();
+
+            EventQueue.invokeAndWait(() -> {
+                frame.setLayout(new BorderLayout());
+                tf.setFont(new Font("Monospaced", Font.PLAIN, 15));
+                ta.setFont(new Font("Monospaced", Font.PLAIN, 15));
+
+                frame.add(tf, BorderLayout.NORTH);
+                frame.add(ta, BorderLayout.SOUTH);
+                frame.setSize(200, 200);
+                frame.setVisible(true);
+            });
+            r.waitForIdle();
+            r.delay(1000);
+            test(tf);
+            test(ta);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static int countFlips(TextComponent tc) {
+        int y = tc.getLocationOnScreen().y + tc.getHeight() / 2;
+        int x1 = tc.getLocationOnScreen().x + 5;
+        int x2 = tc.getLocationOnScreen().x + tc.getWidth() - 5;
+
+        int[] fb = {tc.getBackground().getRGB(), tc.getForeground().getRGB()};
+        int i = 0;
+        int flips = 0;
+
+        BufferedImage img = r.createScreenCapture(new Rectangle(x1, y, x2 - x1, 1));
+        for (int x = 0; x < x2 - x1; x++) {
+            int c = img.getRGB(x, 0);
+            if (c == fb[i]) {
+                ;
+            } else if (c == fb[1 - i]) {
+                flips++;
+                i = 1 - i;
+            } else {
+                throw new RuntimeException("Invalid color detected: " +
+                        Integer.toString(c, 16) + " instead of " +
+                        Integer.toString(fb[i], 16));
+            }
+        }
+        return flips;
+    }
+
+    private static void test(TextComponent tc) throws Exception {
+        if (tc instanceof TextField) {
+            System.out.println("TextField testing ...");
+        } else if (tc instanceof TextArea) {
+            System.out.println("TextArea testing ...");
+        }
+
+        // now passing along the component's vertical center,
+        // skipping 5px from both sides,
+        // we should see bg - textcolor - bg - selcolor -
+        // seltextcolor - selcolor - bg
+        // that is bg-fg-bg-fg-bg-fg-bg, 6 flips
+
+        EventQueue.invokeAndWait(() -> {
+            tc.setForeground(Color.green);
+            tc.setBackground(Color.magenta);
+
+            tc.setText("  I    I    ");
+            tc.select(5, 10);
+            tc.requestFocus();
+        });
+        r.waitForIdle();
+        r.delay(200);
+        EventQueue.invokeAndWait(() -> {
+            flips = countFlips(tc);
+        });
+        if (flips != 6) {
+            throw new RuntimeException("Invalid number of flips: "
+                    + flips + " instead of 6");
+        }
+        EventQueue.invokeAndWait(() -> {
+            // same for caret: spaces in the tc, caret in the middle
+            // bg-fg-bg - 2 flips
+
+            tc.select(0, 0);
+            tc.setText("            ");
+            tc.setCaretPosition(5);
+        });
+        r.waitForIdle();
+        r.delay(200);
+
+        for (int i = 0; i < 10; i++) {
+            EventQueue.invokeAndWait(() -> {
+                flips = countFlips(tc);
+            });
+
+            if (flips == 2) {
+                break;
+            }
+            if (flips == 0) {
+                continue;
+            }
+            throw new RuntimeException("Invalid number of flips: "
+                    + flips + " instead of 2");
+        }
+    }
+}

--- a/test/jdk/java/awt/TextComponent/SelectionTest.java
+++ b/test/jdk/java/awt/TextComponent/SelectionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4056231
+ * @summary Checks that TextComponents don't grab the global CDE selection
+ *  upon construction if their own selection is null.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SelectionTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class SelectionTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. "Select some text in another window, then click the button.",
+                2. "If the text in the other window is de-selected, the test FAILS.",
+                   "If the text remains selected, the test PASSES."
+                    """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(initialize())
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame initialize() {
+        Frame frame = new Frame("Selection Test");
+        frame.setLayout(new BorderLayout());
+        Button b = new Button("Select some text in another window, then" +
+                " click me");
+        b.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                frame.add(new TextField("text field test"));
+                frame.add(new TextArea("text area test"));
+            }
+        });
+        frame.add(b);
+        frame.setSize(400, 400);
+        return frame;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8352865: Open source several AWT TextComponent tests - Batch 2. Adds four text component related tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352865](https://bugs.openjdk.org/browse/JDK-8352865) needs maintainer approval

### Issue
 * [JDK-8352865](https://bugs.openjdk.org/browse/JDK-8352865): Open source several AWT TextComponent tests - Batch 2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3948/head:pull/3948` \
`$ git checkout pull/3948`

Update a local copy of the PR: \
`$ git checkout pull/3948` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3948`

View PR using the GUI difftool: \
`$ git pr show -t 3948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3948.diff">https://git.openjdk.org/jdk17u-dev/pull/3948.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3948#issuecomment-3304582787)
</details>
