### PR TITLE
8296910: Add EdDSA/XDH/RSASSA-PSS to KeyPairGeneratorBench.java

### DIFF
--- a/test/micro/org/openjdk/bench/javax/crypto/full/KeyPairGeneratorBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/KeyPairGeneratorBench.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,8 @@ public class KeyPairGeneratorBench extends CryptoBase {
     @Setup
     public void setup() throws NoSuchAlgorithmException {
         setupProvider();
-        generator = (prov == null) ? KeyPairGenerator.getInstance(algorithm) : KeyPairGenerator.getInstance(algorithm, prov);
+        generator = (prov == null) ? KeyPairGenerator.getInstance(algorithm)
+                                : KeyPairGenerator.getInstance(algorithm, prov);
         generator.initialize(keyLength);
     }
 
@@ -57,9 +58,17 @@ public class KeyPairGeneratorBench extends CryptoBase {
         @Param({"RSA"})
         private String algorithm;
 
-        @Param({"1024", "2048", "3072"})
+        @Param({"1024", "2048", "3072", "4096"})
         private int keyLength;
+    }
 
+    public static class RSASSAPSS extends KeyPairGeneratorBench {
+
+        @Param({"RSASSA-PSS"})
+        private String algorithm;
+
+        @Param({"1024", "2048", "3072", "4096"})
+        private int keyLength;
     }
 
     public static class EC extends KeyPairGeneratorBench {
@@ -69,7 +78,23 @@ public class KeyPairGeneratorBench extends CryptoBase {
 
         @Param({"256", "384", "521"})
         private int keyLength;
-
     }
 
+    public static class EdDSA extends KeyPairGeneratorBench {
+
+        @Param({"EdDSA"})
+        private String algorithm;
+
+        @Param({"255", "448"})
+        private int keyLength;
+    }
+
+    public static class XDH extends KeyPairGeneratorBench {
+
+        @Param({"XDH"})
+        private String algorithm;
+
+        @Param({"255", "448"})
+        private int keyLength;
+    }
 }


### PR DESCRIPTION
Backporting JDK-8296910: Add EdDSA/XDH/RSASSA-PSS to KeyPairGeneratorBench.java.

This PR adds the EdDSA, XDH, and RSASSA-PSS algorithms to the KeyPairGeneratorBench.java benchmarks.

For parity with Oracle JDK.

Ran the benchmark tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

```./build/*/images/jdk/bin/java -jar build/*/images/test/micro/benchmarks.jar org.openjdk.bench.javax.crypto.full.KeyPairGeneratorBench```

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29703897/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29703899/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29703900/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29703901/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8296910](https://bugs.openjdk.org/browse/JDK-8296910) needs maintainer approval

### Issue
 * [JDK-8296910](https://bugs.openjdk.org/browse/JDK-8296910): Add EdDSA/XDH/RSASSA-PSS to KeyPairGeneratorBench.java (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4560/head:pull/4560` \
`$ git checkout pull/4560`

Update a local copy of the PR: \
`$ git checkout pull/4560` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4560`

View PR using the GUI difftool: \
`$ git pr show -t 4560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4560.diff">https://git.openjdk.org/jdk17u-dev/pull/4560.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4560#issuecomment-4893087432)
</details>
