### PR TITLE
8372120: Add missing sound keyword to MIDI tests

### DIFF
--- a/test/jdk/javax/sound/midi/MidiDeviceConnectors/TestAllDevices.java
+++ b/test/jdk/javax/sound/midi/MidiDeviceConnectors/TestAllDevices.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 4933700
+ * @key sound
  * @summary Tests that default devices return MidiDeviceTransmitter/Receiver and returned objects return correct MidiDevice
  * @compile TestAllDevices.java
  * @run main TestAllDevices

--- a/test/jdk/javax/sound/midi/SysexMessage/SendRawSysexMessage.java
+++ b/test/jdk/javax/sound/midi/SysexMessage/SendRawSysexMessage.java
@@ -35,6 +35,7 @@ import static javax.sound.midi.SysexMessage.SYSTEM_EXCLUSIVE;
 /**
  * @test
  * @bug 8237495 8301310
+ * @key sound
  * @summary fail with memory errors when asked to send a sysex message starting
  *          with 0xF7
  */

--- a/test/jdk/javax/sound/midi/spi/MidiDeviceProvider/ExpectedNPEOnNull.java
+++ b/test/jdk/javax/sound/midi/spi/MidiDeviceProvider/ExpectedNPEOnNull.java
@@ -32,6 +32,7 @@ import static java.util.ServiceLoader.load;
 /**
  * @test
  * @bug 8143909
+ * @key sound
  * @author Sergey Bylokhov
  */
 public final class ExpectedNPEOnNull {

--- a/test/jdk/javax/sound/midi/spi/MidiDeviceProvider/FakeInfo.java
+++ b/test/jdk/javax/sound/midi/spi/MidiDeviceProvider/FakeInfo.java
@@ -35,6 +35,7 @@ import static java.util.ServiceLoader.load;
 /**
  * @test
  * @bug 8059743
+ * @key sound
  * @summary MidiDeviceProvider shouldn't returns incorrect results in case of
  *          some unknown MidiDevice.Info
  * @author Sergey Bylokhov

--- a/test/jdk/javax/sound/midi/spi/MidiDeviceProvider/UnsupportedInfo.java
+++ b/test/jdk/javax/sound/midi/spi/MidiDeviceProvider/UnsupportedInfo.java
@@ -30,6 +30,7 @@ import static java.util.ServiceLoader.load;
 /**
  * @test
  * @bug 8058115
+ * @key sound
  * @summary MidiDeviceProvider shouldn't returns incorrect results in case of
  *          unsupported MidiDevice.Info
  * @author Sergey Bylokhov


### PR DESCRIPTION
Backporting JDK-8372120: Add missing sound keyword to MIDI tests.

This PR adds the sound keyword to affected tests to ensure they run properly when audio hardware is available.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/sound/midi

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27521520/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27521545/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27521546/linux-aarch64-specific-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/27527981/windows-x64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8372120](https://bugs.openjdk.org/browse/JDK-8372120) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8372120](https://bugs.openjdk.org/browse/JDK-8372120): Add missing sound keyword to MIDI tests (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4424/head:pull/4424` \
`$ git checkout pull/4424`

Update a local copy of the PR: \
`$ git checkout pull/4424` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4424`

View PR using the GUI difftool: \
`$ git pr show -t 4424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4424.diff">https://git.openjdk.org/jdk17u-dev/pull/4424.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4424#issuecomment-4401101414)
</details>
