### PR TITLE
8129778: Few  awt test fail for Solaris 11 with RuntimeException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -205,9 +205,6 @@ java/awt/Focus/6981400/Test1.java 8029675 windows-all,macosx-all
 java/awt/Focus/6981400/Test3.java 8173264 generic-all
 java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows-all,macosx-all
 java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all
-java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java 8129778 generic-all
-java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java 8129778 generic-all
-java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java 8129778 generic-all
 
 java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java 8242805 macosx-all
 java/awt/dnd/DnDCursorCrashTest.java 8242805 macosx-all

--- a/test/jdk/java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@
  * @build LWButton
  * @build LWList
  * @build ExtendedRobot
- * @run main/timeout=600 ExtendedModifiersTest
+ * @run main/timeout=300 ExtendedModifiersTest
  */
 import java.awt.Button;
 import java.awt.Color;
@@ -71,7 +71,7 @@ public class ExtendedModifiersTest implements KeyListener {
 
     private final ExtendedRobot robot;
     private static final int WAIT_DELAY = 5000;
-    private static final int KEY_DELAY = 500;
+    private static final int KEY_DELAY = 100;
     private final Object lock;
 
     private boolean keyPressedFlag;
@@ -106,6 +106,7 @@ public class ExtendedModifiersTest implements KeyListener {
         frame = new Frame();
         frame.setTitle("ExtendedModifiersTest");
         frame.setLayout(new GridLayout(1, 6));
+        frame.setLocationRelativeTo(null);
 
         button = new Button();
         button.addKeyListener(this);

--- a/test/jdk/java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,11 +35,20 @@
  * @build LWButton
  * @build LWList
  * @build ExtendedRobot
- * @run main/timeout=600 KeyMaskTest
+ * @run main/timeout=300 KeyMaskTest
  */
 
 
-import java.awt.*;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.TextArea;
+import java.awt.TextField;
 import java.awt.event.InputEvent;
 
 import java.awt.event.KeyAdapter;
@@ -47,7 +56,8 @@ import java.awt.event.KeyEvent;
 
 import java.util.ArrayList;
 
-import static jdk.test.lib.Asserts.*;
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertTrue;
 
 import test.java.awt.event.helpers.lwcomponents.LWButton;
 import test.java.awt.event.helpers.lwcomponents.LWList;
@@ -65,12 +75,9 @@ public class KeyMaskTest extends KeyAdapter {
     List      list;
     LWList    listLW;
 
-    int buttonPressedNumber;
-    int buttonReleasedNumber;
-
     ExtendedRobot robot;
 
-    private final static int robotDelay = 1500;
+    private final static int robotDelay = 500;
     private final static int waitDelay  = 3500;
 
     final Object lock;
@@ -89,6 +96,7 @@ public class KeyMaskTest extends KeyAdapter {
         frame = new Frame();
         frame.setTitle("KeyMaskTest");
         frame.setLayout(new GridLayout(1, 6));
+        frame.setLocationRelativeTo(null);
 
         button = new Button();
         button.addKeyListener(this);

--- a/test/jdk/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,16 @@
  */
 
 
-import java.awt.*;
-
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.TextArea;
+import java.awt.TextField;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
@@ -31,7 +39,8 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
 
-import static jdk.test.lib.Asserts.*;
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertTrue;
 
 
 import test.java.awt.event.helpers.lwcomponents.LWButton;
@@ -52,7 +61,7 @@ import test.java.awt.event.helpers.lwcomponents.LWList;
  * @build LWButton
  * @build LWList
  * @build ExtendedRobot
- * @run main/timeout=600 MouseButtonsAndKeyMasksTest
+ * @run main/timeout=300 MouseButtonsAndKeyMasksTest
  */
 
 public class MouseButtonsAndKeyMasksTest implements MouseListener, KeyListener {
@@ -68,11 +77,11 @@ public class MouseButtonsAndKeyMasksTest implements MouseListener, KeyListener {
 
     ExtendedRobot robot;
 
-    private final static int robotDelay = 1500;
-    private final static int   keyDelay =  500;
+    private final static int robotDelay = 500;
+    private final static int   keyDelay =  100;
     private final static int  waitDelay = 5000;
 
-    int modMouse = 0, modMouseEx = 0, modKey = 0, modAction = 0;
+    int modMouse = 0, modMouseEx = 0, modKey = 0;
 
     boolean mousePressFired = false;
     boolean keyPressFired = false;
@@ -90,6 +99,7 @@ public class MouseButtonsAndKeyMasksTest implements MouseListener, KeyListener {
         frame = new Frame();
         frame.setTitle("MouseButtonsAndKeysTest");
         frame.setLayout(new GridLayout(1, 6));
+        frame.setLocationRelativeTo(null);
 
         button = new Button();
         button.addKeyListener(this);


### PR DESCRIPTION
Backporting JDK-8129778: Few awt test fail for Solaris 11 with RuntimeException.

This PR removes Solaris specific failing tests from the problem list, since Solaris is no longer supported, and reduces delays for faster execution time.

This PR is not clean because of a trivial conflict in the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/event/KeyEvent/ExtendedModifiersTest/ExtendedModifiersTest.java
make test TEST=test/jdk/java/awt/event/KeyEvent/KeyMaskTest/KeyMaskTest.java
make test TEST=test/jdk/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29354260/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/29354261/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/29354262/macos-aarch64-specific-3-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/29354273/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/29354274/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/29354275/windows-x64-specific-3-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29354276/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/29354277/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/29354278/linux-x64-specific-3-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29354279/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/29354280/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/29354281/linux-aarch64-specific-3-test.log)

Please note that ```test/jdk/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java``` failed on windows-x64. so I re-ran it directly on jtreg (```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk test/jdk/java/awt/event/MouseEvent/MouseButtonsAndKeyMasksTest/MouseButtonsAndKeyMasksTest.java```), where it passed:

[MouseButtonsAndKeyMasksTest.jtr.log](https://github.com/user-attachments/files/29354537/MouseButtonsAndKeyMasksTest.jtr.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8129778](https://bugs.openjdk.org/browse/JDK-8129778) needs maintainer approval

### Issue
 * [JDK-8129778](https://bugs.openjdk.org/browse/JDK-8129778): Few  awt test fail for Solaris 11 with RuntimeException (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4540/head:pull/4540` \
`$ git checkout pull/4540`

Update a local copy of the PR: \
`$ git checkout pull/4540` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4540`

View PR using the GUI difftool: \
`$ git pr show -t 4540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4540.diff">https://git.openjdk.org/jdk17u-dev/pull/4540.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4540#issuecomment-4802145798)
</details>
