### PR TITLE
8196440: Regression automated Test 'java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java' fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -222,7 +222,6 @@ java/awt/TrayIcon/TrayIconEvents/TrayIconEventsTest.java 8150540,8295300 windows
 java/awt/TrayIcon/TrayIconMouseTest/TrayIconMouseTest.java 8150540 windows-all
 java/awt/TrayIcon/TrayIconPopup/TrayIconPopupClickTest.java 8150540 windows-all,macosx-all
 java/awt/TrayIcon/TrayIconPopup/TrayIconPopupTest.java 8150540 windows-all
-java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java 8196440 linux-all
 java/awt/TrayIcon/MouseMoveTest.java 8203053 linux-all
 java/awt/TrayIcon/TrayIconKeySelectTest.java 8341557 windows-all
 java/awt/TrayIcon/TrayIconTest.java 8341559 generic-all

--- a/test/jdk/java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java
+++ b/test/jdk/java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,10 @@ public class PopupMenuLeakTest {
     static final AtomicReference<WeakReference<PopupMenu>> popupWeakReference = new AtomicReference<>();
     static ExtendedRobot robot;
     public static void main(String[] args) throws Exception {
+        if (!SystemTray.isSupported()) {
+            System.out.println("SystemTray not supported. Skipping the test.");
+            return;
+        }
         robot = new ExtendedRobot();
         SwingUtilities.invokeAndWait(PopupMenuLeakTest::createSystemTrayIcon);
         sleep();


### PR DESCRIPTION
Backporting JDK-8196440: Regression automated Test 'java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java' fails.

This PR fixes the PopupMenuLeakTest.java test by adding a guard to gracefully skip the test on systems without system tray support, and removes it from the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29598492/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29598493/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29598494/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29598495/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8196440](https://bugs.openjdk.org/browse/JDK-8196440) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8196440](https://bugs.openjdk.org/browse/JDK-8196440): Regression automated Test 'java/awt/TrayIcon/PopupMenuLeakTest/PopupMenuLeakTest.java' fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4556/head:pull/4556` \
`$ git checkout pull/4556`

Update a local copy of the PR: \
`$ git checkout pull/4556` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4556`

View PR using the GUI difftool: \
`$ git pr show -t 4556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4556.diff">https://git.openjdk.org/jdk17u-dev/pull/4556.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4556#issuecomment-4865936464)
</details>
