### PR TITLE
8352800: [PPC] OpenJDK fails to build on PPC after JDK-8350106

### DIFF
--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -25,8 +25,8 @@
 
 #include "precompiled.hpp"
 #include "memory/metaspace.hpp"
-#include "os_linux.hpp"
 #include "runtime/frame.inline.hpp"
+#include "runtime/os.hpp"
 #include "runtime/thread.hpp"
 
 frame JavaThread::pd_last_frame() {

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "memory/metaspace.hpp"
+#include "os_linux.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/thread.hpp"
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [72bcd824](https://github.com/openjdk/jdk21u-dev/commit/72bcd824606d8a9bc25fb088e73de4c25738ecea) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

https://github.com/openjdk/jdk17u-dev/pull/3957 depends on this backport.
It fixes build problems by including the declaration of `class os::Linux` referenced in https://github.com/openjdk/jdk17u-dev/pull/3957 .
In jdk17 os_linux.hpp cannot be included directly though. os.hpp needs to be included which includes os_linux.hpp into the declaration of `class os` (see [here](https://github.com/openjdk/jdk17u-dev/blob/78cafc3138f09de208a786b7e55bed585e42ade8/src/hotspot/share/runtime/os.hpp#L896)).

Risk is low.

Thanks, Richard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8352800](https://bugs.openjdk.org/browse/JDK-8352800) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8352800](https://bugs.openjdk.org/browse/JDK-8352800): [PPC] OpenJDK fails to build on PPC after JDK-8350106 (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3949/head:pull/3949` \
`$ git checkout pull/3949`

Update a local copy of the PR: \
`$ git checkout pull/3949` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3949`

View PR using the GUI difftool: \
`$ git pr show -t 3949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3949.diff">https://git.openjdk.org/jdk17u-dev/pull/3949.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3949#issuecomment-3327079129)
</details>
