### PR TITLE
8368885: NMT CommandLine tests can check for error better

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/CommandLineDetail.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineDetail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,14 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class CommandLineDetail {
 
-  public static void main(String args[]) throws Exception {
-
-    ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-      "-XX:NativeMemoryTracking=detail",
-      "-version");
-    OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldNotContain("error");
-    output.shouldHaveExitValue(0);
-  }
+    public static void main(String args[]) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+            "-Xlog:nmt=warning",
+            "-XX:NativeMemoryTracking=detail",
+            "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotContain("NMT initialization failed");
+        output.shouldNotContain("Could not create the Java Virtual Machine.");
+        output.shouldHaveExitValue(0);
+    }
 }

--- a/test/hotspot/jtreg/runtime/NMT/CommandLineSummary.java
+++ b/test/hotspot/jtreg/runtime/NMT/CommandLineSummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,14 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class CommandLineSummary {
 
-  public static void main(String args[]) throws Exception {
-
-    ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-      "-XX:NativeMemoryTracking=summary",
-      "-version");
-    OutputAnalyzer output = new OutputAnalyzer(pb.start());
-    output.shouldNotContain("error");
-    output.shouldHaveExitValue(0);
-  }
+    public static void main(String args[]) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+            "-Xlog:nmt=warning",
+            "-XX:NativeMemoryTracking=summary",
+            "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldNotContain("NMT initialization failed");
+        output.shouldNotContain("Could not create the Java Virtual Machine.");
+        output.shouldHaveExitValue(0);
+    }
 }


### PR DESCRIPTION
Backporting JDK-8368885: NMT CommandLine tests can check for error better.

This PR implements more specific error text checks to catch both parsing and initialization failures and standardizes indentation to 4 spaces in Java source files.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/runtime/NMT

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/27802365/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/27802366/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/27802367/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/27802369/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368885](https://bugs.openjdk.org/browse/JDK-8368885) needs maintainer approval

### Issue
 * [JDK-8368885](https://bugs.openjdk.org/browse/JDK-8368885): NMT CommandLine tests can check for error better (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4463/head:pull/4463` \
`$ git checkout pull/4463`

Update a local copy of the PR: \
`$ git checkout pull/4463` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4463`

View PR using the GUI difftool: \
`$ git pr show -t 4463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4463.diff">https://git.openjdk.org/jdk17u-dev/pull/4463.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4463#issuecomment-4460044542)
</details>
