### PR TITLE
8384540: [25u, 21u, 17u] Update GHA JDKs after Apr/26 updates

### DIFF
--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -29,17 +29,17 @@ GTEST_VERSION=1.13.0
 JTREG_VERSION=7.5.2+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
-LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.14%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.14_7.tar.gz
-LINUX_X64_BOOT_JDK_SHA256=a3af83983fb94dd7d11b13ba2dba0fb6819dc2caaf87e6937afd22ad4680ae9a
+LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz
+LINUX_X64_BOOT_JDK_SHA256=d8afc263758141a66e0e3aafc321e783f7016696f4eaea067d340a269037d331
 
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
-MACOS_AARCH64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.14%2B7/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.14_7.tar.gz
-MACOS_AARCH64_BOOT_JDK_SHA256=95bcc8052340394b87644d71a60fb26f31857f4090a7dfee57113e9e0f2dfacb
+MACOS_AARCH64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.tar.gz
+MACOS_AARCH64_BOOT_JDK_SHA256=8fa1eff40bb637a33613b2ccb8b12c70dc3661cc22cf8e784943715769a05336
 
 MACOS_X64_BOOT_JDK_EXT=tar.gz
-MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.14%2B7/OpenJDK17U-jdk_x64_mac_hotspot_17.0.14_7.tar.gz
-MACOS_X64_BOOT_JDK_SHA256=bc2e9225d156d27149fc7a91817e6b64f76132b2b81d1f44cb8c90d7497b6ea7
+MACOS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_mac_hotspot_17.0.19_10.tar.gz
+MACOS_X64_BOOT_JDK_SHA256=03632d1fbf139ab3719a9f4b47dc206251449b87557143c822336dbf8c06560f
 
 WINDOWS_X64_BOOT_JDK_EXT=zip
-WINDOWS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.14%2B7/OpenJDK17U-jdk_x64_windows_hotspot_17.0.14_7.zip
-WINDOWS_X64_BOOT_JDK_SHA256=dddb108e0bf8c3e3a9c5c782fee5874a6a86d5323189969f17094260cf3a1125
+WINDOWS_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.zip
+WINDOWS_X64_BOOT_JDK_SHA256=b5b235c48adf6a081874b812c630b9f4b5f637b7a5ed18b9174d08a41ec4c235


### PR DESCRIPTION
Update the GHA boot JDK URLs and SHA256 checksums to Temurin 17.0.19+10 for all platforms (linux-x64, macos-aarch64, macos-x64, windows-x64).




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8384540](https://bugs.openjdk.org/browse/JDK-8384540) needs maintainer approval

### Issue
 * [JDK-8384540](https://bugs.openjdk.org/browse/JDK-8384540): [25u, 21u, 17u] Update GHA JDKs after Apr/26 updates (**Bug** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4469/head:pull/4469` \
`$ git checkout pull/4469`

Update a local copy of the PR: \
`$ git checkout pull/4469` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4469`

View PR using the GUI difftool: \
`$ git pr show -t 4469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4469.diff">https://git.openjdk.org/jdk17u-dev/pull/4469.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4469#issuecomment-4488126723)
</details>
