### PR TITLE
Resource leak due to unclosed Scanner and FileOutputStream

### DIFF
--- a/make/jdk/src/classes/build/tools/spp/Spp.java
+++ b/make/jdk/src/classes/build/tools/spp/Spp.java
@@ -96,11 +96,15 @@ public class Spp {
         }
 
         StringBuffer out = new StringBuffer();
-        new Spp().spp(new Scanner(new FileInputStream(inputFile)),
-                      out, "",
-                      keys, vars, be, el,
-                      false);
-        new FileOutputStream(outputFile, true).write(out.toString().getBytes());
+        try (Scanner scanner = new Scanner(new FileInputStream(inputFile))) {
+            new Spp().spp(scanner,
+                          out, "",
+                          keys, vars, be, el,
+                          false);
+        }
+        try (FileOutputStream fos = new FileOutputStream(outputFile, true)) {
+            fos.write(out.toString().getBytes());
+        }
     }
 
     static final String LNSEP = System.getProperty("line.separator");


### PR DESCRIPTION
**Description:** To fix the resource handling to prevent potential resource leaks by using try-with-resources for `Scanner` and `FileOutputStream`.

**Issue:** The previous implementation created `Scanner` and `FileOutputStream` instances without explicitly closing them, which could lead to resource leaks and warnings from static analysis tools.

**Fix:** Updated the implementation to use try-with-resources for automatic resource management and safer cleanup handling.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4455/head:pull/4455` \
`$ git checkout pull/4455`

Update a local copy of the PR: \
`$ git checkout pull/4455` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4455`

View PR using the GUI difftool: \
`$ git pr show -t 4455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4455.diff">https://git.openjdk.org/jdk17u-dev/pull/4455.diff</a>

</details>
