### PR TITLE
8373866: Refactor java/net/httpclient/ThrowingSubscribers*.java tests to use JUnit5

### DIFF
--- a/test/jdk/java/net/httpclient/AbstractThrowingSubscribers.java
+++ b/test/jdk/java/net/httpclient/AbstractThrowingSubscribers.java
@@ -22,14 +22,6 @@
  */
 
 import jdk.test.lib.net.SimpleSSLContext;
-import org.testng.ITestContext;
-import org.testng.ITestResult;
-import org.testng.SkipException;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.DataProvider;
 
 import javax.net.ssl.SSLContext;
 import java.io.BufferedReader;
@@ -47,7 +39,6 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -71,24 +62,33 @@ import static java.lang.String.format;
 import static java.net.http.HttpClient.Version.HTTP_1_1;
 import static java.net.http.HttpClient.Version.HTTP_2;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.AfterAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.TestWatcher;
 
 public abstract class AbstractThrowingSubscribers implements HttpServerAdapters {
 
-    SSLContext sslContext;
-    HttpTestServer httpTestServer;    // HTTP/1.1    [ 4 servers ]
-    HttpTestServer httpsTestServer;   // HTTPS/1.1
-    HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
-    HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
-    String httpURI_fixed;
-    String httpURI_chunk;
-    String httpsURI_fixed;
-    String httpsURI_chunk;
-    String http2URI_fixed;
-    String http2URI_chunk;
-    String https2URI_fixed;
-    String https2URI_chunk;
+    static SSLContext sslContext;
+    static HttpTestServer httpTestServer;    // HTTP/1.1    [ 4 servers ]
+    static HttpTestServer httpsTestServer;   // HTTPS/1.1
+    static HttpTestServer http2TestServer;   // HTTP/2 ( h2c )
+    static HttpTestServer https2TestServer;  // HTTP/2 ( h2  )
+    static String httpURI_fixed;
+    static String httpURI_chunk;
+    static String httpsURI_fixed;
+    static String httpsURI_chunk;
+    static String http2URI_fixed;
+    static String http2URI_chunk;
+    static String https2URI_fixed;
+    static String https2URI_chunk;
 
     static final int ITERATION_COUNT = 1;
     static final int REPEAT_RESPONSE = 3;
@@ -107,8 +107,34 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         return String.format("[%d s, %d ms, %d ns] ", secs, mill, nan);
     }
 
-    final ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
-    private volatile HttpClient sharedClient;
+    static final class TestStopper implements TestWatcher, BeforeEachCallback {
+        final AtomicReference<String> failed = new AtomicReference<>();
+        TestStopper() { }
+        @Override
+        public void testFailed(ExtensionContext context, Throwable cause) {
+            if (stopAfterFirstFailure()) {
+                String msg = "Aborting due to: " + cause;
+                failed.compareAndSet(null, msg);
+                FAILURES.putIfAbsent(context.getDisplayName(), cause);
+                System.out.printf("%nTEST FAILED: %s%s%n\tAborting due to %s%n%n",
+                        now(), context.getDisplayName(), cause);
+                System.err.printf("%nTEST FAILED: %s%s%n\tAborting due to %s%n%n",
+                        now(), context.getDisplayName(), cause);
+            }
+        }
+
+        @Override
+        public void beforeEach(ExtensionContext context) {
+            String msg = failed.get();
+            Assumptions.assumeTrue(msg == null, msg);
+        }
+    }
+
+    @RegisterExtension
+    static final TestStopper stopper = new TestStopper();
+
+    static final ReferenceTracker TRACKER = ReferenceTracker.INSTANCE;
+    private static volatile HttpClient sharedClient;
 
     static class TestExecutor implements Executor {
         final AtomicLong tasks = new AtomicLong();
@@ -134,34 +160,12 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         }
     }
 
