### PR TITLE
8194946: Regression automated Test 'javax/swing/JFileChooser/6738668/bug6738668.java' fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -696,7 +696,6 @@ javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8327236 windows-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/SwingUtilities/TestBadBreak/TestBadBreak.java 8160720 generic-all
 javax/swing/JFileChooser/bug6798062.java 8146446 windows-all
-javax/swing/JFileChooser/6738668/bug6738668.java 8194946 generic-all
 javax/swing/JInternalFrame/Test6325652.java 8224977 macosx-all
 javax/swing/JPopupMenu/4870644/bug4870644.java 8194130 macosx-all,linux-all
 javax/swing/dnd/8139050/NativeErrorsInTableDnD.java 8202765  macosx-all,linux-all

--- a/test/jdk/javax/swing/JFileChooser/6738668/bug6738668.java
+++ b/test/jdk/javax/swing/JFileChooser/6738668/bug6738668.java
@@ -22,6 +22,7 @@
  */
 
 /* @test
+   @key headful
    @bug 6738668 6962725
    @summary JFileChooser cannot be created under SecurityManager
    @author Pavel Porvatov
@@ -31,11 +32,20 @@
 import java.io.File;
 import javax.swing.JFileChooser;
 import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 public class bug6738668 {
     public static void main(String[] args) throws Exception {
         for (UIManager.LookAndFeelInfo lookAndFeelInfo : UIManager.getInstalledLookAndFeels()) {
-            UIManager.setLookAndFeel(lookAndFeelInfo.getClassName());
+            try {
+                UIManager.setLookAndFeel(lookAndFeelInfo.getClassName());
+            } catch (UnsupportedLookAndFeelException ignored) {
+                System.out.println("Unsupported L&F: " + lookAndFeelInfo.getClassName());
+                continue;
+            } catch (ClassNotFoundException | InstantiationException
+                 | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
 
             String tmpdir = System.getProperty("java.io.tmpdir");
             System.out.println("tmp dir " + tmpdir);


### PR DESCRIPTION
Backporting JDK-8194946: Regression automated Test 'javax/swing/JFileChooser/6738668/bug6738668.java' fails.

This PR fixes the JFileChooser.java test by marking it as headful, handling unsupported look and feels, and removes it from the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/javax/swing/JFileChooser/6738668/bug6738668.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29598562/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29598564/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29598565/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29598566/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8194946](https://bugs.openjdk.org/browse/JDK-8194946) needs maintainer approval

### Issue
 * [JDK-8194946](https://bugs.openjdk.org/browse/JDK-8194946): Regression automated Test 'javax/swing/JFileChooser/6738668/bug6738668.java' fails (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4557/head:pull/4557` \
`$ git checkout pull/4557`

Update a local copy of the PR: \
`$ git checkout pull/4557` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4557`

View PR using the GUI difftool: \
`$ git pr show -t 4557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4557.diff">https://git.openjdk.org/jdk17u-dev/pull/4557.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4557#issuecomment-4865995976)
</details>
