### PR TITLE
8339975: Open some dialog awt tests 2

### DIFF
--- a/test/jdk/java/awt/Dialog/DialogDisposeLeak.java
+++ b/test/jdk/java/awt/Dialog/DialogDisposeLeak.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.FontMetrics;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Label;
+import java.awt.Toolkit;
+import java.awt.event.MouseEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.MouseAdapter;
+
+/*
+ * @test
+ * @bug 4193022
+ * @summary Test for bug(s): 4193022, disposing dialog leaks memory
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DialogDisposeLeak
+ */
+
+public class DialogDisposeLeak {
+    private static final String INSTRUCTIONS = """
+            Click on the Dialog... button in the frame that appears.
+            Now dismiss the dialog by clicking on the label in the dialog.
+
+            Repeat this around 10 times. At some point the label in the frame should change
+            to indicated that the dialog has been garbage collected and the test passed.
+            """;
+
+    public static void main(String args[]) throws Exception {
+        Frame frame = new DisposeFrame();
+        PassFailJFrame.builder()
+                .title("DialogDisposeLeak")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(frame)
+                .build()
+                .awaitAndCheck();
+    }
+}
+
+class DisposeFrame extends Frame {
+    Label label = new Label("Test not passed yet");
+
+    DisposeFrame() {
+        super("DisposeLeak test");
+        setLayout(new FlowLayout());
+        Button btn = new Button("Dialog...");
+        add(btn);
+        btn.addActionListener(ev -> {
+                    Dialog dlg = new DisposeDialog(DisposeFrame.this);
+                    dlg.setVisible(true);
+                }
+        );
+        add(label);
+        pack();
+    }
+
+    public void testOK() {
+        label.setText("Test has passed. Dialog finalized.");
+    }
+}
+
+class DisposeDialog extends Dialog {
+    DisposeDialog(Frame frame) {
+        super(frame, "DisposeDialog", true);
+        setLocation(frame.getX(), frame.getY());
+
+        setLayout(new FlowLayout());
+        LightweightComp lw = new LightweightComp("Click here to dispose");
+        lw.addMouseListener(
+                new MouseAdapter() {
+                    public void mouseEntered(MouseEvent ev) {
+                        System.out.println("Entered lw");
+                    }
+
+                    public void mouseExited(MouseEvent ev) {
+                        System.out.println("Exited lw");
+                    }
+
+                    public void mouseReleased(MouseEvent ev) {
+                        System.out.println("Released lw");
+                        DisposeDialog.this.dispose();
+                        // try to force GC and finalization
+                        for (int n = 0; n < 100; n++) {
+                            byte[] bytes = new byte[1024 * 1024 * 8];
+                            System.gc();
+                        }
+                    }
+                }
+        );
+        add(lw);
+        pack();
+    }
+
+    public void finalize() {
+        ((DisposeFrame) getParent()).testOK();
+    }
+}
+
+// simple lightweight component, focus traversable, highlights upon focus
+class LightweightComp extends Component {
+    FontMetrics fm;
+    String label;
+    private static final int FOCUS_GONE = 0;
+    private static final int FOCUS_TEMP = 1;
+    private static final int FOCUS_HAVE = 2;
+    int focusLevel = FOCUS_GONE;
+    public static int nameCounter = 0;
+
+    public LightweightComp(String lwLabel) {
+        label = lwLabel;
+        enableEvents(AWTEvent.FOCUS_EVENT_MASK | AWTEvent.MOUSE_EVENT_MASK);
+        setName("lw" + nameCounter++);
+    }
+
+    public Dimension getPreferredSize() {
+        if (fm == null) fm = Toolkit.getDefaultToolkit().getFontMetrics(getFont());
+        return new Dimension(fm.stringWidth(label) + 2, fm.getHeight() + 2);
+    }
+
+    public void paint(Graphics g) {
+        Dimension s = getSize();
+
+        // erase the background
+        g.setColor(getBackground());
+        g.fillRect(0, 0, s.width, s.height);
+
+        g.setColor(getForeground());
+
+        // draw the string
+        g.drawString(label, 2, fm.getHeight());
+
+        // draw a focus rectangle
+        if (focusLevel > FOCUS_GONE) {
+            if (focusLevel == FOCUS_TEMP) {
+                g.setColor(Color.gray);
+            } else {
+                g.setColor(Color.blue);
+            }
+        } else {
+            g.setColor(Color.black);
+        }
+        g.drawRect(1, 1, s.width - 2, s.height - 2);
+    }
+
+    public boolean isFocusTraversable() {
+        return true;
+    }
+
+    protected void processFocusEvent(FocusEvent e) {
+        super.processFocusEvent(e);
+        if (e.getID() == FocusEvent.FOCUS_GAINED) {
+            focusLevel = FOCUS_HAVE;
+        } else {
+            if (e.isTemporary()) {
+                focusLevel = FOCUS_TEMP;
+            } else {
+                focusLevel = FOCUS_GONE;
+            }
+        }
+        repaint();
+    }
+
+    protected void processMouseEvent(MouseEvent e) {
+        if (e.getID() == MouseEvent.MOUSE_PRESSED) {
+            requestFocus();
+        }
+        super.processMouseEvent(e);
+    }
+}
+

