### PR TITLE
8333200: Test containers/docker/TestPids.java fails Limit value -1 is not accepted as unlimited

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -113,12 +113,13 @@ public class TestPids {
 
                 Asserts.assertEquals(parts.length, 2);
                 String actual = parts[1].replaceAll("\\s","");
-                // Unlimited pids leads on some setups not to "max" in the output, but to a high number
                 if (expectedValue.equals("max")) {
-                    if (actual.equals("max")) {
-                        System.out.println("Found expected max for unlimited pids value.");
+                    // Unlimited pids accept max or -1
+                    if (actual.equals("max") || actual.equals("-1")) {
+                        System.out.println("Found expected " + actual + " for unlimited pids value.");
                     } else {
                         try {
+                            // Unlimited pids leads on some setups not to "max" in the output, but to a high number
                             int ai = Integer.parseInt(actual);
                             if (ai > 20000) {
                                 System.out.println("Limit value " + ai + " got accepted as unlimited, log line was " + line);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7ab74c5f](https://github.com/openjdk/jdk/commit/7ab74c5f268dac82bbd36355acf8e4f3d357134c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 31 May 2024 and was reviewed by Severin Gehwolf.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8333200](https://bugs.openjdk.org/browse/JDK-8333200) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333200](https://bugs.openjdk.org/browse/JDK-8333200): Test containers/docker/TestPids.java fails Limit value -1 is not accepted as unlimited (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3986/head:pull/3986` \
`$ git checkout pull/3986`

Update a local copy of the PR: \
`$ git checkout pull/3986` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3986`

View PR using the GUI difftool: \
`$ git pr show -t 3986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3986.diff">https://git.openjdk.org/jdk17u-dev/pull/3986.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3986#issuecomment-3321994146)
</details>
