### PR TITLE
8267617: Certificate's IP x509 NameConstraints raises ArrayIndexOutOfBoundsException

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/IPAddressName.java
+++ b/src/java.base/share/classes/sun/security/x509/IPAddressName.java
@@ -404,11 +404,12 @@ public class IPAddressName implements GeneralNameInterface {
         else {
             IPAddressName otherName = (IPAddressName)inputName;
             byte[] otherAddress = otherName.address;
-            if (otherAddress.length == 4 && address.length == 4)
+            if ((otherAddress.length == 4 && address.length == 4) ||
+                    (otherAddress.length == 16 && address.length == 16)) {
                 // Two host addresses
                 constraintType = NAME_SAME_TYPE;
-            else if ((otherAddress.length == 8 && address.length == 8) ||
-                     (otherAddress.length == 32 && address.length == 32)) {
+            } else if ((otherAddress.length == 8 && address.length == 8) ||
+                       (otherAddress.length == 32 && address.length == 32)) {
                 // Two subnet addresses
                 // See if one address fully encloses the other address
                 boolean otherSubsetOfThis = true;
@@ -443,7 +444,8 @@ public class IPAddressName implements GeneralNameInterface {
                     constraintType = NAME_WIDENS;
                 else
                     constraintType = NAME_SAME_TYPE;
-            } else if (otherAddress.length == 8 || otherAddress.length == 32) {
+            } else if ((otherAddress.length == 8 && address.length == 4) ||
+                       (otherAddress.length == 32 && address.length == 16)) {
                 //Other is a subnet, this is a host address
                 int i = 0;
                 int maskOffset = otherAddress.length/2;
@@ -457,7 +459,8 @@ public class IPAddressName implements GeneralNameInterface {
                     constraintType = NAME_WIDENS;
                 else
                     constraintType = NAME_SAME_TYPE;
-            } else if (address.length == 8 || address.length == 32) {
+            } else if ((otherAddress.length == 4 && address.length == 8) ||
+                       (otherAddress.length == 16 && address.length == 32)) {
                 //This is a subnet, other is a host address
                 int i = 0;
                 int maskOffset = address.length/2;

--- a/test/jdk/sun/security/x509/IPAddressName/ConstrainsTest.java
+++ b/test/jdk/sun/security/x509/IPAddressName/ConstrainsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import sun.security.x509.GeneralNameInterface;
+import sun.security.x509.IPAddressName;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+
+/*
+ * @test
+ * @summary Verify IPAddressName.constrains
+ * @bug 8267617
+ * @modules java.base/sun.security.x509
+ * @run testng ConstrainsTest
+ */
+public class ConstrainsTest {
+
+    IPAddressName ipv4Addr = new IPAddressName("127.0.0.1");
+    IPAddressName ipv4Mask = new IPAddressName("127.0.0.0/255.0.0.0");
+    IPAddressName ipv6Addr = new IPAddressName("::1");
+    IPAddressName ipv6Mask = new IPAddressName("::/0");
+
+    public ConstrainsTest() throws IOException {
+    }
+
+    @DataProvider(name = "names")
+    public Object[][] names() {
+        Object[][] data = {
+                {ipv4Addr, ipv4Addr, GeneralNameInterface.NAME_MATCH},
+                {ipv4Addr, ipv4Mask, GeneralNameInterface.NAME_WIDENS},
+                {ipv4Addr, ipv6Addr, GeneralNameInterface.NAME_SAME_TYPE},
+                {ipv4Addr, ipv6Mask, GeneralNameInterface.NAME_SAME_TYPE},
+                {ipv4Mask, ipv4Addr, GeneralNameInterface.NAME_NARROWS},
+                {ipv4Mask, ipv4Mask, GeneralNameInterface.NAME_MATCH},
+                {ipv4Mask, ipv6Addr, GeneralNameInterface.NAME_SAME_TYPE},
+                {ipv4Mask, ipv6Mask, GeneralNameInterface.NAME_SAME_TYPE},
+                {ipv6Addr, ipv4Addr, GeneralNameInterface.NAME_SAME_TYPE},
+                {ipv6Addr, ipv4Mask, GeneralNameInterface.NAME_SAME_TYPE},
+                {ipv6Addr, ipv6Addr, GeneralNameInterface.NAME_MATCH},
+                {ipv6Addr, ipv6Mask, GeneralNameInterface.NAME_WIDENS},
+                {ipv6Mask, ipv4Addr, GeneralNameInterface.NAME_SAME_TYPE},
+                {ipv6Mask, ipv4Mask, GeneralNameInterface.NAME_SAME_TYPE},
+                {ipv6Mask, ipv6Addr, GeneralNameInterface.NAME_NARROWS},
+                {ipv6Mask, ipv6Mask, GeneralNameInterface.NAME_MATCH},
+        };
+        return data;
+    }
+
+    @Test(dataProvider = "names")
+    public void testNameContains(IPAddressName addr1, IPAddressName addr2, int result) throws IOException {
+        assertEquals(addr1.constrains(addr2), result);
+    }
+
+}


### PR DESCRIPTION
I backport this for parity with 17.0.21-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8267617](https://bugs.openjdk.org/browse/JDK-8267617) needs maintainer approval

### Issue
 * [JDK-8267617](https://bugs.openjdk.org/browse/JDK-8267617): Certificate's IP x509 NameConstraints raises ArrayIndexOutOfBoundsException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4515/head:pull/4515` \
`$ git checkout pull/4515`

Update a local copy of the PR: \
`$ git checkout pull/4515` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4515`

View PR using the GUI difftool: \
`$ git pr show -t 4515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4515.diff">https://git.openjdk.org/jdk17u-dev/pull/4515.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4515#issuecomment-4682041331)
</details>
