### PR TITLE
8355332: Fix failing semi-manual test EDT issue

### DIFF
--- a/test/jdk/javax/swing/JScrollPane/AcceleratedWheelScrolling/HorizScrollers.java
+++ b/test/jdk/javax/swing/JScrollPane/AcceleratedWheelScrolling/HorizScrollers.java
@@ -161,8 +161,9 @@ public class HorizScrollers {
             if (scrollAmount != 3) {
                 JOptionPane.showMessageDialog(
                         ConfigPanel.this.getTopLevelAncestor(),
-                        ("Test %s. please make sure you have restored " +
-                                "the original speed value blah blah")
+                        ("Test %s. Please make sure you have restored " +
+                                "the original scrolling speed in the " +
+                                "Mouse settings.")
                                 .formatted(isFailure
                                         ? "failed"
                                         : "passed"),

--- a/test/jdk/javax/swing/JScrollPane/AcceleratedWheelScrolling/RTLScrollers.java
+++ b/test/jdk/javax/swing/JScrollPane/AcceleratedWheelScrolling/RTLScrollers.java
@@ -265,22 +265,21 @@ public class RTLScrollers extends JDialog
             }
         }
 
+        robot.delay(1000);
         SwingUtilities.invokeAndWait(() -> {
             rtl = new RTLScrollers(scrollAmount);
             rtl.setVisible(true);
         });
         robot.delay(100);
 
-        SwingUtilities.invokeAndWait(() -> {
-            try {
-                retVal = rtl.runTests(scrollAmount);
-            } catch (Exception e) {
-                e.printStackTrace();
-            } finally {
+        try {
+            retVal = rtl.runTests(scrollAmount);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
                 rtl.setVisible(false);
                 rtl.dispose();
-            }
-        });
+            });
+        }
 
         robot.delay(100);
         System.out.println("RTLS.runTest(): " + retVal);
@@ -312,9 +311,8 @@ public class RTLScrollers extends JDialog
         System.out.println("Testing List");
         testComp(list, scrollAmount);
 
-        SwingUtilities.invokeAndWait(() -> {
-            applyComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
-        });
+        SwingUtilities.invokeAndWait(() ->
+                applyComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT));
         robot.delay(100);
 
         System.out.println("Testing RTL Table");
@@ -467,9 +465,7 @@ public class RTLScrollers extends JDialog
         // Test acceleration for max scrolling
         // (this part should still work for RTL JList)
         if (scrollAmount == 30) {
-            SwingUtilities.invokeAndWait(() -> {
-                hsb.setValue(hsb.getMinimum());
-            });
+            SwingUtilities.invokeAndWait(() -> hsb.setValue(hsb.getMinimum()));
             robot.delay(100);
             robot.mouseWheel(2);
             robot.mouseWheel(2);


### PR DESCRIPTION
Backporting JDK-8355332: Fix failing semi-manual test EDT issue. Fixes failing test and confusing test language. Ran GHA Sanity Checks and fixed test directly to confirm passing. Patch is clean. Backporting for parity with Oracle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8355332](https://bugs.openjdk.org/browse/JDK-8355332) needs maintainer approval

### Issue
 * [JDK-8355332](https://bugs.openjdk.org/browse/JDK-8355332): Fix failing semi-manual test EDT issue (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4356/head:pull/4356` \
`$ git checkout pull/4356`

Update a local copy of the PR: \
`$ git checkout pull/4356` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4356`

View PR using the GUI difftool: \
`$ git pr show -t 4356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4356.diff">https://git.openjdk.org/jdk17u-dev/pull/4356.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4356#issuecomment-4195501729)
</details>
