### PR TITLE
8378201: [OGL] glXMakeContextCurrent() drops the buffers of the unbound drawable

### DIFF
--- a/src/java.desktop/unix/native/common/java2d/opengl/GLXSurfaceData.c
+++ b/src/java.desktop/unix/native/common/java2d/opengl/GLXSurfaceData.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@
 
 #ifndef HEADLESS
 
+#include <X11/Xresource.h>
+
 extern LockFunc       OGLSD_Lock;
 extern GetRasInfoFunc OGLSD_GetRasInfo;
 extern UnlockFunc     OGLSD_Unlock;
@@ -49,6 +51,74 @@ extern void
     OGLSD_SetNativeDimensions(JNIEnv *env, OGLSDOps *oglsdo, jint w, jint h);
 
 jboolean surfaceCreationFailed = JNI_FALSE;
+
+/**
+ * Per-Window GLXWindow entry with reference counting.
+ * Stored in an XContext keyed by the X Window XID.
+ */
+typedef struct {
+    GLXWindow glxWindow;
+    int       refCount;
+} GLXWindowRef;
+
+static XContext glxWindowContext;
+
+/**
+ * Gets or creates a shared GLXWindow for the given X Window.
+ * All callers are synchronized by the AWT lock.
+ */
+static GLXWindow acquireGLXWindow(Window window, GLXFBConfig fbconfig)
+{
+    if (glxWindowContext == 0) {
+        glxWindowContext = XUniqueContext();
+    }
+
+    XPointer data;
+    if (XFindContext(awt_display, window, glxWindowContext, &data) == 0) {
+        GLXWindowRef *ref = (GLXWindowRef *)data;
+        ref->refCount++;
+        return ref->glxWindow;
+    }
+
+    GLXWindow glxWin = j2d_glXCreateWindow(awt_display, fbconfig, window, NULL);
+    if (glxWin == 0) {
+        return 0;
+    }
+
+    GLXWindowRef *ref = malloc(sizeof(*ref));
+    if (ref == NULL) {
+        j2d_glXDestroyWindow(awt_display, glxWin);
+        return 0;
+    }
+    ref->glxWindow = glxWin;
+    ref->refCount = 1;
+    if (XSaveContext(awt_display, window, glxWindowContext, (XPointer)ref) != 0)
+    {
+        j2d_glXDestroyWindow(awt_display, glxWin);
+        free(ref);
+        return 0;
+    }
+    return glxWin;
+}
+
+/**
+ * Decrements the reference count for the GLXWindow associated with the given
+ * X Window. Destroys it when the count reaches zero.
+ * All callers are synchronized by the AWT lock.
+ */
+static void releaseGLXWindow(Window window)
+{
+    XPointer data;
+    if (XFindContext(awt_display, window, glxWindowContext, &data) != 0) {
+        return;
+    }
+    GLXWindowRef *ref = (GLXWindowRef *)data;
+    if (--ref->refCount <= 0) {
+        j2d_glXDestroyWindow(awt_display, ref->glxWindow);
+        XDeleteContext(awt_display, window, glxWindowContext);
+        free(ref);
+    }
+}
 
 #endif /* !HEADLESS */
 
