### PR TITLE
8225787: java/awt/Window/GetScreenLocation/GetScreenLocationTest.java fails on Ubuntu

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -463,7 +463,6 @@ java/awt/Focus/TranserFocusToWindow/TranserFocusToWindow.java 6848810 macosx-all
 java/awt/Component/NativeInLightShow/NativeInLightShow.java 8202932 linux-all
 java/awt/FileDialog/ModalFocus/FileDialogModalFocusTest.java 8194751 linux-all
 java/awt/image/VolatileImage/BitmaskVolatileImage.java 8133102 linux-all
-java/awt/SplashScreen/MultiResolutionSplash/unix/UnixMultiResolutionSplashTest.java 8203004 linux-all
 java/awt/ScrollPane/ScrollPaneEventType.java 8296516 macosx-all
 java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java 7107528 linux-all,macosx-all
 java/awt/Mouse/MouseDragEvent/MouseDraggedTest.java 8080676 linux-all
@@ -503,7 +502,6 @@ java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 ge
 java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all
 java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java 8257529 windows-x64
 
-java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
 java/awt/Dialog/FileDialogUserFilterTest.java 8001142 generic-all
 


### PR DESCRIPTION
Backporting JDK-8225787 and JDK-8203004: java/awt/Window/GetScreenLocation/GetScreenLocationTest.java fails on Ubuntu, and UnixMultiResolutionSplashTest.java fails on Ubuntu16.04.

This PR removes two AWT tests from the problem list, indicating that the underlying bugs (JDK-8203004 for multi-resolution splash screen and JDK-8225787 for window screen location) have been fixed and the tests now pass reliably on Linux platforms.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=java/awt/SplashScreen/MultiResolutionSplash/unix/UnixMultiResolutionSplashTest.java
make test TEST=java/awt/Window/GetScreenLocation/GetScreenLocationTest.java

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27529440/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27529442/macos-aarch64-specific-2-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/27530730/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27530731/windows-x64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27530732/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27530733/linux-x64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27530734/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27530735/linux-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] [JDK-8225787](https://bugs.openjdk.org/browse/JDK-8225787) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8203004](https://bugs.openjdk.org/browse/JDK-8203004) needs maintainer approval

### Issues
 * [JDK-8225787](https://bugs.openjdk.org/browse/JDK-8225787): java/awt/Window/GetScreenLocation/GetScreenLocationTest.java fails on Ubuntu (**Bug** - P3)
 * [JDK-8203004](https://bugs.openjdk.org/browse/JDK-8203004): UnixMultiResolutionSplashTest.java fails on Ubuntu16.04 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4426/head:pull/4426` \
`$ git checkout pull/4426`

Update a local copy of the PR: \
`$ git checkout pull/4426` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4426`

View PR using the GUI difftool: \
`$ git pr show -t 4426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4426.diff">https://git.openjdk.org/jdk17u-dev/pull/4426.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4426#issuecomment-4407071869)
</details>
