### PR TITLE
8366369: Add @requires linux for GTK L&F tests

### DIFF
--- a/test/jdk/com/sun/java/swing/plaf/gtk/4928019/bug4928019.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/4928019/bug4928019.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,25 +26,25 @@
  * @bug 4928019
  * @key headful
  * @summary Makes sure all the basic classes can be created with GTK.
- * @author Scott Violet
+ * @requires (os.family != "windows" & os.family != "mac")
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @run main bug4928019
  */
 
 import javax.swing.*;
 import javax.swing.plaf.basic.*;
 
+import jtreg.SkippedException;
+
 public class bug4928019 {
     public static void main(String[] args) throws Throwable {
         try {
             UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
-        } catch (UnsupportedLookAndFeelException ex) {
-            System.err.println("GTKLookAndFeel is not supported on this platform." +
-                    " Test is considered passed.");
-            return;
-        } catch (ClassNotFoundException ex) {
-            System.err.println("GTKLookAndFeel class is not found." +
-                    " Test is considered passed.");
-            return;
+        } catch (Exception e) {
+            throw new SkippedException("GTKLookAndFeel isn't supported", e);
         }
+
         new JButton() {
             public void updateUI() {
                 setUI(new BasicButtonUI());

--- a/test/jdk/com/sun/java/swing/plaf/gtk/Test6635110.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/Test6635110.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,18 +21,28 @@
  * questions.
  */
 
-/* @test
-   @bug 6635110
-   @key headful
-   @summary GTK icons should not throw NPE when called by non-GTK UI
-   @author Peter Zhelezniakov
-   @run main Test6635110
+/*
+ * @test
+ * @bug 6635110
+ * @key headful
+ * @summary GTK icons should not throw NPE when called by non-GTK UI
+ * @requires (os.family != "windows" & os.family != "mac")
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @run main Test6635110
 */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.Component;
 import java.awt.image.BufferedImage;
-import javax.swing.plaf.basic.*;
+
+import javax.swing.JMenu;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.plaf.basic.BasicMenuUI;
+import javax.swing.plaf.basic.BasicToolBarUI;
+
+import jtreg.SkippedException;
 
 
 public class Test6635110 implements Runnable {
@@ -53,7 +63,7 @@ public class Test6635110 implements Runnable {
         paint(tb);
     }
 
-    void paint(Component c) {
+    private void paint(Component c) {
         c.setSize(WIDTH, HEIGHT);
         c.paint(IMAGE.getGraphics());
     }
@@ -62,9 +72,9 @@ public class Test6635110 implements Runnable {
         try {
             UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
         } catch (Exception e) {
-            System.out.println("GTKLookAndFeel cannot be set, skipping this test");
-            return;
+            throw new SkippedException("GTKLookAndFeel isn't supported", e);
         }
+
         SwingUtilities.invokeAndWait(new Test6635110());
     }
 }

--- a/test/jdk/com/sun/java/swing/plaf/gtk/Test6963870.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/Test6963870.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,23 +21,28 @@
  * questions.
  */
 
-/* @test
-   @bug 6963870
-   @key headful
-   @summary Tests that GTKPainter.ListTableFocusBorder.getBorderInsets()
-            doesn't return null
-   @author Peter Zhelezniakov
-   @run main Test6963870
-*/
+/*
+ * @test
+ * @bug 6963870
+ * @key headful
+ * @summary Tests that GTKPainter.ListTableFocusBorder.getBorderInsets()
+ *          doesn't return null
+ * @requires (os.family != "windows" & os.family != "mac")
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @run main Test6963870
+ */
 
 import java.awt.Insets;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
 
+import jtreg.SkippedException;
+
 public class Test6963870 implements Runnable {
 
-    final static String[] UI_NAMES = {
+    static final String[] UI_NAMES = {
         "List.focusCellHighlightBorder",
         "List.focusSelectedCellHighlightBorder",
         "List.noFocusBorder",
@@ -45,6 +50,7 @@ public class Test6963870 implements Runnable {
         "Table.focusSelectedCellHighlightBorder",
     };
 
+    @Override
     public void run() {
         for (String uiName: UI_NAMES) {
             test(uiName);
@@ -63,11 +69,9 @@ public class Test6963870 implements Runnable {
         try {
             UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
         } catch (Exception e) {
-            System.out.println("GTKLookAndFeel cannot be set, skipping this test");
-            return;
+            throw new SkippedException("GTKLookAndFeel isn't supported", e);
         }
 
         SwingUtilities.invokeAndWait(new Test6963870());
     }
 }
-


### PR DESCRIPTION
Backporting JDK-8366369: Add @requires linux for GTK L&F tests.

This PR restricts GTK tests to Linux/Unix systems and improves test hygiene.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64 and linux-aarch64 (should only run on Linux):

make test TEST=test/jdk/com/sun/java/swing/plaf/gtk/4928019/bug4928019.java
make test TEST=test/jdk/com/sun/java/swing/plaf/gtk/Test6635110.java
make test TEST=test/jdk/com/sun/java/swing/plaf/gtk/Test6963870.java

Results:

[linux-x64-specific-test.log](https://github.com/user-attachments/files/27415517/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27415518/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/27415519/linux-x64-specific-3-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27415520/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27415521/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27415522/linux-aarch64-specific-3-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8366369](https://bugs.openjdk.org/browse/JDK-8366369) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366369](https://bugs.openjdk.org/browse/JDK-8366369): Add @<!---->requires linux for GTK L&amp;F tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4412/head:pull/4412` \
`$ git checkout pull/4412`

Update a local copy of the PR: \
`$ git checkout pull/4412` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4412`

View PR using the GUI difftool: \
`$ git pr show -t 4412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4412.diff">https://git.openjdk.org/jdk17u-dev/pull/4412.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4412#issuecomment-4381700103)
</details>
