### PR TITLE
8365168: Use 64-bit aligned addresses for CK_ULONG access in PKCS11 native key code

### DIFF
--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
@@ -1317,8 +1317,7 @@ jobject ckAttributeValueToJObject(JNIEnv *env, const CK_ATTRIBUTE_PTR ckpAttribu
         case CKA_OWNER:
         case CKA_AC_ISSUER:
         case CKA_ATTR_TYPES:
-        case CKA_ECDSA_PARAMS:
-            /* CKA_EC_PARAMS is the same, these two are equivalent */
+        case CKA_EC_PARAMS:
         case CKA_EC_POINT:
         case CKA_PRIVATE_EXPONENT:
         case CKA_PRIME_1:

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -56,69 +56,78 @@
 
 #ifdef P11_ENABLE_GETNATIVEKEYINFO
 
-#define CK_ATTRIBUTES_TEMPLATE_LENGTH (CK_ULONG)61U
+#define CK_ATTRIBUTES_TEMPLATE_LENGTH (CK_ULONG)60U
 
+// Group attributes based on their value types; put attributes whose values
+// requiring address alignments, e.g. CK_ULONG, first
 static CK_ATTRIBUTE ckpAttributesTemplate[CK_ATTRIBUTES_TEMPLATE_LENGTH] = {
-        {CKA_CLASS, 0, 0},
-        {CKA_TOKEN, 0, 0},
-        {CKA_PRIVATE, 0, 0},
-        {CKA_LABEL, 0, 0},
-        {CKA_APPLICATION, 0, 0},
-        {CKA_VALUE, 0, 0},
-        {CKA_OBJECT_ID, 0, 0},
+        // CK_ULONG
         {CKA_CERTIFICATE_TYPE, 0, 0},
-        {CKA_ISSUER, 0, 0},
-        {CKA_SERIAL_NUMBER, 0, 0},
-        {CKA_AC_ISSUER, 0, 0},
-        {CKA_OWNER, 0, 0},
-        {CKA_ATTR_TYPES, 0, 0},
-        {CKA_TRUSTED, 0, 0},
+        {CKA_CLASS, 0, 0},
+        {CKA_HW_FEATURE_TYPE, 0, 0},
+        {CKA_KEY_GEN_MECHANISM, 0, 0},
         {CKA_KEY_TYPE, 0, 0},
-        {CKA_SUBJECT, 0, 0},
-        {CKA_ID, 0, 0},
-        {CKA_SENSITIVE, 0, 0},
-        {CKA_ENCRYPT, 0, 0},
-        {CKA_DECRYPT, 0, 0},
-        {CKA_WRAP, 0, 0},
-        {CKA_UNWRAP, 0, 0},
-        {CKA_SIGN, 0, 0},
-        {CKA_SIGN_RECOVER, 0, 0},
-        {CKA_VERIFY, 0, 0},
-        {CKA_VERIFY_RECOVER, 0, 0},
-        {CKA_DERIVE, 0, 0},
-        {CKA_START_DATE, 0, 0},
-        {CKA_END_DATE, 0, 0},
-        {CKA_MODULUS, 0, 0},
         {CKA_MODULUS_BITS, 0, 0},
-        {CKA_PUBLIC_EXPONENT, 0, 0},
-        {CKA_PRIVATE_EXPONENT, 0, 0},
-        {CKA_PRIME_1, 0, 0},
-        {CKA_PRIME_2, 0, 0},
-        {CKA_EXPONENT_1, 0, 0},
-        {CKA_EXPONENT_2, 0, 0},
-        {CKA_COEFFICIENT, 0, 0},
-        {CKA_PRIME, 0, 0},
-        {CKA_SUBPRIME, 0, 0},
-        {CKA_BASE, 0, 0},
         {CKA_PRIME_BITS, 0, 0},
         {CKA_SUB_PRIME_BITS, 0, 0},
         {CKA_VALUE_BITS, 0, 0},
         {CKA_VALUE_LEN, 0, 0},
-        {CKA_EXTRACTABLE, 0, 0},
-        {CKA_LOCAL, 0, 0},
-        {CKA_NEVER_EXTRACTABLE, 0, 0},
+        // CK_BBOOL
         {CKA_ALWAYS_SENSITIVE, 0, 0},
-        {CKA_KEY_GEN_MECHANISM, 0, 0},
+        {CKA_DECRYPT, 0, 0},
+        {CKA_DERIVE, 0, 0},
+        {CKA_ENCRYPT, 0, 0},
+        {CKA_EXTRACTABLE, 0, 0},
+        {CKA_HAS_RESET, 0, 0},
+        {CKA_LOCAL, 0, 0},
         {CKA_MODIFIABLE, 0, 0},
-        {CKA_ECDSA_PARAMS, 0, 0},
+        {CKA_NEVER_EXTRACTABLE, 0, 0},
+        {CKA_PRIVATE, 0, 0},
+        {CKA_RESET_ON_INIT, 0, 0},
+        {CKA_SENSITIVE, 0, 0},
+        {CKA_SIGN, 0, 0},
+        {CKA_SIGN_RECOVER, 0, 0},
+        {CKA_TOKEN, 0, 0},
+        {CKA_TRUSTED, 0, 0},
+        {CKA_UNWRAP, 0, 0},
+        {CKA_VERIFY, 0, 0},
+        {CKA_VERIFY_RECOVER, 0, 0},
+        {CKA_WRAP, 0, 0},
+        // PTR: byte[]
+        {CKA_AC_ISSUER, 0, 0},
+        {CKA_ATTR_TYPES, 0, 0},
+        {CKA_BASE, 0, 0},
+        {CKA_COEFFICIENT, 0, 0},
         {CKA_EC_PARAMS, 0, 0},
         {CKA_EC_POINT, 0, 0},
+        {CKA_EXPONENT_1, 0, 0},
+        {CKA_EXPONENT_2, 0, 0},
+        {CKA_ID, 0, 0},
+        {CKA_ISSUER, 0, 0},
+        {CKA_MODULUS, 0, 0},
+        {CKA_OBJECT_ID, 0, 0},
+        {CKA_OWNER, 0, 0},
+        {CKA_PRIME, 0, 0},
+        {CKA_PRIME_1, 0, 0},
+        {CKA_PRIME_2, 0, 0},
+        {CKA_PRIVATE_EXPONENT, 0, 0},
+        {CKA_PUBLIC_EXPONENT, 0, 0},
+        {CKA_SERIAL_NUMBER, 0, 0},
+        {CKA_SUBJECT, 0, 0},
+        {CKA_SUBPRIME, 0, 0},
+        {CKA_VALUE, 0, 0},
+        // PTR: CK_UTF8CHAR[]
+        {CKA_APPLICATION, 0, 0},
+        {CKA_LABEL, 0, 0},
+        // PTR: CK_DATE
+        {CKA_START_DATE, 0, 0},
+        {CKA_END_DATE, 0, 0},
+        // deprecated
         {CKA_SECONDARY_AUTH, 0, 0},
         {CKA_AUTH_PIN_FLAGS, 0, 0},
-        {CKA_HW_FEATURE_TYPE, 0, 0},
-        {CKA_RESET_ON_INIT, 0, 0},
-        {CKA_HAS_RESET, 0, 0},
+        // misc
         {CKA_VENDOR_DEFINED, 0, 0},
+        // keep this at the end to match the impl in getNativeKeyInfo(...)
         {CKA_NETSCAPE_DB, 0, 0},
 };
 


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle

Resolved Copyright.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365168](https://bugs.openjdk.org/browse/JDK-8365168) needs maintainer approval

### Issue
 * [JDK-8365168](https://bugs.openjdk.org/browse/JDK-8365168): Use 64-bit aligned addresses for CK_ULONG access in PKCS11 native key code (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3966/head:pull/3966` \
`$ git checkout pull/3966`

Update a local copy of the PR: \
`$ git checkout pull/3966` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3966`

View PR using the GUI difftool: \
`$ git pr show -t 3966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3966.diff">https://git.openjdk.org/jdk17u-dev/pull/3966.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3966#issuecomment-3311748307)
</details>
