### PR TITLE
8368498: Use JUnit instead of TestNG for jdk_text tests

### DIFF
--- a/test/jdk/java/text/Format/CompactNumberFormat/CompactFormatAndParseHelper.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/CompactFormatAndParseHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,14 +24,15 @@
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
-import static org.testng.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CompactFormatAndParseHelper {
 
     static void testFormat(NumberFormat cnf, Object number,
             String expected) {
         String result = cnf.format(number);
-        assertEquals(result, expected, "Incorrect formatting of the number '"
+        assertEquals(expected, result, "Incorrect formatting of the number '"
                 + number + "'");
     }
 
@@ -46,11 +47,11 @@ class CompactFormatAndParseHelper {
         }
 
         if (returnType != null) {
-            assertEquals(number.getClass(), returnType,
+            assertEquals(returnType, number.getClass(),
                     "Incorrect return type for string '" + parseString + "'");
         }
 
-        assertEquals(number, expected, "Incorrect parsing of the string '"
+        assertEquals(expected, number, "Incorrect parsing of the string '"
                 + parseString + "'");
     }
 }

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestCNFRounding.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestCNFRounding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,21 +20,28 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8177552
  * @summary Checks the rounding of formatted number in compact number formatting
- * @run testng/othervm TestCNFRounding
+ * @run junit/othervm TestCNFRounding
  */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.List;
 import java.util.Locale;
-import static org.testng.Assert.*;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestCNFRounding {
 
     private static final List<RoundingMode> MODES = List.of(
@@ -46,7 +53,6 @@ public class TestCNFRounding {
             RoundingMode.CEILING,
             RoundingMode.FLOOR);
 
-    @DataProvider(name = "roundingData")
     Object[][] roundingData() {
         return new Object[][]{
             // Number, half_even, half_up, half_down, up, down, ceiling, floor
@@ -70,7 +76,6 @@ public class TestCNFRounding {
             {-4500, new String[]{"-4K", "-5K", "-4K", "-5K", "-4K", "-4K", "-5K"}},};
     }
 
-    @DataProvider(name = "roundingFract")
     Object[][] roundingFract() {
         return new Object[][]{
             // Number, half_even, half_up, half_down, up, down, ceiling, floor
@@ -94,7 +99,6 @@ public class TestCNFRounding {
             {-4500, new String[]{"-4.5K", "-4.5K", "-4.5K", "-4.5K", "-4.5K", "-4.5K", "-4.5K"}},};
     }
 
-    @DataProvider(name = "rounding2Fract")
     Object[][] rounding2Fract() {
         return new Object[][]{
             // Number, half_even, half_up, half_down
@@ -118,37 +122,42 @@ public class TestCNFRounding {
             {4686, new String[]{"4.69K", "4.69K", "4.69K"}},};
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullMode() {
-        NumberFormat fmt = NumberFormat
-                .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
-        fmt.setRoundingMode(null);
+    @Test
+    void testNullMode() {
+        assertThrows(NullPointerException.class, () -> {
+            NumberFormat fmt = NumberFormat
+                    .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
+            fmt.setRoundingMode(null);
+        });
     }
 
     @Test
-    public void testDefaultRoundingMode() {
+    void testDefaultRoundingMode() {
         NumberFormat fmt = NumberFormat
                 .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
-        assertEquals(fmt.getRoundingMode(), RoundingMode.HALF_EVEN,
+        assertEquals(RoundingMode.HALF_EVEN, fmt.getRoundingMode(),
                 "Default RoundingMode should be " + RoundingMode.HALF_EVEN);
     }
 
-    @Test(dataProvider = "roundingData")
-    public void testRounding(Object number, String[] expected) {
+    @ParameterizedTest
+    @MethodSource("roundingData")
+    void testRounding(Object number, String[] expected) {
         for (int index = 0; index < MODES.size(); index++) {
             testRoundingMode(number, expected[index], 0, MODES.get(index));
         }
     }
 
-    @Test(dataProvider = "roundingFract")
-    public void testRoundingFract(Object number, String[] expected) {
+    @ParameterizedTest
+    @MethodSource("roundingFract")
+    void testRoundingFract(Object number, String[] expected) {
         for (int index = 0; index < MODES.size(); index++) {
             testRoundingMode(number, expected[index], 1, MODES.get(index));
         }
     }
 
-    @Test(dataProvider = "rounding2Fract")
-    public void testRounding2Fract(Object number, String[] expected) {
+    @ParameterizedTest
+    @MethodSource("rounding2Fract")
+    void testRounding2Fract(Object number, String[] expected) {
         List<RoundingMode> rModes = List.of(RoundingMode.HALF_EVEN,
                 RoundingMode.HALF_UP, RoundingMode.HALF_DOWN);
         for (int index = 0; index < rModes.size(); index++) {
@@ -161,12 +170,12 @@ public class TestCNFRounding {
         NumberFormat fmt = NumberFormat
                 .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
         fmt.setRoundingMode(rounding);
-        assertEquals(fmt.getRoundingMode(), rounding,
+        assertEquals(rounding, fmt.getRoundingMode(),
                 "RoundingMode set is not returned by getRoundingMode");
 
         fmt.setMinimumFractionDigits(fraction);
         String result = fmt.format(number);
-        assertEquals(result, expected, "Incorrect formatting of number "
+        assertEquals(expected, result, "Incorrect formatting of number "
                 + number + " using rounding mode: " + rounding);
     }
 

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestCompactNumber.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestCompactNumber.java
@@ -25,8 +25,14 @@
  * @bug 8177552 8217721 8222756
  * @summary Checks the functioning of compact number format
  * @modules jdk.localedata
- * @run testng/othervm TestCompactNumber
+ * @run junit/othervm TestCompactNumber
  */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.FieldPosition;
@@ -36,10 +42,11 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.Locale;
 import java.util.stream.Stream;
-import static org.testng.Assert.*;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestCompactNumber {
 
     private static final NumberFormat FORMAT_DZ_LONG = NumberFormat
@@ -81,7 +88,6 @@ public class TestCompactNumber {
     private static final NumberFormat FORMAT_SL_LONG = NumberFormat
             .getCompactNumberInstance(new Locale("sl"), NumberFormat.Style.LONG);
 
-    @DataProvider(name = "format")
     Object[][] compactFormatData() {
         return new Object[][]{
             // compact number format instance, number to format, formatted output
@@ -342,7 +348,6 @@ public class TestCompactNumber {
         };
     }
 
-    @DataProvider(name = "parse")
     Object[][] compactParseData() {
         return new Object[][]{
                 // compact number format instance, string to parse, parsed number, return type
@@ -444,7 +449,6 @@ public class TestCompactNumber {
         };
     }
 
-    @DataProvider(name = "exceptionParse")
     Object[][] exceptionParseData() {
         return new Object[][]{
             // compact number instance, string to parse, null (no o/p; must throws exception)
@@ -462,7 +466,6 @@ public class TestCompactNumber {
             {FORMAT_SE_SHORT, "-8\u00a0mn", null},};
     }
 
-    @DataProvider(name = "invalidParse")
     Object[][] invalidParseData() {
         return new Object[][]{
             // compact number instance, string to parse, parsed number
@@ -492,7 +495,6 @@ public class TestCompactNumber {
         };
     }
 
-    @DataProvider(name = "fieldPosition")
     Object[][] formatFieldPositionData() {
         return new Object[][]{
             //compact number instance, number to format, field, start position, end position, formatted string
@@ -538,7 +540,6 @@ public class TestCompactNumber {
             {FORMAT_SE_SHORT, new BigDecimal("-48982865901234567890.98"), NumberFormat.Field.INTEGER, 1, 9, "\u221248982866\u00a0bn"},};
     }
 
-    @DataProvider(name = "varParsePosition")
     Object[][] varParsePosition() {
         return new Object[][]{
                 // compact number instance, parse string, parsed number,
@@ -566,73 +567,82 @@ public class TestCompactNumber {
     }
 
     @Test
-    public void testInstanceCreation() {
+    void testInstanceCreation() {
         Stream.of(NumberFormat.getAvailableLocales()).forEach(l -> NumberFormat
                 .getCompactNumberInstance(l, NumberFormat.Style.SHORT).format(10000));
         Stream.of(NumberFormat.getAvailableLocales()).forEach(l -> NumberFormat
                 .getCompactNumberInstance(l, NumberFormat.Style.LONG).format(10000));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testFormatWithNullParam() {
-        FORMAT_EN_US_SHORT.format(null);
+    @Test
+    void testFormatWithNullParam() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            FORMAT_EN_US_SHORT.format(null);
+        });
     }
 
-    @Test(dataProvider = "format")
-    public void testFormat(NumberFormat cnf, Object number,
+    @ParameterizedTest
+    @MethodSource("compactFormatData")
+    void testFormat(NumberFormat cnf, Object number,
             String expected) {
         CompactFormatAndParseHelper.testFormat(cnf, number, expected);
     }
 
-    @Test(dataProvider = "parse")
-    public void testParse(NumberFormat cnf, String parseString,
+    @ParameterizedTest
+    @MethodSource("compactParseData")
+    void testParse(NumberFormat cnf, String parseString,
             Number expected, Class<? extends Number> returnType) throws ParseException {
         CompactFormatAndParseHelper.testParse(cnf, parseString, expected, null, returnType);
     }
 
-    @Test(dataProvider = "parse")
-    public void testParsePosition(NumberFormat cnf, String parseString,
+    @ParameterizedTest
+    @MethodSource("compactParseData")
+    void testParsePosition(NumberFormat cnf, String parseString,
             Number expected, Class<? extends Number> returnType) throws ParseException {
         ParsePosition pos = new ParsePosition(0);
         CompactFormatAndParseHelper.testParse(cnf, parseString, expected, pos, returnType);
-        assertEquals(pos.getIndex(), parseString.length());
-        assertEquals(pos.getErrorIndex(), -1);
+        assertEquals(parseString.length(), pos.getIndex());
+        assertEquals(-1, pos.getErrorIndex());
     }
 
-    @Test(dataProvider = "varParsePosition")
-    public void testVarParsePosition(NumberFormat cnf, String parseString,
+    @ParameterizedTest
+    @MethodSource("varParsePosition")
+    void testVarParsePosition(NumberFormat cnf, String parseString,
             Number expected, int startPosition, int indexPosition,
             int errPosition) throws ParseException {
         ParsePosition pos = new ParsePosition(startPosition);
         CompactFormatAndParseHelper.testParse(cnf, parseString, expected, pos, null);
-        assertEquals(pos.getIndex(), indexPosition);
-        assertEquals(pos.getErrorIndex(), errPosition);
+        assertEquals(indexPosition, pos.getIndex());
+        assertEquals(errPosition, pos.getErrorIndex());
     }
 
-    @Test(dataProvider = "exceptionParse", expectedExceptions = ParseException.class)
-    public void throwsParseException(NumberFormat cnf, String parseString,
+    @ParameterizedTest
+    @MethodSource("exceptionParseData")
+    void throwsParseException(NumberFormat cnf, String parseString,
+            Number expected) {
+        assertThrows(ParseException.class, () -> CompactFormatAndParseHelper.testParse(cnf, parseString, expected, null, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidParseData")
+    void testInvalidParse(NumberFormat cnf, String parseString,
             Number expected) throws ParseException {
         CompactFormatAndParseHelper.testParse(cnf, parseString, expected, null, null);
     }
 
-    @Test(dataProvider = "invalidParse")
-    public void testInvalidParse(NumberFormat cnf, String parseString,
-            Number expected) throws ParseException {
-        CompactFormatAndParseHelper.testParse(cnf, parseString, expected, null, null);
-    }
-
-    @Test(dataProvider = "fieldPosition")
-    public void testFormatWithFieldPosition(NumberFormat nf,
+    @ParameterizedTest
+    @MethodSource("formatFieldPositionData")
+    void testFormatWithFieldPosition(NumberFormat nf,
             Object number, Format.Field field, int posStartExpected,
             int posEndExpected, String expected) {
         FieldPosition pos = new FieldPosition(field);
         StringBuffer buf = new StringBuffer();
         StringBuffer result = nf.format(number, buf, pos);
-        assertEquals(result.toString(), expected, "Incorrect formatting of the number '"
+        assertEquals(expected, result.toString(), "Incorrect formatting of the number '"
                 + number + "'");
-        assertEquals(pos.getBeginIndex(), posStartExpected, "Incorrect start position"
+        assertEquals(posStartExpected, pos.getBeginIndex(), "Incorrect start position"
                 + " while formatting the number '" + number + "', for the field " + field);
-        assertEquals(pos.getEndIndex(), posEndExpected, "Incorrect end position"
+        assertEquals(posEndExpected, pos.getEndIndex(), "Incorrect end position"
                 + " while formatting the number '" + number + "', for the field " + field);
     }
 

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestCompactPatternsValidity.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestCompactPatternsValidity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,12 @@
  * @bug 8177552 8217254 8251499
  * @summary Checks the validity of compact number patterns specified through
  *          CompactNumberFormat constructor
- * @run testng/othervm TestCompactPatternsValidity
+ * @run junit/othervm TestCompactPatternsValidity
  */
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -35,9 +39,10 @@ import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Locale;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestCompactPatternsValidity {
 
     // Max range 10^4
@@ -74,7 +79,6 @@ public class TestCompactPatternsValidity {
     private static final String[] COMPACT_PATTERN14 =
         new String[]{"", "", "", "{one:Kun other:0' 'Kun}"}; // from Somali in CLDR 38
 
-    @DataProvider(name = "invalidPatterns")
     Object[][] invalidCompactPatterns() {
         return new Object[][] {
             // compact patterns
@@ -90,7 +94,6 @@ public class TestCompactPatternsValidity {
         };
     }
 
-    @DataProvider(name = "validPatternsFormat")
     Object[][] validPatternsFormat() {
         return new Object[][] {
             // compact patterns, numbers, expected output
@@ -114,7 +117,6 @@ public class TestCompactPatternsValidity {
         };
     }
 
-    @DataProvider(name = "validPatternsParse")
     Object[][] validPatternsParse() {
         return new Object[][] {
             // compact patterns, parse string, expected output
@@ -134,7 +136,6 @@ public class TestCompactPatternsValidity {
         };
     }
 
-    @DataProvider(name = "validPatternsFormatWithPluralRules")
     Object[][] validPatternsFormatWithPluralRules() {
         return new Object[][] {
             // compact patterns, plural rules, numbers, expected output
@@ -142,7 +143,6 @@ public class TestCompactPatternsValidity {
         };
     }
 
-    @DataProvider(name = "validPatternsParseWithPluralRules")
     Object[][] validPatternsParseWithPluralRules() {
         return new Object[][] {
             // compact patterns, plural rules, parse string, expected output
@@ -150,15 +150,18 @@ public class TestCompactPatternsValidity {
         };
     }
 
-    @Test(dataProvider = "invalidPatterns",
-            expectedExceptions = IllegalArgumentException.class)
-    public void testInvalidCompactPatterns(String[] compactPatterns) {
-        new CompactNumberFormat("#,##0.0#", DecimalFormatSymbols
-                .getInstance(Locale.US), compactPatterns);
+    @ParameterizedTest
+    @MethodSource("invalidCompactPatterns")
+    void testInvalidCompactPatterns(String[] compactPatterns) {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new CompactNumberFormat("#,##0.0#", DecimalFormatSymbols
+                    .getInstance(Locale.US), compactPatterns);
+        });
     }
 
-    @Test(dataProvider = "validPatternsFormat")
-    public void testValidPatternsFormat(String[] compactPatterns,
+    @ParameterizedTest
+    @MethodSource("validPatternsFormat")
+    void testValidPatternsFormat(String[] compactPatterns,
             List<Object> numbers, List<String> expected) {
         CompactNumberFormat fmt = new CompactNumberFormat("#,##0.0#",
                 DecimalFormatSymbols.getInstance(Locale.US), compactPatterns);
@@ -168,8 +171,9 @@ public class TestCompactPatternsValidity {
         }
     }
 
-    @Test(dataProvider = "validPatternsParse")
-    public void testValidPatternsParse(String[] compactPatterns,
+    @ParameterizedTest
+    @MethodSource("validPatternsParse")
+    void testValidPatternsParse(String[] compactPatterns,
             List<String> parseString, List<Number> numbers) throws ParseException {
         CompactNumberFormat fmt = new CompactNumberFormat("#,##0.0#",
                     DecimalFormatSymbols.getInstance(Locale.US), compactPatterns);
@@ -179,8 +183,9 @@ public class TestCompactPatternsValidity {
         }
     }
 
-    @Test(dataProvider = "validPatternsFormatWithPluralRules")
-    public void testValidPatternsFormatWithPluralRules(String[] compactPatterns, String pluralRules,
+    @ParameterizedTest
+    @MethodSource("validPatternsFormatWithPluralRules")
+    void testValidPatternsFormatWithPluralRules(String[] compactPatterns, String pluralRules,
             List<Object> numbers, List<String> expected) {
         CompactNumberFormat fmt = new CompactNumberFormat("#,##0.0#",
                         DecimalFormatSymbols.getInstance(Locale.US), compactPatterns, pluralRules);
@@ -190,8 +195,9 @@ public class TestCompactPatternsValidity {
         }
     }
 
-    @Test(dataProvider = "validPatternsParseWithPluralRules")
-    public void testValidPatternsParsewithPluralRules(String[] compactPatterns, String pluralRules,
+    @ParameterizedTest
+    @MethodSource("validPatternsParseWithPluralRules")
+    void testValidPatternsParsewithPluralRules(String[] compactPatterns, String pluralRules,
             List<String> parseString, List<Number> numbers) throws ParseException {
         CompactNumberFormat fmt = new CompactNumberFormat("#,##0.0#",
                         DecimalFormatSymbols.getInstance(Locale.US), compactPatterns, pluralRules);

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestEquality.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestEquality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,25 +20,26 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8177552 8222756
  * @summary Checks the equals and hashCode method of CompactNumberFormat
  * @modules jdk.localedata
- * @run testng/othervm TestEquality
- *
+ * @run junit/othervm TestEquality
  */
+
+import org.junit.jupiter.api.Test;
 
 import java.text.CompactNumberFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
-import org.testng.annotations.Test;
 
 public class TestEquality {
 
     @Test
-    public void testEquality() {
+    void testEquality() {
         CompactNumberFormat cnf1 = (CompactNumberFormat) NumberFormat
                 .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
 
@@ -148,7 +149,7 @@ public class TestEquality {
     }
 
     @Test
-    public void testHashCode() {
+    void testHashCode() {
         NumberFormat cnf1 = NumberFormat
                 .getCompactNumberInstance(Locale.JAPAN, NumberFormat.Style.SHORT);
         NumberFormat cnf2 = NumberFormat
@@ -163,7 +164,7 @@ public class TestEquality {
     // Test the property of equals and hashCode i.e. two equal object must
     // always have the same hashCode
     @Test
-    public void testEqualsAndHashCode() {
+    void testEqualsAndHashCode() {
         NumberFormat cnf1 = NumberFormat
                 .getCompactNumberInstance(new Locale("hi", "IN"), NumberFormat.Style.SHORT);
         cnf1.setMinimumIntegerDigits(5);

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestFormatToCharacterIterator.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestFormatToCharacterIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,14 +20,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8177552
  * @summary Checks the functioning of
  *          CompactNumberFormat.formatToCharacterIterator method
  * @modules jdk.localedata
- * @run testng/othervm TestFormatToCharacterIterator
+ * @run junit/othervm TestFormatToCharacterIterator
  */
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.AttributedCharacterIterator;
@@ -36,10 +42,10 @@ import java.text.Format;
 import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.Set;
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestFormatToCharacterIterator {
 
     private static final NumberFormat FORMAT_DZ = NumberFormat
@@ -54,7 +60,6 @@ public class TestFormatToCharacterIterator {
             .getCompactNumberInstance(new Locale("en"),
                     NumberFormat.Style.LONG);
 
-    @DataProvider(name = "fieldPositions")
     Object[][] compactFieldPositionData() {
         return new Object[][]{
             // compact format instance, number, resulted string, attributes/fields, attribute positions
@@ -149,22 +154,23 @@ public class TestFormatToCharacterIterator {
         };
     }
 
-    @Test(dataProvider = "fieldPositions")
-    public void testFormatToCharacterIterator(NumberFormat fmt, Object number,
+    @ParameterizedTest
+    @MethodSource("compactFieldPositionData")
+    void testFormatToCharacterIterator(NumberFormat fmt, Object number,
             String expected, Format.Field[] expectedFields, int[] positions) {
         AttributedCharacterIterator iterator = fmt.formatToCharacterIterator(number);
-        assertEquals(getText(iterator), expected, "Incorrect formatting of the number '"
+        assertEquals(expected, getText(iterator), "Incorrect formatting of the number '"
                 + number + "'");
 
         iterator.first();
         // Check start and end index of the formatted string
-        assertEquals(iterator.getBeginIndex(), 0, "Incorrect start index: "
+        assertEquals(0, iterator.getBeginIndex(), "Incorrect start index: "
                 + iterator.getBeginIndex() + " of the formatted string: " + expected);
-        assertEquals(iterator.getEndIndex(), expected.length(), "Incorrect end index: "
+        assertEquals(expected.length(), iterator.getEndIndex(), "Incorrect end index: "
                 + iterator.getEndIndex() + " of the formatted string: " + expected);
 
         // Check the attributes returned by the formatToCharacterIterator
-        assertEquals(iterator.getAllAttributeKeys(), Set.of(expectedFields),
+        assertEquals(Set.of(expectedFields), iterator.getAllAttributeKeys(),
                 "Attributes do not match while formatting number: " + number);
 
         // Check the begin and end index for attributes
@@ -173,10 +179,10 @@ public class TestFormatToCharacterIterator {
         do {
             int start = iterator.getRunStart();
             int end = iterator.getRunLimit();
-            assertEquals(start, positions[currentPosition],
+            assertEquals(positions[currentPosition], start,
                     "Incorrect start position for the attribute(s): "
                     + iterator.getAttributes().keySet());
-            assertEquals(end, positions[currentPosition + 1],
+            assertEquals(positions[currentPosition + 1], end,
                     "Incorrect end position for the attribute(s): "
                     + iterator.getAttributes().keySet());
             currentPosition = currentPosition + 2;

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestMutatingInstance.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestMutatingInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8177552
@@ -29,8 +30,14 @@
  *          formatting parameters. For example, min fraction digits, grouping
  *          size etc.
  * @modules jdk.localedata
- * @run testng/othervm TestMutatingInstance
+ * @run junit/othervm TestMutatingInstance
  */
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.CompactNumberFormat;
@@ -38,10 +45,8 @@ import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestMutatingInstance {
 
     private static final NumberFormat FORMAT_FRACTION = NumberFormat
@@ -63,8 +68,8 @@ public class TestMutatingInstance {
             "#,##0.0#", DecimalFormatSymbols.getInstance(Locale.US),
             new String[]{"", "", "", "", "00K", "", "", "", "", "", "", "", "", "", ""});
 
-    @BeforeTest
-    public void mutateInstances() {
+    @BeforeAll
+    void mutateInstances() {
         FORMAT_FRACTION.setMinimumFractionDigits(2);
         FORMAT_GROUPING.setGroupingSize(3);
         FORMAT_GROUPING.setGroupingUsed(true);
@@ -77,7 +82,6 @@ public class TestMutatingInstance {
         FORMAT_NO_PATTERNS.setMinimumFractionDigits(2);
     }
 
-    @DataProvider(name = "format")
     Object[][] compactFormatData() {
         return new Object[][]{
             {FORMAT_FRACTION, 1900, "1.90 thousand"},
@@ -97,7 +101,6 @@ public class TestMutatingInstance {
             {FORMAT_NO_PATTERNS, new BigDecimal(12346567890987654.32), "12,346,567,890,987,654"},};
     }
 
-    @DataProvider(name = "parse")
     Object[][] compactParseData() {
         return new Object[][]{
             {FORMAT_FRACTION, "190 thousand", 190000L},
@@ -108,14 +111,16 @@ public class TestMutatingInstance {
             {FORMAT_PARSEINTONLY, "12.345 thousand", 12000L},};
     }
 
-    @Test(dataProvider = "format")
-    public void formatCompactNumber(NumberFormat nf,
+    @ParameterizedTest
+    @MethodSource("compactFormatData")
+    void formatCompactNumber(NumberFormat nf,
             Object number, String expected) {
         CompactFormatAndParseHelper.testFormat(nf, number, expected);
     }
 
-    @Test(dataProvider = "parse")
-    public void parseCompactNumber(NumberFormat nf,
+    @ParameterizedTest
+    @MethodSource("compactParseData")
+    void parseCompactNumber(NumberFormat nf,
             String parseString, Number expected) throws ParseException {
         CompactFormatAndParseHelper.testParse(nf, parseString, expected, null, null);
     }

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestParseBigDecimal.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestParseBigDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,17 +20,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8177552
  * @summary Checks CNF.parse() when parseBigDecimal is set to true
  * @modules jdk.localedata
- * @run testng/othervm TestParseBigDecimal
+ * @run junit/othervm TestParseBigDecimal
  */
 
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
 import java.text.CompactNumberFormat;
@@ -38,6 +40,7 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestParseBigDecimal {
 
     private static final CompactNumberFormat FORMAT_DZ_LONG = (CompactNumberFormat) NumberFormat
@@ -64,8 +67,8 @@ public class TestParseBigDecimal {
     private static final CompactNumberFormat FORMAT_SE_SHORT = (CompactNumberFormat) NumberFormat
             .getCompactNumberInstance(new Locale("se"), NumberFormat.Style.SHORT);
 
-    @BeforeTest
-    public void mutateInstances() {
+    @BeforeAll
+    void mutateInstances() {
         FORMAT_DZ_LONG.setParseBigDecimal(true);
         FORMAT_EN_US_SHORT.setParseBigDecimal(true);
         FORMAT_EN_LONG.setParseBigDecimal(true);
@@ -76,7 +79,6 @@ public class TestParseBigDecimal {
         FORMAT_SE_SHORT.setParseBigDecimal(true);
     }
 
-    @DataProvider(name = "parse")
     Object[][] compactParseData() {
         return new Object[][]{
             // compact number format instance, string to parse, parsed number
@@ -165,8 +167,9 @@ public class TestParseBigDecimal {
             {FORMAT_SE_SHORT, "\u221212345679,89\u00a0bn", new BigDecimal("-12345679890000000000.00")},};
     }
 
-    @Test(dataProvider = "parse")
-    public void testParse(NumberFormat cnf, String parseString,
+    @ParameterizedTest
+    @MethodSource("compactParseData")
+    void testParse(NumberFormat cnf, String parseString,
             Number expected) throws ParseException {
         CompactFormatAndParseHelper.testParse(cnf, parseString, expected, null, BigDecimal.class);
     }

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestPlurals.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestPlurals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,21 +20,27 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8222756
  * @summary Tests plurals support in CompactNumberFormat
- * @run testng/othervm TestPlurals
+ * @run junit/othervm TestPlurals
  */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.CompactNumberFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
-import static org.testng.Assert.*;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestPlurals {
 
     private final static DecimalFormatSymbols DFS = DecimalFormatSymbols.getInstance(Locale.ROOT);
@@ -45,7 +51,6 @@ public class TestPlurals {
     private final static String RULE_3 = "one:n%2=0andn/3=2;";
 
 
-    @DataProvider
     Object[][] pluralRules() {
         return new Object[][]{
             // rules, number, expected
@@ -78,7 +83,6 @@ public class TestPlurals {
         };
     }
 
-    @DataProvider
     Object[][] invalidRules() {
         return new Object [][] {
             {"one:a = 1"},
@@ -92,27 +96,34 @@ public class TestPlurals {
         };
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testNullPluralRules() {
-        String[] pattern = {""};
-        new CompactNumberFormat("#", DFS, PATTERN, null);
+    @Test
+    void testNullPluralRules() {
+        assertThrows(NullPointerException.class, () -> {
+            String[] pattern = {""};
+            new CompactNumberFormat("#", DFS, PATTERN, null);
+        });
     }
 
-    @Test(dataProvider = "pluralRules")
-    public void testPluralRules(String rules, Number n, String expected) {
+    @ParameterizedTest
+    @MethodSource("pluralRules")
+    void testPluralRules(String rules, Number n, String expected) {
         var cnp = new CompactNumberFormat("#", DFS, PATTERN, rules);
-        assertEquals(cnp.format(n), expected);
+        assertEquals(expected, cnp.format(n));
     }
 
-    @Test(dataProvider = "invalidRules", expectedExceptions = IllegalArgumentException.class)
-    public void testInvalidRules(String rules) {
-        new CompactNumberFormat("#", DFS, PATTERN, rules);
+    @ParameterizedTest
+    @MethodSource("invalidRules")
+    void testInvalidRules(String rules) {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CompactNumberFormat("#", DFS, PATTERN, rules));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testLimitExceedingRules() {
-        String andCond = " and n = 1";
-        String invalid = "one: n = 1" + andCond.repeat(2_048 / andCond.length());
-        new CompactNumberFormat("#", DFS, PATTERN, invalid);
+    @Test
+    void testLimitExceedingRules() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            String andCond = " and n = 1";
+            String invalid = "one: n = 1" + andCond.repeat(2_048 / andCond.length());
+            new CompactNumberFormat("#", DFS, PATTERN, invalid);
+        });
     }
 }

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestSpecialValues.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestSpecialValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,25 +20,29 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8177552
  * @summary Checks the formatting and parsing of special values
  * @modules jdk.localedata
- * @run testng/othervm TestSpecialValues
+ * @run junit/othervm TestSpecialValues
  */
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestSpecialValues {
 
     private static final NumberFormat FORMAT = NumberFormat
             .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
 
-    @DataProvider(name = "formatSpecialValues")
     Object[][] formatSpecialValues() {
         return new Object[][]{
             // number , formatted ouput
@@ -53,7 +57,6 @@ public class TestSpecialValues {
             {Long.MAX_VALUE, "9223372T"},};
     }
 
-    @DataProvider(name = "parseSpecialValues")
     Object[][] parseSpecialValues() {
         return new Object[][]{
             // parse string, parsed number
@@ -65,13 +68,15 @@ public class TestSpecialValues {
             {"-\u221E", Double.NEGATIVE_INFINITY},};
     }
 
-    @Test(dataProvider = "formatSpecialValues")
-    public void testFormatSpecialValues(Object number, String expected) {
+    @ParameterizedTest
+    @MethodSource("formatSpecialValues")
+    void testFormatSpecialValues(Object number, String expected) {
         CompactFormatAndParseHelper.testFormat(FORMAT, number, expected);
     }
 
-    @Test(dataProvider = "parseSpecialValues")
-    public void testParseSpecialValues(String parseString, Number expected)
+    @ParameterizedTest
+    @MethodSource("parseSpecialValues")
+    void testParseSpecialValues(String parseString, Number expected)
             throws ParseException {
         CompactFormatAndParseHelper.testParse(FORMAT, parseString, expected, null, null);
     }

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestUExtensionOverride.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestUExtensionOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,23 +20,27 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8177552 8221432
  * @summary Checks the behaviour of Unicode BCP 47 U Extension with
  *          compact number format
  * @modules jdk.localedata
- * @run testng/othervm TestUExtensionOverride
+ * @run junit/othervm TestUExtensionOverride
  */
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestUExtensionOverride {
 
-    @DataProvider(name = "compactFormatData")
     Object[][] compactFormatData() {
         return new Object[][]{
             // locale, number, formatted string
@@ -61,7 +65,6 @@ public class TestUExtensionOverride {
                 "\u0967\u0968\u00a0k"},};
     }
 
-    @DataProvider(name = "compactParseData")
     Object[][] compactParseData() {
         return new Object[][]{
             // locale, parse string, parsed number
@@ -87,16 +90,18 @@ public class TestUExtensionOverride {
                 "\u0967\u0968\u00a0k", 12000L},};
     }
 
-    @Test(dataProvider = "compactFormatData")
-    public void testFormat(Locale locale, double num,
+    @ParameterizedTest
+    @MethodSource("compactFormatData")
+    void testFormat(Locale locale, double num,
             String expected) {
         NumberFormat cnf = NumberFormat.getCompactNumberInstance(locale,
                 NumberFormat.Style.SHORT);
         CompactFormatAndParseHelper.testFormat(cnf, num, expected);
     }
 
-    @Test(dataProvider = "compactParseData")
-    public void testParse(Locale locale, String parseString,
+    @ParameterizedTest
+    @MethodSource("compactParseData")
+    void testParse(Locale locale, String parseString,
             Number expected) throws ParseException {
         NumberFormat cnf = NumberFormat.getCompactNumberInstance(locale,
                 NumberFormat.Style.SHORT);

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestWithCompatProvider.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestWithCompatProvider.java
@@ -28,16 +28,19 @@
  *          as a provider should always use the default patterns added in the
  *          FormatData.java resource bundle
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=COMPAT TestWithCompatProvider
+ * @run junit/othervm -Djava.locale.providers=COMPAT TestWithCompatProvider
  */
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Locale;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestWithCompatProvider {
 
     private static final NumberFormat FORMAT_DZ_SHORT = NumberFormat
@@ -46,7 +49,6 @@ public class TestWithCompatProvider {
     private static final NumberFormat FORMAT_EN_US_SHORT = NumberFormat
             .getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
 
-    @DataProvider(name = "format")
     Object[][] compactFormatData() {
         return new Object[][]{
             {FORMAT_DZ_SHORT, 1000.09, "1K"},
@@ -61,7 +63,6 @@ public class TestWithCompatProvider {
             {FORMAT_EN_US_SHORT, new BigDecimal("12345678901234567890.89"), "12345679T"},};
     }
 
-    @DataProvider(name = "parse")
     Object[][] compactParseData() {
         return new Object[][]{
             {FORMAT_DZ_SHORT, "1K", 1000L},
@@ -72,13 +73,15 @@ public class TestWithCompatProvider {
             {FORMAT_EN_US_SHORT, "12345679T", 1.2345679E19},};
     }
 
-    @Test(dataProvider = "format")
+    @ParameterizedTest
+    @MethodSource("compactFormatData")
     public void testFormat(NumberFormat cnf, Object number,
             String expected) {
         CompactFormatAndParseHelper.testFormat(cnf, number, expected);
     }
 
-    @Test(dataProvider = "parse")
+    @ParameterizedTest
+    @MethodSource("compactParseData")
     public void testParse(NumberFormat cnf, String parseString,
             Number expected) throws ParseException {
         CompactFormatAndParseHelper.testParse(cnf, parseString, expected, null, null);

--- a/test/jdk/java/text/Format/CompactNumberFormat/serialization/TestDeserializeCNF.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/serialization/TestDeserializeCNF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,11 +30,12 @@
  * @summary Checks deserialization of compact number format
  * @library /java/text/testlib
  * @build TestDeserializeCNF HexDumpReader
- * @run testng/othervm TestDeserializeCNF
+ * @run junit/othervm TestDeserializeCNF
  */
 
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,8 +44,10 @@ import java.math.RoundingMode;
 import java.text.CompactNumberFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
-import static org.testng.Assert.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestDeserializeCNF {
 
     // This object is serialized in cnf1.ser.txt with HALF_UP
@@ -62,8 +65,8 @@ public class TestDeserializeCNF {
     private static final String FILE_COMPACT_FORMAT1 = "cnf1.ser.txt";
     private static final String FILE_COMPACT_FORMAT2 = "cnf2.ser.txt";
 
-    @BeforeTest
-    public void mutateInstances() {
+    @BeforeAll
+    void mutateInstances() {
         COMPACT_FORMAT1.setRoundingMode(RoundingMode.HALF_UP);
         COMPACT_FORMAT1.setGroupingSize(3);
         COMPACT_FORMAT1.setParseBigDecimal(true);
@@ -73,18 +76,18 @@ public class TestDeserializeCNF {
     }
 
     @Test
-    public void testDeserialization() throws IOException, ClassNotFoundException {
+    void testDeserialization() throws IOException, ClassNotFoundException {
         try (InputStream istream1 = HexDumpReader.getStreamFromHexDump(FILE_COMPACT_FORMAT1);
                 ObjectInputStream ois1 = new ObjectInputStream(istream1);
                 InputStream istream2 = HexDumpReader.getStreamFromHexDump(FILE_COMPACT_FORMAT2);
                 ObjectInputStream ois2 = new ObjectInputStream(istream2);) {
 
             CompactNumberFormat obj1 = (CompactNumberFormat) ois1.readObject();
-            assertEquals(obj1, COMPACT_FORMAT1, "Deserialized instance is not"
+            assertEquals(COMPACT_FORMAT1, obj1, "Deserialized instance is not"
                     + " equal to the instance serialized in " + FILE_COMPACT_FORMAT1);
 
             CompactNumberFormat obj2 = (CompactNumberFormat) ois2.readObject();
-            assertEquals(obj2, COMPACT_FORMAT2, "Deserialized instance is not"
+            assertEquals(COMPACT_FORMAT2, obj2, "Deserialized instance is not"
                     + " equal to the instance serialized in " + FILE_COMPACT_FORMAT2);
         }
     }

--- a/test/jdk/java/text/Format/CompactNumberFormat/serialization/TestSerialization.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/serialization/TestSerialization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,16 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8177552
  * @modules jdk.localedata
  * @summary Checks the serialization feature of CompactNumberFormat
- * @run testng/othervm TestSerialization
+ * @run junit/othervm TestSerialization
  */
 
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -40,8 +42,10 @@ import java.math.RoundingMode;
 import java.text.CompactNumberFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
-import static org.testng.Assert.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestSerialization {
 
     private static final NumberFormat FORMAT_HI = NumberFormat.getCompactNumberInstance(
@@ -57,8 +61,8 @@ public class TestSerialization {
     private static final NumberFormat FORMAT_KO_KR = NumberFormat.getCompactNumberInstance(
             Locale.KOREA, NumberFormat.Style.SHORT);
 
-    @BeforeTest
-    public void mutateInstances() {
+    @BeforeAll
+    void mutateInstances() {
         FORMAT_HI.setMinimumFractionDigits(2);
         FORMAT_HI.setMinimumIntegerDigits(5);
 
@@ -80,7 +84,7 @@ public class TestSerialization {
     }
 
     @Test
-    public void testSerialization() throws IOException, ClassNotFoundException {
+    void testSerialization() throws IOException, ClassNotFoundException {
         // Serialize
         serialize("cdf.ser", FORMAT_HI, FORMAT_EN_US, FORMAT_JA_JP, FORMAT_FR_FR, FORMAT_DE_DE, FORMAT_KO_KR);
         // Deserialize
@@ -103,13 +107,13 @@ public class TestSerialization {
                 new FileInputStream(fileName))) {
             for (NumberFormat fmt : formats) {
                 NumberFormat obj = (NumberFormat) os.readObject();
-                assertEquals(fmt, obj, "Serialized and deserialized"
+                assertEquals(obj, fmt, "Serialized and deserialized"
                         + " objects do not match");
 
                 long number = 123456789789L;
                 String expected = fmt.format(number);
                 String actual = obj.format(number);
-                assertEquals(actual, expected, "Serialized and deserialized"
+                assertEquals(expected, actual, "Serialized and deserialized"
                         + " objects are expected to return same formatted"
                         + " output for number: " + number);
             }

--- a/test/jdk/java/text/Format/DateFormat/Bug8193444.java
+++ b/test/jdk/java/text/Format/DateFormat/Bug8193444.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,29 +20,32 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * @test
  * @bug 8193444
  * @summary Checks SimpleDateFormat.format/parse for the AIOOB exception when
  *          formatting/parsing dates through a pattern string that contains a
  *          sequence of 256 or more non-ASCII unicode characters.
- * @run testng/othervm Bug8193444
+ * @run junit/othervm Bug8193444
  */
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class Bug8193444 {
 
     private static final String NON_ASCII_CHAR = "\u263A";
 
-    @DataProvider(name = "dateFormat")
     Object[][] dateFormatData() {
         return new Object[][]{
             // short_length (between 0 and 254)
@@ -53,8 +56,9 @@ public class Bug8193444 {
             {257},};
     }
 
-    @Test(dataProvider = "dateFormat")
-    public void testDateFormatAndParse(int length)
+    @ParameterizedTest
+    @MethodSource("dateFormatData")
+    void testDateFormatAndParse(int length)
             throws ParseException {
 
         String pattern = NON_ASCII_CHAR.repeat(length);
@@ -66,7 +70,7 @@ public class Bug8193444 {
         // Since the tested format patterns do not contain any character
         // representing date/time field, those characters are not interpreted,
         // they are simply copied into the output string during formatting
-        assertEquals(result, pattern, "Failed to format the date using"
+        assertEquals(pattern, result, "Failed to format the date using"
                 + " pattern of length: " + length);
 
         // The format pattern used by this SimpleDateFormat

--- a/test/jdk/java/text/Format/DateFormat/CaseInsensitiveParseTest.java
+++ b/test/jdk/java/text/Format/DateFormat/CaseInsensitiveParseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,17 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8248434
  * @modules jdk.localedata
- * @run testng/othervm CaseInsensitiveParseTest
  * @summary Checks format/parse round trip in case-insensitive manner.
+ * @run junit/othervm CaseInsensitiveParseTest
  */
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -37,36 +41,36 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.stream.Stream;
 
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CaseInsensitiveParseTest {
 
     private final static String PATTERN = "GGGG/yyyy/MMMM/dddd/hhhh/mmmm/ss/aaaa";
     private final static Date EPOCH = new Date(0L);
 
-    @DataProvider
-    private Object[][] locales() {
+    Object[][] locales() {
         return (Object[][])Arrays.stream(DateFormat.getAvailableLocales())
             .map(Stream::of)
             .map(Stream::toArray)
             .toArray(Object[][]::new);
     }
 
-    @Test(dataProvider = "locales")
-    public void testUpperCase(Locale loc) throws ParseException {
+    @ParameterizedTest
+    @MethodSource("locales")
+    void testUpperCase(Locale loc) throws ParseException {
         SimpleDateFormat sdf = new SimpleDateFormat(PATTERN, loc);
         String formatted = sdf.format(EPOCH);
-        assertEquals(sdf.parse(formatted.toUpperCase(Locale.ROOT)), EPOCH,
+        assertEquals(EPOCH, sdf.parse(formatted.toUpperCase(Locale.ROOT)),
                 "roundtrip failed for string '" + formatted + "', locale: " + loc);
     }
 
-    @Test(dataProvider = "locales")
-    public void testLowerCase(Locale loc) throws ParseException {
+    @ParameterizedTest
+    @MethodSource("locales")
+    void testLowerCase(Locale loc) throws ParseException {
         SimpleDateFormat sdf = new SimpleDateFormat(PATTERN, loc);
         String formatted = sdf.format(EPOCH);
-        assertEquals(sdf.parse(formatted.toLowerCase(Locale.ROOT)), EPOCH,
+        assertEquals(EPOCH, sdf.parse(formatted.toLowerCase(Locale.ROOT)),
                 "roundtrip failed for string '" + formatted + "', locale: " + loc);
     }
 }

--- a/test/jdk/java/text/Format/DateFormat/LocaleDateFormats.java
+++ b/test/jdk/java/text/Format/DateFormat/LocaleDateFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,34 +21,38 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8080774
  * @modules jdk.localedata
- * @run testng/othervm -Djava.locale.providers=JRE,CLDR LocaleDateFormats
  * @summary This file contains tests for JRE locales date formats
+ * @run junit/othervm -Djava.locale.providers=JRE,CLDR LocaleDateFormats
  */
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.DateFormat;
 import java.util.Calendar;
 import java.util.Locale;
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class LocaleDateFormats {
 
-    @Test(dataProvider = "dateFormats")
-    public void testDateFormat(Locale loc, int style, int year, int month, int date, String expectedString) {
+    @ParameterizedTest
+    @MethodSource("dateFormats")
+    void testDateFormat(Locale loc, int style, int year, int month, int date, String expectedString) {
         Calendar cal = Calendar.getInstance(loc);
         cal.set(year, month-1, date);
         // Create date formatter based on requested style and test locale
         DateFormat df = DateFormat.getDateInstance(style, loc);
         // Test the date format
-        assertEquals(df.format(cal.getTime()), expectedString);
+        assertEquals(expectedString, df.format(cal.getTime()));
     }
 
-    @DataProvider(name = "dateFormats" )
     private Object[][] dateFormats() {
         return new Object[][] {
             //8080774

--- a/test/jdk/java/text/Format/DateFormat/SimpleDateFormatPatternTest.java
+++ b/test/jdk/java/text/Format/DateFormat/SimpleDateFormatPatternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,21 +21,25 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 4326988 6990146 8231213
  * @summary test SimpleDateFormat, check its pattern in the constructor
- * @run testng/othervm SimpleDateFormatPatternTest
+ * @run junit/othervm SimpleDateFormatPatternTest
  */
-import java.lang.IllegalArgumentException;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.text.DateFormat;
 import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SimpleDateFormatPatternTest {
     private static String[] validPat = {
             "yyyy-MM-dd h.mm.ss.a z",
@@ -136,90 +140,104 @@ public class SimpleDateFormatPatternTest {
         return objArray;
     }
 
-    @DataProvider(name = "dfAllLocalesObj")
     Object[][] dfAllLocalesObj() {
         return dfAllLocalesObj;
     }
 
-    @DataProvider(name = "invalidPatternObj")
     Object[][] invalidPatternObj() {
         return invalidPatObj;
     }
 
-    @DataProvider(name = "validPatternObj")
     Object[][] validPatternObj() {
         return validPatObj;
     }
 
     //check Constructors for invalid pattern
-    @Test(dataProvider = "invalidPatternObj",
-            expectedExceptions = IllegalArgumentException.class)
-    public void testIllegalArgumentException1(String pattern, Locale loc)
+    @ParameterizedTest
+    @MethodSource("invalidPatternObj")
+    void testIllegalArgumentException1(String pattern, Locale loc)
             throws IllegalArgumentException {
-        Locale.setDefault(loc);
-        new SimpleDateFormat(pattern);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Locale.setDefault(loc);
+            new SimpleDateFormat(pattern);
+        });
     }
 
-    @Test(dataProvider = "invalidPatternObj",
-            expectedExceptions = IllegalArgumentException.class)
-    public void testIllegalArgumentException2(String pattern, Locale loc)
+    @ParameterizedTest
+    @MethodSource("invalidPatternObj")
+    void testIllegalArgumentException2(String pattern, Locale loc)
             throws IllegalArgumentException {
-        Locale.setDefault(loc);
-        new SimpleDateFormat(pattern, new DateFormatSymbols());
+        assertThrows(IllegalArgumentException.class, () -> {
+            Locale.setDefault(loc);
+            new SimpleDateFormat(pattern, new DateFormatSymbols());
+        });
     }
 
-    @Test(dataProvider = "invalidPatternObj",
-            expectedExceptions = IllegalArgumentException.class)
-    public void testIllegalArgumentException3 (String pattern, Locale loc)
+    @ParameterizedTest
+    @MethodSource("invalidPatternObj")
+    void testIllegalArgumentException3 (String pattern, Locale loc)
             throws IllegalArgumentException {
-        Locale.setDefault(loc);
-        new SimpleDateFormat(pattern, Locale.getDefault());
+        assertThrows(IllegalArgumentException.class, () -> {
+            Locale.setDefault(loc);
+            new SimpleDateFormat(pattern, Locale.getDefault());
+        });
     }
 
-    @Test(dataProvider = "invalidPatternObj",
-            expectedExceptions = IllegalArgumentException.class)
-    public void testIllegalArgumentException4(String pattern, Locale loc)
+    @ParameterizedTest
+    @MethodSource("invalidPatternObj")
+    void testIllegalArgumentException4(String pattern, Locale loc)
             throws IllegalArgumentException {
-        Locale.setDefault(loc);
-        new SimpleDateFormat().applyPattern(pattern);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Locale.setDefault(loc);
+            new SimpleDateFormat().applyPattern(pattern);
+        });
     }
 
     //check Constructors for null pattern
-    @Test(dataProvider = "dfAllLocalesObj",
-            expectedExceptions = NullPointerException.class)
-    public void testNullPointerException1(Locale loc)
+    @ParameterizedTest
+    @MethodSource("dfAllLocalesObj")
+    void testNullPointerException1(Locale loc)
             throws NullPointerException {
-        Locale.setDefault(loc);
-        new SimpleDateFormat(null);
+        assertThrows(NullPointerException.class, () -> {
+            Locale.setDefault(loc);
+            new SimpleDateFormat(null);
+        });
     }
 
-    @Test(dataProvider = "dfAllLocalesObj",
-            expectedExceptions = NullPointerException.class)
-    public void testNullPointerException2(Locale loc)
+    @ParameterizedTest
+    @MethodSource("dfAllLocalesObj")
+    void testNullPointerException2(Locale loc)
             throws NullPointerException {
-        Locale.setDefault(loc);
-        new SimpleDateFormat(null, new DateFormatSymbols());
+        assertThrows(NullPointerException.class, () -> {
+            Locale.setDefault(loc);
+            new SimpleDateFormat(null, new DateFormatSymbols());
+        });
     }
 
-    @Test(dataProvider = "dfAllLocalesObj",
-            expectedExceptions = NullPointerException.class)
-    public void testNullPointerException3(Locale loc)
+    @ParameterizedTest
+    @MethodSource("dfAllLocalesObj")
+    void testNullPointerException3(Locale loc)
             throws NullPointerException {
-        Locale.setDefault(loc);
-        new SimpleDateFormat(null, Locale.getDefault());
+        assertThrows(NullPointerException.class, () -> {
+            Locale.setDefault(loc);
+            new SimpleDateFormat(null, Locale.getDefault());
+        });
     }
 
-    @Test(dataProvider = "dfAllLocalesObj",
-            expectedExceptions = NullPointerException.class)
-    public void testNullPointerException4(Locale loc)
+    @ParameterizedTest
+    @MethodSource("dfAllLocalesObj")
+    void testNullPointerException4(Locale loc)
             throws NullPointerException {
-        Locale.setDefault(loc);
-        new SimpleDateFormat().applyPattern(null);
+        assertThrows(NullPointerException.class, () -> {
+            Locale.setDefault(loc);
+            new SimpleDateFormat().applyPattern(null);
+        });
     }
 
-    @Test(dataProvider = "validPatternObj")
+    @ParameterizedTest
     //check Constructors for valid pattern
-    public void testValidPattern(String pattern, Locale loc) {
+    @MethodSource("validPatternObj")
+    void testValidPattern(String pattern, Locale loc) {
         Locale.setDefault(loc);
         new SimpleDateFormat(pattern);
         new SimpleDateFormat(pattern, new DateFormatSymbols());

--- a/test/jdk/java/text/Format/DecimalFormat/SetGroupingSizeTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/SetGroupingSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,28 +26,27 @@
  * @bug 8212749
  * @summary test whether input value check for
  *          DecimalFormat.setGroupingSize(int) works correctly.
- * @run testng/othervm SetGroupingSizeTest
+ * @run junit/othervm SetGroupingSizeTest
  */
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.DecimalFormat;
 
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@Test
 public class SetGroupingSizeTest {
 
-    @DataProvider
-    public static Object[][] validGroupingSizes() {
+    static Object[][] validGroupingSizes() {
         return new Object[][] {
             { 0 },
             { Byte.MAX_VALUE },
         };
     }
 
-    @DataProvider
-    public static Object[][] invalidGroupingSizes() {
+    static Object[][] invalidGroupingSizes() {
         return new Object[][] {
             { Byte.MIN_VALUE - 1 },
             { Byte.MIN_VALUE },
@@ -58,17 +57,20 @@ public class SetGroupingSizeTest {
         };
     }
 
-    @Test(dataProvider = "validGroupingSizes")
-    public void test_validGroupingSize(int newVal) {
+    @ParameterizedTest
+    @MethodSource("validGroupingSizes")
+    void test_validGroupingSize(int newVal) {
         DecimalFormat df = new DecimalFormat();
         df.setGroupingSize(newVal);
-        assertEquals(df.getGroupingSize(), newVal);
+        assertEquals(newVal, df.getGroupingSize());
     }
 
-    @Test(dataProvider = "invalidGroupingSizes",
-        expectedExceptions = IllegalArgumentException.class)
-    public void test_invalidGroupingSize(int newVal) {
-        DecimalFormat df = new DecimalFormat();
-        df.setGroupingSize(newVal);
+    @ParameterizedTest
+    @MethodSource("invalidGroupingSizes")
+    void test_invalidGroupingSize(int newVal) {
+        assertThrows(IllegalArgumentException.class, () -> {
+            DecimalFormat df = new DecimalFormat();
+            df.setGroupingSize(newVal);
+        });
     }
 }

--- a/test/jdk/java/text/Format/NumberFormat/DFSMinusPerCentMill.java
+++ b/test/jdk/java/text/Format/NumberFormat/DFSMinusPerCentMill.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8220309 8230284
  * @library /java/text/testlib
@@ -29,17 +29,26 @@
  *          This test assumes CLDR has numbering systems for "arab" and
  *          "arabext", and their minus/percent representations include
  *          BiDi formatting control characters.
- * @run testng/othervm DFSMinusPerCentMill
+ * @run junit/othervm DFSMinusPerCentMill
  */
 
-import java.io.*;
-import java.util.*;
-import java.text.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.testng.Assert.*;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DFSMinusPerCentMill {
     private enum Type {
         NUMBER, PERCENT, CURRENCY, INTEGER, COMPACT, PERMILL
@@ -49,7 +58,6 @@ public class DFSMinusPerCentMill {
     private static final Locale US_ARABEXT = Locale.forLanguageTag("en-US-u-nu-arabext");
     private static final double SRC_NUM = -1234.56;
 
-    @DataProvider
     Object[][] formatData() {
         return new Object[][] {
             // Locale, FormatStyle, expected format, expected single char symbol
@@ -69,7 +77,6 @@ public class DFSMinusPerCentMill {
         };
     }
 
-    @DataProvider
     Object[][] charSymbols() {
         return new Object[][]{
             // Locale, percent, per mille, minus sign
@@ -78,8 +85,9 @@ public class DFSMinusPerCentMill {
         };
     }
 
-    @Test(dataProvider="formatData")
-    public void testFormatData(Locale l, Type style, String expected) {
+    @ParameterizedTest
+    @MethodSource("formatData")
+    void testFormatData(Locale l, Type style, String expected) {
         NumberFormat nf = null;
         switch (style) {
             case NUMBER:
@@ -102,19 +110,20 @@ public class DFSMinusPerCentMill {
                 break;
         }
 
-        assertEquals(nf.format(SRC_NUM), expected);
+        assertEquals(expected, nf.format(SRC_NUM));
     }
 
-    @Test(dataProvider="charSymbols")
-    public void testCharSymbols(Locale l, char percent, char permill, char minus) {
+    @ParameterizedTest
+    @MethodSource("charSymbols")
+    void testCharSymbols(Locale l, char percent, char permill, char minus) {
         DecimalFormatSymbols dfs = DecimalFormatSymbols.getInstance(l);
-        assertEquals(dfs.getPercent(), percent);
-        assertEquals(dfs.getPerMill(), permill);
-        assertEquals(dfs.getMinusSign(), minus);
+        assertEquals(percent, dfs.getPercent());
+        assertEquals(permill, dfs.getPerMill());
+        assertEquals(minus, dfs.getMinusSign());
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         DecimalFormatSymbols dfs = DecimalFormatSymbols.getInstance();
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         new ObjectOutputStream(bos).writeObject(dfs);
@@ -122,7 +131,7 @@ public class DFSMinusPerCentMill {
                 new ByteArrayInputStream(bos.toByteArray())
         ).readObject();
 
-        assertEquals(dfs, dfsSerialized);
+        assertEquals(dfsSerialized, dfs);
 
         // set minus/percent/permille
         dfs.setMinusSign('a');
@@ -134,6 +143,6 @@ public class DFSMinusPerCentMill {
                 new ByteArrayInputStream(bos.toByteArray())
         ).readObject();
 
-        assertEquals(dfs, dfsSerialized);
+        assertEquals(dfsSerialized, dfs);
     }
 }

--- a/test/jdk/java/text/Normalizer/SquareEraCharacterTest.java
+++ b/test/jdk/java/text/Normalizer/SquareEraCharacterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,20 @@
  * @test
  * @bug 8221431
  * @summary Tests decomposition of Japanese square era characters.
- * @run testng/othervm SquareEraCharacterTest
+ * @run junit/othervm SquareEraCharacterTest
  */
 
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.Normalizer;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SquareEraCharacterTest {
 
-    @DataProvider
     Object[][] squareEras() {
         return new Object[][] {
 
@@ -51,12 +51,10 @@ public class SquareEraCharacterTest {
         };
     }
 
-    @Test(dataProvider="squareEras")
-    public void test_normalize(char squareChar, String expected) {
-
-        assertEquals(
-            Normalizer.normalize(Character.toString(squareChar), Normalizer.Form.NFKD),
-            expected,
+    @ParameterizedTest
+    @MethodSource("squareEras")
+    void test_normalize(char squareChar, String expected) {
+        assertEquals(expected, Normalizer.normalize(Character.toString(squareChar), Normalizer.Form.NFKD),
             "decomposing " + Character.getName(squareChar) + ".");
     }
 }


### PR DESCRIPTION
Backporting JDK-8368498: Use JUnit instead of TestNG for jdk_text tests.

This PR converts TestNG-based tests in the jdk_text suite to JUnit.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/text

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27403073/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27403074/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27403075/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27403076/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8368498](https://bugs.openjdk.org/browse/JDK-8368498) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368498](https://bugs.openjdk.org/browse/JDK-8368498): Use JUnit instead of TestNG for jdk_text tests (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4405/head:pull/4405` \
`$ git checkout pull/4405`

Update a local copy of the PR: \
`$ git checkout pull/4405` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4405`

View PR using the GUI difftool: \
`$ git pr show -t 4405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4405.diff">https://git.openjdk.org/jdk17u-dev/pull/4405.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4405#issuecomment-4373326917)
</details>
