### PR TITLE
8323089: networkaddress.cache.ttl is not a system property

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,8 +165,8 @@ import sun.nio.cs.UTF_8;
  * caching. Likewise, a system admin can configure a different
  * negative caching TTL value when needed.
  *
- * <p> Two Java security properties control the TTL values used for
- *  positive and negative host name resolution caching:
+ * <p> Two Java {@linkplain java.security.Security security} properties control
+ *  the TTL values used for positive and negative host name resolution caching:
  *
  * <dl style="margin-left:2em">
  * <dt><b>networkaddress.cache.ttl</b></dt>

--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
- Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -261,14 +261,14 @@ successful or not, so that subsequent identical requests will not
 have to access the naming service. These properties allow for some
 tuning on how the cache is operating.</P>
 <UL>
-	<LI><P><B>{@systemProperty networkaddress.cache.ttl}</B> (default: see below)<BR>
+	<LI><P><B>{@code networkaddress.cache.ttl}</B> (default: see below)<BR>
 	Value is an integer corresponding to the number of seconds successful
 	name lookups will be kept in the cache. A value of -1, or any other
 	negative value for that matter,	indicates a &ldquo;cache forever&rdquo;
 	policy, while a value of 0 (zero) means no caching. The default value
 	is -1 (forever) if a security manager is installed, and implementation-specific
 	when no security manager is installed.</P>
-	<LI><P><B>{@systemProperty networkaddress.cache.negative.ttl}</B> (default: {@code 10})<BR>
+	<LI><P><B>{@code networkaddress.cache.negative.ttl}</B> (default: {@code 10})<BR>
 	Value is an integer corresponding to the number of seconds an
 	unsuccessful name lookup will be kept in the cache. A value of -1,
 	or any negative value, means &ldquo;cache forever&rdquo;, while a
@@ -276,7 +276,7 @@ tuning on how the cache is operating.</P>
 </UL>
 <P>Since these 2 properties are part of the security policy, they are
 not set by either the -D option or the {@code System.setProperty()} API,
-instead they are set as security properties.</P>
+instead they are set as {@linkplain java.security.Security security} properties.</P>
 <a id="Unixdomain"></a>
 <H2>Unix domain sockets</H2>
 <p>


### PR DESCRIPTION
I backport this for parity with 17.0.20-oracle

Trivial resolves needed. 
17 knows one less ttl security property as https://bugs.openjdk.org/browse/JDK-8304885: Reuse stale data to improve DNS resolver resiliency is only in 21.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323089](https://bugs.openjdk.org/browse/JDK-8323089) needs maintainer approval

### Issue
 * [JDK-8323089](https://bugs.openjdk.org/browse/JDK-8323089): networkaddress.cache.ttl is not a system property (**Bug** - P4 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4371/head:pull/4371` \
`$ git checkout pull/4371`

Update a local copy of the PR: \
`$ git checkout pull/4371` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4371`

View PR using the GUI difftool: \
`$ git pr show -t 4371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4371.diff">https://git.openjdk.org/jdk17u-dev/pull/4371.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4371#issuecomment-4266721332)
</details>
