### PR TITLE
8378180: Compiling OpenJDK with C23 C-Compiler gives warning: initialization discards ‘const’ qualifier from pointer target type

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -936,7 +936,7 @@ static void
 SetMainModule(const char *s)
 {
     static const char format[] = "-Djdk.module.main=%s";
-    char* slash = JLI_StrChr(s, '/');
+    const char* slash = JLI_StrChr(s, '/');
     size_t s_len, def_len;
     char *def;
 

--- a/src/java.base/share/native/libjli/jli_util.c
+++ b/src/java.base/share/native/libjli/jli_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ JLI_MemFree(void *ptr)
 jboolean
 JLI_HasSuffix(const char *s1, const char *s2)
 {
-    char *p = JLI_StrRChr(s1, '.');
+    const char* p = JLI_StrRChr(s1, '.');
     if (p == NULL || *p == '\0') {
         return JNI_FALSE;
     }

--- a/src/java.base/share/native/libverify/check_code.c
+++ b/src/java.base/share/native/libverify/check_code.c
@@ -3833,7 +3833,7 @@ signature_to_fieldtype(context_type *context,
             case JVM_SIGNATURE_CLASS: {
                 char buffer_space[256];
                 char *buffer = buffer_space;
-                char *finish = strchr(p, JVM_SIGNATURE_ENDCLASS);
+                const char* finish = strchr(p, JVM_SIGNATURE_ENDCLASS);
                 int length;
                 if (finish == NULL) {
                     /* Signature must have ';' after the class name.

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ getZoneName(char *str)
 {
     static const char *zidir = "zoneinfo/";
 
-    char *pos = strstr((const char *)str, zidir);
+    char* pos = strstr(str, zidir);
     if (pos == NULL) {
         return NULL;
     }

--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,7 +204,7 @@ JNIEXPORT jobject JNICALL Java_java_net_NetworkInterface_getByName0
     netif *ifs, *curr;
     jboolean isCopy;
     const char* name_utf;
-    char *colonP;
+    const char* colonP;
     jobject obj = NULL;
 
     if (name != NULL) {

--- a/src/java.instrument/share/native/libinstrument/JPLISAgent.c
+++ b/src/java.instrument/share/native/libinstrument/JPLISAgent.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -772,7 +772,7 @@ getModuleObject(jvmtiEnv*               jvmti,
     jobject moduleObject = NULL;
 
     /* find last slash in the class name */
-    char* last_slash = (cname == NULL) ? NULL : strrchr(cname, '/');
+    const char* last_slash = (cname == NULL) ? NULL : strrchr(cname, '/');
     int len = (last_slash == NULL) ? 0 : (int)(last_slash - cname);
     char* pkg_name_buf = (char*)malloc(len + 1);
 

--- a/src/java.instrument/unix/native/libinstrument/FileSystemSupport_md.c
+++ b/src/java.instrument/unix/native/libinstrument/FileSystemSupport_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
 #define slash           '/'
 
 char* basePath(const char* path) {
-    char* last = strrchr(path, slash);
+    const char* last = strrchr(path, slash);
     if (last == NULL) {
         return (char*)path;
     } else {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,8 +90,8 @@ get_time_stamp(char *tbuf, size_t ltbuf)
 static const char *
 file_basename(const char *file)
 {
-    char *p1;
-    char *p2;
+    const char* p1;
+    const char* p2;
 
     if ( file==NULL )
         return "unknown";

--- a/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
+++ b/src/jdk.jpackage/linux/native/applauncher/LinuxPackage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,7 +109,7 @@ static PackageDesc* initPackageDesc(PackageDesc* desc, const char* str,
 #define POPEN_CALLBACK_USE 1
 #define POPEN_CALLBACK_IGNORE 0
 
-typedef int (*popenCallbackType)(void*, const char*);
+typedef int (*popenCallbackType)(void*, char*);
 
 static int popenCommand(const char* cmdlineFormat, const char* arg,
                             popenCallbackType callback, void* callbackData) {
@@ -220,13 +220,13 @@ static char* concat(const char *x, const char *y) {
 }
 
 
-static int initRpmPackage(void* desc, const char* str) {
+static int initRpmPackage(void* desc, char* str) {
     initPackageDesc((PackageDesc*)desc, str, PACKAGE_TYPE_RPM);
     return POPEN_CALLBACK_IGNORE;
 }
 
 
-static int initDebPackage(void* desc, const char* str) {
+static int initDebPackage(void* desc, char* str) {
     char* colonChrPos = strchr(str, ':');
     if (colonChrPos) {
         *colonChrPos = 0;
@@ -238,7 +238,7 @@ static int initDebPackage(void* desc, const char* str) {
 
 #define LAUNCHER_LIB_NAME "/libapplauncher.so"
 
-static int findLauncherLib(void* launcherLibPath, const char* str) {
+static int findLauncherLib(void* launcherLibPath, char* str) {
     char* buf = 0;
     const size_t strLen = strlen(str);
     const size_t launcherLibNameLen = strlen(LAUNCHER_LIB_NAME);


### PR DESCRIPTION
This is an unclean backport of of commit [548d07d3](https://github.com/openjdk/jdk-21u-dev/commit/548d07d313ba16e6d99cfdfcc37165be89c242dc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository (itslef a backport of [76a44b3e](https://github.com/openjdk/jdk/commit/76a44b3e0341a9c59eaff0bfe8884ad104bda8d5) from [openjdk/jdk](https://git.openjdk.org/jdk)).

The aim for this backport is to address compiler warnings that arise when attempting to build with with more recent version of gcc (16.1+).

The backport does not apply cleanly, because I had to omit the clean-up of an used variable  in `log_messages.c` that was introduced in jdk 20 as part of [JDK-8289768](https://bugs.openjdk.org/browse/JDK-8289768). 
I opted to not do a prior backport for JDK-8289768, as it touches quite a large number of files.

I have verified that with this patch, jdk17u-dev compiles without warning on Fedora 44 with gcc 16.1.1.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8378180](https://bugs.openjdk.org/browse/JDK-8378180) needs maintainer approval

### Issue
 * [JDK-8378180](https://bugs.openjdk.org/browse/JDK-8378180): Compiling OpenJDK with C23 C-Compiler gives warning: initialization discards ‘const’ qualifier from pointer target type (**Enhancement** - P3 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4522/head:pull/4522` \
`$ git checkout pull/4522`

Update a local copy of the PR: \
`$ git checkout pull/4522` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4522`

View PR using the GUI difftool: \
`$ git pr show -t 4522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4522.diff">https://git.openjdk.org/jdk17u-dev/pull/4522.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4522#issuecomment-4729474781)
</details>
