### PR TITLE
8361298: SwingUtilities/bug4967768.java fails where character P is not underline

### DIFF
--- a/test/jdk/javax/swing/SwingUtilities/bug4967768.java
+++ b/test/jdk/javax/swing/SwingUtilities/bug4967768.java
@@ -37,13 +37,19 @@ import javax.swing.JPanel;
 
 public class bug4967768 {
     private static final String INSTRUCTIONS = """
-            When the test starts you'll see a button "Oops"
-            with the "p" letter underlined at the bottom
-            of the instruction frame.
+            When the test starts you'll see a button "Oops".
+
+            For Windows and GTK Look and Feel, you will need to
+            press the ALT key to make the mnemonic visible.
+            Once the ALT key is pressed, the letter "p" will be
+            underlined at the bottom of the instruction frame.
 
             Ensure the underline cuts through the descender
             of letter "p", i.e. the underline is painted
             not below the letter but below the baseline.
+
+            Press Pass if you see the expected behaviour else
+            press Fail.
             """;
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361298](https://bugs.openjdk.org/browse/JDK-8361298) needs maintainer approval

### Issue
 * [JDK-8361298](https://bugs.openjdk.org/browse/JDK-8361298): SwingUtilities/bug4967768.java fails where character P is not underline (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3969/head:pull/3969` \
`$ git checkout pull/3969`

Update a local copy of the PR: \
`$ git checkout pull/3969` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3969`

View PR using the GUI difftool: \
`$ git pr show -t 3969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3969.diff">https://git.openjdk.org/jdk17u-dev/pull/3969.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3969#issuecomment-3311865183)
</details>
