### PR TITLE
8297302: gtest/AsyncLogGtest.java fails AsyncLogTest.stdoutOutput_vm

### DIFF
--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -90,10 +90,8 @@ LOG_LEVEL_LIST
     if (f != NULL) {
       size_t sz = output.size();
       size_t written = fwrite(output.c_str(), sizeof(char), output.size(), f);
-
-      if (written == sz * sizeof(char)) {
-        return fclose(f) == 0;
-      }
+      // at least see "header"
+      return fclose(f) == 0 && sz == written && sz >= 6;
     }
 
     return false;
@@ -240,38 +238,46 @@ TEST_VM_F(AsyncLogTest, droppingMessage) {
 
 TEST_VM_F(AsyncLogTest, stdoutOutput) {
   testing::internal::CaptureStdout();
+  fprintf(stdout, "header");
   set_log_config("stdout", "logging=debug");
 
   test_asynclog_ls();
   test_asynclog_drop_messages();
 
   AsyncLogWriter::flush();
-  EXPECT_TRUE(write_to_file(testing::internal::GetCapturedStdout()));
+  fflush(nullptr);
 
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+  if (write_to_file(testing::internal::GetCapturedStdout())) {
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
-  if (AsyncLogWriter::instance() != nullptr) {
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+    if (AsyncLogWriter::instance() != nullptr) {
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+    }
   }
 }
 
 TEST_VM_F(AsyncLogTest, stderrOutput) {
   testing::internal::CaptureStderr();
+  fprintf(stderr, "header");
   set_log_config("stderr", "logging=debug");
 
   test_asynclog_ls();
   test_asynclog_drop_messages();
 
   AsyncLogWriter::flush();
-  EXPECT_TRUE(write_to_file(testing::internal::GetCapturedStderr()));
+  fflush(nullptr);
 
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+  if (write_to_file(testing::internal::GetCapturedStderr())) {
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
-  if (AsyncLogWriter::instance() != nullptr) {
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+    if (AsyncLogWriter::instance() != nullptr) {
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+    }
   }
 }


### PR DESCRIPTION
Clean backport to resolve intermittent failures gtest/AsyncLogGtest.java test.
Tested with GHA and Tier 1 test run locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8297302](https://bugs.openjdk.org/browse/JDK-8297302) needs maintainer approval

### Issue
 * [JDK-8297302](https://bugs.openjdk.org/browse/JDK-8297302): gtest/AsyncLogGtest.java fails AsyncLogTest.stdoutOutput_vm (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3996/head:pull/3996` \
`$ git checkout pull/3996`

Update a local copy of the PR: \
`$ git checkout pull/3996` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3996`

View PR using the GUI difftool: \
`$ git pr show -t 3996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3996.diff">https://git.openjdk.org/jdk17u-dev/pull/3996.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3996#issuecomment-3340042248)
</details>
