### PR TITLE
8278102: containers/docker/TestJcmd.java failed with "RuntimeException: Could not find specified process"

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestJcmd.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmd.java
@@ -168,13 +168,9 @@ public class TestJcmd {
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/:z")
             .addJavaOpts("-cp", "/test-classes/")
             .addDockerOpts("--cap-add=SYS_PTRACE")
+            .addDockerOpts("--pull=never")
             .addDockerOpts("--name", CONTAINER_NAME)
             .addClassOptions("" + TIME_TO_RUN_CONTAINER_PROCESS);
-
-        if (IS_PODMAN) {
-            // map the current userid to the one in the target namespace
-            opts.addDockerOpts("--userns=keep-id");
-        }
 
         // avoid large Xmx
         opts.appendTestJavaOptions = false;
@@ -184,7 +180,7 @@ public class TestJcmd {
         return ProcessTools.startProcess("main-container-process",
                                       pb,
                                       line -> line.contains(EventGeneratorLoop.MAIN_METHOD_STARTED),
-                                      5, TimeUnit.SECONDS);
+                                      15, TimeUnit.SECONDS);
     }
 
 


### PR DESCRIPTION
Backporting JDK-8278102: containers/docker/TestJcmd.java failed with "RuntimeException: Could not find specified process".

This PR re-enables the TestJcmd.java Docker container test (previously disabled via ProblemList for bug 8278102) by fixing its reliability issues.

This PR is not clean due to a conflict in the problem list (no change needed) and a trivial difference (root user check) in a section that was deleted as part of this PR.

For parity with Oracle JDK. Already backported to 21.

Ran related test on linux-x64:

```sudo ../jtreg/build/images/jtreg/bin/jtreg -jdk:build/linux-x86_64-server-release/images/jdk -Drequires.container.support=true test/hotspot/jtreg/containers/docker/TestJcmd.java```

Results:

```test result: Passed. Execution successful```

[TestJcmd.jtr.txt](https://github.com/user-attachments/files/28761559/TestJcmd.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8278102](https://bugs.openjdk.org/browse/JDK-8278102) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8278102](https://bugs.openjdk.org/browse/JDK-8278102): containers/docker/TestJcmd.java failed with "RuntimeException: Could not find specified process" (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4507/head:pull/4507` \
`$ git checkout pull/4507`

Update a local copy of the PR: \
`$ git checkout pull/4507` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4507`

View PR using the GUI difftool: \
`$ git pr show -t 4507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4507.diff">https://git.openjdk.org/jdk17u-dev/pull/4507.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4507#issuecomment-4661395846)
</details>
