### PR TITLE
8373716: Refactor further java/util tests from TestNG to JUnit

### DIFF
--- a/test/jdk/java/util/Calendar/CalendarDisplayNamesTest.java
+++ b/test/jdk/java/util/Calendar/CalendarDisplayNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,21 +21,21 @@
  * questions.
  */
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * @test
  * @bug 8262108
  * @summary Verify the results returned by Calendar.getDisplayNames() API
  * @comment Locale providers: COMPAT,SPI
- * @run testng/othervm -Djava.locale.providers=COMPAT,SPI CalendarDisplayNamesTest
+ * @run junit/othervm -Djava.locale.providers=COMPAT,SPI CalendarDisplayNamesTest
  * @comment Locale providers: CLDR
- * @run testng/othervm -Djava.locale.providers=CLDR CalendarDisplayNamesTest
+ * @run junit/othervm -Djava.locale.providers=CLDR CalendarDisplayNamesTest
  */
 public class CalendarDisplayNamesTest {
 
@@ -55,7 +55,7 @@ public class CalendarDisplayNamesTest {
                     continue;
                 }
                 for (final Integer fieldValue : names.values()) {
-                    Assert.assertTrue(fieldValue == Calendar.AM || fieldValue == Calendar.PM,
+                    Assertions.assertTrue(fieldValue == Calendar.AM || fieldValue == Calendar.PM,
                             "Invalid field value " + fieldValue + " for calendar field AM_PM, in locale "
                                     + locale + " with style " + style);
                 }

--- a/test/jdk/java/util/Calendar/JapaneseLenientEraTest.java
+++ b/test/jdk/java/util/Calendar/JapaneseLenientEraTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8206120
  * @summary Test whether lenient era is accepted in JapaneseImperialCalendar
- * @run testng/othervm JapaneseLenientEraTest
+ * @run junit/othervm JapaneseLenientEraTest
  */
 
 import java.text.DateFormat;
@@ -34,15 +34,15 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class JapaneseLenientEraTest {
 
-    @DataProvider(name="lenientEra")
-    Object[][] names() {
+    Object[][] lenientEra() {
         return new Object[][] {
             // lenient era/year, strict era/year
             { "Meiji 123", "Heisei 2" },
@@ -51,7 +51,8 @@ public class JapaneseLenientEraTest {
         };
     }
 
-    @Test(dataProvider="lenientEra")
+    @ParameterizedTest
+    @MethodSource("lenientEra")
     public void testLenientEra(String lenient, String strict) throws Exception {
         Calendar c = new Calendar.Builder()
             .setCalendarType("japanese")
@@ -61,6 +62,6 @@ public class JapaneseLenientEraTest {
         Date lenDate = df.parse(lenient + "-01-01");
         df.setLenient(false);
         Date strDate = df.parse(strict + "-01-01");
-        assertEquals(lenDate, strDate);
+        assertEquals(strDate, lenDate);
     }
 }

--- a/test/jdk/java/util/Calendar/SupplementalJapaneseEraTestRun.java
+++ b/test/jdk/java/util/Calendar/SupplementalJapaneseEraTestRun.java
@@ -27,7 +27,7 @@
  * @summary Test for jdk.calendar.japanese.supplemental.era support
  * @library /test/lib
  * @build SupplementalJapaneseEraTest
- * @run testng/othervm SupplementalJapaneseEraTestRun
+ * @run junit/othervm SupplementalJapaneseEraTestRun
  */
 
 import java.util.Calendar;
@@ -45,11 +45,12 @@ import static java.util.Calendar.YEAR;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Utils;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SupplementalJapaneseEraTestRun {
-    @DataProvider(name = "validprop")
     Object[][] validPropertyData() {
         return new Object[][] {
                 //Tests with valid property values
@@ -58,7 +59,6 @@ public class SupplementalJapaneseEraTestRun {
         };
     }
 
-    @DataProvider(name = "invalidprop")
     Object[][] invalidPropertyData() {
         return new Object[][] {
                 //Tests with invalid property values
@@ -76,7 +76,8 @@ public class SupplementalJapaneseEraTestRun {
         };
     }
 
-    @Test(dataProvider = "validprop")
+    @ParameterizedTest
+    @MethodSource("validPropertyData")
     public void ValidPropertyValuesTest(String prop)
             throws Throwable {
         //get the start time of the fictional next era
@@ -84,7 +85,8 @@ public class SupplementalJapaneseEraTestRun {
         testRun(prop + startTime, List.of("-t"));
     }
 
-    @Test(dataProvider = "invalidprop")
+    @ParameterizedTest
+    @MethodSource("invalidPropertyData")
     public void InvalidPropertyValuesTest(String prop)
             throws Throwable {
         //get the start time of the fictional next era

--- a/test/jdk/java/util/Properties/CompatibilityTest.java
+++ b/test/jdk/java/util/Properties/CompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,19 +24,19 @@
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Properties;
-import org.testng.Assert;
-
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /*
  * @test
  * @bug 8252354
- * @run testng CompatibilityTest
+ * @run junit CompatibilityTest
  * @summary Verify compatibility.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CompatibilityTest {
-    @DataProvider(name = "entries")
     public Object[][] getEntries() throws IOException {
         return new Object[][]{
             {8, 238923},
@@ -53,9 +53,10 @@ public class CompatibilityTest {
      * @param value the value
      * @throws IOException
      */
-    @Test(dataProvider = "entries")
+    @ParameterizedTest
+    @MethodSource("getEntries")
     void testThrows(Object key, Object value) throws IOException {
-        Assert.assertThrows(ClassCastException.class, () -> storeToXML(key, value));
+        Assertions.assertThrows(ClassCastException.class, () -> storeToXML(key, value));
     }
 
     void storeToXML(Object key, Object value) throws IOException {

--- a/test/jdk/java/util/Properties/EncodingTest.java
+++ b/test/jdk/java/util/Properties/EncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,19 +27,20 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
-import org.testng.Assert;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @test
  * @bug 8183743
  * @summary Test to verify the new overload method with Charset functions the
  * same as the existing method that takes a charset name.
- * @run testng EncodingTest
+ * @run junit EncodingTest
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class EncodingTest {
-    @DataProvider(name = "parameters")
     public Object[][] getParameters() throws IOException {
         return new Object[][]{
             {StandardCharsets.UTF_8.name(), null},
@@ -51,7 +52,8 @@ public class EncodingTest {
      * encoding name or a charset can be read with Properties#loadFromXML that
      * returns the same Properties object.
      */
-    @Test(dataProvider = "parameters")
+    @ParameterizedTest
+    @MethodSource("getParameters")
     void testLoadAndStore(String encoding, Charset charset) throws IOException {
         Properties props = new Properties();
         props.put("k0", "\u6C34");
@@ -74,6 +76,6 @@ public class EncodingTest {
             }
         }
 
-        Assert.assertEquals(props, p);
+        Assertions.assertEquals(p, props);
     }
 }

--- a/test/jdk/java/util/Properties/InitialCapacity.java
+++ b/test/jdk/java/util/Properties/InitialCapacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,18 +22,22 @@
  */
 
 import java.util.Properties;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /*
  * @test
  * @bug 8189319
  * @summary Test that Properties(int initialCapacity) throws exceptions (or
             doesn't) as expected
- * @run testng InitialCapacity
+ * @run junit InitialCapacity
  */
 public class InitialCapacity {
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void negativeInitCap() { Properties p = new Properties(-1); }
+    @Test
+    public void negativeInitCap() { Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        Properties p = new Properties(-1);
+        });
+}
 
     @Test
     public void positiveInitCap() { Properties p = new Properties(10); }

--- a/test/jdk/java/util/Properties/PropertiesEntrySetTest.java
+++ b/test/jdk/java/util/Properties/PropertiesEntrySetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,17 +26,17 @@
  * @bug        8245694
  * @summary    tests the entrySet() method of Properties class
  * @author     Yu Li
- * @run testng PropertiesEntrySetTest
+ * @run junit PropertiesEntrySetTest
  */
 
-import org.testng.annotations.Test;
 
 import java.util.Properties;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class PropertiesEntrySetTest {
 
@@ -99,13 +99,13 @@ public class PropertiesEntrySetTest {
     public void testToString() {
         Properties a = new Properties();
         var aEntrySet = a.entrySet();
-        assertEquals(aEntrySet.toString(), "[]");
+        assertEquals("[]", aEntrySet.toString());
 
         a.setProperty("p1", "1");
-        assertEquals(aEntrySet.toString(), "[p1=1]");
+        assertEquals("[p1=1]", aEntrySet.toString());
 
         a.setProperty("p2", "2");
-        assertEquals(aEntrySet.size(), 2);
+        assertEquals(2, aEntrySet.size());
         assertTrue(aEntrySet.toString().trim().startsWith("["));
         assertTrue(aEntrySet.toString().contains("p1=1"));
         assertTrue(aEntrySet.toString().contains("p2=2"));
@@ -115,18 +115,18 @@ public class PropertiesEntrySetTest {
         b.setProperty("p2", "2");
         b.setProperty("p1", "1");
         var bEntrySet = b.entrySet();
-        assertEquals(bEntrySet.size(), 2);
+        assertEquals(2, bEntrySet.size());
         assertTrue(bEntrySet.toString().trim().startsWith("["));
         assertTrue(bEntrySet.toString().contains("p1=1"));
         assertTrue(bEntrySet.toString().contains("p2=2"));
         assertTrue(bEntrySet.toString().trim().endsWith("]"));
 
         b.setProperty("p0", "0");
-        assertEquals(bEntrySet.size(), 3);
+        assertEquals(3, bEntrySet.size());
         assertTrue(bEntrySet.toString().contains("p0=0"));
 
         b.remove("p1");
-        assertEquals(bEntrySet.size(), 2);
+        assertEquals(2, bEntrySet.size());
         assertFalse(bEntrySet.toString().contains("p1=1"));
         assertTrue(bEntrySet.toString().trim().startsWith("["));
         assertTrue(bEntrySet.toString().contains("p0=0"));
@@ -134,7 +134,7 @@ public class PropertiesEntrySetTest {
         assertTrue(bEntrySet.toString().trim().endsWith("]"));
 
         b.remove("p0", "0");
-        assertEquals(bEntrySet.size(), 1);
+        assertEquals(1, bEntrySet.size());
         assertFalse(bEntrySet.toString().contains("p0=0"));
         assertTrue(bEntrySet.toString().trim().startsWith("["));
         assertTrue(bEntrySet.toString().contains("p2=2"));
@@ -151,13 +151,13 @@ public class PropertiesEntrySetTest {
         a.setProperty("p1", "1");
         a.setProperty("p2", "2");
         var aEntrySet = a.entrySet();
-        assertEquals(aEntrySet.size(), 2);
+        assertEquals(2, aEntrySet.size());
 
         var i = aEntrySet.iterator();
         var e1 = i.next();
         i.remove();
         assertFalse(aEntrySet.contains(e1));
-        assertEquals(aEntrySet.size(), 1);
+        assertEquals(1, aEntrySet.size());
 
         var e2 = i.next();
         aEntrySet.remove(e2);
@@ -172,14 +172,14 @@ public class PropertiesEntrySetTest {
         var bEntrySet = b.entrySet();
 
         assertFalse(bEntrySet.containsAll(aEntrySet));
-        assertEquals(bEntrySet.size(), 2);
+        assertEquals(2, bEntrySet.size());
 
         assertTrue(bEntrySet.removeAll(aEntrySet));
-        assertEquals(bEntrySet.size(), 1);
+        assertEquals(1, bEntrySet.size());
 
         assertTrue(bEntrySet.retainAll(aEntrySet));
         assertTrue(bEntrySet.isEmpty());
-        assertEquals(aEntrySet.size(), 2);
+        assertEquals(2, aEntrySet.size());
 
         aEntrySet.clear();
         assertTrue(aEntrySet.isEmpty());

--- a/test/jdk/java/util/ResourceBundle/modules/basic/BasicTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/basic/BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@
  *        jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.process.ProcessTools
  *        ModuleTestUtil
- * @run testng BasicTest
+ * @run junit BasicTest
  */
 
 import java.nio.file.Path;
@@ -54,13 +54,15 @@ import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
 import jdk.test.lib.compiler.CompilerUtils;
 import jdk.test.lib.process.ProcessTools;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import static jdk.test.lib.Asserts.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BasicTest {
     private static final String SRC_DIR_APPBASIC = "srcAppbasic";
     private static final String SRC_DIR_APPBASIC2 = "srcAppbasic2";
@@ -92,7 +94,6 @@ public class BasicTest {
 
     private static final String MAIN = "test/jdk.test.Main";
 
-    @DataProvider(name = "basicTestData")
     Object[][] basicTestData() {
         return new Object[][] {
                 // Named module "test" contains resource bundles for root and en,
@@ -122,7 +123,8 @@ public class BasicTest {
         };
     }
 
-    @Test(dataProvider = "basicTestData")
+    @ParameterizedTest
+    @MethodSource("basicTestData")
     public void runBasicTest(String src, String mod, List<String> moduleList,
             List<String> localeList, String resFormat) throws Throwable {
         Path srcPath = Paths.get(Utils.TEST_SRC, src);

--- a/test/jdk/java/util/ResourceBundle/modules/cache/CacheTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/cache/CacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @library /test/lib
  * @modules jdk.compiler
  * @build CacheTest jdk.test.lib.compiler.CompilerUtils
- * @run testng CacheTest
+ * @run junit CacheTest
  */
 
 import java.nio.file.Files;
@@ -37,11 +37,12 @@ import java.nio.file.Paths;
 import static jdk.test.lib.process.ProcessTools.*;
 import jdk.test.lib.compiler.CompilerUtils;
 
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CacheTest {
 
     private static final String TEST_SRC = System.getProperty("test.src");
@@ -55,7 +56,7 @@ public class CacheTest {
     private static final String MAIN = "test/jdk.test.Main";
     private static final String MAIN_CLASS = "jdk.test.Main";
 
-    @BeforeTest
+    @BeforeAll
     public void compileTestModules() throws Exception {
 
         for (String mn : new String[] {MAIN_BUNDLES_MODULE, TEST_MODULE}) {

--- a/test/jdk/java/util/ResourceBundle/modules/casesensitive/CaseInsensitiveNameClash.java
+++ b/test/jdk/java/util/ResourceBundle/modules/casesensitive/CaseInsensitiveNameClash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @modules jdk.compiler
  * @build jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.process.ProcessTools CaseInsensitiveNameClash
- * @run testng CaseInsensitiveNameClash
+ * @run junit CaseInsensitiveNameClash
  */
 
 import java.nio.file.Files;
@@ -37,10 +37,12 @@ import java.nio.file.Paths;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.compiler.CompilerUtils;
 
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CaseInsensitiveNameClash {
 
     private static final String TEST_SRC = System.getProperty("test.src");
@@ -54,7 +56,7 @@ public class CaseInsensitiveNameClash {
     /**
      * Compiles the module used by the test
      */
-    @BeforeTest
+    @BeforeAll
     public void compileAll() throws Exception {
         Path msrc = SRC_DIR.resolve(MODULE);
         assertTrue(CompilerUtils.compile(msrc, MODS_DIR,

--- a/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  *        jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.process.ProcessTools
  *        ModuleTestUtil
- * @run testng VisibilityTest
+ * @run junit VisibilityTest
  */
 
 import java.nio.file.Path;
@@ -46,13 +46,13 @@ import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
 
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.testng.Assert.assertEquals;
-
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class VisibilityTest {
     private static final Path SRC_DIR = Paths.get(Utils.TEST_SRC, "src");
     private static final Path MODS_DIR = Paths.get(Utils.TEST_CLASSES, "mods");
@@ -63,7 +63,7 @@ public class VisibilityTest {
     private static final List<String> MODULE_LIST = List.of("embargo",
             "exported.named.bundles", "named.bundles", "test");
 
-    @BeforeTest
+    @BeforeAll
     public void prepareTestEnv() throws Throwable {
         MODULE_LIST.forEach(mn -> ModuleTestUtil.prepareModule(SRC_DIR,
                 MODS_DIR, mn, ".properties"));
@@ -93,7 +93,6 @@ public class VisibilityTest {
      * "exported.named.bundle" are exported to unnamed modules.
      */
 
-    @DataProvider(name = "RunWithTestResData")
     Object[][] RunWithTestResData() {
         return new Object[][] {
                 // Tests using jdk.test.TestWithNoModuleArg and jdk.embargo.TestWithNoModuleArg.
@@ -188,7 +187,6 @@ public class VisibilityTest {
         };
     }
 
-    @DataProvider(name = "RunWithExportedResData")
     Object[][] RunWithExportedResData() {
         return new Object[][] {
                 // Tests using jdk.test.TestWithNoModuleArg and jdk.embargo.TestWithNoModuleArg
@@ -285,7 +283,6 @@ public class VisibilityTest {
         };
     }
 
-    @DataProvider(name = "RunWithPkgResData")
     Object[][] RunWithPkgResData() {
         return new Object[][] {
                 // jdk.pkg.resources.* are in an unnamed module.
@@ -300,10 +297,11 @@ public class VisibilityTest {
     /**
      * Test cases with jdk.test.resources.*
      */
-    @Test(dataProvider = "RunWithTestResData")
+    @ParameterizedTest
+    @MethodSource("RunWithTestResData")
     public void RunWithTestRes(List<String> argsList) throws Throwable {
         int exitCode = runCmd(argsList);
-        assertEquals(exitCode, 0, "Execution of the tests with "
+        assertEquals(0, exitCode, "Execution of the tests with "
                 + "jdk.test.resources.* failed. "
                 + "Unexpected exit code: " + exitCode);
     }
@@ -311,10 +309,11 @@ public class VisibilityTest {
     /**
      * Test cases with jdk.test.resources.exported.*
      */
-    @Test(dataProvider = "RunWithExportedResData")
+    @ParameterizedTest
+    @MethodSource("RunWithExportedResData")
     public void RunWithExportedRes(List<String> argsList) throws Throwable {
         int exitCode = runCmd(argsList);
-        assertEquals(exitCode, 0, "Execution of the tests with "
+        assertEquals(0, exitCode, "Execution of the tests with "
                 + "jdk.test.resources.exported.* failed. "
                 + "Unexpected exit code: " + exitCode);
     }
@@ -322,10 +321,11 @@ public class VisibilityTest {
     /**
      * Test cases with jdk.pkg.resources.*
      */
-    @Test(dataProvider = "RunWithPkgResData")
+    @ParameterizedTest
+    @MethodSource("RunWithPkgResData")
     public void RunWithPkgRes(List<String> argsList) throws Throwable {
         int exitCode = runCmd(argsList);
-        assertEquals(exitCode, 0, "Execution of the tests with "
+        assertEquals(0, exitCode, "Execution of the tests with "
                 + "jdk.pkg.resources.* failed. "
                 + "Unexpected exit code: " + exitCode);
     }

--- a/test/jdk/java/util/TimeZone/NegativeDSTTest.java
+++ b/test/jdk/java/util/TimeZone/NegativeDSTTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -31,18 +31,19 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.testng.annotations.Test;
-import org.testng.annotations.DataProvider;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @test
  * @bug 8212970 8324065
  * @summary Test whether the savings are positive in time zones that have
  *      negative savings in the source TZ files.
- * @run testng NegativeDSTTest
+ * @run junit NegativeDSTTest
  */
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class NegativeDSTTest {
 
     private static final TimeZone DUBLIN = TimeZone.getTimeZone("Europe/Dublin");
@@ -51,7 +52,6 @@ public class NegativeDSTTest {
     private static final TimeZone CASABLANCA = TimeZone.getTimeZone("Africa/Casablanca");
     private static final int ONE_HOUR = 3600_000;
 
-    @DataProvider
     private Object[][] negativeDST () {
         return new Object[][] {
             // TimeZone, localDate, offset, isDaylightSavings
@@ -88,10 +88,11 @@ public class NegativeDSTTest {
         };
     }
 
-    @Test(dataProvider="negativeDST")
+    @ParameterizedTest
+    @MethodSource("negativeDST")
     public void test_NegativeDST(TimeZone tz, LocalDate ld, int offset, boolean isDST) {
         Date d = Date.from(Instant.from(ZonedDateTime.of(ld, LocalTime.MIN, tz.toZoneId())));
-        assertEquals(tz.getOffset(d.getTime()), offset);
-        assertEquals(tz.inDaylightTime(d), isDST);
+        assertEquals(offset, tz.getOffset(d.getTime()));
+        assertEquals(isDST, tz.inDaylightTime(d));
     }
 }


### PR DESCRIPTION
Backporting JDK-8373716: Refactor further java/util tests from TestNG to JUnit.

This PR converts java/util test files from TestNG to JUnit across Calendar, TimeZone, Properties, and ResourceBundle packages.

The PR is not clean because the following tests are not present, so the changes are not applicable:

- test/jdk/java/util/Properties/PropertiesStoreTest.java
- test/jdk/java/util/TimeZone/ZoneIdRoundTripTest.java

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/util/Calendar
make test TEST=test/jdk/java/util/Properties
make test TEST=test/jdk/java/util/ResourceBundle/modules
make test TEST=test/jdk/java/util/TimeZone

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27375132/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27375133/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/27375134/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/27375135/windows-x64-specific-4-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27375136/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27375137/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27375138/macos-aarch64-specific-3-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27375139/macos-aarch64-specific-4-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27375140/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27375141/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/27375142/linux-x64-specific-3-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/27375143/linux-x64-specific-4-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27375144/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27375145/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27375146/linux-aarch64-specific-3-test.log)
[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27375147/linux-aarch64-specific-4-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8373716](https://bugs.openjdk.org/browse/JDK-8373716) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373716](https://bugs.openjdk.org/browse/JDK-8373716): Refactor further java/util tests from TestNG to JUnit (**Sub-task** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4404/head:pull/4404` \
`$ git checkout pull/4404`

Update a local copy of the PR: \
`$ git checkout pull/4404` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4404`

View PR using the GUI difftool: \
`$ git pr show -t 4404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4404.diff">https://git.openjdk.org/jdk17u-dev/pull/4404.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4404#issuecomment-4373295883)
</details>
