### PR TITLE
8068293: [TEST_BUG] Test closed/com/sun/java/swing/plaf/motif/InternalFrame/4150591/bug4150591.java fails with GTKLookAndFeel

### DIFF
--- a/test/jdk/javax/swing/plaf/motif/bug4150591.java
+++ b/test/jdk/javax/swing/plaf/motif/bug4150591.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 import com.sun.java.swing.plaf.motif.MotifInternalFrameTitlePane;
 import javax.swing.JInternalFrame;
+import javax.swing.UIManager;
 
 /*
  * @test
@@ -36,7 +37,8 @@ import javax.swing.JInternalFrame;
  */
 
 public class bug4150591 {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
         MotifInternalFrameTitlePane mtp = new MotifInternalFrameTitlePane(new JInternalFrame());
     }
 }


### PR DESCRIPTION
Backporting JDK-8068293: [TEST_BUG] Test closed/com/sun/java/swing/plaf/motif/InternalFrame/4150591/bug4150591.java fails with GTKLookAndFeel.

This PR fixes test bug4150591 by explicitly setting the Motif Look & Feel before instantiating MotifInternalFrameTitlePane, preventing NPE that occurred when running under GTK Look & Feel where activeCaptionBorder and inactiveCaptionBorder colors are undefined and caused BorderFactory.createBevelBorder() to fail.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/swing/plaf/motif/bug4150591.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27491723/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27491724/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27491725/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27491726/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8068293](https://bugs.openjdk.org/browse/JDK-8068293) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8068293](https://bugs.openjdk.org/browse/JDK-8068293): [TEST_BUG] Test closed/com/sun/java/swing/plaf/motif/InternalFrame/4150591/bug4150591.java fails with GTKLookAndFeel (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4416/head:pull/4416` \
`$ git checkout pull/4416`

Update a local copy of the PR: \
`$ git checkout pull/4416` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4416`

View PR using the GUI difftool: \
`$ git pr show -t 4416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4416.diff">https://git.openjdk.org/jdk17u-dev/pull/4416.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4416#issuecomment-4399095704)
</details>
