### PR TITLE
8374433: java/util/Locale/PreserveTagCase.java does not run any tests

### DIFF
--- a/test/jdk/java/util/Locale/PreserveTagCase.java
+++ b/test/jdk/java/util/Locale/PreserveTagCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class PreserveTagCase {
      */
     @ParameterizedTest
     @MethodSource("filterProvider")
-    public static void testFilterTags(String ranges, List<String> tags,
+    public void testFilterTags(String ranges, List<String> tags,
                                   List<String> expected, FilteringMode mode) {
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         List<String> actual = Locale.filterTags(priorityList, tags, mode);
@@ -67,7 +67,7 @@ public class PreserveTagCase {
      */
     @ParameterizedTest
     @MethodSource("lookupProvider")
-    public static void testLookupTag(String ranges, List<String> tags,
+    public void testLookupTag(String ranges, List<String> tags,
                                   String expected) {
         List<LanguageRange> priorityList = LanguageRange.parse(ranges);
         String actual = Locale.lookupTag(priorityList, tags);


### PR DESCRIPTION
Backporting JDK-8374433: java/util/Locale/PreserveTagCase.java does not run any tests.

This PR removes the static modifier from the JUnit test cases to ensure they execute properly.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/util/Locale/PreserveTagCase.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27534185/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27534186/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27534187/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27534189/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8374433](https://bugs.openjdk.org/browse/JDK-8374433) needs maintainer approval

### Issue
 * [JDK-8374433](https://bugs.openjdk.org/browse/JDK-8374433): java/util/Locale/PreserveTagCase.java does not run any tests (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4430/head:pull/4430` \
`$ git checkout pull/4430`

Update a local copy of the PR: \
`$ git checkout pull/4430` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4430`

View PR using the GUI difftool: \
`$ git pr show -t 4430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4430.diff">https://git.openjdk.org/jdk17u-dev/pull/4430.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4430#issuecomment-4408775355)
</details>
