### PR TITLE
8068310: [TEST_BUG] Test javax/swing/JColorChooser/Test4234761.java fails with GTKL&F

### DIFF
--- a/test/jdk/javax/swing/JColorChooser/Test4234761.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4234761.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,12 @@
 
 /*
  * @test
- * @key headful
  * @bug 4234761
+ * @key headful
  * @summary RGB values sholdn't be changed in transition to HSB tab
- * @author Oleg Mokhovikov
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @run main Test4234761
  */
 
 import java.awt.Color;
@@ -35,11 +37,17 @@ import java.beans.PropertyChangeListener;
 import javax.swing.JColorChooser;
 import javax.swing.JDialog;
 import javax.swing.JTabbedPane;
+import javax.swing.UIManager;
+
+import jtreg.SkippedException;
 
 public class Test4234761 implements PropertyChangeListener {
     private static final Color COLOR = new Color(51, 51, 51);
 
     public static void main(String[] args) {
+        if (UIManager.getLookAndFeel().getName().contains("GTK")) {
+            throw new SkippedException("Test skipped for GTK");
+        }
         JColorChooser chooser = new JColorChooser(COLOR);
         JDialog dialog = Test4177735.show(chooser);
 


### PR DESCRIPTION
Backporting JDK-8068310: [TEST_BUG] Test javax/swing/JColorChooser/Test4234761.java fails with GTKL&F.

This PR fixes a bug where Test4234761.java throws a ClassCastException (JPanel cannot be cast to JTabbedPane
) when run under the GTK Look and Feel. The GTK L&F uses a different internal component structure for JColorChooser and it doesn't use a JTabbedPane for the color panel tabs, so the test's assumption of casting a child component to JTabbedPane fails. The fix skips the test entirely under GTK L&F using jtreg.SkippedException, since the test's tab-switching logic is structurally incompatible with GTK's implementation.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/swing/JColorChooser/Test4234761.java

Results attached:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27491824/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27491826/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27491828/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27491830/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8068310](https://bugs.openjdk.org/browse/JDK-8068310) needs maintainer approval

### Issue
 * [JDK-8068310](https://bugs.openjdk.org/browse/JDK-8068310): [TEST_BUG] Test javax/swing/JColorChooser/Test4234761.java fails with GTKL&amp;F (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4417/head:pull/4417` \
`$ git checkout pull/4417`

Update a local copy of the PR: \
`$ git checkout pull/4417` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4417`

View PR using the GUI difftool: \
`$ git pr show -t 4417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4417.diff">https://git.openjdk.org/jdk17u-dev/pull/4417.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4417#issuecomment-4399107353)
</details>
