### PR TITLE
8375999: com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails sporadically on Windows

### DIFF
--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,6 +131,7 @@ public class LdapPoolTimeoutTest {
                                 || msg.contains("No route to host")
                                 || msg.contains("Timed out waiting for lock")
                                 || msg.contains("Connect timed out")
+                                || msg.contains("Connection timed out")
                                 || msg.contains("Timeout exceeded while waiting for a connection"))) {
                     // got the expected exception
                     System.out.println("Received expected NamingException with message: " + msg);


### PR DESCRIPTION
Backporting JDK-8375999: com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails sporadically on Windows.

This PR fixes sporadic LdapPoolTimeoutTest.java failures on Windows by restoring a Windows-specific exception message that was accidentally removed in https://bugs.openjdk.org/browse/JDK-8287062.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27521369/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27521370/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27521371/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27521372/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8375999](https://bugs.openjdk.org/browse/JDK-8375999) needs maintainer approval

### Issue
 * [JDK-8375999](https://bugs.openjdk.org/browse/JDK-8375999): com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails sporadically on Windows (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4423/head:pull/4423` \
`$ git checkout pull/4423`

Update a local copy of the PR: \
`$ git checkout pull/4423` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4423`

View PR using the GUI difftool: \
`$ git pr show -t 4423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4423.diff">https://git.openjdk.org/jdk17u-dev/pull/4423.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4423#issuecomment-4400592396)
</details>
