### PR TITLE
8332495: java/util/logging/LoggingDeadlock2.java fails with AssertionError: Some tests failed

### DIFF
--- a/test/jdk/java/util/logging/LoggingDeadlock2.java
+++ b/test/jdk/java/util/logging/LoggingDeadlock2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -309,7 +309,7 @@ public class LoggingDeadlock2 {
             errAccumulator.join();
 
             out = outAccumulator.result();
-            err = errAccumulator.result();
+            err = errAccumulator.result().replaceAll(".* VM warning:.* deprecated.*\\R", "");
         } catch (Throwable t) {
             throwable = t;
         }


### PR DESCRIPTION
Backporting JDK-8332495: java/util/logging/LoggingDeadlock2.java fails with AssertionError: Some tests failed.

This PR filters JVM deprecation warnings from the child process's stderr.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/util/logging/LoggingDeadlock2.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27642099/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27642100/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27642101/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27642102/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8332495](https://bugs.openjdk.org/browse/JDK-8332495) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332495](https://bugs.openjdk.org/browse/JDK-8332495): java/util/logging/LoggingDeadlock2.java fails with AssertionError: Some tests failed (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4442/head:pull/4442` \
`$ git checkout pull/4442`

Update a local copy of the PR: \
`$ git checkout pull/4442` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4442`

View PR using the GUI difftool: \
`$ git pr show -t 4442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4442.diff">https://git.openjdk.org/jdk17u-dev/pull/4442.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4442#issuecomment-4424198743)
</details>
