### PR TITLE
8279954: java/lang/StringBuffer(StringBuilder)/HugeCapacity.java intermittently fails

### DIFF
--- a/test/jdk/java/lang/StringBuffer/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuffer/HugeCapacity.java
@@ -26,8 +26,8 @@
  * @bug 8218227
  * @summary StringBuilder/StringBuffer constructor throws confusing
  *          NegativeArraySizeException
- * @requires (sun.arch.data.model == "64" & os.maxMemory >= 6G)
- * @run main/othervm -Xms5G -Xmx5G HugeCapacity
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 8G)
+ * @run main/othervm -Xms6G -Xmx6G HugeCapacity
  */
 
 public class HugeCapacity {

--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -26,9 +26,9 @@
  * @bug 8149330 8218227
  * @summary Capacity should not get close to Integer.MAX_VALUE unless
  *          necessary
- * @requires (sun.arch.data.model == "64" & os.maxMemory >= 6G)
- * @run main/othervm -Xms5G -Xmx5G -XX:+CompactStrings HugeCapacity true
- * @run main/othervm -Xms5G -Xmx5G -XX:-CompactStrings HugeCapacity false
+ * @requires (sun.arch.data.model == "64" & os.maxMemory >= 8G)
+ * @run main/othervm -Xms6G -Xmx6G -XX:+CompactStrings HugeCapacity true
+ * @run main/othervm -Xms6G -Xmx6G -XX:-CompactStrings HugeCapacity false
  */
 
 public class HugeCapacity {


### PR DESCRIPTION
Backporting JDK-8279954: java/lang/StringBuffer(StringBuilder)/HugeCapacity.java intermittently fails.

This PR increases heap memory requirements for StringBuffer/StringBuilder HugeCapacity tests.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/lang/StringBuffer/HugeCapacity.java
make test TEST=test/jdk/java/lang/StringBuilder/HugeCapacity.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/28849915/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/28849916/windows-x64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/28849917/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28849919/macos-aarch64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/28849920/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/28849921/linux-aarch64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/28849922/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/28849923/linux-x64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8279954](https://bugs.openjdk.org/browse/JDK-8279954) needs maintainer approval

### Issue
 * [JDK-8279954](https://bugs.openjdk.org/browse/JDK-8279954): java/lang/StringBuffer(StringBuilder)/HugeCapacity.java intermittently fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4511/head:pull/4511` \
`$ git checkout pull/4511`

Update a local copy of the PR: \
`$ git checkout pull/4511` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4511`

View PR using the GUI difftool: \
`$ git pr show -t 4511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4511.diff">https://git.openjdk.org/jdk17u-dev/pull/4511.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4511#issuecomment-4673512729)
</details>
