### PR TITLE
8290504: Close streams returned by ModuleReader::list

### DIFF
--- a/test/jdk/java/lang/ClassLoader/getResource/automaticmodules/Main.java
+++ b/test/jdk/java/lang/ClassLoader/getResource/automaticmodules/Main.java
@@ -28,6 +28,7 @@ import java.lang.module.ModuleReference;
 import java.lang.module.ResolvedModule;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.stream.Stream;
 
 /**
  * Usage: Main $MODULE
@@ -79,8 +80,9 @@ public class Main {
                 .map(ResolvedModule::reference)
                 .orElseThrow(() -> new RuntimeException(mn + " not resolved!!"));
 
-        try (ModuleReader reader = mref.open()) {
-            reader.list().forEach(name -> {
+        try (ModuleReader reader = mref.open();
+             Stream<String> stream = reader.list()) {
+            stream.forEach(name -> {
                 testFindUnchecked(name);
 
                 // if the resource is a directory then find without trailing slash

--- a/test/jdk/java/lang/invoke/CallerSensitiveAccess.java
+++ b/test/jdk/java/lang/invoke/CallerSensitiveAccess.java
@@ -62,9 +62,10 @@ public class CallerSensitiveAccess {
      */
     @DataProvider(name = "callerSensitiveMethods")
     static Object[][] callerSensitiveMethods() {
-        return callerSensitiveMethods(Object.class.getModule())
-                .map(m -> new Object[] { m, shortDescription(m) })
-                .toArray(Object[][]::new);
+        try (Stream<Method> stream = callerSensitiveMethods(Object.class.getModule())) {
+            return stream.map(m -> new Object[]{m, shortDescription(m)})
+                    .toArray(Object[][]::new);
+        }
     }
 
     /**
@@ -100,11 +101,13 @@ public class CallerSensitiveAccess {
      */
     @DataProvider(name = "accessibleCallerSensitiveMethods")
     static Object[][] accessibleCallerSensitiveMethods() {
-        return callerSensitiveMethods(Object.class.getModule())
+        try (Stream<Method> stream = callerSensitiveMethods(Object.class.getModule())) {
+            return stream
                 .filter(m -> Modifier.isPublic(m.getModifiers()))
                 .map(m -> { m.setAccessible(true); return m; })
                 .map(m -> new Object[] { m, shortDescription(m) })
                 .toArray(Object[][]::new);
+        }
     }
 
     /**

--- a/test/jdk/java/lang/module/ModuleReader/ModuleReaderTest.java
+++ b/test/jdk/java/lang/module/ModuleReader/ModuleReaderTest.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.spi.ToolProvider;
+import java.util.stream.Stream;
 
 import jdk.internal.module.ModulePath;
 import jdk.test.lib.compiler.CompilerUtils;
@@ -413,7 +414,10 @@ public class ModuleReaderTest {
      * Test ModuleReader#list
      */
     void testList(ModuleReader reader, String name) throws IOException {
-        List<String> list = reader.list().collect(Collectors.toList());
+        final List<String> list;
+        try (Stream<String> stream = reader.list()) {
+            list = stream.toList();
+        }
         Set<String> names = new HashSet<>(list);
         assertTrue(names.size() == list.size()); // no duplicates
 

--- a/test/jdk/java/lang/module/customfs/ModulesInCustomFileSystem.java
+++ b/test/jdk/java/lang/module/customfs/ModulesInCustomFileSystem.java
@@ -44,6 +44,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import jdk.test.lib.util.JarUtils;
 
@@ -108,8 +109,9 @@ public class ModulesInCustomFileSystem {
     private void listAllModules(ModuleFinder finder) throws Exception {
         for (ModuleReference mref : finder.findAll()) {
             System.out.println(mref.descriptor());
-            try (ModuleReader reader = mref.open()) {
-                reader.list().forEach(name -> System.out.format("  %s%n", name));
+            try (ModuleReader reader = mref.open();
+                 Stream<String> stream = reader.list()) {
+                stream.forEach(name -> System.out.format("  %s%n", name));
             }
         }
     }


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8290504](https://bugs.openjdk.org/browse/JDK-8290504) needs maintainer approval

### Issue
 * [JDK-8290504](https://bugs.openjdk.org/browse/JDK-8290504): Close streams returned by ModuleReader::list (**Bug** - P3 - Approved)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4473/head:pull/4473` \
`$ git checkout pull/4473`

Update a local copy of the PR: \
`$ git checkout pull/4473` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4473`

View PR using the GUI difftool: \
`$ git pr show -t 4473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4473.diff">https://git.openjdk.org/jdk17u-dev/pull/4473.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4473#issuecomment-4498547304)
</details>
