### PR TITLE
8339386: Assertion on AIX - original PC must be in the main code section of the compiled method

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -129,18 +129,20 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
-    intptr_t* unextended_sender_sp = is_interpreted_frame() ? interpreter_frame_sender_sp() : sender_sp;
-
-    // If the sender is a deoptimized nmethod we need to check if the original pc is valid.
-    nmethod* sender_nm = sender_blob->as_nmethod_or_null();
-    if (sender_nm != nullptr && sender_nm->is_deopt_pc(sender_pc)) {
-      address orig_pc = *(address*)((address)unextended_sender_sp + sender_nm->orig_pc_offset());
-      if (!sender_nm->insts_contains_inclusive(orig_pc)) return false;
-    }
+    intptr_t* unextended_sender_sp = is_interpreted_frame() ? (intptr_t*)get_ijava_state()->sender_sp : sender_sp;
 
     // It should be safe to construct the sender though it might not be valid.
 
-    frame sender(sender_sp, sender_pc, unextended_sender_sp, nullptr /* fp */, sender_blob);
+    // JDK-8339386 is different than the upstream version:
+    // The frame constructor doesn't check sanity of a deopt pc, but determines it.
+    // Other accessors for reading it are not available in 17u.
+    frame sender(sender_sp, sender_pc, unextended_sender_sp);
+    // If the sender is a deoptimized nmethod we need to check if the original pc is valid.
+    nmethod* sender_nm = sender_blob->as_nmethod_or_null();
+    if (sender_nm != nullptr && sender._deopt_state == is_deoptimized) {
+      address orig_pc = sender.pc();
+      if (!sender_nm->insts_contains_inclusive(orig_pc)) return false;
+    }
 
     // Do we have a valid fp?
     address sender_fp = (address) sender.fp();

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -114,9 +114,9 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
-    abi_minframe* sender_abi = (abi_minframe*) fp;
+    volatile abi_minframe* sender_abi = (abi_minframe*) fp; // May get updated concurrently by deoptimization!
     intptr_t* sender_sp = (intptr_t*) fp;
-    address   sender_pc = (address) sender_abi->lr;;
+    address   sender_pc = (address) sender_abi->lr;
 
     // We must always be able to find a recognizable pc.
     CodeBlob* sender_blob = CodeCache::find_blob_unsafe(sender_pc);
@@ -129,9 +129,18 @@ bool frame::safe_for_sender(JavaThread *thread) {
       return false;
     }
 
+    intptr_t* unextended_sender_sp = is_interpreted_frame() ? interpreter_frame_sender_sp() : sender_sp;
+
+    // If the sender is a deoptimized nmethod we need to check if the original pc is valid.
+    nmethod* sender_nm = sender_blob->as_nmethod_or_null();
+    if (sender_nm != nullptr && sender_nm->is_deopt_pc(sender_pc)) {
+      address orig_pc = *(address*)((address)unextended_sender_sp + sender_nm->orig_pc_offset());
+      if (!sender_nm->insts_contains_inclusive(orig_pc)) return false;
+    }
+
     // It should be safe to construct the sender though it might not be valid.
 
-    frame sender(sender_sp, sender_pc);
+    frame sender(sender_sp, sender_pc, unextended_sender_sp, nullptr /* fp */, sender_blob);
 
     // Do we have a valid fp?
     address sender_fp = (address) sender.fp();


### PR DESCRIPTION
Backport of [JDK-8339386](https://bugs.openjdk.org/browse/JDK-8339386). Applies almost cleanly, but needs a modification (see 2nd commit). `orig_pc_offset()` is not available in 17u. We can use the `frame` constructor which doesn't have the problematic assertion in 17u (see comment in the new code).
So, this backport doesn't fix the assertion mentioned in the title (because it doesn't exist in 17u). But, it makes checks more reliable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8339386](https://bugs.openjdk.org/browse/JDK-8339386) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339386](https://bugs.openjdk.org/browse/JDK-8339386): Assertion on AIX - original PC must be in the main code section of the compiled method (**Bug** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/3998/head:pull/3998` \
`$ git checkout pull/3998`

Update a local copy of the PR: \
`$ git checkout pull/3998` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/3998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3998`

View PR using the GUI difftool: \
`$ git pr show -t 3998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/3998.diff">https://git.openjdk.org/jdk17u-dev/pull/3998.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/3998#issuecomment-3347244832)
</details>
