### PR TITLE
8345684: OperatingSystemMXBean.getSystemCpuLoad() throws NPE

### DIFF
--- a/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
+++ b/src/jdk.management/unix/classes/com/sun/management/internal/OperatingSystemImpl.java
@@ -282,8 +282,13 @@ class OperatingSystemImpl extends BaseOperatingSystemImpl
     }
 
     private boolean isCpuSetSameAsHostCpuSet() {
-        if (containerMetrics != null && containerMetrics.getCpuSetCpus() != null) {
-            return containerMetrics.getCpuSetCpus().length == getHostOnlineCpuCount0();
+        if (containerMetrics != null) {
+            // The return value may change (including from non-null to null) and
+            // the call may involve I/O, so keep the result in a local variable.
+            int[] cpuSetCpus = containerMetrics.getCpuSetCpus();
+            if (cpuSetCpus != null) {
+                return cpuSetCpus.length == getHostOnlineCpuCount0();
+            }
         }
         return false;
     }


### PR DESCRIPTION
I backport this for parity with 17.0.21-oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8345684](https://bugs.openjdk.org/browse/JDK-8345684) needs maintainer approval

### Issue
 * [JDK-8345684](https://bugs.openjdk.org/browse/JDK-8345684): OperatingSystemMXBean.getSystemCpuLoad() throws NPE (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4523/head:pull/4523` \
`$ git checkout pull/4523`

Update a local copy of the PR: \
`$ git checkout pull/4523` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4523`

View PR using the GUI difftool: \
`$ git pr show -t 4523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4523.diff">https://git.openjdk.org/jdk17u-dev/pull/4523.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4523#issuecomment-4728517167)
</details>
