### PR TITLE
8357280: (bf) Remove @requires tags from java/nio/Buffer/LimitDirectMemory[NegativeTest].java

### DIFF
--- a/test/jdk/java/nio/Buffer/LimitDirectMemory.java
+++ b/test/jdk/java/nio/Buffer/LimitDirectMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @test
  * @bug 4627316 6743526
  * @summary Test option to limit direct memory allocation
- * @requires (os.arch == "x86_64") | (os.arch == "amd64")
  * @library /test/lib
  *
  * @summary Test: memory is properly limited using multiple buffers

--- a/test/jdk/java/nio/Buffer/LimitDirectMemoryNegativeTest.java
+++ b/test/jdk/java/nio/Buffer/LimitDirectMemoryNegativeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
  * @bug 4627316 6743526
  * @summary Test option to limit direct memory allocation,
  *          various bad values fail to launch the VM
- * @requires (os.arch == "x86_64") | (os.arch == "amd64")
  * @library /test/lib
  * @build jdk.test.lib.Utils
  *        jdk.test.lib.Asserts


### PR DESCRIPTION
Backporting JDK-8357280: (bf) Remove @requires tags from java/nio/Buffer/LimitDirectMemory[NegativeTest].java.

This PR removes the @requires 64 bit platform restriction from two direct memory tests since 32-bit is no longer supported.

This PR is not clean due to a slight mismatch in the initial @requires restriction. It doesn't matter because the intent of the PR is to remove the restriction. 

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/nio/Buffer/LimitDirectMemory.java
make test TEST=test/jdk/java/nio/Buffer/LimitDirectMemoryNegativeTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27643066/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27643067/windows-x64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27643068/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27643069/macos-aarch64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27643070/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27643071/linux-x64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27643072/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27643074/linux-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8357280](https://bugs.openjdk.org/browse/JDK-8357280) needs maintainer approval

### Issue
 * [JDK-8357280](https://bugs.openjdk.org/browse/JDK-8357280): (bf) Remove @<!---->requires tags from java/nio/Buffer/LimitDirectMemory[NegativeTest].java (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4445/head:pull/4445` \
`$ git checkout pull/4445`

Update a local copy of the PR: \
`$ git checkout pull/4445` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4445`

View PR using the GUI difftool: \
`$ git pr show -t 4445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4445.diff">https://git.openjdk.org/jdk17u-dev/pull/4445.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4445#issuecomment-4431057497)
</details>
