### PR TITLE
8374886: CAInterop.java#microsoftrsa2017 test fails as EE certificate does not specify OCSP responder

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -290,9 +290,8 @@
  * @summary Interoperability tests with Microsoft TLS root CAs
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop microsoftrsa2017 OCSP
- * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftrsa2017 OCSP
- * @run main/othervm/manual -Djava.security.debug=certpath CAInterop microsoftrsa2017 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop microsoftrsa2017 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftrsa2017 DEFAULT
  */
 
 /*


### PR DESCRIPTION
Backporting JDK-8374886: CAInterop.java#microsoftrsa2017 test fails as EE certificate does not specify OCSP responder.

This PR updates CAInterop.java#microsoftrsa2017 to use DEFAULT mode instead of OCPS or CRL only.

For parity with Oracle JDK. Already backported to 21.

Ran related test on macos-aarch64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk -m test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#microsoftrsa2017```

Results:

```test result: Passed. Execution successful```

[CAInterop_microsoftrsa2017.jtr.txt](https://github.com/user-attachments/files/28808907/CAInterop_microsoftrsa2017.jtr.txt)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8374886](https://bugs.openjdk.org/browse/JDK-8374886) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8374886](https://bugs.openjdk.org/browse/JDK-8374886): CAInterop.java#microsoftrsa2017 test fails as EE certificate does not specify OCSP responder (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4513/head:pull/4513` \
`$ git checkout pull/4513`

Update a local copy of the PR: \
`$ git checkout pull/4513` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4513`

View PR using the GUI difftool: \
`$ git pr show -t 4513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4513.diff">https://git.openjdk.org/jdk17u-dev/pull/4513.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4513#issuecomment-4673742103)
</details>
