### PR TITLE
8320677: Printer tests use invalid '@run main/manual=yesno

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PageRanges.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageRanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,58 +21,63 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 6575331 8297191 8373239 8378417
  * @key printer
  * @summary The specified pages should be printed.
- * @run main/manual=yesno PageRanges
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
+ * @run main/manual PageRanges
  */
 
-import java.awt.*;
-import java.awt.print.*;
+import java.awt.Graphics;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import jtreg.SkippedException;
 
 public class PageRanges implements Printable {
-
-    static String[] instr = {
-     "This test prints two jobs, and tests that the specified range",
-     "of pages is printed. You must have a printer installed for this test.",
-     "In the first dialog, select a page range of 2 to 3, and press OK",
-     "In the second dialog, select ALL, to print all pages (in total 5 pages).",
-     "Collect the two print outs and confirm the jobs printed correctly",
-    };
+    private static final String INSTRUCTIONS = """
+                 This test prints two jobs and tests that the specified range
+                 of pages is printed.
+                 In the first dialog, select a page range of 2 to 3, and press OK.
+                 In the second dialog, select ALL, to print all pages (in total 5 pages).
+                 Collect the two print outs and confirm the jobs are printed correctly.
+                 """;
 
     public static void main(String args[]) throws Exception {
-        for (int i=0;i<instr.length;i++) {
-            System.out.println(instr[i]);
-        }
         PrinterJob job = PrinterJob.getPrinterJob();
         if (job.getPrintService() == null) {
-           System.out.println("No printers. Test cannot continue.");
-           return;
+            throw new SkippedException("Printer not configured or available.");
         }
-        job.setPrintable(new PageRanges());
-        if (!job.printDialog()) {
-           return;
-        }
-        job.print();
-        if (!job.printDialog()) {
-           return;
-        }
-        job.print();
 
-        return;
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .build();
+
+        job.setPrintable(new PageRanges());
+        if (job.printDialog()) {
+            job.print();
+        }
+        if (job.printDialog()) {
+            job.print();
+        }
+
+        passFailJFrame.awaitAndCheck();
     }
 
     public int print(Graphics g, PageFormat pf, int pi)
-                     throws PrinterException  {
-
+                     throws PrinterException {
         if (pi >= 5) {
             return NO_SUCH_PAGE;
         }
 
         g.drawString("Page : " + (pi+1), 200, 200);
-
         return PAGE_EXISTS;
     }
 }

--- a/test/jdk/java/awt/print/PrinterJob/PolylinePrintingTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PolylinePrintingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,31 +21,56 @@
  * questions.
  */
 
-/**
+/*
+ * @test
  * @bug 8041902
  * @key printer
  * @summary Test printing of wide poly lines.
- * @run main/manual=yesno PolylinePrintingTest
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
+ * @run main/manual PolylinePrintingTest
  */
 
-import java.awt.Dialog;
-import java.awt.Frame;
-import java.awt.TextArea;
 import java.awt.BasicStroke;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.geom.Path2D;
 import java.awt.print.PageFormat;
-import java.awt.print.Paper;
 import java.awt.print.Printable;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
+import jtreg.SkippedException;
 
 public class PolylinePrintingTest implements Printable {
+    private static final String INSTRUCTIONS = """
+              Press OK in the print dialog and collect the printed page.
+              Passing test : Output should show two identical chevrons.
+              Failing test : The line joins will appear different.
+              """;
+
+    public static void main(String[] args) throws Exception {
+        PrinterJob job = PrinterJob.getPrinterJob();
+        if (job.getPrintService() == null) {
+            throw new SkippedException("Printer not configured or available.");
+        }
+
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(45)
+                .build();
+
+        job.setPrintable(new PolylinePrintingTest());
+        if (job.printDialog()) {
+            job.print();
+        }
+
+        passFailJFrame.awaitAndCheck();
+    }
 
     public int print(Graphics graphics, PageFormat pageFormat,
                      int pageIndex) throws PrinterException {
-
         if (pageIndex > 0) {
             return NO_SUCH_PAGE;
         }
@@ -66,7 +91,6 @@ public class PolylinePrintingTest implements Printable {
 
     private void drawPolylineGOOD(Graphics2D g2d,
                                   int[] x2Points, int[] y2Points) {
-
         Path2D polyline =
             new Path2D.Float(Path2D.WIND_EVEN_ODD, x2Points.length);
 
@@ -83,141 +107,4 @@ public class PolylinePrintingTest implements Printable {
         g.translate(0, offset);
         g.drawPolyline(xp, yp, xp.length);
     }
-
-    public PolylinePrintingTest() throws PrinterException {
-        PrinterJob job = PrinterJob.getPrinterJob();
-        PageFormat pf = job.defaultPage();
-        Paper p = pf.getPaper();
-        p.setImageableArea(0,0,p.getWidth(), p.getHeight());
-        pf.setPaper(p);
-        job.setPrintable(this, pf);
-        if (job.printDialog()) {
-            job.print();
-        }
-    }
-
-    public static void main(String[] args) throws PrinterException {
-        String[] instructions = {
-             "You must have a printer available to perform this test.",
-             "OK the print dialog, and collect the printed page.",
-             "Passing test : Output should show two identical chevrons.",
-             "Failing test : The line joins will appear different."
-           };
-        Sysout.createDialog();
-        Sysout.printInstructions(instructions);
-        new PolylinePrintingTest();
-    }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-  TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
-}// TestDialog  class
-


### PR DESCRIPTION
I backport this for parity with 17.0.20-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8320677](https://bugs.openjdk.org/browse/JDK-8320677) needs maintainer approval

### Issue
 * [JDK-8320677](https://bugs.openjdk.org/browse/JDK-8320677): Printer tests use invalid '@<!---->run main/manual=yesno (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4373/head:pull/4373` \
`$ git checkout pull/4373`

Update a local copy of the PR: \
`$ git checkout pull/4373` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4373`

View PR using the GUI difftool: \
`$ git pr show -t 4373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4373.diff">https://git.openjdk.org/jdk17u-dev/pull/4373.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4373#issuecomment-4286638435)
</details>
