### PR TITLE
8360562: sun/security/tools/keytool/i18n.java add an ability to add comment for failures

### DIFF
--- a/test/jdk/sun/security/tools/keytool/i18n.java
+++ b/test/jdk/sun/security/tools/keytool/i18n.java
@@ -63,10 +63,20 @@
 
 import jdk.test.lib.UIBuilder;
 
-import javax.swing.*;
+import javax.swing.JDialog;
+import javax.swing.SwingUtilities;
+import javax.swing.JTextArea;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JFrame;
+import java.awt.FlowLayout;
+import java.awt.BorderLayout;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Locale;
+
+import static javax.swing.BorderFactory.createEmptyBorder;
 
 public class i18n {
     private static final String[][] TABLE = new String[][]{
@@ -238,11 +248,12 @@ public class i18n {
                     "Output in ${LANG}. Check keytool error: java.lang"
                             + ".IllegalArgumentException: if -protected is "
                             + "specified, then -storepass, -keypass, and -new "
-                            + "must not be specified."},
+                            + "must not be specified."}
     };
     private static String TEST_SRC = System.getProperty("test.src");
     private static int TIMEOUT_MS = 120000;
     private volatile boolean failed = false;
+    private volatile String failureReason = "";
     private volatile boolean aborted = false;
     private Thread currentThread = null;
 
@@ -334,6 +345,7 @@ public class i18n {
 
             if (failed) {
                 System.out.println(command + ": TEST FAILED");
+                System.out.println("REASON: " + failureReason);
                 System.out.println(message);
             } else {
                 System.out.println(command + ": TEST PASSED");
@@ -352,11 +364,41 @@ public class i18n {
 
     public void fail() {
         failed = true;
+        failureReason = requestFailDescription();
         currentThread.interrupt();
     }
 
     public void abort() {
         aborted = true;
         currentThread.interrupt();
+    }
+
+    /**
+     * Opens a prompt to enter a failure reason to be filled by the tester
+     */
+     public static String requestFailDescription() {
+
+        final JDialog dialogWindow = new JDialog(new JFrame(), "Failure Description", true);
+        final JTextArea reasonTextArea = new JTextArea(5, 20);
+
+        final JButton okButton = new JButton("OK");
+        okButton.addActionListener(e -> dialogWindow.setVisible(false));
+
+        final JPanel okayBtnPanel = new JPanel(
+                new FlowLayout(FlowLayout.CENTER, 4, 0));
+        okayBtnPanel.setBorder(createEmptyBorder(4, 0, 0, 0));
+        okayBtnPanel.add(okButton);
+
+        final JPanel mainPanel = new JPanel(new BorderLayout());
+        mainPanel.add(new JScrollPane(reasonTextArea), BorderLayout.CENTER);
+        mainPanel.add(okayBtnPanel, BorderLayout.SOUTH);
+
+        dialogWindow.add(mainPanel);
+        dialogWindow.pack();
+        dialogWindow.setVisible(true);
+
+        dialogWindow.dispose();
+
+        return reasonTextArea.getText();
     }
 }


### PR DESCRIPTION
Backporting JDK-8360562: sun/security/tools/keytool/i18n.java add an ability to add comment for failures.

This PR adds failure comment capability to sun/security/tools/keytool/i18n.java to enable faster verification and reporting.

For parity with Oracle JDK. Already backported to 21.

Ran related test macos-aarch64:

```~/github/jtreg/build/images/jtreg/bin/jtreg -jdk build/macosx-aarch64-server-release/images/jdk -vmoption:-Duser.language=en -m test/jdk/sun/security/tools/keytool/i18n.java```

As expected, when "fail" is selected, the input dialog is shown to capture the "reason" (failure comment).

Screenshots:

<img width="1230" height="521" alt="Screenshot 2026-06-04 at 7 51 50 AM" src="https://github.com/user-attachments/assets/c4e073e2-1372-43d5-85d6-7cf50edee217" />

Results:

The "reason" for the fail is recorded on the logs.

```
----------System.out:(52/3539)----------
-help: TEST FAILED 
REASON: This is a sample fail description. Java 17.
```

[i18n_id0.jtr.txt](https://github.com/user-attachments/files/28601198/i18n_id0.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8360562](https://bugs.openjdk.org/browse/JDK-8360562) needs maintainer approval

### Issue
 * [JDK-8360562](https://bugs.openjdk.org/browse/JDK-8360562): sun/security/tools/keytool/i18n.java add an ability to add comment for failures (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4501/head:pull/4501` \
`$ git checkout pull/4501`

Update a local copy of the PR: \
`$ git checkout pull/4501` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4501`

View PR using the GUI difftool: \
`$ git pr show -t 4501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4501.diff">https://git.openjdk.org/jdk17u-dev/pull/4501.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4501#issuecomment-4623386736)
</details>
