### PR TITLE
8381205: GHA: Upgrade Node.js 20 to 24

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -37,13 +37,13 @@ runs:
 
     - name: 'Check cache for already built JTReg'
       id: get-cached
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: jtreg/installed
         key: jtreg-${{ steps.version.outputs.value }}
 
     - name: 'Checkout the JTReg source'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: openjdk/jtreg
         ref: jtreg-${{ steps.version.outputs.value }}
@@ -61,7 +61,7 @@ runs:
       if: (steps.get-cached.outputs.cache-hit != 'true')
 
     - name: 'Upload JTReg artifact'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: bundles-jtreg-${{ steps.version.outputs.value }}
         path: jtreg/installed

--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-logs-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: failure-logs
@@ -74,7 +74,7 @@ runs:
 
       # This is the best way I found to abort the job with an error message
     - name: 'Notify about build failures'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: core.setFailed('Build failed. See summary for details.')
       if: steps.check.outputs.failure == 'true'

--- a/.github/actions/get-bootjdk/action.yml
+++ b/.github/actions/get-bootjdk/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: 'Check cache for BootJDK'
       id: get-cached-bootjdk
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: bootjdk/jdk
         key: boot-jdk-${{ inputs.platform }}-${{ steps.sha256.outputs.value }}

--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -48,18 +48,19 @@ runs:
   steps:
     - name: 'Download bundles artifact'
       id: download-bundles
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles
       continue-on-error: true
 
     - name: 'Download bundles artifact (retry)'
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles
       if: steps.download-bundles.outcome == 'failure'
+
 
     - name: 'Unpack bundles'
       run: |

--- a/.github/actions/get-gtest/action.yml
+++ b/.github/actions/get-gtest/action.yml
@@ -40,7 +40,7 @@ runs:
         var: GTEST_VERSION
 
     - name: 'Checkout GTest source'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: google/googletest
         ref: 'v${{ steps.version.outputs.value }}'

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - name: 'Download JTReg artifact'
       id: download-jtreg
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: bundles-jtreg-${{ steps.version.outputs.value }}
         path: jtreg/installed

--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: 'Install MSYS2'
       id: msys2
-      uses: msys2/setup-msys2@v2.28.0
+      uses: msys2/setup-msys2@v2.31.0
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
 
     - name: 'Upload bundles artifact'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Get the BootJDK'
         id: bootjdk
@@ -118,7 +118,7 @@ jobs:
 
       - name: 'Check cache for sysroot'
         id: get-cached-sysroot
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: sysroot
           key: sysroot-${{ matrix.debian-arch }}-${{ hashFiles('./.github/workflows/build-cross-compile.yml') }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Get the BootJDK'
         id: bootjdk

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Get the BootJDK'
         id: bootjdk

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Get MSYS2'
         uses: ./.github/actions/get-msys2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: 'Checkout the scripts'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Get MSYS2'
         uses: ./.github/actions/get-msys2
@@ -214,7 +214,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -222,7 +222,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'


### PR DESCRIPTION
This pull request contains a backport of commit [3e223dd0](https://github.com/openjdk/jdk21u-dev/commit/3e223dd01c9fb772ec531ec2568e86a26d2bbf98) from the [openjdk/jdk21u-dev](https://git.openjdk.org/jdk21u-dev) repository.

It upgrades the GitHub Actions Node.js runtime from 20 to 24, keeping the update releases in sync with the fix already applied to 25u-dev, 26u, 21u-dev, and OpenJDK head.

The backport applied cleanly.

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8381205](https://bugs.openjdk.org/browse/JDK-8381205) needs maintainer approval

### Issue
 * [JDK-8381205](https://bugs.openjdk.org/browse/JDK-8381205): GHA: Upgrade Node.js 20 to 24 (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4468/head:pull/4468` \
`$ git checkout pull/4468`

Update a local copy of the PR: \
`$ git checkout pull/4468` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4468`

View PR using the GUI difftool: \
`$ git pr show -t 4468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4468.diff">https://git.openjdk.org/jdk17u-dev/pull/4468.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4468#issuecomment-4481307377)
</details>
