### PR TITLE
6626492: Event time in future part 2, now on X

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -143,7 +143,6 @@ java/awt/Focus/TestDisabledAutoTransfer.java 8159871 macosx-all,windows-all
 java/awt/Focus/TestDisabledAutoTransferSwing.java 6962362 windows-all
 java/awt/Focus/ActivateOnProperAppContextTest.java 8136516 macosx-all
 java/awt/Focus/FocusPolicyTest.java 7160904 linux-all
-java/awt/event/KeyEvent/CorrectTime/CorrectTime.java 6626492 generic-all
 java/awt/Graphics/SmallPrimitives.java 8047070 macosx-all,linux-all
 java/awt/EventQueue/6980209/bug6980209.java 8198615 macosx-all
 java/awt/EventQueue/PushPopDeadlock/PushPopDeadlock.java 8024034 generic-all


### PR DESCRIPTION
Backporting JDK-6626492: Event time in future part 2, now on X.

This PR removes a test from the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/event/KeyEvent/CorrectTime/CorrectTime.java

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29351864/macos-aarch64-specific-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/29351879/windows-x64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29351881/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29351882/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-6626492](https://bugs.openjdk.org/browse/JDK-6626492) needs maintainer approval

### Issue
 * [JDK-6626492](https://bugs.openjdk.org/browse/JDK-6626492): Event time in future part 2, now on X (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4541/head:pull/4541` \
`$ git checkout pull/4541`

Update a local copy of the PR: \
`$ git checkout pull/4541` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4541`

View PR using the GUI difftool: \
`$ git pr show -t 4541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4541.diff">https://git.openjdk.org/jdk17u-dev/pull/4541.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4541#issuecomment-4802907473)
</details>