-    protected boolean stopAfterFirstFailure() {
+    protected static boolean stopAfterFirstFailure() {
         return Boolean.getBoolean("jdk.internal.httpclient.debug");
     }
 
-    final AtomicReference<SkipException> skiptests = new AtomicReference<>();
-    void checkSkip() {
-        var skip = skiptests.get();
-        if (skip != null) throw skip;
-    }
-    static String name(ITestResult result) {
-        var params = result.getParameters();
-        return result.getName()
-                + (params == null ? "()" : Arrays.toString(result.getParameters()));
-    }
-
-    @BeforeMethod
-    void beforeMethod(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            if (skiptests.get() == null) {
-                SkipException skip = new SkipException("some tests failed");
-                skip.setStackTrace(new StackTraceElement[0]);
-                skiptests.compareAndSet(null, skip);
-            }
-        }
-    }
-
-    @AfterClass
-    static final void printFailedTests(ITestContext context) {
+    @AfterAll
+    static final void printFailedTests() {
         out.println("\n=========================");
         try {
             // Exceptions should already have been added to FAILURES
@@ -186,7 +190,7 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         }
     }
 
-    private String[] uris() {
+    private static String[] uris() {
         return new String[] {
                 httpURI_fixed,
                 httpURI_chunk,
@@ -199,10 +203,9 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         };
     }
 
-    static AtomicLong URICOUNT = new AtomicLong();
+    static final AtomicLong URICOUNT = new AtomicLong();
 
-    @DataProvider(name = "sanity")
-    public Object[][] sanity() {
+    public static Object[][] sanity() {
         String[] uris = uris();
         Object[][] result = new Object[uris.length * 2][];
         int i = 0;
@@ -215,11 +218,7 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         return result;
     }
 
-    @DataProvider(name = "variants")
-    public Object[][] variants(ITestContext context) {
-        if (stopAfterFirstFailure() && context.getFailedTests().size() > 0) {
-            return new Object[0][];
-        }
+    public static Object[][] variants() {
         String[] uris = uris();
         Object[][] result = new Object[uris.length * 2 * 2][];
         int i = 0;
@@ -236,7 +235,7 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         return result;
     }
 
-    private HttpClient makeNewClient() {
+    private static HttpClient makeNewClient() {
         clientCount.incrementAndGet();
         HttpClient client =  HttpClient.newBuilder()
                 .proxy(HttpClient.Builder.NO_PROXY)
@@ -246,11 +245,11 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         return TRACKER.track(client);
     }
 
-    HttpClient newHttpClient(boolean share) {
+    static HttpClient newHttpClient(boolean share) {
         if (!share) return makeNewClient();
         HttpClient shared = sharedClient;
         if (shared != null) return shared;
-        synchronized (this) {
+        synchronized (AbstractThrowingSubscribers.class) {
             shared = sharedClient;
             if (shared == null) {
                 shared = sharedClient = makeNewClient();
@@ -307,7 +306,7 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
             HttpResponse<String> response = client.send(req, handler);
             String body = response.body();
             Stream.of(body.split("\n")).forEach(u ->
-                assertEquals(URI.create(u).getPath(), URI.create(uri2).getPath()));
+                assertEquals(URI.create(uri2).getPath(), URI.create(u).getPath()));
             if (!sameClient) {
                 // Wait for the client to be garbage collected.
                 // we use the ReferenceTracker API rather than HttpClient::close here,
@@ -419,7 +418,6 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
                                     boolean async, EnumSet<Where> excludes)
             throws Exception
     {
-        checkSkip();
         out.printf("%n%s%s%n", now(), name);
         try {
             testThrowing(uri, sameClient, handlers, finisher, thrower, async, excludes);
@@ -498,7 +496,6 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
                 if (error != null) throw error;
                 System.out.println(now() + "operation finished normally: " + tracker.getName());
                 System.err.println(now() + "operation finished normally: " + tracker.getName());
-
             }
         }
     }
@@ -758,8 +755,11 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
     }
 
 
-    @BeforeTest
-    public void setup() throws Exception {
+    @BeforeAll
+    public static void setup() throws Exception {
+        System.out.println(now() + "setup");
+        System.err.println(now() + "setup");
+
         sslContext = new SimpleSSLContext().get();
         if (sslContext == null)
             throw new AssertionError("Unexpected null sslContext");
@@ -802,8 +802,11 @@ public abstract class AbstractThrowingSubscribers implements HttpServerAdapters 
         https2TestServer.start();
     }
 
-    @AfterTest
-    public void teardown() throws Exception {
+    @AfterAll
+    public static void teardown() throws Exception {
+        System.out.println(now() + "teardown");
+        System.err.println(now() + "teardown");
+
         String sharedClientName =
                 sharedClient == null ? null : sharedClient.toString();
         sharedClient = null;

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStream.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsInputStream AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsInputStream
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsInputStream
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsInputStream extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsInputStream(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsInputStreamImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStreamAsync.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStreamAsync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsInputStreamAsync AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsInputStreamAsync
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsInputStreamAsync
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsInputStreamAsync extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsInputStreamAsync(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsInputStreamAsyncImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsLines.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsLines.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsLines AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLines
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLines
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsLines extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsLines(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsLinesImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsLinesAsync.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsLinesAsync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsLinesAsync AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLinesAsync
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsLinesAsync
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsLinesAsync extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsLinesAsync(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsLinesAsyncImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsString.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsString AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsString
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsString
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsString extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsString(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsStringImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersAsStringAsync.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersAsStringAsync.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersAsStringAsync AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsStringAsync
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersAsStringAsync
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersAsStringAsync extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "variants")
+    @ParameterizedTest
+    @MethodSource("variants")
     public void testThrowingAsStringAsync(String uri, boolean sameClient, Thrower thrower)
             throws Exception {
         super.testThrowingAsStringAsyncImpl(uri, sameClient, thrower);

--- a/test/jdk/java/net/httpclient/ThrowingSubscribersSanity.java
+++ b/test/jdk/java/net/httpclient/ThrowingSubscribersSanity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @build jdk.test.lib.net.SimpleSSLContext
  *        ReferenceTracker ThrowingSubscribersSanity AbstractThrowingSubscribers
  *        jdk.httpclient.test.lib.common.HttpServerAdapters
- * @run testng/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersSanity
+ * @run junit/othervm -Djdk.internal.httpclient.debug=true ThrowingSubscribersSanity
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ThrowingSubscribersSanity extends AbstractThrowingSubscribers {
 
-    @Test(dataProvider = "sanity")
+    @ParameterizedTest
+    @MethodSource("sanity")
     public void testSanity(String uri, boolean sameClient)
             throws Exception {
         super.testSanityImpl(uri, sameClient);


### PR DESCRIPTION
Backporting JDK-8373866: Refactor java/net/httpclient/ThrowingSubscribers*.java tests to use JUnit5.

This PR migrates the ThrowingSubscribers test suite from TestNG to JUnit 5.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStream.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingSubscribersAsInputStreamAsync.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingSubscribersAsLines.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingSubscribersAsLinesAsync.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingSubscribersAsString.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingSubscribersAsStringAsync.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"
make test TEST=test/jdk/java/net/httpclient/ThrowingSubscribersSanity.java JTREG="OPTIONS=-e:LC_ALL=en_US.UTF-8"

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28552208/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28552209/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/28552210/macos-aarch64-specific-3-test.log)
[macos-aarch64-specific-4-test.log](https://github.com/user-attachments/files/28552212/macos-aarch64-specific-4-test.log)
[macos-aarch64-specific-5-test.log](https://github.com/user-attachments/files/28552214/macos-aarch64-specific-5-test.log)
[macos-aarch64-specific-6-test.log](https://github.com/user-attachments/files/28552215/macos-aarch64-specific-6-test.log)
[macos-aarch64-specific-7-test.log](https://github.com/user-attachments/files/28552216/macos-aarch64-specific-7-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/28552294/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/28552295/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/28552297/windows-x64-specific-3-test.log)
[windows-x64-specific-4-test.log](https://github.com/user-attachments/files/28552298/windows-x64-specific-4-test.log)
[windows-x64-specific-5-test.log](https://github.com/user-attachments/files/28552299/windows-x64-specific-5-test.log)
[windows-x64-specific-6-test.log](https://github.com/user-attachments/files/28552301/windows-x64-specific-6-test.log)
[windows-x64-specific-7-test.log](https://github.com/user-attachments/files/28552303/windows-x64-specific-7-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28552305/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/28552306/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/28552311/linux-x64-specific-3-test.log)
[linux-x64-specific-4-test.log](https://github.com/user-attachments/files/28552312/linux-x64-specific-4-test.log)
[linux-x64-specific-5-test.log](https://github.com/user-attachments/files/28552313/linux-x64-specific-5-test.log)
[linux-x64-specific-6-test.log](https://github.com/user-attachments/files/28552315/linux-x64-specific-6-test.log)
[linux-x64-specific-7-test.log](https://github.com/user-attachments/files/28552317/linux-x64-specific-7-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28552318/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28552319/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/28552320/linux-aarch64-specific-3-test.log)
[linux-aarch64-specific-4-test.log](https://github.com/user-attachments/files/28552321/linux-aarch64-specific-4-test.log)
[linux-aarch64-specific-5-test.log](https://github.com/user-attachments/files/28552324/linux-aarch64-specific-5-test.log)
[linux-aarch64-specific-6-test.log](https://github.com/user-attachments/files/28552325/linux-aarch64-specific-6-test.log)
[linux-aarch64-specific-7-test.log](https://github.com/user-attachments/files/28552326/linux-aarch64-specific-7-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8373866](https://bugs.openjdk.org/browse/JDK-8373866) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8373866](https://bugs.openjdk.org/browse/JDK-8373866): Refactor java/net/httpclient/ThrowingSubscribers*.java tests to use JUnit5 (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4497/head:pull/4497` \
`$ git checkout pull/4497`

Update a local copy of the PR: \
`$ git checkout pull/4497` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4497`

View PR using the GUI difftool: \
`$ git pr show -t 4497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4497.diff">https://git.openjdk.org/jdk17u-dev/pull/4497.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4497#issuecomment-4612632700)
</details>
