### PR TITLE
8380565: PPC64: deoptimization stub should save vector registers

### DIFF
--- a/src/hotspot/cpu/ppc/registerMap_ppc.cpp
+++ b/src/hotspot/cpu/ppc/registerMap_ppc.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "runtime/registerMap.hpp"
+
+address RegisterMap::pd_location(VMReg base_reg, int slot_idx) const {
+  if (base_reg->is_VectorSRegister()) {
+    // Not all physical slots belonging to a VectorRegister have corresponding
+    // valid VMReg locations in the RegisterMap.
+    // (See RegisterSaver::push_frame_reg_args_and_save_live_registers.)
+    // However, the slots are always saved to the stack in a contiguous region
+    // of memory so we can calculate the address of the upper slots by
+    // offsetting from the base address.
+    assert(base_reg->is_concrete(), "must pass base reg");
+    address base_location = location(base_reg);
+    if (base_location != nullptr) {
+      intptr_t offset_in_bytes = slot_idx * VMRegImpl::stack_slot_size;
+      return base_location + offset_in_bytes;
+    } else {
+      return nullptr;
+    }
+  } else {
+    return location(base_reg->next(slot_idx));
+  }
+}

--- a/src/hotspot/cpu/ppc/registerMap_ppc.hpp
+++ b/src/hotspot/cpu/ppc/registerMap_ppc.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2026 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,9 +35,7 @@
   // Since there is none, we just return NULL.
   address pd_location(VMReg reg) const { return NULL; }
 
