### PR TITLE
8356040: java/util/PluggableLocale/LocaleNameProviderTest.java timed out

### DIFF
--- a/test/jdk/java/util/PluggableLocale/LocaleNameProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/LocaleNameProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4052440 8000273 8062588 8210406
+ * @bug 4052440 8000273 8062588 8210406 8356040
  * @summary LocaleNameProvider tests
  * @library providersrc/foobarutils
  *          providersrc/barprovider
@@ -31,97 +31,112 @@
  *          java.base/sun.util.resources
  * @build com.foobar.Utils
  *        com.bar.*
- * @run main/othervm -Djava.locale.providers=JRE,SPI LocaleNameProviderTest
+ * @run junit/othervm -Djava.locale.providers=JRE,SPI LocaleNameProviderTest
  */
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 
 import com.bar.LocaleNameProviderImpl;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import sun.util.locale.provider.LocaleProviderAdapter;
 import sun.util.locale.provider.ResourceBundleBasedAdapter;
 import sun.util.resources.OpenListResourceBundle;
 
 public class LocaleNameProviderTest extends ProviderTest {
 
-    public static void main(String[] s) {
-        new LocaleNameProviderTest();
+    private static final LocaleNameProviderImpl LNP = new LocaleNameProviderImpl();
+
+    /*
+     * This is not an exhaustive test. Such a test would require iterating (1000x1000)+
+     * inputs. Instead, we check against Japanese lang locales which guarantees
+     * we will run into cases where the CLDR is not the preferred provider as the
+     * SPI has defined variants of the Japanese locale (E.g. osaka).
+     * See LocaleNameProviderImpl and LocaleNames ResourceBundle.
+     */
+    @ParameterizedTest
+    @MethodSource
+    void checkAvailLocValidityTest(Locale target, Locale test, ResourceBundle rb,
+                                   boolean jreSupports, boolean spiSupports) {
+        // codes
+        String lang = test.getLanguage();
+        String ctry = test.getCountry();
+        String vrnt = test.getVariant();
+
+        // the localized name
+        String langresult = test.getDisplayLanguage(target);
+        String ctryresult = test.getDisplayCountry(target);
+        String vrntresult = test.getDisplayVariant(target);
+
+        // provider's name (if any)
+        String providerslang = null;
+        String providersctry = null;
+        String providersvrnt = null;
+        if (spiSupports) {
+            providerslang = LNP.getDisplayLanguage(lang, target);
+            providersctry = LNP.getDisplayCountry(ctry, target);
+            providersvrnt = LNP.getDisplayVariant(vrnt, target);
+        }
+
+        // JRE's name
+        String jreslang = null;
+        String jresctry = null;
+        String jresvrnt = null;
+        if (!lang.isEmpty()) {
+            try {
+                jreslang = rb.getString(lang);
+            } catch (MissingResourceException mre) {}
+        }
+        if (!ctry.isEmpty()) {
+            try {
+                jresctry = rb.getString(ctry);
+            } catch (MissingResourceException mre) {}
+        }
+        if (!vrnt.isEmpty()) {
+            try {
+                jresvrnt = rb.getString("%%"+vrnt);
+            } catch (MissingResourceException mre) {}
+        }
+
+        checkValidity(target, jreslang, providerslang, langresult,
+            jreSupports && jreslang != null);
+        checkValidity(target, jresctry, providersctry, ctryresult,
+            jreSupports && jresctry != null);
+        checkValidity(target, jresvrnt, providersvrnt, vrntresult,
+            jreSupports && jresvrnt != null);
     }
 
-    LocaleNameProviderTest() {
-        checkAvailLocValidityTest();
-        variantFallbackTest();
-    }
+    public static List<Arguments> checkAvailLocValidityTest() {
+        var args = new ArrayList<Arguments>();
+        Locale[] availloc = Arrays.stream(Locale.getAvailableLocales())
+                .filter(l -> l.getLanguage().equals("ja"))
+                .toArray(Locale[]::new);
+        List<Locale> jreimplloc = Arrays.stream(LocaleProviderAdapter.forJRE().getLocaleNameProvider().getAvailableLocales())
+                .filter(l -> l.getLanguage().equals("ja"))
+                .toList();
+        List<Locale> providerloc = Arrays.asList(LNP.getAvailableLocales());
 
-    void checkAvailLocValidityTest() {
-        LocaleNameProviderImpl lnp = new LocaleNameProviderImpl();
-        Locale[] availloc = Locale.getAvailableLocales();
-        Locale[] testloc = availloc.clone();
-        List<Locale> jreimplloc = Arrays.asList(LocaleProviderAdapter.forJRE().getLocaleNameProvider().getAvailableLocales());
-        List<Locale> providerloc = Arrays.asList(lnp.getAvailableLocales());
-
-        for (Locale target: availloc) {
+        for (Locale target : availloc) {
             // pure JRE implementation
-            OpenListResourceBundle rb = ((ResourceBundleBasedAdapter)LocaleProviderAdapter.forJRE()).getLocaleData().getLocaleNames(target);
+            OpenListResourceBundle rb = ((ResourceBundleBasedAdapter) LocaleProviderAdapter.forJRE()).getLocaleData().getLocaleNames(target);
             boolean jreSupportsTarget = jreimplloc.contains(target);
-
-            for (Locale test: testloc) {
-                // codes
-                String lang = test.getLanguage();
-                String ctry = test.getCountry();
-                String vrnt = test.getVariant();
-
-                // the localized name
-                String langresult = test.getDisplayLanguage(target);
-                String ctryresult = test.getDisplayCountry(target);
-                String vrntresult = test.getDisplayVariant(target);
-
-                // provider's name (if any)
-                String providerslang = null;
-                String providersctry = null;
-                String providersvrnt = null;
-                if (providerloc.contains(target)) {
-                    providerslang = lnp.getDisplayLanguage(lang, target);
-                    providersctry = lnp.getDisplayCountry(ctry, target);
-                    providersvrnt = lnp.getDisplayVariant(vrnt, target);
-                }
-
-                // JRE's name
-                String jreslang = null;
-                String jresctry = null;
-                String jresvrnt = null;
-                if (!lang.equals("")) {
-                    try {
-                        jreslang = rb.getString(lang);
-                    } catch (MissingResourceException mre) {}
-                }
-                if (!ctry.equals("")) {
-                    try {
-                        jresctry = rb.getString(ctry);
-                    } catch (MissingResourceException mre) {}
-                }
-                if (!vrnt.equals("")) {
-                    try {
-                        jresvrnt = rb.getString("%%"+vrnt);
-                    } catch (MissingResourceException mre) {}
-                }
-
-                System.out.print("For key: "+lang+" ");
-                checkValidity(target, jreslang, providerslang, langresult,
-                    jreSupportsTarget && jreslang != null);
-                System.out.print("For key: "+ctry+" ");
-                checkValidity(target, jresctry, providersctry, ctryresult,
-                    jreSupportsTarget && jresctry != null);
-                System.out.print("For key: "+vrnt+" ");
-                checkValidity(target, jresvrnt, providersvrnt, vrntresult,
-                    jreSupportsTarget && jresvrnt != null);
+            boolean providerSupportsTarget = providerloc.contains(target);
+            for (Locale test : availloc) {
+                args.add(Arguments.of(target, test, rb, jreSupportsTarget, providerSupportsTarget));
             }
         }
+        return args;
     }
 
+    @Test
     void variantFallbackTest() {
         Locale YY = new Locale("yy", "YY", "YYYY");
         Locale YY_suffix = new Locale("yy", "YY", "YYYY_suffix");


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle based on the  push to 21.

I resolved Copyright and modified the test as [8282319: java.util.Locale method to stream available Locales](https://github.com/openjdk/jdk21u-dev/commit/7e47d51e10eef7b3bead636d20ff392e7b1dd185) is not in 17.  I replaced the call to Locale.availableLocales().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8356040](https://bugs.openjdk.org/browse/JDK-8356040) needs maintainer approval

### Issue
 * [JDK-8356040](https://bugs.openjdk.org/browse/JDK-8356040): java/util/PluggableLocale/LocaleNameProviderTest.java timed out (**Bug** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3950/head:pull/3950` \
`$ git checkout pull/3950`

Update a local copy of the PR: \
`$ git checkout pull/3950` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3950`

View PR using the GUI difftool: \
`$ git pr show -t 3950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3950.diff">https://git.openjdk.org/jdk17u-dev/pull/3950.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3950#issuecomment-3308513662)
</details>
