### PR TITLE
8346154: [XWayland] Some tests fail intermittently in the CI, but not locally

### DIFF
--- a/test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
+++ b/test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,8 @@ class TestFrame extends Frame implements ItemListener {
                               pt.y + choice.getHeight()*3/4);
             // testing that ItemEvent doesn't generated on a simple
             // mouse click when the dropdown appears under mouse : 6425067
+            robot.waitForIdle();
+            robot.delay(250);
             stateChanged = false;
             openChoice();
             closeChoice();

--- a/test/jdk/java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java
+++ b/test/jdk/java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class ClearLwQueueBreakTest {
     JTextField tf1 = new JTextField("     ");
     JTextField tf2 = new JTextField("     ");
     JTextField tf3 = new JTextField("     ");
-    AtomicBoolean typed = new AtomicBoolean(false);
+    final AtomicBoolean typed = new AtomicBoolean(false);
     FocusListener listener1;
     FocusListener listener2;
 
@@ -114,6 +114,7 @@ public class ClearLwQueueBreakTest {
         f1.setLocationRelativeTo(null);
         f1.setVisible(true);
         Util.waitForIdle(robot);
+        robot.delay(1000);
 
         /*
          * Break the sequence of LW requests in the middle.

--- a/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,16 @@
   @run        main ButtonActionKeyTest
 */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.FlowLayout;
+import java.awt.Robot;
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.util.concurrent.atomic.AtomicBoolean;
 import test.java.awt.regtesthelpers.Util;
 
@@ -42,7 +49,7 @@ public class ButtonActionKeyTest {
     JFrame frame = new JFrame("Frame");
     JButton button = new JButton("button");
     JTextField text = new JTextField("text");
-    AtomicBoolean gotEvent = new AtomicBoolean(false);
+    final AtomicBoolean gotEvent = new AtomicBoolean(false);
 
     public static void main(String[] args) {
         ButtonActionKeyTest app = new ButtonActionKeyTest();
@@ -82,9 +89,11 @@ public class ButtonActionKeyTest {
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         Util.waitForIdle(robot);
+        robot.delay(1000);
 
         Util.clickOnComp(button, robot);
         Util.waitForIdle(robot);
+        robot.delay(500);
 
         if (!button.isFocusOwner()) {
             throw new Error("Test error: a button didn't gain focus.");

--- a/test/jdk/java/awt/LightweightComponent/LightWeightTabFocus/LightWeightTabFocus.java
+++ b/test/jdk/java/awt/LightweightComponent/LightWeightTabFocus/LightWeightTabFocus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,6 +97,7 @@ public class LightWeightTabFocus {
         } catch (Exception e) {
             e.printStackTrace();
         } finally {
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             EventQueue.invokeAndWait(() -> {
                 if (f != null) {
                     f.dispose();

--- a/test/jdk/java/awt/Modal/ToFront/DialogToFrontModeless1Test.java
+++ b/test/jdk/java/awt/Modal/ToFront/DialogToFrontModeless1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,12 +34,27 @@
  * @build Flag
  * @build TestDialog
  * @build TestFrame
+ * @build jdk.test.lib.Platform
  * @run main DialogToFrontModeless1Test
  */
+
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 public class DialogToFrontModeless1Test {
 
     public static void main(String[] args) throws Exception {
+        if (Platform.isOnWayland()) {
+            // Some tested systems are still use XTEST(X11 protocol)
+            // for key and mouse press emulation, but this will not work
+            // outside of X11.
+            // An emulated input event will reach X11 clients, but not the
+            // Wayland compositor, which is responsible for window restacking.
+            //
+            // This skip can be removed later once all systems switch to
+            // the default remote desktop XDG portal.
+             throw new SkippedException("SKIPPED: robot functionality is limited on the current platform.");
+        }
         (new DialogToFrontModelessTest()).doTest();
     }
 }


### PR DESCRIPTION
Backporting JDK-8346154: [XWayland] Some tests fail intermittently in the CI, but not locally.

This PR fixes intermittent test failures on XWayland by adding delays after setVisible() calls and refactoring tests that immediately checked window state, addressing timing differences where XWayland delivers ConfigureNotify events asynchronously compared to X11.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Choice/PopupPosTest/PopupPosTest.java
make test TEST=test/jdk/java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java
make test TEST=test/jdk/java/awt/Frame/FrameSetMinimumSizeTest.java
make test TEST=test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java
make test TEST=test/jdk/java/awt/LightweightComponent/LightWeightTabFocus/LightWeightTabFocus.java
make test TEST=test/jdk/java/awt/Modal/ToFront/DialogToFrontModeless1Test.java"

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27606153/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27606155/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/27606156/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/27606157/windows-x64-specific-4-test.log)
[windows-x64-specific-5-test.log](https://github.com/user-attachments/files/27606158/windows-x64-specific-5-test.log)
[windows-x64-specific-6-test.log](https://github.com/user-attachments/files/27606159/windows-x64-specific-6-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27606162/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27606164/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27606165/macos-aarch64-specific-3-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27606166/macos-aarch64-specific-4-test.log)
[macos-aarch64-specific-5-test.log](https://github.com/user-attachments/files/27606167/macos-aarch64-specific-5-test.log)
[macos-aarch64-specific-6-test.log](https://github.com/user-attachments/files/27606187/macos-aarch64-specific-6-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27606169/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27606170/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/27606171/linux-x64-specific-3-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/27606172/linux-x64-specific-4-test.log)
[linux-x64-specific-5-test.log](https://github.com/user-attachments/files/27606173/linux-x64-specific-5-test.log)
[linux-x64-specific-6-test.log](https://github.com/user-attachments/files/27606174/linux-x64-specific-6-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27606175/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27606176/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27606177/linux-aarch64-specific-3-test.log)
[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27606178/linux-aarch64-specific-4-test.log)
[linux-aarch64-specific-5-test.log](https://github.com/user-attachments/files/27606179/linux-aarch64-specific-5-test.log)
[linux-aarch64-specific-6-test.log](https://github.com/user-attachments/files/27606180/linux-aarch64-specific-6-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346154](https://bugs.openjdk.org/browse/JDK-8346154) needs maintainer approval

### Issue
 * [JDK-8346154](https://bugs.openjdk.org/browse/JDK-8346154): [XWayland] Some tests fail intermittently in the CI, but not locally (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4436/head:pull/4436` \
`$ git checkout pull/4436`

Update a local copy of the PR: \
`$ git checkout pull/4436` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4436`

View PR using the GUI difftool: \
`$ git pr show -t 4436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4436.diff">https://git.openjdk.org/jdk17u-dev/pull/4436.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4436#issuecomment-4422071287)
</details>