--- a/test/jdk/java/awt/Dialog/FileDialogTest.java
+++ b/test/jdk/java/awt/Dialog/FileDialogTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Container;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4105025 4153487 4177107 4146229 4119383 4181310 4152317
+ * @summary Test: FileDialogTest
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FileDialogTest
+ */
+
+public class FileDialogTest extends Panel implements ActionListener {
+    Button buttonShow, buttonNullShow, buttonShowHide, buttonShowDispose;
+    TextField fieldFile;
+    TextField fieldDir;
+    TextField fieldTitle;
+    private static final String INSTRUCTIONS = """
+             1. Set file, directory, and title fields to some real values
+                Title will not show on macos dialog
+             2. Click the "Get File..." button.
+             3. Verify that dialog is set to proper file and directory, and that
+                title is also set.
+             4. Select a file and OK the dialog
+                (or whatever the selection button is).
+             5. Verify that the file and directory fields reflect the file chosen.
+             6. Now, click the "Get null File with null Directory..." button.
+             7. Verify that the file list matches the listed directory.
+             8. Cancel or OK the dialog.
+             9. Verify that no NullPointerException is thrown.
+            10. Now, click the "Show FileDialog, then hide() in 5 s..." button.
+            11. Wait for 5 seconds. The FileDialog should then
+                disappear automatically.
+            12. 12-14 are Windows specific. Set file to some invalid value,
+                like "/<>++".
+            13. Click the "Get File..." button.
+            14. Verify that FileDialog is shown with empty "file" field.
+            15. Run the test on different locales. Verify that filter string
+                "All Files" is localized.
+            """;
+
+    public static void main(String args[]) throws Exception {
+        Frame frame = new Frame("FileDialogTest");
+        frame.setLayout(new GridLayout());
+        frame.add(new FileDialogTest());
+        frame.pack();
+
+        PassFailJFrame.builder()
+                .title("FileDialogTest")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(frame)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public FileDialogTest() {
+        setLayout(new GridLayout(6, 2));
+
+        buttonShow = new Button("Get File...");
+        add(buttonShow);
+        buttonNullShow = new Button("Get null File with null Directory...");
+        add(buttonNullShow);
+        buttonShowHide = new Button("Show FileDialog, then hide() in 5 s...");
+        add(buttonShowHide);
+        buttonShowDispose =
+                new Button("Show FileDialog, then dispose() in 5 s...");
+        add(buttonShowDispose);
+
+        add(new Label(""));
+        add(new Label(""));
+
+        add(new Label("File:"));
+        fieldFile = new TextField(20);
+        add(fieldFile);
+
+        add(new Label("Directory:"));
+        fieldDir = new TextField(20);
+        add(fieldDir);
+
+        add(new Label("Title:"));
+        fieldTitle = new TextField(20);
+        fieldTitle.setText("TestTitle");
+        add(fieldTitle);
+
+        buttonShow.addActionListener(this);
+        buttonNullShow.addActionListener(this);
+        buttonShowHide.addActionListener(this);
+        buttonShowDispose.addActionListener(this);
+    }
+
+    public void actionPerformed(ActionEvent evt) {
+        if (evt.getSource() == buttonShow) {
+            FileDialog fd = new FileDialog(getFrame(), fieldTitle.getText());
+            fd.setFile(fieldFile.getText());
+            fd.setDirectory(fieldDir.getText());
+            fd.show();
+            System.out.println("back from show");
+            fieldFile.setText(fd.getFile());
+            fieldDir.setText(fd.getDirectory());
+            fd.dispose();
+        } else if (evt.getSource() == buttonNullShow) {
+            FileDialog fd = new FileDialog(getFrame(), fieldTitle.getText());
+            fd.setFile(null);
+            fd.setDirectory(null);
+            fd.show();
+            System.out.println("back from show");
+            fieldFile.setText(fd.getFile());
+            fieldDir.setText(fd.getDirectory());
+            fd.setFile(null);
+            fd.setDirectory(null);
+            fd.dispose();
+        } else if (evt.getSource() == buttonShowHide) {
+            final FileDialog fd = new FileDialog(getFrame(),
+                    fieldTitle.getText());
+            fd.setFile(fieldFile.getText());
+            fd.setDirectory(fieldDir.getText());
+            new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        Thread.currentThread().sleep(5000);
+                    } catch (InterruptedException ex) {
+                    }
+                    fd.hide();
+                }
+            }).start();
+            fd.show();
+            System.out.println("back from show");
+            fd.dispose();
+        } else if (evt.getSource() == buttonShowDispose) {
+            final FileDialog fd = new FileDialog(getFrame(),
+                    fieldTitle.getText());
+            fd.setFile(fieldFile.getText());
+            fd.setDirectory(fieldDir.getText());
+            new Thread(() -> {
+                try {
+                    Thread.currentThread().sleep(5000);
+                } catch (InterruptedException ex) {
+                }
+                fd.dispose();
+            }).start();
+            fd.show();
+            System.out.println("back from show");
+            fd.dispose();
+        }
+    }
+
+    private Frame getFrame() {
+        Container cont = getParent();
+        while (cont != null) {
+            if (cont instanceof Frame) {
+                return (Frame) cont;
+            }
+            cont = cont.getParent();
+        }
+        return null;
+    }
+}

