### PR TITLE
8354163: Open source Swing tests Batch 1

### DIFF
--- a/test/jdk/javax/swing/AbstractButton/bug4133768.java
+++ b/test/jdk/javax/swing/AbstractButton/bug4133768.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2000, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4133768 4363569
+ * @summary Tests how button displays its icons
+ * @key headful
+ * @run main bug4133768
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import javax.swing.AbstractButton;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JToggleButton;
+import javax.swing.SwingUtilities;
+
+public class bug4133768 {
+    private static Icon RED, GREEN;
+    private static JFrame f;
+    private static AbstractButton[] buttons;
+    private static volatile Point buttonLocation;
+    private static volatile int buttonWidth;
+    private static volatile int buttonHeight;
+    private static Robot robot;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            createTestImages();
+            createUI();
+            robot = new Robot();
+            robot.delay(1000);
+            for (AbstractButton b : buttons) {
+                testEnabledButton(b);
+            }
+            for (AbstractButton b : buttons) {
+                b.setEnabled(false);
+                robot.delay(1000);
+                testDisabledButton(b);
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createTestImages() throws IOException {
+        int imageWidth = 32;
+        int imageHeight = 32;
+        BufferedImage redImg = new BufferedImage(imageWidth, imageHeight,
+            BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = redImg.createGraphics();
+        g.setColor(Color.RED);
+        g.fillRect(0, 0, imageWidth, imageHeight);
+        g.dispose();
+        RED = new ImageIcon(redImg);
+        BufferedImage greenImg = new BufferedImage(imageWidth, imageHeight,
+            BufferedImage.TYPE_INT_RGB);
+        g = greenImg.createGraphics();
+        g.setColor(Color.GREEN);
+        g.fillRect(0, 0, imageWidth, imageHeight);
+        g.dispose();
+        GREEN = new ImageIcon(greenImg);
+    }
+
+    private static void createUI() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            f = new JFrame("ButtonIconsTest");
+            buttons = new AbstractButton[] {
+                new JToggleButton(),
+                new JRadioButton(),
+                new JCheckBox()
+            };
+
+            JPanel buttonPanel = new JPanel();
+            for (int i = 0; i < buttons.length; i++) {
+                AbstractButton b = buttons[i];
+                b.setIcon(RED);
+                b.setSelected(true);
+                b.setRolloverSelectedIcon(GREEN);
+                buttonPanel.add(b);
+            }
+            f.setLayout(new GridLayout(2, 1));
+            f.add(buttonPanel);
+            f.pack();
+            f.setLocationRelativeTo(null);
+            f.setAlwaysOnTop(true);
+            f.setVisible(true);
+        });
+    }
+
+    private static void testEnabledButton(AbstractButton button) throws Exception {
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            buttonLocation = button.getLocationOnScreen();
+            buttonWidth = button.getWidth();
+            buttonHeight = button.getHeight();
+        });
+        robot.mouseMove(buttonLocation.x + buttonWidth / 2,
+            buttonLocation.y + buttonHeight / 2 );
+        robot.delay(1000);
+        Color buttonColor = robot.getPixelColor(buttonLocation.x +
+            buttonWidth / 2, buttonLocation.y + buttonHeight / 2);
+        if (!buttonColor.equals(Color.GREEN)) {
+            throw new RuntimeException("Button roll over color is : " +
+                buttonColor + " but it should be : " + Color.GREEN);
+        }
+    }
+
+    private static void testDisabledButton(AbstractButton button) throws Exception {
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            buttonLocation = button.getLocationOnScreen();
+            buttonWidth = button.getWidth();
+            buttonHeight = button.getHeight();
+        });
+        robot.mouseMove(buttonLocation.x + buttonWidth / 2,
+            buttonLocation.y + buttonHeight / 2 );
+        robot.delay(1000);
+        Color buttonColor = robot.getPixelColor(buttonLocation.x +
+            buttonWidth / 2, buttonLocation.y + buttonHeight / 2);
+        if (buttonColor.equals(Color.GREEN) ||
+            buttonColor.equals(Color.RED)) {
+            throw new RuntimeException("Disabled button color should not be : "
+                + buttonColor);
+        }
+    }
+}

