### PR TITLE
8378417: Printing All pages results in NPE for 1.1 PrintJob

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1743,6 +1743,10 @@ public final class WPrinterJob extends RasterPrinterJob
             if (isRangeSet) {
                 attributes.add(new PageRanges(from, to));
                 setPageRange(from, to);
+            } else {
+                attributes.remove(PageRanges.class);
+                setPageRange(Pageable.UNKNOWN_NUMBER_OF_PAGES,
+                             Pageable.UNKNOWN_NUMBER_OF_PAGES);
             }
             defaultCopies = false;
             attributes.add(new Copies(copies));

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -1744,7 +1744,9 @@ public final class WPrinterJob extends RasterPrinterJob
                 attributes.add(new PageRanges(from, to));
                 setPageRange(from, to);
             } else {
-                attributes.remove(PageRanges.class);
+                // Sets default values for PageRange attribute and setPageRange
+                attributes.add(new PageRanges(1,
+                                              Integer.MAX_VALUE));
                 setPageRange(Pageable.UNKNOWN_NUMBER_OF_PAGES,
                              Pageable.UNKNOWN_NUMBER_OF_PAGES);
             }

--- a/test/jdk/java/awt/PrintJob/TestPrintNoException.java
+++ b/test/jdk/java/awt/PrintJob/TestPrintNoException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.JobAttributes;
+import java.awt.PrintJob;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
+
+/*
+ * @test
+ * @bug 8378417
+ * @key headful printer
+ * @summary Verifies No Exception is thrown when Printing "All" pages
+ * @run main TestPrintNoException
+ */
+
+public class TestPrintNoException {
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        Thread t = new Thread (() -> {
+            robot.delay(5000);
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+            robot.waitForIdle();
+        });
+
+        Frame testFrame = new Frame("print");
+        try {
+            t.start();
+            PrintJob pj = Toolkit.getDefaultToolkit().getPrintJob(testFrame, null, null);
+            if (pj != null) {
+                pj.end();
+            }
+        } finally {
+            testFrame.dispose();
+        }
+    }
+}

--- a/test/jdk/java/awt/print/PrinterJob/PageRanges.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageRanges.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 6575331 8297191 8373239
+ * @bug 6575331 8297191 8373239 8378417
  * @key printer
  * @summary The specified pages should be printed.
  * @run main/manual=yesno PageRanges

--- a/test/jdk/java/awt/print/PrinterJob/PageRanges.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageRanges.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 6575331 8297191
+ * @bug 6575331 8297191 8373239
  * @key printer
  * @summary The specified pages should be printed.
  * @run main/manual=yesno PageRanges


### PR DESCRIPTION
I backport this for parity with 17.0.20-oracle

Based on change in 25.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8378417](https://bugs.openjdk.org/browse/JDK-8378417) needs maintainer approval

### Issue
 * [JDK-8378417](https://bugs.openjdk.org/browse/JDK-8378417): Printing All pages results in NPE for 1.1 PrintJob (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4369/head:pull/4369` \
`$ git checkout pull/4369`

Update a local copy of the PR: \
`$ git checkout pull/4369` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4369`

View PR using the GUI difftool: \
`$ git pr show -t 4369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4369.diff">https://git.openjdk.org/jdk17u-dev/pull/4369.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4369#issuecomment-4260436485)
</details>
