### PR TITLE
8320192: SHAKE256 does not work correctly if n >= 137

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SHA3.java
+++ b/src/java.base/share/classes/sun/security/provider/SHA3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,15 @@ abstract class SHA3 extends DigestBase {
             throw new ProviderException("Incorrect pad size: " + numOfPadding);
         }
         implCompress(buffer, 0);
-        System.arraycopy(state, 0, out, ofs, engineGetDigestLength());
+        int availableBytes = buffer.length;
+        int numBytes = engineGetDigestLength();
+        while (numBytes > availableBytes) {
+            System.arraycopy(state, 0, out, ofs, availableBytes);
+            numBytes -= availableBytes;
+            ofs += availableBytes;
+            keccak();
+        }
+        System.arraycopy(state, 0, out, ofs, numBytes);
     }
 
     /**
@@ -253,7 +261,7 @@ abstract class SHA3 extends DigestBase {
 
     /**
      * The function Keccak as defined in section 5.2 with
-     * rate r = 1600 and capacity c = (digest length x 2).
+     * rate r = 1600 and capacity c.
      */
     private void keccak() {
         // convert the 200-byte state into 25 lanes


### PR DESCRIPTION
Backporting JDK-8320192: SHAKE256 does not work correctly if n >= 137.

This PR fixes the SHA-3 squeeze function to correctly produce digests longer than the block size.

For parity with Oracle JDK. Already backported to 21.

Please note that this PR is not clean due to a trivial conflict in the copyright header.

Ran related tests on macos-aarch64:

make test TEST=test/jdk/java/security
make test TEST=test/jdk/sun/security/provider

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28800248/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28800249/macos-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8320192](https://bugs.openjdk.org/browse/JDK-8320192) needs maintainer approval

### Issue
 * [JDK-8320192](https://bugs.openjdk.org/browse/JDK-8320192): SHAKE256 does not work correctly if n &gt;= 137 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4509/head:pull/4509` \
`$ git checkout pull/4509`

Update a local copy of the PR: \
`$ git checkout pull/4509` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4509`

View PR using the GUI difftool: \
`$ git pr show -t 4509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4509.diff">https://git.openjdk.org/jdk17u-dev/pull/4509.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4509#issuecomment-4671647018)
</details>
