### PR TITLE
8375231: Refactor util/ServiceLoader tests to use JUnit

### DIFF
--- a/test/jdk/java/util/ServiceLoader/BadProvidersTest.java
+++ b/test/jdk/java/util/ServiceLoader/BadProvidersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          jdk.compiler
  * @build jdk.test.lib.compiler.CompilerUtils
- * @run testng/othervm BadProvidersTest
+ * @run junit/othervm BadProvidersTest
  * @summary Basic test of ServiceLoader with bad provider and bad provider
  *          factories deployed on the module path
  */
@@ -51,15 +51,16 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
 
 import jdk.test.lib.compiler.CompilerUtils;
 
-import org.testng.annotations.Test;
-import org.testng.annotations.DataProvider;
-import static org.testng.Assert.*;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Basic test of `provides S with PF` and `provides S with P` where the provider
  * factory or provider
  */
-
 public class BadProvidersTest {
 
     private static final String TEST_SRC = System.getProperty("test.src");
@@ -132,21 +133,10 @@ public class BadProvidersTest {
     }
 
 
-    @DataProvider(name = "badfactories")
-    public Object[][] createBadFactories() {
-        return new Object[][] {
-                { "classnotpublic",     null },
-                { "methodnotpublic",    null },
-                { "badreturntype",      null },
-                { "returnsnull",        null },
-                { "throwsexception",    null },
-        };
-    }
-
-
-    @Test(dataProvider = "badfactories",
-          expectedExceptions = ServiceConfigurationError.class)
-    public void testBadFactory(String testName, String ignore) throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = { "classnotpublic", "methodnotpublic", "badreturntype",
+            "returnsnull", "throwsexception" })
+    public void testBadFactory(String testName) throws Exception {
         Path mods = compileTest(TEST1_MODULE);
 
         // compile the bad factory
@@ -158,28 +148,18 @@ public class BadProvidersTest {
         // copy the compiled class into the module
         Path classFile = Paths.get("p", "ProviderFactory.class");
         Files.copy(output.resolve(classFile),
-                   mods.resolve(TEST1_MODULE).resolve(classFile),
-                   StandardCopyOption.REPLACE_EXISTING);
+               mods.resolve(TEST1_MODULE).resolve(classFile),
+               StandardCopyOption.REPLACE_EXISTING);
 
-        // load providers and instantiate each one
-        loadProviders(mods, TEST1_MODULE).forEach(Provider::get);
+        Assertions.assertThrows(ServiceConfigurationError.class,
+                // load providers and instantiate each one
+                () -> loadProviders(mods, TEST1_MODULE).forEach(Provider::get)
+        );
     }
 
-
-    @DataProvider(name = "badproviders")
-    public Object[][] createBadProviders() {
-        return new Object[][] {
-                { "notpublic",          null },
-                { "ctornotpublic",      null },
-                { "notasubtype",        null },
-                { "throwsexception",    null }
-        };
-    }
-
-
-    @Test(dataProvider = "badproviders",
-          expectedExceptions = ServiceConfigurationError.class)
-    public void testBadProvider(String testName, String ignore) throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = { "notpublic", "ctornotpublic", "notasubtype", "throwsexception" })
+    public void testBadProvider(String testName) throws Exception {
         Path mods = compileTest(TEST2_MODULE);
 
         // compile the bad provider
@@ -191,11 +171,13 @@ public class BadProvidersTest {
         // copy the compiled class into the module
         Path classFile = Paths.get("p", "Provider.class");
         Files.copy(output.resolve(classFile),
-                   mods.resolve(TEST2_MODULE).resolve(classFile),
-                   StandardCopyOption.REPLACE_EXISTING);
+               mods.resolve(TEST2_MODULE).resolve(classFile),
+               StandardCopyOption.REPLACE_EXISTING);
 
-        // load providers and instantiate each one
-        loadProviders(mods, TEST2_MODULE).forEach(Provider::get);
+        Assertions.assertThrows(ServiceConfigurationError.class,
+                // load providers and instantiate each one
+                () -> loadProviders(mods, TEST2_MODULE).forEach(Provider::get)
+        );
     }
 
 
