### PR TITLE
8361894: sun/security/krb5/config/native/TestDynamicStore.java ensure that the test is run with sudo

### DIFF
--- a/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
+++ b/test/jdk/sun/security/krb5/config/native/TestDynamicStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,14 @@
  * @summary SCDynamicStoreConfig works
  * @modules java.security.jgss/sun.security.krb5
  * @library /test/lib
- * @run main/manual/native TestDynamicStore
+ * @run main/manual/native/timeout=180 TestDynamicStore
  * @requires (os.family == "mac")
  */
 
 import jdk.test.lib.Asserts;
 import sun.security.krb5.Config;
+
+import javax.swing.JOptionPane;
 
 // =================== Attention ===================
 // This test calls a native method implemented in libTestDynamicStore.m
@@ -55,6 +57,17 @@ public class TestDynamicStore {
     }
 
     public static void main(String[] args) throws Exception {
+
+        // Show a popup to remind to run this test as sudo user
+        // this will only trigger if sudo (root) user is not detected
+        if (!"root".equals(System.getProperty("user.name"))) {
+
+            JOptionPane.showMessageDialog(null, """
+                            This test MUST be run as ROOT.\s
+                            Please close and RESTART the test.""");
+
+            Asserts.assertFalse(true, "This test must be run as ROOT");
+        }
 
         System.loadLibrary("TestDynamicStore");
 


### PR DESCRIPTION
Backporting JDK-8361894: sun/security/krb5/config/native/TestDynamicStore.java ensure that the test is run with sudo.

This PR adds a UI popup that detects and warns users when TestDynamicStore.java is run without required sudo privileges, preventing confusing access-related failures.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on macos-aarch64:

```sudo -E ~/github/jtreg/build/images/jtreg/bin/jtreg -nativepath:./build/macosx-aarch64-server-release/images/test/jdk/jtreg/native -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/sun/security/krb5/config/native/TestDynamicStore.java```

Result:

```test result: Error. Parse Exception: `/manual' disables use of `/timeout'```

[TestDynamicStore.jtr.txt](https://github.com/user-attachments/files/28514290/TestDynamicStore.jtr.txt)

The test fails due to https://bugs.openjdk.org/browse/JDK-8373793, which will be backported in a dependent PR (https://github.com/openjdk/jdk17u-dev/pull/4492), where the test successfully executes with the behavior indicated in this PR.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8361894](https://bugs.openjdk.org/browse/JDK-8361894) needs maintainer approval

### Issue
 * [JDK-8361894](https://bugs.openjdk.org/browse/JDK-8361894): sun/security/krb5/config/native/TestDynamicStore.java ensure that the test is run with sudo (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4489/head:pull/4489` \
`$ git checkout pull/4489`

Update a local copy of the PR: \
`$ git checkout pull/4489` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4489`

View PR using the GUI difftool: \
`$ git pr show -t 4489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4489.diff">https://git.openjdk.org/jdk17u-dev/pull/4489.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4489#issuecomment-4603353776)
</details>
