### PR TITLE
8367784: java/awt/Focus/InitialFocusTest/InitialFocusTest1.java failed with Wrong focus owner

### DIFF
--- a/test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java
+++ b/test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java
@@ -22,8 +22,10 @@
  */
 
 import java.awt.Button;
+import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Frame;
+import java.awt.Robot;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 
@@ -39,27 +41,36 @@ public class InitialFocusTest1 extends Frame implements FocusListener {
     Button button1 = new Button("Button1");
     Button button2 = new Button("Button2");
     private static volatile Object focused;
+    private static InitialFocusTest1 app;
 
     public static void main(final String[] args) throws Exception {
-        InitialFocusTest1 app = new InitialFocusTest1();
         try {
-            app.setSize(200, 200);
-            app.setLocationRelativeTo(null);
-            app.setLayout(new FlowLayout());
+            Robot robot = new Robot();
+            EventQueue.invokeAndWait(() -> {
+                app = new InitialFocusTest1();
+                app.setLayout(new FlowLayout());
 
-            app.button1.addFocusListener(app);
-            app.button2.addFocusListener(app);
-            app.add(app.button1);
-            app.add(app.button2);
-            app.setVisible(true);
-            app.button2.requestFocus();
+                app.button1.addFocusListener(app);
+                app.button2.addFocusListener(app);
+                app.add(app.button1);
+                app.add(app.button2);
+
+                app.setSize(200, 200);
+                app.setLocationRelativeTo(null);
+                app.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> {
+                app.button2.requestFocus();
+            });
             // wait for the very very last focus event
-            Thread.sleep(10000);
+            robot.delay(1000);
             if (app.button2 != focused) {
                 throw new RuntimeException("Wrong focus owner: " + focused);
             }
         } finally {
-            app.dispose();
+            EventQueue.invokeAndWait(() -> app.dispose());
         }
     }
 


### PR DESCRIPTION
Backporting JDK-8367784: java/awt/Focus/InitialFocusTest/InitialFocusTest1.java failed with Wrong focus owner.

This PR fixes intermittent failure in InitialFocusTest1.java where wrong component receives initial focus.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Focus/InitialFocusTest/InitialFocusTest1.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27641303/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27641304/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27641305/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27641306/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367784](https://bugs.openjdk.org/browse/JDK-8367784) needs maintainer approval

### Issue
 * [JDK-8367784](https://bugs.openjdk.org/browse/JDK-8367784): java/awt/Focus/InitialFocusTest/InitialFocusTest1.java failed with Wrong focus owner (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4439/head:pull/4439` \
`$ git checkout pull/4439`

Update a local copy of the PR: \
`$ git checkout pull/4439` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4439`

View PR using the GUI difftool: \
`$ git pr show -t 4439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4439.diff">https://git.openjdk.org/jdk17u-dev/pull/4439.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4439#issuecomment-4424098856)
</details>
