### PR TITLE
8370325: G1: Disallow GC for TLAB allocation

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -360,22 +360,26 @@ HeapWord* G1CollectedHeap::allocate_new_tlab(size_t min_size,
   assert_heap_not_locked_and_not_at_safepoint();
   assert(!is_humongous(requested_size), "we do not allow humongous TLABs");
 
-  return attempt_allocation(min_size, requested_size, actual_size);
+  // Do not allow a GC because we are allocating a new TLAB to avoid an issue
+  // with UseGCOverheadLimit: although this GC would return null if the overhead
+  // limit would be exceeded, but it would likely free at least some space.
+  // So the subsequent outside-TLAB allocation could be successful anyway and
+  // the indication that the overhead limit had been exceeded swallowed.
+  return attempt_allocation(min_size, requested_size, actual_size, false /* allow_gc */);
 }
 
-HeapWord*
-G1CollectedHeap::mem_allocate(size_t word_size,
-                              bool*  gc_overhead_limit_was_exceeded) {
+HeapWord* G1CollectedHeap::mem_allocate(size_t word_size,
+                                        bool*  gc_overhead_limit_was_exceeded) {
   assert_heap_not_locked_and_not_at_safepoint();
 
   if (is_humongous(word_size)) {
     return attempt_allocation_humongous(word_size);
   }
   size_t dummy = 0;
-  return attempt_allocation(word_size, word_size, &dummy);
+  return attempt_allocation(word_size, word_size, &dummy, true /* allow_gc */);
 }
 
-HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
+HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size, bool allow_gc) {
   ResourceMark rm; // For retrieving the thread names in log messages.
 
   // Make sure you read the note in attempt_allocation_humongous().
@@ -448,6 +452,8 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
         log_trace(gc, alloc)("%s: Successfully scheduled collection returning " PTR_FORMAT,
                              Thread::current()->name(), p2i(result));
         return result;
+      } else if (!allow_gc) {
+        return nullptr;
       }
 
       if (succeeded) {
@@ -706,7 +712,8 @@ void G1CollectedHeap::fill_archive_regions(MemRegion* ranges, size_t count) {
 
 inline HeapWord* G1CollectedHeap::attempt_allocation(size_t min_word_size,
                                                      size_t desired_word_size,
-                                                     size_t* actual_word_size) {
+                                                     size_t* actual_word_size,
+                                                     bool allow_gc) {
   assert_heap_not_locked_and_not_at_safepoint();
   assert(!is_humongous(desired_word_size), "attempt_allocation() should not "
          "be called for humongous allocation requests");
@@ -715,7 +722,7 @@ inline HeapWord* G1CollectedHeap::attempt_allocation(size_t min_word_size,
 
   if (result == NULL) {
     *actual_word_size = desired_word_size;
-    result = attempt_allocation_slow(desired_word_size);
+    result = attempt_allocation_slow(desired_word_size, allow_gc);
   }
 
   assert_heap_not_locked();

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -410,6 +410,8 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size, bool allow_
       result = _allocator->attempt_allocation(word_size, word_size, &actual_size);
       if (result != NULL) {
         return result;
+      } else if (!allow_gc) {
+        return nullptr;
       }
 
       preventive_collection_required = policy()->preventive_collection_required(1);
@@ -419,8 +421,6 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size, bool allow_
         result = _allocator->attempt_allocation_using_new_region(word_size);
         if (result != NULL) {
           return result;
-        } else if (!allow_gc) {
-          return nullptr;
         }
 
         // If the GCLocker is active and we are bound for a GC, try expanding young gen.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -419,6 +419,8 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size, bool allow_
         result = _allocator->attempt_allocation_using_new_region(word_size);
         if (result != NULL) {
           return result;
+        } else if (!allow_gc) {
+          return nullptr;
         }
 
         // If the GCLocker is active and we are bound for a GC, try expanding young gen.
@@ -452,8 +454,6 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size, bool allow_
         log_trace(gc, alloc)("%s: Successfully scheduled collection returning " PTR_FORMAT,
                              Thread::current()->name(), p2i(result));
         return result;
-      } else if (!allow_gc) {
-        return nullptr;
       }
 
       if (succeeded) {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -439,18 +439,14 @@ private:
   //
   // * If either call cannot satisfy the allocation request using the
   //   current allocating region, they will try to get a new one. If
-  //   this fails, they will attempt to do an evacuation pause and
-  //   retry the allocation.
-  //
-  // * If all allocation attempts fail, even after trying to schedule
-  //   an evacuation pause, allocate_new_tlab() will return NULL,
-  //   whereas mem_allocate() will attempt a heap expansion and/or
-  //   schedule a Full GC.
+  //   this fails, (only) mem_allocate() will attempt to do an evacuation
+  //   pause and retry the allocation. Allocate_new_tlab() will return null,
+  //   deferring to the following mem_allocate().
   //
   // * We do not allow humongous-sized TLABs. So, allocate_new_tlab
   //   should never be called with word_size being humongous. All
   //   humongous allocation requests should go to mem_allocate() which
-  //   will satisfy them with a special path.
+  //   will satisfy them in a special path.
 
   virtual HeapWord* allocate_new_tlab(size_t min_size,
                                       size_t requested_size,
@@ -464,12 +460,14 @@ private:
   // should only be used for non-humongous allocations.
   inline HeapWord* attempt_allocation(size_t min_word_size,
                                       size_t desired_word_size,
-                                      size_t* actual_word_size);
+                                      size_t* actual_word_size,
+                                      bool allow_gc);
 
   // Second-level mutator allocation attempt: take the Heap_lock and
   // retry the allocation attempt, potentially scheduling a GC
-  // pause. This should only be used for non-humongous allocations.
-  HeapWord* attempt_allocation_slow(size_t word_size);
+  // pause if allow_gc is set. This should only be used for non-humongous
+  // allocations.
+  HeapWord* attempt_allocation_slow(size_t word_size, bool allow_gc);
 
   // Takes the Heap_lock and attempts a humongous allocation. It can
   // potentially schedule a GC pause.

--- a/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java
+++ b/test/jdk/jdk/jfr/event/allocation/TestObjectAllocationInNewTLABEvent.java
@@ -86,7 +86,7 @@ public class TestObjectAllocationInNewTLABEvent {
         allocate();
         recording.stop();
         verifyRecording(recording);
-        int minCount = (int) floor(OBJECTS_TO_ALLOCATE * 0.80);
+        int minCount = (int) floor(OBJECTS_TO_ALLOCATE * 0.75);
         Asserts.assertGreaterThanOrEqual(countAllTlabs, minCount, "Too few tlab objects allocated");
         Asserts.assertLessThanOrEqual(countAllTlabs, OBJECTS_TO_ALLOCATE, "Too many tlab objects allocated");
 


### PR DESCRIPTION
I backport this for parity with 17.0.19-oracle.

Based on the push to 25. (which is equal to 21).

Simple resolves needed.

[add on]
We occasionally see [TestObjectAllocationInNewTLABEvent.java](https://github.com/openjdk/jdk17u-dev/pull/4210/changes/aa08b3874e91bd1fd286bbc8a0bd29a376ab839f) failing in our nightly testing.
It fails on all platforms with the error message "RuntimeException: Too few tlab objects allocated: expected 79 >= 80"

The boundary of 80 is choosen randomly in this test.  I adapted it to 75 and don't see failures any more.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8370325](https://bugs.openjdk.org/browse/JDK-8370325) needs maintainer approval

### Issue
 * [JDK-8370325](https://bugs.openjdk.org/browse/JDK-8370325): G1: Disallow GC for TLAB allocation (**Enhancement** - P4 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4210/head:pull/4210` \
`$ git checkout pull/4210`

Update a local copy of the PR: \
`$ git checkout pull/4210` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4210`

View PR using the GUI difftool: \
`$ git pr show -t 4210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4210.diff">https://git.openjdk.org/jdk17u-dev/pull/4210.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4210#issuecomment-4162238617)
</details>
