### PR TITLE
8342401: [TESTBUG] javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java test fails in ubuntu 22.04 on SBR Hosts

### DIFF
--- a/test/jdk/javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java
+++ b/test/jdk/javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class JSpinnerButtonFocusTest {
                 robot.setAutoDelay(50);
 
                 SwingUtilities.invokeAndWait(() -> {
-                    frame = new JFrame();
+                    frame = new JFrame("JSpinnerButtonFocusTest");
                     spinner1 = new JSpinner();
                     spinner2 = new JSpinner();
 
@@ -72,6 +72,15 @@ public class JSpinnerButtonFocusTest {
                     frame.getContentPane().add(spinner2, BorderLayout.SOUTH);
 
                     editor1 = ((DefaultEditor)spinner1.getEditor());
+                    editor1.getTextField().addFocusListener(new FocusAdapter() {
+                        @Override
+                        public void focusGained(FocusEvent e) {
+                            super.focusGained(e);
+                            robot.keyPress(KeyEvent.VK_TAB);
+                            robot.keyRelease(KeyEvent.VK_TAB);
+                            latch1.countDown();
+                        }
+                    });
                     editor1.setFocusable(false);
                     spinner1.setFocusable(false);
 
@@ -84,26 +93,18 @@ public class JSpinnerButtonFocusTest {
                     frame.setFocusTraversalPolicyProvider(true);
 
                     frame.setAlwaysOnTop(true);
-                    frame.pack();
+                    frame.setSize(100, 100);
+                    frame.setLocationRelativeTo(null);
                     frame.setVisible(true);
                 });
                 robot.waitForIdle();
-
-                editor1.getTextField().addFocusListener(new FocusAdapter() {
-                    @Override
-                    public void focusGained(FocusEvent e) {
-                        super.focusGained(e);
-                        robot.keyPress(KeyEvent.VK_TAB);
-                        robot.keyRelease(KeyEvent.VK_TAB);
-                        latch1.countDown();
-                    }
-                });
+                robot.delay(1000);
 
                 SwingUtilities.invokeAndWait(() -> {
                     editor1.getTextField().requestFocusInWindow();
                 });
 
-                if (!latch1.await(15, TimeUnit.MINUTES)) {
+                if (!latch1.await(1, TimeUnit.MINUTES)) {
                     throw new RuntimeException(LF.getClassName() +
                             ": Timeout waiting for editor1 to gain focus.");
                 }


### PR DESCRIPTION
Backporting JDK-8342401: [TESTBUG] javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java test fails in ubuntu 22.04 on SBR Hosts.

This PR fixes intermittent JSpinnerButtonFocusTest.java failures caused by timing issues between UI creation and test execution. It adds proper delays, centers frame positioning, and moves listener registration.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27605965/macos-aarch64-specific-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/27605971/windows-x64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27605973/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27605974/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8342401](https://bugs.openjdk.org/browse/JDK-8342401) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342401](https://bugs.openjdk.org/browse/JDK-8342401): [TESTBUG] javax/swing/JSpinner/8223788/JSpinnerButtonFocusTest.java test fails in ubuntu 22.04 on SBR Hosts (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4435/head:pull/4435` \
`$ git checkout pull/4435`

Update a local copy of the PR: \
`$ git checkout pull/4435` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4435`

View PR using the GUI difftool: \
`$ git pr show -t 4435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4435.diff">https://git.openjdk.org/jdk17u-dev/pull/4435.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4435#issuecomment-4422055018)
</details>
