### PR TITLE
8373847: Test javax/swing/JMenuItem/MenuItemTest/bug6197830.java failed because The test case automatically fails when clicking any items in the “Nothing” menu in all four windows (Left-to-right)-Menu Item Test and (Right-to-left)-Menu Item Test

### DIFF
--- a/test/jdk/javax/swing/JMenuItem/MenuItemTest/bug6197830.java
+++ b/test/jdk/javax/swing/JMenuItem/MenuItemTest/bug6197830.java
@@ -49,6 +49,7 @@ public class bug6197830 {
                 .columns(35)
                 .testUI(bug6197830::createTestUI)
                 .positionTestUIBottomRowCentered()
+                .logArea()
                 .build()
                 .awaitAndCheck();
     }


### PR DESCRIPTION
Backporting JDK-8373847: Test javax/swing/JMenuItem/MenuItemTest/bug6197830.java failed because The test case automatically fails when clicking any items in the “Nothing” menu in all four windows (Left-to-right)-Menu Item Test and (Right-to-left)-Menu Item Test.

This PR fixes TBD.

For parity with Oracle JDK. Already backported to 21.

Ran related test on linux-x64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/javax/swing/JMenuItem/MenuItemTest/bug6197830.java```

Screenshot:

<img width="1001" height="709" alt="Screenshot 2026-05-19 at 6 59 17 AM" src="https://github.com/user-attachments/assets/02ba0d84-1b10-4ad4-b6d1-1dfbfb1582ba" />

Results:

```test result: Passed. Execution successful```

[bug6197830.jtr.txt](https://github.com/user-attachments/files/28016162/bug6197830.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373847](https://bugs.openjdk.org/browse/JDK-8373847) needs maintainer approval

### Issue
 * [JDK-8373847](https://bugs.openjdk.org/browse/JDK-8373847): Test javax/swing/JMenuItem/MenuItemTest/bug6197830.java failed because The test case automatically fails when clicking any items in the “Nothing” menu in all four windows (Left-to-right)-Menu Item Test and (Right-to-left)-Menu Item Test (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4470/head:pull/4470` \
`$ git checkout pull/4470`

Update a local copy of the PR: \
`$ git checkout pull/4470` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4470`

View PR using the GUI difftool: \
`$ git pr show -t 4470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4470.diff">https://git.openjdk.org/jdk17u-dev/pull/4470.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4470#issuecomment-4488773946)
</details>
