### PR TITLE
8365098: make/RunTests.gmk generates a wrong path to test artifacts on Alpine

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1055,7 +1055,7 @@ UseSpecialTestHandler = \
 # Now process each test to run and setup a proper make rule
 $(foreach test, $(TESTS_TO_RUN), \
   $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
-      $(TR) -cs '[a-z][A-Z][0-9]\n' '[_*1000]')) \
+      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
   $(eval ALL_TEST_IDS += $(TEST_ID)) \
   $(if $(call UseCustomTestHandler, $(test)), \
     $(eval $(call SetupRunCustomTest, $(TEST_ID), \
@@ -1135,9 +1135,9 @@ run-test-report: post-run-test
 	    TEST TOTAL PASS FAIL ERROR " "
 	$(foreach test, $(TESTS_TO_RUN), \
 	  $(eval TEST_ID := $(shell $(ECHO) $(strip $(test)) | \
-	      $(TR) -cs '[a-z][A-Z][0-9]\n' '[_*1000]')) \
+	      $(TR) -cs '[a-z][A-Z][0-9]\n' '_')) \
 	    $(ECHO) >> $(TEST_LAST_IDS) $(TEST_ID) $(NEWLINE) \
-	  $(eval NAME_PATTERN := $(shell $(ECHO) $(test) | $(TR) -c '\n' '[_*1000]')) \
+	  $(eval NAME_PATTERN := $(shell $(ECHO) $(test) | $(TR) -c '\n' '_')) \
 	  $(if $(filter __________________________________________________%, $(NAME_PATTERN)), \
 	    $(eval TEST_NAME := ) \
 	    $(PRINTF) >> $(TEST_SUMMARY) "%2s %-49s\n" "  " "$(test)"  $(NEWLINE) \


### PR DESCRIPTION
This is backport of "[JDK-8365098](https://bugs.openjdk.org/browse/JDK-8365098) make/RunTests.gmk generates a wrong path to test artifacts on Alpine" as JDK17 tests have the same issue on Alpine - generate a wrong path to test artifacts.

Clean backport. Build system fix, test artifacts path processing.

Tier1 passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365098](https://bugs.openjdk.org/browse/JDK-8365098) needs maintainer approval

### Issue
 * [JDK-8365098](https://bugs.openjdk.org/browse/JDK-8365098): make/RunTests.gmk generates a wrong path to test artifacts on Alpine (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3956/head:pull/3956` \
`$ git checkout pull/3956`

Update a local copy of the PR: \
`$ git checkout pull/3956` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3956`

View PR using the GUI difftool: \
`$ git pr show -t 3956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3956.diff">https://git.openjdk.org/jdk17u-dev/pull/3956.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3956#issuecomment-3310958868)
</details>
