### PR TITLE
8358058: sun/java2d/OpenGL/DrawImageBg.java Test fails intermittently

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -255,6 +255,7 @@ sun/awt/shell/ShellFolderMemoryLeak.java 8197794 windows-all
 sun/java2d/DirectX/OverriddenInsetsTest/OverriddenInsetsTest.java 8196102 generic-all
 sun/java2d/DirectX/RenderingToCachedGraphicsTest/RenderingToCachedGraphicsTest.java 8196180 windows-all,macosx-all
 sun/java2d/OpenGL/MultiWindowFillTest.java 8378506 macosx-all
+sun/java2d/OpenGL/OpaqueDest.java#id1 8367574 macosx-all
 sun/java2d/SunGraphics2D/EmptyClipRenderingTest.java 8144029 macosx-all,linux-all
 sun/java2d/SunGraphics2D/DrawImageBilinear.java 8191406 generic-all
 sun/java2d/SunGraphics2D/PolyVertTest.java 6986565 generic-all

--- a/test/jdk/sun/java2d/OpenGL/DrawBitmaskImage.java
+++ b/test/jdk/sun/java2d/OpenGL/DrawBitmaskImage.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6248561 6264014
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that bitmask image copies work properly with the
+ * OGL pipeline when a SrcOver composite with extra alpha is involved.
+ * @run main/othervm -Dsun.java2d.opengl=True DrawBitmaskImage
+ * @run main/othervm DrawBitmaskImage
+ */
+
+/*
+ * @test
+ * @bug 6248561 6264014
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that bitmask image copies work properly with the
+ * OGL pipeline when a SrcOver composite with extra alpha is involved.
+ * @run main/othervm -Dsun.java2d.opengl=True DrawBitmaskImage
+ * @run main/othervm DrawBitmaskImage
+ */
+
+import java.awt.AlphaComposite;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Transparency;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class DrawBitmaskImage extends Panel {
+
+    static final int TESTW = 200, TESTH = 200;
+    private static volatile DrawBitmaskImage test;
+    private static volatile Frame frame;
+
+    public void paint(Graphics g) {
+
+        Graphics2D g2d = (Graphics2D)g;
+        g2d.setColor(Color.black);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+        g2d.setComposite(AlphaComposite.SrcOver.derive(0.50f));
+
+        BufferedImage img = getGraphicsConfiguration().createCompatibleImage(50, 50,
+                                                        Transparency.BITMASK);
+        Graphics2D gimg = img.createGraphics();
+        gimg.setComposite(AlphaComposite.Src);
+        gimg.setColor(new Color(0, 0, 0, 0));
+        gimg.fillRect(0, 0, 50, 50);
+        gimg.setColor(Color.red);
+        gimg.fillRect(10, 10, 30, 30);
+        gimg.dispose();
+
+
+        g2d.drawImage(img, 10, 10, null);
+
+        // draw a second time to ensure that the cached copy is used
+        g2d.drawImage(img, 80, 10, null);
+    }
+
+    public Dimension getPreferredSize() {
+         return new Dimension(TESTW, TESTH);
+    }
+
+    static void createUI() {
+        test = new DrawBitmaskImage();
+        frame = new Frame("OpenGL DrawBitmaskImage Test");
+        Panel p = new Panel();
+        p.add(test);
+        frame.add(p);
+        frame.setSize(TESTW+100, TESTH+100);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        EventQueue.invokeAndWait(DrawBitmaskImage::createUI);
+
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        BufferedImage capture = null;
+        try {
+            GraphicsConfiguration gc = frame.getGraphicsConfiguration();
+            if (gc.getColorModel() instanceof IndexColorModel) {
+                System.out.println("IndexColorModel detected: " +
+                                   "test considered PASSED");
+                return;
+            }
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x, pt1.y, TESTW, TESTH);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+            if (frame != null) {
+                 EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+
+        // Test background color
+        int pixel = capture.getRGB(5, 10);
+        if (pixel != 0xff000000) {
+            saveImage(capture);
+            throw new RuntimeException("Failed: Incorrect color for " +
+                                       "background (actual=" +
+                                       Integer.toHexString(pixel) + ")");
+        }
+
+        // Test pixels (allow for small error in the actual red value)
+        pixel = capture.getRGB(25, 25);
+        System.out.println("pixel1 is " + Integer.toHexString(pixel));
+
+        if ((pixel < 0xff7e0000) || (pixel > 0xff900000)) {
+            saveImage(capture);
+            throw new RuntimeException("Failed: Incorrect color for " +
+                                       "first pixel (actual=" +
+                                       Integer.toHexString(pixel) + ")");
+        }
+
+        pixel = capture.getRGB(95, 25);
+        System.out.println("pixel2 is " + Integer.toHexString(pixel));
+        if ((pixel < 0xff7e0000) || (pixel > 0xff900000)) {
+            saveImage(capture);
+            throw new RuntimeException("Failed: Incorrect color for " +
+                                       "second pixel (actual=" +
+                                       Integer.toHexString(pixel) + ")");
+        }
+    }
+
+    static void saveImage(BufferedImage img) {
+        try {
+            File file = new File("capture.png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/DrawBufImgOp.java
+++ b/test/jdk/sun/java2d/OpenGL/DrawBufImgOp.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6514990
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that calling
+ * Graphics2D.drawImage(BufferedImage, BufferedImageOp, x, y) to an
+ * OpenGL-accelerated destination produces the same results when performed
+ * in software via BufferedImageOp.filter().
+ * @run main/othervm -Dsun.java2d.opengl=True DrawBufImgOp -ignore
+ */
+
+/*
+ * @test
+ * @bug 6514990
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that calling
+ * Graphics2D.drawImage(BufferedImage, BufferedImageOp, x, y) to an
+ * OpenGL-accelerated destination produces the same results when performed
+ * in software via BufferedImageOp.filter().
+ * @run main/othervm -Dsun.java2d.opengl=True DrawBufImgOp -ignore
+ */
+
+import java.awt.AlphaComposite;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.awt.image.ByteLookupTable;
+import java.awt.image.ColorModel;
+import java.awt.image.ConvolveOp;
+import java.awt.image.IndexColorModel;
+import java.awt.image.Kernel;
+import java.awt.image.LookupOp;
+import java.awt.image.RescaleOp;
+import java.awt.image.ShortLookupTable;
+import java.awt.image.VolatileImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+/**
+ * REMIND: This testcase was originally intended to automatically compare
+ * the results of the software BufferedImageOp implementations against
+ * the OGL-accelerated codepaths.  However, there are just too many open
+ * bugs in the mediaLib-based codepaths (see below), which means that
+ * creating the reference image may cause crashes or exceptions,
+ * and even if we work around those cases using the "-ignore" flag,
+ * the visual results of the reference image are often buggy as well
+ * (so the comparison will fail even though the OGL results are correct).
+ * Therefore, for now we will run the testcase with the "-ignore" flag
+ * but without the "-compare" flag, so at least it will be checking for
+ * any exceptions/crashes in the OGL code.  When we fix all of the
+ * outstanding bugs with the software codepaths, we can remove the
+ * "-ignore" flag and maybe even restore the "-compare" flag.  In the
+ * meantime, it also functions well as a manual testcase (with either
+ * the "-show" or "-dump" options).
+ */
+public class DrawBufImgOp extends Canvas {
+
+    private static final int TESTW = 600;
+    private static final int TESTH = 500;
+
+    private static volatile DrawBufImgOp test;
+    private static volatile Frame frame;
+
+    /*
+     * If true, skips tests that are known to trigger bugs (which in
+     * turn may cause crashes, exceptions, or other artifacts).
+     */
+    private static boolean ignore;
+
+    // Test both pow2 and non-pow2 sized images
+    private static final int[] srcSizes = { 32, 17 };
+    private static final int[] srcTypes = {
+        BufferedImage.TYPE_INT_RGB,
+        BufferedImage.TYPE_INT_ARGB,
+        BufferedImage.TYPE_INT_ARGB_PRE,
+        BufferedImage.TYPE_INT_BGR,
+        BufferedImage.TYPE_3BYTE_BGR,
+        BufferedImage.TYPE_4BYTE_ABGR,
+        BufferedImage.TYPE_USHORT_565_RGB,
+        BufferedImage.TYPE_BYTE_GRAY,
+        BufferedImage.TYPE_USHORT_GRAY,
+    };
+
+    private static final RescaleOp
+        rescale1band, rescale3band, rescale4band;
+    private static final LookupOp
+        lookup1bandbyte, lookup3bandbyte, lookup4bandbyte;
+    private static final LookupOp
+        lookup1bandshort, lookup3bandshort, lookup4bandshort;
+    private static final ConvolveOp
+        convolve3x3zero, convolve5x5zero, convolve7x7zero;
+    private static final ConvolveOp
+        convolve3x3noop, convolve5x5noop, convolve7x7noop;
+
+    static {
+        rescale1band = new RescaleOp(0.5f, 10.0f, null);
+        rescale3band = new RescaleOp(
+            new float[] {  0.6f,  0.4f, 0.6f },
+            new float[] { 10.0f, -3.0f, 5.0f },
+            null);
+        rescale4band = new RescaleOp(
+            new float[] {  0.6f, 0.4f, 0.6f, 0.9f },
+            new float[] { -1.0f, 5.0f, 3.0f, 1.0f },
+            null);
+
+        // REMIND: we should probably test non-zero offsets, but that
+        // would require massaging the source image data to avoid going
+        // outside the lookup table array bounds
+        int offset = 0;
+        {
+            byte invert[] = new byte[256];
+            byte halved[] = new byte[256];
+            for (int j = 0; j < 256 ; j++) {
+                invert[j] = (byte) (255-j);
+                halved[j] = (byte) (j / 2);
+            }
+            ByteLookupTable lut1 = new ByteLookupTable(offset, invert);
+            lookup1bandbyte = new LookupOp(lut1, null);
+            ByteLookupTable lut3 =
+                new ByteLookupTable(offset,
+                                    new byte[][] {invert, halved, invert});
+            lookup3bandbyte = new LookupOp(lut3, null);
+            ByteLookupTable lut4 =
+                new ByteLookupTable(offset,
+                               new byte[][] {invert, halved, invert, halved});
+            lookup4bandbyte = new LookupOp(lut4, null);
+        }
+
+        {
+            short invert[] = new short[256];
+            short halved[] = new short[256];
+            for (int j = 0; j < 256 ; j++) {
+                invert[j] = (short) ((255-j) * 255);
+                halved[j] = (short) ((j / 2) * 255);
+            }
+            ShortLookupTable lut1 = new ShortLookupTable(offset, invert);
+            lookup1bandshort = new LookupOp(lut1, null);
+            ShortLookupTable lut3 =
+                new ShortLookupTable(offset,
+                                     new short[][] {invert, halved, invert});
+            lookup3bandshort = new LookupOp(lut3, null);
+            ShortLookupTable lut4 =
+                new ShortLookupTable(offset,
+                              new short[][] {invert, halved, invert, halved});
+            lookup4bandshort = new LookupOp(lut4, null);
+        }
+
+        // 3x3 blur
+        float[] data3 = {
+            0.1f, 0.1f, 0.1f,
+            0.1f, 0.2f, 0.1f,
+            0.1f, 0.1f, 0.1f,
+        };
+        Kernel k3 = new Kernel(3, 3, data3);
+
+        // 5x5 edge
+        float[] data5 = {
+            -1.0f, -1.0f, -1.0f, -1.0f, -1.0f,
+            -1.0f, -1.0f, -1.0f, -1.0f, -1.0f,
+            -1.0f, -1.0f, 24.0f, -1.0f, -1.0f,
+            -1.0f, -1.0f, -1.0f, -1.0f, -1.0f,
+            -1.0f, -1.0f, -1.0f, -1.0f, -1.0f,
+        };
+        Kernel k5 = new Kernel(5, 5, data5);
+
+        // 7x7 blur
+        float[] data7 = {
+            0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f,
+            0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f,
+            0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f,
+            0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f,
+            0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f,
+            0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f,
+            0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f, 0.02f,
+        };
+        Kernel k7 = new Kernel(7, 7, data7);
+
+        convolve3x3zero = new ConvolveOp(k3, ConvolveOp.EDGE_ZERO_FILL, null);
+        convolve5x5zero = new ConvolveOp(k5, ConvolveOp.EDGE_ZERO_FILL, null);
+        convolve7x7zero = new ConvolveOp(k7, ConvolveOp.EDGE_ZERO_FILL, null);
+
+        convolve3x3noop = new ConvolveOp(k3, ConvolveOp.EDGE_NO_OP, null);
+        convolve5x5noop = new ConvolveOp(k5, ConvolveOp.EDGE_NO_OP, null);
+        convolve7x7noop = new ConvolveOp(k7, ConvolveOp.EDGE_NO_OP, null);
+    }
+
+    public void paint(Graphics g) {
+
+        VolatileImage vimg = createVolatileImage(TESTW, TESTH);
+        vimg.validate(getGraphicsConfiguration());
+
+        Graphics2D g2d = vimg.createGraphics();
+        renderTest(g2d);
+        g2d.dispose();
+
+        g.drawImage(vimg, 0, 0, null);
+    }
+
+    /*
+     * foreach source image size (once with pow2, once with non-pow2)
+     *
+     *   foreach BufferedImage type
+     *
+     *     RescaleOp (1 band)
+     *     RescaleOp (3 bands, if src has 3 bands)
+     *     RescaleOp (4 bands, if src has 4 bands)
+     *
+     *     foreach LookupTable type (once with ByteLUT, once with ShortLUT)
+     *       LookupOp (1 band)
+     *       LookupOp (3 bands, if src has 3 bands)
+     *       LookupOp (4 bands, if src has 4 bands)
+     *
+     *     foreach edge condition (once with ZERO_FILL, once with EDGE_NO_OP)
+     *       ConvolveOp (3x3)
+     *       ConvolveOp (5x5)
+     *       ConvolveOp (7x7)
+     */
+    private void renderTest(Graphics2D g2d) {
+        g2d.setColor(Color.white);
+        g2d.fillRect(0, 0, TESTW, TESTH);
+
+        int yorig = 2;
+        int xinc = 34;
+        int yinc = srcSizes[0] + srcSizes[1] + 2 + 2;
+
+        for (int srcType : srcTypes) {
+            int y = yorig;
+
+            for (int srcSize : srcSizes) {
+                int x = 2;
+                System.out.printf("type=%d size=%d\n", srcType, srcSize);
+
+                BufferedImage srcImg = makeSourceImage(srcSize, srcType);
+                ColorModel srcCM = srcImg.getColorModel();
+
+                // RescaleOp
+                g2d.drawImage(srcImg, rescale1band, x, y);
+                x += xinc;
+                // REMIND: 3-band RescaleOp.filter() throws IAE for images
+                //         that contain an alpha channel (bug to be filed)
+                if (srcCM.getNumColorComponents() == 3 &&
+                    !(ignore && srcCM.hasAlpha()))
+                {
+                    g2d.drawImage(srcImg, rescale3band, x, y);
+                }
+                x += xinc;
+                if (srcCM.getNumComponents() == 4) {
+                    g2d.drawImage(srcImg, rescale4band, x, y);
+                }
+                x += xinc;
+
+                // LookupOp
+                // REMIND: Our LUTs are only 256 elements long, so won't
+                //         currently work with USHORT_GRAY data
+                if (srcType != BufferedImage.TYPE_USHORT_GRAY) {
+                    g2d.drawImage(srcImg, lookup1bandbyte, x, y);
+                    x += xinc;
+                    if (srcCM.getNumColorComponents() == 3) {
+                        g2d.drawImage(srcImg, lookup3bandbyte, x, y);
+                    }
+                    x += xinc;
+                    if (srcCM.getNumComponents() == 4) {
+                        g2d.drawImage(srcImg, lookup4bandbyte, x, y);
+                    }
+                    x += xinc;
+
+                    // REMIND: LookupOp.createCompatibleDestImage() throws
+                    //         IAE for 3BYTE_BGR/4BYTE_ABGR (bug to be filed)
+                    if (!(ignore &&
+                          (srcType == BufferedImage.TYPE_3BYTE_BGR ||
+                           srcType == BufferedImage.TYPE_4BYTE_ABGR)))
+                    {
+                        g2d.drawImage(srcImg, lookup1bandshort, x, y);
+                        x += xinc;
+                        // REMIND: 3-band LookupOp.filter() throws IAE for
+                        //         images that contain an alpha channel
+                        //         (bug to be filed)
+                        if (srcCM.getNumColorComponents() == 3 &&
+                            !(ignore && srcCM.hasAlpha()))
+                        {
+                            g2d.drawImage(srcImg, lookup3bandshort, x, y);
+                        }
+                        x += xinc;
+                        if (srcCM.getNumComponents() == 4) {
+                            g2d.drawImage(srcImg, lookup4bandshort, x, y);
+                        }
+                        x += xinc;
+                    } else {
+                        x += 3*xinc;
+                    }
+                } else {
+                    x += 6*xinc;
+                }
+
+                // ConvolveOp
+                // REMIND: ConvolveOp.filter() throws ImagingOpException
+                //         for 3BYTE_BGR (see 4957775)
+                if (srcType != BufferedImage.TYPE_3BYTE_BGR) {
+                    g2d.drawImage(srcImg, convolve3x3zero, x, y);
+                    x += xinc;
+                    g2d.drawImage(srcImg, convolve5x5zero, x, y);
+                    x += xinc;
+                    g2d.drawImage(srcImg, convolve7x7zero, x, y);
+                    x += xinc;
+
+                    g2d.drawImage(srcImg, convolve3x3noop, x, y);
+                    x += xinc;
+                    g2d.drawImage(srcImg, convolve5x5noop, x, y);
+                    x += xinc;
+                    g2d.drawImage(srcImg, convolve7x7noop, x, y);
+                    x += xinc;
+                } else {
+                    x += 6*xinc;
+                }
+
+                y += srcSize + 2;
+            }
+
+            yorig += yinc;
+        }
+    }
+
+    private BufferedImage makeSourceImage(int size, int type) {
+        int s2 = size/2;
+        BufferedImage img = new BufferedImage(size, size, type);
+        Graphics2D g2d = img.createGraphics();
+        g2d.setComposite(AlphaComposite.Src);
+        g2d.setColor(Color.orange);
+        g2d.fillRect(0, 0, size, size);
+        g2d.setColor(Color.red);
+        g2d.fillRect(0, 0, s2, s2);
+        g2d.setColor(Color.green);
+        g2d.fillRect(s2, 0, s2, s2);
+        g2d.setColor(Color.blue);
+        g2d.fillRect(0, s2, s2, s2);
+        g2d.setColor(new Color(255, 255, 0, 128));
+        g2d.fillRect(s2, s2, s2, s2);
+        g2d.setColor(Color.pink);
+        g2d.fillOval(s2-3, s2-3, 6, 6);
+        g2d.dispose();
+        return img;
+    }
+
+    public BufferedImage makeReferenceImage() {
+        BufferedImage img = new BufferedImage(TESTW, TESTH,
+                                              BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = img.createGraphics();
+        renderTest(g2d);
+        g2d.dispose();
+        return img;
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(TESTW, TESTH);
+    }
+
+    private static void compareImages(BufferedImage refImg,
+                                      BufferedImage testImg,
+                                      int tolerance)
+    {
+        int x1 = 0;
+        int y1 = 0;
+        int x2 = refImg.getWidth();
+        int y2 = refImg.getHeight();
+
+        for (int y = y1; y < y2; y++) {
+            for (int x = x1; x < x2; x++) {
+                Color expected = new Color(refImg.getRGB(x, y));
+                Color actual   = new Color(testImg.getRGB(x, y));
+                if (!isSameColor(expected, actual, tolerance)) {
+                    saveImage("referenceimage", refImg);
+                    saveImage("testimage", testImg);
+                    throw new RuntimeException("Test failed at x="+x+" y="+y+
+                                               " (expected="+expected+
+                                               " actual="+actual+
+                                               ")");
+                }
+            }
+        }
+    }
+
+    private static boolean isSameColor(Color c1, Color c2, int e) {
+        int r1 = c1.getRed();
+        int g1 = c1.getGreen();
+        int b1 = c1.getBlue();
+        int r2 = c2.getRed();
+        int g2 = c2.getGreen();
+        int b2 = c2.getBlue();
+        int rmin = Math.max(r2-e, 0);
+        int gmin = Math.max(g2-e, 0);
+        int bmin = Math.max(b2-e, 0);
+        int rmax = Math.min(r2+e, 255);
+        int gmax = Math.min(g2+e, 255);
+        int bmax = Math.min(b2+e, 255);
+        if (r1 >= rmin && r1 <= rmax &&
+            g1 >= gmin && g1 <= gmax &&
+            b1 >= bmin && b1 <= bmax)
+        {
+            return true;
+        }
+        return false;
+    }
+
+
+    static void createUI() {
+        test = new DrawBufImgOp();
+        Panel panel = new Panel();
+        panel.add(test);
+        frame = new Frame("OpenGL DrawBufImgOp Test");
+        frame.add(panel);
+        frame.setSize(TESTW+100, TESTH+100);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        boolean show = false;
+        boolean dump = false;
+        boolean compare = false;
+
+        for (String arg : args) {
+            if (arg.equals("-show")) {
+                show = true;
+            } else if (arg.equals("-dump")) {
+                dump = true;
+            } else if (arg.equals("-compare")) {
+                compare = true;
+            } else if (arg.equals("-ignore")) {
+                ignore = true;
+            }
+        }
+
+        Robot robot = new Robot();
+
+        EventQueue.invokeAndWait(DrawBufImgOp::createUI);
+
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        BufferedImage capture = null;
+        try {
+            GraphicsConfiguration gc = frame.getGraphicsConfiguration();
+            if (gc.getColorModel() instanceof IndexColorModel) {
+                System.out.println("IndexColorModel detected: " +
+                                   "test considered PASSED");
+                return;
+            }
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x, pt1.y, TESTW, TESTH);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+            if (frame != null) {
+                 EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+
+        // Compare the images (allow for +/- 1 bit differences in color comps)
+        if (dump || compare) {
+            BufferedImage ref = test.makeReferenceImage();
+            if (dump) {
+                saveImage("DrawBufImgOp_ref", ref);
+                saveImage("DrawBufImgOp_cap", capture);
+            }
+            if (compare) {
+                test.compareImages(ref, capture, 1);
+            }
+        }
+    }
+
+    static void saveImage(String name, BufferedImage img) {
+        try {
+            File file = new File(name + ".png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/DrawImageBg.java
+++ b/test/jdk/sun/java2d/OpenGL/DrawImageBg.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4993274
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that managed image copies and transforms work properly
+ * with the OGL pipeline when a background color is specified.
+ * @run main/othervm -Dsun.java2d.opengl=True DrawImageBg
+ * @run main/othervm DrawImageBg
+ */
+
+/*
+ * @test
+ * @bug 4993274
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that managed image copies and transforms work properly
+ * with the OGL pipeline when a background color is specified.
+ * @run main/othervm -Dsun.java2d.opengl=True DrawImageBg
+ * @run main/othervm DrawImageBg
+ */
+
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class DrawImageBg extends Panel {
+
+    static volatile Frame frame;
+    static volatile DrawImageBg test;
+
+    public void paint(Graphics g) {
+
+        Graphics2D g2d = (Graphics2D)g;
+        g2d.setColor(Color.black);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+
+        BufferedImage img = getGraphicsConfiguration().createCompatibleImage(50, 50,
+                                                   Transparency.BITMASK);
+        Graphics2D gimg = img.createGraphics();
+        gimg.setComposite(AlphaComposite.Src);
+        gimg.setColor(new Color(0, 0, 0, 0));
+        gimg.fillRect(0, 0, 50, 50);
+        gimg.setColor(Color.red);
+        gimg.fillRect(10, 10, 30, 30);
+        gimg.dispose();
+
+        g2d.drawImage(img, 10, 10, Color.blue, null);
+
+        // draw a second time to ensure that the cached copy is used
+        g2d.drawImage(img, 80, 10, Color.blue, null);
+    }
+
+    static void createUI() {
+        frame = new Frame("OpenGL DrawImageBg Test");
+        test = new DrawImageBg();
+        frame.add(test);
+        frame.setSize(300, 300);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedImage capture = null;
+        Robot robot = new Robot();
+        try {
+            EventQueue.invokeAndWait(DrawImageBg::createUI);
+            robot.waitForIdle();
+            robot.delay(3000);
+
+            // Grab the screen region
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x+80, pt1.y, 80, 80);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+
+        if (capture == null) {
+            throw new RuntimeException("Screen capture is null");
+        }
+
+        // Test inner and outer pixels
+        int pixel1 = capture.getRGB(5, 10);
+        if (pixel1 != 0xff0000ff) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("outer", pixel1));
+        }
+        int pixel2 = capture.getRGB(25, 25);
+        if (pixel2 != 0xffff0000) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("inner", pixel2));
+        }
+    }
+
+    static String getMsg(String r, int p1) {
+         return "Failed: Incorrect color for " + r + " pixel: got " + Integer.toHexString(p1);
+    }
+
+    static void saveImage(BufferedImage img) {
+        try {
+            File file = new File("capture.png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/LargeOps.java
+++ b/test/jdk/sun/java2d/OpenGL/LargeOps.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6219284 6358147 6274813 6578452
+ * @key headful
+ * @summary Verifies that OGLRenderer.drawPoly(),
+ * OGLTextRenderer.drawGlyphList(), and OGLMaskFill work properly when the
+ * operation parameters exceed the capacity of the render queue.  With the
+ * single-threaded OpenGL pipeline, there are some operations that require
+ * a separate buffer to be spawned if the parameters cannot fit entirely on
+ * the standard buffer.  This test exercises this special case.
+ * @run main/othervm  -Dsun.java2d.opengl=True -Dsun.java2d.opengl.lcdshader=true LargeOps
+ */
+
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Robot;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class LargeOps extends Canvas {
+
+    private static final int NUM_POINTS = 8000;
+    private int[] xPoints, yPoints;
+    private String str;
+
+    public LargeOps() {
+        xPoints = new int[NUM_POINTS];
+        yPoints = new int[NUM_POINTS];
+        for (int i = 0; i < NUM_POINTS; i++) {
+            xPoints[i] = (i % 2 == 0) ? 10 : 400;
+            yPoints[i] = (i % 2 == 1) ? i+3 : i;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < NUM_POINTS; i+=11) {
+            sb.append("ThisIsATest");
+        }
+        str = sb.toString();
+    }
+
+    public void paint(Graphics g) {
+        Graphics2D g2d = (Graphics2D)g;
+        g2d.setColor(Color.white);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+
+        // draw large polyline
+        g2d.setColor(Color.green);
+        g2d.drawPolyline(xPoints, yPoints, NUM_POINTS);
+
+        // draw long string
+        g2d.setColor(Color.blue);
+        g2d.drawString(str, 10, 100);
+
+        // draw long string with larger pt size
+        Font font = g2d.getFont();
+        g2d.setFont(font.deriveFont(40.0f));
+        g2d.drawString(str, 10, 150);
+
+        // do the same with LCD hints enabled
+        g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+        g2d.setFont(font);
+        g2d.drawString(str, 10, 200);
+        g2d.setFont(font.deriveFont(43.0f));
+        g2d.drawString(str, 10, 250);
+
+        g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                             RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HBGR);
+        g2d.setFont(font);
+        g2d.drawString(str, 10, 300);
+        g2d.setFont(font.deriveFont(37.0f));
+        g2d.drawString(str, 10, 350);
+    }
+
+    static volatile Frame frame;
+    static volatile LargeOps test;
+
+    static void createUI() {
+        frame = new Frame("OpenGL LargeOps Test");
+        frame.addWindowListener(new WindowAdapter() {
+                public void windowClosing(WindowEvent e) {
+                    frame.dispose();
+                }
+            });
+        test = new LargeOps();
+        frame.add(test);
+        frame.setSize(600, 600);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+             Robot robot = new Robot();
+             EventQueue.invokeAndWait(LargeOps::createUI);
+             robot.waitForIdle();
+             robot.delay(6000);
+        } finally {
+            if (frame != null) {
+                 EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/OpaqueDest.java
+++ b/test/jdk/sun/java2d/OpenGL/OpaqueDest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6277977 6319663
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that blending operations do not inadvertantly leave
+ * non-opaque alpha values in the framebuffer.  Note that this test is
+ * intended to run on GraphicsConfigs that support a stored alpha channel
+ * (to verify the bug at hand), but it is also a useful for testing the
+ * compositing results on any configuration.
+ * @run main/othervm  -Dsun.java2d.opengl=True OpaqueDest
+ * @run main/othervm  OpaqueDest
+ */
+
+/*
+ * @test
+ * @bug 6277977 6319663
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that blending operations do not inadvertantly leave
+ * non-opaque alpha values in the framebuffer.  Note that this test is
+ * intended to run on GraphicsConfigs that support a stored alpha channel
+ * (to verify the bug at hand), but it is also a useful for testing the
+ * compositing results on any configuration.
+ * @run main/othervm -Dsun.java2d.opengl=True OpaqueDest
+ * @run main/othervm  OpaqueDest
+ */
+
+import java.awt.AlphaComposite;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class OpaqueDest extends Canvas {
+
+    private static volatile Frame frame;
+    private static volatile OpaqueDest test;
+
+    public void paint(Graphics g) {
+
+        Graphics2D g2d = (Graphics2D)g;
+
+        g2d.setColor(Color.red);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+
+        // This will clear the rectangle to black
+        g2d.setComposite(AlphaComposite.Clear);
+        g2d.fillRect(10, 10, 80, 80);
+
+        // If everything is working properly, then this will fill the
+        // rectangle with red again.  Before this bug was fixed, the previous
+        // Clear operation would leave zero values in the destination's
+        // alpha channel (if present), and therefore a SrcIn operation
+        // would result in all-black.
+        g2d.setComposite(AlphaComposite.SrcIn);
+        g2d.fillRect(10, 10, 80, 80);
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(100, 100);
+    }
+
+    static void createUI() {
+        test = new OpaqueDest();
+        frame = new Frame("OpenGL OpaqueDest Test");
+        Panel p = new Panel();
+        p.add(test);
+        frame.add(p);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        EventQueue.invokeAndWait(OpaqueDest::createUI);
+
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        BufferedImage capture = null;
+        try {
+            GraphicsConfiguration gc = frame.getGraphicsConfiguration();
+            if (gc.getColorModel() instanceof IndexColorModel) {
+                System.out.println("IndexColorModel detected: " +
+                                   "test considered PASSED");
+                return;
+            }
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x, pt1.y, 100, 100);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+            if (frame != null) {
+                 EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+
+
+        // Test all pixels (every one should be red)
+        for (int y = 0; y < 100; y++) {
+            for (int x = 0; x < 100; x++) {
+                int actual = capture.getRGB(x, y);
+                    int expected = 0xffff0000;
+                if (!similar(actual, expected)) {
+                    saveImage(capture);
+                    throw new RuntimeException("Test failed at x="+x+" y="+y+
+                                               " (expected="+
+                                               Integer.toHexString(expected) +
+                                               " actual="+
+                                               Integer.toHexString(actual) +
+                                               ")");
+                }
+            }
+        }
+    }
+
+    static boolean similar(int p1, int p2) {
+        int a1 = (p1 >> 24) & 0xff;
+        int r1 = (p1 >> 16) & 0xff;
+        int g1 = (p1 >> 8) & 0xff;
+        int b1 = p1 & 0xff;
+        int a2 = (p2 >> 24) & 0xff;
+        int r2 = (p2 >> 16) & 0xff;
+        int g2 = (p2 >> 8) & 0xff;
+        int b2 = p2 & 0xff;
+
+        int allowedDiff = 0x01; // tiny rounding error allowed.
+        return
+            (Math.abs(a1 - a2) <= allowedDiff) &&
+            (Math.abs(r1 - r2) <= allowedDiff) &&
+            (Math.abs(g1 - g2) <= allowedDiff) &&
+            (Math.abs(b1 - b2) <= allowedDiff);
+    }
+
+    static void saveImage(BufferedImage img) {
+        try {
+            File file = new File("capture.png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/ScaleParamsOOB.java
+++ b/test/jdk/sun/java2d/OpenGL/ScaleParamsOOB.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5104584 8237244
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that scaling an image works properly when the
+ * source parameters are outside the source bounds.
+ * @run main/othervm -Dsun.java2d.opengl=True ScaleParamsOOB
+ * @run main/othervm ScaleParamsOOB
+ */
+
+/*
+ * @test
+ * @bug 5104584 8237244
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that scaling an image works properly when the
+ * source parameters are outside the source bounds.
+ * @run main/othervm -Dsun.java2d.opengl=True ScaleParamsOOB
+ * @run main/othervm ScaleParamsOOB
+ */
+
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class ScaleParamsOOB extends Panel {
+
+    private static final int TOLERANCE = 12;
+
+    private static volatile ScaleParamsOOB test;
+    private static volatile Frame frame;
+
+    private BufferedImage img;
+
+    public void paint(Graphics g) {
+
+        Graphics2D g2d = (Graphics2D)g;
+        g2d.setColor(Color.black);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+
+        BufferedImage img = getGraphicsConfiguration().createCompatibleImage(40, 40);
+        Graphics2D gimg = img.createGraphics();
+        gimg.setColor(Color.red);
+        gimg.fillRect(0, 0, 40, 40);
+        gimg.dispose();
+
+        // first time will be a sw->surface blit
+        g2d.drawImage(img,
+                      10, 10, 90, 90,
+                      -60, -60, 100, 100,
+                      null);
+
+        // second time will be a texture->surface blit
+        g2d.drawImage(img,
+                      110, 10, 190, 90,
+                      -60, -60, 100, 100,
+                      null);
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(300, 200);
+    }
+
+    private static void testRegion(BufferedImage bi,
+                                   Rectangle wholeRegion,
+                                   Rectangle affectedRegion)
+    {
+        int x1 = wholeRegion.x;
+        int y1 = wholeRegion.y;
+        int x2 = x1 + wholeRegion.width;
+        int y2 = y1 + wholeRegion.height;
+
+        for (int y = y1; y < y2; y++) {
+            for (int x = x1; x < x2; x++) {
+                int actual = bi.getRGB(x, y);
+                int expected = 0;
+                if (affectedRegion.contains(x, y)) {
+                    expected = Color.red.getRGB();
+                } else {
+                    expected = Color.black.getRGB();
+                }
+                int alpha = (actual >> 24) & 0xFF;
+                int red = (actual >> 16) & 0xFF;
+                int green = (actual >> 8) & 0xFF;
+                int blue = (actual) & 0xFF;
+
+                int standardAlpha = (expected >> 24) & 0xFF;
+                int standardRed = (expected >> 16) & 0xFF;
+                int standardGreen = (expected >> 8) & 0xFF;
+                int standardBlue = (expected) & 0xFF;
+
+                if ((Math.abs(alpha - standardAlpha) > TOLERANCE) ||
+                    (Math.abs(red - standardRed) > TOLERANCE) ||
+                    (Math.abs(green - standardGreen) > TOLERANCE) ||
+                    (Math.abs(blue - standardBlue) > TOLERANCE)) {
+                    saveImage(bi);
+                    throw new RuntimeException("Test failed at x="+x+" y="+y+
+                                               " (expected="+
+                                               Integer.toHexString(expected) +
+                                               " actual="+
+                                               Integer.toHexString(actual) +
+                                               ")");
+                }
+            }
+        }
+    }
+
+    private static void createAndShowGUI() {
+        test = new ScaleParamsOOB();
+        frame = new Frame("OpenGL ScaleParamsOOB Test");
+        frame.setAlwaysOnTop(true);
+        frame.add(test);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        EventQueue.invokeAndWait(() -> createAndShowGUI());
+
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        // Grab the screen region
+        BufferedImage capture = null;
+        try {
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x, pt1.y, 200, 200);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+
+        // Test background color
+        int pixel = capture.getRGB(5, 5);
+        if (pixel != 0xff000000) {
+            saveImage(capture);
+            throw new RuntimeException("Failed: Incorrect color for " +
+                                       "background: " + Integer.toHexString(pixel));
+        }
+
+        // Test pixels
+        testRegion(capture,
+                   new Rectangle(5, 5, 90, 90),
+                   new Rectangle(40, 40, 20, 20));
+        testRegion(capture,
+                   new Rectangle(105, 5, 90, 90),
+                   new Rectangle(140, 40, 20, 20));
+    }
+
+    static void saveImage(BufferedImage img) {
+        try {
+            File file = new File("capture.png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/ShapeClip.java
+++ b/test/jdk/sun/java2d/OpenGL/ShapeClip.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5002133
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that the OpenGL pipeline does not affect the color
+ * buffer when setting up a complex (shape) clip region.  The test fails if
+ * the circular clip region is filled with a green color (the green region
+ * should not be visible at all).
+ * @run main/othervm -Dsun.java2d.opengl=True ShapeClip
+ * @run main/othervm ShapeClip
+ */
+
+/*
+ * @test
+ * @bug 5002133
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that the OpenGL pipeline does not affect the color
+ * buffer when setting up a complex (shape) clip region.  The test fails if
+ * the circular clip region is filled with a green color (the green region
+ * should not be visible at all).
+ * @run main/othervm -Dsun.java2d.opengl=True ShapeClip
+ * @run main/othervm ShapeClip
+ */
+
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.geom.Ellipse2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class ShapeClip extends Panel {
+
+    private static volatile Frame frame;
+    private static volatile ShapeClip test;
+
+    public void paint(Graphics g) {
+
+        Graphics2D g2d = (Graphics2D)g;
+
+        int width = getWidth();
+        int height = getHeight();
+
+        g2d.setColor(Color.black);
+        g2d.fillRect(0, 0, width, height);
+
+        g2d.setColor(Color.green);
+        g2d.fillRect(0, 0, 1, 1);
+        g2d.setClip(new Ellipse2D.Double(10, 10, 100, 100));
+        g2d.setColor(Color.blue);
+        g2d.fillRect(30, 30, 20, 20);
+    }
+
+    static void createUI() {
+        test = new ShapeClip();
+        frame = new Frame("OpenGL ShapeClip Test");
+        frame.add(test);
+        frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        EventQueue.invokeAndWait(ShapeClip::createUI);
+
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        // Grab the screen region
+        BufferedImage capture = null;
+        try {
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x, pt1.y, 80, 80);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+            if (frame != null) {
+                 EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+
+        // Test blue rectangle
+        int pixel1 = capture.getRGB(40, 40);
+        if (pixel1 != 0xff0000ff) {
+            saveImage(capture);
+            throw new RuntimeException("Failed: Incorrect color for " +
+                                       "rectangle " + Integer.toHexString(pixel1));
+        }
+
+        // Test clip region (should be same color as background)
+        int pixel2 = capture.getRGB(60, 40);
+        if (pixel2 != 0xff000000) {
+            saveImage(capture);
+            throw new RuntimeException("Failed: Incorrect color for " +
+                                       "clip region " + Integer.toHexString(pixel2));
+        }
+    }
+
+    static void saveImage(BufferedImage img) {
+        try {
+            File file = new File("capture.png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/SrcMaskOps.java
+++ b/test/jdk/sun/java2d/OpenGL/SrcMaskOps.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4942939 4970674
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that OGLMaskFill, OGLMaskBlit, and OGLTextRenderer
+ * operations work properly for non-SrcOver composites.
+ * @run main/othervm -Dsun.java2d.opengl=True SrcMaskOps
+ * @run main/othervm SrcMaskOps
+ */
+
+/*
+ * @test
+ * @bug 4942939 4970674
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that OGLMaskFill, OGLMaskBlit, and OGLTextRenderer
+ * operations work properly for non-SrcOver composites.
+ * @run main/othervm -Dsun.java2d.opengl=True SrcMaskOps
+ * @run main/othervm SrcMaskOps
+ */
+
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.EventQueue;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class SrcMaskOps extends Panel {
+
+    static volatile Frame frame;
+    static volatile SrcMaskOps test;
+
+    static final int SRX = 50;
+    static final int SRY = 50;
+    static final int GPX = 90;
+    static final int GPY = 50;
+    static final int DTX = 120;
+    static final int DTY = 70;
+
+    public void paint(Graphics g) {
+
+        Graphics2D g2d = (Graphics2D)g;
+
+        g2d.setColor(Color.white);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                             RenderingHints.VALUE_ANTIALIAS_ON);
+        g2d.setComposite(AlphaComposite.Src);
+
+        g2d.setColor(Color.blue);
+        g2d.drawRect(SRX, SRY, 20, 20);
+
+        g2d.setPaint(new GradientPaint(0.0f, 0.0f, Color.red,
+                                       100.0f, 100.f, Color.red, true));
+        g2d.drawRect(GPX, GPY, 20, 20);
+
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                             RenderingHints.VALUE_ANTIALIAS_OFF);
+
+        g2d.setColor(Color.red);
+        Font font = new Font(Font.DIALOG, Font.PLAIN, 20);
+        g2d.setFont(font);
+        g2d.drawString("HELLO", DTX, DTY);
+    }
+
+    static void createUI() {
+        frame = new Frame("OpenGL SrcMaskOps Test");
+        test = new SrcMaskOps();
+        frame.add(test);
+        frame.setSize(300, 300);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        Robot robot = new Robot();
+        BufferedImage capture = null;
+        try {
+            EventQueue.invokeAndWait(SrcMaskOps::createUI);
+            robot.waitForIdle();
+            robot.delay(3000);
+
+            // Grab the screen region
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x, pt1.y, 300, 300);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+            if (frame != null) {
+                EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+
+        // Test solid rectangle
+        int pixel1, pixel2;
+        pixel1 = capture.getRGB(SRX, SRY);
+        pixel2 = capture.getRGB(SRX+2, SRY+2);
+        if (!similar(pixel1, 0xff0000ff) || !similar(pixel2, 0xffffffff)) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("solid rectangle", pixel1, pixel2));
+        }
+
+        // Test GradientPaint rectangle
+        pixel1 = capture.getRGB(GPX, GPY);
+        pixel2 = capture.getRGB(GPX+2, GPY+2);
+        if (!similar(pixel1, 0xffff0000) || !similar(pixel2, 0xffffffff)) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("GradientPaint rectangle", pixel1, pixel2));
+        }
+
+        // Test solid text
+        pixel1 = capture.getRGB(DTX+2, DTY-5);
+        pixel2 = capture.getRGB(DTX+5, DTY-5);
+        if (!similar(pixel1, 0xffff0000) || !similar(pixel2, 0xffffffff)) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("solid text", pixel1, pixel2));
+        }
+
+    }
+
+    static boolean similar(int p1, int p2) {
+        int a1 = (p1 >> 24) & 0xff;
+        int r1 = (p1 >> 16) & 0xff;
+        int g1 = (p1 >> 8) & 0xff;
+        int b1 = p1 & 0xff;
+        int a2 = (p2 >> 24) & 0xff;
+        int r2 = (p2 >> 16) & 0xff;
+        int g2 = (p2 >> 8) & 0xff;
+        int b2 = p2 & 0xff;
+
+        int allowedDiff = 0x10;
+        return
+            (Math.abs(a1 - a2) <= allowedDiff) &&
+            (Math.abs(r1 - r2) <= allowedDiff) &&
+            (Math.abs(g1 - g2) <= allowedDiff) &&
+            (Math.abs(b1 - b2) <= allowedDiff);
+    }
+
+    static String getMsg(String r, int p1, int p2) {
+         return "Failed: Incorrect color[s] for " + r + " got " +
+                Integer.toHexString(p1) + " and " + Integer.toHexString(p2);
+    }
+
+    static void saveImage(BufferedImage img) {
+        try {
+            File file = new File("capture.png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/jdk/sun/java2d/OpenGL/VolatileSubRegion.java
+++ b/test/jdk/sun/java2d/OpenGL/VolatileSubRegion.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6244071
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that copying a subregion from a VolatileImage works
+ * properly with the OGL pipeline.
+ * @run main/othervm  VolatileSubRegion
+ * @run main/othervm -Dsun.java2d.opengl=True -Dsun.java2d.opengl.fbobject=true VolatileSubRegion
+ * @run main/othervm -Dsun.java2d.opengl=True -Dsun.java2d.opengl.fbobject=false VolatileSubRegion
+ */
+
+/*
+ * @test
+ * @bug 6244071
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that copying a subregion from a VolatileImage works
+ * properly with the OGL pipeline.
+ * @run main/othervm VolatileSubRegion
+ * @run main/othervm -Dsun.java2d.opengl=True -Dsun.java2d.opengl.fbobject=true VolatileSubRegion
+ * @run main/othervm -Dsun.java2d.opengl=True -Dsun.java2d.opengl.fbobject=false VolatileSubRegion
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import java.awt.image.VolatileImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class VolatileSubRegion extends Panel {
+
+    private VolatileImage img;
+
+    public void paint(Graphics g) {
+
+        Graphics2D g2d = (Graphics2D)g;
+
+        if (img == null) {
+            img = createVolatileImage(200, 200);
+            Graphics2D goff = img.createGraphics();
+            goff.setColor(Color.green);
+            goff.fillRect(50, 0, 100, 50);
+            goff.setColor(Color.blue);
+            goff.fillRect(0, 0, 200, 200);
+            goff.setColor(Color.red);
+            goff.fillRect(50, 50, 100, 100);
+            goff.setColor(Color.yellow);
+            goff.fillRect(50, 150, 100, 50);
+            goff.dispose();
+        }
+
+        g2d.setColor(Color.white);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+
+        g2d.drawImage(img,
+                      50, 50, 200, 200,
+                      50, 50, 200, 200,
+                      null);
+
+    }
+
+
+    private static volatile VolatileSubRegion test;
+    private static volatile Frame frame;
+
+    static void createUI() {
+        test = new VolatileSubRegion();
+        frame = new Frame("OpenGL VolatileSubRegion Test");
+        frame.add(test);
+        frame.setSize(300, 300);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+
+        EventQueue.invokeAndWait(VolatileSubRegion::createUI);
+
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        BufferedImage capture = null;
+        try {
+            GraphicsConfiguration gc = frame.getGraphicsConfiguration();
+            if (gc.getColorModel() instanceof IndexColorModel) {
+                System.out.println("IndexColorModel detected: " +
+                                   "test considered PASSED");
+                return;
+            }
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x, pt1.y, 200, 200);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+            if (frame != null) {
+                 EventQueue.invokeAndWait(frame::dispose);
+            }
+        }
+
+        // Test pixels
+        int pixel1 = capture.getRGB(49, 50);
+        if (pixel1 != 0xffffffff) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("background pixel", pixel1));
+        }
+        int pixel2 = capture.getRGB(50, 50);
+        if (pixel2 != 0xffff0000) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("red region", pixel2));
+        }
+        int pixel3 = capture.getRGB(50, 150);
+        if (pixel3 != 0xffffff00) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("yellow region", pixel3));
+        }
+    }
+
+    static String getMsg(String r, int p1) {
+         return "Failed: Incorrect color for " + r + " : got " + Integer.toHexString(p1);
+    }
+
+    static void saveImage(BufferedImage img) {
+        try {
+            File file = new File("capture.png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/test/jdk/sun/java2d/OpenGL/XformVolatile.java
+++ b/test/jdk/sun/java2d/OpenGL/XformVolatile.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4970836
+ * @key headful
+ * @requires (os.family != "mac")
+ * @summary Verifies that transformed VolatileImage copies work properly with
+ * the OGL pipeline.
+ * @run main/othervm XformVolatile
+ * @run main/othervm -Dsun.java2d.opengl=True -Dsun.java2d.opengl.fbobject=true XformVolatile
+ * @run main/othervm -Dsun.java2d.opengl=True -Dsun.java2d.opengl.fbobject=false XformVolatile
+ */
+
+/*
+ * @test
+ * @bug 4970836
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies that transformed VolatileImage copies work properly with
+ * the OGL pipeline.
+ * @run main/othervm XformVolatile
+ * @run main/othervm -Dsun.java2d.opengl=True -Dsun.java2d.opengl.fbobject=true XformVolatile
+ * @run main/othervm -Dsun.java2d.opengl=True -Dsun.java2d.opengl.fbobject=false XformVolatile
+ */
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.awt.image.VolatileImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+
+public class XformVolatile extends Panel {
+
+    private static volatile Frame frame;
+    private static volatile XformVolatile test;
+    private volatile VolatileImage img;
+
+    public void paint(Graphics g) {
+
+        Graphics2D g2d = (Graphics2D)g;
+
+        if (img == null) {
+            img = createVolatileImage(200, 200);
+            Graphics2D goff = img.createGraphics();
+            goff.setColor(Color.blue);
+            goff.fillRect(0, 0, 200, 200);
+            goff.setColor(Color.red);
+            goff.fillPolygon(new int[] {10, 100, 190},
+                             new int[] {190, 10, 190}, 3);
+            goff.dispose();
+        }
+
+        g2d.setColor(Color.black);
+        g2d.fillRect(0, 0, getWidth(), getHeight());
+
+        g2d.rotate(Math.toRadians(3.0));
+        g2d.drawImage(img, 0, 0, null);
+    }
+
+    static void createUI() {
+        test = new XformVolatile();
+        frame = new Frame("OpenGL XformVolatile Test");
+        frame.add(test);
+        frame.setSize(300, 300);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        Robot robot = new Robot();
+
+        EventQueue.invokeAndWait(XformVolatile::createUI);
+
+        robot.waitForIdle();
+        robot.delay(2000);
+
+        // Grab the screen region
+        BufferedImage capture = null;
+        try {
+            Point pt1 = test.getLocationOnScreen();
+            Rectangle rect = new Rectangle(pt1.x, pt1.y, 200, 200);
+            capture = robot.createScreenCapture(rect);
+        } finally {
+             if (frame != null) {
+                 EventQueue.invokeAndWait(frame::dispose);
+             }
+        }
+
+        // Test inner and outer pixels
+        int pixel1 = capture.getRGB(5, 175);
+        if (pixel1 != 0xff0000ff) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("inner", pixel1));
+        }
+        int pixel2 = capture.getRGB(5, 188);
+        if (pixel2 != 0xffff0000) {
+            saveImage(capture);
+            throw new RuntimeException(getMsg("inner", pixel2));
+        }
+    }
+
+    static String getMsg(String r, int p1) {
+         return "Failed: Incorrect color for " + r + " pixel: got " + Integer.toHexString(p1);
+    }
+
+    static void saveImage(BufferedImage img) {
+        try {
+            File file = new File("capture.png");
+            ImageIO.write(img, "png", file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Backporting JDK-8358058: sun/java2d/OpenGL/DrawImageBg.java Test fails intermittently.

This PR migrates tests from a closed repository with improvements including corrected thread logic, paint-on-demand behavior, and support for all systems (not just OpenGL).

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/sun/java2d/OpenGL/DrawBitmaskImage.java
make test TEST=test/jdk/sun/java2d/OpenGL/DrawBufImgOp.java
make test TEST=test/jdk/sun/java2d/OpenGL/DrawImageBg.java
make test TEST=test/jdk/sun/java2d/OpenGL/LargeOps.java
make test TEST=test/jdk/sun/java2d/OpenGL/OpaqueDest.java
make test TEST=test/jdk/sun/java2d/OpenGL/ScaleParamsOOB.java
make test TEST=test/jdk/sun/java2d/OpenGL/ShapeClip.java
make test TEST=test/jdk/sun/java2d/OpenGL/SrcMaskOps.java
make test TEST=test/jdk/sun/java2d/OpenGL/VolatileSubRegion.java
make test TEST=test/jdk/sun/java2d/OpenGL/XformVolatile.java

Results:

Please note that similar to the backport for 21 and 25, "test/jdk/sun/java2d/OpenGL/ScaleParamsOOB.java" fails on linux-x64 and linux-aarch64. This will be addressed by https://github.com/openjdk/jdk17u-dev/pull/4471

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28022096/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28022097/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/28022098/macos-aarch64-specific-3-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/28022099/macos-aarch64-specific-4-test.log)
[macos-aarch64-specific-5-test.log](https://github.com/user-attachments/files/28022100/macos-aarch64-specific-5-test.log)
[macos-aarch64-specific-6-test.log](https://github.com/user-attachments/files/28022101/macos-aarch64-specific-6-test.log)
[macos-aarch64-specific-7-test.log](https://github.com/user-attachments/files/28022102/macos-aarch64-specific-7-test.log)
[macos-aarch64-specific-8-test.log](https://github.com/user-attachments/files/28022103/macos-aarch64-specific-8-test.log)
[macos-aarch64-specific-9-test.log](https://github.com/user-attachments/files/28022104/macos-aarch64-specific-9-test.log)
[macos-aarch64-specific-10-test.log](https://github.com/user-attachments/files/28022105/macos-aarch64-specific-10-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/28022124/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/28022125/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/28022126/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/28022129/windows-x64-specific-4-test.log)
[windows-x64-specific-5-test.log](https://github.com/user-attachments/files/28022130/windows-x64-specific-5-test.log)
[windows-x64-specific-6-test.log](https://github.com/user-attachments/files/28022131/windows-x64-specific-6-test.log)
[windows-x64-specific-7-test.log](https://github.com/user-attachments/files/28022132/windows-x64-specific-7-test.log)
[windows-x64-specific-8-test.log](https://github.com/user-attachments/files/28022133/windows-x64-specific-8-test.log)
[windows-x64-specific-9-test.log](https://github.com/user-attachments/files/28022134/windows-x64-specific-9-test.log)
[windows-x64-specific-10-test.log](https://github.com/user-attachments/files/28022135/windows-x64-specific-10-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28022148/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/28022149/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/28022150/linux-x64-specific-3-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/28022151/linux-x64-specific-4-test.log)
[linux-x64-specific-5-test.log](https://github.com/user-attachments/files/28022152/linux-x64-specific-5-test.log)
[linux-x64-specific-6-test.log](https://github.com/user-attachments/files/28022153/linux-x64-specific-6-test.log)
[linux-x64-specific-7-test.log](https://github.com/user-attachments/files/28022154/linux-x64-specific-7-test.log)
[linux-x64-specific-8-test.log](https://github.com/user-attachments/files/28022155/linux-x64-specific-8-test.log)
[linux-x64-specific-9-test.log](https://github.com/user-attachments/files/28022156/linux-x64-specific-9-test.log)
[linux-x64-specific-10-test.log](https://github.com/user-attachments/files/28022158/linux-x64-specific-10-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28022169/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28022170/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/28022171/linux-aarch64-specific-3-test.log)
[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/28022172/linux-aarch64-specific-4-test.log)
[linux-aarch64-specific-5-test.log](https://github.com/user-attachments/files/28022173/linux-aarch64-specific-5-test.log)
[linux-aarch64-specific-6-test.log](https://github.com/user-attachments/files/28022174/linux-aarch64-specific-6-test.log)
[macos-aarch64-specific-7-test.log](https://github.com/user-attachments/files/28022175/macos-aarch64-specific-7-test.log)
[macos-aarch64-specific-8-test.log](https://github.com/user-attachments/files/28022176/macos-aarch64-specific-8-test.log)
[macos-aarch64-specific-9-test.log](https://github.com/user-attachments/files/28022177/macos-aarch64-specific-9-test.log)
[macos-aarch64-specific-10-test.log](https://github.com/user-attachments/files/28022178/macos-aarch64-specific-10-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358058](https://bugs.openjdk.org/browse/JDK-8358058) needs maintainer approval

### Issue
 * [JDK-8358058](https://bugs.openjdk.org/browse/JDK-8358058): sun/java2d/OpenGL/DrawImageBg.java Test fails intermittently (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4465/head:pull/4465` \
`$ git checkout pull/4465`

Update a local copy of the PR: \
`$ git checkout pull/4465` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4465`

View PR using the GUI difftool: \
`$ git pr show -t 4465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4465.diff">https://git.openjdk.org/jdk17u-dev/pull/4465.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4465#issuecomment-4462600932)
</details>
