### PR TITLE
8349192: jvmti/scenarios/contention/TC05/tc05t001 fails: ERROR: tc05t001.cpp, 281: (waitedThreadCpuTime - waitThreadCpuTime) < (EXPECTED_ACCURACY * 1000000)

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC05/tc05t001/tc05t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/contention/TC05/tc05t001/tc05t001.cpp
@@ -42,7 +42,7 @@ static const jlong EXPECTED_TIMEOUT_ACCURACY_NS = 300000;
 #if (defined(WIN32) || defined(_WIN32))
 static const jlong EXPECTED_ACCURACY = 16; // 16ms is longest clock update interval
 #else
-static const jlong EXPECTED_ACCURACY = 10; // high frequency clock updates expected
+static const jlong EXPECTED_ACCURACY = 32; // high frequency clock updates expected
 #endif
 
 /* scaffold objects */


### PR DESCRIPTION
I backport this for parity with 17.0.20-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8349192](https://bugs.openjdk.org/browse/JDK-8349192) needs maintainer approval

### Issue
 * [JDK-8349192](https://bugs.openjdk.org/browse/JDK-8349192): jvmti/scenarios/contention/TC05/tc05t001 fails: ERROR: tc05t001.cpp, 281: (waitedThreadCpuTime - waitThreadCpuTime) &lt; (EXPECTED_ACCURACY * 1000000) (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4406/head:pull/4406` \
`$ git checkout pull/4406`

Update a local copy of the PR: \
`$ git checkout pull/4406` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4406`

View PR using the GUI difftool: \
`$ git pr show -t 4406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4406.diff">https://git.openjdk.org/jdk17u-dev/pull/4406.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4406#issuecomment-4376918547)
</details>
