### PR TITLE
8373796: Refactor java/net/httpclient/ThrowingPublishers*.java tests to use JUnit5

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingPublishers.java
@@ -25,15 +25,6 @@ import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
 import jdk.test.lib.net.SimpleSSLContext;
-import org.testng.ITestContext;
-import org.testng.ITestResult;
-import org.testng.SkipException;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
@@ -52,7 +43,6 @@ import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -80,24 +70,31 @@ import static java.lang.System.out;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.AfterAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.TestWatcher;
 
 public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
 
-    SSLContext sslContext;
-    HttpTestServer httpTestServer;    // HTTP/1.1    [ 4 servers ]
-    HttpTestServer httpsTestServer;   // HTTPS/1.1
-    HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
-    HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
-    String httpURI_fixed;
-    String httpURI_chunk;
-    String httpsURI_fixed;
-    String httpsURI_chunk;
-    String http2URI_fixed;
-    String http2URI_chunk;
-    String https2URI_fixed;
-    String https2URI_chunk;
+    static SSLContext sslContext;
+    static HttpTestServer httpTestServer;    // HTTP/1.1    [ 4 servers ]
+    static HttpTestServer httpsTestServer;   // HTTPS/1.1
+    static HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
+    static HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
+    static String httpURI_fixed;
+    static String httpURI_chunk;
+    static String httpsURI_fixed;
+    static String httpsURI_chunk;
+    static String http2URI_fixed;
+    static String http2URI_chunk;
+    static String https2URI_fixed;
+    static String https2URI_chunk;
 
     static final int ITERATION_COUNT = 1;
     // a shared executor helps reduce the amount of threads created by the test
@@ -115,8 +112,34 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         return String.format("[%d s, %d ms, %d ns] ", secs, mill, nan);
     }
 
-    final ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
-    private volatile HttpClient sharedClient;
+    final static class TestStopper implements TestWatcher, BeforeEachCallback {
+        final AtomicReference<String> failed = new AtomicReference<>();
+        TestStopper() { }
+        @Override
+        public void testFailed(ExtensionContext context, Throwable cause) {
+            if (stopAfterFirstFailure()) {
+                String msg = "Aborting due to: " + cause;
+                failed.compareAndSet(null, msg);
+                FAILURES.putIfAbsent(context.getDisplayName(), cause);
+                System.out.printf("%nTEST FAILED: %s%s%n\tAborting due to %s%n%n",
+                        now(), context.getDisplayName(), cause);
+                System.err.printf("%nTEST FAILED: %s%s%n\tAborting due to %s%n%n",
+                        now(), context.getDisplayName(), cause);
+            }
+        }
+
+        @Override
+        public void beforeEach(ExtensionContext context) {
+            String msg = failed.get();
+            Assumptions.assumeTrue(msg == null, msg);
+        }
+    }
+
+    @RegisterExtension
+    static final TestStopper stopper = new TestStopper();
+
+    static final ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
+    private static volatile HttpClient sharedClient;
 
     static class TestExecutor implements Executor {
         final AtomicLong tasks = new AtomicLong();
@@ -142,34 +165,12 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         }
     }
 
