### PR TITLE
8386991: Insets are incorrectly set in newer Gnome versions

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java
@@ -340,7 +340,19 @@ abstract class XDecoratedPeer extends XWindowPeer {
             || ev.get_atom() == XWM.XA_NET_FRAME_EXTENTS.getAtom())
         {
             if (XWM.getWMID() != XWM.UNITY_COMPIZ_WM) {
-                getWMSetInsets(XAtom.get(ev.get_atom()));
+                if (XWM.getWMID() == XWM.MUTTER_WM && !isTargetUndecorated() && isVisible()) {
+                    // Insets might have changed "in-flight" if that property
+                    // is present, so we need to get the actual values of
+                    // insets from the WM and propagate them through all the
+                    // proper channels.
+                    wm_set_insets = null;
+                    Insets in = getWMSetInsets(XAtom.get(ev.get_atom()));
+                    if (in != null && !in.equals(dimensions.getInsets())) {
+                        handleCorrectInsets(in);
+                    }
+                } else {
+                    getWMSetInsets(XAtom.get(ev.get_atom()));
+                }
             } else {
                 if (!isReparented()) {
                     return;


### PR DESCRIPTION
The original backport of [JDK-8305825](https://bugs.openjdk.org/browse/JDK-8305825) missed changes to `src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java` for JDK 17 and below. For 21 and above, JDK-8305825 reuses an [if statement](https://github.com/azvegint/jdk/blob/f2210a19f2364324c8e3636e740325f93b19701d/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java#L344-L354) introduced by [JDK-8267307](https://bugs.openjdk.org/browse/JDK-8267307). For 17 and below, since JDK-8267307 wasn't backported/present, a similar if statement should have been added just without the JDK-8267307-specific condition.

This leads to the `SimpleTest.java` test included on that JBS issue continuing to fail on Ubuntu 24.04.

This patch adds in the relevant code from the original JDK-8305825 patch to ensure the test passes and windows are rendered with the correct insets and size. 

---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8386991](https://bugs.openjdk.org/browse/JDK-8386991) needs maintainer approval

### Issue
 * [JDK-8386991](https://bugs.openjdk.org/browse/JDK-8386991): Insets are incorrectly set in newer Gnome versions (**Bug** - P3 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4533/head:pull/4533` \
`$ git checkout pull/4533`

Update a local copy of the PR: \
`$ git checkout pull/4533` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4533`

View PR using the GUI difftool: \
`$ git pr show -t 4533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4533.diff">https://git.openjdk.org/jdk17u-dev/pull/4533.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4533#issuecomment-4755016547)
</details>
