### PR TITLE
8333857: Test sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java failed: Existing session was used

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksClient.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksClient.java
@@ -291,7 +291,7 @@ public class ResumeChecksClient extends SSLContextTemplate {
                     } catch (Exception ex) {
                         throw new AssertionError("Server Down", ex);
                     } finally {
-                        threadPool.close();
+                        threadPool.shutdown();
                     }
                 }).start();
 

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8206929
+ * @bug 8206929 8333857
  * @summary ensure that server only resumes a session if certain properties
  *    of the session are compatible with the new connection
  * @library /javax/net/ssl/templates
@@ -48,6 +48,9 @@ import java.io.*;
 import java.security.*;
 import java.net.*;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class ResumeChecksServer extends SSLContextTemplate {
 
@@ -60,51 +63,50 @@ public class ResumeChecksServer extends SSLContextTemplate {
         SIGNATURE_SCHEME
     }
 
+    static CountDownLatch latch = new CountDownLatch(1);
+    static TestMode testMode;
+    static int serverPort;
+
     public static void main(String[] args) throws Exception {
-
-        new ResumeChecksServer(TestMode.valueOf(args[0])).run();
-    }
-    private final TestMode testMode;
-
-    public ResumeChecksServer(TestMode testMode) {
-        this.testMode = testMode;
+        testMode = TestMode.valueOf(args[0]);
+        new ResumeChecksServer().test();
     }
 
-    private void run() throws Exception {
-        SSLSession secondSession = null;
+    private void test() throws Exception {
+        SSLSession firstSession, secondSession;
+        HexFormat hex = HexFormat.of();
 
-        SSLContext sslContext = createServerSSLContext();
-        ServerSocketFactory fac = sslContext.getServerSocketFactory();
-        SSLServerSocket ssock = (SSLServerSocket)
-            fac.createServerSocket(0);
+        serverPort = new Server().port;
+        latch.await();
+        Client c = new Client(serverPort);
 
-        Client client = startClient(ssock.getLocalPort());
+        System.out.println("Waiting for connection");
+        long firstStartTime = System.currentTimeMillis();
+        firstSession = c.test();
 
-        try {
-            connect(client, ssock, testMode, false);
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
+        System.err.println("firstStartTime = " + firstStartTime);
+        System.err.println("firstId = " + hex.formatHex(firstSession.getId()));
+        System.err.println("firstSession.getCreationTime() = " +
+            firstSession.getCreationTime());
 
         long secondStartTime = System.currentTimeMillis();
-        Thread.sleep(10);
-        try {
-            secondSession = connect(client, ssock, testMode, true);
-        } catch (SSLHandshakeException ex) {
-            // this is expected
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
+        secondSession = c.test();
 
-        client.go = false;
-        client.signal();
+        System.err.println("secondStartTime = " + secondStartTime);
+        // Note: Ids will never match with TLS 1.3 due to spec
+        System.err.println("secondId = " + hex.formatHex(secondSession.getId()));
+        System.err.println("secondSession.getCreationTime() = " +
+            secondSession.getCreationTime());
 
         switch (testMode) {
         case BASIC:
             // fail if session is not resumed
-            if (secondSession.getCreationTime() > secondStartTime) {
-                throw new RuntimeException("Session was not reused");
+            if (firstSession.getCreationTime() !=
+                secondSession.getCreationTime()) {
+                throw new AssertionError("Session was not reused: FAIL");
             }
+
+            System.out.println("secondSession used resumption: PASS");
             break;
         case CLIENT_AUTH:
             // throws an exception if the client is not authenticated
@@ -115,23 +117,22 @@ public class ResumeChecksServer extends SSLContextTemplate {
         case CIPHER_SUITE:
         case SIGNATURE_SCHEME:
             // fail if a new session is not created
-            if (secondSession.getCreationTime() <= secondStartTime) {
-                throw new RuntimeException("Existing session was used");
+            if (secondSession.getCreationTime() < secondStartTime) {
+                throw new AssertionError("Existing session was used: FAIL");
             }
+            System.out.println("secondSession not resumed: PASS");
             break;
         default:
-            throw new RuntimeException("unknown mode: " + testMode);
+            throw new AssertionError("unknown mode: " + testMode);
         }
     }
 
     private static class NoSig implements AlgorithmConstraints {
-
         private final String alg;
 
         NoSig(String alg) {
             this.alg = alg;
         }
-
 
         private boolean test(String a) {
             return !a.toLowerCase().contains(alg.toLowerCase());
@@ -140,160 +141,137 @@ public class ResumeChecksServer extends SSLContextTemplate {
         public boolean permits(Set<CryptoPrimitive> primitives, Key key) {
             return true;
         }
+
         public boolean permits(Set<CryptoPrimitive> primitives,
             String algorithm, AlgorithmParameters parameters) {
-
             return test(algorithm);
         }
+
         public boolean permits(Set<CryptoPrimitive> primitives,
             String algorithm, Key key, AlgorithmParameters parameters) {
-
             return test(algorithm);
         }
     }
 
-    private static SSLSession connect(Client client, SSLServerSocket ssock,
-        TestMode mode, boolean second) throws Exception {
 
-        try {
-            client.signal();
-            System.out.println("Waiting for connection");
-            SSLSocket sock = (SSLSocket) ssock.accept();
-            SSLParameters params = sock.getSSLParameters();
-
-            switch (mode) {
-            case BASIC:
-                // do nothing to ensure resumption works
-                break;
-            case CLIENT_AUTH:
-                if (second) {
-                    params.setNeedClientAuth(true);
-                } else {
-                    params.setNeedClientAuth(false);
-                }
-                break;
-            case VERSION_2_TO_3:
-                if (second) {
-                    params.setProtocols(new String[] {"TLSv1.3"});
-                } else {
-                    params.setProtocols(new String[] {"TLSv1.2"});
-                }
-                break;
-            case VERSION_3_TO_2:
-                if (second) {
-                    params.setProtocols(new String[] {"TLSv1.2"});
-                } else {
-                    params.setProtocols(new String[] {"TLSv1.3"});
-                }
-                break;
-            case CIPHER_SUITE:
-                if (second) {
-                    params.setCipherSuites(
-                        new String[] {"TLS_AES_128_GCM_SHA256"});
-                } else {
-                    params.setCipherSuites(
-                        new String[] {"TLS_AES_256_GCM_SHA384"});
-                }
-                break;
-            case SIGNATURE_SCHEME:
-                params.setNeedClientAuth(true);
-                AlgorithmConstraints constraints =
-                    params.getAlgorithmConstraints();
-                if (second) {
-                    params.setAlgorithmConstraints(new NoSig("ecdsa"));
-                } else {
-                    params.setAlgorithmConstraints(new NoSig("rsa"));
-                }
-                break;
-            default:
-                throw new RuntimeException("unknown mode: " + mode);
-            }
-            sock.setSSLParameters(params);
-            BufferedReader reader = new BufferedReader(
-                new InputStreamReader(sock.getInputStream()));
-            String line = reader.readLine();
-            System.out.println("server read: " + line);
-            PrintWriter out = new PrintWriter(
-                new OutputStreamWriter(sock.getOutputStream()));
-            out.println(line);
-            out.flush();
-            out.close();
-            SSLSession result = sock.getSession();
-            sock.close();
-            return result;
-        } catch (SSLHandshakeException ex) {
-            if (!second) {
-                throw ex;
-            }
-        }
-        return null;
-    }
-
-    private static Client startClient(int port) {
-        Client client = new Client(port);
-        new Thread(client).start();
-        return client;
-    }
-
-    private static class Client extends SSLContextTemplate implements Runnable {
-
-        public volatile boolean go = true;
-        private boolean signal = false;
+    private static class Client extends SSLContextTemplate {
         private final int port;
+        private final SSLContext sc;
+        public SSLSession session;
 
-        Client(int port) {
+        Client(int port) throws Exception {
+            sc = createClientSSLContext();
             this.port = port;
         }
 
-        private synchronized void waitForSignal() {
-            while (!signal) {
+        public SSLSession test() throws Exception {
+            SSLSocket sock = null;
+            latch.await();
+            do {
                 try {
-                    wait();
-                } catch (InterruptedException ex) {
-                    // do nothing
+                    sock = (SSLSocket) sc.getSocketFactory().createSocket();
+                } catch (IOException e) {
+                    // If the server never starts, test will time out.
+                    System.err.println("client trying again to connect");
+                    Thread.sleep(500);
+                 }
+            } while (sock == null);
+            sock.connect(new InetSocketAddress("localhost", port));
+            PrintWriter out = new PrintWriter(
+                new OutputStreamWriter(sock.getOutputStream()));
+            out.println("message");
+            out.flush();
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(sock.getInputStream()));
+            String inMsg = reader.readLine();
+            System.out.println("Client received: " + inMsg);
+            out.close();
+            session = sock.getSession();
+            sock.close();
+            return session;
+        }
+    }
+
+    // The server will only have two connections each tests
+    private static class Server extends SSLContextTemplate {
+        public int port;
+        ExecutorService threadPool = Executors.newFixedThreadPool(1);
+        // Stores the certs from the first connection in mode LOCAL_CERTS
+        // first connection to the server
+        static boolean first = true;
+
+        Server() throws Exception {
+            SSLContext sc = createServerSSLContext();
+            ServerSocketFactory fac = sc.getServerSocketFactory();
+            SSLServerSocket ssock = (SSLServerSocket) fac.createServerSocket(0);
+            port = ssock.getLocalPort();
+
+            // Thread to allow multiple clients to connect
+            new Thread(() -> {
+                try {
+                    System.err.println("Server starting to accept");
+                    latch.countDown();
+                    do {
+                        threadPool.submit(new ServerThread(ssock.accept()));
+                    } while (true);
+                } catch (Exception ex) {
+                    throw new AssertionError("Server Down", ex);
+                } finally {
+                    threadPool.close();
                 }
-            }
-            signal = false;
-
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException ex) {
-                // do nothing
-            }
-        }
-        public synchronized void signal() {
-            signal = true;
-            notify();
+            }).start();
         }
 
-        public void run() {
-            try {
+        static class ServerThread implements Runnable {
+            final SSLSocket sock;
 
-                SSLContext sc = createClientSSLContext();
+            ServerThread(Socket s) {
+                this.sock = (SSLSocket) s;
+                System.err.println("(Server) client connection on port " +
+                    sock.getPort());
+            }
 
-                waitForSignal();
-                while (go) {
-                    try {
-                        SSLSocket sock = (SSLSocket)
-                            sc.getSocketFactory().createSocket();
-                        sock.connect(new InetSocketAddress("localhost", port));
-                        PrintWriter out = new PrintWriter(
-                            new OutputStreamWriter(sock.getOutputStream()));
-                        out.println("message");
-                        out.flush();
-                        BufferedReader reader = new BufferedReader(
-                            new InputStreamReader(sock.getInputStream()));
-                        String inMsg = reader.readLine();
-                        System.out.println("Client received: " + inMsg);
-                        out.close();
-                        sock.close();
-                        waitForSignal();
-                    } catch (Exception ex) {
-                        ex.printStackTrace();
+
+            public void run() {
+                try {
+                    SSLParameters params = sock.getSSLParameters();
+                    switch (testMode) {
+                        case BASIC -> {}  // do nothing
+                        case CLIENT_AUTH -> params.setNeedClientAuth(!first);
+                        case VERSION_2_TO_3 -> params.setProtocols(new String[]{
+                            first ? "TLSv1.2" : "TLSv1.3"});
+                        case VERSION_3_TO_2 -> params.setProtocols(new String[]{
+                            first ? "TLSv1.3" : "TLSv1.2"});
+                        case CIPHER_SUITE -> params.setCipherSuites(
+                            new String[]{
+                                first ? "TLS_AES_256_GCM_SHA384" :
+                                    "TLS_AES_128_GCM_SHA256"});
+                        case SIGNATURE_SCHEME -> {
+                            params.setNeedClientAuth(true);
+                            params.setAlgorithmConstraints(new NoSig(
+                                first ? "ecdsa_secp521r1_sha512" :
+                                    "ecdsa_secp384r1_sha384"));
+                        }
+                        default ->
+                            throw new AssertionError("Server: " +
+                                "unknown mode: " + testMode);
                     }
+                    sock.setSSLParameters(params);
+                    BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(sock.getInputStream()));
+                    String line = reader.readLine();
+                    System.err.println("server read: " + line);
+                    PrintWriter out = new PrintWriter(
+                        new OutputStreamWriter(sock.getOutputStream()));
+                    out.println(line);
+                    out.flush();
+                    out.close();
+                    SSLSession session = sock.getSession();
+                    first = false;
+                    System.err.println("server socket closed: " + session);
+                } catch (Exception e) {
+                    throw new AssertionError("Server error", e);
                 }
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
             }
         }
     }

--- a/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
+++ b/test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java
@@ -217,7 +217,7 @@ public class ResumeChecksServer extends SSLContextTemplate {
                 } catch (Exception ex) {
                     throw new AssertionError("Server Down", ex);
                 } finally {
-                    threadPool.close();
+                    threadPool.shutdown();
                 }
             }).start();
         }


### PR DESCRIPTION
Backporting JDK-8333857: Test sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java failed: Existing session was used.

This PR rewrites the tests to use ExecutorService/CountDownLatch and adds stricter validation.

This PR is not clean because ExecutorService.close() is not available in Java 17, so we replaced it with shutdown().

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksClient.java
make test TEST=test/jdk/sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29761967/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/29761969/windows-x64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29761970/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/29761971/macos-aarch64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29761972/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/29761973/linux-x64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29761974/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/29761975/linux-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8333857](https://bugs.openjdk.org/browse/JDK-8333857) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8333857](https://bugs.openjdk.org/browse/JDK-8333857): Test sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java failed: Existing session was used (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4562/head:pull/4562` \
`$ git checkout pull/4562`

Update a local copy of the PR: \
`$ git checkout pull/4562` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4562`

View PR using the GUI difftool: \
`$ git pr show -t 4562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4562.diff">https://git.openjdk.org/jdk17u-dev/pull/4562.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4562#issuecomment-4904087157)
</details>
