### PR TITLE
8377727: Ghost caret and focus appear in non‑editable text fields

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.swing.text;
 
+import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.HeadlessException;
 import java.awt.Point;
@@ -694,7 +695,25 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
                     // semantics of damage we can't really get around this.
                     damage(r);
                 }
-                g.setColor(component.getCaretColor());
+                if (component.isEditable()) {
+                    g.setColor(component.getCaretColor());
+                } else {
+                    Color caretColor = component.getCaretColor();
+                    if (caretColor == null) {
+                        caretColor = g.getColor();
+                    }
+                    Color bg = component.getBackground();
+                    if (bg == null) {
+                        g.setColor(caretColor);
+                    } else {
+                        int red = (caretColor.getRed() + bg.getRed()) / 2;
+                        int green = (caretColor.getGreen() + bg.getGreen()) / 2;
+                        int blue = (caretColor.getBlue() + bg.getBlue()) / 2;
+                        int alpha = 127;
+                        Color newCaretColor = new Color(red, green, blue, alpha);
+                        g.setColor(newCaretColor);
+                    }
+                }
                 int paintWidth = getCaretWidth(r.height);
                 r.x -= paintWidth  >> 1;
                 g.fillRect(r.x, r.y, paintWidth, r.height);


### PR DESCRIPTION
I backport this for parity with 17.0.20-oracle.

Fixes regression in 17.0.15

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8377727](https://bugs.openjdk.org/browse/JDK-8377727) needs maintainer approval

### Issue
 * [JDK-8377727](https://bugs.openjdk.org/browse/JDK-8377727): Ghost caret and focus appear in non‑editable text fields (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4425/head:pull/4425` \
`$ git checkout pull/4425`

Update a local copy of the PR: \
`$ git checkout pull/4425` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4425`

View PR using the GUI difftool: \
`$ git pr show -t 4425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4425.diff">https://git.openjdk.org/jdk17u-dev/pull/4425.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4425#issuecomment-4404716407)
</details>
