### PR TITLE
8374343: Fix SIGSEGV when lib/modules is unreadable

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1429,6 +1429,10 @@ char* ClassLoader::lookup_vm_options() {
   jio_snprintf(modules_path, JVM_MAXPATHLEN, "%s%slib%smodules", Arguments::get_java_home(), fileSep, fileSep);
   JImage_file =(*JImageOpen)(modules_path, &error);
   if (JImage_file == NULL) {
+    if (Arguments::has_jimage()) {
+      // The modules file exists but is unreadable or corrupt
+      vm_exit_during_initialization(err_msg("Unable to load %s", modules_path));
+    }
     return NULL;
   }
 


### PR DESCRIPTION
This pull request contains a backport of commit [48846744](https://github.com/openjdk/jdk/commit/48846744ca96ce3c6464a1a440b9e46119dfbb88) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

This simple change fixes SIGSEGV crash during startup if the runtime image (lib/modules) exists but is unreadable.

The change required manual merge. The only merge issue was nullptr/NULL difference (8300241: Replace NULL with nullptr in share/classfile/).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8374343](https://bugs.openjdk.org/browse/JDK-8374343) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374343](https://bugs.openjdk.org/browse/JDK-8374343): Fix SIGSEGV when lib/modules is unreadable (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4329/head:pull/4329` \
`$ git checkout pull/4329`

Update a local copy of the PR: \
`$ git checkout pull/4329` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4329`

View PR using the GUI difftool: \
`$ git pr show -t 4329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4329.diff">https://git.openjdk.org/jdk17u-dev/pull/4329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4329#issuecomment-4120918762)
</details>
