### PR TITLE
8368754: runtime/cds/appcds/SignedJar.java log regex is too strict

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java
@@ -49,7 +49,7 @@ public class SignedJar {
         // instead of from the shared archive since a class from a signed
         // jar shouldn't be dumped into the archive.
         output = TestCommon.exec(signedJar, "-verbose:class", "Hello");
-        String expectedOutput = ".class,load. Hello source: file:.*signed_hello.jar";
+        String expectedOutput = ".class,load\s*. Hello source: file:.*signed_hello.jar";
 
         try {
             output.shouldMatch(expectedOutput);


### PR DESCRIPTION
Backporting JDK-8368754: runtime/cds/appcds/SignedJar.java log regex is too strict.

This PR allows whitespace after log tags and before the message content.

This PR is not clean because of divergence of commit histories. The backport prior to this PR was not clean and skipped commits. The trivial change introduced by this PR was refactored to preserve the intent.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/runtime/cds/appcds/SignedJar.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27764472/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27764473/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27764474/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27764475/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368754](https://bugs.openjdk.org/browse/JDK-8368754) needs maintainer approval

### Issue
 * [JDK-8368754](https://bugs.openjdk.org/browse/JDK-8368754): runtime/cds/appcds/SignedJar.java log regex is too strict (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4459/head:pull/4459` \
`$ git checkout pull/4459`

Update a local copy of the PR: \
`$ git checkout pull/4459` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4459`

View PR using the GUI difftool: \
`$ git pr show -t 4459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4459.diff">https://git.openjdk.org/jdk17u-dev/pull/4459.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4459#issuecomment-4451814065)
</details>
