### PR TITLE
8355478: DoubleActionESC.java fails intermittently

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -838,6 +838,7 @@ java/awt/print/PrinterJob/PrintTextTest.java 8148334 generic-all
 java/awt/font/TextLayout/TestJustification.java 8250791 macosx-all
 java/awt/TrayIcon/DragEventSource/DragEventSource.java 8252242 macosx-all
 java/awt/FileDialog/DefaultFocusOwner/DefaultFocusOwner.java 7187728 macosx-all,linux-all
+java/awt/FileDialog/DoubleActionESC.java 8356981 linux-all
 java/awt/print/PageFormat/Orient.java 8016055 macosx-all
 java/awt/TextArea/TextAreaCursorTest/HoveringAndDraggingTest.java 8024986 macosx-all,linux-all
 java/awt/TextComponent/CorrectTextComponentSelectionTest.java 8237220 macosx-all

--- a/test/jdk/java/awt/FileDialog/DoubleActionESC.java
+++ b/test/jdk/java/awt/FileDialog/DoubleActionESC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,12 +34,15 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.concurrent.CountDownLatch;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 /*
  * @test
  * @bug 5097243
  * @summary Tests that FileDialog can be closed by ESC any time
  * @key headful
  * @run main DoubleActionESC
+ * @run main/othervm -Dsun.awt.disableGtkFileDialogs=true DoubleActionESC
  */
 
 public class DoubleActionESC {
@@ -49,47 +52,48 @@ public class DoubleActionESC {
     private static Robot robot;
     private static volatile Point p;
     private static volatile Dimension d;
-    private static volatile CountDownLatch latch;
     private static final int REPEAT_COUNT = 2;
+    private static final long LATCH_TIMEOUT = 10;
+
+    private static final CountDownLatch latch = new CountDownLatch(REPEAT_COUNT);
 
     public static void main(String[] args) throws Exception {
-        latch = new CountDownLatch(1);
-
         robot = new Robot();
-        robot.setAutoDelay(100);
+        robot.setAutoDelay(50);
         try {
             EventQueue.invokeAndWait(() -> {
                 createAndShowUI();
             });
 
+            robot.waitForIdle();
             robot.delay(1000);
+
             EventQueue.invokeAndWait(() -> {
                 p = showBtn.getLocationOnScreen();
                 d = showBtn.getSize();
             });
 
             for (int i = 0; i < REPEAT_COUNT; ++i) {
-                Thread thread = new Thread(() -> {
-                    robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
-                    robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-                });
-                thread.start();
-                robot.delay(3000);
+                robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                robot.waitForIdle();
+                robot.delay(1000);
 
-                Thread thread1 = new Thread(() -> {
-                    robot.keyPress(KeyEvent.VK_ESCAPE);
-                    robot.keyRelease(KeyEvent.VK_ESCAPE);
-                    robot.waitForIdle();
-                });
-                thread1.start();
-                robot.delay(3000);
+                robot.keyPress(KeyEvent.VK_ESCAPE);
+                robot.keyRelease(KeyEvent.VK_ESCAPE);
+                robot.waitForIdle();
+                robot.delay(1000);
             }
 
-            latch.await();
-            if (fd.isVisible()) {
-                throw new RuntimeException("File Dialog is not closed");
+            if (!latch.await(LATCH_TIMEOUT, SECONDS)) {
+                throw new RuntimeException("Test failed: Latch timeout reached");
             }
+            EventQueue.invokeAndWait(() -> {
+                if (fd.isVisible()) {
+                    throw new RuntimeException("File Dialog is not closed");
+                }
+            });
         } finally {
             EventQueue.invokeAndWait(() -> {
                 if (f != null) {


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8355478](https://bugs.openjdk.org/browse/JDK-8355478) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8355478](https://bugs.openjdk.org/browse/JDK-8355478): DoubleActionESC.java fails intermittently (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3951/head:pull/3951` \
`$ git checkout pull/3951`

Update a local copy of the PR: \
`$ git checkout pull/3951` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3951`

View PR using the GUI difftool: \
`$ git pr show -t 3951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3951.diff">https://git.openjdk.org/jdk17u-dev/pull/3951.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3951#issuecomment-3308888748)
</details>
