### PR TITLE
8213120: java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java fails on mac10.13

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -468,7 +468,6 @@ java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java 8148041 linux-all
 java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Enable.java 6847163 linux-all
 java/awt/xembed/server/RunTestXEmbed.java 7034201 linux-all
 java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 8164473 linux-all
-java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java 8213120 macosx-all
 
 java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223,8274106 macosx-aarch64,linux-all,windows-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all

--- a/test/jdk/java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java
+++ b/test/jdk/java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java
@@ -101,12 +101,14 @@ public class AutoScrollOnSelectAndAppend {
     public AutoScrollOnSelectAndAppend() {
         try {
             robot = new Robot();
+            robot.setAutoDelay(100);
         } catch (Exception ex) {
             throw new RuntimeException("Robot Creation Failed.");
         }
         frame = new Frame();
         frame.setSize(200, 200);
         frame.setLayout(new FlowLayout());
+        frame.setLocationRelativeTo(null);
 
         textArea = new TextArea(5, 20);
         composeTextArea();
@@ -128,11 +130,11 @@ public class AutoScrollOnSelectAndAppend {
         // Delay to make sure auto scroll is finished.
         robot.waitForIdle();
         robot.delay(500);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(100);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.waitForIdle();
     }
 


### PR DESCRIPTION
Backporting JDK-8213120: java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java fails on mac10.13.

This PR fixes the AutoScrollOnSelectAndAppend.java test and removes it from ProblemList.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29552248/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29552249/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29552250/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29552251/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8213120](https://bugs.openjdk.org/browse/JDK-8213120) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8213120](https://bugs.openjdk.org/browse/JDK-8213120): java/awt/TextArea/AutoScrollOnSelectAndAppend/AutoScrollOnSelectAndAppend.java fails on mac10.13 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4552/head:pull/4552` \
`$ git checkout pull/4552`

Update a local copy of the PR: \
`$ git checkout pull/4552` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4552`

View PR using the GUI difftool: \
`$ git pr show -t 4552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4552.diff">https://git.openjdk.org/jdk17u-dev/pull/4552.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4552#issuecomment-4855285293)
</details>
