### PR TITLE
8298823: [macos] java/awt/Mouse/EnterExitEvents/DragWindowTest.java continues to fail with "No MouseReleased event on label!"

### DIFF
--- a/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
+++ b/test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,8 @@
  * @key headful
  * @bug 7154048
  * @summary Window created under a mouse does not receive mouse enter event.
- *     Mouse Entered/Exited events are wrongly generated during dragging the window
- *     from one component to another
- * @library ../../regtesthelpers
- * @build Util
- * @author alexandr.scherbatiy area=awt.event
+ *     Mouse Entered/Exited events are wrongly generated during dragging the
+ *     window from one component to another
  * @run main DragWindowTest
  */
 
@@ -50,76 +47,67 @@ import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
-import java.util.concurrent.Callable;
-
-import test.java.awt.regtesthelpers.Util;
-
 public class DragWindowTest {
-
     private static volatile int dragWindowMouseEnteredCount = 0;
-    private static volatile int dragWindowMouseReleasedCount = 0;
     private static volatile int buttonMouseEnteredCount = 0;
     private static volatile int labelMouseReleasedCount = 0;
+
+    private static volatile Point pointToClick;
+    private static volatile Point pointToDrag;
+
     private static MyDragWindow dragWindow;
     private static JLabel label;
     private static JButton button;
+    private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
 
-        Robot robot = new Robot();
-        robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(DragWindowTest::createAndShowGUI);
 
-        SwingUtilities.invokeAndWait(new Runnable() {
+            robot.delay(250);
+            robot.waitForIdle();
 
-            @Override
-            public void run() {
-                createAndShowGUI();
+            SwingUtilities.invokeAndWait(() -> {
+                pointToClick = getCenterPoint(label);
+                pointToDrag = getCenterPoint(button);
+            });
+
+            robot.mouseMove(pointToClick.x, pointToClick.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(250);
+
+            if (dragWindowMouseEnteredCount != 1) {
+                throw new RuntimeException("No MouseEntered event on Drag Window!");
             }
-        });
 
-        robot.delay(250);
-        robot.waitForIdle();
+            // Reset entered count to check if mouse entered starting from here
+            buttonMouseEnteredCount = 0;
+            robot.mouseMove(pointToDrag.x, pointToDrag.y);
+            robot.waitForIdle();
+            robot.delay(250);
 
-        Point pointToClick = Util.invokeOnEDT(new Callable<Point>() {
-
-            @Override
-            public Point call() throws Exception {
-                return getCenterPoint(label);
+            if (buttonMouseEnteredCount != 0) {
+                throw new RuntimeException("Extra MouseEntered event on button!");
             }
-        });
 
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            robot.delay(250);
 
-        robot.mouseMove(pointToClick.x, pointToClick.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.waitForIdle();
-
-        if (dragWindowMouseEnteredCount != 1) {
-            throw new RuntimeException("No MouseEntered event on Drag Window!");
-        }
-
-        Point pointToDrag = Util.invokeOnEDT(new Callable<Point>() {
-
-            @Override
-            public Point call() throws Exception {
-                button.addMouseListener(new ButtonMouseListener());
-                return getCenterPoint(button);
+            if (labelMouseReleasedCount != 1) {
+                throw new RuntimeException("No MouseReleased event on label!");
             }
-        });
-
-        robot.mouseMove(pointToDrag.x, pointToDrag.y);
-        robot.waitForIdle();
-
-        if (buttonMouseEnteredCount != 0) {
-            throw new RuntimeException("Extra MouseEntered event on button!");
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
-
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        robot.waitForIdle();
-
-        if (labelMouseReleasedCount != 1) {
-            throw new RuntimeException("No MouseReleased event on label!");
-        }
-
     }
 
     private static Point getCenterPoint(Component comp) {
@@ -129,8 +117,7 @@ public class DragWindowTest {
     }
 
     private static void createAndShowGUI() {
-
-        JFrame frame = new JFrame("Main Frame");
+        frame = new JFrame("DragWindowTest");
         frame.setSize(300, 200);
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
@@ -142,6 +129,7 @@ public class DragWindowTest {
 
         button = new JButton("Button");
         Panel panel = new Panel(new BorderLayout());
+        button.addMouseListener(new ButtonMouseListener());
 
         panel.add(label, BorderLayout.NORTH);
         panel.add(button, BorderLayout.CENTER);
@@ -149,7 +137,6 @@ public class DragWindowTest {
         frame.getContentPane().add(panel);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
-
     }
 
     private static Point getAbsoluteLocation(MouseEvent e) {
@@ -157,7 +144,6 @@ public class DragWindowTest {
     }
 
     static class MyDragWindow extends Window {
-
         static int d = 30;
 
         public MyDragWindow(Window parent, Point location) {
@@ -176,8 +162,6 @@ public class DragWindowTest {
     }
 
     static class LabelMouseListener extends MouseAdapter {
-
-        Point origin;
         Window parent;
 
         public LabelMouseListener(Window parent) {
@@ -210,20 +194,13 @@ public class DragWindowTest {
     }
 
     static class DragWindowMouseListener extends MouseAdapter {
-
         @Override
         public void mouseEntered(MouseEvent e) {
             dragWindowMouseEnteredCount++;
         }
-
-        @Override
-        public void mouseReleased(MouseEvent e) {
-            dragWindowMouseReleasedCount++;
-        }
     }
 
     static class ButtonMouseListener extends MouseAdapter {
-
         @Override
         public void mouseEntered(MouseEvent e) {
             buttonMouseEnteredCount++;


### PR DESCRIPTION
Backporting JDK-8298823: [macos] java/awt/Mouse/EnterExitEvents/DragWindowTest.java continues to fail with "No MouseReleased event on label!".

This PR fixes DragWindowTest.java, which was failing on macOS.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Mouse/EnterExitEvents/DragWindowTest.java

Results attached:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27213684/macos-aarch64-specific-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/27245257/windows-x64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27245258/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27245259/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8298823](https://bugs.openjdk.org/browse/JDK-8298823) needs maintainer approval

### Issue
 * [JDK-8298823](https://bugs.openjdk.org/browse/JDK-8298823): [macos] java/awt/Mouse/EnterExitEvents/DragWindowTest.java continues to fail with "No MouseReleased event on label!" (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4380/head:pull/4380` \
`$ git checkout pull/4380`

Update a local copy of the PR: \
`$ git checkout pull/4380` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4380`

View PR using the GUI difftool: \
`$ git pr show -t 4380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4380.diff">https://git.openjdk.org/jdk17u-dev/pull/4380.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4380#issuecomment-4345803696)
</details>