@@ -74,7 +144,7 @@ Java_sun_java2d_opengl_GLXSurfaceData_initOps(JNIEnv *env, jobject glxsd,
     // later the graphicsConfig will be used for deallocation of oglsdo
     oglsdo->graphicsConfig = gc;
 
-    GLXSDOps *glxsdo = (GLXSDOps *)malloc(sizeof(GLXSDOps));
+    GLXSDOps *glxsdo = (GLXSDOps *)calloc(1, sizeof(GLXSDOps));
 
     if (glxsdo == NULL) {
         JNU_ThrowOutOfMemoryError(env, "creating native GLX ops");
@@ -125,8 +195,13 @@ Java_sun_java2d_opengl_GLXSurfaceData_initOps(JNIEnv *env, jobject glxsd,
 void
 OGLSD_DestroyOGLSurface(JNIEnv *env, OGLSDOps *oglsdo)
 {
+    GLXSDOps *glxsdo = (GLXSDOps *)oglsdo->privOps;
     J2dTraceLn(J2D_TRACE_INFO, "OGLSD_DestroyOGLSurface");
-    // X Window is free'd later by AWT code...
+    if (glxsdo != NULL && glxsdo->drawable != 0) {
+        releaseGLXWindow(glxsdo->window);
+        glxsdo->drawable = 0;
+        oglsdo->drawableType = OGLSD_UNDEFINED;
+    }
 }
 
 /**
@@ -296,6 +371,13 @@ OGLSD_InitOGLWindow(JNIEnv *env, OGLSDOps *oglsdo)
         return JNI_FALSE;
     }
 
+    glxsdo->drawable = acquireGLXWindow(window,
+                                        glxsdo->configData->glxInfo->fbconfig);
+    if (glxsdo->drawable == 0) {
+        J2dRlsTraceLn(J2D_TRACE_ERROR, "OGLSD_InitOGLWindow: GLXWindow is 0");
+        return JNI_FALSE;
+    }
+
     XGetWindowAttributes(awt_display, window, &attr);
     oglsdo->width = attr.width;
     oglsdo->height = attr.height;
@@ -304,7 +386,6 @@ OGLSD_InitOGLWindow(JNIEnv *env, OGLSDOps *oglsdo)
     oglsdo->isOpaque = JNI_TRUE;
     oglsdo->xOffset = 0;
     oglsdo->yOffset = 0;
-    glxsdo->drawable = window;
     glxsdo->xdrawable = window;
 
     J2dTraceLn2(J2D_TRACE_VERBOSE, "  created window: w=%d h=%d",
@@ -333,7 +414,16 @@ OGLSD_SwapBuffers(JNIEnv *env, jlong window)
         return;
     }
 
-    j2d_glXSwapBuffers(awt_display, (Window)window);
+    XPointer data;
+    if (XFindContext(awt_display, (Window)window, glxWindowContext, &data) != 0)
+    {
+        J2dRlsTraceLn(J2D_TRACE_ERROR,
+                      "OGLSD_SwapBuffers: GLXWindow not found");
+        return;
+    }
+
+    GLXWindowRef *ref = (GLXWindowRef *)data;
+    j2d_glXSwapBuffers(awt_display, ref->glxWindow);
 }
 
 // needed by Mac OS X port, no-op on other platforms

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -254,6 +254,7 @@ sun/awt/datatransfer/SuplementaryCharactersTransferTest.java 8011371 generic-all
 sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
+sun/java2d/OpenGL/MultiWindowFillTest.java 8378506 macosx-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all
 sun/java2d/SunGraphics2D/DrawImageBilinear.java 8191406 generic-all
 sun/java2d/SunGraphics2D/PolyVertTest.java 6986565 generic-all

--- a/test/jdk/sun/java2d/OpenGL/FlipCoexistTest.java
+++ b/test/jdk/sun/java2d/OpenGL/FlipCoexistTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferStrategy;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+import javax.imageio.ImageIO;
+
+/**
+ * @test
+ * @bug 8378201
+ * @key headful
+ * @summary Verifies that WINDOW and FLIP_BACKBUFFER surfaces sharing the same X
+ *          Window render and flip correctly
+ * @run main/othervm FlipCoexistTest
+ * @run main/othervm -Dsun.java2d.opengl=True FlipCoexistTest
+ */
+public final class FlipCoexistTest {
+
+    private static final int SIZE = 200;
+    private static final int TOLERANCE = 10;
+
+    public static void main(String[] args) throws Exception {
+        Frame f = new Frame("FlipCoexistTest");
+        try {
+            f.setUndecorated(true);
+            f.setSize(SIZE, SIZE);
+            f.setLocation(100, 100);
+            f.setVisible(true);
+
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            int w = f.getWidth();
+            int h = f.getHeight();
+
+            // Fill window RED via direct render (WINDOW surface)
+            Graphics g = f.getGraphics();
+            g.setColor(Color.RED);
+            g.fillRect(0, 0, w, h);
+            g.dispose();
+            robot.waitForIdle();
+            robot.delay(500);
+
+            // Request flip if available, blit is also useful to cover
+            f.createBufferStrategy(2);
+            BufferStrategy bs = f.getBufferStrategy();
+
+            // Render BLUE to back buffer, do not flip yet
+            Graphics bg = bs.getDrawGraphics();
+            bg.setColor(Color.BLUE);
+            bg.fillRect(0, 0, w, h);
+            bg.dispose();
+
+            // Paint small GREEN rect via direct render
+            g = f.getGraphics();
+            g.setColor(Color.GREEN);
+            g.fillRect(0, 0, 10, 10);
+            g.dispose();
+            robot.waitForIdle();
+            robot.delay(500);
+
+            // GREEN rect must be visible
+            check(robot, f, 5, 5, Color.GREEN, "small rect");
+
+            // RED must survive the context round-trip
+            check(robot, f, w / 2, h / 2, Color.RED, "survived");
+
+            // Show back buffer, BLUE must appear
+            bs.show();
+
+            robot.waitForIdle();
+            robot.delay(500);
+            check(robot, f, w / 2, h / 2, Color.BLUE, "flip");
+        } finally {
+            f.dispose();
+        }
+    }
+
+    private static void check(Robot robot, Frame frame, int x, int y, Color exp,
+                              String desc)
+    {
+        Point loc = frame.getLocationOnScreen();
+        Color c = robot.getPixelColor(loc.x + x, loc.y + y);
+        if (!isAlmostEqual(c, exp)) {
+            saveImage(robot, frame, desc);
+            throw new RuntimeException("%s: %s != %s".formatted(desc, exp, c));
+        }
+    }
+
+    private static void saveImage(Robot r, Frame f, String name) {
+        try {
+            Rectangle rect = f.getBounds();
+            BufferedImage img = r.createScreenCapture(rect);
+            ImageIO.write(img, "png", new File(name + ".png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static boolean isAlmostEqual(Color c1, Color c2) {
+        return Math.abs(c1.getRed() - c2.getRed()) <= TOLERANCE
+                && Math.abs(c1.getGreen() - c2.getGreen()) <= TOLERANCE
+                && Math.abs(c1.getBlue() - c2.getBlue()) <= TOLERANCE;
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/MultiWindowFillTest.java
+++ b/test/jdk/sun/java2d/OpenGL/MultiWindowFillTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+
+import javax.imageio.ImageIO;
+
+/**
+ * @test
+ * @bug 8378201
+ * @key headful
+ * @summary Verifies that window content survives a GL context switch to another
+ *          window and back
+ * @run main/othervm MultiWindowFillTest
+ * @run main/othervm -Dsun.java2d.opengl=True MultiWindowFillTest
+ */
+public final class MultiWindowFillTest {
+
+    private static final int SIZE = 100;
+    private static final int TOLERANCE = 10;
+
+    public static void main(String[] args) throws Exception {
+        Frame f1 = new Frame("f1");
+        Frame f2 = new Frame("f2");
+        try {
+            f1.setUndecorated(true);
+            f1.setSize(SIZE, SIZE);
+            f1.setLocation(100, 100);
+            f2.setUndecorated(true);
+            f2.setSize(SIZE, SIZE);
+            f2.setLocation(300, 100);
+
+            f1.setVisible(true);
+            f2.setVisible(true);
+
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            int w = f1.getWidth();
+            int h = f1.getHeight();
+
+            // Fill both, initializes surfaces
+            fill(f1, Color.RED, w, h);
+            fill(f2, Color.BLUE, w, h);
+
+            // Touch both again
+            fill(f1, Color.RED, 2, 2);
+            fill(f2, Color.BLUE, 2, 2);
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            check(robot, f1, w, h, Color.RED, "f1 red");
+            check(robot, f2, w, h, Color.BLUE, "f2 blue");
+        } finally {
+            f1.dispose();
+            f2.dispose();
+        }
+    }
+
+    private static void fill(Frame frame, Color c, int w, int h) {
+        Graphics g = frame.getGraphics();
+        g.setColor(c);
+        g.fillRect(0, 0, w, h);
+        g.dispose();
+    }
+
+    private static void check(Robot robot, Frame frame, int w, int h,
+                              Color exp, String desc)
+    {
+        Point loc = frame.getLocationOnScreen();
+        Color c = robot.getPixelColor(loc.x + w / 2, loc.y + h / 2);
+        if (!isAlmostEqual(c, exp)) {
+            saveImage(robot, frame, desc);
+            throw new RuntimeException("%s: %s != %s".formatted(desc, exp, c));
+        }
+    }
+
+    private static void saveImage(Robot r, Frame f, String name) {
+        try {
+            Rectangle rect = f.getBounds();
+            BufferedImage img = r.createScreenCapture(rect);
+            ImageIO.write(img, "png", new File(name + ".png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static boolean isAlmostEqual(Color c1, Color c2) {
+        return Math.abs(c1.getRed() - c2.getRed()) <= TOLERANCE
+                && Math.abs(c1.getGreen() - c2.getGreen()) <= TOLERANCE
+                && Math.abs(c1.getBlue() - c2.getBlue()) <= TOLERANCE;
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.20-oracle.

Resolved ProblemList

Ran the headful jdk_desktop tests succesfully.

Omitted javax/swing/plaf/nimbus/8057791/bug8057791.java because it is slow.
Four tests are failing:
sun/awt/font/TestArabicHebrew.java, SwingFontMetricsTest.java, NonEmptyErrorStream.java and UnninstallUIMemoryLeaks.java, but this happens also without the change, partially due to my setup.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8369561](https://bugs.openjdk.org/browse/JDK-8369561) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8378201](https://bugs.openjdk.org/browse/JDK-8378201) needs maintainer approval

### Issues
 * [JDK-8378201](https://bugs.openjdk.org/browse/JDK-8378201): [OGL] glXMakeContextCurrent() drops the buffers of the unbound drawable (**Bug** - P3 - Approved)
 * [JDK-8369561](https://bugs.openjdk.org/browse/JDK-8369561): sun/java2d/OpenGL/DrawBitmaskImage.java#id0: Incorrect color for first pixel (actual=ff000000) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4361/head:pull/4361` \
`$ git checkout pull/4361`

Update a local copy of the PR: \
`$ git checkout pull/4361` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4361`

View PR using the GUI difftool: \
`$ git pr show -t 4361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4361.diff">https://git.openjdk.org/jdk17u-dev/pull/4361.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4361#issuecomment-4213176359)
</details>
