### PR TITLE
8355445: [java.nio] Use @requires tag instead of exiting based on "os.name" property value

### DIFF
--- a/test/jdk/java/nio/channels/Selector/HelperSlowToDie.java
+++ b/test/jdk/java/nio/channels/Selector/HelperSlowToDie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 6823609
  * @summary Selector.select can hangs on Windows for cases where a helper thread
  *   becomes redudant but a new helper is immediately needed.
+ * @requires (os.family == "windows")
  */
 
 import java.nio.channels.*;
@@ -37,11 +38,6 @@ public class HelperSlowToDie {
     private static volatile boolean done;
 
     public static void main(String[] args) throws IOException {
-        if (!System.getProperty("os.name").startsWith("Windows")) {
-            System.out.println("Test skipped as it verifies a Windows specific bug");
-            return;
-        }
-
         Selector sel = Selector.open();
 
         // register channels

--- a/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
+++ b/test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
  * @bug 6285901 6501089
  * @summary Check no data is written to wrong socket channel during async closing.
+ * @requires (os.family != "windows")
  */
 
 import java.io.IOException;
@@ -44,10 +45,6 @@ public class AsyncCloseChannel {
     static int targetPort;
 
     public static void main(String args[]) throws Exception {
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            System.err.println("WARNING: Still does not work on Windows!");
-            return;
-        }
         Thread ss = new SensorServer(); ss.start();
         Thread ts = new TargetServer(); ts.start();
 

--- a/test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
+++ b/test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Sockets shouldn't be inherited when creating a child process
+ * @requires (os.family == "windows")
  */
 import java.nio.ByteBuffer;
 import java.nio.channels.*;
@@ -138,9 +139,6 @@ public class SocketInheritance {
     }
 
     public static void main(String[] args) throws Exception {
-        if (!System.getProperty("os.name").startsWith("Windows"))
-            return;
-
         if (args.length == 0) {
             start();
         } else {

--- a/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
+++ b/test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,11 +63,6 @@ public class InheritedChannelTest {
     private static final String TEST_CLASSES = System.getProperty("test.classes");
     private static final Path POLICY_PASS = Paths.get(TEST_SRC, "java.policy.pass");
     private static final Path POLICY_FAIL = Paths.get(TEST_SRC, "java.policy.fail");
-
-    private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
-
-    private static final String ARCH = System.getProperty("os.arch");
-    private static final String OS_ARCH = ARCH.equals("i386") ? "i586" : ARCH;
 
     private static final Path libraryPath
             = Paths.get(System.getProperty("java.library.path"));

--- a/test/jdk/java/nio/charset/RemovingSunIO/TestCOMP.java
+++ b/test/jdk/java/nio/charset/RemovingSunIO/TestCOMP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
    @bug 6176819
    @summary Check if COMPUND_TEXT charset works as expected
+   @requires (os.family != "windows")
    @run main/timeout=1200 TestCOMP
  */
 
@@ -35,9 +36,6 @@ import java.nio.*;
 
 public class TestCOMP {
     public static void main(String[] argv) throws CharacterCodingException {
-        String osName = System.getProperty("os.name");
-        if (osName.startsWith("Windows"))
-            return;
         try {
             String src =
                 "JIS0208\u4eb0" +

--- a/test/jdk/java/nio/file/DirectoryStream/DriveLetter.java
+++ b/test/jdk/java/nio/file/DirectoryStream/DriveLetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @bug 6808647
  * @summary Checks that a DirectoryStream's iterator returns the expected
  *    path when opening a directory by specifying only the drive letter.
+ * @requires (os.family == "windows")
  * @library ..
  */
 
@@ -35,11 +36,6 @@ import java.io.IOException;
 public class DriveLetter {
 
     public static void main(String[] args) throws IOException {
-        String os = System.getProperty("os.name");
-        if (!os.startsWith("Windows")) {
-            System.out.println("This is Windows specific test");
-            return;
-        }
         String here = System.getProperty("user.dir");
         if (here.length() < 2 || here.charAt(1) != ':')
             throw new RuntimeException("Unable to determine drive letter");

--- a/test/jdk/java/nio/file/WatchService/FileTreeModifier.java
+++ b/test/jdk/java/nio/file/WatchService/FileTreeModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /* @test
  * @bug 4313887 6838333
  * @summary Sanity test for JDK-specific FILE_TREE watch event modifier
+ * @requires (os.family == "windows")
  * @library ..
  * @modules jdk.unsupported
  */
@@ -129,11 +130,6 @@ public class FileTreeModifier {
 
 
     public static void main(String[] args) throws IOException {
-        if (!System.getProperty("os.name").startsWith("Windows")) {
-            System.out.println("This is Windows-only test at this time!");
-            return;
-        }
-
         Path dir = TestUtil.createTemporaryDirectory();
         try {
             doTest(dir);


### PR DESCRIPTION
Backporting JDK-8355445: [java.nio] Use @requires tag instead of exiting based on "os.name" property value.

This PR replaces runtime OS checks with jtreg @requires tags across several java.nio tests.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/nio/channels/Selector/HelperSlowToDie.java
make test TEST=test/jdk/java/nio/channels/SocketChannel/AsyncCloseChannel.java
make test TEST=test/jdk/java/nio/channels/SocketChannel/SocketInheritance.java
make test TEST=test/jdk/java/nio/channels/spi/SelectorProvider/inheritedChannel/InheritedChannelTest.java
make test TEST=test/jdk/java/nio/charset/RemovingSunIO/TestCOMP.java
make test TEST=test/jdk/java/nio/file/DirectoryStream/DriveLetter.java
make test TEST=test/jdk/java/nio/file/WatchService/FileTreeModifier.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27645778/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27645779/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/27645780/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/27645781/windows-x64-specific-4-test.log)
[windows-x64-specific-5-test.log](https://github.com/user-attachments/files/27645782/windows-x64-specific-5-test.log)
[windows-x64-specific-6-test.log](https://github.com/user-attachments/files/27645783/windows-x64-specific-6-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27645785/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27645786/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27645788/macos-aarch64-specific-3-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27645789/macos-aarch64-specific-4-test.log)
[macos-aarch64-specific-5-test.log](https://github.com/user-attachments/files/27645790/macos-aarch64-specific-5-test.log)
[macos-aarch64-specific-6-test.log](https://github.com/user-attachments/files/27645791/macos-aarch64-specific-6-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27645792/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27645793/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/27645794/linux-x64-specific-3-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/27645795/linux-x64-specific-4-test.log)
[linux-x64-specific-5-test.log](https://github.com/user-attachments/files/27645796/linux-x64-specific-5-test.log)
[linux-x64-specific-6-test.log](https://github.com/user-attachments/files/27645797/linux-x64-specific-6-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27645798/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27645799/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27645800/linux-aarch64-specific-3-test.log)
[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27645801/linux-aarch64-specific-4-test.log)
[linux-aarch64-specific-5-test.log](https://github.com/user-attachments/files/27645802/linux-aarch64-specific-5-test.log)
[linux-aarch64-specific-6-test.log](https://github.com/user-attachments/files/27645804/linux-aarch64-specific-6-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8355445](https://bugs.openjdk.org/browse/JDK-8355445) needs maintainer approval

### Issue
 * [JDK-8355445](https://bugs.openjdk.org/browse/JDK-8355445): [java.nio] Use @<!---->requires tag instead of exiting based on "os.name" property value (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4447/head:pull/4447` \
`$ git checkout pull/4447`

Update a local copy of the PR: \
`$ git checkout pull/4447` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4447`

View PR using the GUI difftool: \
`$ git pr show -t 4447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4447.diff">https://git.openjdk.org/jdk17u-dev/pull/4447.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4447#issuecomment-4431092198)
</details>
