### PR TITLE
8255463: java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java failed with ThreadTimeoutException

### DIFF
--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
@@ -39,7 +39,6 @@
  * @key intermittent
  */
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -102,7 +101,7 @@ public class InheritedChannelTest {
         };
     }
 
-    @Test(dataProvider = "testCases", timeOut=30000)
+    @Test(dataProvider = "testCases")
     public void test(String desc, List<String> opts) throws Throwable {
         String pathVar = Platform.sharedLibraryPathVariableName();
         System.out.println(pathVar + "=" + libraryPath);


### PR DESCRIPTION
Backporting JDK-8255463: java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java failed with ThreadTimeoutException.

This PR removes the 30-second timeout from InheritedChannelTest.test() method to enable better debugging of intermittent timeout failures.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27641895/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27641896/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27641897/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27641898/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8255463](https://bugs.openjdk.org/browse/JDK-8255463) needs maintainer approval

### Issue
 * [JDK-8255463](https://bugs.openjdk.org/browse/JDK-8255463): java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java failed with ThreadTimeoutException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4441/head:pull/4441` \
`$ git checkout pull/4441`

Update a local copy of the PR: \
`$ git checkout pull/4441` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4441`

View PR using the GUI difftool: \
`$ git pr show -t 4441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4441.diff">https://git.openjdk.org/jdk17u-dev/pull/4441.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4441#issuecomment-4431576092)
</details>
