### PR TITLE
8300399: EdDSA does not verify when there is no message

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSASignature.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ed/EdDSASignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -210,9 +210,7 @@ public class EdDSASignature extends SignatureSpi {
         if (publicKeyBytes == null) {
             throw new SignatureException("Missing publicKey");
         }
-        if (message == null) {
-            return false;
-        }
+        ensureMessageInit();
         boolean result = ops.verify(this.sigParams, this.publicKeyPoint,
             this.publicKeyBytes, message.getMessage(), sigBytes);
         message = null;

--- a/test/jdk/sun/security/ec/ed/EmptyMessage.java
+++ b/test/jdk/sun/security/ec/ed/EmptyMessage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8300399
+ * @summary EdDSA does not verify when there is no message
+ * @run main EmptyMessage
+ */
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.security.spec.NamedParameterSpec;
+
+public class EmptyMessage {
+    public static void main(String[] args) throws Exception {
+        var g = KeyPairGenerator.getInstance("EdDSA");
+        g.initialize(NamedParameterSpec.ED25519);
+        var kp = g.generateKeyPair();
+
+        var ss = Signature.getInstance("EdDSA");
+        ss.initSign(kp.getPrivate());
+        var sig = ss.sign();
+
+        var ps = Signature.getInstance("EdDSA");
+        ps.initVerify(kp.getPublic());
+        if (!ps.verify(sig)) {
+            throw new RuntimeException();
+        }
+    }
+}


### PR DESCRIPTION
I backport this for parity with 17.0.21-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8300399](https://bugs.openjdk.org/browse/JDK-8300399) needs maintainer approval

### Issue
 * [JDK-8300399](https://bugs.openjdk.org/browse/JDK-8300399): EdDSA does not verify when there is no message (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4516/head:pull/4516` \
`$ git checkout pull/4516`

Update a local copy of the PR: \
`$ git checkout pull/4516` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4516`

View PR using the GUI difftool: \
`$ git pr show -t 4516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4516.diff">https://git.openjdk.org/jdk17u-dev/pull/4516.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4516#issuecomment-4682090553)
</details>
