### PR TITLE
8368683: [process] Increase jtreg debug output maxOutputSize for TreeTest

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/TEST.properties
+++ b/test/jdk/java/lang/ProcessHandle/TEST.properties
@@ -1,0 +1,1 @@
+maxOutputSize=6000000


### PR DESCRIPTION
Backporting JDK-8368683: [process] Increase jtreg debug output maxOutputSize for TreeTest.

This PR adds maxOutputSize property to TEST.properties in the ProcessHandle test directory to capture complete output for better failure diagnosis.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/lang/ProcessHandle

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27414935/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27414936/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27414937/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27414938/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368683](https://bugs.openjdk.org/browse/JDK-8368683) needs maintainer approval

### Issue
 * [JDK-8368683](https://bugs.openjdk.org/browse/JDK-8368683): [process] Increase jtreg debug output maxOutputSize for TreeTest (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4411/head:pull/4411` \
`$ git checkout pull/4411`

Update a local copy of the PR: \
`$ git checkout pull/4411` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4411`

View PR using the GUI difftool: \
`$ git pr show -t 4411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4411.diff">https://git.openjdk.org/jdk17u-dev/pull/4411.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4411#issuecomment-4381310057)
</details>
