### PR TITLE
8365861: test/jdk/sun/security/pkcs11/Provider/ tests skipped without SkippedException

### DIFF
--- a/test/jdk/sun/security/pkcs11/Provider/Absolute.java
+++ b/test/jdk/sun/security/pkcs11/Provider/Absolute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@
  * @summary load DLLs and launch executables using fully qualified path
  */
 
+import jtreg.SkippedException;
+
 import java.security.InvalidParameterException;
 import java.security.Provider;
 
@@ -40,12 +42,11 @@ public class Absolute {
         try {
             Provider p = PKCS11Test.getSunPKCS11(config);
             if (p == null) {
-                System.out.println("Skipping test - no PKCS11 provider available");
+                throw new SkippedException("Skipping test - no PKCS11 provider available");
             }
         } catch (InvalidParameterException ipe) {
             Throwable ex = ipe.getCause();
-            if (ex.getMessage().indexOf(
-                    "Absolute path required for library value:") != -1) {
+            if (ex.getMessage().contains("Absolute path required for library value:")) {
                 System.out.println("Test Passed: expected exception thrown");
             } else {
                 // rethrow

--- a/test/jdk/sun/security/pkcs11/Provider/ConfigShortPath.java
+++ b/test/jdk/sun/security/pkcs11/Provider/ConfigShortPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,17 @@
  * @bug 6581254 6986789 7196009 8062170
  * @summary Allow '~', '+', and quoted paths in config file
  * @author Valerie Peng
+ * @library /test/lib
  */
 
-import java.security.*;
-import java.io.*;
-import java.lang.reflect.*;
+import jtreg.SkippedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.security.Provider;
+import java.security.ProviderException;
+import java.security.Security;
 
 public class ConfigShortPath {
 
@@ -43,8 +49,7 @@ public class ConfigShortPath {
     public static void main(String[] args) throws Exception {
         Provider p = Security.getProvider("SunPKCS11");
         if (p == null) {
-            System.out.println("Skipping test - no PKCS11 provider available");
-            return;
+            throw new SkippedException("Skipping test - no PKCS11 provider available");
         }
 
         String osInfo = System.getProperty("os.name", "");
@@ -65,7 +70,7 @@ public class ConfigShortPath {
                 if (cause.getClass().getName().equals
                         ("sun.security.pkcs11.ConfigurationException")) {
                     // Error occurred during parsing
-                    if (cause.getMessage().indexOf("Unexpected") != -1) {
+                    if (cause.getMessage().contains("Unexpected")) {
                         throw (ProviderException) cause;
                     }
                 }

--- a/test/jdk/sun/security/pkcs11/Provider/LoginISE.java
+++ b/test/jdk/sun/security/pkcs11/Provider/LoginISE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,16 +21,22 @@
  * questions.
  */
 
-import java.io.*;
-import java.util.*;
-import java.security.*;
-import javax.security.auth.callback.*;
+import jtreg.SkippedException;
+
+import java.io.IOException;
+import java.security.AuthProvider;
+import java.security.Provider;
+import java.security.Security;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
 
 /**
  * @test
  * @bug 8130648
  * @summary make sure IllegalStateException is thrown for uninitialized
  * SunPKCS11 provider instance
+ * @library /test/lib
  */
 public class LoginISE {
 
@@ -38,8 +44,7 @@ public class LoginISE {
 
         Provider p = Security.getProvider("SunPKCS11");
         if (p == null) {
-            System.out.println("No un-initialized PKCS11 provider available; skip");
-            return;
+            throw new SkippedException("No un-initialized PKCS11 provider available; skip");
         }
         if (!(p instanceof AuthProvider)) {
             throw new RuntimeException("Error: expect AuthProvider!");


### PR DESCRIPTION
Backporting JDK-8365861: test/jdk/sun/security/pkcs11/Provider/ tests skipped without SkippedException.

This PR fixes three PKCS11 provider tests that were being skipped without properly throwing SkippedException.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/sun/security/pkcs11/Provider

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28709975/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28709977/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28709978/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28709979/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8365861](https://bugs.openjdk.org/browse/JDK-8365861) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8365861](https://bugs.openjdk.org/browse/JDK-8365861): test/jdk/sun/security/pkcs11/Provider/ tests skipped without SkippedException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4505/head:pull/4505` \
`$ git checkout pull/4505`

Update a local copy of the PR: \
`$ git checkout pull/4505` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4505`

View PR using the GUI difftool: \
`$ git pr show -t 4505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4505.diff">https://git.openjdk.org/jdk17u-dev/pull/4505.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4505#issuecomment-4649644278)
</details>
