### PR TITLE
8366182: Some PKCS11Tests are being skipped when they shouldn't

### DIFF
--- a/test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
@@ -320,14 +320,19 @@ public class TestKATForGCM extends PKCS11Test {
                 System.out.println("Test Passed!");
             }
         } catch (Exception e) {
-            System.out.println("Exception occured using " + p.getName() + " version " + p.getVersionStr());
+            System.out.println("Exception occured using " + p.getName()
+                    + " version " + p.getVersionStr());
 
             if (isNSS(p)) {
-                double ver = getNSSInfo("nss");
+                Version ver = getNSSInfo("nss");
                 String osName = System.getProperty("os.name");
-                if (ver > 3.139 && ver < 3.15 && osName.equals("Linux")) {
+
+                if (osName.equals("Linux") &&
+                        ver.major() == 3 && ver.minor() < 15
+                        && (ver.minor() > 13 && ver.patch() >= 9)) {
                     // warn about buggy behaviour on Linux with nss 3.14
-                    System.out.println("Warning: old NSS " + ver + " might be problematic, consider upgrading it");
+                    System.out.println("Warning: old NSS " + ver
+                            + " might be problematic, consider upgrading it");
                 }
             }
             throw e;

--- a/test/jdk/sun/security/pkcs11/KeyStore/SecretKeysBasic.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/SecretKeysBasic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,11 +116,14 @@ public class SecretKeysBasic extends PKCS11Test {
         // A bug in NSS 3.12 (Mozilla bug 471665) causes AES key lengths
         // to be read incorrectly.  Checking for improper 16 byte length
         // in key string.
-        if (isNSS(provider) && expected.getAlgorithm().equals("AES") &&
-                (getNSSVersion() >= 3.12 && getNSSVersion() <= 3.122)) {
-            System.out.println("NSS 3.12 bug returns incorrect AES key "+
-                    "length breaking key storage. Aborting...");
-            return true;
+        if (isNSS(provider) && expected.getAlgorithm().equals("AES")) {
+            Version version = getNSSVersion();
+            if (version.major() == 3 && version.minor() == 12
+                    && version.patch() <= 2) {
+                System.out.println("NSS 3.12 bug returns incorrect AES key " +
+                        "length breaking key storage. Aborting...");
+                return true;
+            }
         }
 
         if (saveBeforeCheck) {
@@ -168,7 +171,7 @@ public class SecretKeysBasic extends PKCS11Test {
     private static void doTest() throws Exception {
         // Make sure both NSS libraries are the same version.
         if (isNSS(provider) &&
-                (getLibsoftokn3Version() != getLibnss3Version())) {
+                (!getLibsoftokn3Version().equals(getLibnss3Version()))) {
             System.out.println("libsoftokn3 and libnss3 versions do not match.  Aborting test...");
             return;
         }

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -80,7 +80,7 @@ public abstract class PKCS11Test {
     private static final String NSS_BUNDLE_VERSION = "3.111";
     private static final String NSSLIB = "jpg.tests.jdk.nsslib";
 
-    static double nss_version = -1;
+    static Version nss_version = null;
     static ECCState nss_ecc_status = ECCState.Basic;
 
     // The NSS library we need to search for in getNSSLibDir()
@@ -90,8 +90,8 @@ public abstract class PKCS11Test {
 
     // NSS versions of each library.  It is simpler to keep nss_version
     // for quick checking for generic testing than many if-else statements.
-    static double softoken3_version = -1;
-    static double nss3_version = -1;
+    static Version softoken3_version = null;
+    static Version nss3_version = null;
     static Provider pkcs11 = newPKCS11Provider();
     private static String PKCS11_BASE;
     private static Map<String, String[]> osMap;
@@ -266,13 +266,29 @@ public abstract class PKCS11Test {
     }
 
     static boolean isBadNSSVersion(Provider p) {
-        double nssVersion = getNSSVersion();
-        if (isNSS(p) && nssVersion >= 3.11 && nssVersion < 3.12) {
-            System.out.println("NSS 3.11 has a DER issue that recent " +
-                    "version do not, skipping");
-            return true;
+        Version nssVersion = getNSSVersion();
+        if (isNSS(p)) {
+            // bad version is just between [3.11,3.12)
+            return nssVersion.major == 3 && 11 == nssVersion.minor;
+        } else {
+            return false;
         }
-        return false;
+    }
+
+    public record Version(int major, int minor, int patch) {}
+
+    protected static Version parseVersionString(String version) {
+        String [] parts = version.split("\\.");
+        int major = Integer.parseInt(parts[0]);
+        int minor = 0;
+        int patch = 0;
+        if (parts.length >= 2) {
+            minor = Integer.parseInt(parts[1]);
+        }
+        if (parts.length >= 3) {
+            patch = Integer.parseInt(parts[2]);
+        }
+        return new Version(major, minor, patch);
     }
 
     protected static void safeReload(String lib) {
@@ -301,26 +317,26 @@ public abstract class PKCS11Test {
         return p.getName().equalsIgnoreCase("SUNPKCS11-NSS");
     }
 
-    static double getNSSVersion() {
-        if (nss_version == -1)
+    static Version getNSSVersion() {
+        if (nss_version == null)
             getNSSInfo();
         return nss_version;
     }
 
     static ECCState getNSSECC() {
-        if (nss_version == -1)
+        if (nss_version == null)
             getNSSInfo();
         return nss_ecc_status;
     }
 
-    public static double getLibsoftokn3Version() {
-        if (softoken3_version == -1)
+    public static Version getLibsoftokn3Version() {
+        if (softoken3_version == null)
             return getNSSInfo("softokn3");
         return softoken3_version;
     }
 
-    public static double getLibnss3Version() {
-        if (nss3_version == -1)
+    public static Version getLibnss3Version() {
+        if (nss3_version == null)
             return getNSSInfo("nss3");
         return nss3_version;
     }
@@ -335,7 +351,7 @@ public abstract class PKCS11Test {
     // $Header: NSS <version>
     // Version: NSS <version>
     // Here, <version> stands for NSS version.
-    static double getNSSInfo(String library) {
+    static Version getNSSInfo(String library) {
         // look for two types of headers in NSS libraries
         String nssHeader1 = "$Header: NSS";
         String nssHeader2 = "Version: NSS";
@@ -344,15 +360,15 @@ public abstract class PKCS11Test {
         int i = 0;
         Path libfile = null;
 
-        if (library.compareTo("softokn3") == 0 && softoken3_version > -1)
+        if (library.compareTo("softokn3") == 0 && softoken3_version != null)
             return softoken3_version;
-        if (library.compareTo("nss3") == 0 && nss3_version > -1)
+        if (library.compareTo("nss3") == 0 && nss3_version != null)
             return nss3_version;
 
         try {
             libfile = getNSSLibPath();
             if (libfile == null) {
-                return 0.0;
+                return parseVersionString("0.0");
             }
             try (InputStream is = Files.newInputStream(libfile)) {
                 byte[] data = new byte[1000];
@@ -388,7 +404,7 @@ public abstract class PKCS11Test {
         if (!found) {
             System.out.println("lib" + library +
                     " version not found, set to 0.0: " + libfile);
-            nss_version = 0.0;
+            nss_version = parseVersionString("0.0");
             return nss_version;
         }
 
@@ -401,26 +417,7 @@ public abstract class PKCS11Test {
             version.append(c);
         }
 
-        // If a "dot dot" release, strip the extra dots for double parsing
-        String[] dot = version.toString().split("\\.");
-        if (dot.length > 2) {
-            version = new StringBuilder(dot[0] + "." + dot[1]);
-            for (int j = 2; dot.length > j; j++) {
-                version.append(dot[j]);
-            }
-        }
-
-        // Convert to double for easier version value checking
-        try {
-            nss_version = Double.parseDouble(version.toString());
-        } catch (NumberFormatException e) {
-            System.out.println("===== Content start =====");
-            System.out.println(s);
-            System.out.println("===== Content end =====");
-            System.out.println("Failed to parse lib" + library +
-                    " version. Set to 0.0");
-            e.printStackTrace();
-        }
+        nss_version = parseVersionString(version.toString());
 
         System.out.print("library: " + library + ", version: " + version + ".  ");
 

--- a/test/jdk/sun/security/pkcs11/Secmod/AddTrustedCert.java
+++ b/test/jdk/sun/security/pkcs11/Secmod/AddTrustedCert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,10 +131,10 @@ public class AddTrustedCert extends SecmodTest {
     }
 
     private static boolean improperNSSVersion(Provider p) {
-        double nssVersion = getNSSVersion();
-        if (p.getName().equalsIgnoreCase("SunPKCS11-NSSKeyStore")
-                && nssVersion >= 3.28 && nssVersion < 3.35) {
-            return true;
+        Version nssVersion = getNSSVersion();
+        if (p.getName().equalsIgnoreCase("SunPKCS11-NSSKeyStore")) {
+            return nssVersion.major() == 3 &&
+                    (nssVersion.minor() >= 28 && nssVersion.minor() < 35);
         }
 
         return false;

--- a/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
+++ b/test/jdk/sun/security/pkcs11/Signature/TestDSAKeyLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,13 +48,15 @@ public class TestDSAKeyLength extends PKCS11Test {
 
     @Override
     protected boolean skipTest(Provider provider) {
-        double version = getNSSVersion();
-        String[] versionStrs = Double.toString(version).split("\\.");
-        int major = Integer.parseInt(versionStrs[0]);
-        int minor = Integer.parseInt(versionStrs[1]);
-        if (isNSS(provider) && (version == 0.0 || (major >= 3 && minor >= 14))) {
-            System.out.println("Skip testing NSS " + version);
-            return true;
+        if (isNSS(provider)) {
+            Version version = getNSSVersion();
+            if (version == null) {
+                return true;
+            }
+            if (version.major() >= 3 && version.minor() >= 14){
+                System.out.println("Skip testing NSS " + version);
+                return true;
+            }
         }
 
         return false;

--- a/test/jdk/sun/security/pkcs11/ec/TestECDH.java
+++ b/test/jdk/sun/security/pkcs11/ec/TestECDH.java
@@ -112,6 +112,7 @@ public class TestECDH extends PKCS11Test {
          * PKCS11Test.main will remove this provider if needed
          */
         Providers.setAt(p, 1);
+        System.out.println("Testing provider " + p.getName());
 
         if (false) {
             KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", p);


### PR DESCRIPTION
Backporting JDK-8366182: Some PKCS11Tests are being skipped when they shouldn't.

For parity with Oracle JDK. The commit fixes PKCS11 tests to correctly parse NSS version numbers by comparing major and minor versions separately instead of treating them as doubles, which incorrectly ordered versions like 3.111 between 3.11 and 3.12.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/sun/security/pkcs11

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28640006/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28640007/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28640008/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28640009/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8366182](https://bugs.openjdk.org/browse/JDK-8366182) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8366182](https://bugs.openjdk.org/browse/JDK-8366182): Some PKCS11Tests are being skipped when they shouldn't (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4503/head:pull/4503` \
`$ git checkout pull/4503`

Update a local copy of the PR: \
`$ git checkout pull/4503` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4503`

View PR using the GUI difftool: \
`$ git pr show -t 4503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4503.diff">https://git.openjdk.org/jdk17u-dev/pull/4503.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4503#issuecomment-4631887890)
</details>
