### PR TITLE
8272477: Additional cleanup of test/jdk/java/nio/file/spi/SetDefaultProvider.java

### DIFF
--- a/test/jdk/java/nio/file/spi/SetDefaultProvider.java
+++ b/test/jdk/java/nio/file/spi/SetDefaultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.spi.ToolProvider;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jdk.test.lib.process.ProcessTools;
@@ -51,7 +50,7 @@ import static org.testng.Assert.*;
 @Test
 public class SetDefaultProvider {
 
-    private static String SET_DEFAULT_FSP =
+    private static final String SET_DEFAULT_FSP =
         "-Djava.nio.file.spi.DefaultFileSystemProvider=TestProvider";
 
     private static final ToolProvider JAR_TOOL = ToolProvider.findFirst("jar")
@@ -73,7 +72,7 @@ public class SetDefaultProvider {
         String testClasses = System.getProperty("test.classes");
         String classpath = moduleClasses + File.pathSeparator + testClasses;
         int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
-        assertTrue(exitValue == 0);
+        assertEquals(exitValue, 0);
     }
 
     /**
@@ -88,7 +87,7 @@ public class SetDefaultProvider {
         String classpath = jar + File.pathSeparator + testClasses
                 + File.separator + "modules" + File.separator + "m";
         int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath, "p.Main");
-        assertTrue(exitValue == 0);
+        assertEquals(exitValue, 0);
     }
 
     /**
@@ -112,7 +111,7 @@ public class SetDefaultProvider {
             }
         }
         int ret = JAR_TOOL.run(System.out, System.out, args.toArray(new String[0]));
-        assertTrue(ret == 0);
+        assertEquals(ret, 0);
     }
 
     /**
@@ -128,7 +127,7 @@ public class SetDefaultProvider {
         int exitValue = exec(SET_DEFAULT_FSP, "-cp", classpath,
             "-Dtest.classes=" + testClasses, "-Djava.security.manager",
             "-Djava.security.policy==" + policyFile, "p.Main");
-        assertTrue(exitValue == 0);
+        assertEquals(exitValue, 0);
     }
 
     /**
@@ -138,7 +137,7 @@ public class SetDefaultProvider {
     public void testExplodedModule() throws Exception {
         String modulePath = System.getProperty("jdk.module.path");
         int exitValue = exec(SET_DEFAULT_FSP, "-p", modulePath, "-m", "m/p.Main");
-        assertTrue(exitValue == 0);
+        assertEquals(exitValue, 0);
     }
 
     /**
@@ -148,7 +147,7 @@ public class SetDefaultProvider {
     public void testModularJar() throws Exception {
         String jarFile = createModularJar();
         int exitValue = exec(SET_DEFAULT_FSP, "-p", jarFile, "-m", "m/p.Main");
-        assertTrue(exitValue == 0);
+        assertEquals(exitValue, 0);
     }
 
     /**
@@ -162,7 +161,7 @@ public class SetDefaultProvider {
                              "--patch-module", "m=" + patchdir,
                              "-p", modulePath,
                              "-m", "m/p.Main");
-        assertTrue(exitValue == 0);
+        assertEquals(exitValue, 0);
     }
 
     /**
@@ -178,7 +177,7 @@ public class SetDefaultProvider {
                              "--patch-module", "m=" + patch,
                              "-p", modulePath,
                              "-m", "m/p.Main");
-        assertTrue(exitValue == 0);
+        assertEquals(exitValue, 0);
     }
 
     /**
@@ -190,7 +189,7 @@ public class SetDefaultProvider {
             Path m = Paths.get(dir, "m");
             if (Files.exists(m)) return m.toString();
         }
-        assertFalse(true);
+        fail();
         return null;
     }
 
@@ -210,7 +209,7 @@ public class SetDefaultProvider {
         Path jar = createTempDirectory("tmp").resolve("m.jar");
         String[] args = { "--create", "--file=" + jar, "-C", dir.toString(), "." };
         int ret = JAR_TOOL.run(System.out, System.out, args);
-        assertTrue(ret == 0);
+        assertEquals(ret, 0);
         return jar;
     }
 


### PR DESCRIPTION
Backporting JDK-8272477: Additional cleanup of test/jdk/java/nio/file/spi/SetDefaultProvider.java.

This PR does some cleanup for the SetDefaultProvider test.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/nio/file/spi/SetDefaultProvider.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27648702/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27648704/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27648706/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27648707/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8272477](https://bugs.openjdk.org/browse/JDK-8272477) needs maintainer approval

### Issue
 * [JDK-8272477](https://bugs.openjdk.org/browse/JDK-8272477): Additional cleanup of test/jdk/java/nio/file/spi/SetDefaultProvider.java (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4449/head:pull/4449` \
`$ git checkout pull/4449`

Update a local copy of the PR: \
`$ git checkout pull/4449` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4449`

View PR using the GUI difftool: \
`$ git pr show -t 4449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4449.diff">https://git.openjdk.org/jdk17u-dev/pull/4449.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4449#issuecomment-4433234179)
</details>
