### PR TITLE
8144124: [macosx] The tabs can't be aligned when we pressing the key of 'R','B','L','C' or 'T'.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -820,7 +820,6 @@ java/awt/xembed/server/TestXEmbedServerJava.java 8001150,8004031 generic-all
 javax/swing/JFileChooser/6698013/bug6698013.java 8024419 macosx-all
 javax/swing/JColorChooser/8065098/bug8065098.java 8065647 macosx-all
 java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java 8068378 generic-all
-javax/swing/JTabbedPane/bug4666224.java 8144124  macosx-all
 java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java 8162380 generic-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all


### PR DESCRIPTION
Backporting JDK-8144124: [macosx] The tabs can't be aligned when we pressing the key of 'R','B','L','C' or 'T'.

This PR removes "bug4666224.java" to the problem list.

For parity with Oracle JDK. Already backported to 21.

Ran related test on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/javax/swing/JTabbedPane/bug4666224.java```

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8144124](https://bugs.openjdk.org/browse/JDK-8144124) needs maintainer approval

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8144124: [macosx] The tabs can't be aligned when we pressing the key of 'R','B','L','C' or 'T'.`

### Issue
 * [JDK-8144124](https://bugs.openjdk.org/browse/JDK-8144124): [macosx] The tabs can't be aligned when we pressing the key of 'R','B','L','C' or 'T'. (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4419/head:pull/4419` \
`$ git checkout pull/4419`

Update a local copy of the PR: \
`$ git checkout pull/4419` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4419`

View PR using the GUI difftool: \
`$ git pr show -t 4419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4419.diff">https://git.openjdk.org/jdk17u-dev/pull/4419.diff</a>

</details>
