### PR TITLE
8353957: Open source several AWT ScrollPane tests - Batch 1

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -459,6 +459,7 @@ java/awt/Component/NativeInLightShow/NativeInLightShow.java 8202932 linux-all
 java/awt/FileDialog/ModalFocus/FileDialogModalFocusTest.java 8194751 linux-all
 java/awt/image/VolatileImage/BitmaskVolatileImage.java 8133102 linux-all
 java/awt/SplashScreen/MultiResolutionSplash/unix/UnixMultiResolutionSplashTest.java 8203004 linux-all
+java/awt/ScrollPane/ScrollPositionTest.java 8040070 linux-all
 java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java 7107528 linux-all,macosx-all
 java/awt/Mouse/MouseDragEvent/MouseDraggedTest.java 8080676 linux-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersInKeyEvent.java 8157147 linux-all,windows-all,macosx-all

--- a/test/jdk/java/awt/ScrollPane/ScrollPaneFlicker.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPaneFlicker.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4073822
+ * @summary ScrollPane repaints entire window when scrolling fast
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollPaneFlicker
+ */
+
+import java.awt.Button;
+import java.awt.Canvas;
+import java.awt.Checkbox;
+import java.awt.Choice;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Label;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Panel;
+import java.awt.Rectangle;
+import java.awt.ScrollPane;
+import java.awt.Scrollbar;
+import java.awt.TextArea;
+import java.awt.TextField;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollBar;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+
+public class ScrollPaneFlicker {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                When scrolling a ScrollPane fast(i.e. holding the down/up arrow
+                down for a while), the ScrollPane would inexplicably refresh
+                the entire window.
+
+                1. Select a type of ScrollPane content from the content menu.
+                2. Scroll the content using the up/down/left/right arrows on
+                   the scroll bar. Try scrolling the entire content area using
+                   the scroll arrows-- from top to bottom and left to right.
+                3. Verify that the entire pane does not refresh when scrolling
+                   - only the newly exposed areas should be repainting.
+                4. Repeat for all content types.
+                """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ScrollPaneFlicker::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        return new FlickerFrame();
+    }
+}
+
+class FlickerFrame extends Frame {
+    ScrollPane pane;
+
+    public FlickerFrame() {
+        super("ScrollPane Flicker Test");
+        TextPanel textPanel = new TextPanel();
+        GradientPanel gradientPanel = new GradientPanel();
+        ComponentPanel componentPanel = new ComponentPanel();
+        SwingPanel swingPanel = new SwingPanel();
+        MenuBar menubar = new MenuBar();
+        Menu testMenu = new Menu("Test Options");
+
+        pane = new ScrollPane();
+        pane.getHAdjustable().setUnitIncrement(8);
+        pane.getVAdjustable().setUnitIncrement(16);
+        pane.add(textPanel);
+        add(pane);
+
+        testMenu.add(makeContentItem("Text Lines", textPanel));
+        testMenu.add(makeContentItem("Gradient Fill", gradientPanel));
+        testMenu.add(makeContentItem("AWT Components", componentPanel));
+        testMenu.add(makeContentItem("Swing Components", swingPanel));
+        menubar.add(testMenu);
+
+        setMenuBar(menubar);
+        setSize(400, 300);
+    }
+
+    public MenuItem makeContentItem(String title, final Component content) {
+        MenuItem menuItem = new MenuItem(title);
+        menuItem.addActionListener(
+                ev -> {
+                    pane.add(content);
+                    pane.validate();
+                }
+        );
+        return menuItem;
+    }
+}
+
+class GradientPanel extends Canvas {
+    public void paint(Graphics g) {
+        // just paint something that'll take a while
+        int x, y;
+        int width = getSize().width;
+        int height = getSize().height;
+        int step = 8;
+
+        for (x = 0; x < width; x += step) {
+            for (y = 0; y < height; y += step) {
+                int red = (255 * y) / height;
+                int green = (255 * x * y) / (width * height);
+                int blue = (255 * x) / width;
+                Rectangle bounds = g.getClipBounds();
+                Rectangle fbounds = new Rectangle(x, y, x + step, y + step);
+                if (bounds.intersects(fbounds)) {
+                    Color color = new Color(red, green, blue);
+                    g.setColor(color);
+                    g.fillRect(x, y, x + step, y + step);
+                }
+            }
+        }
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(200, 1000);
+    }
+}
+
+class TextPanel extends Canvas {
+    public void paint(Graphics g) {
+        Font font = new Font("SanSerif", Font.ITALIC, 12);
+
+        g.setFont(font);
+        // just paint something that'll take a while
+        int x, y;
+        int width = getWidth();
+        int height = getHeight();
+        int step = 16;
+
+        for (x = y = 0; y < height; y += step) {
+            Rectangle bounds = g.getClipBounds();
+            Rectangle tbounds = new Rectangle(x, y - 16, x + width, y);
+            if (bounds.intersects(tbounds)) {
+                g.drawString(y + " : The quick brown fox jumps over the lazy dog. " +
+                        "The rain in Spain falls mainly on the plain.", x, y);
+            }
+        }
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(640, 1000);
+    }
+}
+
+class ComponentPanel extends Panel {
+    ComponentPanel() {
+        add(new Label("Label"));
+        add(new Button("Button"));
+        add(new Checkbox("Checkbox"));
+        Choice c = new Choice();
+        c.add("choice");
+        java.awt.List l = new java.awt.List();
+        l.add("list");
+        add(new Scrollbar());
+        add(new TextField("TextField"));
+        add(new TextArea("TextArea"));
+        add(new Panel());
+        add(new Canvas());
+    }
+}
+
+class SwingPanel extends JPanel {
+    SwingPanel() {
+        add(new JLabel("JLabel"));
+        add(new JButton("JButton"));
+        add(new JCheckBox("JCheckBox"));
+        JComboBox c = new JComboBox();
+        JList l = new JList();
+        add(new JScrollBar());
+        add(new JTextField("This is a JTextField with some text in it to make it longer."));
+        add(new JTextArea("This is a JTextArea with some text in it to make it longer."));
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPanePaint.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPanePaint.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * Licensed Materials - Property of IBM
+ *
+ * (C) Copyright IBM Corporation 1998  All Rights Reserved.
+ *
+ * US Government Users Restricted Rights - Use, duplication or disclosure
+ * restricted by GSA ADP Schedule Contract with IBM Corp.
+ */
+
+/*
+ * @test
+ * @bug 4160721
+ * @summary AWT ScrollPane painting problem
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollPanePaint
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Panel;
+import java.awt.ScrollPane;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+public class ScrollPanePaint {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. Press the button marked "Toggle" a few times.
+                2. The contents of the frame should alternate between
+                    a red panel and a scroll pane containing a green panel.
+                    If this does not happen (specifically, if the scroll
+                    pane does not consistently contain a green panel),
+                    then the test has FAILED.
+                """;
+        ScrollPaintTest scrollPaintTest = new ScrollPaintTest();
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(scrollPaintTest::initialize)
+                .positionTestUI(WindowLayouts::rightOneColumn)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static class ScrollPaintTest implements ActionListener {
+        static Frame f;
+        static boolean showScroll;
+
+        public List<Frame> initialize() {
+            Frame frame = new Frame("Scrollpane paint test");
+            frame.setLayout(new BorderLayout());
+            f = new Frame("Scrollpane paint test");
+            f.setLayout(new GridLayout(0, 1));
+
+            Button b = new Button("Toggle");
+            b.addActionListener(this);
+
+            frame.add(b, BorderLayout.CENTER);
+            frame.pack();
+
+            showScroll = false;
+            actionPerformed(null);
+            return List.of(frame, f);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            Container c;
+            if (!showScroll) {
+                c = (Container) new TestPanel(new Dimension(100, 100));
+                c.setBackground(Color.red);
+            } else {
+                c = new ScrollPane(ScrollPane.SCROLLBARS_ALWAYS);
+                Panel p = new TestPanel(new Dimension(20, 20));
+                p.setBackground(Color.green);
+                c.add(p);
+            }
+
+            f.removeAll();
+            f.add("Center", c);
+            f.pack();
+            showScroll = !showScroll;
+        }
+    }
+
+    private static class TestPanel extends Panel {
+        Dimension dim;
+
+        TestPanel(Dimension d) {
+            dim = d;
+        }
+
+        public Dimension getMinimumSize() {
+            return getPreferredSize();
+        }
+
+        public Dimension getPreferredSize() {
+            return dim;
+        }
+    }
+
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollPositionTest.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollPositionTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4008152
+ * @summary ScrollPane position does not return correct values
+ * @key headful
+ * @run main ScrollPositionTest
+ */
+
+import java.awt.Adjustable;
+import java.awt.BorderLayout;
+import java.awt.Canvas;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.ScrollPane;
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
+
+public class ScrollPositionTest {
+    static Frame frame;
+    static int i = 0;
+    static Point p;
+    static ScrollPane sp;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            EventQueue.invokeAndWait(() -> {
+                frame = new Frame("Scroll Position Test");
+                frame.setLayout(new BorderLayout());
+                frame.setSize(200, 200);
+                sp = new ScrollPane(ScrollPane.SCROLLBARS_AS_NEEDED);
+                Canvas canvas = new Canvas();
+                canvas.setSize(300, 300);
+                sp.add(canvas);
+                frame.add("Center", sp);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> {
+                Adjustable saH = sp.getHAdjustable();
+                saH.addAdjustmentListener(new TestAdjustmentListener());
+            });
+            for (i = 0; i < 1000; i++) {
+                EventQueue.invokeAndWait(() -> {
+                    p = new Point(i % 100, i % 100);
+                    sp.setScrollPosition(p);
+                });
+
+                robot.waitForIdle();
+                robot.delay(10);
+                EventQueue.invokeAndWait(() -> {
+                    if (!sp.getScrollPosition().equals(p)) {
+                        throw new RuntimeException("Test failed. " + i + " : " +
+                                "Expected " + p + ", but Returned: " + sp.getScrollPosition());
+                    }
+                });
+            }
+            System.out.println("Test Passed.");
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static class TestAdjustmentListener implements AdjustmentListener {
+        public void adjustmentValueChanged(AdjustmentEvent e) {
+            System.out.println("AdjEvent caught:" + e);
+        }
+    }
+}

--- a/test/jdk/java/awt/ScrollPane/ScrollbarsAsNeededTest.java
+++ b/test/jdk/java/awt/ScrollPane/ScrollbarsAsNeededTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4094248
+ * @summary Test initial appearance of SCROLLBARS_AS_NEEDED policy
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ScrollbarsAsNeededTest
+ */
+
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.ScrollPane;
+
+public class ScrollbarsAsNeededTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                1. A Frame window with a ScrollPane that is
+                   initially created with the SCROLLBARS_AS_NEEDED policy.
+                2. If there are no scrollbars around the ScrollPane then
+                    the test PASS. Otherwise the test FAILS.
+                """;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(ScrollbarsAsNeededTest::initialize)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static Frame initialize() {
+        Frame frame = new Frame("Scrollbar as needed test");
+        ScrollPane scrollPane = new ScrollPane() {
+            @Override
+            public void paint(Graphics g) {
+                super.paint(g);
+                g.drawString("ScrollPane", 10, 50);
+            }
+        };
+        scrollPane.setBackground(Color.WHITE);
+        frame.setBackground(Color.GRAY);
+        frame.setSize(200, 200);
+        frame.setLayout(new FlowLayout());
+        frame.add(scrollPane);
+        return frame;
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353957: Open source several AWT ScrollPane tests - Batch 1. Adds four AWT ScrollPane related tests. Ran GHA Sanity Checks, local Tier 1 and 2, and new tests directly. Patch should be clean, had to adjust ProblemList.txt locally. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353957](https://bugs.openjdk.org/browse/JDK-8353957) needs maintainer approval

### Issue
 * [JDK-8353957](https://bugs.openjdk.org/browse/JDK-8353957): Open source several AWT ScrollPane tests - Batch 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3953/head:pull/3953` \
`$ git checkout pull/3953`

Update a local copy of the PR: \
`$ git checkout pull/3953` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3953`

View PR using the GUI difftool: \
`$ git pr show -t 3953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3953.diff">https://git.openjdk.org/jdk17u-dev/pull/3953.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3953#issuecomment-3309784387)
</details>
