### PR TITLE
8309142: Refactor test/langtools/tools/javac/versions/Versions.java

### DIFF
--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -23,7 +23,9 @@
 
 /*
  * @test
- * @bug 4981566 5028634 5094412 6304984 7025786 7025789 8001112 8028545 8000961 8030610 8028546 8188870 8173382 8173382 8193290 8205619 8028563 8245147 8245586 8257453
+ * @bug 4981566 5028634 5094412 6304984 7025786 7025789 8001112 8028545
+ * 8000961 8030610 8028546 8188870 8173382 8173382 8193290 8205619 8028563
+ * 8245147 8245586 8257453
  * @summary Check interpretation of -target and -source options
  * @modules java.compiler
  *          jdk.compiler
@@ -40,9 +42,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /*
@@ -75,33 +75,45 @@ public class Versions {
     public static final String LATEST_MAJOR_VERSION = "61.0";
 
     static enum SourceTarget {
-        SEVEN(true,   "51.0",  "7", Versions::checksrc7),
-        EIGHT(true,   "52.0",  "8", Versions::checksrc8),
-        NINE(true,    "53.0",  "9", Versions::checksrc9),
-        TEN(true,     "54.0", "10", Versions::checksrc10),
-        ELEVEN(false, "55.0", "11", Versions::checksrc11),
-        TWELVE(false, "56.0", "12", Versions::checksrc12),
-        THIRTEEN(false, "57.0", "13", Versions::checksrc13),
-        FOURTEEN(false, "58.0", "14", Versions::checksrc14),
-        FIFTEEN(false,  "59.0", "15", Versions::checksrc15),
-        SIXTEEN(false,  "60.0", "16", Versions::checksrc16),
-        SEVENTEEN(false,  "61.0", "17", Versions::checksrc17);
+        SEVEN(true,      "51.0",  "7"),
+        EIGHT(true,      "52.0",  "8"),
+        NINE(true,       "53.0",  "9"),
+        TEN(true,        "54.0", "10"),
+        ELEVEN(false,    "55.0", "11"),
+        TWELVE(false,    "56.0", "12"),
+        THIRTEEN(false,  "57.0", "13"),
+        FOURTEEN(false,  "58.0", "14"),
+        FIFTEEN(false,   "59.0", "15"),
+        SIXTEEN(false,   "60.0", "16"),
+        SEVENTEEN(false, "61.0", "17"),
+        ; // Reduce code churn when appending new constants
 
         private final boolean dotOne;
         private final String classFileVer;
         private final String target;
-        private final BiConsumer<Versions, List<String>> checker;
+        private final int intTarget;
 
-        private SourceTarget(boolean dotOne, String classFileVer, String target,
-                             BiConsumer<Versions, List<String>> checker) {
+        private SourceTarget(boolean dotOne, String classFileVer, String target) {
             this.dotOne = dotOne;
             this.classFileVer = classFileVer;
             this.target = target;
-            this.checker = checker;
+            this.intTarget = Integer.parseInt(target);
         }
 
-        public void checksrc(Versions version, List<String> args) {
-            checker.accept(version, args);
+        public void checksrc(Versions versions, List<String> args) {
+            // checker.accept(version, args);
+            versions.printargs("checksrc" + target, args);
+            List<String> expectedPassFiles = new ArrayList<>();
+            List<String> expectedFailFiles = new ArrayList<>();
+
+            for (SourceExample srcEg : SourceExample.values()) {
+                var x = (srcEg.sourceLevel <= this.intTarget) ?
+                    expectedPassFiles.add(srcEg.fileName()):
+                    expectedFailFiles.add(srcEg.fileName());
+            }
+
+            versions.expectedPass(args, expectedPassFiles);
+            versions.expectedFail(args, expectedFailFiles);
         }
 
         public boolean dotOne() {
@@ -114,6 +126,10 @@ public class Versions {
 
         public String target() {
             return target;
+        }
+
+        public int intTarget() {
+            return intTarget;
         }
     }
 
@@ -217,16 +233,8 @@ public class Versions {
 
     protected void check(String major, List<String> args) {
         printargs("check", args);
-        List<String> jcargs = new ArrayList<>();
-        jcargs.add("-Xlint:-options");
 
-        // add in args conforming to List requrements of JavaCompiler
-        for (String onearg : args) {
-            String[] fields = onearg.split(" ");
-            for (String onefield : fields) {
-                jcargs.add(onefield);
-            }
-        }
+        List<String> jcargs = javaCompilerOptions(args);
 
         boolean creturn = compile("Base.java", jcargs);
         if (!creturn) {
@@ -241,74 +249,134 @@ public class Versions {
         }
     }
 
-    protected void checksrc7(List<String> args) {
-        printargs("checksrc7", args);
-        expectedPass(args, List.of("New7.java"));
-        expectedFail(args, List.of("New8.java"));
+    /**
+     * Create a list of options suitable for use with {@link JavaCompiler}
+     * @param args a list of space-delimited options, such as "-source 11"
+     * @return a list of arguments suitable for use with {@link JavaCompiler}
+     */
+    private static List<String> javaCompilerOptions(List<String> args) {
+        List<String> jcargs = new ArrayList<>();
+        jcargs.add("-Xlint:-options");
+
+        // add in args conforming to List requirements of JavaCompiler
+        for (String onearg : args) {
+            String[] fields = onearg.split(" ");
+            for (String onefield : fields) {
+                jcargs.add(onefield);
+            }
+        }
+        return jcargs;
     }
 
