### PR TITLE
8370511: test/jdk/javax/swing/JSlider/bug4382876.java does not release previously pressed keys

### DIFF
--- a/test/jdk/javax/swing/JSlider/bug4382876.java
+++ b/test/jdk/javax/swing/JSlider/bug4382876.java
@@ -48,8 +48,8 @@ public class bug4382876 {
     private static Robot r;
     private static JFrame f;
     private static JSlider slider;
-    private static boolean upFail;
-    private static boolean downFail;
+    private static volatile boolean upFail;
+    private static volatile boolean downFail;
 
     public static void main(String[] args) throws Exception {
         try {
@@ -70,23 +70,30 @@ public class bug4382876 {
             r.delay(1000);
 
             r.keyPress(KeyEvent.VK_PAGE_UP);
+            r.keyRelease(KeyEvent.VK_PAGE_UP);
+
             SwingUtilities.invokeAndWait(() -> {
                 if (slider.getValue() < -1000) {
                     System.out.println("PAGE_UP VAL: " + slider.getValue());
                     upFail = true;
                 }
             });
+
             if (upFail) {
                 writeFailImage();
                 throw new RuntimeException("Slider value did NOT change with PAGE_UP");
             }
+
             r.keyPress(KeyEvent.VK_PAGE_DOWN);
+            r.keyRelease(KeyEvent.VK_PAGE_DOWN);
+
             SwingUtilities.invokeAndWait(() -> {
                 if (slider.getValue() > -1000) {
                     System.out.println("PAGE_DOWN VAL: " + slider.getValue());
                     downFail = true;
                 }
             });
+
             if (downFail) {
                 writeFailImage();
                 throw new RuntimeException("Slider value did NOT change with PAGE_DOWN");


### PR DESCRIPTION
Backporting JDK-8370511: test/jdk/javax/swing/JSlider/bug4382876.java does not release previously pressed keys.

This PR fixes test/jdk/javax/swing/JSlider/bug4382876.java to properly release pressed keys, preventing failures in subsequent tests on Wayland.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/swing/JSlider/bug4382876.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28106147/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28106150/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28106151/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28106153/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8370511](https://bugs.openjdk.org/browse/JDK-8370511) needs maintainer approval

### Issue
 * [JDK-8370511](https://bugs.openjdk.org/browse/JDK-8370511): test/jdk/javax/swing/JSlider/bug4382876.java does not release previously pressed keys (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4477/head:pull/4477` \
`$ git checkout pull/4477`

Update a local copy of the PR: \
`$ git checkout pull/4477` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4477`

View PR using the GUI difftool: \
`$ git pr show -t 4477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4477.diff">https://git.openjdk.org/jdk17u-dev/pull/4477.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4477#issuecomment-4509515546)
</details>
