### PR TITLE
8305714: Add an extra test for JDK-8292755

### DIFF
--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8292755
+ * @summary InternalError seen while throwing undefined exception
+ * @modules
+ *     jdk.compiler/com.sun.tools.javac.api
+ *     jdk.compiler/com.sun.tools.javac.main
+ *     jdk.jshell/jdk.internal.jshell.tool:open
+ *     jdk.jshell/jdk.internal.jshell.tool.resources:open
+ *     jdk.jshell/jdk.jshell:open
+ * @library /tools/lib
+ * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
+ * @build Compiler UITesting
+ * @build UndefinedClassTest
+ * @run testng UndefinedClassTest
+ */
+
+import org.testng.annotations.Test;
+
+@Test
+public class UndefinedClassTest extends UITesting {
+
+    public UndefinedClassTest() {
+        super(true);
+    }
+
+    public void testUndefinedClassWithStaticAccess() throws Exception{
+        String code = "@FunctionalInterface\n" +
+                "interface RunnableWithThrowable {\n" +
+                " void run() throws Throwable;\n" +
+                "\n" +
+                " static RunnableWithThrowable getInstance() {\n" +
+                " return () -> { throw new NotExist(); };\n" +
+                " }\n" +
+                "}";
+        doRunTest((inputSink, out) -> {
+            inputSink.write(code + "\n");
+            waitOutput(out, "NotExist");
+        });
+    }
+
+    public void testUndefinedClassWithDefaultAccess() throws Exception{
+        String code = "@FunctionalInterface\n" +
+                "interface RunnableWithThrowable {\n" +
+                " void run() throws Throwable;\n" +
+                "\n" +
+                " default RunnableWithThrowable getInstance() {\n" +
+                " return () -> { throw new NotExist(); };\n" +
+                " }\n" +
+                "}";
+        doRunTest((inputSink, out) -> {
+            inputSink.write(code + "\n");
+            waitOutput(out, "NotExist");
+        });
+    }
+}


### PR DESCRIPTION
Backporting JDK-8305714: Add an extra test for JDK-8292755.

This PR adds a test for undefined classes in Java JShell.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/langtools/jdk/jshell/UndefinedClassTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28597444/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28597445/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28597446/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28597447/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8305714](https://bugs.openjdk.org/browse/JDK-8305714) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8305714](https://bugs.openjdk.org/browse/JDK-8305714): Add an extra test for JDK-8292755 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4500/head:pull/4500` \
`$ git checkout pull/4500`

Update a local copy of the PR: \
`$ git checkout pull/4500` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4500`

View PR using the GUI difftool: \
`$ git pr show -t 4500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4500.diff">https://git.openjdk.org/jdk17u-dev/pull/4500.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4500#issuecomment-4622521733)
</details>
