### PR TITLE
8364927: Add @requires annotation to TestReclaimStringsLeaksMemory.java

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
+++ b/test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java
@@ -24,17 +24,58 @@
 package gc.stress;
 
 /*
- * @test TestReclaimStringsLeaksMemory
+ * @test id=Serial
  * @bug 8180048
- * @summary Ensure that during a Full GC interned string memory is reclaimed completely.
- * @requires vm.gc == "null"
+ * @summary Ensure that during a Full GC interned string memory is reclaimed completely with SerialGC.
+ * @requires vm.gc.Serial
  * @requires !vm.debug
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run driver gc.stress.TestReclaimStringsLeaksMemory
- * @run driver gc.stress.TestReclaimStringsLeaksMemory -XX:+UseSerialGC
- * @run driver gc.stress.TestReclaimStringsLeaksMemory -XX:+UseParallelGC
- * @run driver gc.stress.TestReclaimStringsLeaksMemory -XX:+UseG1GC
+ * @run driver/timeout=480 gc.stress.TestReclaimStringsLeaksMemory -XX:+UseSerialGC
+ */
+
+/*
+ * @test id=Parallel
+ * @bug 8180048
+ * @summary Ensure that during a Full GC interned string memory is reclaimed completely with ParallelGC.
+ * @requires vm.gc.Parallel
+ * @requires !vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=480 gc.stress.TestReclaimStringsLeaksMemory -XX:+UseParallelGC
+ */
+
+/*
+ * @test id=G1
+ * @bug 8180048
+ * @summary Ensure that during a Full GC interned string memory is reclaimed completely with G1GC.
+ * @requires vm.gc.G1
+ * @requires !vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=480 gc.stress.TestReclaimStringsLeaksMemory -XX:+UseG1GC
+ */
+
+/*
+ * @test id=Shenandoah
+ * @bug 8180048
+ * @summary Ensure that during a Full GC interned string memory is reclaimed completely with ShenandoahGC.
+ * @requires vm.gc.Shenandoah
+ * @requires !vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=480 gc.stress.TestReclaimStringsLeaksMemory -XX:+UseShenandoahGC
+ */
+
+/*
+ * @test id=Z
+ * @bug 8180048
+ * @summary Ensure that during a Full GC interned string memory is reclaimed completely with ZGC.
+ * @requires vm.gc.Z
+ * @requires !vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=480 gc.stress.TestReclaimStringsLeaksMemory -XX:+UseZGC
  */
 
 import java.util.Arrays;


### PR DESCRIPTION
Backporting JDK-8364927: Add @requires annotation to TestReclaimStringsLeaksMemory.java.

This PR fixes Fixes TestReclaimStringsLeaksMemory to properly guard against unsupported GC configurations by splitting from a single test with vm.gc == "null" requirement into 5 separate GC-specific tests (Serial, Parallel, G1, Shenandoah, Z), each with explicit @requires clauses that ensure the test only runs when the specified GC is supported, preventing test failures on VMs lacking particular GC implementations.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/gc/stress/TestReclaimStringsLeaksMemory.java

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27402924/macos-aarch64-specific-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/27402951/windows-x64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27402952/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27402953/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8364927](https://bugs.openjdk.org/browse/JDK-8364927) needs maintainer approval

### Issue
 * [JDK-8364927](https://bugs.openjdk.org/browse/JDK-8364927): Add @<!---->requires annotation to TestReclaimStringsLeaksMemory.java (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4403/head:pull/4403` \
`$ git checkout pull/4403`

Update a local copy of the PR: \
`$ git checkout pull/4403` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4403`

View PR using the GUI difftool: \
`$ git pr show -t 4403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4403.diff">https://git.openjdk.org/jdk17u-dev/pull/4403.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4403#issuecomment-4373038957)
</details>
