### PR TITLE
8374886: CAInterop.java#microsoftrsa2017 test fails as EE certificate does not specify OCSP responder

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -122,6 +122,10 @@ jobs:
             --add Microsoft.VisualStudio.Component.VC.${{ inputs.msvc-toolset-version }}.${{ inputs.msvc-toolset-architecture }}
         if: steps.toolchain-check.outputs.toolchain-installed != 'true'
 
+      - name: 'Fix make detection for newer MSYS2'
+        run: |
+          sed -i "s/MAKE_EXPECTED_ENV='msys'/MAKE_EXPECTED_ENV='msys\\\|cygwin'/" make/autoconf/basic_tools.m4
+
       - name: 'Configure'
         run: >
           bash configure

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -290,9 +290,8 @@
  * @summary Interoperability tests with Microsoft TLS root CAs
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop microsoftrsa2017 OCSP
- * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftrsa2017 OCSP
- * @run main/othervm/manual -Djava.security.debug=certpath CAInterop microsoftrsa2017 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop microsoftrsa2017 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftrsa2017 DEFAULT
  */
 
 /*


### PR DESCRIPTION
IGNORE THIS PR. THIS IS FOR INVESTIGATING A GHA ISSUE. DO NOT MERGE!

REVIEW/APPROVE THIS PR INSTEAD: https://github.com/openjdk/jdk17u-dev/pull/4513

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8374886](https://bugs.openjdk.org/browse/JDK-8374886) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8374886](https://bugs.openjdk.org/browse/JDK-8374886): CAInterop.java#microsoftrsa2017 test fails as EE certificate does not specify OCSP responder (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4517/head:pull/4517` \
`$ git checkout pull/4517`

Update a local copy of the PR: \
`$ git checkout pull/4517` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4517`

View PR using the GUI difftool: \
`$ git pr show -t 4517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4517.diff">https://git.openjdk.org/jdk17u-dev/pull/4517.diff</a>

</details>
