### PR TITLE
8296405: java/util/concurrent/forkjoin/AsyncShutdownNow.java is too slow

### DIFF
--- a/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java
+++ b/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,7 @@
  *          invokeAll, and invokeAny
  */
 
-// TODO: this test is far too slow
-
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
@@ -38,12 +37,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import static java.lang.Thread.State.*;
 
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
@@ -55,29 +51,6 @@ public class AsyncShutdownNow {
         Thread.sleep(86400_000);
         return null;
     };
-
-    private ScheduledExecutorService scheduledExecutor;
-
-    @BeforeClass
-    public void setup() {
-        scheduledExecutor = Executors.newScheduledThreadPool(1);
-    }
-
-    @AfterClass
-    public void teardown() {
-        scheduledExecutor.shutdown();
-    }
-
-    /**
-     * Schedule the given executor service to be shutdown abruptly after the given
-     * delay, in seconds.
-     */
-    private void scheduleShutdownNow(ExecutorService executor, int delayInSeconds) {
-        scheduledExecutor.schedule(() -> {
-            executor.shutdownNow();
-            return null;
-        }, delayInSeconds, TimeUnit.SECONDS);
-    }
 
     /**
      * The executors to test.
@@ -96,18 +69,17 @@ public class AsyncShutdownNow {
     @Test(dataProvider = "executors")
     public void testFutureGet(ExecutorService executor) throws Exception {
         System.out.format("testFutureGet: %s%n", executor);
-        scheduleShutdownNow(executor, 5);
-        try {
-            // submit long running task, the task should be cancelled
+        try (executor) {
             Future<?> future = executor.submit(SLEEP_FOR_A_DAY);
+
+            // shutdownNow when main thread waits in ForkJoinTask.get
+            onWait("java.util.concurrent.ForkJoinTask.get", executor::shutdownNow);
             try {
                 future.get();
-                assertTrue(false);
-            } catch (ExecutionException | RejectedExecutionException e) {
+                fail();
+            } catch (ExecutionException | CancellationException e) {
                 // expected
             }
-        } finally {
-            executor.shutdown();
         }
     }
 
@@ -117,18 +89,17 @@ public class AsyncShutdownNow {
     @Test(dataProvider = "executors")
     public void testTimedFutureGet(ExecutorService executor) throws Exception {
         System.out.format("testTimedFutureGet: %s%n", executor);
-        scheduleShutdownNow(executor, 5);
-        try {
-            // submit long running task, the task should be cancelled
+        try (executor) {
             Future<?> future = executor.submit(SLEEP_FOR_A_DAY);
+
+            // shutdownNow when main thread waits in ForkJoinTask.get
+            onWait("java.util.concurrent.ForkJoinTask.get", executor::shutdownNow);
             try {
                 future.get(1, TimeUnit.HOURS);
-                assertTrue(false);
-            } catch (ExecutionException | RejectedExecutionException e) {
+                fail();
+            } catch (ExecutionException | CancellationException e) {
                 // expected
             }
-        } finally {
-            executor.shutdown();
         }
     }
 
@@ -138,41 +109,79 @@ public class AsyncShutdownNow {
     @Test(dataProvider = "executors")
     public void testInvokeAll(ExecutorService executor) throws Exception {
         System.out.format("testInvokeAll: %s%n", executor);
-        scheduleShutdownNow(executor, 5);
-        try {
-            // execute long running tasks
+        try (executor) {
+            // shutdownNow when main thread waits in ForkJoinTask.quietlyJoin
+            onWait("java.util.concurrent.ForkJoinTask.quietlyJoin", executor::shutdownNow);
             List<Future<Void>> futures = executor.invokeAll(List.of(SLEEP_FOR_A_DAY, SLEEP_FOR_A_DAY));
             for (Future<Void> f : futures) {
                 assertTrue(f.isDone());
                 try {
                     Object result = f.get();
-                    assertTrue(false);
+                    fail();
                 } catch (ExecutionException | CancellationException e) {
                     // expected
                 }
             }
-        } finally {
-            executor.shutdown();
         }
     }
 
     /**
      * Test shutdownNow with thread blocked in invokeAny.
      */
