### PR TITLE
8286737: Test vmTestbase/gc/gctests/WeakReference/weak006/weak006.java fails: Last soft reference has not been cleared

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak006/weak006.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak006/weak006.java
@@ -32,7 +32,7 @@
  *          /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI gc.gctests.WeakReference.weak006.weak006 -t 1
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+IgnoreUnrecognizedVMOptions -XX:-ScavengeBeforeFullGC gc.gctests.WeakReference.weak006.weak006 -t 1
  */
 
 package gc.gctests.WeakReference.weak006;
@@ -54,6 +54,20 @@ import java.lang.ref.Reference;
  * to the next, then provokes GC with WB.fullGC().
  * The test succedes if last reference has been cleared.
  */
+
+class MySoftReference<T> extends SoftReference<T> {
+    public MySoftReference(T obj) {
+        super(obj);
+    }
+}
+
+
+class MyWeakReference<T> extends WeakReference<T> {
+    public MyWeakReference(T obj) {
+        super(obj);
+    }
+}
+
 public class weak006 extends ThreadedGCTest {
 
     class Worker implements Runnable {
@@ -63,40 +77,14 @@ public class weak006 extends ThreadedGCTest {
         private Object[] references;
         private Reference lastReference;
 
-        private Object makeReference(int n, Object o) {
+        private Reference<Object> makeReference(int n, Object o) {
             switch (n) {
                 case 0:
-                    return new WeakReference(o);
+                    return new MyWeakReference(o);
                 case 1:
-                    return new SoftReference(o);
-                case 2:
-                    return new PhantomReference(o, null);
-                case 4: {
-                    // Array of strong references
-                    int len = Memory.getArrayLength(objectSize, Memory.getReferenceSize());
-                    Object[] arr = new Object[len];
-                    for (int i = 0; i < len; ++i) {
-                        arr[i] = o;
-                    }
-                    return arr;
-                }
-                case 5: {
-                    // reference to array of strong references and strong reference to reference
-                    int len = Memory.getArrayLength(objectSize, Memory.getReferenceSize());
-                    Object[] arr = new Object[len];
-                    for (int i = 1; i < len; ++i) {
-                        arr[i] = o;
-                    }
-                    Reference ref = (Reference) makeReference(LocalRandom.nextInt(3), arr);
-                    if (len > 0) {
-                        arr[0] = ref;
-                    }
-                    return ref;
-                }
-                case 3:
+                    return new MySoftReference(o);
                 default:
-                    // Strong reference
-                    return o;
+                    throw new RuntimeException("Incorrect reference type");
             }
         }
 
@@ -108,12 +96,12 @@ public class weak006 extends ThreadedGCTest {
         private void makeReferences(int n) {
             clear();
             MemoryObject obj = new MemoryObject(objectSize);
-            references[0] = new WeakReference(obj);
+            references[0] = new MyWeakReference(obj);
             for (int i = 1; i < length; ++i) {
                 if (i != length - 1) {
                     references[i] = makeReference(LocalRandom.nextInt(2), references[i - 1]);
                 } else {
-                    lastReference = (Reference) makeReference(n, references[i - 1]);
+                    lastReference = makeReference(n, references[i - 1]);
                     references[i] = lastReference;
                 }
             }


### PR DESCRIPTION
Backporting JDK-8286737: Test vmTestbase/gc/gctests/WeakReference/weak006/weak006.java fails: Last soft reference has not been cleared.

This PR fixes test by simplifying reference chains and disabling ScavengeBeforeFullGC.

This PR isn't clean because the test didn't need to be removed from the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/vmTestbase/gc/gctests/WeakReference/weak006/weak006.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29214479/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29214480/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29214481/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29214482/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8286737](https://bugs.openjdk.org/browse/JDK-8286737) needs maintainer approval

### Issue
 * [JDK-8286737](https://bugs.openjdk.org/browse/JDK-8286737): Test vmTestbase/gc/gctests/WeakReference/weak006/weak006.java fails: Last soft reference has not been cleared (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4534/head:pull/4534` \
`$ git checkout pull/4534`

Update a local copy of the PR: \
`$ git checkout pull/4534` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4534`

View PR using the GUI difftool: \
`$ git pr show -t 4534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4534.diff">https://git.openjdk.org/jdk17u-dev/pull/4534.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4534#issuecomment-4769127493)
</details>
