### PR TITLE
8372609: Bug4944439 does not enforce locale correctly

### DIFF
--- a/test/jdk/java/text/Format/NumberFormat/Bug4944439.java
+++ b/test/jdk/java/text/Format/NumberFormat/Bug4944439.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,22 +23,19 @@
 
 /*
  * @test
- * @bug 4944439
+ * @bug 4944439 8372609
  * @summary Confirm that numbers where all digits after the decimal separator are 0
  *          and which are between Long.MIN_VALUE and Long.MAX_VALUE are returned
  *          as Long(not double).
  * @run junit Bug4944439
  */
 
-import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -47,21 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class Bug4944439 {
 
-    // Save JVM default locale
-    private static final Locale savedLocale = Locale.getDefault();
-    private static final DecimalFormat df = new DecimalFormat();
-
-    // Set JVM default locale to US for testing
-    @BeforeAll
-    static void initAll() {
-        Locale.setDefault(Locale.US);
-    }
-
-    // Restore JVM default locale
-    @AfterAll
-    static void tearDownAll() {
-        Locale.setDefault(savedLocale);
-    }
+    private static final NumberFormat df = NumberFormat.getInstance(Locale.US);
 
     // Check return type and value returned by DecimalFormat.parse() for longs
     @ParameterizedTest


### PR DESCRIPTION
Backporting JDK-8372609: Bug4944439 does not enforce locale correctly.

This PR fixes an issue where DecimalFormat was initialized with the wrong locale.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/text/Format/NumberFormat/Bug4944439.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27608744/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27608746/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27608747/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27608749/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8372609](https://bugs.openjdk.org/browse/JDK-8372609) needs maintainer approval

### Issue
 * [JDK-8372609](https://bugs.openjdk.org/browse/JDK-8372609): Bug4944439 does not enforce locale correctly (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4437/head:pull/4437` \
`$ git checkout pull/4437`

Update a local copy of the PR: \
`$ git checkout pull/4437` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4437`

View PR using the GUI difftool: \
`$ git pr show -t 4437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4437.diff">https://git.openjdk.org/jdk17u-dev/pull/4437.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4437#issuecomment-4422349179)
</details>
