### PR TITLE
8357390: java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java Test failing on Ubuntu 24.04 Vm Hosts used by Oracle's internal CI system

### DIFF
--- a/test/jdk/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
+++ b/test/jdk/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @key headful
- * @bug 8020443 6899304 4737732
+ * @bug 8020443 6899304 4737732 8357390
  * @summary Tests that Toolkit.getScreenInsets() returns correct insets
  * @library /test/lib
  * @build jdk.test.lib.Platform
@@ -44,7 +44,7 @@ import jdk.test.lib.Platform;
 public class ScreenInsetsTest {
     private static final int SIZE = 100;
     // Allow a margin tolerance of 1 pixel due to scaling
-    private static final int MARGIN_TOLERANCE = 1;
+    private static final int MARGIN_TOLERANCE = 2;
 
     public static void main(String[] args) throws InterruptedException {
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();


### PR DESCRIPTION
Backporting JDK-8357390: java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java Test failing on Ubuntu 24.04 Vm Hosts used by Oracle's internal CI system.

This PR increases the acceptable margin from 1px to 2px to accommodate the Ubuntu 24.04 window manager quirk.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27641672/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27641673/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27641674/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27641677/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8357390](https://bugs.openjdk.org/browse/JDK-8357390) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357390](https://bugs.openjdk.org/browse/JDK-8357390): java/awt/Toolkit/ScreenInsetsTest/ScreenInsetsTest.java Test failing on Ubuntu 24.04 Vm Hosts used by Oracle's internal CI system (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4440/head:pull/4440` \
`$ git checkout pull/4440`

Update a local copy of the PR: \
`$ git checkout pull/4440` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4440`

View PR using the GUI difftool: \
`$ git pr show -t 4440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4440.diff">https://git.openjdk.org/jdk17u-dev/pull/4440.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4440#issuecomment-4424094813)
</details>
