### PR TITLE
8376151: Test javax/swing/JFileChooser/4966171/bug4966171.java is failing with OOME

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/4966171/bug4966171.java
+++ b/test/jdk/javax/swing/JFileChooser/4966171/bug4966171.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,8 @@ public final class bug4966171 {
     }
 
     private static void test() {
-        // Will run the test no more than 10 seconds per L&F
-        long endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        // Will run the test no more than 5 seconds per L&F
+        long endtime = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
         while (System.nanoTime() < endtime) {
             try {
                 var byteOut = new ByteArrayOutputStream();


### PR DESCRIPTION
Backporting JDK-8376151: Test javax/swing/JFileChooser/4966171/bug4966171.java is failing with OOME.

This PR reduces the JFileChooser serialization stress test duration from 10 seconds to 5 seconds per Look & Feel to decrease overall test execution time while still providing adequate coverage for detecting serialization issues.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/swing/JFileChooser/4966171/bug4966171.java

Results attached:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28509658/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28509659/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28509660/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28509661/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8376151](https://bugs.openjdk.org/browse/JDK-8376151) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8376151](https://bugs.openjdk.org/browse/JDK-8376151): Test javax/swing/JFileChooser/4966171/bug4966171.java is failing with OOME (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4486/head:pull/4486` \
`$ git checkout pull/4486`

Update a local copy of the PR: \
`$ git checkout pull/4486` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4486`

View PR using the GUI difftool: \
`$ git pr show -t 4486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4486.diff">https://git.openjdk.org/jdk17u-dev/pull/4486.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4486#issuecomment-4602828511)
</details>
