### PR TITLE
8196367: java/awt/List/SingleModeDeselect/SingleModeDeselect.java times out

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -448,7 +448,6 @@ java/awt/Modal/ToBack/ToBackNonModal2Test.java 8196441 macosx-all,linux-all
 java/awt/Modal/ToBack/ToBackNonModal3Test.java 8196441 macosx-all,linux-all
 java/awt/Modal/ToBack/ToBackNonModal4Test.java 8196441 macosx-all,linux-all
 java/awt/Modal/ToBack/ToBackNonModal5Test.java 8196441 macosx-all
-java/awt/List/SingleModeDeselect/SingleModeDeselect.java 8196367 windows-all
 java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java 8061235 macosx-all
 javax/print/PrintSEUmlauts/PrintSEUmlauts.java 8135174 generic-all
 java/awt/font/Rotate/RotatedTextTest.java 8219641 linux-all

--- a/test/jdk/java/awt/List/SingleModeDeselect/SingleModeDeselect.java
+++ b/test/jdk/java/awt/List/SingleModeDeselect/SingleModeDeselect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,17 @@
   @key headful
   @bug 6248040
   @summary List.deselect() de-selects the currently selected item regardless of the index, win32
-  @author Dmitry Cherepanov area=awt.list
   @run main SingleModeDeselect
 */
 
-import java.awt.*;
+import java.awt.AWTException;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Robot;
 
-public class SingleModeDeselect
-{
-    public static final void main(String args[])
-    {
+public class SingleModeDeselect {
+    public static final void main(String args[]) {
         final Frame frame = new Frame();
         final List list = new List();
 
@@ -45,6 +46,7 @@ public class SingleModeDeselect
         frame.add(list);
         frame.setLayout(new FlowLayout());
         frame.setBounds(100,100,300,300);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
 
         list.select(0);
@@ -53,14 +55,16 @@ public class SingleModeDeselect
         try {
             Robot robot = new Robot();
             robot.waitForIdle();
-        }catch(Exception ex) {
+            if (list.getSelectedIndex() != 0) {
+                throw new RuntimeException("Test failed: List.getSelectedIndex() returns "
+                                           + list.getSelectedIndex());
+            }
+        } catch(AWTException ex) {
             ex.printStackTrace();
             throw new RuntimeException("Unexpected failure");
+        } finally {
+            frame.setVisible(false);
+            frame.dispose();
         }
-
-        if (list.getSelectedIndex() != 0){
-            throw new RuntimeException("Test failed: List.getSelectedIndex() returns "+list.getSelectedIndex());
-        }
-
-    }//End  init()
+    }
 }


### PR DESCRIPTION
Backporting JDK-8196367: java/awt/List/SingleModeDeselect/SingleModeDeselect.java times out.

This PR does some code cleanup for SingleModeDeselect.java and removes it from the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/List/SingleModeDeselect/SingleModeDeselect.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29470025/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29470026/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29470027/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29470028/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8196367](https://bugs.openjdk.org/browse/JDK-8196367) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8196367](https://bugs.openjdk.org/browse/JDK-8196367): java/awt/List/SingleModeDeselect/SingleModeDeselect.java times out (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4547/head:pull/4547` \
`$ git checkout pull/4547`

Update a local copy of the PR: \
`$ git checkout pull/4547` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4547`

View PR using the GUI difftool: \
`$ git pr show -t 4547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4547.diff">https://git.openjdk.org/jdk17u-dev/pull/4547.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4547#issuecomment-4833996574)
</details>
