### PR TITLE
8308474: DSA does not reset SecureRandom when initSign is called again

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/DSA.java
+++ b/src/java.base/share/classes/sun/security/provider/DSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,6 +161,7 @@ abstract class DSA extends SignatureSpi {
             checkKey(params, md.getDigestLength()*8, md.getAlgorithm());
         }
 
+        this.signingRandom = null;
         this.params = params;
         this.presetX = priv.getX();
         this.presetY = null;

--- a/test/jdk/sun/security/provider/DSA/SecureRandomReset.java
+++ b/test/jdk/sun/security/provider/DSA/SecureRandomReset.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8308474
+ * @summary Test that calling initSign resets RNG
+ */
+
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.util.Arrays;
+import java.util.Random;
+
+
+public class SecureRandomReset {
+
+    public static void main(String[] args) throws Exception {
+        KeyPairGenerator g = KeyPairGenerator.getInstance("DSA");
+        PrivateKey sk = g.generateKeyPair().getPrivate();
+        Signature s = Signature.getInstance("SHA256withDSA");
+
+        // Initialize deterministic RNG and sign
+        s.initSign(sk, deterministic());
+        byte[] sig1 = s.sign();
+
+        // Re-initialize deterministic RNG and sign
+        s.initSign(sk, deterministic());
+        byte[] sig2 = s.sign();
+
+        if (!Arrays.equals(sig1,sig2)) {
+            System.out.println("Expected equal signatures");
+            throw new RuntimeException("initSign not properly resetting RNG");
+        }
+    }
+
+    static SecureRandom deterministic() {
+        return new SecureRandom() {
+            final Random r = new Random(0);
+            @Override
+            public void nextBytes(byte[] bytes) {
+                r.nextBytes(bytes);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Resolved one Copyright. Probably clean anyways.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8308474](https://bugs.openjdk.org/browse/JDK-8308474) needs maintainer approval

### Issue
 * [JDK-8308474](https://bugs.openjdk.org/browse/JDK-8308474): DSA does not reset SecureRandom when initSign is called again (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4530/head:pull/4530` \
`$ git checkout pull/4530`

Update a local copy of the PR: \
`$ git checkout pull/4530` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4530`

View PR using the GUI difftool: \
`$ git pr show -t 4530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4530.diff">https://git.openjdk.org/jdk17u-dev/pull/4530.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4530#issuecomment-4750118379)
</details>
