### PR TITLE
8373632: Some sound tests failing in CI due to lack of sound key

### DIFF
--- a/test/jdk/javax/sound/midi/Sequencer/Looping.java
+++ b/test/jdk/javax/sound/midi/Sequencer/Looping.java
@@ -36,7 +36,7 @@ import javax.sound.midi.Track;
  * @test
  * @bug 4204105
  * @summary RFE: add loop() method(s) to Sequencer
- * @key intermittent
+ * @key sound
  */
 public class Looping {
 

--- a/test/jdk/javax/sound/sampled/Clip/IsRunningHang.java
+++ b/test/jdk/javax/sound/sampled/Clip/IsRunningHang.java
@@ -36,6 +36,7 @@ import javax.sound.sampled.LineUnavailableException;
 /**
  * @test
  * @bug 8156169
+ * @key sound
  * @run main/othervm/timeout=300 IsRunningHang
  */
 public final class IsRunningHang {

--- a/test/jdk/javax/sound/sampled/DataLine/LongFramePosition.java
+++ b/test/jdk/javax/sound/sampled/DataLine/LongFramePosition.java
@@ -29,6 +29,7 @@ import javax.sound.sampled.SourceDataLine;
 /**
  * @test
  * @bug 5049129
+ * @key sound
  * @summary DataLine.getLongFramePosition
  */
 public class LongFramePosition {

--- a/test/jdk/javax/sound/sampled/DirectAudio/bug6372428.java
+++ b/test/jdk/javax/sound/sampled/DirectAudio/bug6372428.java
@@ -31,6 +31,7 @@ import javax.sound.sampled.TargetDataLine;
 /*
  * @test
  * @bug 6372428
+ * @key sound
  * @summary playback and capture doesn't interrupt after terminating thread that
  *          calls start()
  * @run main bug6372428


### PR DESCRIPTION
Backporting JDK-8373632: Some sound tests failing in CI due to lack of sound key.

This PR adds missing sound keyword to 4 jtreg tests that access audio devices, preventing hangs on macOS 26 when run without sound permissions due to a macOS bug.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/sound

Results attached:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28515365/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28515366/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28515368/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28515369/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8373632](https://bugs.openjdk.org/browse/JDK-8373632) needs maintainer approval

### Issue
 * [JDK-8373632](https://bugs.openjdk.org/browse/JDK-8373632): Some sound tests failing in CI due to lack of sound key (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4490/head:pull/4490` \
`$ git checkout pull/4490`

Update a local copy of the PR: \
`$ git checkout pull/4490` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4490`

View PR using the GUI difftool: \
`$ git pr show -t 4490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4490.diff">https://git.openjdk.org/jdk17u-dev/pull/4490.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4490#issuecomment-4603700516)
</details>
