### PR TITLE
8369858: Remove darcy author tags from jdk tests

### DIFF
--- a/test/jdk/java/io/Serializable/cloneArray/CloneArray.java
+++ b/test/jdk/java/io/Serializable/cloneArray/CloneArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 /* @test
  * @bug 6990094
  * @summary Verify ObjectInputStream.cloneArray works on many kinds of arrays
- * @author Stuart Marks, Joseph D. Darcy
  */
 
 import java.io.ByteArrayInputStream;

--- a/test/jdk/java/lang/Byte/Decode.java
+++ b/test/jdk/java/lang/Byte/Decode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
  * @test
  * @bug 4242173 5017980 6576055
  * @summary Test Byte.decode method
- * @author madbot
- * @author Joseph D. Darcy
  */
 
 /**

--- a/test/jdk/java/lang/Class/IsAnnotationType.java
+++ b/test/jdk/java/lang/Class/IsAnnotationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4891872 4988155
  * @summary Check isAnnotation() method
- * @author Joseph D. Darcy
  */
 
 import java.lang.annotation.*;

--- a/test/jdk/java/lang/Class/IsEnum.java
+++ b/test/jdk/java/lang/Class/IsEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4891872 4989735 4990789 5020490
  * @summary Check isEnum() method
- * @author Joseph D. Darcy
  */
 
 import java.lang.annotation.*;

--- a/test/jdk/java/lang/Class/IsSynthetic.java
+++ b/test/jdk/java/lang/Class/IsSynthetic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5012133
  * @summary Check Class.isSynthetic method
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/Class/getEnclosingConstructor/EnclosingConstructorTests.java
+++ b/test/jdk/java/lang/Class/getEnclosingConstructor/EnclosingConstructorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4962341 6832557
  * @summary Check getEnclosingMethod method
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.Constructor;

--- a/test/jdk/java/lang/Class/getEnclosingMethod/EnclosingMethodTests.java
+++ b/test/jdk/java/lang/Class/getEnclosingMethod/EnclosingMethodTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4962341
  * @summary Check getEnclosingMethod method
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.Method;

--- a/test/jdk/java/lang/Double/BitwiseConversion.java
+++ b/test/jdk/java/lang/Double/BitwiseConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @library ../Math
  * @build DoubleConsts
  * @run main BitwiseConversion
- * @author Joseph D. Darcy
  */
 
 import static java.lang.Double.*;

--- a/test/jdk/java/lang/Double/Constants.java
+++ b/test/jdk/java/lang/Double/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  * @compile Constants.java
  * @bug 4397405 4826652
  * @summary Testing constant-ness of Double.{MIN_VALUE, MAX_VALUE}, etc.
