### PR TITLE
8367772: Refactor createUI in PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -486,9 +486,11 @@ public final class PassFailJFrame {
                           long testTimeOut,
                           int rows, int columns)
             throws InterruptedException, InvocationTargetException {
-        invokeOnEDT(() -> createUI(title, instructions,
-                                   testTimeOut,
-                                   rows, columns));
+        this(builder().title(title)
+                      .instructions(instructions)
+                      .testTimeOut(testTimeOut)
+                      .rows(rows)
+                      .columns(columns));
     }
 
     /**
@@ -503,6 +505,7 @@ public final class PassFailJFrame {
      */
     private PassFailJFrame(final Builder builder)
             throws InterruptedException, InvocationTargetException {
+        builder.validate();
         invokeOnEDT(() -> createUI(builder));
 
         if (!builder.splitUI && builder.panelCreator != null) {
@@ -584,39 +587,13 @@ public final class PassFailJFrame {
         }
     }
 
-    private static void createUI(String title, String instructions,
-                                 long testTimeOut, int rows, int columns) {
-        frame = new JFrame(title);
-        frame.setLayout(new BorderLayout());
-
-        frame.addWindowListener(windowClosingHandler);
-
-        frame.add(createInstructionUIPanel(instructions,
-                                           testTimeOut,
-                                           rows, columns,
-                                           null,
-                                           false,
-                                           false, 0),
-                  BorderLayout.CENTER);
-        frame.pack();
-        frame.setLocationRelativeTo(null);
-        addTestWindow(frame);
-    }
-
     private static void createUI(Builder builder) {
         frame = new JFrame(builder.title);
         frame.setLayout(new BorderLayout());
 
         frame.addWindowListener(windowClosingHandler);
 
-        JComponent instructionUI =
-                createInstructionUIPanel(builder.instructions,
-                                         builder.testTimeOut,
-                                         builder.rows, builder.columns,
-                                         builder.hyperlinkListener,
-                                         builder.screenCapture,
-                                         builder.addLogArea,
-                                         builder.logAreaRows);
+        JComponent instructionUI = createInstructionUIPanel(builder);
         if (builder.splitUI) {
             JSplitPane splitPane = new JSplitPane(
                     builder.splitUIOrientation,
@@ -632,24 +609,23 @@ public final class PassFailJFrame {
         addTestWindow(frame);
     }
 
-    private static JComponent createInstructionUIPanel(String instructions,
-                                                       long testTimeOut,
-                                                       int rows, int columns,
-                                                       HyperlinkListener hyperlinkListener,
-                                                       boolean enableScreenCapture,
-                                                       boolean addLogArea,
-                                                       int logAreaRows) {
+    private static JComponent createInstructionUIPanel(final Builder builder) {
         JPanel main = new JPanel(new BorderLayout());
         main.setBorder(createFrameBorder());
 
-        timeoutHandlerPanel = new TimeoutHandlerPanel(testTimeOut);
+        timeoutHandlerPanel = new TimeoutHandlerPanel(builder.testTimeOut);
         main.add(timeoutHandlerPanel, BorderLayout.NORTH);
 
-        JTextComponent text = instructions.startsWith("<html>")
-                              ? configureHTML(instructions, rows, columns)
-                              : configurePlainText(instructions, rows, columns);
-        if (hyperlinkListener != null && text instanceof JEditorPane ep) {
-            ep.addHyperlinkListener(hyperlinkListener);
+        JTextComponent text = builder.instructions.startsWith("<html>")
+                              ? configureHTML(builder.instructions,
+                                              builder.rows,
+                                              builder.columns)
+                              : configurePlainText(builder.instructions,
+                                                   builder.rows,
+                                                   builder.columns);
+        if (builder.hyperlinkListener != null
+            && text instanceof JEditorPane ep) {
+            ep.addHyperlinkListener(builder.hyperlinkListener);
         }
         text.setEditable(false);
         text.setBorder(createTextBorder());
@@ -678,12 +654,12 @@ public final class PassFailJFrame {
         buttonsPanel.add(btnPass);
         buttonsPanel.add(btnFail);
 
-        if (enableScreenCapture) {
+        if (builder.screenCapture) {
             buttonsPanel.add(createCapturePanel());
         }
 
-        if (addLogArea) {
-            logArea = new JTextArea(logAreaRows, columns);
+        if (builder.addLogArea) {
+            logArea = new JTextArea(builder.logAreaRows, builder.columns);
             logArea.setEditable(false);
             logArea.setBorder(createTextBorder());
 
@@ -1843,7 +1819,6 @@ public final class PassFailJFrame {
         public PassFailJFrame build() throws InterruptedException,
                 InvocationTargetException {
             try {
-                validate();
                 return new PassFailJFrame(this);
             } catch (final Throwable t) {
                 // Dispose of all the windows, including those that may not


### PR DESCRIPTION
Backporting JDK-8367772: Refactor createUI in PassFailJFrame.

This PR refactors PassFailJFrame UI creation to use Builder pattern internally, eliminating parameter proliferation and code duplication.

For parity with Oracle JDK. Already backported to 21.

Ran a manual test that uses the PassFailJFrame on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/java/awt/grab/CursorTest.java```

ScreenShots:

<img width="1185" height="408" alt="Screenshot 2026-05-14 at 7 41 33 AM" src="https://github.com/user-attachments/assets/4f885275-b05d-4a60-ab16-e64f991e82d2" />

Results:

```test result: Passed. Execution successful```

[CursorTest.jtr.txt](https://github.com/user-attachments/files/27764346/CursorTest.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367772](https://bugs.openjdk.org/browse/JDK-8367772) needs maintainer approval

### Issue
 * [JDK-8367772](https://bugs.openjdk.org/browse/JDK-8367772): Refactor createUI in PassFailJFrame (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4462/head:pull/4462` \
`$ git checkout pull/4462`

Update a local copy of the PR: \
`$ git checkout pull/4462` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4462`

View PR using the GUI difftool: \
`$ git pr show -t 4462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4462.diff">https://git.openjdk.org/jdk17u-dev/pull/4462.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4462#issuecomment-4451772557)
</details>
