### PR TITLE
8366128: jdk/jdk/nio/zipfs/TestPosix.java::testJarFile uses wrong file

### DIFF
--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -66,7 +66,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-/**
+/*
  * @test
  * @bug 8213031 8273935
  * @modules jdk.zipfs
@@ -695,7 +695,7 @@ public class TestPosix {
         delTree(UNZIP_DIR);
         Files.createDirectory(UNZIP_DIR);
         File targetDir = UNZIP_DIR.toFile();
-        try (JarFile jf = new JarFile(ZIP_FILE.toFile())) {
+        try (JarFile jf = new JarFile(JAR_FILE.toFile())) {
             Enumeration<? extends JarEntry> zenum = jf.entries();
             while (zenum.hasMoreElements()) {
                 JarEntry ze = zenum.nextElement();


### PR DESCRIPTION
Backporting JDK-8366128: jdk/jdk/nio/zipfs/TestPosix.java::testJarFile uses wrong file.

This PR fixes the issue where testJarFile() opens ZIP_FILE instead of JAR_FILE, causing an ordering dependency.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/jdk/nio/zipfs/TestPosix.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27642403/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27642406/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27642409/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27642410/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8366128](https://bugs.openjdk.org/browse/JDK-8366128) needs maintainer approval

### Issue
 * [JDK-8366128](https://bugs.openjdk.org/browse/JDK-8366128): jdk/jdk/nio/zipfs/TestPosix.java::testJarFile uses wrong file (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4444/head:pull/4444` \
`$ git checkout pull/4444`

Update a local copy of the PR: \
`$ git checkout pull/4444` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4444`

View PR using the GUI difftool: \
`$ git pr show -t 4444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4444.diff">https://git.openjdk.org/jdk17u-dev/pull/4444.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4444#issuecomment-4424268810)
</details>
