### PR TITLE
8353586: Open source several toolkit tests

### DIFF
--- a/test/jdk/java/awt/Toolkit/DesktopProperties/DesktopPropertyTest.java
+++ b/test/jdk/java/awt/Toolkit/DesktopProperties/DesktopPropertyTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4287882
+ * @summary Tests internal use Windows properties
+ * @requires os.family == "windows"
+ * @key headful
+ * @run main DesktopPropertyTest
+ */
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableModel;
+import java.awt.Robot;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Arrays;
+import java.util.Vector;
+
+/*
+ * This is a test of new Windows-specific desktop
+ * properties added in Kestrel.
+ *
+ * The new properties are meant for the use of the
+ * Windows PLAF only and are not public at this time.
+ */
+public class DesktopPropertyTest {
+    private static JFrame frame;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {
+            SwingUtilities.invokeAndWait(DesktopPropertyTest::runTest);
+            robot.waitForIdle();
+            robot.delay(1000);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public static void runTest() {
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        frame = new DesktopPropertyFrame();
+        frame.setVisible(true);
+    }
+
+    static class DesktopPropertyFrame extends JFrame {
+        JTable table;
+
+        DesktopPropertyFrame() {
+            super("Toolkit.getDesktopProperty API Test");
+            setBackground(Color.white);
+            add(new JScrollPane(createTable()));
+            setLocationRelativeTo(null);
+            setSize(500, 400);
+        }
+
+        public JTable createTable() {
+            TableModel dataModel = new AbstractTableModel() {
+                final PropertyVector pv = new PropertyVector();
+
+                public int getColumnCount() {
+                    return 3;
+                }
+
+                public int getRowCount() {
+                    return pv.size();
+                }
+
+                public String getColumnName(int column) {
+                    String[] colnames = {"Property", "Type", "Value"};
+                    return colnames[column];
+                }
+
+                public Object getValueAt(int row, int col) {
+                    Object[] prow = pv.get(row);
+                    return prow[col];
+                }
+            };
+
+            table = new JTable(dataModel);
+            table.setDefaultRenderer(Object.class, new DesktopPropertyRenderer());
+            table.addMouseListener(new ClickListener());
+            return table;
+        }
+
+        class ClickListener extends MouseAdapter {
+            ClickListener() {
+            }
+
+            public void mouseClicked(MouseEvent e) {
+                for (int row = 0; row <= table.getModel().getRowCount(); row++) {
+                    Rectangle r = table.getCellRect(row, 2, false);
+                    if (r.contains(e.getX(), e.getY())) {
+                        Object value = table.getModel().getValueAt(row, 2);
+                        if (value instanceof Runnable) {
+                            ((Runnable) value).run();
+                        }
+                    }
+                }
+            }
+        }
+
+        class PropertyVector {
+            private static final int NAME = 0;
+            private static final int TYPE = 1;
+            private static final int VALUE = 2;
+
+            private final Vector<Object> vector = new Vector<>();
+
+            PropertyVector() {
+                Object[] props = (Object[]) getToolkit()
+                        .getDesktopProperty("win.propNames");
+                if (props == null) {
+                    throw new RuntimeException(
+                            "'win.propNames' property not available. " +
+                            "This test is valid only on Windows.");
+                }
+                for (Object prop : props) {
+                    String propertyName = prop.toString();
+                    vector.addElement(createEntry(propertyName));
+                }
+            }
+
+            Object[] createEntry(String name) {
+                Object[] row = new Object[3];
+                Object value = getToolkit().getDesktopProperty(name);
+                row[NAME] = name;
+                row[TYPE] = value.getClass().getName();
+                row[VALUE] = value;
+
+                System.out.println(Arrays.toString(row));
+                // update this vector when property changes
+                getToolkit().addPropertyChangeListener(name, new DesktopPropertyChangeListener(row));
+                return row;
+            }
+
+            Object[] get(int row) {
+                return (Object[]) vector.elementAt(row);
+            }
+
+            int size() {
+                return vector.size();
+            }
+
+            static class DesktopPropertyChangeListener implements PropertyChangeListener {
+                Object[] row;
+
+                DesktopPropertyChangeListener(Object[] row) {
+                    this.row = row;
+                }
+
+                public void propertyChange(PropertyChangeEvent evt) {
+                    this.row[VALUE] = evt.getNewValue();
+                }
+            }
+        }
+
+        static class DesktopPropertyRenderer implements TableCellRenderer {
+            ValueProp vprop = new ValueProp();
+            FontProp fprop = new FontProp();
+            ColorProp cprop = new ColorProp();
+            RunnableProp rprop = new RunnableProp();
+            RenderingHintsProp rhprop = new RenderingHintsProp();
+
+            public Component getTableCellRendererComponent(JTable table, Object value,
+                                                           boolean isSelected, boolean hasFocus,
+                                                           int row, int column) {
+
+                ValueProp propComponent;
+                if (value instanceof Boolean
+                        || value instanceof Integer
+                        || value instanceof String) {
+                    propComponent = vprop;
+                } else if (value instanceof Font) {
+                    propComponent = fprop;
+                } else if (value instanceof Color) {
+                    propComponent = cprop;
+                } else if (value instanceof Runnable) {
+                    propComponent = rprop;
+                } else if (value instanceof RenderingHints) {
+                    propComponent = rhprop;
+                } else {
+                    throw new RuntimeException("ASSERT unexpected value %s / %s\n"
+                            .formatted(value != null ? value.getClass() : "", value));
+                }
+
+                propComponent.setValue(value);
+
+                return propComponent;
+            }
+        }
+
+        static class ValueProp extends JLabel {
+            public void setValue(Object value) {
+                setText(value.toString());
+            }
+        }
+
+        static class FontProp extends ValueProp {
+            public void setValue(Object value) {
+                Font font = (Font) value;
+                String style;
+                if (font.getStyle() == Font.BOLD) {
+                    style = "Bold";
+                } else if (font.getStyle() > Font.BOLD) {
+                    style = "BoldItalic";
+                } else {
+                    style = "Plain";
+                }
+                setText(font.getName() + ", " + style + ", " + font.getSize());
+                setFont(font);
+            }
+        }
+
+        static class ColorProp extends ValueProp {
+            public void setValue(Object value) {
+                Color color = (Color) value;
+                setText("%d, %d, %d"
+                        .formatted(color.getRed(), color.getGreen(), color.getBlue()));
+                setBackground(color);
+                setOpaque(true);
+            }
+        }
+
+        static class RunnableProp extends ValueProp {}
+        static class RenderingHintsProp extends ValueProp {}
+    }
+}

--- a/test/jdk/java/awt/Toolkit/TimeUnsignedConversionTest.java
+++ b/test/jdk/java/awt/Toolkit/TimeUnsignedConversionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5097241
+ * @summary Tests the problem of time type conversion on XToolkit. The conversion should be unsigned.
+ * @requires os.family == "linux"
+ * @key headful
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build Util jtreg.SkippedException
+ * @run main/othervm -Dsun.awt.disableGtkFileDialogs=true TimeUnsignedConversionTest
+ */
+
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.FileDialog;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import jtreg.SkippedException;
+import test.java.awt.regtesthelpers.Util;
+
+public class TimeUnsignedConversionTest  {
+    static Robot robot;
+    static Frame frame;
+    static volatile Button button;
+    static volatile FileDialog dialog;
+    static volatile boolean dialogShown = false;
+
+    static final CountDownLatch passedLatch = new CountDownLatch(1);
+
+    public static void main(String[] args) throws Exception {
+        if (!Toolkit.getDefaultToolkit().getClass().getName().equals("sun.awt.X11.XToolkit")) {
+            throw new SkippedException("XAWT test only! Skipped.");
+        }
+
+        try {
+            EventQueue.invokeAndWait(TimeUnsignedConversionTest::createAndShowGUI);
+            test();
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowGUI() {
+        frame = new Frame("TimeUnsignedConversionTest frame");
+        button = new Button("Show Dialog");
+        dialog = new FileDialog(frame, "TimeUnsignedConversionTest Dialog", FileDialog.LOAD);
+
+        Toolkit.getDefaultToolkit().addAWTEventListener(e -> {
+            System.out.println(e);
+            if (dialogShown && ((KeyEvent)e).getKeyCode() == KeyEvent.VK_K) {
+                passedLatch.countDown();
+            }
+        }, KeyEvent.KEY_EVENT_MASK);
+
+        frame.setLayout(new FlowLayout());
+        frame.add(button);
+
+        button.addActionListener(ae -> {
+            if (ae.getActionCommand().equals("Show Dialog")) {
+                dialog.setSize(200, 200);
+                dialog.setLocationRelativeTo(frame);
+                dialog.setVisible(true);
+            }
+        });
+
+        frame.setSize(100, 100);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void test() throws Exception {
+        robot = new Robot();
+        robot.waitForIdle();
+
+        Util.waitTillShown(button);
+
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_SPACE);
+        robot.delay(50);
+        robot.keyRelease(KeyEvent.VK_SPACE);
+
+        Util.waitTillShown(dialog);
+        dialogShown = true;
+
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_K);
+        robot.delay(50);
+        robot.keyRelease(KeyEvent.VK_K);
+
+        if (!passedLatch.await(2, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Test failed!");
+        }
+
+        System.out.println("Test passed.");
+    }
+}


### PR DESCRIPTION
Backporting JDK-8353586: Open source several toolkit tests. Adds two toolkit tests - one for window and one for linux systems. Ran GHA Sanity Checks and new tests directly. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353586](https://bugs.openjdk.org/browse/JDK-8353586) needs maintainer approval

### Issue
 * [JDK-8353586](https://bugs.openjdk.org/browse/JDK-8353586): Open source several toolkit tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4010/head:pull/4010` \
`$ git checkout pull/4010`

Update a local copy of the PR: \
`$ git checkout pull/4010` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4010`

View PR using the GUI difftool: \
`$ git pr show -t 4010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4010.diff">https://git.openjdk.org/jdk17u-dev/pull/4010.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4010#issuecomment-3363375136)
</details>
