### PR TITLE
8303136: MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded005 failed with "isCollectionUsageThresholdExceeded() returned true, while threshold = 1 and used = 0"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001.java
@@ -119,15 +119,11 @@ public class isexceeded001 {
                 isExceeded = monitor.isCollectionThresholdExceeded(pool);
                 if (!isExceeded) {
 
-                    // Refresh the values
-                    threshold = monitor.getCollectionThreshold(pool);
-                    usage = monitor.getCollectionUsage(pool);
-                    if (used >= threshold) {
-                        log.complain("isCollectionUsageThresholdExceeded() "
-                                   + "returned false, while threshold = "
-                                   + threshold + " and " + "used = " + used);
-                        testFailed = true;
-                    }
+                    // Don't refresh the values: usage may have decreased outside our control.
+                    log.complain("isCollectionUsageThresholdExceeded() "
+                               + "returned false, while threshold = "
+                               + threshold + " and " + "used = " + used);
+                    testFailed = true;
                 }
             } else {
                 log.display("  used value (" + used + ") did not cross the "
@@ -136,9 +132,10 @@ public class isexceeded001 {
                 isExceeded = monitor.isCollectionThresholdExceeded(pool);
                 if (isExceeded) {
 
-                    // Refresh the values
+                    // Refresh the values: usage may have increased outside our control.
                     threshold = monitor.getCollectionThreshold(pool);
                     usage = monitor.getCollectionUsage(pool);
+                    used = usage.getUsed();
                     if (used < threshold) {
                         log.complain("isCollectionUsageThresholdExceeded() "
                                    + "returned true, while threshold = "


### PR DESCRIPTION
Backporting JDK-8303136: MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded005 failed with "isCollectionUsageThresholdExceeded() returned true, while threshold = 1 and used = 0".

This PR fixes an intermittent issue in isexceeded001 test by updating the refresh logic.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29552413/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29552414/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29552415/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29552416/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8303136](https://bugs.openjdk.org/browse/JDK-8303136) needs maintainer approval

### Issue
 * [JDK-8303136](https://bugs.openjdk.org/browse/JDK-8303136): MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded005 failed with "isCollectionUsageThresholdExceeded() returned true, while threshold = 1 and used = 0" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4553/head:pull/4553` \
`$ git checkout pull/4553`

Update a local copy of the PR: \
`$ git checkout pull/4553` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4553`

View PR using the GUI difftool: \
`$ git pr show -t 4553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4553.diff">https://git.openjdk.org/jdk17u-dev/pull/4553.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4553#issuecomment-4855297297)
</details>
