### PR TITLE
8323672: Suppress unwanted autoconf added flags in CC and CXX

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -360,7 +360,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_POST_DETECTION],
 [
   # Restore old path, except for the microsoft toolchain, which requires the
   # toolchain path to remain in place. Otherwise the compiler will not work in
-  # some siutations in later configure checks.
+  # some situations in later configure checks.
   if test "x$TOOLCHAIN_TYPE" != "xmicrosoft"; then
     PATH="$OLD_PATH"
   fi
@@ -369,10 +369,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_POST_DETECTION],
   # This is necessary since AC_PROG_CC defaults CFLAGS to "-g -O2"
   CFLAGS="$ORG_CFLAGS"
   CXXFLAGS="$ORG_CXXFLAGS"
-
-  # filter out some unwanted additions autoconf may add to CXX; we saw this on macOS with autoconf 2.72
-  UTIL_GET_NON_MATCHING_VALUES(cxx_filtered, $CXX, -std=c++11 -std=gnu++11)
-  CXX="$cxx_filtered"
 ])
 
 # Check if a compiler is of the toolchain type we expect, and save the version

--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -26,6 +26,70 @@
 m4_include([util_paths.m4])
 
 ###############################################################################
+# Overwrite the existing version of AC_PROG_CC with our own custom variant.
+# Unlike the regular AC_PROG_CC, the compiler list must always be passed.
+AC_DEFUN([AC_PROG_CC],
+[
+  AC_LANG_PUSH(C)
+  AC_ARG_VAR([CC], [C compiler command])
+  AC_ARG_VAR([CFLAGS], [C compiler flags])
+
+  _AC_ARG_VAR_LDFLAGS()
+  _AC_ARG_VAR_LIBS()
+  _AC_ARG_VAR_CPPFLAGS()
+
+  AC_CHECK_TOOLS(CC, [$1])
+
+  test -z "$CC" && AC_MSG_FAILURE([no acceptable C compiler found in \$PATH])
+
+  # Provide some information about the compiler.
+  _AS_ECHO_LOG([checking for _AC_LANG compiler version])
+  set X $ac_compile
+  ac_compiler=$[2]
+  for ac_option in --version -v -V -qversion -version; do
+    _AC_DO_LIMIT([$ac_compiler $ac_option >&AS_MESSAGE_LOG_FD])
+  done
+
+  m4_expand_once([_AC_COMPILER_EXEEXT])
+  m4_expand_once([_AC_COMPILER_OBJEXT])
+
+  _AC_PROG_CC_G
+
+  AC_LANG_POP(C)
+])
+
+###############################################################################
+# Overwrite the existing version of AC_PROG_CXX with our own custom variant.
+# Unlike the regular AC_PROG_CXX, the compiler list must always be passed.
+AC_DEFUN([AC_PROG_CXX],
+[
+  AC_LANG_PUSH(C++)
+  AC_ARG_VAR([CXX], [C++ compiler command])
+  AC_ARG_VAR([CXXFLAGS], [C++ compiler flags])
+
+  _AC_ARG_VAR_LDFLAGS()
+  _AC_ARG_VAR_LIBS()
+  _AC_ARG_VAR_CPPFLAGS()
+
+  AC_CHECK_TOOLS(CXX, [$1])
+
+  # Provide some information about the compiler.
+  _AS_ECHO_LOG([checking for _AC_LANG compiler version])
+  set X $ac_compile
+  ac_compiler=$[2]
+  for ac_option in --version -v -V -qversion; do
+    _AC_DO_LIMIT([$ac_compiler $ac_option >&AS_MESSAGE_LOG_FD])
+  done
+
+  m4_expand_once([_AC_COMPILER_EXEEXT])
+  m4_expand_once([_AC_COMPILER_OBJEXT])
+
+  _AC_PROG_CXX_G
+
+  AC_LANG_POP(C++)
+])
+
+################################################################################
 # Create a function/macro that takes a series of named arguments. The call is
 # similar to AC_DEFUN, but the setup of the function looks like this:
 # UTIL_DEFUN_NAMED([MYFUNC], [FOO *BAR], [$@], [


### PR DESCRIPTION
Modern `autoconf` configures the C/C++ standards versions based on the compiler path, causing failures for the GHA integration tests for macOS. This patch makes the OpenJDK Makefiles responsible for C and C++ compiler detection. This should resolve the current GHA failures issues for macOS.

I worked from [@gnu-andrew 's backport to 21u](https://github.com/openjdk/jdk21u-dev/pull/2812).

Testing: configure and build on linux; the macos GHA jobs have passed the build phase (which is where they were getting stuck for 11u although it seems not for 17u); configure and build on macOS.

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8323672](https://bugs.openjdk.org/browse/JDK-8323672) needs maintainer approval

### Issue
 * [JDK-8323672](https://bugs.openjdk.org/browse/JDK-8323672): Suppress unwanted autoconf added flags in CC and CXX (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4375/head:pull/4375` \
`$ git checkout pull/4375`

Update a local copy of the PR: \
`$ git checkout pull/4375` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4375`

View PR using the GUI difftool: \
`$ git pr show -t 4375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4375.diff">https://git.openjdk.org/jdk17u-dev/pull/4375.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4375#issuecomment-4287668958)
</details>
