### PR TITLE
8373690: Unexpected Keystore message using jdk.crypto.disabledAlgorithms

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -1774,6 +1774,7 @@ public class KeyStore {
         }
 
         KeyStore keystore = null;
+        String matched = null;
 
         try (DataInputStream dataStream =
             new DataInputStream(
@@ -1797,8 +1798,10 @@ public class KeyStore {
                                 if (CryptoAlgorithmConstraints.permits(
                                         "KEYSTORE", ksAlgo)) {
                                     keystore = new KeyStore(impl, p, ksAlgo);
-                                    break;
+                                } else {
+                                    matched = ksAlgo;
                                 }
+                                break;
                             }
                         } catch (NoSuchAlgorithmException e) {
                             // ignore
@@ -1828,9 +1831,14 @@ public class KeyStore {
                 return keystore;
             }
         }
-
-        throw new KeyStoreException("Unrecognized keystore format. "
-                + "Please load it with a specified type");
+        if (matched == null) {
+            throw new KeyStoreException("Unrecognized keystore format. "
+                    + "Please load it with a specified type");
+        } else {
+            throw new KeyStoreException("Keystore format " +
+                    matched +
+                    " disabled by jdk.crypto.disabledAlgorithms property");
+        }
     }
 
     /**

--- a/test/jdk/java/security/KeyStore/DisabledKnownType.java
+++ b/test/jdk/java/security/KeyStore/DisabledKnownType.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8373690
+ * @summary verify that the exception message indicates the keystore type
+ *         when the type is disabled instead of being unrecognized
+ * @run main/othervm -Djdk.crypto.disabledAlgorithms=KeyStore.PKCS12 DisabledKnownType
+ */
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+
+public class DisabledKnownType {
+    public static void main(String[] args) throws Exception {
+        String cacertsPath = System.getProperty("java.home") +
+                "/lib/security/cacerts";
+        try {
+            KeyStore ks = KeyStore.getInstance(new java.io.File(cacertsPath),
+                    "changeit".toCharArray());
+            throw new RuntimeException("Expected KeyStoreException not thrown");
+        } catch (KeyStoreException kse) {
+            if (kse.getMessage().contains("PKCS12")) {
+                System.out.println("Passed: expected ex thrown: " + kse);
+            } else {
+                // pass it up
+                throw kse;
+            }
+        }
+    }
+}
+

--- a/test/jdk/java/security/KeyStore/DisabledKnownType.java
+++ b/test/jdk/java/security/KeyStore/DisabledKnownType.java
@@ -26,7 +26,7 @@
  * @bug 8373690
  * @summary verify that the exception message indicates the keystore type
  *         when the type is disabled instead of being unrecognized
- * @run main/othervm -Djdk.crypto.disabledAlgorithms=KeyStore.PKCS12 DisabledKnownType
+ * @run main/othervm -Djdk.crypto.disabledAlgorithms=KeyStore.JKS DisabledKnownType
  */
 
 import java.security.KeyStore;
@@ -41,7 +41,7 @@ public class DisabledKnownType {
                     "changeit".toCharArray());
             throw new RuntimeException("Expected KeyStoreException not thrown");
         } catch (KeyStoreException kse) {
-            if (kse.getMessage().contains("PKCS12")) {
+            if (kse.getMessage().contains("JKS")) {
                 System.out.println("Passed: expected ex thrown: " + kse);
             } else {
                 // pass it up


### PR DESCRIPTION
I backport this for parity with 17.0.20-oracle.

Clean backport, but the test does not pass out of the box.

The second commit shows the adaption.
It seems that the cacerts file in the JVM is using JKS in 17, PKCS12 in 21.
But [JDK-8044445](https://bugs.openjdk.org/browse/JDK-8044445): JEP 229: Create PKCS12 Keystores by Default
came in Java 9.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8373690](https://bugs.openjdk.org/browse/JDK-8373690) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8373690](https://bugs.openjdk.org/browse/JDK-8373690): Unexpected Keystore message using jdk.crypto.disabledAlgorithms (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4414/head:pull/4414` \
`$ git checkout pull/4414`

Update a local copy of the PR: \
`$ git checkout pull/4414` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4414`

View PR using the GUI difftool: \
`$ git pr show -t 4414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4414.diff">https://git.openjdk.org/jdk17u-dev/pull/4414.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4414#issuecomment-4389002675)
</details>
