### PR TITLE
8374888: Implement internal test cache to help UserIterCount test performance

### DIFF
--- a/test/jdk/sun/security/krb5/auto/UserIterCount.java
+++ b/test/jdk/sun/security/krb5/auto/UserIterCount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,11 +30,19 @@
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
  * @run main/othervm -Djdk.net.hosts.file=TestHosts UserIterCount
  */
+
+import java.util.HashMap;
+
+import sun.security.krb5.EncryptionKey;
+import sun.security.krb5.KrbException;
 import sun.security.krb5.PrincipalName;
 
 public class UserIterCount {
 
     static class MyKDC extends OneKDC {
+        static final HashMap<String, EncryptionKey> CACHE
+                = new HashMap<>();
+
         public MyKDC() throws Exception {
             super(null);
         }
@@ -50,6 +58,18 @@ public class UserIterCount {
             } else {
                 return super.getParams(p, etype);
             }
+        }
+
+        @Override
+        EncryptionKey keyForUser(PrincipalName p, int etype, boolean server)
+                throws KrbException {
+            var key = p.toString() + etype + server;
+            var v = CACHE.get(key);
+            if (v == null) {
+                v = super.keyForUser(p, etype, server);
+                CACHE.put(key, v);
+            }
+            return v;
         }
     }
 


### PR DESCRIPTION
We see this issue failing in this release.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374888](https://bugs.openjdk.org/browse/JDK-8374888) needs maintainer approval

### Issue
 * [JDK-8374888](https://bugs.openjdk.org/browse/JDK-8374888): Implement internal test cache to help UserIterCount test performance (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4385/head:pull/4385` \
`$ git checkout pull/4385`

Update a local copy of the PR: \
`$ git checkout pull/4385` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4385`

View PR using the GUI difftool: \
`$ git pr show -t 4385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4385.diff">https://git.openjdk.org/jdk17u-dev/pull/4385.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4385#issuecomment-4351569739)
</details>
