### PR TITLE
8139228: JFileChooser renders file names as HTML document

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
@@ -1181,6 +1181,9 @@ public class AquaFileChooserUI extends FileChooserUI {
             setText(fc.getName(file));
             setIcon(fc.getIcon(file));
             setEnabled(isSelectableInList(file));
+
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }
@@ -1246,6 +1249,9 @@ public class AquaFileChooserUI extends FileChooserUI {
                 final JFileChooser chooser = getFileChooser();
                 setText(chooser.getName(directory));
                 setIcon(chooser.getIcon(directory));
+
+                putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
                 return this;
             }
         };

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifFileChooserUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/motif/MotifFileChooserUI.java
@@ -664,6 +664,9 @@ public class MotifFileChooserUI extends BasicFileChooserUI {
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             setText(getFileChooser().getName((File) value));
             setInheritsPopupMenu(true);
+
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }
@@ -676,6 +679,9 @@ public class MotifFileChooserUI extends BasicFileChooserUI {
             super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
             setText(getFileChooser().getName((File) value));
             setInheritsPopupMenu(true);
+
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -398,6 +398,7 @@ public class JFileChooser extends JComponent implements Accessible {
             setFileFilter(getAcceptAllFileFilter());
         }
         enableEvents(AWTEvent.MOUSE_EVENT_MASK);
+        putClientProperty("html.disable", true);
     }
 
     private void installHierarchyListener() {

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalFileChooserUI.java
@@ -953,6 +953,8 @@ public class MetalFileChooserUI extends BasicFileChooserUI {
             ii.depth = directoryComboBoxModel.getDepth(index);
             setIcon(ii);
 
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }

--- a/src/java.desktop/share/classes/sun/swing/FilePane.java
+++ b/src/java.desktop/share/classes/sun/swing/FilePane.java
@@ -1214,6 +1214,8 @@ public class FilePane extends JPanel implements PropertyChangeListener {
 
             setText(text);
 
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }
@@ -1601,6 +1603,8 @@ public class FilePane extends JPanel implements PropertyChangeListener {
                     setText(fileName+File.separator);
                 }
             }
+
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
 
             return this;
         }

--- a/src/java.desktop/share/classes/sun/swing/plaf/synth/SynthFileChooserUIImpl.java
+++ b/src/java.desktop/share/classes/sun/swing/plaf/synth/SynthFileChooserUIImpl.java
@@ -692,6 +692,8 @@ public class SynthFileChooserUIImpl extends SynthFileChooserUI {
             ii.depth = directoryComboBoxModel.getDepth(index);
             label.setIcon(ii);
 
+            label.putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return label;
         }
     }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
@@ -1048,6 +1048,8 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
             ii.depth = directoryComboBoxModel.getDepth(index);
             setIcon(ii);
 
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }

--- a/test/jdk/javax/swing/JFileChooser/HTMLFileName.java
+++ b/test/jdk/javax/swing/JFileChooser/HTMLFileName.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.util.List;
+import javax.swing.Icon;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.filechooser.FileSystemView;
+
+/*
+ * @test id=metal
+ * @bug 8139228
+ * @summary JFileChooser should not render Directory names in HTML format
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual HTMLFileName metal
+ */
+
+/*
+ * @test id=system
+ * @bug 8139228
+ * @summary JFileChooser should not render Directory names in HTML format
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual HTMLFileName system
+ */
+
+public class HTMLFileName {
+    private static final String INSTRUCTIONS = """
+            <html>
+            <ol>
+            <li>FileChooser shows up a virtual directory and file with name
+               <html><h1 color=#ff00ff><font face="Comic Sans MS">Swing Rocks!.
+            <li>On "HTML disabled" frame :
+                <ol>
+                  <li>Verify that the folder and file name must be plain text.
+                  <li>If the name in file pane window and also in directory
+                     ComboBox remains in plain text, then press <b>Pass</b>.
+                     If it appears to be in HTML format with Pink color as
+                     shown, then press <b>Fail</b>.
+                </ol>
+
+            <li>On "HTML enabled" frame :
+                <ol>
+                  <li>Verify that the folder and file name remains in HTML
+                     format with name "Swing Rocks!" pink in color as shown.
+                  <li>If the name in file pane window and also in directory
+                     ComboBox remains in HTML format string, then press <b>Pass</b>.
+                     If it appears to be in plain text, then press <b>Fail</b>.
+                </ol>
+            </ol>
+            </html>
+            """;
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Look-and-Feel keyword is required");
+        }
+
+        final String lafClassName;
+        switch (args[0]) {
+            case "metal" -> lafClassName = UIManager.getCrossPlatformLookAndFeelClassName();
+            case "system" -> lafClassName = UIManager.getSystemLookAndFeelClassName();
+            default -> throw new IllegalArgumentException("Unsupported Look-and-Feel keyword: " + args[0]);
+        }
+
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                UIManager.setLookAndFeel(lafClassName);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        System.out.println("Test for LookAndFeel " + lafClassName);
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .testUI(HTMLFileName::initialize)
+                .positionTestUIBottomRowCentered()
+                .build()
+                .awaitAndCheck();
+        System.out.println("Test passed for LookAndFeel " + lafClassName);
+    }
+
+    private static List<JFrame> initialize() {
+        return List.of(createFileChooser(true), createFileChooser(false));
+    }
+
+    private static JFrame createFileChooser(boolean htmlEnabled) {
+        JFileChooser jfc = new JFileChooser(new VirtualFileSystemView());
+        jfc.putClientProperty("html.disable", htmlEnabled);
+        jfc.setControlButtonsAreShown(false);
+
+        JFrame frame = new JFrame((htmlEnabled) ? "HTML enabled" : "HTML disabled");
+        frame.add(jfc);
+        frame.pack();
+        return frame;
+    }
+
+    private static class VirtualFileSystemView extends FileSystemView {
+        @Override
+        public File createNewFolder(File containingDir) {
+            return null;
+        }
+
+        @Override
+        public File[] getRoots() {
+            return new File[]{
+                    new File("/", "<html><h1 color=#ff00ff><font " +
+                            "face=\"Comic Sans MS\">Swing Rocks!"),
+                    new File("/", "virtualFile2.txt"),
+                    new File("/", "virtualFolder")
+            };
+        }
+
+        @Override
+        public File getHomeDirectory() {
+            return new File("/");
+        }
+
+        @Override
+        public File getDefaultDirectory() {
+            return new File("/");
+        }
+
+        @Override
+        public File[] getFiles(File dir, boolean useFileHiding) {
+            // Simulate a virtual folder structure
+            return new File[]{
+                    new File("/", "<html><h1 color=#ff00ff><font " +
+                            "face=\"Comic Sans MS\">Swing Rocks!"),
+                    new File(dir, "virtualFile2.txt"),
+                    new File(dir, "virtualFolder")
+            };
+        }
+
+        @Override
+        public Icon getSystemIcon(File f) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.18-oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8139228](https://bugs.openjdk.org/browse/JDK-8139228) needs maintainer approval

### Issue
 * [JDK-8139228](https://bugs.openjdk.org/browse/JDK-8139228): JFileChooser renders file names as HTML document (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3978/head:pull/3978` \
`$ git checkout pull/3978`

Update a local copy of the PR: \
`$ git checkout pull/3978` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3978`

View PR using the GUI difftool: \
`$ git pr show -t 3978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3978.diff">https://git.openjdk.org/jdk17u-dev/pull/3978.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3978#issuecomment-3317491371)
</details>
