### PR TITLE
8148041: Test java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick fails on Ubuntu with  mouseReleased event after double click on title bar

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -464,7 +464,6 @@ java/awt/Robot/AcceptExtraMouseButtons/AcceptExtraMouseButtons.java 7107528 linu
 java/awt/Mouse/MouseDragEvent/MouseDraggedTest.java 8080676 linux-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersInKeyEvent.java 8157147 linux-all,windows-all,macosx-all
 java/awt/Mouse/MouseClickCount.java 8017182 macosx-all
-java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java 8148041 linux-all
 java/awt/Toolkit/ToolkitPropertyTest/ToolkitPropertyTest_Enable.java 6847163 linux-all
 java/awt/xembed/server/RunTestXEmbed.java 7034201 linux-all
 java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 8164473 linux-all

--- a/test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
+++ b/test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,17 +26,22 @@
   @key headful
   @bug 4664415
   @summary Test that double clicking the titlebar does not send RELEASE/CLICKED
-  @library    ../../regtesthelpers
-  @build      Util
   @run main TitleBarDoubleClick
 */
 
-import java.awt.*;
-import java.awt.event.*;
-import test.java.awt.regtesthelpers.Util;
+import java.awt.AWTError;
+import java.awt.AWTException;
+import java.awt.Frame;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 
 public class TitleBarDoubleClick implements MouseListener,
- WindowListener
+        WindowListener
 {
     //Declare things used in the test, like buttons and labels here
     private final static Rectangle BOUNDS = new Rectangle(300, 300, 300, 300);
@@ -45,69 +50,85 @@ public class TitleBarDoubleClick implements MouseListener,
     Frame frame;
     Robot robot;
 
-    public static void main(final String[] args) {
-        TitleBarDoubleClick app = new TitleBarDoubleClick();
-        app.start();
+    private volatile boolean failed = false;
+
+    public static void main(final String[] args) throws AWTException {
+        new TitleBarDoubleClick().doTest();
     }
 
-    public void start ()
-    {
-            robot = Util.createRobot();
-            robot.setAutoDelay(100);
-            robot.mouseMove(BOUNDS.x + (BOUNDS.width / 2),
-                            BOUNDS.y + (BOUNDS.height/ 2));
+    public TitleBarDoubleClick() throws AWTException {
+        robot = new Robot();
+        robot.setAutoDelay(100);
 
-            frame = new Frame("TitleBarDoubleClick");
-            frame.setBounds(BOUNDS);
-            frame.addMouseListener(this);
-            frame.addWindowListener(this);
-            frame.setVisible(true);
-    }// start()
+        robot.mouseMove(
+                BOUNDS.x + (BOUNDS.width / 2),
+                BOUNDS.y + (BOUNDS.height/ 2)
+        );
 
-    // Move the mouse into the title bar and double click to maximize the
-    // Frame
-    static boolean hasRun = false;
+        frame = new Frame("TitleBarDoubleClick");
+        frame.setBounds(BOUNDS);
+        frame.addMouseListener(this);
+        frame.addWindowListener(this);
+        frame.setVisible(true);
 
-    private void doTest() {
-        if (hasRun) return;
-        hasRun = true;
+        robot.waitForIdle();
+        robot.delay(1000);
+    }
 
+    public void doTest() throws AWTException {
         System.out.println("doing test");
-            robot.mouseMove(BOUNDS.x + (BOUNDS.width / 2),
-                            BOUNDS.y + TITLE_BAR_OFFSET);
-            robot.delay(50);
-            // Util.waitForIdle(robot) seem always hangs here.
-            // Need to use it instead robot.delay() when the bug become fixed.
-            System.out.println("1st press:   currentTimeMillis: " + System.currentTimeMillis());
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.delay(50);
-            System.out.println("1st release: currentTimeMillis: " + System.currentTimeMillis());
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
-            robot.delay(50);
-            System.out.println("2nd press:   currentTimeMillis: " + System.currentTimeMillis());
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.delay(50);
-            System.out.println("2nd release: currentTimeMillis: " + System.currentTimeMillis());
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
-            System.out.println("done:        currentTimeMillis: " + System.currentTimeMillis());
+        robot.mouseMove(
+                BOUNDS.x + (BOUNDS.width / 2),
+                BOUNDS.y + TITLE_BAR_OFFSET
+        );
+        robot.waitForIdle();
+
+        System.out.println("1st press:   currentTimeMillis: "
+                + System.currentTimeMillis());
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+
+        System.out.println("1st release: currentTimeMillis: "
+                + System.currentTimeMillis());
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        System.out.println("2nd press:   currentTimeMillis: "
+                + System.currentTimeMillis());
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+
+        System.out.println("2nd release: currentTimeMillis: "
+                + System.currentTimeMillis());
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        System.out.println("done:        currentTimeMillis: "
+                + System.currentTimeMillis());
+
+        robot.waitForIdle();
+        robot.delay(500);
+
+        frame.dispose();
+
+        if (failed) {
+            throw new AWTError("Test failed");
+        }
     }
 
-    private void fail() {
-        throw new AWTError("Test failed");
+    private void fail(MouseEvent e) {
+        System.err.println("Failed: " + e);
+        failed = true;
     }
 
     public void mouseEntered(MouseEvent e) {}
     public void mouseExited(MouseEvent e) {}
-    public void mousePressed(MouseEvent e) {fail();}
-    public void mouseReleased(MouseEvent e) {fail();}
-    public void mouseClicked(MouseEvent e) {fail();}
+    public void mousePressed(MouseEvent e) { fail(e); }
+    public void mouseReleased(MouseEvent e) { fail(e); }
+    public void mouseClicked(MouseEvent e) { fail(e); }
 
-    public void windowActivated(WindowEvent  e) {doTest();}
-    public void windowClosed(WindowEvent  e) {}
-    public void windowClosing(WindowEvent  e) {}
-    public void windowDeactivated(WindowEvent  e) {}
-    public void windowDeiconified(WindowEvent  e) {}
-    public void windowIconified(WindowEvent  e) {}
-    public void windowOpened(WindowEvent  e) {}
+    public void windowActivated(WindowEvent e) {}
+    public void windowClosed(WindowEvent e) {}
+    public void windowClosing(WindowEvent e) {}
+    public void windowDeactivated(WindowEvent e) {}
+    public void windowDeiconified(WindowEvent e) {}
+    public void windowIconified(WindowEvent e) {}
+    public void windowOpened(WindowEvent e) {}
 
 }// class TitleBarDoubleClick


### PR DESCRIPTION
Backporting JDK-8148041: Test java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick fails on Ubuntu with mouseReleased event after double click on title bar.

This PR fixes a race condition in TitleBarDoubleClick.java, and removes it from the problem list.

For parity with Oracle JDK.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29703849/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29703850/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29703851/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29703852/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8148041](https://bugs.openjdk.org/browse/JDK-8148041) needs maintainer approval

### Issue
 * [JDK-8148041](https://bugs.openjdk.org/browse/JDK-8148041): Test java/awt/Mouse/TitleBarDoubleClick/TitleBarDoubleClick fails on Ubuntu with  mouseReleased event after double click on title bar (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4559/head:pull/4559` \
`$ git checkout pull/4559`

Update a local copy of the PR: \
`$ git checkout pull/4559` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4559`

View PR using the GUI difftool: \
`$ git pr show -t 4559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4559.diff">https://git.openjdk.org/jdk17u-dev/pull/4559.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4559#issuecomment-4893067484)
</details>