-    @Test(dataProvider = "executors")
+    @Test(dataProvider = "executors", enabled = false)
     public void testInvokeAny(ExecutorService executor) throws Exception {
         System.out.format("testInvokeAny: %s%n", executor);
-        scheduleShutdownNow(executor, 5);
-        try {
+        try (executor) {
+            // shutdownNow when main thread waits in ForkJoinTask.get
+            onWait("java.util.concurrent.ForkJoinTask.get", executor::shutdownNow);
             try {
-                // execute long running tasks
                 executor.invokeAny(List.of(SLEEP_FOR_A_DAY, SLEEP_FOR_A_DAY));
-                assertTrue(false);
-            } catch (ExecutionException | RejectedExecutionException e) {
+                fail();
+            } catch (ExecutionException e) {
                 // expected
             }
-        } finally {
-            executor.shutdown();
         }
+    }
+
+    /**
+     * Runs the given action when the current thread is sampled as waiting (timed or
+     * untimed) at the given location. The location takes the form "{@code c.m}" where
+     * {@code c} is the fully qualified class name and {@code m} is the method name.
+     */
+    private void onWait(String location, Runnable action) {
+        int index = location.lastIndexOf('.');
+        String className = location.substring(0, index);
+        String methodName = location.substring(index + 1);
+        Thread target = Thread.currentThread();
+        var thread = new Thread(() -> {
+            try {
+                boolean found = false;
+                while (!found) {
+                    Thread.State state = target.getState();
+                    assertTrue(state != TERMINATED);
+                    if ((state == WAITING || state == TIMED_WAITING)
+                            && contains(target.getStackTrace(), className, methodName)) {
+                        found = true;
+                    } else {
+                        Thread.sleep(20);
+                    }
+                }
+                action.run();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    /**
+     * Returns true if the given stack trace contains an element for the given class
+     * and method name.
+     */
+    private boolean contains(StackTraceElement[] stack, String className, String methodName) {
+        return Arrays.stream(stack)
+                .anyMatch(e -> className.equals(e.getClassName())
+                        && methodName.equals(e.getMethodName()));
     }
 }

--- a/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java
+++ b/test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java
@@ -69,7 +69,7 @@ public class AsyncShutdownNow {
     @Test(dataProvider = "executors")
     public void testFutureGet(ExecutorService executor) throws Exception {
         System.out.format("testFutureGet: %s%n", executor);
-        try (executor) {
+        try {
             Future<?> future = executor.submit(SLEEP_FOR_A_DAY);
 
             // shutdownNow when main thread waits in ForkJoinTask.get
@@ -80,6 +80,8 @@ public class AsyncShutdownNow {
             } catch (ExecutionException | CancellationException e) {
                 // expected
             }
+        } finally {
+            executor.shutdownNow();
         }
     }
 
@@ -89,7 +91,7 @@ public class AsyncShutdownNow {
     @Test(dataProvider = "executors")
     public void testTimedFutureGet(ExecutorService executor) throws Exception {
         System.out.format("testTimedFutureGet: %s%n", executor);
-        try (executor) {
+        try {
             Future<?> future = executor.submit(SLEEP_FOR_A_DAY);
 
             // shutdownNow when main thread waits in ForkJoinTask.get
@@ -100,6 +102,8 @@ public class AsyncShutdownNow {
             } catch (ExecutionException | CancellationException e) {
                 // expected
             }
+        } finally {
+            executor.shutdownNow();
         }
     }
 
@@ -109,9 +113,9 @@ public class AsyncShutdownNow {
     @Test(dataProvider = "executors")
     public void testInvokeAll(ExecutorService executor) throws Exception {
         System.out.format("testInvokeAll: %s%n", executor);
-        try (executor) {
-            // shutdownNow when main thread waits in ForkJoinTask.quietlyJoin
-            onWait("java.util.concurrent.ForkJoinTask.quietlyJoin", executor::shutdownNow);
+        try {
+            // shutdownNow when main thread waits in ForkJoinTask.awaitPoolInvoke
+            onWait("java.util.concurrent.ForkJoinTask.awaitPoolInvoke", executor::shutdownNow);
             List<Future<Void>> futures = executor.invokeAll(List.of(SLEEP_FOR_A_DAY, SLEEP_FOR_A_DAY));
             for (Future<Void> f : futures) {
                 assertTrue(f.isDone());
@@ -122,6 +126,8 @@ public class AsyncShutdownNow {
                     // expected
                 }
             }
+        } finally {
+            executor.shutdownNow();
         }
     }
 
@@ -131,7 +137,7 @@ public class AsyncShutdownNow {
     @Test(dataProvider = "executors", enabled = false)
     public void testInvokeAny(ExecutorService executor) throws Exception {
         System.out.format("testInvokeAny: %s%n", executor);
-        try (executor) {
+        try {
             // shutdownNow when main thread waits in ForkJoinTask.get
             onWait("java.util.concurrent.ForkJoinTask.get", executor::shutdownNow);
             try {
@@ -140,6 +146,8 @@ public class AsyncShutdownNow {
             } catch (ExecutionException e) {
                 // expected
             }
+        } finally {
+            executor.shutdownNow();
         }
     }
 


### PR DESCRIPTION
Backporting JDK-8296405: java/util/concurrent/forkjoin/AsyncShutdownNow.java is too slow.

This PR improves test execution time.

This PR isn't clean because ExecutorService (ForkJoinPool) doesn't implement AutoCloseable in Java 17, so shutdownNow() needed to be called explicitly. We also needed to monitor ForkJoinTask.awaitPoolInvoke instead of ForkJoinTask.quietlyJoin in ForkJoinPool.invokeAll(), since that's where the blocking occurs in Java 17.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/util/concurrent/forkjoin/AsyncShutdownNow.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29223668/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29223670/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29223672/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29223674/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8296405](https://bugs.openjdk.org/browse/JDK-8296405) needs maintainer approval

### Issue
 * [JDK-8296405](https://bugs.openjdk.org/browse/JDK-8296405): java/util/concurrent/forkjoin/AsyncShutdownNow.java is too slow (**Enhancement** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4535/head:pull/4535` \
`$ git checkout pull/4535`

Update a local copy of the PR: \
`$ git checkout pull/4535` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4535`

View PR using the GUI difftool: \
`$ git pr show -t 4535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4535.diff">https://git.openjdk.org/jdk17u-dev/pull/4535.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4535#issuecomment-4770693213)
</details>