-    protected void checksrc8(List<String> args) {
-        printargs("checksrc8", args);
-        expectedPass(args, List.of("New7.java", "New8.java"));
-        expectedFail(args, List.of("New10.java"));
-    }
+    /**
+     * The BASE source example is expected to compile on all source
+     * levels. Otherwise, an example is expected to compile on its
+     * declared source level and later, but to _not_ compile on
+     * earlier source levels. (This enum is _not_ intended to capture
+     * the uncommon program that is accepted in one version of the
+     * language and rejected in a later version.)
+     *
+     * When version of the language get a new, non-preview feature, a
+     * new source example enum constant should be added.
+     */
+    enum SourceExample {
+        BASE(7, "Base.java", "public class Base { }\n"),
 
-    protected void checksrc9(List<String> args) {
-        printargs("checksrc9", args);
-        expectedPass(args, List.of("New7.java", "New8.java"));
-        expectedFail(args, List.of("New10.java"));
-    }
+        SOURCE_8(8, "New8.java",
+            // New feature in 8: lambda
+            """
+            public class New8 {
+                void m() {
+                    new Thread(() -> { });
+                }
+            }
+             """),
 
-    protected void checksrc10(List<String> args) {
-        printargs("checksrc10", args);
-        expectedPass(args, List.of("New7.java", "New8.java", "New10.java"));
-        expectedFail(args, List.of("New11.java"));
-    }
+        SOURCE_10(10, "New10.java",
+            // New feature in 10: var
+            """
+            public class New10 {
+                void m() {
+                    var tmp = new Thread(() -> { });
+                }
+            }
+            """),
 
-    protected void checksrc11(List<String> args) {
-        printargs("checksrc11", args);
-        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java"));
-        expectedFail(args, List.of("New14.java"));
-    }
+        SOURCE_11(11, "New11.java",
+            // New feature in 11: var for lambda parameters
+            """
+            public class New11 {
+                static java.util.function.Function<String,String> f = (var x) -> x.substring(0);
+                void m(String name) {
+                    var tmp = new Thread(() -> { }, f.apply(name));
+                }
+            }
+            """),
 
-    protected void checksrc12(List<String> args) {
-        printargs("checksrc12", args);
-        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java"));
-        expectedFail(args, List.of("New14.java"));
-    }
+         SOURCE_14(14, "New14.java",
+             // New feature in 14: switch expressions
+             """
+             public class New14 {
+                 static {
+                     int i = 5;
+                     System.out.println(
+                         switch(i) {
+                             case 0 -> false;
+                             default -> true;
+                         }
+                     );
+                 }
+             }
+             """),
 
-    protected void checksrc13(List<String> args) {
-        printargs("checksrc13", args);
-        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java"));
-        expectedFail(args, List.of("New14.java"));
-    }
+         SOURCE_15(15, "New15.java",
+             // New feature in 15: text blocks
+             """
+             public class New15 {
+                 public static final String s =
+                 \"\"\"
+                 Hello, World.
+                 \"\"\"
+                 ;
+             }
+             """),
 
-    protected void checksrc14(List<String> args) {
-        printargs("checksrc14", args);
-        expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
-                                   "New14.java"));
-        expectedFail(args, List.of("New15.java"));
-    }
+         SOURCE_16(16, "New16.java",
+             // New feature in 16: records
+             """
+             public class New16 {
+                 public record Record(double rpm) {
+                     public static final Record LONG_PLAY = new Record(100.0/3.0);
+                 }
+             }
+             """),
 