@@ -203,7 +185,7 @@ public class BadProvidersTest {
      * Test a service provider that defines more than one no-args
      * public static "provider" method.
      */
-    @Test(expectedExceptions = ServiceConfigurationError.class)
+    @Test
     public void testWithTwoFactoryMethods() throws Exception {
         Path mods = compileTest(TEST1_MODULE);
 
@@ -257,8 +239,10 @@ public class BadProvidersTest {
                 .resolve("ProviderFactory.class");
         Files.write(classFile, cw.toByteArray());
 
-        // load providers and instantiate each one
-        loadProviders(mods, TEST1_MODULE).forEach(Provider::get);
+        Assertions.assertThrows(ServiceConfigurationError.class,
+                // load providers and instantiate each one
+                () -> loadProviders(mods, TEST1_MODULE).forEach(Provider::get)
+        );
     }
 
 }

--- a/test/jdk/java/util/ServiceLoader/CachingTest.java
+++ b/test/jdk/java/util/ServiceLoader/CachingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /**
  * @test
  * @summary Test ServiceLoader caches
- * @run testng CachingTest
+ * @run junit CachingTest
  */
 
 import java.nio.file.Files;
@@ -38,9 +38,9 @@ import java.util.ServiceLoader.Provider;
 import java.util.Spliterator;
 import java.util.stream.Collectors;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CachingTest {
 
@@ -52,17 +52,17 @@ public class CachingTest {
 
     public static class S2 implements S { }
 
-    private ClassLoader testClassLoader;
+    private static ClassLoader testClassLoader;
 
     // creates the services configuration file and sets the ClassLoader
-    @BeforeClass
-    void setup() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String classes = System.getProperty("test.classes");
         Path dir = Paths.get(classes, "META-INF", "services");
         Files.createDirectories(dir);
         Path config = dir.resolve(S.class.getName());
         Files.write(config, List.of(S1.class.getName(), S2.class.getName()));
-        this.testClassLoader = CachingTest.class.getClassLoader();
+        testClassLoader = CachingTest.class.getClassLoader();
     }
 
     private void checkLists(List<?> list1, List<?> list2) {

--- a/test/jdk/java/util/ServiceLoader/ModulesTest.java
+++ b/test/jdk/java/util/ServiceLoader/ModulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @build jdk.test.lib.util.JarUtils
  * @compile classpath/pearscript/org/pear/PearScriptEngineFactory.java
  *          classpath/pearscript/org/pear/PearScript.java
- * @run testng/othervm ModulesTest
+ * @run junit/othervm ModulesTest
  * @summary Basic test for ServiceLoader with a provider deployed as a module.
  */
 
@@ -55,9 +55,10 @@ import javax.script.ScriptEngineFactory;
 
 import jdk.test.lib.util.JarUtils;
 
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeTest;
-import static org.testng.Assert.*;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Basic test for ServiceLoader. The test make use of two service providers:
@@ -67,12 +68,11 @@ import static org.testng.Assert.*;
  * 2. PearScriptEngine - a ScriptEngineFactory deployed on the class path
  *    with a service configuration file.
  */
-
 public class ModulesTest {
 
     // Copy the services configuration file for "pearscript" into place.
-    @BeforeTest
-    public void setup() throws Exception {
+    @BeforeAll
+    public static void setup() throws Exception {
         Path src = Paths.get(System.getProperty("test.src"));
         Path classes = Paths.get(System.getProperty("test.classes"));
         String st = ScriptEngineFactory.class.getName();
@@ -428,30 +428,36 @@ public class ModulesTest {
 
     // -- nulls --
 
-    @Test(expectedExceptions = { NullPointerException.class })
+    @Test
     public void testLoadNull1() {
-        ServiceLoader.load(null);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> ServiceLoader.load(null));
     }
 
-    @Test(expectedExceptions = { NullPointerException.class })
+    @Test
     public void testLoadNull2() {
-        ServiceLoader.load((Class<?>) null, ClassLoader.getSystemClassLoader());
+        Assertions.assertThrows(NullPointerException.class,
+                () -> ServiceLoader.load((Class<?>) null, ClassLoader.getSystemClassLoader()));
     }
 
-    @Test(expectedExceptions = { NullPointerException.class })
+    @Test
     public void testLoadNull3() {
         class S { }
-        ServiceLoader.load((ModuleLayer) null, S.class);
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            ServiceLoader.load((ModuleLayer) null, S.class);
+        });
     }
 
-    @Test(expectedExceptions = { NullPointerException.class })
+    @Test
     public void testLoadNull4() {
-        ServiceLoader.load(ModuleLayer.empty(), null);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> ServiceLoader.load(ModuleLayer.empty(), null));
     }
 
-    @Test(expectedExceptions = { NullPointerException.class })
+    @Test
     public void testLoadNull5() {
-        ServiceLoader.loadInstalled(null);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> ServiceLoader.loadInstalled(null));
     }
 
     /**

--- a/test/jdk/java/util/ServiceLoader/NoInterferenceTest.java
+++ b/test/jdk/java/util/ServiceLoader/NoInterferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @library /test/lib
  * @modules jdk.compiler
  * @build jdk.test.lib.compiler.CompilerUtils
- * @run testng NoInterferenceTest
+ * @run junit NoInterferenceTest
  * @summary Basic test of ServiceLoader that ensures there is no interference
  *          when there are two service interfaces of the same name in a layer
  *          or overridden in a child layer.
@@ -46,9 +46,9 @@ import java.util.Set;
 
 import jdk.test.lib.compiler.CompilerUtils;
 
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class NoInterferenceTest {
 
@@ -57,8 +57,8 @@ public class NoInterferenceTest {
     private static final Path MODS_DIR = Paths.get("mods");
     private static final List<String> MODULES = Arrays.asList("s1", "p1", "s2", "p2");
 
-    @BeforeTest
-    void compile() throws Exception {
+    @BeforeAll
+    static void compile() throws Exception {
         Files.createDirectory(MODS_DIR);
         for (String name : MODULES) {
             Path src = SRC_DIR.resolve(name);

--- a/test/jdk/java/util/ServiceLoader/ReloadTest.java
+++ b/test/jdk/java/util/ServiceLoader/ReloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @modules java.scripting
  * @library modules classpath/pearscript
  * @build ReloadTest org.pear.PearScript org.pear.PearScriptEngineFactory bananascript/*
- * @run testng/othervm ReloadTest
+ * @run junit/othervm ReloadTest
  * @summary Basic test of ServiceLoader.reload
  */
 
@@ -40,12 +40,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import static java.util.ServiceLoader.*;
 import javax.script.ScriptEngineFactory;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
 
-@Test
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
 public class ReloadTest {
 
+    @Test
     public void testReload() {
         ServiceLoader<ScriptEngineFactory> sl = load(ScriptEngineFactory.class);
         List<String> names1 = sl.stream()
@@ -58,41 +60,42 @@ public class ReloadTest {
                 .map(Provider::get)
                 .map(ScriptEngineFactory::getEngineName)
                 .collect(Collectors.toList());
-        assertEquals(names1, names2);
+        assertEquals(names2, names1);
     }
 
-    @Test(expectedExceptions = { ConcurrentModificationException.class })
+    @Test
     public void testIteratorHasNext() {
         ServiceLoader<ScriptEngineFactory> sl = load(ScriptEngineFactory.class);
         Iterator<ScriptEngineFactory> iterator = sl.iterator();
         sl.reload();
-        iterator.hasNext();
+        Assertions.assertThrows(ConcurrentModificationException.class, iterator::hasNext);
     }
 
-    @Test(expectedExceptions = { ConcurrentModificationException.class })
+    @Test
     public void testIteratorNext() {
         ServiceLoader<ScriptEngineFactory> sl = load(ScriptEngineFactory.class);
         Iterator<ScriptEngineFactory> iterator = sl.iterator();
         assertTrue(iterator.hasNext());
         sl.reload();
-        iterator.next();
+        Assertions.assertThrows(ConcurrentModificationException.class, iterator::next);
     }
 
-    @Test(expectedExceptions = { ConcurrentModificationException.class })
+    @Test
     public void testStreamFindAny() {
         ServiceLoader<ScriptEngineFactory> sl = load(ScriptEngineFactory.class);
         Stream<Provider<ScriptEngineFactory>> stream = sl.stream();
         sl.reload();
-        stream.findAny();
+        Assertions.assertThrows(ConcurrentModificationException.class, stream::findAny);
     }
 
-    @Test(expectedExceptions = { ConcurrentModificationException.class })
+    @Test
     public void testSpliteratorTryAdvance() {
         ServiceLoader<ScriptEngineFactory> sl = load(ScriptEngineFactory.class);
         Stream<Provider<ScriptEngineFactory>> stream = sl.stream();
         Spliterator<Provider<ScriptEngineFactory>> spliterator = stream.spliterator();
         sl.reload();
-        spliterator.tryAdvance(System.out::println);
+        Assertions.assertThrows(ConcurrentModificationException.class,
+                () -> spliterator.tryAdvance(System.out::println));
     }
 
 }

--- a/test/jdk/java/util/ServiceLoader/TwoIterators.java
+++ b/test/jdk/java/util/ServiceLoader/TwoIterators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @summary Test ServiceLoader with two iterators, interleaving their use
  *   to test that they don't interfere with each other
- * @run testng TwoIterators
+ * @run junit TwoIterators
  */
 
 import java.nio.file.Files;
@@ -35,9 +35,9 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TwoIterators {
 
@@ -48,18 +48,17 @@ public class TwoIterators {
     public static class S1 implements S { }
     public static class S2 implements S { }
 
-    private ClassLoader testClassLoader;
+    private static ClassLoader testClassLoader;
 
     // creates the services configuration file and sets the ClassLoader
-    @BeforeClass
-    void setup() throws Exception {
+    @BeforeAll
+    static void setup() throws Exception {
         String classes = System.getProperty("test.classes");
         Path dir = Paths.get(classes, "META-INF", "services");
         Files.createDirectories(dir);
         Path config = dir.resolve(S.class.getName());
         Files.write(config, Arrays.asList(S1.class.getName(), S2.class.getName()));
-
-        this.testClassLoader = TwoIterators.class.getClassLoader();
+        testClassLoader = TwoIterators.class.getClassLoader();
     }
 
     @Test

--- a/test/jdk/java/util/StringJoiner/MergeTest.java
+++ b/test/jdk/java/util/StringJoiner/MergeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,17 +27,18 @@
  * @summary test  StringJoiner::merge
  * @modules java.base/jdk.internal.util
  * @requires vm.bits == "64" & os.maxMemory > 4G
- * @run testng/othervm -Xmx4g -XX:+CompactStrings MergeTest
+ * @run junit/othervm -Xmx4g -XX:+CompactStrings MergeTest
  */
 
 import java.util.StringJoiner;
 import java.util.stream.Stream;
-import org.testng.annotations.Test;
 import static jdk.internal.util.ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
-@Test
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+
 public class MergeTest {
     private static final String[] PREFIXES = {"", "{", "@#$%"};
     private static final String[] SUFFIXES = {"", "}", "*&%$"};
@@ -69,12 +70,13 @@ public class MergeTest {
         return builder.build();
     }
 
-    @Test(expectedExceptions = {NullPointerException.class})
+    @Test
     public void testNull() {
         StringJoiner sj = new StringJoiner(",", "{", "}");
-        sj.merge(null);
+        Assertions.assertThrows(NullPointerException.class, () -> sj.merge(null));
     }
 
+    @Test
     public void testSimple() {
         fixesStream().forEach(fixes -> {
             StringJoiner sj = new StringJoiner(",", fixes.pre0, fixes.suf0);
@@ -83,10 +85,11 @@ public class MergeTest {
             Stream.of("d", "e", "f").forEachOrdered(other::add);
 
             sj.merge(other);
-            assertEquals(sj.toString(), fixes.pre0 + "a,b,c,d,e,f" + fixes.suf0);
+            assertEquals(fixes.pre0 + "a,b,c,d,e,f" + fixes.suf0, sj.toString());
         });
     }
 
+    @Test
     public void testEmptyOther() {
         fixesStream().forEach(fixes -> {
             StringJoiner sj = new StringJoiner(",", fixes.pre0, fixes.suf0);
@@ -94,14 +97,15 @@ public class MergeTest {
             Stream.of("a", "b", "c").forEachOrdered(sj::add);
 
             sj.merge(other);
-            assertEquals(sj.toString(), fixes.pre0 + "a,b,c" + fixes.suf0);
+            assertEquals(fixes.pre0 + "a,b,c" + fixes.suf0, sj.toString());
 
             other.setEmptyValue("EMPTY");
             sj.merge(other);
-            assertEquals(sj.toString(), fixes.pre0 + "a,b,c" + fixes.suf0);
+            assertEquals(fixes.pre0 + "a,b,c" + fixes.suf0, sj.toString());
         });
     }
 
+    @Test
     public void testEmptyThis() {
         fixesStream().forEach(fixes -> {
             StringJoiner sj = new StringJoiner(",", fixes.pre0, fixes.suf0);
@@ -109,34 +113,36 @@ public class MergeTest {
             Stream.of("d", "e", "f").forEachOrdered(other::add);
 
             sj.merge(other);
-            assertEquals(sj.toString(), fixes.pre0 + "d:e:f" + fixes.suf0);
+            assertEquals(fixes.pre0 + "d:e:f" + fixes.suf0, sj.toString());
 
             sj = new StringJoiner(",", fixes.pre0, fixes.suf0).setEmptyValue("EMPTY");
-            assertEquals(sj.toString(), "EMPTY");
+            assertEquals("EMPTY", sj.toString());
             sj.merge(other);
-            assertEquals(sj.toString(), fixes.pre0 + "d:e:f" + fixes.suf0);
+            assertEquals(fixes.pre0 + "d:e:f" + fixes.suf0, sj.toString());
         });
     }
 
+    @Test
     public void testEmptyBoth() {
         fixesStream().forEach(fixes -> {
             StringJoiner sj = new StringJoiner(",", fixes.pre0, fixes.suf0);
             StringJoiner other = new StringJoiner(":", fixes.pre1, fixes.suf1);
 
             sj.merge(other);
-            assertEquals(sj.toString(), fixes.pre0 + fixes.suf0);
+            assertEquals(fixes.pre0 + fixes.suf0, sj.toString());
 
             other.setEmptyValue("NOTHING");
             sj.merge(other);
-            assertEquals(sj.toString(), fixes.pre0 + fixes.suf0);
+            assertEquals(fixes.pre0 + fixes.suf0, sj.toString());
 
             sj = new StringJoiner(",", fixes.pre0, fixes.suf0).setEmptyValue("EMPTY");
-            assertEquals(sj.toString(), "EMPTY");
+            assertEquals("EMPTY", sj.toString());
             sj.merge(other);
-            assertEquals(sj.toString(), "EMPTY");
+            assertEquals("EMPTY", sj.toString());
         });
     }
 
+    @Test
     public void testCascadeEmpty() {
         fixesStream().forEach(fixes -> {
             StringJoiner sj = new StringJoiner(",", fixes.pre0, fixes.suf0);
@@ -144,13 +150,14 @@ public class MergeTest {
             StringJoiner o2 = new StringJoiner(",", "<", ">").setEmptyValue("Empty2");
 
             o1.merge(o2);
-            assertEquals(o1.toString(), "Empty1");
+            assertEquals("Empty1", o1.toString());
 
             sj.merge(o1);
-            assertEquals(sj.toString(), fixes.pre0 + fixes.suf0);
+            assertEquals(fixes.pre0 + fixes.suf0, sj.toString());
         });
     }
 
+    @Test
     public void testDelimiter() {
         fixesStream().forEach(fixes -> {
             StringJoiner sj = new StringJoiner(",", fixes.pre0, fixes.suf0);
@@ -159,18 +166,20 @@ public class MergeTest {
             Stream.of("d", "e", "f").forEachOrdered(other::add);
 
             sj.merge(other);
-            assertEquals(sj.toString(), fixes.pre0 + "a,b,c,d:e:f" + fixes.suf0);
+            assertEquals(fixes.pre0 + "a,b,c,d:e:f" + fixes.suf0, sj.toString());
         });
     }
 
+    @Test
     public void testMergeSelf() {
         fixesStream().forEach(fixes -> {
             final StringJoiner sj = new StringJoiner(",", fixes.pre0, fixes.suf0).add("a").add("b");
-            assertEquals(sj.merge(sj).toString(), fixes.pre0 + "a,b,a,b" + fixes.suf0);
-            assertEquals(sj.merge(sj).toString(), fixes.pre0 + "a,b,a,b,a,b,a,b" + fixes.suf0);
+            assertEquals(fixes.pre0 + "a,b,a,b" + fixes.suf0, sj.merge(sj).toString());
+            assertEquals(fixes.pre0 + "a,b,a,b,a,b,a,b" + fixes.suf0, sj.merge(sj).toString());
         });
     }
 
+    @Test
     public void OOM() {
         String maxString = "*".repeat(SOFT_MAX_ARRAY_LENGTH);
 

--- a/test/jdk/java/util/StringJoiner/StringJoinerOomUtf16Test.java
+++ b/test/jdk/java/util/StringJoiner/StringJoinerOomUtf16Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,18 +26,23 @@
  * @summary tests StringJoiner OOME when joining sub-max-length Strings
  * @modules java.base/jdk.internal.util
  * @requires vm.bits == "64" & os.maxMemory > 4G
- * @run testng/othervm -Xmx4g -XX:+CompactStrings StringJoinerOomUtf16Test
+ * @run junit/othervm -Xmx4g -XX:+CompactStrings StringJoinerOomUtf16Test
  */
 
-import org.testng.annotations.Test;
 
 import static jdk.internal.util.ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
-import static org.testng.Assert.fail;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.StringJoiner;
 
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Test(groups = {"unit","string","util","libs"})
+@Tag("unit")
+@Tag("string")
+@Tag("util")
+@Tag("libs")
 public class StringJoinerOomUtf16Test {
 
     // the sum of lengths of the following two strings is way less than
@@ -48,6 +53,7 @@ public class StringJoinerOomUtf16Test {
     private static final String OVERFLOW_UTF16_STRING =
         "\u017D".repeat(((Integer.MAX_VALUE - SOFT_MAX_ARRAY_LENGTH) >> 1) + 1);
 
+    @Test
     public void OOM1() {
         try {
             new StringJoiner("")
@@ -60,6 +66,7 @@ public class StringJoinerOomUtf16Test {
         }
     }
 
+    @Test
     public void OOM2() {
         try {
             new StringJoiner(HALF_MAX_LATIN1_STRING)
@@ -72,6 +79,7 @@ public class StringJoinerOomUtf16Test {
         }
     }
 
+    @Test
     public void OOM3() {
         try {
             new StringJoiner(OVERFLOW_UTF16_STRING)
@@ -84,6 +92,7 @@ public class StringJoinerOomUtf16Test {
         }
     }
 
+    @Test
     public void OOM4() {
         try {
             new StringJoiner("", HALF_MAX_LATIN1_STRING, OVERFLOW_UTF16_STRING)

--- a/test/jdk/java/util/StringJoiner/StringJoinerTest.java
+++ b/test/jdk/java/util/StringJoiner/StringJoinerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,18 +26,25 @@
  * @summary tests StringJoinerTest
  * @modules java.base/jdk.internal.util
  * @requires vm.bits == "64" & os.maxMemory > 4G
- * @run testng/othervm -Xmx4g -XX:+CompactStrings StringJoinerTest
+ * @run junit/othervm -Xmx4g -XX:+CompactStrings StringJoinerTest
  * @author Jim Gish
  */
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.StringJoiner;
-import org.testng.annotations.Test;
+
 import static jdk.internal.util.ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-
-@Test(groups = {"unit","string","util","libs"})
+@Tag("unit")
+@Tag("string")
+@Tag("util")
+@Tag("libs")
 public class StringJoinerTest {
 
     private static final String EMPTY = "EMPTY";
@@ -51,6 +58,7 @@ public class StringJoinerTest {
     private static final String DASH = "-";
     private static final String MAX_STRING = "*".repeat(SOFT_MAX_ARRAY_LENGTH);
 
+    @Test
     public void addAddAll() {
         StringJoiner sj = new StringJoiner(DASH, "{", "}");
         sj.add(ONE);
@@ -61,7 +69,7 @@ public class StringJoinerTest {
         nextOne.stream().forEachOrdered(sj::add);
 
         String expected = "{"+ONE+DASH+TWO+DASH+THREE+"}";
-        assertEquals(sj.toString(), expected);
+        assertEquals(expected, sj.toString());
     }
 
     void addAlladd() {
@@ -75,10 +83,11 @@ public class StringJoinerTest {
         sj.add(THREE);
 
         String expected = "{"+ONE+DASH+TWO+DASH+THREE+"}";
-        assertEquals(sj.toString(), expected);
+        assertEquals(expected, sj.toString());
     }
 
     // The following tests do two successive adds of different types
+    @Test
     public void addAlladdAll() {
         StringJoiner sj = new StringJoiner(DASH, "{", "}");
         ArrayList<String> firstOne = new ArrayList<>();
@@ -93,9 +102,10 @@ public class StringJoinerTest {
         nextOne.stream().forEachOrdered(sj::add);
 
         String expected = "{"+ONE+DASH+TWO+DASH+THREE+DASH+FOUR+DASH+FIVE+"}";
-        assertEquals(sj.toString(), expected);
+        assertEquals(expected, sj.toString());
     }
 
+    @Test
     public void addCharSequence() {
         StringJoiner sj = new StringJoiner(",");
         CharSequence cs_one = ONE;
@@ -104,13 +114,13 @@ public class StringJoinerTest {
         sj.add(cs_one);
         sj.add(cs_two);
 
-        assertEquals(sj.toString(), ONE + "," + TWO);
+        assertEquals(ONE + "," + TWO, sj.toString());
 
         sj = new StringJoiner(DASH, "{", "}");
         sj.add(cs_one);
         sj.add(cs_two);
 
-        assertEquals(sj.toString(), "{" + ONE + DASH + TWO + "}");
+        assertEquals("{" + ONE + DASH + TWO + "}", sj.toString());
 
         StringBuilder builder = new StringBuilder(ONE);
         StringBuffer buffer = new StringBuffer(THREE);
@@ -118,13 +128,14 @@ public class StringJoinerTest {
         sj.add(builder).add(buffer);
         builder.append(TWO);
         buffer.append(FOUR);
-        assertEquals(sj.toString(), "{ " + ONE + ", " + THREE + " }",
+        assertEquals("{ " + ONE + ", " + THREE + " }", sj.toString(),
                 "CharSequence is copied when add");
         sj.add(builder);
-        assertEquals(sj.toString(), "{ " + ONE + ", " + THREE + ", " + ONE +
-                TWO + " }");
+        assertEquals("{ " + ONE + ", " + THREE + ", " + ONE +
+                TWO + " }", sj.toString());
     }
 
+    @Test
     public void addCharSequenceWithEmptyValue() {
         StringJoiner sj = new StringJoiner(",").setEmptyValue(EMPTY);
         CharSequence cs_one = ONE;
@@ -133,189 +144,200 @@ public class StringJoinerTest {
         sj.add(cs_one);
         sj.add(cs_two);
 
-        assertEquals(sj.toString(), ONE + "," + TWO);
+        assertEquals(ONE + "," + TWO, sj.toString());
 
         sj = new StringJoiner(DASH, "{", "}");
         sj.add(cs_one);
         sj.add(cs_two);
-        assertEquals(sj.toString(), "{" + ONE + DASH + TWO + "}");
+        assertEquals("{" + ONE + DASH + TWO + "}", sj.toString());
 
         sj = new StringJoiner(DASH, "{", "}");
-        assertEquals(sj.toString(), "{}");
+        assertEquals("{}", sj.toString());
 
         sj = new StringJoiner("=", "{", "}").setEmptyValue("");
-        assertEquals(sj.toString(), "");
+        assertEquals("", sj.toString());
 
         sj = new StringJoiner(DASH, "{", "}").setEmptyValue(EMPTY);
-        assertEquals(sj.toString(), EMPTY);
+        assertEquals(EMPTY, sj.toString());
 
         sj.add(cs_one);
         sj.add(cs_two);
-        assertEquals(sj.toString(), "{" + ONE + DASH + TWO + "}");
+        assertEquals("{" + ONE + DASH + TWO + "}", sj.toString());
     }
 
+    @Test
     public void addString() {
         StringJoiner sj = new StringJoiner(DASH);
         sj.add(ONE);
-        assertEquals(sj.toString(), ONE);
+        assertEquals(ONE, sj.toString());
 
         sj = new StringJoiner(DASH, "{", "}");
         sj.add(ONE);
-        assertEquals(sj.toString(), "{" + ONE + "}");
+        assertEquals("{" + ONE + "}", sj.toString());
 
         sj.add(TWO);
-        assertEquals(sj.toString(), "{" + ONE + DASH + TWO + "}");
+        assertEquals("{" + ONE + DASH + TWO + "}", sj.toString());
     }
 
+    @Test
     public void lengthWithCustomEmptyValue() {
         StringJoiner sj = new StringJoiner(DASH, "<", ">").setEmptyValue(EMPTY);
-        assertEquals(sj.length(), EMPTY.length());
+        assertEquals(EMPTY.length(), sj.length());
         sj.add("");
-        assertEquals(sj.length(), "<>".length());
+        assertEquals("<>".length(), sj.length());
         sj.add("");
-        assertEquals(sj.length(), "<->".length());
+        assertEquals("<->".length(), sj.length());
         sj.add(ONE);
-        assertEquals(sj.length(), 4 + ONE_LEN);
-        assertEquals(sj.toString().length(), sj.length());
+        assertEquals(4 + ONE_LEN, sj.length());
+        assertEquals(sj.length(), sj.toString().length());
         sj.add(TWO);
-        assertEquals(sj.length(), 5 + ONE_LEN + TWO_LEN);
-        assertEquals(sj.toString().length(), sj.length());
+        assertEquals(5 + ONE_LEN + TWO_LEN, sj.length());
+        assertEquals(sj.length(), sj.toString().length());
         sj = new StringJoiner("||", "<", "-->");
-        assertEquals(sj.length(), 4);
-        assertEquals(sj.toString().length(), sj.length());
+        assertEquals(4, sj.length());
+        assertEquals(sj.length(), sj.toString().length());
         sj.add("abcdef");
-        assertEquals(sj.length(), 10);
-        assertEquals(sj.toString().length(), sj.length());
+        assertEquals(10, sj.length());
+        assertEquals(sj.length(), sj.toString().length());
         sj.add("xyz");
-        assertEquals(sj.length(), 15);
-        assertEquals(sj.toString().length(), sj.length());
+        assertEquals(15, sj.length());
+        assertEquals(sj.length(), sj.toString().length());
     }
 
+    @Test
     public void noAddAndEmptyValue() {
         StringJoiner sj = new StringJoiner(DASH, "", "").setEmptyValue(EMPTY);
-        assertEquals(sj.toString(), EMPTY);
+        assertEquals(EMPTY, sj.toString());
 
         sj = new StringJoiner(DASH, "<..", "");
-        assertEquals(sj.toString(), "<..");
+        assertEquals("<..", sj.toString());
 
         sj = new StringJoiner(DASH, "<..", "");
-        assertEquals(sj.toString(), "<..");
+        assertEquals("<..", sj.toString());
 
         sj = new StringJoiner(DASH, "", "==>");
-        assertEquals(sj.toString(), "==>");
+        assertEquals("==>", sj.toString());
 
         sj = new StringJoiner(DASH, "{", "}");
-        assertEquals(sj.toString(), "{}");
+        assertEquals("{}", sj.toString());
     }
 
-    @Test(expectedExceptions = {NullPointerException.class})
+    @Test
     public void setEmptyValueNull() {
-        new StringJoiner(DASH, "{", "}").setEmptyValue(null);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new StringJoiner(DASH, "{", "}").setEmptyValue(null));
     }
 
-    @Test(expectedExceptions = {NullPointerException.class})
+    @Test
     public void setDelimiterNull() {
-        new StringJoiner(null);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new StringJoiner(null));
     }
 
-    @Test(expectedExceptions = {NullPointerException.class})
+    @Test
     public void setPrefixNull() {
-        new StringJoiner(DASH, null, "}");
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new StringJoiner(DASH, null, "}"));
     }
 
-    @Test(expectedExceptions = {NullPointerException.class})
+    @Test
     public void setSuffixNull() {
-        new StringJoiner(DASH, "{", null);
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new StringJoiner(DASH, "{", null));
     }
 
+    @Test
     public void stringFromtoString() {
         StringJoiner sj = new StringJoiner(", ");
-        assertEquals(sj.toString(), "");
+        assertEquals("", sj.toString());
         sj = new StringJoiner(",", "{", "}");
-        assertEquals(sj.toString(), "{}");
+        assertEquals("{}", sj.toString());
 
         sj = new StringJoiner(",");
         sj.add(ONE);
-        assertEquals(sj.toString(), ONE);
+        assertEquals(ONE, sj.toString());
 
         sj.add(TWO);
-        assertEquals(sj.toString(), ONE + "," + TWO);
+        assertEquals(ONE + "," + TWO, sj.toString());
 
         sj = new StringJoiner(",", "{--", "--}");
         sj.add(ONE);
         sj.add(TWO);
-        assertEquals(sj.toString(), "{--" + ONE + "," + TWO + "--}");
+        assertEquals("{--" + ONE + "," + TWO + "--}", sj.toString());
 
     }
 
+    @Test
     public void stringFromtoStringWithEmptyValue() {
         StringJoiner sj = new StringJoiner(" ", "", "");
-        assertEquals(sj.toString(), "");
+        assertEquals("", sj.toString());
         sj = new StringJoiner(", ");
-        assertEquals(sj.toString(), "");
+        assertEquals("", sj.toString());
         sj = new StringJoiner(",", "{", "}");
-        assertEquals(sj.toString(), "{}");
+        assertEquals("{}", sj.toString());
 
         sj = new StringJoiner(",", "{", "}").setEmptyValue("");
-        assertEquals(sj.toString(), "");
+        assertEquals("", sj.toString());
 
         sj = new StringJoiner(",");
         sj.add(ONE);
-        assertEquals(sj.toString(), ONE);
+        assertEquals(ONE, sj.toString());
 
         sj.add(TWO);
-        assertEquals(sj.toString(), ONE + "," + TWO);
+        assertEquals(ONE + "," + TWO, sj.toString());
 
         sj = new StringJoiner(",", "{--", "--}");
         sj.add(ONE);
-        assertEquals(sj.toString(), "{--" + ONE + "--}" );
+        assertEquals("{--" + ONE + "--}", sj.toString() );
 
         sj.add(TWO);
-        assertEquals(sj.toString(), "{--" + ONE + "," + TWO + "--}");
+        assertEquals("{--" + ONE + "," + TWO + "--}", sj.toString());
 
     }
 
+    @Test
     public void toStringWithCustomEmptyValue() {
         StringJoiner sj = new StringJoiner(DASH, "<", ">").setEmptyValue(EMPTY);
-        assertEquals(sj.toString(), EMPTY);
+        assertEquals(EMPTY, sj.toString());
         sj.add("");
-        assertEquals(sj.toString(), "<>");
+        assertEquals("<>", sj.toString());
         sj.add("");
-        assertEquals(sj.toString(), "<->");
+        assertEquals("<->", sj.toString());
     }
 
     private void testCombos(String infix, String prefix, String suffix) {
         StringJoiner sj = new StringJoiner(infix, prefix, suffix);
-        assertEquals(sj.toString(), prefix + suffix);
-        assertEquals(sj.toString().length(), sj.length());
+        assertEquals(prefix + suffix, sj.toString());
+        assertEquals(sj.length(), sj.toString().length());
         // EmptyValue
         sj = new StringJoiner(infix, prefix, suffix).setEmptyValue("<NONE>");
-        assertEquals(sj.toString(), "<NONE>");
-        assertEquals(sj.toString().length(), sj.length());
+        assertEquals("<NONE>", sj.toString());
+        assertEquals(sj.length(), sj.toString().length());
 
         // empty in front
         sj.add("");
-        assertEquals(sj.toString(), prefix + suffix);
+        assertEquals(prefix + suffix, sj.toString());
         // empty in middle
         sj.add("");
-        assertEquals(sj.toString(), prefix + infix + suffix);
+        assertEquals(prefix + infix + suffix, sj.toString());
         sj.add("1");
-        assertEquals(sj.toString(), prefix + infix + infix + "1" + suffix);
+        assertEquals(prefix + infix + infix + "1" + suffix, sj.toString());
         // empty at end
         sj.add("");
-        assertEquals(sj.toString(), prefix + infix + infix + "1" + infix + suffix);
+        assertEquals(prefix + infix + infix + "1" + infix + suffix, sj.toString());
 
         sj = new StringJoiner(infix, prefix, suffix).setEmptyValue("<NONE>");
         sj.add("1");
-        assertEquals(sj.toString(), prefix + "1" + suffix);
+        assertEquals(prefix + "1" + suffix, sj.toString());
         sj.add("2");
-        assertEquals(sj.toString(), prefix + "1" + infix + "2" + suffix);
+        assertEquals(prefix + "1" + infix + "2" + suffix, sj.toString());
         sj.add("");
-        assertEquals(sj.toString(), prefix + "1" + infix + "2" + infix + suffix);
+        assertEquals(prefix + "1" + infix + "2" + infix + suffix, sj.toString());
         sj.add("3");
-        assertEquals(sj.toString(), prefix + "1" + infix + "2" + infix + infix + "3" + suffix);
+        assertEquals(prefix + "1" + infix + "2" + infix + infix + "3" + suffix, sj.toString());
     }
 
+    @Test
     public void testDelimiterCombinations() {
         testCombos("", "", "");
         testCombos("", "<", "");
@@ -327,6 +349,7 @@ public class StringJoinerTest {
         testCombos(",", "<", ">");
     }
 
+    @Test
     public void OOM1() {
         try {
             new StringJoiner(MAX_STRING, MAX_STRING, MAX_STRING).toString();
@@ -336,6 +359,7 @@ public class StringJoinerTest {
         }
     }
 
+    @Test
     public void OOM2() {
         try {
             new StringJoiner(MAX_STRING, MAX_STRING, "").toString();
@@ -345,6 +369,7 @@ public class StringJoinerTest {
         }
     }
 
+    @Test
     public void OOM3() {
         try {
             new StringJoiner(MAX_STRING, "", MAX_STRING).toString();
@@ -354,6 +379,7 @@ public class StringJoinerTest {
         }
     }
 
+    @Test
     public void OOM4() {
         try {
             new StringJoiner("", MAX_STRING, MAX_STRING).toString();

--- a/test/jdk/java/util/Vector/ArrayManagement.java
+++ b/test/jdk/java/util/Vector/ArrayManagement.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2016 Google, Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,7 +26,7 @@
  * @test
  * @bug 8148174
  * @summary brittle white box test of internal array management
- * @run testng ArrayManagement
+ * @run junit ArrayManagement
  */
 
 import java.lang.reflect.Field;
@@ -35,8 +36,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.SplittableRandom;
 
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class ArrayManagement {
 
@@ -61,9 +62,9 @@ public class ArrayManagement {
             super.ensureCapacity(minCapacity);
             assertTrue(capacity() >= minCapacity);
             if (minCapacity <= oldCapacity)
-                assertEquals(capacity(), oldCapacity);
+                assertEquals(oldCapacity, capacity());
             if (minCapacity > 0)
-                assertEquals(modCount(), oldModCount + 1);
+                assertEquals(oldModCount + 1, modCount());
         }
     }
 
@@ -89,117 +90,117 @@ public class ArrayManagement {
         case 3: assertTrue(list.addAll(size, singletonList())); break;
         default: throw new AssertionError();
         }
-        assertEquals(list.modCount(), modCount + 1);
-        assertEquals(list.size(), size + 1);
+        assertEquals(modCount + 1, list.modCount());
+        assertEquals(size + 1, list.size());
     }
 
     @Test public void defaultCapacity() {
         PublicVector<Object> list = new PublicVector<>();
-        assertEquals(new PublicVector<Object>().capacity(), DEFAULT_CAPACITY);
+        assertEquals(DEFAULT_CAPACITY, new PublicVector<Object>().capacity());
         for (int i = 0; i < DEFAULT_CAPACITY; i++) {
             addOneElement(list);
-            assertEquals(list.capacity(), DEFAULT_CAPACITY);
+            assertEquals(DEFAULT_CAPACITY, list.capacity());
         }
         addOneElement(list);
-        assertEquals(list.capacity(), newCapacity(DEFAULT_CAPACITY));
+        assertEquals(newCapacity(DEFAULT_CAPACITY), list.capacity());
     }
 
     @Test public void defaultCapacityEnsureCapacity() {
         PublicVector<Object> list = new PublicVector<>();
         for (int i = 0; i <= DEFAULT_CAPACITY; i++) {
             list.ensureCapacity(i);     // no-op!
-            assertEquals(list.capacity(), DEFAULT_CAPACITY);
+            assertEquals(DEFAULT_CAPACITY, list.capacity());
         }
         for (int i = 0; i < DEFAULT_CAPACITY; i++) {
             addOneElement(list);
-            assertEquals(list.capacity(), DEFAULT_CAPACITY);
+            assertEquals(DEFAULT_CAPACITY, list.capacity());
         }
         addOneElement(list);
-        assertEquals(list.capacity(), newCapacity(DEFAULT_CAPACITY));
+        assertEquals(newCapacity(DEFAULT_CAPACITY), list.capacity());
         {
             int capacity = list.capacity();
             list.ensureCapacity(capacity + 1);
-            assertEquals(list.capacity(), newCapacity(capacity));
+            assertEquals(newCapacity(capacity), list.capacity());
         }
         {
             int capacity = list.capacity();
             list.ensureCapacity(3 * capacity);
-            assertEquals(list.capacity(), 3 * capacity);
+            assertEquals(3 * capacity, list.capacity());
         }
     }
 
     @Test public void ensureCapacityBeyondDefaultCapacity() {
         PublicVector<Object> list = new PublicVector<>();
         list.ensureCapacity(DEFAULT_CAPACITY + 1);
-        assertEquals(list.capacity(), newCapacity(DEFAULT_CAPACITY));
+        assertEquals(newCapacity(DEFAULT_CAPACITY), list.capacity());
     }
 
     @Test public void explicitZeroCapacity() {
         PublicVector<Object> list = new PublicVector<>(0);
-        assertEquals(list.capacity(), 0);
+        assertEquals(0, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 1);
+        assertEquals(1, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 2);
+        assertEquals(2, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 4);
+        assertEquals(4, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 4);
+        assertEquals(4, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 8);
+        assertEquals(8, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 8);
+        assertEquals(8, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 8);
+        assertEquals(8, list.capacity());
         list.clear();
-        assertEquals(list.capacity(), 8);
+        assertEquals(8, list.capacity());
     }
 
     @Test public void explicitZeroCapacityWithCapacityIncrement() {
         PublicVector<Object> list = new PublicVector<>(0, 2);
-        assertEquals(list.capacity(), 0);
+        assertEquals(0, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 2);
+        assertEquals(2, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 2);
+        assertEquals(2, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 4);
+        assertEquals(4, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 4);
+        assertEquals(4, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 6);
+        assertEquals(6, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 6);
+        assertEquals(6, list.capacity());
         addOneElement(list);
-        assertEquals(list.capacity(), 8);
+        assertEquals(8, list.capacity());
         list.clear();
-        assertEquals(list.capacity(), 8);
+        assertEquals(8, list.capacity());
     }
 
     @Test public void explicitLargeCapacity() {
         int n = DEFAULT_CAPACITY * 3;
         PublicVector<Object> list = new PublicVector<>(n);
-        assertEquals(list.capacity(), n);
+        assertEquals(n, list.capacity());
         list.ensureCapacity(0);
         list.ensureCapacity(n);
         for (int i = 0; i < n; i++) addOneElement(list);
-        assertEquals(list.capacity(), n);
+        assertEquals(n, list.capacity());
 
         addOneElement(list);
-        assertEquals(list.capacity(), newCapacity(n));
+        assertEquals(newCapacity(n), list.capacity());
     }
 
     @Test public void explicitLargeCapacityWithCapacityIncrement() {
         int n = DEFAULT_CAPACITY * 3;
         PublicVector<Object> list = new PublicVector<>(n, 2);
-        assertEquals(list.capacity(), n);
+        assertEquals(n, list.capacity());
         list.ensureCapacity(0);
         list.ensureCapacity(n);
         for (int i = 0; i < n; i++) addOneElement(list);
-        assertEquals(list.capacity(), n);
+        assertEquals(n, list.capacity());
 
         addOneElement(list);
-        assertEquals(list.capacity(), n + 2);
+        assertEquals(n + 2, list.capacity());
     }
 
     @Test public void emptyArraysAreNotShared() {


### PR DESCRIPTION
Backporting JDK-8375231, JDK-8375232 and JDK-8375233: Refactor util/ServiceLoader, util/StringJoiner and util/Vector tests to use JUnit.

This PR converts ServiceLoader, StringJoiner and Vector TestNG tests to JUnit in a single commit.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/util/ServiceLoader
make test TEST=test/jdk/java/util/StringJoiner
make test TEST=test/jdk/java/util/Vector/ArrayManagement.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27413376/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27413378/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/27413379/windows-x64-specific-3-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27413380/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27413381/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27413382/macos-aarch64-specific-3-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27413385/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27413386/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/27413388/linux-x64-specific-3-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27413389/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27413390/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27413391/linux-aarch64-specific-3-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8375231](https://bugs.openjdk.org/browse/JDK-8375231) needs maintainer approval
- [x] [JDK-8375232](https://bugs.openjdk.org/browse/JDK-8375232) needs maintainer approval
- [x] [JDK-8375233](https://bugs.openjdk.org/browse/JDK-8375233) needs maintainer approval

### Issues
 * [JDK-8375231](https://bugs.openjdk.org/browse/JDK-8375231): Refactor util/ServiceLoader tests to use JUnit (**Sub-task** - P4 - Approved)
 * [JDK-8375232](https://bugs.openjdk.org/browse/JDK-8375232): Refactor util/StringJoiner tests to use JUnit (**Sub-task** - P4 - Approved)
 * [JDK-8375233](https://bugs.openjdk.org/browse/JDK-8375233): Refactor util/Vector tests to use JUnit (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4409/head:pull/4409` \
`$ git checkout pull/4409`

Update a local copy of the PR: \
`$ git checkout pull/4409` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4409`

View PR using the GUI difftool: \
`$ git pr show -t 4409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4409.diff">https://git.openjdk.org/jdk17u-dev/pull/4409.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4409#issuecomment-4380589866)
</details>
