### PR TITLE
8278965: crash in SymbolTable::do_lookup

### DIFF
--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -180,6 +180,9 @@ PlaceholderEntry* PlaceholderTable::new_entry(int hash, Symbol* name,
   // Hashtable with Symbol* literal must increment and decrement refcount.
   name->increment_refcount();
   entry->set_loader_data(loader_data);
+  // _supername is raw (uninitialized) memory here; NULL it before the first
+  // set_supername so that set_supername does not decrement a garbage pointer.
+  entry->_supername = NULL;
   entry->set_supername(supername);
   entry->set_superThreadQ(NULL);
   entry->set_loadInstanceThreadQ(NULL);
@@ -327,10 +330,7 @@ void PlaceholderTable::find_and_remove(unsigned int hash,
     if (probe != NULL) {
        log(probe, "find_and_remove", action);
 
-       bool empty = probe->remove_seen_thread(thread, action);
-       if (empty && action == LOAD_SUPER) {
-          probe->set_supername(NULL);
-       }
+       probe->remove_seen_thread(thread, action);
 
        // If no other threads using this entry, and this thread is not using this entry for other states
        if ((probe->superThreadQ() == NULL) && (probe->loadInstanceThreadQ() == NULL)

--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -25,12 +25,12 @@
 #ifndef SHARE_CLASSFILE_PLACEHOLDERS_HPP
 #define SHARE_CLASSFILE_PLACEHOLDERS_HPP
 
+#include "oops/symbol.hpp"
 #include "utilities/hashtable.hpp"
 
 class PlaceholderEntry;
 class Thread;
 class ClassLoaderData;
-class Symbol;
 
 // Placeholder objects. These represent classes currently
 // being loaded, as well as arrays of primitives.
@@ -143,6 +143,9 @@ class PlaceholderEntry : public HashtableEntry<Symbol*, mtClass> {
   Symbol*            supername()           const { return _supername; }
   void               set_supername(Symbol* supername) {
     if (supername != _supername) {
+      if (_supername != NULL) {
+        _supername->decrement_refcount();
+      }
       _supername = supername;
       if (_supername != NULL) {
         _supername->increment_refcount();

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -623,7 +623,7 @@ InstanceKlass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
 
   bool super_load_in_progress  = false;
   InstanceKlass* loaded_class = NULL;
-  Symbol* superclassname = NULL;
+  Symbol* superclassname = NULL; // Keep alive while loading in parallel thread.
 
   assert(THREAD->can_call_java(),
          "can not load classes with compiler thread: class=%s, classloader=%s",
@@ -645,6 +645,7 @@ InstanceKlass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
          super_load_in_progress = true;
          superclassname = placeholder->supername();
          assert(superclassname != NULL, "superclass has to have a name");
+         superclassname->increment_refcount();
       }
     }
   }
@@ -655,7 +656,11 @@ InstanceKlass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
     handle_parallel_super_load(name, superclassname,
                                class_loader,
                                protection_domain,
-                               CHECK_NULL);
+                               THREAD);
+    superclassname->decrement_refcount();
+    if (HAS_PENDING_EXCEPTION) {
+      return NULL;
+    }
   }
 
   bool throw_circularity_error = false;

--- a/test/hotspot/gtest/classfile/test_placeholders.cpp
+++ b/test/hotspot/gtest/classfile/test_placeholders.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "classfile/classLoaderData.hpp"
+#include "classfile/placeholders.hpp"
+#include "classfile/symbolTable.hpp"
+#include "classfile/systemDictionary.hpp"
+#include "oops/symbol.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "threadHelper.inline.hpp"
+#include "unittest.hpp"
+
+// Test that multiple threads calling handle_parallel_super_load don't underflow supername refcount.
+TEST_VM(PlaceholderTable, supername) {
+  JavaThread* THREAD = JavaThread::current();
+  JavaThread* T2 = THREAD;
+  // the thread should be in vm to use locks
+  ThreadInVMfromNative tivfn(THREAD);
+
+  // Assert messages assume these symbols are unique, and the refcounts start at one.
+  // Use raw Symbol* (not TempNewSymbol) so the TempSymbol cleanup delayer does not
+  // bump the starting refcount to two; the symbols are released manually at the end.
+  Symbol* A = SymbolTable::new_symbol("abc2_8_2023_class");
+  Symbol* D = SymbolTable::new_symbol("def2_8_2023_class");
+  Symbol* super = SymbolTable::new_symbol("super2_8_2023_supername");
+  Symbol* interf = SymbolTable::new_symbol("interface2_8_2023_supername");
+
+  ClassLoaderData* loader_data = ClassLoaderData::the_null_class_loader_data();
+
+  PlaceholderTable table(137);
+  unsigned int A_hash = table.compute_hash(A);
+  unsigned int D_hash = table.compute_hash(D);
+
+  {
+    MutexLocker ml(THREAD, SystemDictionary_lock);
+
+    PlaceholderTable::classloadAction super_action = PlaceholderTable::LOAD_SUPER;
+    PlaceholderTable::classloadAction define_action = PlaceholderTable::DEFINE_CLASS;
+
+    // DefineClass A and D
+    table.find_and_add(A_hash, A, loader_data, define_action, NULL, THREAD);
+    table.find_and_add(D_hash, D, loader_data, define_action, NULL, T2);
+
+    // Load interfaces first to get supername replaced
+    table.find_and_add(A_hash, A, loader_data, super_action, interf, THREAD);
+    table.find_and_remove(A_hash, A, loader_data, super_action, THREAD);
+
+    table.find_and_add(D_hash, D, loader_data, super_action, interf, T2);
+    table.find_and_remove(D_hash, D, loader_data, super_action, T2);
+
+    ASSERT_EQ(interf->refcount(), 3) << "supername isn't replaced until super set";
+
+    // Add placeholder to the table for loading A and super, and D also loading super
+    table.find_and_add(A_hash, A, loader_data, super_action, super, THREAD);
+    table.find_and_add(D_hash, D, loader_data, super_action, super, T2);
+
+    ASSERT_EQ(interf->refcount(), 1) << "now should be one";
+
+    // Another thread comes in and finds A loading Super
+    PlaceholderEntry* placeholder = table.get_entry(A_hash, A, loader_data);
+    Symbol* supername = placeholder->supername();
+    supername->increment_refcount();  // Keep alive (backport of SymbolHandle)
+
+    // Other thread is done before handle_parallel_super_load
+    table.find_and_remove(A_hash, A, loader_data, super_action, THREAD);
+
+    // if THREAD drops reference to supername (loading failed or class unloaded), we're left with
+    // a supername without refcount
+    super->decrement_refcount();
+
+    // handle_parallel_super_load (same thread doesn't assert)
+    table.find_and_add(A_hash, A, loader_data, super_action, supername, T2);
+
+    // Refcount should be 3: one in table for class A, one in table for class D
+    // and one locally keeping it alive
+    placeholder = table.get_entry(A_hash, A, loader_data);
+    EXPECT_EQ(super->refcount(), 3) << "super class name refcount should be 3";
+
+    // Second thread's done too
+    table.find_and_remove(D_hash, D, loader_data, super_action, T2);
+
+    // Other threads are done.
+    table.find_and_remove(A_hash, A, loader_data, super_action, THREAD);
+
+    // Remove A and D define_class placeholder
+    table.find_and_remove(A_hash, A, loader_data, define_action, THREAD);
+    table.find_and_remove(D_hash, D, loader_data, define_action, T2);
+
+    placeholder = table.get_entry(A_hash, A, loader_data);
+    ASSERT_TRUE(placeholder == NULL) << "placeholder should be removed";
+    placeholder = table.get_entry(D_hash, D, loader_data);
+    ASSERT_TRUE(placeholder == NULL) << "placeholder should be removed";
+
+    EXPECT_EQ(super->refcount(), 1) << "super class name refcount should be 1 - kept alive in this scope";
+
+    supername->decrement_refcount();  // Release local hold (backport of SymbolHandle destructor)
+  }
+
+  EXPECT_EQ(A->refcount(), 1) << "first class name refcount should be 1";
+  EXPECT_EQ(D->refcount(), 1) << "second class name refcount should be 1";
+  EXPECT_EQ(super->refcount(), 0) << "super class name refcount should be 0 - was unloaded.";
+
+  // Release the manually-held references (super already reached zero above).
+  A->decrement_refcount();
+  D->decrement_refcount();
+  interf->decrement_refcount();
+}


### PR DESCRIPTION
Backport of 582b943 (https://github.com/openjdk/jdk/commit/582b943439488a0f43482b67c0bc0d4975bf4023). Keeps the superclass name alive while a parallel thread loads the superclass, preventing a refcount underflow.

Adaptation for 17u: Mainline's fix only needed to change systemDictionary.cpp because the placeholder-table supername refcounting was already correct there (introduced by JDK-8292286, Convert PlaceholderTable to ResourceHashtable, which is not in 17u). Rather than backport that structural refactor, this PR open-codes the equivalent behavior on the legacy Hashtable-based PlaceholderTable:
  - set_supername() now decrements the replaced supername before adopting the new one.
  - find_and_remove() keeps the supername alive until the whole entry is removed (released by free_entry), instead of clearing it as soon as the super-load
  queue empties.
  - new_entry() initializes _supername to NULL before the first set_supername(), since the legacy table allocates entries as raw, unconstructed memory.

The added gtest declares its symbols as raw Symbol* (not TempNewSymbol) so the TempSymbol cleanup delayer (JDK-8315559) doesn't bump their starting refcount, and releases them manually.

Testing: 
- [x] gtest:PlaceholderTable passes; full gtest:all (908 tests) passes.
- [x] tier1~tier4  



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8278965](https://bugs.openjdk.org/browse/JDK-8278965) needs maintainer approval

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8278965: crash in SymbolTable::do_lookup`

### Issue
 * [JDK-8278965](https://bugs.openjdk.org/browse/JDK-8278965): crash in SymbolTable::do_lookup (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4544/head:pull/4544` \
`$ git checkout pull/4544`

Update a local copy of the PR: \
`$ git checkout pull/4544` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4544`

View PR using the GUI difftool: \
`$ git pr show -t 4544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4544.diff">https://git.openjdk.org/jdk17u-dev/pull/4544.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4544#issuecomment-4807388943)
</details>
