### PR TITLE
8355241: Move NativeDialogToFrontBackTest.java PL test to manual category

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -405,7 +405,6 @@ java/awt/Modal/MultipleDialogs/MultipleDialogs2Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs3Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs4Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs5Test.java 8198665 macosx-all
-java/awt/Modal/NativeDialogToFrontBackTest.java 7188049 windows-all,linux-all
 java/awt/Mouse/EnterExitEvents/DragWindowOutOfFrameTest.java 8177326 macosx-all
 java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021 macosx-all
 java/awt/Mouse/EnterExitEvents/FullscreenEnterEventTest.java 8051455 macosx-all
@@ -843,6 +842,7 @@ java/awt/Checkbox/CheckboxNullLabelTest.java 8340870 windows-all
 java/awt/dnd/WinMoveFileToShellTest.java 8341665 windows-all
 java/awt/Focus/MinimizeNonfocusableWindowTest.java 8024487 windows-all
 java/awt/Menu/MenuVisibilityTest.java 8161110 macosx-all
+java/awt/Modal/NativeDialogToFrontBackTest.java 7188049 windows-all,linux-all
 java/awt/Cursor/CursorDragTest/ListDragCursor.java 7177297 macosx-all
 
 ############################################################################


### PR DESCRIPTION
Backporting JDK-8355241: Move NativeDialogToFrontBackTest.java PL test to manual category.

This PR moves the NativeDialogToFrontBackTest.java entry within the problem list.

For parity with Oracle JDK. Already backported to 21.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8355241](https://bugs.openjdk.org/browse/JDK-8355241) needs maintainer approval

### Issue
 * [JDK-8355241](https://bugs.openjdk.org/browse/JDK-8355241): Move NativeDialogToFrontBackTest.java PL test to manual category (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4555/head:pull/4555` \
`$ git checkout pull/4555`

Update a local copy of the PR: \
`$ git checkout pull/4555` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4555`

View PR using the GUI difftool: \
`$ git pr show -t 4555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4555.diff">https://git.openjdk.org/jdk17u-dev/pull/4555.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4555#issuecomment-4865983271)
</details>
