### PR TITLE
8373239: Test java/awt/print/PrinterJob/PageRanges.java fails with incorrect selection of printed pages

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1743,6 +1743,10 @@ public final class WPrinterJob extends RasterPrinterJob
             if (isRangeSet) {
                 attributes.add(new PageRanges(from, to));
                 setPageRange(from, to);
+            } else {
+                attributes.remove(PageRanges.class);
+                setPageRange(Pageable.UNKNOWN_NUMBER_OF_PAGES,
+                             Pageable.UNKNOWN_NUMBER_OF_PAGES);
             }
             defaultCopies = false;
             attributes.add(new Copies(copies));

--- a/test/jdk/java/awt/print/PrinterJob/PageRanges.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageRanges.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 6575331 8297191
+ * @bug 6575331 8297191 8373239
  * @key printer
  * @summary The specified pages should be printed.
  * @run main/manual=yesno PageRanges


### PR DESCRIPTION
I backport this for parity with 17.0.20-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8373239](https://bugs.openjdk.org/browse/JDK-8373239) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373239](https://bugs.openjdk.org/browse/JDK-8373239): Test java/awt/print/PrinterJob/PageRanges.java fails with incorrect selection of printed pages (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4368/head:pull/4368` \
`$ git checkout pull/4368`

Update a local copy of the PR: \
`$ git checkout pull/4368` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4368`

View PR using the GUI difftool: \
`$ git pr show -t 4368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4368.diff">https://git.openjdk.org/jdk17u-dev/pull/4368.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4368#issuecomment-4260308375)
</details>