-    protected boolean stopAfterFirstFailure() {
+    protected static boolean stopAfterFirstFailure() {
         return Boolean.getBoolean("jdk.internal.httpclient.debug");
     }
 
-    final AtomicReference<SkipException> skiptests = new AtomicReference<>();
-    void checkSkip() {
-        var skip = skiptests.get();
-        if (skip != null) throw skip;
-    }
-    static String name(ITestResult result) {
-        var params = result.getParameters();
-        return result.getName()
-                + (params == null ? "()" : Arrays.toString(result.getParameters()));
-    }
-
-    @BeforeMethod
-    void beforeMethod(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            if (skiptests.get() == null) {
-                SkipException skip = new SkipException("some tests failed");
-                skip.setStackTrace(new StackTraceElement[0]);
-                skiptests.compareAndSet(null, skip);
-            }
-        }
-    }
-
-    @AfterClass
-    static final void printFailedTests(ITestContext context) {
+    @AfterAll
+    static final void printFailedTests() {
         out.println("\n=========================");
         try {
             // Exceptions should already have been added to FAILURES
@@ -193,7 +194,7 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         }
     }
 
-    private String[] uris() {
+    private static String[] uris() {
         return new String[] {
                 httpURI_fixed,
                 httpURI_chunk,
@@ -206,8 +207,7 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         };
     }
 
-    @DataProvider(name = "sanity")
-    public Object[][] sanity() {
+    public static Object[][] sanity() {
         String[] uris = uris();
         Object[][] result = new Object[uris.length * 2][];
         //Object[][] result = new Object[uris.length][];
@@ -238,7 +238,7 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         }
     }
 
-    private Object[][] variants(List<Thrower> throwers, Set<Where> whereValues) {
+    private static Object[][] variants(List<Thrower> throwers, Set<Where> whereValues) {
         String[] uris = uris();
         Object[][] result = new Object[uris.length * 2 * throwers.size()][];
         //Object[][] result = new Object[(uris.length/2) * 2 * 2][];
@@ -257,80 +257,52 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         return result;
     }
 
-    @DataProvider(name = "subscribeProvider")
-    public Object[][] subscribeProvider(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            return new Object[0][];
-        }
+    public static Object[][] subscribeProvider() {
         return  variants(List.of(
                 new UncheckedCustomExceptionThrower(),
                 new UncheckedIOExceptionThrower()),
                 EnumSet.of(Where.BEFORE_SUBSCRIBE, Where.AFTER_SUBSCRIBE));
     }
 
-    @DataProvider(name = "requestProvider")
-    public Object[][] requestProvider(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            return new Object[0][];
-        }
+    public static Object[][] requestProvider() {
         return  variants(List.of(
                 new UncheckedCustomExceptionThrower(),
                 new UncheckedIOExceptionThrower()),
                 EnumSet.of(Where.BEFORE_REQUEST, Where.AFTER_REQUEST));
     }
 
-    @DataProvider(name = "nextRequestProvider")
-    public Object[][] nextRequestProvider(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            return new Object[0][];
-        }
+    public static Object[][] nextRequestProvider() {
         return  variants(List.of(
                 new UncheckedCustomExceptionThrower(),
                 new UncheckedIOExceptionThrower()),
                 EnumSet.of(Where.BEFORE_NEXT_REQUEST, Where.AFTER_NEXT_REQUEST));
     }
 
-    @DataProvider(name = "beforeCancelProviderIO")
-    public Object[][] beforeCancelProviderIO(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            return new Object[0][];
-        }
+    public static Object[][] beforeCancelProviderIO() {
         return  variants(List.of(
                 new UncheckedIOExceptionThrower()),
                 EnumSet.of(Where.BEFORE_CANCEL));
     }
 
-    @DataProvider(name = "afterCancelProviderIO")
-    public Object[][] afterCancelProviderIO(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            return new Object[0][];
-        }
+    public static Object[][] afterCancelProviderIO() {
         return  variants(List.of(
                 new UncheckedIOExceptionThrower()),
                 EnumSet.of(Where.AFTER_CANCEL));
     }
 
-    @DataProvider(name = "beforeCancelProviderCustom")
-    public Object[][] beforeCancelProviderCustom(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            return new Object[0][];
-        }
+    public static Object[][] beforeCancelProviderCustom() {
         return  variants(List.of(
                 new UncheckedCustomExceptionThrower()),
                 EnumSet.of(Where.BEFORE_CANCEL));
     }
 
-    @DataProvider(name = "afterCancelProviderCustom")
-    public Object[][] afterCancelProvider(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            return new Object[0][];
-        }
+    public static Object[][] afterCancelProviderCustom() {
         return  variants(List.of(
                 new UncheckedCustomExceptionThrower()),
                 EnumSet.of(Where.AFTER_CANCEL));
     }
 
-    private HttpClient makeNewClient() {
+    private static HttpClient makeNewClient() {
         clientCount.incrementAndGet();
         return TRACKER.track(HttpClient.newBuilder()
                 .proxy(HttpClient.Builder.NO_PROXY)
@@ -339,11 +311,11 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
                 .build());
     }
 
-    HttpClient newHttpClient(boolean share) {
+    static HttpClient newHttpClient(boolean share) {
         if (!share) return makeNewClient();
         HttpClient shared = sharedClient;
         if (shared != null) return shared;
-        synchronized (this) {
+        synchronized (AbstractThrowingPublishers.class) {
             shared = sharedClient;
             if (shared == null) {
                 shared = sharedClient = makeNewClient();
@@ -387,7 +359,7 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
             CompletableFuture<HttpResponse<String>> response = client.sendAsync(req, handler);
 
             String body = response.join().body();
-            assertEquals(body, Stream.of(BODY.split("\\|")).collect(Collectors.joining()));
+            assertEquals(Stream.of(BODY.split("\\|")).collect(Collectors.joining()), body);
             if (!sameClient) {
                 // Wait for the client to be garbage collected.
                 // we use the ReferenceTracker API rather than HttpClient::close here,
@@ -431,7 +403,6 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
                                     boolean async, Set<Where> whereValues)
             throws Exception
     {
-        checkSkip();
         out.printf("%n%s%s%n", now(), name);
         try {
             testThrowing(uri, sameClient, publishers, finisher, thrower, async, whereValues);
@@ -721,8 +692,11 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
     }
 
 
-    @BeforeTest
-    public void setup() throws Exception {
+    @BeforeAll
+    public static void setup() throws Exception {
+        System.out.println(now() + "setup");
+        System.err.println(now() + "setup");
+
         sslContext = new SimpleSSLContext().get();
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
@@ -765,8 +739,11 @@ public abstract class AbstractThrowingPublishers implements HttpServerAdapters {
         https2TestServer.start();
     }
 
-    @AfterTest
-    public void teardown() throws Exception {
+    @AfterAll
+    public static void teardown() throws Exception {
+        System.out.println(now() + "teardown");
+        System.err.println(now() + "teardown");
+
         String sharedClientName =
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;

--- a/test/jdk/java/net/httpclient/ThrowingPublishersCustomAfterCancel.java
+++ b/test/jdk/java/net/httpclient/ThrowingPublishersCustomAfterCancel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,18 +29,20 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPublishers ThrowingPublishersCustomAfterCancel
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.enableAllMethodRetry=true
  *                     ThrowingPublishersCustomAfterCancel
  */
 
-import org.testng.annotations.Test;
 
 import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPublishersCustomAfterCancel extends AbstractThrowingPublishers {
 
-    @Test(dataProvider = "afterCancelProviderCustom")
+    @ParameterizedTest
+    @MethodSource("afterCancelProviderCustom")
     public void testThrowingAsString(String uri, boolean sameClient,
                                             Thrower thrower, Set<Where> whereValues)
             throws Exception

--- a/test/jdk/java/net/httpclient/ThrowingPublishersCustomBeforeCancel.java
+++ b/test/jdk/java/net/httpclient/ThrowingPublishersCustomBeforeCancel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,18 +29,20 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPublishers ThrowingPublishersCustomBeforeCancel
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.enableAllMethodRetry=true
  *                     ThrowingPublishersCustomBeforeCancel
  */
 
-import org.testng.annotations.Test;
 
 import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPublishersCustomBeforeCancel extends AbstractThrowingPublishers {
 
-    @Test(dataProvider = "beforeCancelProviderCustom")
+    @ParameterizedTest
+    @MethodSource("beforeCancelProviderCustom")
     public void testThrowingAsString(String uri, boolean sameClient,
                                             Thrower thrower, Set<Where> whereValues)
             throws Exception

--- a/test/jdk/java/net/httpclient/ThrowingPublishersIOAfterCancel.java
+++ b/test/jdk/java/net/httpclient/ThrowingPublishersIOAfterCancel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,18 +29,20 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPublishers ThrowingPublishersIOAfterCancel
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.enableAllMethodRetry=true
  *                     ThrowingPublishersIOAfterCancel
  */
 
-import org.testng.annotations.Test;
 
 import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPublishersIOAfterCancel extends AbstractThrowingPublishers {
 
-    @Test(dataProvider = "afterCancelProviderIO")
+    @ParameterizedTest
+    @MethodSource("afterCancelProviderIO")
     public void testThrowingAsString(String uri, boolean sameClient,
                                             Thrower thrower, Set<Where> whereValues)
             throws Exception

--- a/test/jdk/java/net/httpclient/ThrowingPublishersIOBeforeCancel.java
+++ b/test/jdk/java/net/httpclient/ThrowingPublishersIOBeforeCancel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,18 +29,20 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPublishers ThrowingPublishersIOBeforeCancel
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.enableAllMethodRetry=true
  *                     ThrowingPublishersIOBeforeCancel
  */
 
-import org.testng.annotations.Test;
 
 import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPublishersIOBeforeCancel extends AbstractThrowingPublishers {
 
-    @Test(dataProvider = "beforeCancelProviderIO")
+    @ParameterizedTest
+    @MethodSource("beforeCancelProviderIO")
     public void testThrowingAsString(String uri, boolean sameClient,
                                             Thrower thrower, Set<Where> whereValues)
             throws Exception

--- a/test/jdk/java/net/httpclient/ThrowingPublishersInNextRequest.java
+++ b/test/jdk/java/net/httpclient/ThrowingPublishersInNextRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,18 +29,20 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPublishers ThrowingPublishersInNextRequest
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.enableAllMethodRetry=true
  *                     ThrowingPublishersInNextRequest
  */
 
-import org.testng.annotations.Test;
 
 import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPublishersInNextRequest extends AbstractThrowingPublishers {
 
-    @Test(dataProvider = "nextRequestProvider")
+    @ParameterizedTest
+    @MethodSource("nextRequestProvider")
     public void testThrowingAsString(String uri, boolean sameClient,
                                             Thrower thrower, Set<Where> whereValues)
             throws Exception

--- a/test/jdk/java/net/httpclient/ThrowingPublishersInRequest.java
+++ b/test/jdk/java/net/httpclient/ThrowingPublishersInRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,18 +29,20 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPublishers ThrowingPublishersInRequest
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.enableAllMethodRetry=true
  *                     ThrowingPublishersInRequest
  */
 
-import org.testng.annotations.Test;
 
 import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPublishersInRequest extends AbstractThrowingPublishers {
 
-    @Test(dataProvider = "requestProvider")
+    @ParameterizedTest
+    @MethodSource("requestProvider")
     public void testThrowingAsString(String uri, boolean sameClient,
                                             Thrower thrower, Set<Where> whereValues)
             throws Exception

--- a/test/jdk/java/net/httpclient/ThrowingPublishersInSubscribe.java
+++ b/test/jdk/java/net/httpclient/ThrowingPublishersInSubscribe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,18 +29,20 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPublishers ThrowingPublishersInSubscribe
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.enableAllMethodRetry=true
  *                     ThrowingPublishersInSubscribe
  */
 
-import org.testng.annotations.Test;
 
 import java.util.Set;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPublishersInSubscribe extends AbstractThrowingPublishers {
 
-    @Test(dataProvider = "subscribeProvider")
+    @ParameterizedTest
+    @MethodSource("subscribeProvider")
     public void testThrowingAsString(String uri, boolean sameClient,
                                             Thrower thrower, Set<Where> whereValues)
             throws Exception

--- a/test/jdk/java/net/httpclient/ThrowingPublishersSanity.java
+++ b/test/jdk/java/net/httpclient/ThrowingPublishersSanity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,16 +29,18 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker AbstractThrowingPublishers ThrowingPublishersSanity
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true
  *                     -Djdk.httpclient.enableAllMethodRetry=true
  *                     ThrowingPublishersSanity
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingPublishersSanity extends AbstractThrowingPublishers {
 
-    @Test(dataProvider = "sanity")
+    @ParameterizedTest
+    @MethodSource("sanity")
     public void testSanity(String uri, boolean sameClient)
             throws Exception {
         super.testSanityImpl(uri,sameClient);


### PR DESCRIPTION
Backporting JDK-8373796: Refactor java/net/httpclient/ThrowingPublishers*.java tests to use JUnit5.

This PR migrates the ThrowingPublishers test family (8 tests + abstract base) from TestNG to JUnit 5, converting data providers to @MethodSource, instance state to static, and the stop-after-first-failure mechanism to a JUnit TestWatcher/BeforeEachCallback extension.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/net/httpclient/ThrowingPublishersCustomAfterCancel.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingPublishersCustomBeforeCancel.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingPublishersIOAfterCancel.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingPublishersIOBeforeCancel.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingPublishersInNextRequest.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingPublishersInRequest.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingPublishersInSubscribe.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingPublishersSanity.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28552070/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/28552071/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/28552072/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/28552073/windows-x64-specific-4-test.log)
[windows-x64-specific-5-test.log](https://github.com/user-attachments/files/28552074/windows-x64-specific-5-test.log)
[windows-x64-specific-6-test.log](https://github.com/user-attachments/files/28552075/windows-x64-specific-6-test.log)
[windows-x64-specific-7-test.log](https://github.com/user-attachments/files/28552077/windows-x64-specific-7-test.log)
[windows-x64-specific-8-test.log](https://github.com/user-attachments/files/28552078/windows-x64-specific-8-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28552079/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/28552080/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/28552081/linux-x64-specific-3-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/28552082/linux-x64-specific-4-test.log)
[linux-x64-specific-5-test.log](https://github.com/user-attachments/files/28552083/linux-x64-specific-5-test.log)
[linux-x64-specific-6-test.log](https://github.com/user-attachments/files/28552084/linux-x64-specific-6-test.log)
[linux-x64-specific-7-test.log](https://github.com/user-attachments/files/28552086/linux-x64-specific-7-test.log)
[linux-x64-specific-8-test.log](https://github.com/user-attachments/files/28552088/linux-x64-specific-8-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28552089/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28552090/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/28552091/linux-aarch64-specific-3-test.log)
[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/28552092/linux-aarch64-specific-4-test.log)
[linux-aarch64-specific-5-test.log](https://github.com/user-attachments/files/28552093/linux-aarch64-specific-5-test.log)
[linux-aarch64-specific-6-test.log](https://github.com/user-attachments/files/28552094/linux-aarch64-specific-6-test.log)
[linux-aarch64-specific-7-test.log](https://github.com/user-attachments/files/28552095/linux-aarch64-specific-7-test.log)
[linux-aarch64-specific-8-test.log](https://github.com/user-attachments/files/28552097/linux-aarch64-specific-8-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28552130/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28552131/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/28552132/macos-aarch64-specific-3-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/28552134/macos-aarch64-specific-4-test.log)
[macos-aarch64-specific-5-test.log](https://github.com/user-attachments/files/28552135/macos-aarch64-specific-5-test.log)
[macos-aarch64-specific-6-test.log](https://github.com/user-attachments/files/28552136/macos-aarch64-specific-6-test.log)
[macos-aarch64-specific-7-test.log](https://github.com/user-attachments/files/28552137/macos-aarch64-specific-7-test.log)
[macos-aarch64-specific-8-test.log](https://github.com/user-attachments/files/28552139/macos-aarch64-specific-8-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8373796](https://bugs.openjdk.org/browse/JDK-8373796) needs maintainer approval

### Issue
 * [JDK-8373796](https://bugs.openjdk.org/browse/JDK-8373796): Refactor java/net/httpclient/ThrowingPublishers*.java tests to use JUnit5 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4496/head:pull/4496` \
`$ git checkout pull/4496`

Update a local copy of the PR: \
`$ git checkout pull/4496` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4496`

View PR using the GUI difftool: \
`$ git pr show -t 4496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4496.diff">https://git.openjdk.org/jdk17u-dev/pull/4496.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4496#issuecomment-4612630733)
</details>