- * @author Joseph D. Darcy
  */
 
 public class Constants {

--- a/test/jdk/java/lang/Double/Extrema.java
+++ b/test/jdk/java/lang/Double/Extrema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4408489 4826652
  * @summary Testing values of Double.{MIN_VALUE, MIN_NORMAL, MAX_VALUE}
- * @author Joseph D. Darcy
  */
 
 public class Extrema {

--- a/test/jdk/java/lang/Double/NaNInfinityParsing.java
+++ b/test/jdk/java/lang/Double/NaNInfinityParsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4428772
  * @summary Testing recognition of "NaN" and "Infinity" strings
- * @author Joseph D. Darcy
  */
 
 

--- a/test/jdk/java/lang/Double/ParseHexFloatingPoint.java
+++ b/test/jdk/java/lang/Double/ParseHexFloatingPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @run main ParseHexFloatingPoint
  * @bug 4826774 8078672
  * @summary Numerical tests for hexadecimal inputs to parse{Double, Float} (use -Dseed=X to set PRNG seed)
- * @author Joseph D. Darcy
  * @key randomness
  */
 

--- a/test/jdk/java/lang/Double/ToHexString.java
+++ b/test/jdk/java/lang/Double/ToHexString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @library ../Math
  * @build DoubleConsts
  * @run main ToHexString
- * @author Joseph D. Darcy
  */
 
 import java.util.regex.*;

--- a/test/jdk/java/lang/Float/BitwiseConversion.java
+++ b/test/jdk/java/lang/Float/BitwiseConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
  * @library ../Math
  * @build FloatConsts
  * @run main BitwiseConversion
- * @author Joseph D. Darcy
  */
 
 import static java.lang.Float.*;

--- a/test/jdk/java/lang/Float/Constants.java
+++ b/test/jdk/java/lang/Float/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  * @compile Constants.java
  * @bug 4397405 4826652
  * @summary Testing constant-ness of Float.{MIN_VALUE, MAX_VALUE}, etc.
- * @author Joseph D. Darcy
  */
 
 public class Constants {

--- a/test/jdk/java/lang/Float/Extrema.java
+++ b/test/jdk/java/lang/Float/Extrema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4408489 4826652
  * @summary Testing values of Float.{MIN_VALUE, MIN_NORMAL, MAX_VALUE}
- * @author Joseph D. Darcy
  */
 
 public class Extrema {

--- a/test/jdk/java/lang/Float/NaNInfinityParsing.java
+++ b/test/jdk/java/lang/Float/NaNInfinityParsing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4428772
  * @summary Testing recognition of "NaN" and "Infinity" strings
- * @author Joseph D. Darcy
  */
 
 

--- a/test/jdk/java/lang/Integer/Decode.java
+++ b/test/jdk/java/lang/Integer/Decode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
  * @test
  * @bug 4136371 5017980 6576055
  * @summary Test Integer.decode method
- * @author madbot
- * @author Joseph D. Darcy
  */
 
 /**

--- a/test/jdk/java/lang/Integer/ParsingTest.java
+++ b/test/jdk/java/lang/Integer/ParsingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5017980 6576055 8041972 8055251
  * @summary Test parsing methods
- * @author Joseph D. Darcy
  */
 
 import java.lang.IndexOutOfBoundsException;

--- a/test/jdk/java/lang/Integer/Unsigned.java
+++ b/test/jdk/java/lang/Integer/Unsigned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4504839 4215269 6322074
  * @summary Basic tests for unsigned operations.
- * @author Joseph D. Darcy
  */
 public class Unsigned {
     public static void main(String... args) {

--- a/test/jdk/java/lang/Long/Decode.java
+++ b/test/jdk/java/lang/Long/Decode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
  * @test
  * @bug 4136371 5017980 6576055
  * @summary Test Long.decode method
- * @author madbot
- * @author Joseph D. Darcy
  */
 
 import java.math.BigInteger;

--- a/test/jdk/java/lang/Long/ParsingTest.java
+++ b/test/jdk/java/lang/Long/ParsingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5017980 6576055 8041972 8055251
  * @summary Test parsing methods
- * @author Joseph D. Darcy
  */
 
 /**

--- a/test/jdk/java/lang/Long/Unsigned.java
+++ b/test/jdk/java/lang/Long/Unsigned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4504839 4215269 6322074 8030814
  * @summary Basic tests for unsigned operations
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/lang/Short/Decode.java
+++ b/test/jdk/java/lang/Short/Decode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
  * @test
  * @bug 4136371 5017980 6576055
  * @summary Test Short.decode method
- * @author madbot
- * @author Joseph D. Darcy
  */
 
 /**

--- a/test/jdk/java/lang/Throwable/SuppressedExceptions.java
+++ b/test/jdk/java/lang/Throwable/SuppressedExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ import java.util.*;
  * @test
  * @bug     6911258 6962571 6963622 6991528 7005628 8012044
  * @summary Basic tests of suppressed exceptions
- * @author  Joseph D. Darcy
  */
 
 public class SuppressedExceptions {

--- a/test/jdk/java/lang/annotation/Missing/MissingTest.java
+++ b/test/jdk/java/lang/annotation/Missing/MissingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6322301 5041778
  * @summary Verify when missing annotation classes cause exceptions
- * @author Joseph D. Darcy
  * @compile MissingTest.java A.java B.java C.java D.java Marker.java Missing.java MissingWrapper.java MissingDefault.java
  * @clean Missing
  * @run main MissingTest

--- a/test/jdk/java/lang/annotation/TestIncompleteAnnotationExceptionNPE.java
+++ b/test/jdk/java/lang/annotation/TestIncompleteAnnotationExceptionNPE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug     7021922
  * @summary Test null handling of IncompleteAnnotationException constructor
- * @author  Joseph D. Darcy
  */
 
 import java.lang.annotation.*;

--- a/test/jdk/java/lang/reflect/AnnotatedElement/TestAnnotatedElementDefaults.java
+++ b/test/jdk/java/lang/reflect/AnnotatedElement/TestAnnotatedElementDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8005294
  * @summary Check behavior of default methods of AnnotatedElement
- * @author Joseph D. Darcy
  */
 
 import java.lang.annotation.*;

--- a/test/jdk/java/lang/reflect/Constructor/GenericStringTest.java
+++ b/test/jdk/java/lang/reflect/Constructor/GenericStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5033583 6316717 6470106 8161500 8162539 6304578
  * @summary Check toGenericString() and toString() methods
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/Constructor/TestParameterAnnotations.java
+++ b/test/jdk/java/lang/reflect/Constructor/TestParameterAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6332964
  * @summary Verify getParameterAnnotations doesn't throw spurious errors
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/DefaultAccessibility.java
+++ b/test/jdk/java/lang/reflect/DefaultAccessibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6648344
  * @summary Test that default accessibility is false
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/Field/GenericStringTest.java
+++ b/test/jdk/java/lang/reflect/Field/GenericStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5033583 8161500
  * @summary Check toGenericString() method
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/Generics/HashCodeTest.java
+++ b/test/jdk/java/lang/reflect/Generics/HashCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5097856
  * @summary Computing hashCode of objects modeling generics shouldn't blow stack
- * @author Joseph D. Darcy
  */
 
 import java.util.*;

--- a/test/jdk/java/lang/reflect/Generics/Probe.java
+++ b/test/jdk/java/lang/reflect/Generics/Probe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5003916 6704655 6873951 6476261 8004928
  * @summary Testing parsing of signatures attributes of nested classes
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/Generics/StringsAndBounds.java
+++ b/test/jdk/java/lang/reflect/Generics/StringsAndBounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5015676 4987888 4997464
  * @summary Testing upper bounds and availability of toString methods
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/Generics/TestParameterizedType.java
+++ b/test/jdk/java/lang/reflect/Generics/TestParameterizedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5061485
  * @summary Test sematics of ParameterizedType.equals
- * @author Joseph D. Darcy
  */
 
 import java.util.*;

--- a/test/jdk/java/lang/reflect/Generics/exceptionCauseTest.java
+++ b/test/jdk/java/lang/reflect/Generics/exceptionCauseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4981727
  * @summary
- * @author Joseph D. Darcy
  */
 
 import java.io.PrintStream;

--- a/test/jdk/java/lang/reflect/Generics/getAnnotationTest.java
+++ b/test/jdk/java/lang/reflect/Generics/getAnnotationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4979440
  * @summary Test for signature parsing corner case
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/Method/GenericStringTest.java
+++ b/test/jdk/java/lang/reflect/Method/GenericStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5033583 6316717 6470106 8004979 8161500 8162539 6304578
  * @summary Check toGenericString() and toString() methods
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/Method/IsDefaultTest.java
+++ b/test/jdk/java/lang/reflect/Method/IsDefaultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8005042
  * @summary Check behavior of Method.isDefault
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/lang/reflect/Method/defaultMethodModeling/DefaultMethodModeling.java
+++ b/test/jdk/java/lang/reflect/Method/defaultMethodModeling/DefaultMethodModeling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8011590
  * @summary Check modeling of default methods
- * @author Joseph D. Darcy
  */
 
 import java.util.Objects;

--- a/test/jdk/java/lang/reflect/TypeVariable/TestAnnotatedElement.java
+++ b/test/jdk/java/lang/reflect/TypeVariable/TestAnnotatedElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 7086192
  * @summary Verify functionality of AnnotatedElement methods on type variables
- * @author Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/jdk/java/math/BigDecimal/AddTests.java
+++ b/test/jdk/java/math/BigDecimal/AddTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6362557 8200698
  * @summary Some tests of add(BigDecimal, mc)
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigDecimal/CompareToTests.java
+++ b/test/jdk/java/math/BigDecimal/CompareToTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6473768
  * @summary Tests of BigDecimal.compareTo
- * @author Joseph D. Darcy
  */
 import java.math.*;
 import static java.math.BigDecimal.*;

--- a/test/jdk/java/math/BigDecimal/DivideTests.java
+++ b/test/jdk/java/math/BigDecimal/DivideTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4851776 4907265 6177836 6876282 8066842
  * @summary Some tests for the divide methods.
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigDecimal/IntegralDivisionTests.java
+++ b/test/jdk/java/math/BigDecimal/IntegralDivisionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  * @test
  * @bug 4904082 4917089 6337226 6378503
  * @summary Tests that integral division and related methods return the proper result and scale.
- * @author Joseph D. Darcy
  */
 import java.math.*;
 public class IntegralDivisionTests {

--- a/test/jdk/java/math/BigDecimal/NegateTests.java
+++ b/test/jdk/java/math/BigDecimal/NegateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6325535
  * @summary Test for the rounding behavior of negate(MathContext)
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigDecimal/PowTests.java
+++ b/test/jdk/java/math/BigDecimal/PowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4916097
  * @summary Some exponent over/undeflow tests for the pow method
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigDecimal/PrecisionTests.java
+++ b/test/jdk/java/math/BigDecimal/PrecisionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 1234567
  * @summary Test that precision() is computed properly.
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigDecimal/RoundingTests.java
+++ b/test/jdk/java/math/BigDecimal/RoundingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6334849
  * @summary Tests of dropping digits near the scale threshold
- * @author Joseph D. Darcy
  */
 import java.math.*;
 public class RoundingTests {

--- a/test/jdk/java/math/BigDecimal/ScaleByPowerOfTenTests.java
+++ b/test/jdk/java/math/BigDecimal/ScaleByPowerOfTenTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4899722
  * @summary Basic tests of scaleByPowerOfTen
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigDecimal/StrippingZerosTest.java
+++ b/test/jdk/java/math/BigDecimal/StrippingZerosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
  * @summary A few tests of stripTrailingZeros
  * @run main StrippingZerosTest
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+EliminateAutoBox -XX:AutoBoxCacheMax=20000 StrippingZerosTest
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigDecimal/ToPlainStringTests.java
+++ b/test/jdk/java/math/BigDecimal/ToPlainStringTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
  * @summary Basic tests of toPlainString method
  * @run main ToPlainStringTests
  * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+EliminateAutoBox -XX:AutoBoxCacheMax=20000 ToPlainStringTests
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigDecimal/ZeroScalingTests.java
+++ b/test/jdk/java/math/BigDecimal/ZeroScalingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
  * @summary Tests that the scale of zero is propagated properly and has the
  * proper effect and that setting the scale to zero does not mutate the
  * BigDecimal.
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigInteger/CompareToTests.java
+++ b/test/jdk/java/math/BigInteger/CompareToTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6473768
  * @summary Tests of BigInteger.compareTo
- * @author Joseph D. Darcy
  */
 import java.math.*;
 import static java.math.BigInteger.*;

--- a/test/jdk/java/math/BigInteger/ExtremeShiftingTests.java
+++ b/test/jdk/java/math/BigInteger/ExtremeShiftingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
  * @summary Tests of shiftLeft and shiftRight on Integer.MIN_VALUE
  * @requires os.maxMemory >= 1g
  * @run main/othervm -Xmx512m ExtremeShiftingTests
- * @author Joseph D. Darcy
  */
 import java.math.BigInteger;
 import static java.math.BigInteger.*;

--- a/test/jdk/java/math/BigInteger/OperatorNpeTests.java
+++ b/test/jdk/java/math/BigInteger/OperatorNpeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6365176
  * @summary Get NullPointerExceptions when expected
- * @author Joseph D. Darcy
  */
 
 import java.math.*;

--- a/test/jdk/java/math/BigInteger/StringConstructor.java
+++ b/test/jdk/java/math/BigInteger/StringConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4489146 5017980
  * @summary tests String constructors of BigInteger
- * @author Joseph D. Darcy
  */
 import java.math.*;
 

--- a/test/jdk/java/math/BigInteger/TestValueExact.java
+++ b/test/jdk/java/math/BigInteger/TestValueExact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6371401
  * @summary Tests of fooValueExact methods
- * @author Joseph D. Darcy
  */
 import java.math.BigInteger;
 

--- a/test/jdk/java/math/RoundingMode/RoundingModeTests.java
+++ b/test/jdk/java/math/RoundingMode/RoundingModeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4851776 4891522 4905335
  * @summary Basic tests for the RoundingMode class.
- * @author Joseph D. Darcy
  */
 
 import java.math.RoundingMode;

--- a/test/jdk/tools/launcher/ChangeDataModel.java
+++ b/test/jdk/tools/launcher/ChangeDataModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
  * @compile -XDignore.symbol.file ChangeDataModel.java
  * @run main ChangeDataModel
  * @summary Verify -d32, -d64 and -J prefixed data-model options are rejected on all platforms
- * @author Joseph D. Darcy, ksrini
  */
 
 import java.util.Arrays;

--- a/test/jdk/tools/launcher/I18NTest.java
+++ b/test/jdk/tools/launcher/I18NTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@
  * @compile -XDignore.symbol.file I18NTest.java
  * @run main I18NTest
  * @summary Test to see if class files with non-ASCII characters can be run
- * @author Joseph D. Darcy, Kumar Srinivasan
  */
 
 

--- a/test/jdk/tools/launcher/UnresolvedExceptions.java
+++ b/test/jdk/tools/launcher/UnresolvedExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
  * @compile -XDignore.symbol.file UnresolvedExceptions.java
  * @run main UnresolvedExceptions
  * @summary Verifying jvm won't segv if exception not available
- * @author Joseph D. Darcy, ksrini
  */
 
 import java.io.File;


### PR DESCRIPTION
Backporting JDK-8369858: Remove darcy author tags from jdk tests.

This PR removes unwanted author tags from tests.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/io/Serializable/cloneArray/CloneArray.java
make test TEST=test/jdk/java/lang
make test TEST=test/jdk/java/math
make test TEST=test/jdk/tools/launcher

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27279838/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27279839/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/27279840/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/27279841/windows-x64-specific-4-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27279842/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27279843/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27279845/macos-aarch64-specific-3-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27279846/macos-aarch64-specific-4-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27279847/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27279848/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/27279849/linux-x64-specific-3-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/27279850/linux-x64-specific-4-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27279851/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27279852/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27279853/linux-aarch64-specific-3-test.log)
[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27279854/linux-aarch64-specific-4-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8369858](https://bugs.openjdk.org/browse/JDK-8369858) needs maintainer approval

### Issue
 * [JDK-8369858](https://bugs.openjdk.org/browse/JDK-8369858): Remove darcy author tags from jdk tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4399/head:pull/4399` \
`$ git checkout pull/4399`

Update a local copy of the PR: \
`$ git checkout pull/4399` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4399`

View PR using the GUI difftool: \
`$ git pr show -t 4399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4399.diff">https://git.openjdk.org/jdk17u-dev/pull/4399.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4399#issuecomment-4359608311)
</details>
