### PR TITLE
8343342: java/io/File/GetXSpace.java fails on Windows with CD-ROM drive

### DIFF
--- a/test/jdk/java/io/File/GetXSpace.java
+++ b/test/jdk/java/io/File/GetXSpace.java
@@ -59,6 +59,8 @@ public class GetXSpace {
     private static SecurityManager [] sma = { null, new Allow(), new DenyFSA(),
                                               new DenyRead() };
 
+    private static final Pattern DF_PATTERN = Pattern.compile("([^\\s]+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+\\d+%\\s+([^\\s].*)\n");
+
     private static int fail = 0;
     private static int pass = 0;
     private static Throwable first;
@@ -109,8 +111,17 @@ public class GetXSpace {
         Space(String name) {
             this.name = name;
             long[] sizes = new long[4];
-            if (getSpace0(name, sizes))
-                System.err.println("WARNING: total space is estimated");
+            if (Platform.isWindows() & isCDDrive(name)) {
+                try {
+                    getCDDriveSpace(name, sizes);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    throw new RuntimeException("can't get CDDrive sizes");
+                }
+            } else {
+                if (getSpace0(name, sizes))
+                    System.err.println("WARNING: total space is estimated");
+            }
             this.size = sizes[0];
             this.total = sizes[1];
             this.free = sizes[2];
@@ -202,7 +213,8 @@ public class GetXSpace {
 
         out.format("%s (%d):%n", s.name(), s.size());
         String fmt = "  %-4s total = %12d free = %12d usable = %12d%n";
-        out.format(fmt, "getSpace0", s.total(), s.free(), s.available());
+        String method = Platform.isWindows() & isCDDrive(s.name()) ? "getCDDriveSpace" : "getSpace0";
+        out.format(fmt, method, s.total(), s.free(), s.available());
         out.format(fmt, "getXSpace", ts, fs, us);
 
         // If the file system can dynamically change size, this check will fail.
@@ -405,7 +417,7 @@ public class GetXSpace {
     private static int testVolumes() {
         out.println("--- Testing volumes");
         // Find all of the partitions on the machine and verify that the sizes
-        // returned by File::getXSpace are equivalent to those from getSpace0
+        // returned by File::getXSpace are equivalent to those from getSpace0 or getCDDriveSpace
         ArrayList<String> l;
         try {
             l = paths();
@@ -418,17 +430,17 @@ public class GetXSpace {
         if (l.size() == 0)
             throw new RuntimeException("no partitions?");
 
-        for (int i = 0; i < sma.length; i++) {
-            System.setSecurityManager(sma[i]);
-            SecurityManager sm = System.getSecurityManager();
-            if (sma[i] != null && sm == null)
-                throw new RuntimeException("Test configuration error "
-                                           + " - can't set security manager");
+        for (var p : l) {
+            Space s = new Space(p);
+            for (int i = 0; i < sma.length; i++) {
+                System.setSecurityManager(sma[i]);
+                SecurityManager sm = System.getSecurityManager();
+                if (sma[i] != null && sm == null)
+                    throw new RuntimeException("Test configuration error "
+                                            + " - can't set security manager");
 
-            out.format("%nSecurityManager = %s%n" ,
+                out.format("%nSecurityManager = %s%n" ,
                        (sm == null ? "null" : sm.getClass().getName()));
-            for (var p : l) {
-                Space s = new Space(p);
                 if (sm instanceof Deny) {
                     tryCatch(s);
                 } else {
@@ -437,9 +449,8 @@ public class GetXSpace {
                     compareZeroExist();
                 }
             }
+            System.setSecurityManager(null);
         }
-
-        System.setSecurityManager(null);
 
         if (fail != 0) {
             err.format("%d tests: %d failure(s); first: %s%n",
@@ -494,4 +505,40 @@ public class GetXSpace {
     // size[3]  usable space: number of bytes available to the caller
     //
     private static native boolean getSpace0(String root, long[] space);
+
+    private static native boolean isCDDrive(String root);
+
+    private static void getCDDriveSpace(String root, long[] sizes)
+        throws IOException {
+        String[] cmd = new String[] {"df", "-k", "-P", root};
+        Process p = Runtime.getRuntime().exec(cmd);
+        StringBuilder sb = new StringBuilder();
+
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+            String s;
+            int i = 0;
+            while ((s = in.readLine()) != null) {
+                // skip header
+                if (i++ == 0) continue;
+                sb.append(s).append("\n");
+            }
+        }
+        out.println(sb);
+
+        Matcher m = DF_PATTERN.matcher(sb);
+        int j = 0;
+        while (j < sb.length()) {
+            if (m.find(j)) {
+                sizes[0] = Long.parseLong(m.group(2)) * 1024;
+                sizes[1] = Long.parseLong(m.group(3)) * 1024;
+                sizes[2] = sizes[0] - sizes[1];
+                sizes[3] = Long.parseLong(m.group(4)) * 1024;
+                j = m.end();
+            } else {
+                throw new RuntimeException("unrecognized df output format: "
+                                           + "charAt(" + j + ") = '"
+                                           + sb.charAt(j) + "'");
+            }
+        }
+    }
 }

--- a/test/jdk/java/io/File/libGetXSpace.c
+++ b/test/jdk/java/io/File/libGetXSpace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,6 +158,33 @@ Java_GetXSpace_getSpace0
 #endif
     (*env)->SetLongArrayRegion(env, sizes, 0, 4, array);
     return totalSpaceIsEstimated;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_GetXSpace_isCDDrive
+    (JNIEnv *env, jclass cls, jstring root)
+{
+#ifdef WINDOWS
+    const jchar* strchars = (*env)->GetStringChars(env, root, NULL);
+    if (strchars == NULL) {
+        JNU_ThrowByNameWithLastError(env, "java/lang/RuntimeException",
+                                     "GetStringChars");
+        return JNI_FALSE;
+    }
+
+    LPCWSTR path = (LPCWSTR)strchars;
+    UINT driveType = GetDriveTypeW(path);
+
+    (*env)->ReleaseStringChars(env, root, strchars);
+
+    if (driveType != DRIVE_CDROM) {
+        return JNI_FALSE;
+    }
+
+    return JNI_TRUE;
+#else
+    return JNI_FALSE;
+#endif
 }
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Backporting JDK-8343342: java/io/File/GetXSpace.java fails on Windows with CD-ROM drive.

This PR improves the filesystem space checking logic for the test.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/io/File/GetXSpace.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29057747/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29057748/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29057749/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29057750/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8343342](https://bugs.openjdk.org/browse/JDK-8343342) needs maintainer approval

### Issue
 * [JDK-8343342](https://bugs.openjdk.org/browse/JDK-8343342): java/io/File/GetXSpace.java fails on Windows with CD-ROM drive (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4524/head:pull/4524` \
`$ git checkout pull/4524`

Update a local copy of the PR: \
`$ git checkout pull/4524` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4524`

View PR using the GUI difftool: \
`$ git pr show -t 4524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4524.diff">https://git.openjdk.org/jdk17u-dev/pull/4524.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4524#issuecomment-4731168474)
</details>
