### PR TITLE
8369851: Remove darcy author tags from langtools tests

### DIFF
--- a/test/langtools/tools/javac/HexThree.java
+++ b/test/langtools/tools/javac/HexThree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4920023
  * @summary Test hex floating-point literals
- * @author darcy
  */
 
 public class HexThree {

--- a/test/langtools/tools/javac/StringsInSwitch/OneCaseSwitches.java
+++ b/test/langtools/tools/javac/StringsInSwitch/OneCaseSwitches.java
@@ -4,7 +4,6 @@
  * @summary Positive tests for strings in switch with few alternatives.
  * @compile          OneCaseSwitches.java
  * @run main OneCaseSwitches
- * @author  Joseph D. Darcy
  */
 
 import java.lang.reflect.*;

--- a/test/langtools/tools/javac/StringsInSwitch/StringSwitches.java
+++ b/test/langtools/tools/javac/StringsInSwitch/StringSwitches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6827009 7071246
  * @summary Positive tests for strings in switch.
- * @author  Joseph D. Darcy
  */
 
 public class StringSwitches {

--- a/test/langtools/tools/javac/TryWithResources/BadTwr.java
+++ b/test/langtools/tools/javac/TryWithResources/BadTwr.java
@@ -1,7 +1,6 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 6911256 6964740
- * @author Joseph D. Darcy
  * @summary Verify bad TWRs don't compile
  * @compile/fail/ref=BadTwr.out -XDrawDiagnostics BadTwr.java
  */

--- a/test/langtools/tools/javac/TryWithResources/BadTwr.out
+++ b/test/langtools/tools/javac/TryWithResources/BadTwr.out
@@ -1,5 +1,5 @@
-BadTwr.java:12:46: compiler.err.already.defined: kindname.variable, r1, kindname.method, meth(java.lang.String...)
-BadTwr.java:17:20: compiler.err.already.defined: kindname.variable, args, kindname.method, meth(java.lang.String...)
-BadTwr.java:20:13: compiler.err.cant.assign.val.to.final.var: thatsIt
-BadTwr.java:25:24: compiler.err.already.defined: kindname.variable, name, kindname.method, meth(java.lang.String...)
+BadTwr.java:11:46: compiler.err.already.defined: kindname.variable, r1, kindname.method, meth(java.lang.String...)
+BadTwr.java:16:20: compiler.err.already.defined: kindname.variable, args, kindname.method, meth(java.lang.String...)
+BadTwr.java:19:13: compiler.err.cant.assign.val.to.final.var: thatsIt
+BadTwr.java:24:24: compiler.err.already.defined: kindname.variable, name, kindname.method, meth(java.lang.String...)
 4 errors

--- a/test/langtools/tools/javac/TryWithResources/BadTwrSyntax.java
+++ b/test/langtools/tools/javac/TryWithResources/BadTwrSyntax.java
@@ -1,7 +1,6 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 6911256 6964740
- * @author Joseph D. Darcy
  * @summary Verify bad TWRs don't compile
  * @compile/fail/ref=BadTwrSyntax.out -XDrawDiagnostics BadTwrSyntax.java
  */

--- a/test/langtools/tools/javac/TryWithResources/BadTwrSyntax.out
+++ b/test/langtools/tools/javac/TryWithResources/BadTwrSyntax.out
@@ -1,2 +1,2 @@
-BadTwrSyntax.java:13:43: compiler.err.illegal.start.of.expr
+BadTwrSyntax.java:12:43: compiler.err.illegal.start.of.expr
 1 error

--- a/test/langtools/tools/javac/TryWithResources/ExplicitFinal.java
+++ b/test/langtools/tools/javac/TryWithResources/ExplicitFinal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 7013420
- * @author Joseph D. Darcy
  * @summary Test that resource variables are accepted as explicitly final.
  */
 

--- a/test/langtools/tools/javac/TryWithResources/PlainTry.java
+++ b/test/langtools/tools/javac/TryWithResources/PlainTry.java
@@ -1,9 +1,8 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 6911256 6964740
- * @author Joseph D. Darcy
  * @summary Test error messages for an unadorned try
- * @compile/fail/ref=PlainTry.out  -XDrawDiagnostics                           PlainTry.java
+ * @compile/fail/ref=PlainTry.out -XDrawDiagnostics PlainTry.java
  */
 public class PlainTry {
     public static void meth() {

--- a/test/langtools/tools/javac/TryWithResources/PlainTry.out
+++ b/test/langtools/tools/javac/TryWithResources/PlainTry.out
@@ -1,2 +1,2 @@
-PlainTry.java:10:9: compiler.err.try.without.catch.finally.or.resource.decls
+PlainTry.java:9:9: compiler.err.try.without.catch.finally.or.resource.decls
 1 error

--- a/test/langtools/tools/javac/TryWithResources/TwrFlow.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrFlow.java
@@ -1,7 +1,6 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 6911256 6964740 7013420
- * @author Joseph D. Darcy
  * @summary Test exception analysis of try-with-resources blocks
  * @compile/fail/ref=TwrFlow.out -XDrawDiagnostics TwrFlow.java
  */

--- a/test/langtools/tools/javac/TryWithResources/TwrFlow.out
+++ b/test/langtools/tools/javac/TryWithResources/TwrFlow.out
@@ -1,3 +1,3 @@
-TwrFlow.java:14:11: compiler.err.except.never.thrown.in.try: java.io.IOException
-TwrFlow.java:12:21: compiler.err.unreported.exception.implicit.close: CustomCloseException, twrFlow
+TwrFlow.java:13:11: compiler.err.except.never.thrown.in.try: java.io.IOException
+TwrFlow.java:11:21: compiler.err.unreported.exception.implicit.close: CustomCloseException, twrFlow
 2 errors

--- a/test/langtools/tools/javac/TryWithResources/TwrLint.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrLint.java
@@ -1,7 +1,6 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 6911256 6964740 6965277 6967065
- * @author Joseph D. Darcy
  * @summary Check that -Xlint:twr warnings are generated as expected
  * @compile/ref=TwrLint.out -Xlint:try,deprecation -XDrawDiagnostics TwrLint.java
  */

--- a/test/langtools/tools/javac/TryWithResources/TwrLint.out
+++ b/test/langtools/tools/javac/TryWithResources/TwrLint.out
@@ -1,3 +1,3 @@
-TwrLint.java:14:15: compiler.warn.try.explicit.close.call
-TwrLint.java:13:21: compiler.warn.try.resource.not.referenced: r3
+TwrLint.java:13:15: compiler.warn.try.explicit.close.call
+TwrLint.java:12:21: compiler.warn.try.resource.not.referenced: r3
 2 warnings

--- a/test/langtools/tools/javac/TryWithResources/TwrMultiCatch.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrMultiCatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 6911256 6964740 7013420
- * @author Joseph D. Darcy
  * @summary Test that TWR and multi-catch play well together
  * @compile TwrMultiCatch.java
  * @run main TwrMultiCatch

--- a/test/langtools/tools/javac/TryWithResources/TwrOnNonResource.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrOnNonResource.java
@@ -1,7 +1,6 @@
 /*
  * @test  /nodynamiccopyright/
  * @bug 6911256 6964740 7013420
- * @author Joseph D. Darcy
  * @summary Verify invalid TWR block is not accepted.
  * @compile/fail/ref=TwrOnNonResource.out -XDrawDiagnostics TwrOnNonResource.java
  */

--- a/test/langtools/tools/javac/TryWithResources/TwrOnNonResource.out
+++ b/test/langtools/tools/javac/TryWithResources/TwrOnNonResource.out
@@ -1,4 +1,4 @@
-TwrOnNonResource.java:11:30: compiler.err.prob.found.req: (compiler.misc.try.not.applicable.to.type: (compiler.misc.inconvertible.types: TwrOnNonResource, java.lang.AutoCloseable))
-TwrOnNonResource.java:14:30: compiler.err.prob.found.req: (compiler.misc.try.not.applicable.to.type: (compiler.misc.inconvertible.types: TwrOnNonResource, java.lang.AutoCloseable))
-TwrOnNonResource.java:17:30: compiler.err.prob.found.req: (compiler.misc.try.not.applicable.to.type: (compiler.misc.inconvertible.types: TwrOnNonResource, java.lang.AutoCloseable))
+TwrOnNonResource.java:10:30: compiler.err.prob.found.req: (compiler.misc.try.not.applicable.to.type: (compiler.misc.inconvertible.types: TwrOnNonResource, java.lang.AutoCloseable))
+TwrOnNonResource.java:13:30: compiler.err.prob.found.req: (compiler.misc.try.not.applicable.to.type: (compiler.misc.inconvertible.types: TwrOnNonResource, java.lang.AutoCloseable))
+TwrOnNonResource.java:16:30: compiler.err.prob.found.req: (compiler.misc.try.not.applicable.to.type: (compiler.misc.inconvertible.types: TwrOnNonResource, java.lang.AutoCloseable))
 3 errors

--- a/test/langtools/tools/javac/TryWithResources/TwrSuppression.java
+++ b/test/langtools/tools/javac/TryWithResources/TwrSuppression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 6971877
- * @author Joseph D. Darcy
  * @summary Verify a primary exception suppresses all throwables
  */
 

--- a/test/langtools/tools/javac/TryWithResources/WeirdTwr.java
+++ b/test/langtools/tools/javac/TryWithResources/WeirdTwr.java
@@ -1,7 +1,6 @@
 /*
  * @test /nodynamiccopyright/
  * @bug 6911256 6964740
- * @author Joseph D. Darcy
  * @summary Strange TWRs
  * @compile WeirdTwr.java
  * @run main WeirdTwr

--- a/test/langtools/tools/javac/annotations/pos/TrailingComma.java
+++ b/test/langtools/tools/javac/annotations/pos/TrailingComma.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6337964
  * @summary javac incorrectly disallows trailing comma in annotation arrays
- * @author darcy
  * @compile TrailingComma.java
  */
 

--- a/test/langtools/tools/javac/boxing/BoxingCaching.java
+++ b/test/langtools/tools/javac/boxing/BoxingCaching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4990346 8200478
  * @summary Verify autoboxed values are cached as required.
- * @author Joseph D. Darcy
  */
 
 public class BoxingCaching {

--- a/test/langtools/tools/javac/enum/6350057/T6350057.java
+++ b/test/langtools/tools/javac/enum/6350057/T6350057.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6350057 7025809
  * @summary Test that parameters on implicit enum methods have the right kind
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/enum/AbstractEmptyEnum.java
+++ b/test/langtools/tools/javac/enum/AbstractEmptyEnum.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary empty enum cannot be abstract
- * @author Joseph D. Darcy
  *
  * @compile/fail/ref=AbstractEmptyEnum.out -XDrawDiagnostics  AbstractEmptyEnum.java
  */

--- a/test/langtools/tools/javac/enum/AbstractEmptyEnum.out
+++ b/test/langtools/tools/javac/enum/AbstractEmptyEnum.out
@@ -1,2 +1,2 @@
-AbstractEmptyEnum.java:10:8: compiler.err.does.not.override.abstract: AbstractEmptyEnum, m(), AbstractEmptyEnum
+AbstractEmptyEnum.java:9:8: compiler.err.does.not.override.abstract: AbstractEmptyEnum, m(), AbstractEmptyEnum
 1 error

--- a/test/langtools/tools/javac/enum/EnumImplicitPrivateConstructor.java
+++ b/test/langtools/tools/javac/enum/EnumImplicitPrivateConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5009601 5010455 5005748
  * @summary enum constructors can be declared private
- * @author Joseph D. Darcy
  */
 
 import java.util.*;

--- a/test/langtools/tools/javac/enum/EnumPrivateConstructor.java
+++ b/test/langtools/tools/javac/enum/EnumPrivateConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 5009601
  * @summary enum constructors can be declared private
- * @author Joseph D. Darcy
  *
  * @compile EnumPrivateConstructor.java
  */

--- a/test/langtools/tools/javac/enum/EnumProtectedConstructor.java
+++ b/test/langtools/tools/javac/enum/EnumProtectedConstructor.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary enum constructors cannot be declared public or protected
- * @author Joseph D. Darcy
  *
  * @compile/fail/ref=EnumProtectedConstructor.out -XDrawDiagnostics EnumProtectedConstructor.java
  */

--- a/test/langtools/tools/javac/enum/EnumProtectedConstructor.out
+++ b/test/langtools/tools/javac/enum/EnumProtectedConstructor.out
@@ -1,2 +1,2 @@
-EnumProtectedConstructor.java:16:15: compiler.err.mod.not.allowed.here: protected
+EnumProtectedConstructor.java:15:15: compiler.err.mod.not.allowed.here: protected
 1 error

--- a/test/langtools/tools/javac/enum/EnumPublicConstructor.java
+++ b/test/langtools/tools/javac/enum/EnumPublicConstructor.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary enum constructors cannot be declared public or protected
- * @author Joseph D. Darcy
  *
  * @compile/fail/ref=EnumPublicConstructor.out -XDrawDiagnostics  EnumPublicConstructor.java
  */

--- a/test/langtools/tools/javac/enum/EnumPublicConstructor.out
+++ b/test/langtools/tools/javac/enum/EnumPublicConstructor.out
@@ -1,2 +1,2 @@
-EnumPublicConstructor.java:16:12: compiler.err.mod.not.allowed.here: public
+EnumPublicConstructor.java:15:12: compiler.err.mod.not.allowed.here: public
 1 error

--- a/test/langtools/tools/javac/enum/ExplicitlyAbstractEnum1.java
+++ b/test/langtools/tools/javac/enum/ExplicitlyAbstractEnum1.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary enum's cannot be explicitly declared abstract
- * @author Joseph D. Darcy
  * @compile/fail/ref=ExplicitlyAbstractEnum1.out -XDrawDiagnostics ExplicitlyAbstractEnum1.java
  */
 

--- a/test/langtools/tools/javac/enum/ExplicitlyAbstractEnum1.out
+++ b/test/langtools/tools/javac/enum/ExplicitlyAbstractEnum1.out
@@ -1,2 +1,2 @@
-ExplicitlyAbstractEnum1.java:9:10: compiler.err.mod.not.allowed.here: abstract
+ExplicitlyAbstractEnum1.java:8:10: compiler.err.mod.not.allowed.here: abstract
 1 error

--- a/test/langtools/tools/javac/enum/ExplicitlyAbstractEnum2.java
+++ b/test/langtools/tools/javac/enum/ExplicitlyAbstractEnum2.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary enum's cannot be explicitly declared abstract even if they are abstract
- * @author Joseph D. Darcy
  * @compile/fail/ref=ExplicitlyAbstractEnum2.out -XDrawDiagnostics ExplicitlyAbstractEnum2.java
  */
 

--- a/test/langtools/tools/javac/enum/ExplicitlyAbstractEnum2.out
+++ b/test/langtools/tools/javac/enum/ExplicitlyAbstractEnum2.out
@@ -1,2 +1,2 @@
-ExplicitlyAbstractEnum2.java:9:10: compiler.err.mod.not.allowed.here: abstract
+ExplicitlyAbstractEnum2.java:8:10: compiler.err.mod.not.allowed.here: abstract
 1 error

--- a/test/langtools/tools/javac/enum/ExplicitlyFinalEnum1.java
+++ b/test/langtools/tools/javac/enum/ExplicitlyFinalEnum1.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary enum's cannot be explicitly declared final even if they are
- * @author Joseph D. Darcy
  * @compile/fail/ref=ExplicitlyFinalEnum1.out -XDrawDiagnostics ExplicitlyFinalEnum1.java
  */
 

--- a/test/langtools/tools/javac/enum/ExplicitlyFinalEnum1.out
+++ b/test/langtools/tools/javac/enum/ExplicitlyFinalEnum1.out
@@ -1,2 +1,2 @@
-ExplicitlyFinalEnum1.java:9:7: compiler.err.mod.not.allowed.here: final
+ExplicitlyFinalEnum1.java:8:7: compiler.err.mod.not.allowed.here: final
 1 error

--- a/test/langtools/tools/javac/enum/ExplicitlyFinalEnum2.java
+++ b/test/langtools/tools/javac/enum/ExplicitlyFinalEnum2.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary enum's cannot be explicitly declared final
- * @author Joseph D. Darcy
  * @compile/fail/ref=ExplicitlyFinalEnum2.out -XDrawDiagnostics ExplicitlyFinalEnum2.java
  */
 

--- a/test/langtools/tools/javac/enum/ExplicitlyFinalEnum2.out
+++ b/test/langtools/tools/javac/enum/ExplicitlyFinalEnum2.out
@@ -1,2 +1,2 @@
-ExplicitlyFinalEnum2.java:9:7: compiler.err.mod.not.allowed.here: final
+ExplicitlyFinalEnum2.java:8:7: compiler.err.mod.not.allowed.here: final
 1 error

--- a/test/langtools/tools/javac/enum/FauxEnum1.java
+++ b/test/langtools/tools/javac/enum/FauxEnum1.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009574
  * @summary verify java.lang.Enum can't be directly subclassed
- * @author Joseph D. Darcy
  *
  * @compile/fail/ref=FauxEnum1.out -XDrawDiagnostics  FauxEnum1.java
  */

--- a/test/langtools/tools/javac/enum/FauxEnum1.out
+++ b/test/langtools/tools/javac/enum/FauxEnum1.out
@@ -1,4 +1,4 @@
-FauxEnum1.java:10:8: compiler.err.enum.no.subclassing
+FauxEnum1.java:9:8: compiler.err.enum.no.subclassing
 - compiler.note.unchecked.filename: FauxEnum1.java
 - compiler.note.unchecked.recompile
 1 error

--- a/test/langtools/tools/javac/enum/FauxEnum3.java
+++ b/test/langtools/tools/javac/enum/FauxEnum3.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009574
  * @summary verify an enum type can't be directly subclassed
- * @author Joseph D. Darcy
  *
  * @compile/fail/ref=FauxEnum3.out -XDrawDiagnostics  FauxEnum3.java
  */

--- a/test/langtools/tools/javac/enum/FauxEnum3.out
+++ b/test/langtools/tools/javac/enum/FauxEnum3.out
@@ -1,2 +1,2 @@
-FauxEnum3.java:10:14: compiler.err.enum.types.not.extensible
+FauxEnum3.java:9:14: compiler.err.enum.types.not.extensible
 1 error

--- a/test/langtools/tools/javac/enum/FauxSpecialEnum1.java
+++ b/test/langtools/tools/javac/enum/FauxSpecialEnum1.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary verify specialized enum classes can't be abstract
- * @author Joseph D. Darcy
  *
  * @compile/fail/ref=FauxSpecialEnum1.out -XDrawDiagnostics  FauxSpecialEnum1.java
  */

--- a/test/langtools/tools/javac/enum/FauxSpecialEnum1.out
+++ b/test/langtools/tools/javac/enum/FauxSpecialEnum1.out
@@ -1,2 +1,2 @@
-FauxSpecialEnum1.java:14:5: compiler.err.does.not.override.abstract: compiler.misc.anonymous.class: FauxSpecialEnum1$2, test(), compiler.misc.anonymous.class: FauxSpecialEnum1$2
+FauxSpecialEnum1.java:13:5: compiler.err.does.not.override.abstract: compiler.misc.anonymous.class: FauxSpecialEnum1$2, test(), compiler.misc.anonymous.class: FauxSpecialEnum1$2
 1 error

--- a/test/langtools/tools/javac/enum/FauxSpecialEnum2.java
+++ b/test/langtools/tools/javac/enum/FauxSpecialEnum2.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 5009601
  * @summary verify specialized enum classes can't be abstract
- * @author Joseph D. Darcy
  *
  * @compile/fail/ref=FauxSpecialEnum2.out -XDrawDiagnostics  FauxSpecialEnum2.java
  */

--- a/test/langtools/tools/javac/enum/FauxSpecialEnum2.out
+++ b/test/langtools/tools/javac/enum/FauxSpecialEnum2.out
@@ -1,2 +1,2 @@
-FauxSpecialEnum2.java:12:5: compiler.err.does.not.override.abstract: compiler.misc.anonymous.class: FauxSpecialEnum2$1, test(), compiler.misc.anonymous.class: FauxSpecialEnum2$1
+FauxSpecialEnum2.java:11:5: compiler.err.does.not.override.abstract: compiler.misc.anonymous.class: FauxSpecialEnum2$1, test(), compiler.misc.anonymous.class: FauxSpecialEnum2$1
 1 error

--- a/test/langtools/tools/javac/generics/InheritanceConflict3.java
+++ b/test/langtools/tools/javac/generics/InheritanceConflict3.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 4984158
  * @summary two inherited methods with same signature
- * @author darcy
  *
  * @compile/fail/ref=InheritanceConflict3.out -XDrawDiagnostics  InheritanceConflict3.java
  */

--- a/test/langtools/tools/javac/generics/InheritanceConflict3.out
+++ b/test/langtools/tools/javac/generics/InheritanceConflict3.out
@@ -1,3 +1,3 @@
-InheritanceConflict3.java:14:10: compiler.err.name.clash.same.erasure: f(java.lang.Object), f(T)
-InheritanceConflict3.java:17:1: compiler.err.concrete.inheritance.conflict: f(java.lang.Object), inheritance.conflict3.X1, f(T), inheritance.conflict3.X1, inheritance.conflict3.X1
+InheritanceConflict3.java:13:10: compiler.err.name.clash.same.erasure: f(java.lang.Object), f(T)
+InheritanceConflict3.java:16:1: compiler.err.concrete.inheritance.conflict: f(java.lang.Object), inheritance.conflict3.X1, f(T), inheritance.conflict3.X1, inheritance.conflict3.X1
 2 errors

--- a/test/langtools/tools/javac/multicatch/Neg01.java
+++ b/test/langtools/tools/javac/multicatch/Neg01.java
@@ -3,7 +3,6 @@
  * @bug 6943289
  *
  * @summary Project Coin: Improved Exception Handling for Java (aka 'multicatch')
- * @author darcy
  * @compile/fail/ref=Neg01.out -XDrawDiagnostics Neg01.java
  */
 

--- a/test/langtools/tools/javac/multicatch/Neg01.out
+++ b/test/langtools/tools/javac/multicatch/Neg01.out
@@ -1,2 +1,2 @@
-Neg01.java:22:19: compiler.err.except.never.thrown.in.try: Neg01.B2
+Neg01.java:21:19: compiler.err.except.never.thrown.in.try: Neg01.B2
 1 error

--- a/test/langtools/tools/javac/multicatch/Neg01eff_final.java
+++ b/test/langtools/tools/javac/multicatch/Neg01eff_final.java
@@ -3,7 +3,6 @@
  * @bug 6943289
  *
  * @summary Project Coin: Improved Exception Handling for Java (aka 'multicatch')
- * @author darcy
  * @compile/fail/ref=Neg01eff_final.out -XDrawDiagnostics Neg01eff_final.java
  */
 

--- a/test/langtools/tools/javac/multicatch/Neg01eff_final.out
+++ b/test/langtools/tools/javac/multicatch/Neg01eff_final.out
@@ -1,2 +1,2 @@
-Neg01eff_final.java:22:19: compiler.err.except.never.thrown.in.try: Neg01eff_final.B2
+Neg01eff_final.java:21:19: compiler.err.except.never.thrown.in.try: Neg01eff_final.B2
 1 error

--- a/test/langtools/tools/javac/multicatch/Neg07.java
+++ b/test/langtools/tools/javac/multicatch/Neg07.java
@@ -2,7 +2,6 @@
  * @test  /nodynamiccopyright/
  * @bug 7039822
  * @summary Verify typing of lub of exception parameter w.r.t getClass
- * @author Joseph D. Darcy
  * @compile/fail/ref=Neg07.out -XDrawDiagnostics Neg07.java
  */
 

--- a/test/langtools/tools/javac/multicatch/Neg07.out
+++ b/test/langtools/tools/javac/multicatch/Neg07.out
@@ -1,2 +1,2 @@
-Neg07.java:14:56: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends Neg07.ParentException>, java.lang.Class<? extends Neg07.HasFoo>)
+Neg07.java:13:56: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Class<compiler.misc.type.captureof: 1, ? extends Neg07.ParentException>, java.lang.Class<? extends Neg07.HasFoo>)
 1 error

--- a/test/langtools/tools/javac/multicatch/Pos10.java
+++ b/test/langtools/tools/javac/multicatch/Pos10.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 7039822
  * @summary Verify lub of an exception parameter can be an intersection type
- * @author Joseph D. Darcy
  */
 
 public class Pos10 {

--- a/test/langtools/tools/javac/processing/6365040/T6365040.java
+++ b/test/langtools/tools/javac/processing/6365040/T6365040.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 6365040 6358129
  * @summary Test -processor foo,bar,baz
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler
@@ -13,7 +12,7 @@
  * @compile      -processor ProcFoo,ProcBar,T6365040  -proc:only T6365040.java
  * @compile      -processor T6365040                  -proc:only T6365040.java
  * @compile      -processor T6365040,NotThere,        -proc:only T6365040.java
- * @compile/fail/ref=T6365040.out -XDrawDiagnostics -processor NotThere -proc:only T6365040.java
+ * @compile/fail/ref=T6365040.out -XDrawDiagnostics -processor NotThere          -proc:only T6365040.java
  * @compile/fail/ref=T6365040.out -XDrawDiagnostics -processor NotThere,T6365040 -proc:only T6365040.java
  */
 

--- a/test/langtools/tools/javac/processing/6378728/T6378728.java
+++ b/test/langtools/tools/javac/processing/6378728/T6378728.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 /* @test
  * @bug     6378728
  * @summary Verify -proc:only doesn't produce class files
- * @author  Joseph D. Darcy
  * @modules java.compiler
  *          jdk.compiler
  * @compile T6378728.java

--- a/test/langtools/tools/javac/processing/6634138/T6634138.java
+++ b/test/langtools/tools/javac/processing/6634138/T6634138.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 6634138
- * @author  Joseph D. Darcy
  * @summary Verify source files output after processing is over are compiled
  * @library /tools/javac/lib
  * @modules java.compiler

--- a/test/langtools/tools/javac/processing/completion/TestCompletions.java
+++ b/test/langtools/tools/javac/processing/completion/TestCompletions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6341177
  * @summary Some simple tests of the methods in Completions
- * @author Joseph D. Darcy
  * @modules java.compiler
  *          jdk.compiler
  */

--- a/test/langtools/tools/javac/processing/environment/TestSourceVersion.java
+++ b/test/langtools/tools/javac/processing/environment/TestSourceVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6402506 8028545 8028543
  * @summary Test that getSourceVersion works properly
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/environment/round/TestElementsAnnotatedWith.java
+++ b/test/langtools/tools/javac/processing/environment/round/TestElementsAnnotatedWith.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6397298 6400986 6425592 6449798 6453386 6508401 6498938 6911854 8030049 8038080 8032230 8190886
  * @summary Tests that getElementsAnnotatedWith[Any] methods work properly.
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/errors/TestFatalityOfParseErrors.java
+++ b/test/langtools/tools/javac/processing/errors/TestFatalityOfParseErrors.java
@@ -2,7 +2,6 @@
  * @test /nodynamiccopyright/
  * @bug 6403459
  * @summary Test that generating programs with syntax errors is a fatal condition
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/errors/TestOptionSyntaxErrors.java
+++ b/test/langtools/tools/javac/processing/errors/TestOptionSyntaxErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6406212
  * @summary Test that annotation processor options with illegal syntax are rejected
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.main
  * @build JavacTestingAbstractProcessor CompileFail

--- a/test/langtools/tools/javac/processing/errors/TestReturnCode.java
+++ b/test/langtools/tools/javac/processing/errors/TestReturnCode.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 6403468
  * @summary Test that an erroneous return code results from raising an error.
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules jdk.compiler/com.sun.tools.javac.main
  * @build JavacTestingAbstractProcessor CompileFail

--- a/test/langtools/tools/javac/processing/filer/TestFilerConstraints.java
+++ b/test/langtools/tools/javac/processing/filer/TestFilerConstraints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6380018 6453386 6457283
  * @summary Test that the constraints guaranteed by the Filer and maintained
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/filer/TestGetResource.java
+++ b/test/langtools/tools/javac/processing/filer/TestGetResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6380018 6449798
  * @summary Test Filer.getResource
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/filer/TestPackageInfo.java
+++ b/test/langtools/tools/javac/processing/filer/TestPackageInfo.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 6380018 6392177 6993311 8193462
  * @summary Test the ability to create and process package-info.java files
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/messager/MessagerBasics.java
+++ b/test/langtools/tools/javac/processing/messager/MessagerBasics.java
@@ -2,7 +2,6 @@
  * @test    /nodynamiccopyright/
  * @bug     6341173 6341072
  * @summary Test presence of Messager methods
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/TestExceptions.java
+++ b/test/langtools/tools/javac/processing/model/TestExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6794071
  * @summary Test that exceptions have a proper parent class
- * @author  Joseph D. Darcy
  * @modules java.compiler
  *          jdk.compiler
  */

--- a/test/langtools/tools/javac/processing/model/TestSourceVersion.java
+++ b/test/langtools/tools/javac/processing/model/TestSourceVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 7025809 8028543 6415644 8028544 8029942 8187951 8193291 8196551 8233096
  * @summary Test latest, latestSupported, underscore as keyword, etc.
- * @author  Joseph D. Darcy
  * @modules java.compiler
  *          jdk.compiler
  */

--- a/test/langtools/tools/javac/processing/model/element/TestAnonClassNames.java
+++ b/test/langtools/tools/javac/processing/model/element/TestAnonClassNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6449781 6930508
  * @summary Test that reported names of anonymous classes are non-null.
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules jdk.compiler
  * @build   JavacTestingAbstractProcessor TestAnonSourceNames

--- a/test/langtools/tools/javac/processing/model/element/TestElement.java
+++ b/test/langtools/tools/javac/processing/model/element/TestElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6453386
  * @summary Test basic properties of javax.lang.element.Element
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/element/TestExecutableElement.java
+++ b/test/langtools/tools/javac/processing/model/element/TestExecutableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8005046 8011052 8025087
  * @summary Test basic properties of javax.lang.element.ExecutableElement
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/element/TestNames.java
+++ b/test/langtools/tools/javac/processing/model/element/TestNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6380016
  * @summary Test that the constraints guaranteed by the Filer and maintained
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/element/TestPackageElement.java
+++ b/test/langtools/tools/javac/processing/model/element/TestPackageElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6449798 6399404 8173776 8163989
  * @summary Test basic workings of PackageElement
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/element/TestResourceVariable.java
+++ b/test/langtools/tools/javac/processing/model/element/TestResourceVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug  6911256 6964740 6967842 6961571 7025809
  * @summary Test that the resource variable kind is appropriately set
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules jdk.compiler
  * @build   JavacTestingAbstractProcessor TestResourceVariable

--- a/test/langtools/tools/javac/processing/model/type/MirroredTypeEx/NpeTest.java
+++ b/test/langtools/tools/javac/processing/model/type/MirroredTypeEx/NpeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug     6593082
  * @summary MirroredTypeException constructor should not accept null
- * @author  Joseph D. Darcy
  * @modules java.compiler
  *          jdk.compiler
  */

--- a/test/langtools/tools/javac/processing/model/type/MirroredTypeEx/Plurality.java
+++ b/test/langtools/tools/javac/processing/model/type/MirroredTypeEx/Plurality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
  * @build JavacTestingAbstractProcessor
  * @compile Plurality.java
  * @compile -processor Plurality -proc:only Plurality.java
- * @author  Joseph D. Darcy
  */
 import java.lang.annotation.*;
 import java.math.BigDecimal;

--- a/test/langtools/tools/javac/processing/model/type/TestTypeKind.java
+++ b/test/langtools/tools/javac/processing/model/type/TestTypeKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug     6347716
  * @summary Test TypeKind.isPrimitive
- * @author  Joseph D. Darcy
  * @modules java.compiler
  *          jdk.compiler
  */

--- a/test/langtools/tools/javac/processing/model/util/deprecation/TestDeprecation.java
+++ b/test/langtools/tools/javac/processing/model/util/deprecation/TestDeprecation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6392818
  * @summary Tests Elements.isDeprecated(Element)
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/util/elements/TestGetConstantExpression.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/TestGetConstantExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6471577 6517779
  * @summary Test Elements.getConstantExpression
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/util/elements/TestGetPackageOf.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/TestGetPackageOf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6453386 8216404 8230337
  * @summary Test Elements.getPackageOf
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/util/elements/TestIsFunctionalInterface.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/TestIsFunctionalInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8007574
  * @summary Test Elements.isFunctionalInterface
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/util/elements/VacuousEnum.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/VacuousEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6937417
  * @summary Test -Xprint on enum type with no constants
- * @author  Joseph D. Darcy
  * @compile -Xprint VacuousEnum.java
  */
 public enum VacuousEnum {

--- a/test/langtools/tools/javac/processing/model/util/filter/TestIterables.java
+++ b/test/langtools/tools/javac/processing/model/util/filter/TestIterables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 6406164
  * @summary Test that ElementFilter iterable methods behave properly.
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules java.compiler
  *          jdk.compiler

--- a/test/langtools/tools/javac/processing/model/util/types/TestPseudoTypeHandling.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestPseudoTypeHandling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 8175335
  * @summary Test Types methods on module and package TypeMirrors
- * @author  Joseph D. Darcy
  * @library /tools/javac/lib
  * @modules jdk.compiler
  * @build   JavacTestingAbstractProcessor TestPseudoTypeHandling

--- a/test/langtools/tools/javac/processing/warnings/TestSourceVersionWarnings.java
+++ b/test/langtools/tools/javac/processing/warnings/TestSourceVersionWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,11 @@
  * questions.
  */
 
+
 /*
  * @test
  * @bug 6376083 6376084 6458819 7025784 7025786 7025789
  * @summary Test that warnings about source versions are output as expected.
- * @author  Joseph D. Darcy
  * @modules java.compiler
  *          jdk.compiler
  * @compile TestSourceVersionWarnings.java


### PR DESCRIPTION
Backporting JDK-8369851: Remove darcy author tags from langtools tests.

This PR removes unwanted author tags from tests.

This PR is not clean due to a conflict in the copyright headers and the "BadTwr.out" reference file.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/langtools/tools/javac

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27284963/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27284965/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27284966/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27284967/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8369851](https://bugs.openjdk.org/browse/JDK-8369851) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8369851](https://bugs.openjdk.org/browse/JDK-8369851): Remove darcy author tags from langtools tests (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4401/head:pull/4401` \
`$ git checkout pull/4401`

Update a local copy of the PR: \
`$ git checkout pull/4401` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4401`

View PR using the GUI difftool: \
`$ git pr show -t 4401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4401.diff">https://git.openjdk.org/jdk17u-dev/pull/4401.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4401#issuecomment-4361213423)
</details>
