### PR TITLE
8373832: Test java/lang/invoke/TestVHInvokerCaching.java tests nothing

### DIFF
--- a/test/jdk/java/lang/invoke/TestVHInvokerCaching.java
+++ b/test/jdk/java/lang/invoke/TestVHInvokerCaching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.lang.invoke.MethodHandles.lookup;
-import static org.testng.Assert.assertSame;
+import static org.testng.Assert.*;
 
 public class TestVHInvokerCaching {
 
@@ -74,13 +74,15 @@ public class TestVHInvokerCaching {
 
         MethodHandles.Lookup lookup = lookup();
 
-        for (Field field : Holder.class.getFields()) {
+        for (Field field : Holder.class.getDeclaredFields()) {
             String fieldName = field.getName();
             Class<?> fieldType = field.getType();
 
             testHandles.add(MethodHandles.arrayElementVarHandle(fieldType.arrayType()));
             testHandles.add(lookup.findVarHandle(Holder.class, fieldName, fieldType));
         }
+
+        assertFalse(testHandles.isEmpty());
 
         return testHandles.stream().map(vh -> new Object[]{ vh }).toArray(Object[][]::new);
     }


### PR DESCRIPTION
Backporting JDK-8373832: Test java/lang/invoke/TestVHInvokerCaching.java tests nothing.

This PR fixes a test bug where getFields() is incorrectly used to discover package-private fields. Since getFields() only returns public fields, no VarHandle was actually being tested, causing a newly added assertFalse to fail.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/lang/invoke/TestVHInvokerCaching.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28756070/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28756072/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28756073/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28756074/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8373832](https://bugs.openjdk.org/browse/JDK-8373832) needs maintainer approval

### Issue
 * [JDK-8373832](https://bugs.openjdk.org/browse/JDK-8373832): Test java/lang/invoke/TestVHInvokerCaching.java tests nothing (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4506/head:pull/4506` \
`$ git checkout pull/4506`

Update a local copy of the PR: \
`$ git checkout pull/4506` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4506`

View PR using the GUI difftool: \
`$ git pr show -t 4506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4506.diff">https://git.openjdk.org/jdk17u-dev/pull/4506.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4506#issuecomment-4660071222)
</details>
