### PR TITLE
8360882: Tests throw SkippedException when they should fail

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -686,7 +686,12 @@ public abstract class PKCS11Test {
     }
 
     private static Path fetchNssLib(Class<?> clazz, Path libraryName) throws IOException {
-        Path p = ArtifactResolver.fetchOne(clazz);
+        Path p;
+        try {
+            p = ArtifactResolver.fetchOne(clazz);
+        } catch (IOException exc) {
+            throw new SkippedException("Could not find NSS", exc);
+        }
         return findNSSLibrary(p, libraryName);
     }
 

--- a/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
+++ b/test/lib/jdk/test/lib/artifacts/ArtifactResolver.java
@@ -23,8 +23,7 @@
 
 package jdk.test.lib.artifacts;
 
-import jtreg.SkippedException;
-
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -81,15 +80,15 @@ public class ArtifactResolver {
      * @return the local path to the artifact. If the artifact is a compressed
      * file that gets unpacked, this path will point to the root
      * directory of the uncompressed file(s).
-     * @throws SkippedException thrown if the artifact cannot be found
+     * @throws IOException thrown if the artifact cannot be found
      */
-    public static Path fetchOne(Class<?> klass) {
+    public static Path fetchOne(Class<?> klass) throws IOException {
         try {
             return ArtifactResolver.resolve(klass).entrySet().stream()
                     .findAny().get().getValue();
         } catch (ArtifactResolverException e) {
             Artifact artifact = klass.getAnnotation(Artifact.class);
-            throw new SkippedException("Cannot find the artifact " + artifact.name(), e);
+            throw new IOException("Cannot find the artifact " + artifact.name(), e);
         }
     }
 

--- a/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
+++ b/test/lib/jdk/test/lib/security/OpensslArtifactFetcher.java
@@ -23,6 +23,7 @@
 
 package jdk.test.lib.security;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
@@ -49,42 +50,40 @@ public class OpensslArtifactFetcher {
      *
      * @return openssl binary path of the current version
      * @throws SkippedException if a valid version of OpenSSL cannot be found
+     *         or if OpenSSL is not available on the target platform
      */
     public static String getOpensslPath() {
         String path = getOpensslFromSystemProp(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
+            System.out.println("Using OpenSSL from system property.");
             return path;
         }
+
         path = getDefaultSystemOpensslPath(OPENSSL_BUNDLE_VERSION);
         if (path != null) {
+            System.out.println("Using OpenSSL from system.");
             return path;
         }
+
         if (Platform.isX64()) {
             if (Platform.isLinux()) {
-                path = fetchOpenssl(LINUX_X64.class);
+                return fetchOpenssl(LINUX_X64.class);
             } else if (Platform.isOSX()) {
-                path = fetchOpenssl(MACOSX_X64.class);
+                return fetchOpenssl(MACOSX_X64.class);
             } else if (Platform.isWindows()) {
-                path = fetchOpenssl(WINDOWS_X64.class);
+                return fetchOpenssl(WINDOWS_X64.class);
             }
         } else if (Platform.isAArch64()) {
             if (Platform.isLinux()) {
-                path = fetchOpenssl(LINUX_AARCH64.class);
+                return fetchOpenssl(LINUX_AARCH64.class);
             }
             if (Platform.isOSX()) {
-                path = fetchOpenssl(MACOSX_AARCH64.class);
+                return fetchOpenssl(MACOSX_AARCH64.class);
             }
         }
 
-        if (!verifyOpensslVersion(path, OPENSSL_BUNDLE_VERSION)) {
-            String exMsg = "Can't find the version: "
-                    + OpensslArtifactFetcher.getTestOpensslBundleVersion()
-                    + " of openssl binary on this machine, please install"
-                    + " and set openssl path with property 'test.openssl.path'";
-            throw new SkippedException(exMsg);
-        } else {
-            return path;
-        }
+        throw new SkippedException(String.format("No OpenSSL %s found for %s/%s",
+                OPENSSL_BUNDLE_VERSION, Platform.getOsName(), Platform.getOsArch()));
     }
 
     private static String getOpensslFromSystemProp(String version) {
@@ -120,9 +119,13 @@ public class OpensslArtifactFetcher {
     }
 
     private static String fetchOpenssl(Class<?> clazz) {
-        return ArtifactResolver.fetchOne(clazz)
-            .resolve("openssl").resolve("bin").resolve("openssl")
+        try {
+            return ArtifactResolver.fetchOne(clazz)
+                .resolve("openssl").resolve("bin").resolve("openssl")
                 .toString();
+        } catch (IOException exc) {
+            throw new SkippedException("Could not find openssl", exc);
+        }
     }
 
     // retrieve the provider directory path from <OPENSSL_HOME>/bin/openssl


### PR DESCRIPTION
Backporting JDK-8360882: Tests throw SkippedException when they should fail.

This PR fixes ArtifactResolver to throw IOException instead of SkippedException when artifacts fail to fetch, allowing tests to decide whether to skip or fail.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/sun/security/pkcs11

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27521263/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27521265/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27521266/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27521267/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8360882](https://bugs.openjdk.org/browse/JDK-8360882) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360882](https://bugs.openjdk.org/browse/JDK-8360882): Tests throw SkippedException when they should fail (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4420/head:pull/4420` \
`$ git checkout pull/4420`

Update a local copy of the PR: \
`$ git checkout pull/4420` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4420`

View PR using the GUI difftool: \
`$ git pr show -t 4420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4420.diff">https://git.openjdk.org/jdk17u-dev/pull/4420.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4420#issuecomment-4400525734)
</details>
