### PR TITLE
8284993: Replace System.exit call in swing tests with RuntimeException

### DIFF
--- a/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
+++ b/test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
@@ -37,10 +37,24 @@ import javax.swing.SwingUtilities;
 public class Test8019180 implements Runnable {
     private static final CountDownLatch LATCH = new CountDownLatch(1);
     private static final String[] ITEMS = {"First", "Second", "Third", "Fourth"};
+    private static JFrame frame;
+    private static boolean selectionFail = false;
 
-    public static void main(String[] args) throws InterruptedException {
-        SwingUtilities.invokeLater(new Test8019180());
-        LATCH.await();
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeLater(new Test8019180());
+            LATCH.await();
+            System.out.println("selectionFail " + selectionFail);
+            if (selectionFail) {
+                throw new RuntimeException("Combobox not selected");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
     }
 
     private JComboBox<String> test;
@@ -50,8 +64,9 @@ public class Test8019180 implements Runnable {
         if (this.test == null) {
             this.test = new JComboBox<>(ITEMS);
             this.test.addActionListener(this.test);
-            JFrame frame = new JFrame();
+            frame = new JFrame();
             frame.add(test);
+            frame.setLocationRelativeTo(null);
             frame.pack();
             frame.setVisible(true);
             SwingUtilities.invokeLater(this);
@@ -60,9 +75,8 @@ public class Test8019180 implements Runnable {
             this.test.setSelectedIndex(1 + index);
             if (0 > this.test.getSelectedIndex()) {
                 System.err.println("ERROR: no selection");
-                System.exit(8019180);
+                selectionFail = true;
             }
-            SwingUtilities.getWindowAncestor(this.test).dispose();
             LATCH.countDown();
         }
     }

--- a/test/jdk/javax/swing/JFileChooser/8013442/Test8013442.java
+++ b/test/jdk/javax/swing/JFileChooser/8013442/Test8013442.java
@@ -118,6 +118,6 @@ public class Test8013442 extends FileFilter implements Runnable, Thread.Uncaught
 
     public void uncaughtException(Thread thread, Throwable throwable) {
         throwable.printStackTrace();
-        System.exit(1);
+        throw new RuntimeException(throwable);
     }
 }

--- a/test/jdk/javax/swing/plaf/basic/BasicTabbedPaneUI/Test6943780.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTabbedPaneUI/Test6943780.java
@@ -41,7 +41,7 @@ public class Test6943780 implements Runnable, Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
         throwable.printStackTrace();
-        System.exit(1);
+        throw new RuntimeException(throwable);
     }
 
     @Override

--- a/test/jdk/javax/swing/plaf/synth/Test8015926.java
+++ b/test/jdk/javax/swing/plaf/synth/Test8015926.java
@@ -94,6 +94,6 @@ public class Test8015926 implements TreeModelListener, Runnable, Thread.Uncaught
     @Override
     public void uncaughtException(Thread thread, Throwable exception) {
         exception.printStackTrace();
-        System.exit(1);
+        throw new RuntimeException(exception);
     }
 }

--- a/test/jdk/javax/swing/text/AbstractDocument/6968363/Test6968363.java
+++ b/test/jdk/javax/swing/text/AbstractDocument/6968363/Test6968363.java
@@ -68,7 +68,7 @@ public class Test6968363 implements Runnable, Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
         throwable.printStackTrace();
-        System.exit(1);
+        throw new RuntimeException(throwable);
     }
 
     @Override

--- a/test/jdk/javax/swing/text/html/parser/Test8017492.java
+++ b/test/jdk/javax/swing/text/html/parser/Test8017492.java
@@ -65,7 +65,7 @@ public class Test8017492 {
             @Override
             public void uncaughtException(Thread thread, Throwable throwable) {
                 throwable.printStackTrace();
-                System.exit(1);
+                throw new RuntimeException(throwable);
             }
         });
         thread.start();


### PR DESCRIPTION

Backporting JDK-8284993: Replace System.exit call in swing tests with RuntimeException.

This PR replaces System.exit() calls with RuntimeException throws in several tests to prevent a failing test from terminating the test harness.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/swing/JComboBox/8019180/Test8019180.java
make test TEST=test/jdk/javax/swing/JFileChooser/8013442/Test8013442.java
make test TEST=test/jdk/javax/swing/plaf/basic/BasicTabbedPaneUI/Test6943780.java
make test TEST=test/jdk/javax/swing/plaf/synth/Test8015926.java
make test TEST=test/jdk/javax/swing/text/AbstractDocument/6968363/Test6968363.java
make test TEST=test/jdk/javax/swing/text/html/parser/Test8017492.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27710689/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/27710690/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/27710691/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/27710692/windows-x64-specific-4-test.log)
[windows-x64-specific-5-test.log](https://github.com/user-attachments/files/27710693/windows-x64-specific-5-test.log)
[windows-x64-specific-6-test.log](https://github.com/user-attachments/files/27710694/windows-x64-specific-6-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27710696/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27710697/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27710698/macos-aarch64-specific-3-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27710699/macos-aarch64-specific-4-test.log)
[macos-aarch64-specific-5-test.log](https://github.com/user-attachments/files/27710700/macos-aarch64-specific-5-test.log)
[macos-aarch64-specific-6-test.log](https://github.com/user-attachments/files/27710701/macos-aarch64-specific-6-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27710702/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/27710703/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/27710704/linux-x64-specific-3-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/27710705/linux-x64-specific-4-test.log)
[linux-x64-specific-5-test.log](https://github.com/user-attachments/files/27710706/linux-x64-specific-5-test.log)
[linux-x64-specific-6-test.log](https://github.com/user-attachments/files/27710707/linux-x64-specific-6-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27710708/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/27710709/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/27710710/linux-aarch64-specific-3-test.log)
[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/27710711/linux-aarch64-specific-4-test.log)
[linux-aarch64-specific-5-test.log](https://github.com/user-attachments/files/27710712/linux-aarch64-specific-5-test.log)
[linux-aarch64-specific-6-test.log](https://github.com/user-attachments/files/27710713/linux-aarch64-specific-6-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8284993](https://bugs.openjdk.org/browse/JDK-8284993) needs maintainer approval

### Issue
 * [JDK-8284993](https://bugs.openjdk.org/browse/JDK-8284993): Replace System.exit call in swing tests with RuntimeException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4453/head:pull/4453` \
`$ git checkout pull/4453`

Update a local copy of the PR: \
`$ git checkout pull/4453` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4453`

View PR using the GUI difftool: \
`$ git pr show -t 4453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4453.diff">https://git.openjdk.org/jdk17u-dev/pull/4453.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4453#issuecomment-4441375562)
</details>
