### PR TITLE
8360395: sun/security/tools/keytool/i18n.java user country is current user location instead of the language

### DIFF
--- a/test/jdk/sun/security/tools/keytool/i18n.java
+++ b/test/jdk/sun/security/tools/keytool/i18n.java
@@ -28,7 +28,7 @@
  * @author charlie lai
  * @modules java.base/sun.security.tools.keytool
  * @library /test/lib
- * @run main/manual/othervm -Duser.language=en i18n
+ * @run main/manual/othervm -Duser.language=en -Duser.country=USA i18n
  */
 
 /*
@@ -38,7 +38,7 @@
  * @author charlie lai
  * @modules java.base/sun.security.tools.keytool
  * @library /test/lib
- * @run main/manual/othervm -Duser.language=de i18n
+ * @run main/manual/othervm -Duser.language=de -Duser.country=DE i18n
  */
 
 /*
@@ -48,7 +48,7 @@
  * @author charlie lai
  * @modules java.base/sun.security.tools.keytool
  * @library /test/lib
- * @run main/manual/othervm -Duser.language=ja i18n
+ * @run main/manual/othervm -Duser.language=ja -Duser.country=JP i18n
  */
 
 /*


### PR DESCRIPTION
Backporting JDK-8360395: sun/security/tools/keytool/i18n.java user country is current user location instead of the language.

This PR makes the "i18n.java" test use the language location instead of the machines current location.

For parity with Oracle JDK. Already backported to 21.

Ran manual test on macos-aarch64 (Passed):

```~/github/jtreg/build/images/jtreg/bin/jtreg -jdk build/macosx-aarch64-server-release/images/jdk -m test/jdk/sun/security/tools/keytool/i18n.java```

Screenshot:

<img width="1213" height="506" alt="Screenshot 2026-06-04 at 7 59 08 AM" src="https://github.com/user-attachments/assets/4ef6ccfe-4f9a-4e37-bfeb-448824d35c0f" />

Results:

```
sun/security/tools/keytool/i18n.java#id0  Passed. Execution successful
sun/security/tools/keytool/i18n.java#id1  Passed. Execution successful
sun/security/tools/keytool/i18n.java#id2  Passed. Execution successful
sun/security/tools/keytool/i18n.java#id3  Passed. Execution successful
```

[summary.txt](https://github.com/user-attachments/files/28601415/summary.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8360395](https://bugs.openjdk.org/browse/JDK-8360395) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8360395](https://bugs.openjdk.org/browse/JDK-8360395): sun/security/tools/keytool/i18n.java user country is current user location instead of the language (**Enhancement** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4502/head:pull/4502` \
`$ git checkout pull/4502`

Update a local copy of the PR: \
`$ git checkout pull/4502` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4502`

View PR using the GUI difftool: \
`$ git pr show -t 4502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4502.diff">https://git.openjdk.org/jdk17u-dev/pull/4502.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4502#issuecomment-4623459719)
</details>
