### PR TITLE
8373931: Test javax/sound/sampled/Clip/AutoCloseTimeCheck.java timed out

### DIFF
--- a/test/jdk/javax/sound/sampled/Clip/AutoCloseTimeCheck.java
+++ b/test/jdk/javax/sound/sampled/Clip/AutoCloseTimeCheck.java
@@ -39,6 +39,7 @@ import static javax.sound.sampled.AudioSystem.NOT_SPECIFIED;
 
 /**
  * @test
+ * @key sound
  * @bug 8202264
  */
 public final class AutoCloseTimeCheck {


### PR DESCRIPTION
Backporting JDK-8373931: Test javax/sound/sampled/Clip/AutoCloseTimeCheck.java timed out.

This PR adds the @key sound tag to AutoCloseTimeCheck.java to fix intermittent timeout failures by ensuring
the test only runs on systems with sound support.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/sound/sampled/Clip/AutoCloseTimeCheck.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28072743/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28072744/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28072745/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28072746/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8373931](https://bugs.openjdk.org/browse/JDK-8373931) needs maintainer approval

### Issue
 * [JDK-8373931](https://bugs.openjdk.org/browse/JDK-8373931): Test javax/sound/sampled/Clip/AutoCloseTimeCheck.java timed out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4474/head:pull/4474` \
`$ git checkout pull/4474`

Update a local copy of the PR: \
`$ git checkout pull/4474` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4474`

View PR using the GUI difftool: \
`$ git pr show -t 4474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4474.diff">https://git.openjdk.org/jdk17u-dev/pull/4474.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4474#issuecomment-4502315136)
</details>
