### PR TITLE
8337876: [IR Framework] Add support for IR tests with @Stable

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -82,7 +82,16 @@ The framework allows the use of additional compiler control annotations for help
 - [@ForceCompile](./DontCompile.java)
 - [@ForceCompileClassInitializer](./ForceCompileClassInitializer.java)
 
-### 2.5 Framework Debug and Stress Flags
+### 2.5 IR Tests with Privileged Classes
+To run tests in a privileged mode (e.g. when using `@Stable`, `@Contended`, `@ReservedStackAccess` etc.), one need to add the test classes to the boot classpath. This can easily be achieved by calling `TestFramework.addTestClassesToBootClassPath()` on the test framework object:
+```
+TestFramework testFramework = new TestFramework();
+testFramework
+        .addTestClassesToBootClassPath()
+        .start();
+```
+
+### 2.6 Framework Debug and Stress Flags
 The framework provides various stress and debug flags. They should mainly be used as JTreg VM and/or Javaoptions (apart from `VerifyIR`). The following (property) flags are supported:
 
 - `-DVerifyIR=false`: Explicitly disable IR verification. This is useful, for example, if some scenarios use VM flags that let `@IR` annotation rules fail and the user does not want to provide separate IR rules or add flag preconditions to the already existing IR rules.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -158,6 +158,7 @@ public class TestFramework {
     private Set<Integer> scenarioIndices;
     private List<String> flags;
     private int defaultWarmup = -1;
+    private boolean testClassesOnBootClassPath;
 
     /*
      * Public interface methods
@@ -305,6 +306,15 @@ public class TestFramework {
                              "Cannot define two scenarios with the same index " + scenarioIndex);
             this.scenarios.add(scenario);
         }
+        return this;
+    }
+
+    /**
+     * Add test classes to boot classpath. This adds all classes found on path {@link jdk.test.lib.Utils#TEST_CLASSES}
+     * to the boot classpath with "-Xbootclasspath/a". This is useful when trying to run tests in a privileged mode.
+     */
+    public TestFramework addTestClassesToBootClassPath() {
+        this.testClassesOnBootClassPath = true;
         return this;
     }
 
@@ -695,7 +705,8 @@ public class TestFramework {
     }
 
     private void runTestVM(List<String> additionalFlags) {
-        TestVMProcess testVMProcess = new TestVMProcess(additionalFlags, testClass, helperClasses, defaultWarmup);
+        TestVMProcess testVMProcess = new TestVMProcess(additionalFlags, testClass, helperClasses, defaultWarmup,
+                                                        testClassesOnBootClassPath);
         if (shouldVerifyIR) {
             try {
                 new IRMatcher(testVMProcess.getHotspotPidFileName(), testVMProcess.getIrEncoding(), testClass);

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package ir_framework.tests;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
+
+import jdk.internal.vm.annotation.Stable;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @requires vm.debug == true & vm.compiler2.enabled & vm.flagless
+ * @summary Test that IR framework successfully adds test class to boot classpath in order to run in privileged mode.
+ * @modules java.base/jdk.internal.vm.annotation
+ * @library /test/lib /
+ * @run driver ir_framework.tests.TestPrivilegedMode
+ */
+
+public class TestPrivilegedMode {
+    static @Stable int iFld; // Treated as constant after first being set.
+
+    public static void main(String[] args) {
+        try {
+            TestFramework.run();
+            Asserts.fail("should not reach");
+        } catch (IRViolationException e) {
+            // Without adding test class to boot classpath, we fail to replace the field load by a constant.
+            Asserts.assertTrue(e.getExceptionInfo().contains("Matched forbidden node"));
+            Asserts.assertTrue(e.getExceptionInfo().contains("LoadI"));
+        }
+
+        // When adding the test class to the boot classpath, we can replace the field load by a constant.
+        new TestFramework().addTestClassesToBootClassPath().start();
+    }
+
+    @Test
+    @Arguments(setup = "setup")
+    @IR(failOn = IRNode.LOAD_I)
+    public int test() {
+        return iFld;
+    }
+
+    @Setup
+    public void setup() {
+        iFld = 34;
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
@@ -56,14 +56,15 @@ public class TestPrivilegedMode {
     }
 
     @Test
-    @Arguments(setup = "setup")
     @IR(failOn = IRNode.LOAD_I)
     public int test() {
         return iFld;
     }
 
-    @Setup
-    public void setup() {
+    @Run(test = "test")
+    public void runner() {
         iFld = 34;
+        int result = test();
+        Asserts.assertEQ(result, 34);
     }
 }


### PR DESCRIPTION
Backporting JDK-8337876 and JDK-8338112: [IR Framework] Add support for IR tests with @stable, and Test testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java fails with release build.

This PR adds addTestClassesToBootClassPath() to the IR test framework, enabling tests that use privileged annotations.

This PR is not clean because it excludes changes to "test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java", which does not exist in the Java 17 codebase and would require backporting a large dependency chain (JDK-8280378, JDK-8296243, and JDK-8300273). Additionally, the @Setup annotation does not exist in the Java 17 IR framework, so the PR was
refactored to remove its usage.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] [JDK-8338112](https://bugs.openjdk.org/browse/JDK-8338112) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8337876](https://bugs.openjdk.org/browse/JDK-8337876) needs maintainer approval

### Issues
 * [JDK-8337876](https://bugs.openjdk.org/browse/JDK-8337876): [IR Framework] Add support for IR tests with @<!---->Stable (**Enhancement** - P4)
 * [JDK-8338112](https://bugs.openjdk.org/browse/JDK-8338112): Test testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java fails with release build (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4456/head:pull/4456` \
`$ git checkout pull/4456`

Update a local copy of the PR: \
`$ git checkout pull/4456` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4456`

View PR using the GUI difftool: \
`$ git pr show -t 4456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4456.diff">https://git.openjdk.org/jdk17u-dev/pull/4456.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4456#issuecomment-4444065797)
</details>
