### PR TITLE
8365623: test/jdk/sun/security/pkcs11/tls/ tests skipped without skip exception

### DIFF
--- a/test/jdk/sun/security/pkcs11/tls/TestKeyMaterial.java
+++ b/test/jdk/sun/security/pkcs11/tls/TestKeyMaterial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@
 import java.io.BufferedReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.security.InvalidAlgorithmParameterException;
 import java.security.Provider;
 import java.security.ProviderException;
 import java.util.Arrays;
@@ -46,6 +45,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import jtreg.SkippedException;
 import sun.security.internal.spec.TlsKeyMaterialParameterSpec;
 import sun.security.internal.spec.TlsKeyMaterialSpec;
 
@@ -61,8 +61,7 @@ public class TestKeyMaterial extends PKCS11Test {
     @Override
     public void main(Provider provider) throws Exception {
         if (provider.getService("KeyGenerator", "SunTlsKeyMaterial") == null) {
-            System.out.println("Provider does not support algorithm, skipping");
-            return;
+            throw new SkippedException("Provider does not support algorithm, skipping");
         }
 
         try (BufferedReader reader = Files.newBufferedReader(

--- a/test/jdk/sun/security/pkcs11/tls/TestKeyMaterialChaCha20.java
+++ b/test/jdk/sun/security/pkcs11/tls/TestKeyMaterialChaCha20.java
@@ -35,6 +35,8 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
+
+import jtreg.SkippedException;
 import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
 import sun.security.internal.spec.TlsMasterSecretParameterSpec;
 import sun.security.internal.spec.TlsKeyMaterialParameterSpec;
@@ -52,20 +54,17 @@ public class TestKeyMaterialChaCha20 extends PKCS11Test {
         try {
             kg1 = KeyGenerator.getInstance("SunTlsRsaPremasterSecret", provider);
         } catch (Exception e) {
-            System.out.println("Skipping, SunTlsRsaPremasterSecret KeyGenerator not supported");
-            return;
+            throw new SkippedException("Skipping, SunTlsRsaPremasterSecret KeyGenerator not supported");
         }
         try {
             kg2 = KeyGenerator.getInstance("SunTls12MasterSecret", provider);
         } catch (Exception e) {
-            System.out.println("Skipping, SunTls12MasterSecret KeyGenerator not supported");
-            return;
+            throw new SkippedException("Skipping, SunTls12MasterSecret KeyGenerator not supported");
         }
         try {
             kg3 = KeyGenerator.getInstance("SunTls12KeyMaterial", provider);
         } catch (Exception e) {
-            System.out.println("Skipping, SunTls12KeyMaterial KeyGenerator not supported");
-            return;
+            throw new SkippedException("Skipping, SunTls12KeyMaterial KeyGenerator not supported");
         }
 
         kg1.init(new TlsRsaPremasterSecretParameterSpec(0x0303, 0x0303));

--- a/test/jdk/sun/security/pkcs11/tls/TestMasterSecret.java
+++ b/test/jdk/sun/security/pkcs11/tls/TestMasterSecret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@ import java.util.Arrays;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
+import jtreg.SkippedException;
 import sun.security.internal.interfaces.TlsMasterSecret;
 import sun.security.internal.spec.TlsMasterSecretParameterSpec;
 
@@ -57,8 +59,7 @@ public class TestMasterSecret extends PKCS11Test {
     @Override
     public void main(Provider provider) throws Exception {
         if (provider.getService("KeyGenerator", "SunTlsMasterSecret") == null) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
 
         try (BufferedReader reader = Files.newBufferedReader(

--- a/test/jdk/sun/security/pkcs11/tls/TestPRF.java
+++ b/test/jdk/sun/security/pkcs11/tls/TestPRF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,8 @@ import java.util.Arrays;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
+import jtreg.SkippedException;
 import sun.security.internal.spec.TlsPrfParameterSpec;
 
 public class TestPRF extends PKCS11Test {
@@ -54,8 +56,7 @@ public class TestPRF extends PKCS11Test {
     @Override
     public void main(Provider provider) throws Exception {
         if (provider.getService("KeyGenerator", "SunTlsPrf") == null) {
-            System.out.println("Provider does not support algorithm, skipping");
-            return;
+            throw new SkippedException("Provider does not support algorithm, skipping");
         }
 
         try (BufferedReader reader = Files.newBufferedReader(

--- a/test/jdk/sun/security/pkcs11/tls/TestPremaster.java
+++ b/test/jdk/sun/security/pkcs11/tls/TestPremaster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ import java.security.Provider;
 import java.security.InvalidAlgorithmParameterException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+
+import jtreg.SkippedException;
 import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
 
 public class TestPremaster extends PKCS11Test {
@@ -49,8 +51,7 @@ public class TestPremaster extends PKCS11Test {
     public void main(Provider provider) throws Exception {
         if (provider.getService(
                 "KeyGenerator", "SunTlsRsaPremasterSecret") == null) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Not supported by provider, skipping");
         }
         KeyGenerator kg;
         kg = KeyGenerator.getInstance("SunTlsRsaPremasterSecret", provider);
@@ -88,8 +89,7 @@ public class TestPremaster extends PKCS11Test {
         } catch (InvalidAlgorithmParameterException iape) {
             // S12 removed support for SSL v3.0
             if (clientVersion == 0x300 || serverVersion == 0x300) {
-                System.out.println("Skip testing SSLv3 due to no support");
-                return;
+                throw new SkippedException("Skip testing SSLv3 due to no support");
             }
             // unexpected, pass it up
             throw iape;

--- a/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
+++ b/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
@@ -65,6 +65,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManagerFactory;
 
 import jdk.test.lib.security.SecurityUtils;
+import jtreg.SkippedException;
 import sun.security.internal.spec.TlsMasterSecretParameterSpec;
 import sun.security.internal.spec.TlsPrfParameterSpec;
 import sun.security.internal.spec.TlsRsaPremasterSecretParameterSpec;
@@ -88,12 +89,11 @@ public final class FipsModeTLS12 extends SecmodTest {
         try {
             initialize();
         } catch (Exception e) {
-            System.out.println("Test skipped: failure during" +
-                    " initialization");
             if (enableDebug) {
                 System.out.println(e);
             }
-            return;
+            throw new SkippedException("Test skipped: failure during" +
+                                       " initialization");
         }
 
         if (shouldRun()) {
@@ -105,7 +105,7 @@ public final class FipsModeTLS12 extends SecmodTest {
 
             System.out.println("Test PASS - OK");
         } else {
-            System.out.println("Test skipped: TLS 1.2 mechanisms" +
+            throw new SkippedException("Test skipped: TLS 1.2 mechanisms" +
                     " not supported by current SunPKCS11 back-end");
         }
     }

--- a/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
+++ b/test/jdk/sun/security/pkcs11/tls/tls12/FipsModeTLS12.java
@@ -106,7 +106,7 @@ public final class FipsModeTLS12 extends SecmodTest {
             System.out.println("Test PASS - OK");
         } else {
             throw new SkippedException("Test skipped: TLS 1.2 mechanisms" +
-                    " not supported by current SunPKCS11 back-end");
+                                       " not supported by current SunPKCS11 back-end");
         }
     }
 


### PR DESCRIPTION
Hi all,

JDK-8365623 is being backported from JDK 26 to JDK 17 to address an issue where six PKCS#11 TLS tests that handled unavailable-algorithm and failed-initialization conditions would print a skipping message and return. This caused jtreg to misleadingly mark them as "Passed" because no explicit failure occurred. In other words, when PKCS#11 functionality was unavailable, the tests exited normally and were counted the same as successful tests, even though they did not actually verify any functionality.

Additionally, this backport is equivalent to the fix applied in JDK 21. This equivalence ensures consistency and demonstrates that the adjustments are robust and have been previously validated in other releases.

Would everyone review this fix, please?

Thank you.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8365623](https://bugs.openjdk.org/browse/JDK-8365623) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8365623](https://bugs.openjdk.org/browse/JDK-8365623): test/jdk/sun/security/pkcs11/tls/ tests skipped without skip exception (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4536/head:pull/4536` \
`$ git checkout pull/4536`

Update a local copy of the PR: \
`$ git checkout pull/4536` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4536`

View PR using the GUI difftool: \
`$ git pr show -t 4536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4536.diff">https://git.openjdk.org/jdk17u-dev/pull/4536.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4536#issuecomment-4777120735)
</details>
