### PR TITLE
8350106: [PPC] Avoid ticks_unknown_not_Java AsyncGetCallTrace() if JavaFrameAnchor::_last_Java_pc not set

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
@@ -27,8 +27,8 @@
 #include "precompiled.hpp"
 #include "memory/metaspace.hpp"
 #include "runtime/frame.inline.hpp"
-#include "runtime/thread.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/thread.hpp"
 
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");

--- a/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2014 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,6 +28,7 @@
 #include "memory/metaspace.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/thread.hpp"
+#include "runtime/os.inline.hpp"
 
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
@@ -54,9 +55,17 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
     intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
-    // pc can be seen as null because not all writers use store pc + release store sp.
-    // Simply discard the sample in this very rare case.
-    if (pc == nullptr) return false;
+    if (pc == nullptr) {
+      // This is not uncommon. Many c1/c2 runtime stubs do not set the pc in the anchor.
+      intptr_t* top_sp = os::Aix::ucontext_get_sp((const ucontext_t*)ucontext);
+      if ((uint64_t)sp <= ((frame::common_abi*)top_sp)->callers_sp) {
+        // The interrupt occurred either in the last java frame or in its direct callee.
+        // We cannot be sure that the link register LR was already saved to the
+        // java frame. Therefore we discard this sample.
+        return false;
+      }
+      // The last java pc will be found in the abi part of the last java frame.
+    }
     *fr_addr = frame(sp, pc);
     return true;
   }

--- a/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
@@ -65,6 +65,8 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
         return false;
       }
       // The last java pc will be found in the abi part of the last java frame.
+      *fr_addr = frame(sp);
+      return true;
     }
     *fr_addr = frame(sp, pc);
     return true;

--- a/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
@@ -58,7 +58,7 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
     if (pc == nullptr) {
       // This is not uncommon. Many c1/c2 runtime stubs do not set the pc in the anchor.
       intptr_t* top_sp = os::Aix::ucontext_get_sp((const ucontext_t*)ucontext);
-      if ((uint64_t)sp <= ((frame::common_abi*)top_sp)->callers_sp) {
+      if ((uint64_t)sp <= ((frame::abi_minframe*)top_sp)->callers_sp) {
         // The interrupt occurred either in the last java frame or in its direct callee.
         // We cannot be sure that the link register LR was already saved to the
         // java frame. Therefore we discard this sample.

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -56,7 +56,7 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
     if (pc == nullptr) {
       // This is not uncommon. Many c1/c2 runtime stubs do not set the pc in the anchor.
       intptr_t* top_sp = os::Linux::ucontext_get_sp((const ucontext_t*)ucontext);
-      if ((uint64_t)sp <= ((frame::common_abi*)top_sp)->callers_sp) {
+      if ((uint64_t)sp <= ((frame::abi_minframe*)top_sp)->callers_sp) {
         // The interrupt occurred either in the last java frame or in its direct callee.
         // We cannot be sure that the link register LR was already saved to the
         // java frame. Therefore we discard this sample.

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -63,6 +63,8 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
         return false;
       }
       // The last java pc will be found in the abi part of the last java frame.
+      *fr_addr = frame(sp);
+      return true;
     }
     *fr_addr = frame(sp, pc);
     return true;

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,9 +53,17 @@ bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, 
   if (has_last_Java_frame() && frame_anchor()->walkable()) {
     intptr_t* sp = last_Java_sp();
     address pc = _anchor.last_Java_pc();
-    // pc can be seen as null because not all writers use store pc + release store sp.
-    // Simply discard the sample in this very rare case.
-    if (pc == nullptr) return false;
+    if (pc == nullptr) {
+      // This is not uncommon. Many c1/c2 runtime stubs do not set the pc in the anchor.
+      intptr_t* top_sp = os::Linux::ucontext_get_sp((const ucontext_t*)ucontext);
+      if ((uint64_t)sp <= ((frame::common_abi*)top_sp)->callers_sp) {
+        // The interrupt occurred either in the last java frame or in its direct callee.
+        // We cannot be sure that the link register LR was already saved to the
+        // java frame. Therefore we discard this sample.
+        return false;
+      }
+      // The last java pc will be found in the abi part of the last java frame.
+    }
     *fr_addr = frame(sp, pc);
     return true;
   }


### PR DESCRIPTION
This pull request contains a backport of commit [d5908231](https://github.com/openjdk/jdk21u-dev/commit/d5908231ebc16f443b3fc9b2ebf03cc4deb67373) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

There are a few trivial adaptations
* of copyright headers
* of the hunk that includes os.inline.hpp because of a diff in the context
* and because `frame::abi_minframe` was renamed `frame::common_abi` in higher releases

In addition to these there's a non-trivial adaptation. In jdk17, we cannot use the frame constructor that takes a `pc` as 2nd argument because it requires it not to be `nullptr`. The appropriate [frame constructor to use](https://github.com/openjdk/jdk17u-dev/blob/dca33960959f71ef646d346e328acd27196f5bef/src/hotspot/cpu/ppc/frame_ppc.inline.hpp#L61) is the one that takes `sp` as single argument. It reads the pc from the frames `lr` slot just as [`frame::setup()`](https://github.com/openjdk/jdk21u-dev/blob/43c84df4a3d73ca3b0aeddc738d2e2f0e9f5145a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp#L40) in jdk21.

This pr depends on https://github.com/openjdk/jdk17u-dev/pull/3949.

Risk is low because the patch is small and ppc only and the changed method `JavaThread::pd_get_top_frame_for_profiling()` is only used when profiling with jfr or async-profiler.

The backport passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests.
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8350106](https://bugs.openjdk.org/browse/JDK-8350106) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350106](https://bugs.openjdk.org/browse/JDK-8350106): [PPC] Avoid ticks_unknown_not_Java AsyncGetCallTrace() if JavaFrameAnchor::_last_Java_pc not set (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3957/head:pull/3957` \
`$ git checkout pull/3957`

Update a local copy of the PR: \
`$ git checkout pull/3957` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3957`

View PR using the GUI difftool: \
`$ git pr show -t 3957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3957.diff">https://git.openjdk.org/jdk17u-dev/pull/3957.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3957#issuecomment-3327076200)
</details>