-   protected void checksrc15(List<String> args) {
-       printargs("checksrc15", args);
-       expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
-                                  "New14.java", "New15.java"));
-        expectedFail(args, List.of("New16.java"));
-    }
+         SOURCE_17(17, "New17.java",
+             // New feature in 17: sealed classes
+             """
+             public class New17 {
+                 public static sealed class Seal {}
 
-   protected void checksrc16(List<String> args) {
-       printargs("checksrc16", args);
-       expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
-                                  "New14.java", "New15.java", "New16.java"));
-       // Add expectedFail after new language features added in a later release.
-    }
+                 public static final class Pinniped extends Seal {}
+                 public static final class TaperedThread extends Seal {}
+                 public static final class Wax extends Seal {}
+             }
+             """),
 
-   protected void checksrc17(List<String> args) {
-       printargs("checksrc17", args);
-       expectedPass(args, List.of("New7.java", "New8.java", "New10.java", "New11.java",
-                                  "New14.java", "New15.java", "New16.java"));
-       // Add expectedFail after new language features added in a later release.
+            ; // Reduce code churn when appending new constants
+
+        private int sourceLevel;
+        private String fileName;
+        private String fileContents;
+
+        private SourceExample(int sourceLevel, String fileName, String fileContents) {
+            this.sourceLevel = sourceLevel;
+            this.fileName = fileName;
+            this.fileContents = fileContents;
+        }
+
+        public String fileName() {return fileName;}
+        public String fileContents() {return fileContents;}
     }
 
     protected void expected(List<String> args, List<String> fileNames,
@@ -333,16 +401,7 @@ public class Versions {
     protected void pass(List<String> args) {
         printargs("pass", args);
 
-        List<String> jcargs = new ArrayList<>();
-        jcargs.add("-Xlint:-options");
-
-        // add in args conforming to List requrements of JavaCompiler
-        for (String onearg : args) {
-            String[] fields = onearg.split(" ");
-            for (String onefield : fields) {
-                jcargs.add(onefield);
-            }
-        }
+        List<String> jcargs = javaCompilerOptions(args);
 
         // empty list is error
         if (jcargs.isEmpty()) {
@@ -371,16 +430,7 @@ public class Versions {
     protected void fail(List<String> args) {
         printargs("fail", args);
 
-        List<String> jcargs = new ArrayList<>();
-        jcargs.add("-Xlint:-options");
-
-        // add in args conforming to List requrements of JavaCompiler
-        for (String onearg : args) {
-            String[] fields = onearg.split(" ");
-            for (String onefield : fields) {
-                jcargs.add(onefield);
-            }
-        }
+        List<String> jcargs = javaCompilerOptions(args);
 
         // empty list is error
         if (jcargs.isEmpty()) {
@@ -435,106 +485,9 @@ public class Versions {
     }
 
     protected void genSourceFiles() throws IOException{
-        /* Create a file that executes with all supported versions. */
-        writeSourceFile("Base.java","public class Base { }\n");
-
-        /*
-         * Create a file with a new feature in 7, not in 6 : "<>"
-         */
-        writeSourceFile("New7.java",
-            """
-            import java.util.List;
-            import java.util.ArrayList;
-            class New7 { List<String> s = new ArrayList<>(); }
-            """
-        );
-
-        /*
-         * Create a file with a new feature in 8, not in 7 : lambda
-         */
-        writeSourceFile("New8.java",
-            """
-            public class New8 {
-                void m() {
-                new Thread(() -> { });
-                }
-            }
-             """
-        );
-
-        /*
-         * Create a file with a new feature in 10, not in 9 : var
-         */
-        writeSourceFile("New10.java",
-            """
-            public class New10 {
-                void m() {
-                var tmp = new Thread(() -> { });
-                }
-            }
-            """
-        );
-
-        /*
-         * Create a file with a new feature in 11, not in 10 : var for lambda parameters
-         */
-        writeSourceFile("New11.java",
-            """
-            public class New11 {
-                static java.util.function.Function<String,String> f = (var x) -> x.substring(0);
-                void m(String name) {
-                var tmp = new Thread(() -> { }, f.apply(name));
-                }
-            }
-            """
-        );
-
-        /*
-         * Create a file with a new feature in 14, not in 13 : switch expressions
-         */
-        writeSourceFile("New14.java",
-            """
-            public class New14 {
-                static {
-                    int i = 5;
-                    System.out.println(
-                        switch(i) {
-                            case 0 -> false;
-                            default -> true;
-                        }
-                    );
-                }
-            }
-            """
-        );
-
-        /*
-         * Create a file with a new feature in 15, not in 14 : text blocks
-         */
-        writeSourceFile("New15.java",
-            """
-            public class New15 {
-                public static final String s =
-                \"\"\"
-                Hello, World.
-                \"\"\"
-                ;
-            }
-            """
-        );
-
-        /*
-         * Create a file with a new feature in 16, not in 15 : records
-         */
-        writeSourceFile("New16.java",
-            """
-            public class New16 {
-                public record Record(double rpm) {
-                    public static final Record LONG_PLAY = new Record(100.0/3.0);
-                }
-            }
-            """
-        );
+        for (SourceExample srcEg : SourceExample.values()) {
+            writeSourceFile(srcEg.fileName(), srcEg.fileContents());
+        }
     }
 
     protected boolean checkClassFileVersion


### PR DESCRIPTION
Backporting JDK-8309142 and JDK-8321182: Refactor test/langtools/tools/javac/versions/Versions.java and SourceExample.SOURCE_14 comment should refer to 'switch expressions' instead of 'text blocks'.

This PR refactors the Versions.java test from per-version checksrcN() methods into a SourceExample enum.

This PR is not clean because it skips commits and changes related to versions newer than 17.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/langtools/tools/javac/versions/Versions.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27652474/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27652475/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27652476/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27652478/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8321182](https://bugs.openjdk.org/browse/JDK-8321182) needs maintainer approval
- [x] [JDK-8309142](https://bugs.openjdk.org/browse/JDK-8309142) needs maintainer approval

### Issues
 * [JDK-8309142](https://bugs.openjdk.org/browse/JDK-8309142): Refactor test/langtools/tools/javac/versions/Versions.java (**Enhancement** - P4 - Approved)
 * [JDK-8321182](https://bugs.openjdk.org/browse/JDK-8321182): SourceExample.SOURCE_14 comment should refer to 'switch expressions' instead of 'text blocks' (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4450/head:pull/4450` \
`$ git checkout pull/4450`

Update a local copy of the PR: \
`$ git checkout pull/4450` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4450`

View PR using the GUI difftool: \
`$ git pr show -t 4450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4450.diff">https://git.openjdk.org/jdk17u-dev/pull/4450.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4450#issuecomment-4432726853)
</details>
