### PR TITLE
8164464: Consistent failure of java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -126,7 +126,6 @@ java/awt/Frame/FocusTest.java 8341480 macosx-all
 java/awt/FileDialog/FileDialogIconTest/FileDialogIconTest.java 8160558 windows-all
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion.java 8060176 windows-all,macosx-all
 java/awt/event/MouseWheelEvent/InfiniteRecursion/InfiniteRecursion_1.java 8060176 windows-all,macosx-all
-java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java 8164464 linux-all,macosx-all
 java/awt/dnd/URIListBetweenJVMsTest/URIListBetweenJVMsTest.java 8171510 macosx-all
 java/awt/dnd/DragExitBeforeDropTest.java 8242805 macosx-all
 java/awt/dnd/DragThresholdTest.java 8076299 macosx-all

--- a/test/jdk/java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java
+++ b/test/jdk/java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,8 +91,10 @@ public class MissingEventsOnModalDialogTest {
         Robot robot = new Robot();
         robot.setAutoDelay(50);
 
+        robot.waitForIdle();
         sourceFrame.toFront();
         robot.waitForIdle();
+        robot.delay(1000);
 
         Point point = getCenterPoint(sourceFrame);
         robot.mouseMove(point.x, point.y);
@@ -100,7 +102,7 @@ public class MissingEventsOnModalDialogTest {
 
         mouseDragAndDrop(robot, point, getCenterPoint(targetFrame));
 
-        long time = System.currentTimeMillis() + 1000;
+        long time = System.currentTimeMillis() + 2000;
 
         while (!passed) {
             if (time < System.currentTimeMillis()) {
@@ -141,13 +143,13 @@ public class MissingEventsOnModalDialogTest {
         int dx = (x2 - x1) / N;
         int dy = (y2 - y1) / N;
 
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
 
         for (int i = 0; i < N; i++) {
             robot.mouseMove(x += dx, y += dy);
         }
 
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
     }
 
     private static class TestDragGestureListener implements DragGestureListener {
@@ -238,27 +240,23 @@ public class MissingEventsOnModalDialogTest {
 
     private static void clickOnDialog(Dialog dialog) {
         try {
-            long time = System.currentTimeMillis() + 200;
-
-            while (!dialog.isVisible()) {
-                if (time < System.currentTimeMillis()) {
-                    throw new RuntimeException("Dialog is not visible!");
-                }
-                Thread.sleep(10);
-            }
             Robot robot = new Robot();
             robot.setAutoDelay(50);
             robot.waitForIdle();
-            robot.delay(200);
+            robot.delay(1000);
+            if (!dialog.isVisible()) {
+                throw new RuntimeException("Dialog is not visible!");
+            }
 
             Point point = getCenterPoint(dialog);
 
             robot.mouseMove(point.x, point.y);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
-
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         } catch (Exception e) {
             throw new RuntimeException(e);
+        } finally {
+            dialog.dispose();
         }
     }
 


### PR DESCRIPTION
Backporting JDK-8164464: Consistent failure of java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java.

This PR fixes MissingEventsOnModalDialogTest.java for slow machines and removes it from the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29352365/macos-aarch64-specific-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/29352028/windows-x64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29352030/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29352031/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8164464](https://bugs.openjdk.org/browse/JDK-8164464) needs maintainer approval

### Issue
 * [JDK-8164464](https://bugs.openjdk.org/browse/JDK-8164464): Consistent failure of java/awt/dnd/MissingEventsOnModalDialog/MissingEventsOnModalDialogTest.java (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4542/head:pull/4542` \
`$ git checkout pull/4542`

Update a local copy of the PR: \
`$ git checkout pull/4542` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4542`

View PR using the GUI difftool: \
`$ git pr show -t 4542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4542.diff">https://git.openjdk.org/jdk17u-dev/pull/4542.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4542#issuecomment-4802937471)
</details>