-  address pd_location(VMReg base_reg, int slot_idx) const {
-    return location(base_reg->next(slot_idx));
-  }
+  address pd_location(VMReg base_reg, int slot_idx) const;
 
   // no PD state to clear or copy:
   void pd_clear() {}

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -100,7 +100,7 @@ class RegisterSaver {
 
   // During deoptimization only the result registers need to be restored
   // all the other values have already been extracted.
-  static void restore_result_registers(MacroAssembler* masm, int frame_size_in_bytes);
+  static void restore_result_registers(MacroAssembler* masm, int frame_size_in_bytes, bool save_vectors);
 
   // Constants and data structures:
 
@@ -350,6 +350,7 @@ OopMap* RegisterSaver::push_frame_reg_args_and_save_live_registers(MacroAssemble
     __ li(R30, offset);
     __ stxvd2x(as_VectorSRegister(reg_num), R30, R1_SP);
 
+    // RegisterMap::pd_location only uses the first VMReg for each VectorRegister.
     if (generate_oop_map) {
       map->set_callee_saved(VMRegImpl::stack2reg(offset>>2),
                             RegisterSaver_LiveVSRegs[i].vmreg);
@@ -523,10 +524,14 @@ void RegisterSaver::restore_argument_registers_and_pop_frame(MacroAssembler*masm
 }
 
 // Restore the registers that might be holding a result.
-void RegisterSaver::restore_result_registers(MacroAssembler* masm, int frame_size_in_bytes) {
+void RegisterSaver::restore_result_registers(MacroAssembler* masm, int frame_size_in_bytes, bool save_vectors) {
   const int regstosave_num       = sizeof(RegisterSaver_LiveRegs) /
                                    sizeof(RegisterSaver::LiveRegType);
-  const int register_save_size   = regstosave_num * reg_size; // VS registers not relevant here.
+  const int vecregstosave_num    = save_vectors ? (sizeof(RegisterSaver_LiveVSRegs) /
+                                                   sizeof(RegisterSaver::LiveRegType))
+                                                : 0;
+  const int register_save_size   = regstosave_num * reg_size + vecregstosave_num * vs_reg_size;
+
   const int register_save_offset = frame_size_in_bytes - register_save_size;
 
   // restore all result registers (ints and floats)
@@ -555,7 +560,7 @@ void RegisterSaver::restore_result_registers(MacroAssembler* masm, int frame_siz
     offset += reg_size;
   }
 
-  assert(offset == frame_size_in_bytes, "consistency check");
+  assert(offset == frame_size_in_bytes - (save_vectors ? vecregstosave_num * vs_reg_size : 0), "consistency check");
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?
@@ -2701,7 +2706,8 @@ void SharedRuntime::generate_deopt_blob() {
                                                                    &first_frame_size_in_bytes,
                                                                    /*generate_oop_map=*/ true,
                                                                    return_pc_adjustment_no_exception,
-                                                                   RegisterSaver::return_pc_is_lr);
+                                                                   RegisterSaver::return_pc_is_lr,
+                                                                   /*save_vectors*/ SuperwordUseVSX);
   assert(map != NULL, "OopMap must have been created");
 
   __ li(exec_mode_reg, Deoptimization::Unpack_deopt);
@@ -2736,7 +2742,8 @@ void SharedRuntime::generate_deopt_blob() {
                                                              &first_frame_size_in_bytes,
                                                              /*generate_oop_map=*/ false,
                                                              /*return_pc_adjustment_exception=*/ 0,
-                                                             RegisterSaver::return_pc_is_pre_saved);
+                                                             RegisterSaver::return_pc_is_pre_saved,
+                                                             /*save_vectors*/ SuperwordUseVSX);
 
   // Deopt during an exception. Save exec mode for unpack_frames.
   __ li(exec_mode_reg, Deoptimization::Unpack_exception);
@@ -2754,7 +2761,8 @@ void SharedRuntime::generate_deopt_blob() {
                                                              &first_frame_size_in_bytes,
                                                              /*generate_oop_map=*/ false,
                                                              /*return_pc_adjustment_reexecute=*/ 0,
-                                                             RegisterSaver::return_pc_is_pre_saved);
+                                                             RegisterSaver::return_pc_is_pre_saved,
+                                                             /*save_vectors*/ SuperwordUseVSX);
   __ li(exec_mode_reg, Deoptimization::Unpack_reexecute);
 #endif
 
@@ -2781,7 +2789,7 @@ void SharedRuntime::generate_deopt_blob() {
 
   // Restore only the result registers that have been saved
   // by save_volatile_registers(...).
-  RegisterSaver::restore_result_registers(masm, first_frame_size_in_bytes);
+  RegisterSaver::restore_result_registers(masm, first_frame_size_in_bytes, /*save_vectors*/ SuperwordUseVSX);
 
   // reload the exec mode from the UnrollBlock (it might have changed)
   __ lwz(exec_mode_reg, Deoptimization::UnrollBlock::unpack_kind_offset_in_bytes(), unroll_block_reg);

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -27,6 +27,7 @@
 #include "jvm.h"
 #include "asm/assembler.inline.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "compiler/compilerDefinitions.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/globals_extension.hpp"
@@ -129,7 +130,7 @@ void VM_Version::initialize() {
   }
 
   if (PowerArchitecturePPC64 >= 8) {
-    if (FLAG_IS_DEFAULT(SuperwordUseVSX)) {
+    if (FLAG_IS_DEFAULT(SuperwordUseVSX) && CompilerConfig::is_c2_enabled()) {
       FLAG_SET_ERGO(SuperwordUseVSX, true);
     }
   } else {

--- a/test/hotspot/jtreg/compiler/vectorapi/TestVectorReallocation.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestVectorReallocation.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2026 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package compiler.vectorapi;
+
+import java.util.Arrays;
+
+import compiler.lib.ir_framework.*;
+
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.ShortVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.VectorSpecies;
+
+import static jdk.test.lib.Asserts.*;
+
+/**
+ * @test
+ * @bug 8380565
+ * @library /test/lib /
+ * @summary Test deoptimization involving vector reallocation
+ * @modules jdk.incubator.vector
+ * @requires vm.opt.final.MaxVectorSize == null | vm.opt.final.MaxVectorSize >= 16
+ *
+ * @run driver compiler.vectorapi.TestVectorReallocation
+ */
+
+public class TestVectorReallocation {
+
+    private static final VectorSpecies<Byte>    B_SPECIES = ByteVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Short>   S_SPECIES = ShortVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Long>    L_SPECIES = LongVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Float>   F_SPECIES = FloatVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Double>  D_SPECIES = DoubleVector.SPECIES_PREFERRED;
+    private static final int B_LENGTH = B_SPECIES.length();
+    private static final int S_LENGTH = S_SPECIES.length();
+    private static final int I_LENGTH = I_SPECIES.length();
+    private static final int L_LENGTH = L_SPECIES.length();
+    private static final int F_LENGTH = F_SPECIES.length();
+    private static final int D_LENGTH = D_SPECIES.length();
+
+    // The input arrays for the @Test methods match the length of the preferred species for each type
+    private static byte[]   b_a;
+    private static short[]  s_a;
+    private static int[]    i_a;
+    private static long[]   l_a;
+    private static float[]  f_a;
+    private static double[] d_a;
+
+    // The output arrays for the @Test methods
+    private static byte[]   b_r;
+    private static short[]  s_r;
+    private static int[]    i_r;
+    private static long[]   l_r;
+    private static float[]  f_r;
+    private static double[] d_r;
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector");
+    }
+
+    // The test methods annotated with @Test are warmed up by the framework. The calls are indirect
+    // through the runner methods annotated with @Run. Note that each @Test method has its own instance of
+    // the test class TestVectorReallocation as receiver of the calls.
+    //
+    // The @Test methods just copy the elements of the input array (0, 1, 2, 3, ...) to the output array
+    // by means of a vector add operation. The added value is computed but actually always zero. The
+    // computation is done in a loop with a virtual call that is inlined based on class hierarchy analysis
+    // when the method gets compiled.
+    //
+    // The final call after warmup of the now compiled @Test method is performed concurrently in a second
+    // thread. Before the variable `loopIterations` is set very high such that the loop runs practically
+    // infinitely. While the loop is running, a class with an overridden version of the method `value`
+    // (called in the loop) is loaded. This invalidates the result of the class hierarchy analysis that
+    // there is just one implementation of the method and causes deoptimization where the vector `v0` used
+    // in the @Test method is reallocated from a register to the java heap. Finally it is verified that
+    // input and ouput arrays are equal.
+    //
+    // NB: each @Test needs its own Zero class for the desired result of the class hierarchy analysis.
+
+    volatile boolean enteredLoop;
+    volatile long loopIterations;
+
+    void sharedRunner(RunInfo runInfo, Runnable test, Runnable loadOverridingClass, Runnable verify) {
+        enteredLoop = false;
+        if (runInfo.isWarmUp()) {
+            loopIterations = 100;
+            test.run();
+        } else {
+            loopIterations = 1L << 60; // basically infinite
+            Thread t = new Thread(test);
+            t.start();
+            waitUntilLoopEntered();
+            loadOverridingClass.run(); // invalidates inlining causing deoptimization/reallocation of v0
+            loopIterations = 0;
+            waitUntilLoopLeft();
+            joinThread(t);
+            verify.run();              // verify that input and ouput arrays are equal
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // byte
+
+    static class ByteZero {
+        volatile byte zero;
+        byte value() {
+            return zero;
+        }
+    }
+    volatile ByteZero byteZero = new ByteZero();
+
+    @Run(test = "byteIdentityWithReallocation")
+    void byteIdentityWithReallocation_runner(RunInfo runInfo) {
+        sharedRunner(runInfo, () -> byteIdentityWithReallocation(), () -> {
+            // Loading the class with the overridden method will cause deoptimization and reallocation of v0
+            byteZero = new ByteZero() {
+                    @Override
+                    byte value() {
+                        return super.value(); // override but doing the same
+                    }
+                };
+            },
+            () -> assertTrue(Arrays.equals(b_a, b_r), "Input/Output arrays differ"));
+    }
+
+    @Test
+    void byteIdentityWithReallocation() {
+        ByteVector v0 = ByteVector.fromArray(B_SPECIES, b_a, 0);
+        byte zeroSum = 0;
+        enteredLoop = true;
+        for (long i = 0; i < loopIterations; i++) {
+            zeroSum += byteZero.value(); // inlined based on class hierarchy analysis
+        }
+        v0.add(zeroSum).intoArray(b_r, 0);
+        enteredLoop = false;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // short
+
+    static class ShortZero {
+        volatile short zero;
+        short value() {
+            return zero;
+        }
+    }
+    volatile ShortZero shortZero = new ShortZero();
+
+    @Run(test = "shortIdentityWithReallocation")
+    void shortIdentityWithReallocation_runner(RunInfo runInfo) {
+        sharedRunner(runInfo, () -> shortIdentityWithReallocation(), () -> {
+            // Loading the class with the overridden method will cause deoptimization and reallocation of v0
+            shortZero = new ShortZero() {
+                    @Override
+                    short value() {
+                        return super.value(); // override but doing the same
+                    }
+                };
+            },
+            () -> assertTrue(Arrays.equals(s_a, s_r), "Input/Output arrays differ"));
+    }
+
+    @Test
+    void shortIdentityWithReallocation() {
+        ShortVector v0 = ShortVector.fromArray(S_SPECIES, s_a, 0);
+        short zeroSum = 0;
+        enteredLoop = true;
+        for (long i = 0; i < loopIterations; i++) {
+            zeroSum += shortZero.value(); // inlined based on class hierarchy analysis
+        }
+        v0.add(zeroSum).intoArray(s_r, 0);
+        enteredLoop = false;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // int
+
+    static class IntZero {
+        volatile int zero;
+        int value() {
+            return zero;
+        }
+    }
+    volatile IntZero intZero = new IntZero();
+
+    @Run(test = "intIdentityWithReallocation")
+    void intIdentityWithReallocation_runner(RunInfo runInfo) {
+        sharedRunner(runInfo, () -> intIdentityWithReallocation(), () -> {
+            // Loading the class with the overridden method will cause deoptimization and reallocation of v0
+            intZero = new IntZero() {
+                    @Override
+                    int value() {
+                        return super.value(); // override but doing the same
+                    }
+                };
+            },
+            () -> assertTrue(Arrays.equals(i_a, i_r), "Input/Output arrays differ"));
+    }
+
+    @Test
+    void intIdentityWithReallocation() {
+        IntVector v0 = IntVector.fromArray(I_SPECIES, i_a, 0);
+        int zeroSum = 0;
+        enteredLoop = true;
+        for (long i = 0; i < loopIterations; i++) {
+            zeroSum += intZero.value(); // inlined based on class hierarchy analysis
+        }
+        v0.add(zeroSum).intoArray(i_r, 0);
+        enteredLoop = false;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // long
+
+    static class LongZero {
+        volatile long zero;
+        long value() {
+            return zero;
+        }
+    }
+    volatile LongZero longZero = new LongZero();
+
+    @Run(test = "longIdentityWithReallocation")
+    void longIdentityWithReallocation_runner(RunInfo runInfo) {
+        sharedRunner(runInfo, () -> longIdentityWithReallocation(), () -> {
+            // Loading the class with the overridden method will cause deoptimization and reallocation of v0
+            longZero = new LongZero() {
+                    @Override
+                    long value() {
+                        return super.value(); // override but doing the same
+                    }
+                };
+            },
+            () -> assertTrue(Arrays.equals(l_a, l_r), "Input/Output arrays differ"));
+    }
+
+    @Test
+    void longIdentityWithReallocation() {
+        LongVector v0 = LongVector.fromArray(L_SPECIES, l_a, 0);
+        long zeroSum = 0;
+        enteredLoop = true;
+        for (long i = 0; i < loopIterations; i++) {
+            zeroSum += longZero.value(); // inlined based on class hierarchy analysis
+        }
+        v0.add(zeroSum).intoArray(l_r, 0);
+        enteredLoop = false;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // float
+
+    static class FloatZero {
+        volatile float zero;
+        float value() {
+            return zero;
+        }
+    }
+    volatile FloatZero floatZero = new FloatZero();
+
+    @Run(test = "floatIdentityWithReallocation")
+    void floatIdentityWithReallocation_runner(RunInfo runInfo) {
+        sharedRunner(runInfo, () -> floatIdentityWithReallocation(), () -> {
+            // Loading the class with the overridden method will cause deoptimization and reallocation of v0
+            floatZero = new FloatZero() {
+                    @Override
+                    float value() {
+                        return super.value(); // override but doing the same
+                    }
+                };
+            },
+            () -> assertTrue(Arrays.equals(f_a, f_r), "Input/Output arrays differ"));
+    }
+
+    @Test
+    void floatIdentityWithReallocation() {
+        FloatVector v0 = FloatVector.fromArray(F_SPECIES, f_a, 0);
+        float zeroSum = 0;
+        enteredLoop = true;
+        for (long i = 0; i < loopIterations; i++) {
+            zeroSum += floatZero.value(); // inlined based on class hierarchy analysis
+        }
+        v0.add(zeroSum).intoArray(f_r, 0);
+        enteredLoop = false;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+    // double
+
+    static class DoubleZero {
+        volatile double zero;
+        double value() {
+            return zero;
+        }
+    }
+    volatile DoubleZero doubleZero = new DoubleZero();
+
+    @Run(test = "doubleIdentityWithReallocation")
+    void doubleIdentityWithReallocation_runner(RunInfo runInfo) {
+        sharedRunner(runInfo, () -> doubleIdentityWithReallocation(), () -> {
+            // Loading the class with the overridden method will cause deoptimization and reallocation of v0
+            doubleZero = new DoubleZero() {
+                    @Override
+                    double value() {
+                        return super.value(); // override but doing the same
+                    }
+                };
+            },
+            () -> assertTrue(Arrays.equals(d_a, d_r), "Input/Output arrays differ"));
+    }
+
+    @Test
+    void doubleIdentityWithReallocation() {
+        DoubleVector v0 = DoubleVector.fromArray(D_SPECIES, d_a, 0);
+        double zeroSum = 0;
+        enteredLoop = true;
+        for (long i = 0; i < loopIterations; i++) {
+            zeroSum += doubleZero.value(); // inlined based on class hierarchy analysis
+        }
+        v0.add(zeroSum).intoArray(d_r, 0);
+        enteredLoop = false;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////
+
+    private void waitUntilLoopEntered() {
+        while (!enteredLoop) {
+            sleep(10);
+        }
+    }
+
+    private void waitUntilLoopLeft() {
+        while (enteredLoop) {
+            sleep(10);
+        }
+    }
+
+    private static void sleep(int ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) { /* ignore */ }
+    }
+
+    private static void joinThread(Thread t) {
+        try {
+            t.join();
+        } catch (InterruptedException e) { /* ignore */ }
+    }
+
+    static {
+        b_a = new byte[B_LENGTH];
+        s_a = new short[S_LENGTH];
+        i_a = new int[I_LENGTH];
+        l_a = new long[L_LENGTH];
+        f_a = new float[F_LENGTH];
+        d_a = new double[D_LENGTH];
+
+        b_r = new byte[B_LENGTH];
+        s_r = new short[S_LENGTH];
+        i_r = new int[I_LENGTH];
+        l_r = new long[L_LENGTH];
+        f_r = new float[F_LENGTH];
+        d_r = new double[D_LENGTH];
+
+        for (int i = 0; i < b_a.length ; i++) {
+            b_a[i] = (byte)i;
+        }
+        for (int i = 0; i < s_a.length ; i++) {
+            s_a[i] = (short)i;
+        }
+        for (int i = 0; i < i_a.length ; i++) {
+            i_a[i] = i;
+        }
+        for (int i = 0; i < l_a.length ; i++) {
+            l_a[i] = i;
+        }
+        for (int i = 0; i < f_a.length ; i++) {
+            f_a[i] = i;
+        }
+        for (int i = 0; i < d_a.length ; i++) {
+            d_a[i] = i;
+        }
+    }
+}


### PR DESCRIPTION
Backport of [JDK-8380565](https://bugs.openjdk.org/browse/JDK-8380565).

Version from jdk21u only requires trivial adaptations:
- `location(base_reg)` doesn't take an additional argument (removed)
- `base_reg->next(slot_idx)` doesn't take an additional argument (removed)
- "compiler/compilerDefinitions.inline.hpp" doesn't exist ("inline" removed)
- "NULL" instead of "nullptr" in removed code
- Copyright year was different
- `Thread.ofPlatform().start(test);` in the test had to be replaced because it's Java 21 code
- `@IR` annotations are not supported (removed, therefore [JDK-8381315](https://bugs.openjdk.org/browse/JDK-8381315) is not needed)

The included regression test fails without this fix and passes with this fix.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8380565](https://bugs.openjdk.org/browse/JDK-8380565) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380565](https://bugs.openjdk.org/browse/JDK-8380565): PPC64: deoptimization stub should save vector registers (**Bug** - P3 - Approved)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4342/head:pull/4342` \
`$ git checkout pull/4342`

Update a local copy of the PR: \
`$ git checkout pull/4342` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4342`

View PR using the GUI difftool: \
`$ git pr show -t 4342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4342.diff">https://git.openjdk.org/jdk17u-dev/pull/4342.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4342#issuecomment-4156172496)
</details>
