### PR TITLE
8386776: [17u] Test test/langtools/jdk/jshell/UndefinedClassTest.java  fails on JDK 17 with java.lang.ThreadDeath

### DIFF
--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -59,6 +59,7 @@ public class UndefinedClassTest extends UITesting {
         doRunTest((inputSink, out) -> {
             inputSink.write(code + "\n");
             waitOutput(out, "NotExist");
+            waitOutput(out, PROMPT);
         });
     }
 
@@ -74,6 +75,7 @@ public class UndefinedClassTest extends UITesting {
         doRunTest((inputSink, out) -> {
             inputSink.write(code + "\n");
             waitOutput(out, "NotExist");
+            waitOutput(out, PROMPT);
         });
     }
 }


### PR DESCRIPTION
The test fails because waitOutput(out, "NotExist") matches the input echo before JShell finishes compiling. The test exits early and Thread.stop() kills the compiler mid-flight. This doesn't manifest in JDK 20+ because of JDK-8289610.

This PR adds waitOutput(out, PROMPT) after matching "NotExist" in order to ensure that JShell has completed compilation.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/langtools/jdk/jshell/UndefinedClassTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29013557/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29013558/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29013559/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29013560/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8386776](https://bugs.openjdk.org/browse/JDK-8386776) needs maintainer approval

### Issue
 * [JDK-8386776](https://bugs.openjdk.org/browse/JDK-8386776): [17u] Test test/langtools/jdk/jshell/UndefinedClassTest.java  fails on JDK 17 with java.lang.ThreadDeath (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @tamstoreet6011-ops (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4520/head:pull/4520` \
`$ git checkout pull/4520`

Update a local copy of the PR: \
`$ git checkout pull/4520` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4520`

View PR using the GUI difftool: \
`$ git pr show -t 4520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4520.diff">https://git.openjdk.org/jdk17u-dev/pull/4520.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4520#issuecomment-4721088090)
</details>
