### PR TITLE
8168388: GetMousePositionTest fails with the message "Mouse position should not be null"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -188,7 +188,6 @@ java/awt/Mixing/AWT_Mixing/JTextFieldOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonInGlassPaneOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonOverlapping.java 8158801 windows-all
 java/awt/Mixing/NonOpaqueInternalFrame.java 7124549 macosx-all
-java/awt/Mouse/GetMousePositionTest/GetMousePositionWithOverlay.java 8168388 linux-all
 java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java 6829264 generic-all
 java/awt/datatransfer/DragImage/MultiResolutionDragImageTest.java 8080982 generic-all
 java/awt/datatransfer/SystemFlavorMap/AddFlavorTest.java 8079268 linux-all

--- a/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithOverlay.java
+++ b/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.awt.Frame;
 import java.awt.Point;
 import java.awt.Robot;
 import java.awt.Rectangle;
+import javax.swing.SwingUtilities;
 
 /*
  * @test
@@ -42,23 +43,21 @@ public class GetMousePositionWithOverlay {
 
     public static void main(String[] args) throws Throwable {
         robot = new Robot();
+        robot.setAutoDelay(100);
 
-        try{
-            constructTestUI();
-        } catch (Exception e) {
+        try {
+            SwingUtilities.invokeAndWait(GetMousePositionWithOverlay::constructTestUI);
+            doTest();
+        } finally {
             dispose();
-            throw new RuntimeException("Unexpected Exception!");
         }
 
         robot.waitForIdle();
 
-        doTest();
-        dispose();
     }
 
-    private static void doTest() {
-
-        frontFrame.toFront();
+    private static void doTest() throws Exception {
+        SwingUtilities.invokeAndWait(() -> frontFrame.toFront());
         robot.waitForIdle();
 
         Rectangle bounds = new Rectangle(frontFrame.getLocationOnScreen(), frontFrame.getSize());
@@ -67,45 +66,44 @@ public class GetMousePositionWithOverlay {
 
         Point pos = backFrame.getMousePosition();
         if (pos != null) {
-            dispose();
             throw new RuntimeException("Test failed. Mouse position should be null but was " + pos);
         }
 
         pos = frontFrame.getMousePosition();
         if (pos == null) {
-            dispose();
             throw new RuntimeException("Test failed. Mouse position should not be null");
         }
 
-        robot.mouseMove(189, 189);
+        robot.mouseMove(bounds.x + bounds.width + 5, bounds.y + bounds.height + 5);
         robot.waitForIdle();
 
         pos = backFrame.getMousePosition();
         if (pos == null) {
-            dispose();
             throw new RuntimeException("Test failed. Mouse position should not be null");
         }
-
     }
 
-    private static void dispose() {
+    private static void dispose() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            if (backFrame != null) {
+                backFrame.dispose();
+            }
 
-        if (backFrame != null) {
-            backFrame.dispose();
-        }
-
-        if (frontFrame != null) {
-            frontFrame.dispose();
-        }
+            if (frontFrame != null) {
+                frontFrame.dispose();
+            }
+        });
     }
 
     private static void constructTestUI() {
         backFrame = new Frame();
+        backFrame.setUndecorated(true);
         backFrame.setBounds(100, 100, 100, 100);
         backFrame.setResizable(false);
         backFrame.setVisible(true);
 
         frontFrame = new Frame();
+        frontFrame.setUndecorated(true);
         frontFrame.setBounds(120, 120, 60, 60);
         frontFrame.setResizable(false);
         frontFrame.setVisible(true);


### PR DESCRIPTION
Backporting JDK-8168388: GetMousePositionTest fails with the message "Mouse position should not be null".

This PR fixes the GetMousePositionWithOverlay test and removes it from the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithOverlay.java

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29385626/macos-aarch64-specific-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/29385642/windows-x64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29385643/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29385644/linux-aarch64-specific-test.log)


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8168388](https://bugs.openjdk.org/browse/JDK-8168388) needs maintainer approval

### Issue
 * [JDK-8168388](https://bugs.openjdk.org/browse/JDK-8168388): GetMousePositionTest fails with the message "Mouse position should not be null" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4545/head:pull/4545` \
`$ git checkout pull/4545`

Update a local copy of the PR: \
`$ git checkout pull/4545` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4545`

View PR using the GUI difftool: \
`$ git pr show -t 4545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4545.diff">https://git.openjdk.org/jdk17u-dev/pull/4545.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4545#issuecomment-4810275902)
</details>
