### PR TITLE
8294680: Refactor scaled border rendering

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/SwingUtilities3.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/SwingUtilities3.java
@@ -25,27 +25,33 @@
 
 package com.sun.java.swing;
 
-import sun.awt.AppContext;
-import sun.awt.SunToolkit;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
 import java.applet.Applet;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Rectangle;
+import java.awt.Stroke;
 import java.awt.Window;
+import java.awt.geom.AffineTransform;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import javax.swing.ButtonModel;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.RepaintManager;
+
+import sun.awt.AppContext;
+import sun.awt.SunToolkit;
 import sun.swing.MenuItemLayoutHelper;
 import sun.swing.SwingUtilities2;
+
+import static sun.java2d.pipe.Region.clipRound;
 
 /**
  * A collection of utility methods for Swing.
@@ -122,6 +128,31 @@ public class SwingUtilities3 {
     public static boolean isVsyncRequested(Container rootContainer) {
         assert (rootContainer instanceof Applet) || (rootContainer instanceof Window);
         return Boolean.TRUE == vsyncedMap.get(rootContainer);
+    }
+
+    /**
+     * Returns delegate {@code RepaintManager} for {@code component} hierarchy.
+     */
+    public static RepaintManager getDelegateRepaintManager(Component
+                                                            component) {
+        RepaintManager delegate = null;
+        if (Boolean.TRUE == SunToolkit.targetToAppContext(component)
+                                      .get(DELEGATE_REPAINT_MANAGER_KEY)) {
+            while (delegate == null && component != null) {
+                while (component != null
+                         && ! (component instanceof JComponent)) {
+                    component = component.getParent();
+                }
+                if (component != null) {
+                    delegate = (RepaintManager)
+                        ((JComponent) component)
+                          .getClientProperty(DELEGATE_REPAINT_MANAGER_KEY);
+                    component = component.getParent();
+                }
+
+            }
+        }
+        return delegate;
     }
 
     public static void applyInsets(Rectangle rect, Insets insets) {
@@ -247,27 +278,112 @@ public class SwingUtilities3 {
     }
 
     /**
-     * Returns delegate {@code RepaintManager} for {@code component} hierarchy.
+     * A task which paints an <i>unscaled</i> border after {@code Graphics}
+     * transforms are removed. It's used with the
+     * {@link #paintBorder(Component, Graphics, int, int, int, int, UnscaledBorderPainter)
+     * SwingUtilities3.paintBorder} which manages changing the transforms and calculating
+     * the coordinates and size of the border.
      */
-    public static RepaintManager getDelegateRepaintManager(Component
-                                                            component) {
-        RepaintManager delegate = null;
-        if (Boolean.TRUE == SunToolkit.targetToAppContext(component)
-                                      .get(DELEGATE_REPAINT_MANAGER_KEY)) {
-            while (delegate == null && component != null) {
-                while (component != null
-                         && ! (component instanceof JComponent)) {
-                    component = component.getParent();
-                }
-                if (component != null) {
-                    delegate = (RepaintManager)
-                        ((JComponent) component)
-                          .getClientProperty(DELEGATE_REPAINT_MANAGER_KEY);
-                    component = component.getParent();
-                }
+    @FunctionalInterface
+    public interface UnscaledBorderPainter {
+        /**
+         * Paints the border for the specified component after the
+         * {@code Graphics} transforms are removed.
+         *
+         * <p>
+         * The <i>x</i> and <i>y</i> of the painted border are zero.
+         *
+         * @param c the component for which this border is being painted
+         * @param g the paint graphics
+         * @param w the width of the painted border, in physical pixels
+         * @param h the height of the painted border, in physical pixels
+         * @param scaleFactor the scale that was in the {@code Graphics}
+         *
+         * @see #paintBorder(Component, Graphics, int, int, int, int, UnscaledBorderPainter)
+         * SwingUtilities3.paintBorder
+         * @see javax.swing.border.Border#paintBorder(Component, Graphics, int, int, int, int)
+         * Border.paintBorder
+         */
+        void paintUnscaledBorder(Component c, Graphics g,
+                                 int w, int h,
+                                 double scaleFactor);
+    }
 
+    /**
+     * Paints the border for a component ensuring its sides have consistent
+     * thickness at different scales.
+     * <p>
+     * It performs the following steps:
+     * <ol>
+     *     <li>Reset the scale transform on the {@code Graphics},</li>
+     *     <li>Call {@code painter} to paint the border,</li>
+     *     <li>Restores the transform.</li>
+     * </ol>
+     *
+     * @param c the component for which this border is being painted
+     * @param g the paint graphics
+     * @param x the x position of the painted border
+     * @param y the y position of the painted border
+     * @param w the width of the painted border
+     * @param h the height of the painted border
+     * @param painter the painter object which paints the border after
+     *                the transform on the {@code Graphics} is reset
+     */
+    public static void paintBorder(Component c, Graphics g,
+                                   int x, int y,
+                                   int w, int h,
+                                   UnscaledBorderPainter painter) {
+
+        // Step 1: Reset Transform
+        AffineTransform at = null;
+        Stroke oldStroke = null;
+        boolean resetTransform = false;
+        double scaleFactor = 1;
+
+        int xtranslation = x;
+        int ytranslation = y;
+        int width = w;
+        int height = h;
+
+        if (g instanceof Graphics2D) {
+            Graphics2D g2d = (Graphics2D) g;
+            at = g2d.getTransform();
+            oldStroke = g2d.getStroke();
+            scaleFactor = Math.min(at.getScaleX(), at.getScaleY());
+
+            // if m01 or m10 is non-zero, then there is a rotation or shear,
+            // or if scale=1, skip resetting the transform in these cases.
+            resetTransform = ((at.getShearX() == 0) && (at.getShearY() == 0))
+                    && ((at.getScaleX() > 1) || (at.getScaleY() > 1));
+
+            if (resetTransform) {
+                /* Deactivate the HiDPI scaling transform,
+                 * so we can do paint operations in the device
+                 * pixel coordinate system instead of the logical coordinate system.
+                 */
+                g2d.setTransform(new AffineTransform());
+                double xx = at.getScaleX() * x + at.getTranslateX();
+                double yy = at.getScaleY() * y + at.getTranslateY();
+                xtranslation = clipRound(xx);
+                ytranslation = clipRound(yy);
+                width = clipRound(at.getScaleX() * w + xx) - xtranslation;
+                height = clipRound(at.getScaleY() * h + yy) - ytranslation;
             }
         }
-        return delegate;
+
+        g.translate(xtranslation, ytranslation);
+
+        // Step 2: Call respective paintBorder with transformed values
+        painter.paintUnscaledBorder(c, g, width, height, scaleFactor);
+
+        // Step 3: Restore previous stroke & transform
+        g.translate(-xtranslation, -ytranslation);
+        if (g instanceof Graphics2D) {
+            Graphics2D g2d = (Graphics2D) g;
+            g2d.setStroke(oldStroke);
+            if (resetTransform) {
+                g2d.setTransform(at);
+            }
+        }
     }
 }

--- a/src/java.desktop/share/classes/javax/swing/border/EtchedBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/EtchedBorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,9 @@ import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Stroke;
-import java.awt.geom.AffineTransform;
 import java.beans.ConstructorProperties;
+
+import com.sun.java.swing.SwingUtilities3;
 
 /**
  * A class which implements a simple etched border which can
@@ -150,43 +150,19 @@ public class EtchedBorder extends AbstractBorder
      * @param height the height of the painted border
      */
     public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
-        // We remove any initial transforms to prevent rounding errors
-        // when drawing in non-integer scales
-        AffineTransform at = null;
-        Stroke oldStk = null;
-        int stkWidth = 1;
-        boolean resetTransform = false;
+        SwingUtilities3.paintBorder(c, g,
+                                    x, y,
+                                    width, height,
+                                    this::paintUnscaledBorder);
+    }
+
+    private void paintUnscaledBorder(Component c, Graphics g,
+                                     int w, int h,
+                                     double scaleFactor) {
+        int stkWidth = (int) Math.floor(scaleFactor);
         if (g instanceof Graphics2D) {
-            Graphics2D g2d = (Graphics2D) g;
-            at = g2d.getTransform();
-            oldStk = g2d.getStroke();
-            // if m01 or m10 is non-zero, then there is a rotation or shear
-            // skip resetting the transform
-            resetTransform = (at.getShearX() == 0) && (at.getShearY() == 0);
-            if (resetTransform) {
-                g2d.setTransform(new AffineTransform());
-                stkWidth = (int) Math.floor(Math.min(at.getScaleX(), at.getScaleY()));
-                g2d.setStroke(new BasicStroke((float) stkWidth));
-            }
+            ((Graphics2D) g).setStroke(new BasicStroke((float) stkWidth));
         }
-
-        int w;
-        int h;
-        int xtranslation;
-        int ytranslation;
-        if (resetTransform) {
-            w = (int) Math.floor(at.getScaleX() * width - 1);
-            h = (int) Math.floor(at.getScaleY() * height - 1);
-            xtranslation = (int) Math.ceil(at.getScaleX()*x+at.getTranslateX());
-            ytranslation = (int) Math.ceil(at.getScaleY()*y+at.getTranslateY());
-        } else {
-            w = width;
-            h = height;
-            xtranslation = x;
-            ytranslation = y;
-        }
-
-        g.translate(xtranslation, ytranslation);
 
         paintBorderShadow(g, (etchType == LOWERED) ? getHighlightColor(c)
                                                    : getShadowColor(c),
@@ -194,15 +170,6 @@ public class EtchedBorder extends AbstractBorder
         paintBorderHighlight(g, (etchType == LOWERED) ? getShadowColor(c)
                                                       : getHighlightColor(c),
                              w, h, stkWidth);
-
-        g.translate(-xtranslation, -ytranslation);
-
-        // Set the transform we removed earlier
-        if (resetTransform) {
-            Graphics2D g2d = (Graphics2D) g;
-            g2d.setTransform(at);
-            g2d.setStroke(oldStk);
-        }
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalBorders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,9 +33,7 @@ import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
-import java.awt.Stroke;
 import java.awt.Window;
-import java.awt.geom.AffineTransform;
 
 import javax.swing.AbstractButton;
 import javax.swing.ButtonModel;
@@ -62,6 +60,7 @@ import javax.swing.plaf.UIResource;
 import javax.swing.plaf.basic.BasicBorders;
 import javax.swing.text.JTextComponent;
 
+import com.sun.java.swing.SwingUtilities3;
 import sun.swing.StringUIClientPropertyKey;
 import sun.swing.SwingUtilities2;
 
@@ -251,6 +250,14 @@ public class MetalBorders {
 
         public void paintBorder(Component c, Graphics g, int x, int y,
                                 int w, int h) {
+            SwingUtilities3.paintBorder(c, g,
+                                        x, y, w, h,
+                                        this::paintUnscaledBorder);
+        }
+
+        private void paintUnscaledBorder(Component c, Graphics g,
+                                         int width, int height,
+                                         double scaleFactor) {
             Color background;
             Color highlight;
             Color shadow;
@@ -265,48 +272,6 @@ public class MetalBorders {
                 shadow = MetalLookAndFeel.getControlInfo();
             }
 
-            AffineTransform at = null;
-            Stroke oldStk = null;
-            boolean resetTransform = false;
-            int stkWidth = 1;
-            double scaleFactor = 1;
-
-            if (g instanceof Graphics2D g2d) {
-                at = g2d.getTransform();
-                scaleFactor = at.getScaleX();
-                oldStk = g2d.getStroke();
-
-                // if m01 or m10 is non-zero, then there is a rotation or shear
-                // skip resetting the transform
-                resetTransform = ((at.getShearX() == 0) && (at.getShearY() == 0));
-
-                if (resetTransform) {
-                    g2d.setTransform(new AffineTransform());
-                    stkWidth = clipRound(Math.min(at.getScaleX(), at.getScaleY()));
-                    g2d.setStroke(new BasicStroke((float) stkWidth));
-                }
-            }
-
-            int xtranslation;
-            int ytranslation;
-            int width;
-            int height;
-
-            if (resetTransform) {
-                double xx = at.getScaleX() * x + at.getTranslateX();
-                double yy = at.getScaleY() * y + at.getTranslateY();
-                xtranslation = clipRound(xx);
-                ytranslation = clipRound(yy);
-                width = clipRound(at.getScaleX() * w + xx) - xtranslation;
-                height = clipRound(at.getScaleY() * h + yy) - ytranslation;
-            } else {
-                xtranslation = x;
-                ytranslation = y;
-                width = w;
-                height = h;
-            }
-            g.translate(xtranslation, ytranslation);
-
             // scaled border
             int thickness = (int) Math.ceil(4 * scaleFactor);
 
@@ -320,11 +285,16 @@ public class MetalBorders {
                 // midpoint at which highlight & shadow lines
                 // are positioned on the border
                 int midPoint = thickness / 2;
+                int stkWidth = clipRound(scaleFactor);
                 int offset = (((scaleFactor - stkWidth) >= 0) && ((stkWidth % 2) != 0)) ? 1 : 0;
                 int loc1 = thickness % 2 == 0 ? midPoint + stkWidth / 2 - stkWidth : midPoint;
                 int loc2 = thickness % 2 == 0 ? midPoint + stkWidth / 2 : midPoint + stkWidth;
                 // scaled corner
                 int corner = (int) Math.round(CORNER * scaleFactor);
+
+                if (g instanceof Graphics2D) {
+                    ((Graphics2D) g).setStroke(new BasicStroke((float) stkWidth));
+                }
 
                 // Draw the Long highlight lines
                 g.setColor(highlight);
@@ -343,14 +313,6 @@ public class MetalBorders {
                         (width - offset) - loc2, height - corner - 1);
                 g.drawLine(corner, (height - offset) - loc2,
                         width - corner - 1, (height - offset) - loc2);
-            }
-
-            // restore previous transform
-            g.translate(-xtranslation, -ytranslation);
-            if (resetTransform) {
-                Graphics2D g2d = (Graphics2D) g;
-                g2d.setTransform(at);
-                g2d.setStroke(oldStk);
             }
         }
 


### PR DESCRIPTION
I backport this to make later backports more simple. 
We should keep 17 up to date, especially in awt/javax where
subtle bugs can annoy users.

I had to resolve SwingUtilities3.java as two later changes were already backported,
see History of [17](https://github.com/openjdk/jdk17u-dev/commits/master/src/java.desktop/share/classes/com/sun/java/swing/SwingUtilities3.java)  compared to [21](https://github.com/openjdk/jdk21u-dev/commits/master/src/java.desktop/share/classes/com/sun/java/swing/SwingUtilities3.java)

The file is now at the level of 21, except for  [8285306: Fix typos in java.desktop](https://github.com/openjdk/jdk21u-dev/commit/2a799e5c82395919b807561da4a062e0fe6da31d)

I ran the following tests, selected my name:

test/jdk/javax/swing/JComboBox/JComboBoxWithTitledBorderTest.java
test/jdk/javax/swing/JInternalFrame/InternalFrameBorderTest.java
test/jdk/javax/swing/JMenuBar/MisplacedBorder
test/jdk/javax/swing/JTree/8041705/DefaultTreeCellRendererBorderTest.java
test/jdk/javax/swing/border
test/jdk/javax/swing/plaf/metal/MetalBorders
test/jdk/javax/swing/plaf/nimbus/TestDisabledToolTipBorder.java
test/jdk/javax/swing/plaf/synth/TitledBorderLabel.java

Related issues mentioned in the bug are either backported or on my list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8294680](https://bugs.openjdk.org/browse/JDK-8294680) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294680](https://bugs.openjdk.org/browse/JDK-8294680): Refactor scaled border rendering (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3984/head:pull/3984` \
`$ git checkout pull/3984`

Update a local copy of the PR: \
`$ git checkout pull/3984` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3984`

View PR using the GUI difftool: \
`$ git pr show -t 3984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3984.diff">https://git.openjdk.org/jdk17u-dev/pull/3984.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3984#issuecomment-3319819528)
</details>