--- a/test/jdk/javax/swing/AbstractButton/bug4391622.java
+++ b/test/jdk/javax/swing/AbstractButton/bug4391622.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4391622
+ * @summary The toolbar's button which is added as action should ignore text
+ * @key headful
+ * @run main bug4391622
+ */
+
+public class bug4391622 {
+    private static Icon RED, GREEN;
+    private static JButton bt;
+    private static JFrame f;
+    private static volatile Point buttonLocation;
+    private static volatile int buttonWidth;
+    private static volatile int buttonHeight;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            createTestImages();
+            createUI();
+            runTest();
+            verifyTest();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createTestImages() throws IOException {
+        int imageWidth = 32;
+        int imageHeight = 32;
+        BufferedImage redImg = new BufferedImage(imageWidth, imageHeight,
+            BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = redImg.createGraphics();
+        g.setColor(Color.RED);
+        g.fillRect(0, 0, imageWidth, imageHeight);
+        g.dispose();
+        RED = new ImageIcon(redImg);
+        BufferedImage greenImg = new BufferedImage(imageWidth, imageHeight,
+            BufferedImage.TYPE_INT_RGB);
+        g = greenImg.createGraphics();
+        g.setColor(Color.GREEN);
+        g.fillRect(0, 0, imageWidth, imageHeight);
+        g.dispose();
+        GREEN = new ImageIcon(greenImg);
+    }
+
+    private static void createUI() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            f = new JFrame("bug4391622");
+            Action changeIt = new ChangeIt();
+
+            JToolBar toolbar = new JToolBar();
+            bt = toolbar.add(changeIt);
+            f.add(bt);
+            f.pack();
+            f.setLocationRelativeTo(null);
+            f.setVisible(true);
+        });
+    }
+
+    private static void runTest() throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(500);
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            buttonLocation = bt.getLocationOnScreen();
+            buttonWidth = bt.getWidth();
+            buttonHeight = bt.getHeight();
+        });
+        robot.mouseMove(buttonLocation.x + buttonWidth / 2,
+            buttonLocation.y + buttonHeight / 2 );
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+    }
+
+    private static void verifyTest() {
+        if (bt.getText() != null) {
+            throw new RuntimeException("The toolbar's button shouldn't" +
+                " have any text.");
+        }
+    }
+
+    public static class ChangeIt extends AbstractAction {
+        private boolean c = true;
+
+        public ChangeIt() {
+            putValue(Action.NAME, "Red");
+            putValue(Action.SMALL_ICON, RED);
+        }
+
+        public void actionPerformed(ActionEvent event) {
+            c = !c;
+            putValue(Action.NAME, c ? "Red" : "Green");
+            putValue(Action.SMALL_ICON, c ? RED : GREEN);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JList/bug4183379.java
+++ b/test/jdk/javax/swing/JList/bug4183379.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4183379
+ * @summary JList has wrong scrolling behavior when you click in the "troth"
+ * of a scrollbar, in a scrollpane.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4183379
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+
+public class bug4183379 {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            Click mouse several times in the "troth" of a scrollbars
+            in a scrollpane containing a list.
+            The list should scrolls by one block, i.e.:
+
+            For vertical scrolling:
+              - if scrolling down the last visible element should become the
+              first completely visible element
+              - if scrolling up, the first visible element should become the
+              last completely visible element
+
+            For horizontal scrolling:
+              - for scrolling left if the beginning of the first column is not
+              visible it should become visible, otherwise the beginning of the
+              previous column should become visible;
+              - for scrolling right the next colunm after first visible column
+              should become visible.
+            """;
+        PassFailJFrame.builder()
+            .title("bug4183379 Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(35)
+            .testUI(bug4183379::initialize)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static JFrame initialize() {
+        JFrame fr = new JFrame("bug4183379");
+
+        String[] data = new String[90];
+        for (int i=0; i<90; i++) {
+            data[i] = "item number "+i;
+        }
+
+        JList lst = new JList(data);
+        lst.setLayoutOrientation(JList.VERTICAL_WRAP);
+        lst.setVisibleRowCount(20);
+
+        JScrollPane jsp = new JScrollPane(lst);
+        fr.add(jsp);
+        fr.setSize(210,200);
+        fr.setAlwaysOnTop(true);
+        return fr;
+    }
+}

--- a/test/jdk/javax/swing/JList/bug4251306.java
+++ b/test/jdk/javax/swing/JList/bug4251306.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4251306
+ * @summary Test that Shift-Space keybinding works properly in JList.
+ * @key headful
+ * @run main bug4251306
+ */
+
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.JFrame;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+
+public class bug4251306 {
+    private static JFrame f;
+    private static JList lst;
+    private static CountDownLatch listGainedFocusLatch;
+    private static volatile boolean failed;
+    public static void main(String[] args) throws Exception {
+        try {
+            listGainedFocusLatch = new CountDownLatch(1);
+            createUI();
+            runTest();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createUI() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            f = new JFrame("bug4251306");
+            lst = new JList<>(new String[]{"anaheim", "bill",
+                "chicago", "dingo"});
+            lst.addFocusListener(new FocusAdapter() {
+                @Override
+                public void focusGained(FocusEvent e) {
+                    listGainedFocusLatch.countDown();
+                }
+            });
+            JScrollPane sp = new JScrollPane(lst);
+            f.add(sp);
+            f.pack();
+            f.setLocationRelativeTo(null);
+            f.setAlwaysOnTop(true);
+            f.setVisible(true);
+        });
+    }
+
+    private static void runTest() throws Exception {
+        if (!listGainedFocusLatch.await(3, TimeUnit.SECONDS)) {
+            throw new RuntimeException("Waited too long, but can't gain focus for list");
+        }
+        Robot robot = new Robot();
+        robot.setAutoDelay(500);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_A);
+        robot.keyRelease(KeyEvent.VK_A);
+        robot.waitForIdle();
+        robot.keyPress(KeyEvent.VK_SHIFT);
+        robot.keyPress(KeyEvent.VK_SPACE);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
+        robot.keyPress(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_DOWN);
+        robot.keyRelease(KeyEvent.VK_SPACE);
+        robot.keyRelease(KeyEvent.VK_SHIFT);
+
+        SwingUtilities.invokeAndWait(() -> {
+            if (!lst.isSelectedIndex(0) ||
+                !lst.isSelectedIndex(1) ||
+                !lst.isSelectedIndex(2) ||
+                !lst.isSelectedIndex(3)) {
+                failed = true;
+            }
+        });
+        if (failed) {
+            throw new RuntimeException("Required list items are not selected");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JMenu/bug4624845.java
+++ b/test/jdk/javax/swing/JMenu/bug4624845.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4624845
+ * @requires (os.family == "windows")
+ * @summary Tests how submenus in WinLAF are painted
+ * @key headful
+ * @run main bug4624845
+ */
+
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class bug4624845 {
+    private static JFrame f;
+    private static JMenu menu, subMenu;
+    private static JMenuItem menuItem;
+    private static volatile Point menuLocation;
+    private static volatile Point subMenuLocation;
+    private static volatile Point menuItemLocation;
+    private static volatile int menuWidth;
+    private static volatile int menuHeight;
+    private static volatile int subMenuWidth;
+    private static volatile int subMenuHeight;
+    private static volatile int menuItemWidth;
+    private static volatile int menuItemHeight;
+    private static Color menuItemColor;
+    private static Color subMenuColor;
+    private static boolean passed;
+    private final static int OFFSET = 2;
+    private static final int COLOR_TOLERANCE = 10;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel
+                ("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set Windows LAF");
+        }
+        try {
+            bug4624845 test = new bug4624845();
+            SwingUtilities.invokeAndWait(() -> test.createUI());
+            runTest();
+            verifyColor();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+        if (!passed) {
+            throw new RuntimeException("Nested MenuItem color : " +
+                menuItemColor + " is not similar to sub Menu color : "
+                + subMenuColor);
+        }
+    }
+    private void createUI() {
+        f = new JFrame("bug4624845");
+        menu = new JMenu("Menu");
+        menu.add(new JMenuItem("Item 1"));
+
+        subMenu = new JMenu("Submenu");
+        menuItem = new JMenuItem("This");
+        subMenu.add(menuItem);
+        subMenu.add(new JMenuItem("That"));
+        menu.add(subMenu);
+
+        JMenuBar mBar = new JMenuBar();
+        mBar.add(menu);
+        f.add(mBar);
+        f.pack();
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+    private static void runTest() throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(200);
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            menuLocation = menu.getLocationOnScreen();
+            menuWidth = menu.getWidth();
+            menuHeight = menu.getHeight();
+        });
+        robot.mouseMove(menuLocation.x + menuWidth / 2,
+            menuLocation.y + menuHeight / 2 );
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            subMenuLocation = subMenu.getLocationOnScreen();
+            subMenuWidth = subMenu.getWidth();
+            subMenuHeight = subMenu.getHeight();
+        });
+        robot.mouseMove(subMenuLocation.x + subMenuWidth / 2,
+            subMenuLocation.y + subMenuHeight / 2 );
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        subMenuColor = robot.
+            getPixelColor(subMenuLocation.x + OFFSET,
+                subMenuLocation.y + OFFSET);
+        SwingUtilities.invokeAndWait(() -> {
+            menuItemLocation = menuItem.getLocationOnScreen();
+            menuItemWidth = subMenu.getWidth();
+            menuItemHeight = subMenu.getHeight();
+        });
+        robot.mouseMove(menuItemLocation.x + menuItemWidth / 2,
+            menuItemLocation.y + menuItemHeight / 2 );
+        robot.waitForIdle();
+        menuItemColor = robot.
+            getPixelColor(menuItemLocation.x + OFFSET,
+                menuItemLocation.y + OFFSET);
+    }
+
+    private static void verifyColor() {
+
+        int red1 = subMenuColor.getRed();
+        int blue1 = subMenuColor.getBlue();
+        int green1 = subMenuColor.getGreen();
+
+        int red2 = menuItemColor.getRed();
+        int blue2 = menuItemColor.getBlue();
+        int green2 = menuItemColor.getGreen();
+
+        passed = true;
+        if ((Math.abs(red1 - red2) > COLOR_TOLERANCE)
+            || (Math.abs(green1 - green2) > COLOR_TOLERANCE)
+            || (Math.abs(blue1 - blue2) > COLOR_TOLERANCE)) {
+            passed = false;
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8354163: Open source Swing tests Batch 1. Adds five opensource javax swing tests. Ran GHA Sanity Checks and new (non-windows) tests directly. Patch is clean. Backporting for parity with Oracle.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8354163](https://bugs.openjdk.org/browse/JDK-8354163) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354163](https://bugs.openjdk.org/browse/JDK-8354163): Open source Swing tests Batch 1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4362/head:pull/4362` \
`$ git checkout pull/4362`

Update a local copy of the PR: \
`$ git checkout pull/4362` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4362`

View PR using the GUI difftool: \
`$ git pr show -t 4362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4362.diff">https://git.openjdk.org/jdk17u-dev/pull/4362.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4362#issuecomment-4218283794)
</details>