--- a/test/jdk/java/awt/Dialog/TaskbarIconTest.java
+++ b/test/jdk/java/awt/Dialog/TaskbarIconTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+import java.awt.print.PageFormat;
+import java.awt.print.PrinterJob;
+
+/*
+ * @test
+ * @bug 6488834
+ * @requires (os.family == "windows")
+ * @summary Tests that native dialogs (file, page, print) appear or
+    don't appear on the windows taskbar depending of their parent
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TaskbarIconTest
+*/
+
+public class TaskbarIconTest {
+    private static WindowListener wl = new WindowAdapter() {
+        public void windowClosing(WindowEvent we) {
+            Window w = we.getWindow();
+            w.dispose();
+            Window owner = w.getOwner();
+            if (owner != null) {
+                owner.dispose();
+            }
+        }
+    };
+
+    private static ActionListener al = new ActionListener() {
+        public void actionPerformed(ActionEvent ae) {
+            Button b = (Button) ae.getSource();
+
+            String bLabel = b.getLabel();
+            boolean hasParent = (bLabel.indexOf("parentless") < 0);
+            Frame parent = hasParent ? new Frame("Parent") : null;
+
+            if (bLabel.startsWith("Java")) {
+                Dialog d = new Dialog(parent, "Java dialog", true);
+                d.setBounds(0, 0, 160, 120);
+                d.addWindowListener(wl);
+                d.setVisible(true);
+            } else if (bLabel.startsWith("File")) {
+                FileDialog d = new FileDialog(parent, "File dialog");
+                d.setVisible(true);
+            } else if (bLabel.startsWith("Print")) {
+                PrinterJob pj = PrinterJob.getPrinterJob();
+                pj.printDialog();
+            } else if (bLabel.startsWith("Page")) {
+                PrinterJob pj = PrinterJob.getPrinterJob();
+                pj.pageDialog(new PageFormat());
+            }
+        }
+    };
+
+    private static final String INSTRUCTIONS = """
+            When the test starts a frame 'Main' is shown. It contains
+            several buttons, pressing each of them shows a dialog.
+            Some of the dialogs have a parent window, others are
+            parentless, according to the corresponding button's test.
+
+            Press each button one after another. Make sure that all
+            parentless dialogs have an icon in the windows taskbar
+            and all the dialogs with parents don't. Press PASS or
+            FAIL button depending on the result.
+
+            Note: as all the dialogs shown are modal, you have to close
+            them before showing the next dialog or PASS or FAIL buttons."
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("WindowInputBlock")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(TaskbarIconTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Button b;
+
+        Frame mainFrame = new Frame("Main");
+        mainFrame.setBounds(120, 240, 160, 240);
+        mainFrame.setLayout(new GridLayout(6, 1));
+
+        b = new Button("Java dialog, with parent");
+        b.addActionListener(al);
+        mainFrame.add(b);
+
+        b = new Button("Java dialog, parentless");
+        b.addActionListener(al);
+        mainFrame.add(b);
+
+        b = new Button("File dialog, with parent");
+        b.addActionListener(al);
+        mainFrame.add(b);
+
+        b = new Button("File dialog, parentless");
+        b.addActionListener(al);
+        mainFrame.add(b);
+
+        b = new Button("Print dialog, parentless");
+        b.addActionListener(al);
+        mainFrame.add(b);
+
+        b = new Button("Page dialog, parentless");
+        b.addActionListener(al);
+        mainFrame.add(b);
+
+        return mainFrame;
+    }
+}

--- a/test/jdk/java/awt/Dialog/WindowInputBlock.java
+++ b/test/jdk/java/awt/Dialog/WindowInputBlock.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+/*
+ * @test
+ * @bug 4124096
+ * @summary Modal JDialog is not modal on Solaris
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual WindowInputBlock
+ */
+
+public class WindowInputBlock {
+    private static final String INSTRUCTIONS = """
+            When the Window is up, you see a "Show Modal Dialog" button, a
+            "Test" button and a TextField.
+            Verify that the "Test" button is clickable, and the TextField can
+            receive focus.
+
+            Now, click on "Show Modal Dialog" button to bring up a modal dialog
+            and verify that both "Test" button and TextField are not accessible.
+            Close the new dialog window. If the test behaved as described, pass
+            this test. Otherwise, fail this test.
+
+            """;
+
+    public static void main(String[] argv) throws Exception {
+        JFrame frame = new ModalDialogTest();
+        PassFailJFrame.builder()
+                .title("WindowInputBlock")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(frame)
+                .build()
+                .awaitAndCheck();
+    }
+}
+
+class ModalDialogTest extends JFrame implements ActionListener {
+    JDialog dialog = new JDialog(new JFrame(), "Modal Dialog", true);
+
+    public ModalDialogTest() {
+        setTitle("Modal Dialog Test");
+        JPanel controlPanel = new JPanel();
+        JPanel infoPanel = new JPanel();
+        JButton showButton = new JButton("Show Modal Dialog");
+        JButton testButton = new JButton("Test");
+        JTextField textField = new JTextField("Test");
+
+        getContentPane().setLayout(new BorderLayout());
+        infoPanel.setLayout(new GridLayout(0, 1));
+
+        showButton.setOpaque(true);
+        showButton.setBackground(Color.yellow);
+
+        testButton.setOpaque(true);
+        testButton.setBackground(Color.pink);
+
+        controlPanel.add(showButton);
+        controlPanel.add(testButton);
+        controlPanel.add(textField);
+
+        infoPanel.add(new JLabel("Click the \"Show Modal Dialog\" button " +
+                "to display a modal JDialog."));
+        infoPanel.add(new JLabel("Click the \"Test\" button to verify " +
+                "dialog modality."));
+
+        getContentPane().add(BorderLayout.NORTH, controlPanel);
+        getContentPane().add(BorderLayout.SOUTH, infoPanel);
+        dialog.setSize(200, 200);
+
+        showButton.addActionListener(this);
+        testButton.addActionListener(this);
+
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                System.exit(0);
+            }
+
+            public void windowClosed(WindowEvent e) {
+                System.exit(0);
+            }
+        });
+
+        pack();
+        setSize(450, 120);
+    }
+
+    public void actionPerformed(ActionEvent evt) {
+        String command = evt.getActionCommand();
+
+        if (command == "Show Modal Dialog") {
+            System.out.println("*** Invoking JDialog.show() ***");
+            dialog.setLocation(200, 200);
+            dialog.setVisible(true);
+        } else if (command == "Test") {
+            System.out.println("*** Test ***");
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8339975: Open some dialog awt tests 2.

This PR introduces new AWT dialog related tests.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/java/awt/Dialog/DialogDisposeLeak.java```

Screenshot:

<img width="548" height="510" alt="Screenshot 2026-04-30 at 11 29 46 AM" src="https://github.com/user-attachments/assets/e2184095-2ca1-40a1-8874-05b50427c1f4" />

Results:

```test result: Passed. Execution successful```

[DialogDisposeLeak.jtr.txt](https://github.com/user-attachments/files/27255586/DialogDisposeLeak.jtr.txt)

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/java/awt/Dialog/FileDialogTest.java```

Screenshot:

<img width="633" height="773" alt="Screenshot 2026-04-30 at 11 32 16 AM" src="https://github.com/user-attachments/assets/5437e57f-6ed6-4b38-b8ca-8a785713acb1" />

Results:

```test result: Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Failure Reason: Didn't hide in 5s```

[FileDialogTest.jtr.txt](https://github.com/user-attachments/files/27256269/FileDialogTest.jtr.txt)

Please note that this is a manual test, so it wouldn't be a blocker to include. This may be a valid issue on the JDK.

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/java/awt/Dialog/WindowInputBlock.java```

Screenshot:

<img width="746" height="528" alt="Screenshot 2026-04-30 at 11 37 35 AM" src="https://github.com/user-attachments/assets/60b27342-33f1-4611-8b23-c734d34a16f0" />

Results:

```test result: Passed. Execution successful```

[WindowInputBlock.jtr.txt](https://github.com/user-attachments/files/27256731/WindowInputBlock.jtr.txt)

Ran related test on windows-x64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/java/awt/Dialog/TaskbarIconTest.java```

Screenshot:

<img width="653" height="368" alt="Screenshot 2026-04-30 at 12 13 55 PM" src="https://github.com/user-attachments/assets/0cf55115-3da3-4ecb-bc07-11693a219a7d" />

Results:

```test result: Passed. Execution successful```

[TaskbarIconTest.jtr.log](https://github.com/user-attachments/files/27257838/TaskbarIconTest.jtr.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8339975](https://bugs.openjdk.org/browse/JDK-8339975) needs maintainer approval

### Issue
 * [JDK-8339975](https://bugs.openjdk.org/browse/JDK-8339975): Open some dialog awt tests 2 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4393/head:pull/4393` \
`$ git checkout pull/4393`

Update a local copy of the PR: \
`$ git checkout pull/4393` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4393`

View PR using the GUI difftool: \
`$ git pr show -t 4393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4393.diff">https://git.openjdk.org/jdk17u-dev/pull/4393.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4393#issuecomment-4355525848)
</details>
