### PR TITLE
backport of 8ec6b8de3bb3d7aeebdcb45d761b18cce3bab75e

### DIFF
--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -229,7 +229,6 @@ VM_ThreadDump::VM_ThreadDump(ThreadDumpResult* result,
   _result = result;
   _num_threads = 0; // 0 indicates all threads
   _threads = NULL;
-  _result = result;
   _max_depth = max_depth;
   _with_locked_monitors = with_locked_monitors;
   _with_locked_synchronizers = with_locked_synchronizers;
@@ -244,7 +243,6 @@ VM_ThreadDump::VM_ThreadDump(ThreadDumpResult* result,
   _result = result;
   _num_threads = num_threads;
   _threads = threads;
-  _result = result;
   _max_depth = max_depth;
   _with_locked_monitors = with_locked_monitors;
   _with_locked_synchronizers = with_locked_synchronizers;

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -673,6 +673,7 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth) {
 
   if (_thread->has_last_Java_frame()) {
     RegisterMap reg_map(_thread);
+    ResourceMark rm;
     vframe* start_vf = _thread->last_java_vframe(&reg_map);
     int count = 0;
     for (vframe* f = start_vf; f; f = f->sender() ) {


### PR DESCRIPTION
This pull request contains a backport of commit [8ec6b8de3bb3d7aeebdcb45d761b18cce3bab75e](https://github.com/openjdk/jdk/commit/8ec6b8de3bb3d7aeebdcb45d761b18cce3bab75e) from the openjdk/jdk repository to JDK 17.

This backport significantly reduces RSS memory usage during ThreadMXBean.dumpAllThreads(boolean, boolean) execution.

This is not a clean backport due to differences between JDK 17 and upstream:

Threading Context: Changed ResourceMark rm(VMThread::vm_thread()) to ResourceMark rm;
   • Similar to [JDK 21 backport](https://github.com/openjdk/jdk21u-dev/pull/307)

Minor conflict resolved: _threads = nullptr; → _threads = NULL; to match JDK 17 conventions

GHA tested additionally ran tier1 tests on my local mac and passed.
