### PR TITLE
8341292: Open some TextArea awt tests 3

### DIFF
--- a/test/jdk/java/awt/TextArea/PrintTextTest.java
+++ b/test/jdk/java/awt/TextArea/PrintTextTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.PrintJob;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4075786
+ * @key printer
+ * @summary Test that container prints multiline text properly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PrintTextTest
+*/
+
+public class PrintTextTest extends Frame implements ActionListener {
+    Panel p;
+
+    static final String INSTRUCTIONS = """
+                Press "Print" button and check that multiline test
+                printed correctly. If so press Pass, otherwise Fail.
+                """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("PrintTextTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(PrintTextTest::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public PrintTextTest() {
+        p = new Panel();
+        p.setLayout(new BorderLayout());
+        TextArea text_area = new TextArea("multi\nline\ntext\nfield\nis \nhere\n!!!!\n");
+
+        TextField text_field = new TextField("single line textfield");
+        Button button = new Button("button");
+        Label label = new Label("single line label");
+        p.add("South", text_area);
+        p.add("North", new TextArea("one single line of textarea"));
+        p.add("Center", text_field);
+        p.add("West", button);
+
+        add("North", p);
+
+        Button b = new Button("Print");
+        b.addActionListener(this);
+        add("South", b);
+        pack();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        PrintJob pjob = getToolkit().getPrintJob(this, "Print", null);
+        if (pjob != null) {
+            Graphics pg = pjob.getGraphics();
+
+            if (pg != null) {
+                p.printAll(pg);
+                pg.dispose();  //flush page
+            }
+            pjob.end();
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8341292: Open some TextArea awt tests 3.

This PR introduces new AWT TextArea related tests.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/java/awt/TextArea/PrintTextTest.java```

Screenshot:

<img width="1088" height="871" alt="Screenshot 2026-04-30 at 9 11 03 AM" src="https://github.com/user-attachments/assets/aa23d45b-4be9-4f0d-8189-95cf11dbef8e" />

Results:

```test result: Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Failure Reason: Empty printout```

[PrintTextTest.jtr.txt](https://github.com/user-attachments/files/27250490/PrintTextTest.jtr.txt)

[1.pdf](https://github.com/user-attachments/files/27250493/1.pdf)

Please note that this is a manual test, so the failure should not be a blocker. The issue may be a problem with the test itself or the JDK.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8341292](https://bugs.openjdk.org/browse/JDK-8341292) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341292](https://bugs.openjdk.org/browse/JDK-8341292): Open some TextArea awt tests 3 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4389/head:pull/4389` \
`$ git checkout pull/4389`

Update a local copy of the PR: \
`$ git checkout pull/4389` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4389`

View PR using the GUI difftool: \
`$ git pr show -t 4389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4389.diff">https://git.openjdk.org/jdk17u-dev/pull/4389.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4389#issuecomment-4354211796)
</details>
