### PR TITLE
8349959: Test CR6740048.java passes unexpectedly missing CR6740048.xsd

### DIFF
--- a/test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,11 +62,9 @@ public class CR6740048 {
             DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
             docBuilderFactory.setNamespaceAware(true);
 
-            if (xsd != null) {
-                docBuilderFactory.setValidating(true);
-                docBuilderFactory.setAttribute(SCHEMA_LANGUAGE_URL, XML_SCHEMA_URL);
-                docBuilderFactory.setAttribute(SCHEMA_SOURCE_URL, xsd);
-            }
+            docBuilderFactory.setValidating(true);
+            docBuilderFactory.setAttribute(SCHEMA_LANGUAGE_URL, XML_SCHEMA_URL);
+            docBuilderFactory.setAttribute(SCHEMA_SOURCE_URL, xsd);
 
             final DocumentBuilder documentBuilder = docBuilderFactory.newDocumentBuilder();
             documentBuilder.setErrorHandler(new ErrorHandler() {


### PR DESCRIPTION
Backporting JDK-8349959: Test CR6740048.java passes unexpectedly missing CR6740048.xsd.

This PR removes an unnecessary null check.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jaxp/javax/xml/jaxp/unittest/validation/CR6740048.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29055527/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29055528/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29055529/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29055530/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8349959](https://bugs.openjdk.org/browse/JDK-8349959) needs maintainer approval

### Issue
 * [JDK-8349959](https://bugs.openjdk.org/browse/JDK-8349959): Test CR6740048.java passes unexpectedly missing CR6740048.xsd (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4525/head:pull/4525` \
`$ git checkout pull/4525`

Update a local copy of the PR: \
`$ git checkout pull/4525` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4525/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4525`

View PR using the GUI difftool: \
`$ git pr show -t 4525`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4525.diff">https://git.openjdk.org/jdk17u-dev/pull/4525.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4525#issuecomment-4731238953)
</details>
