### PR TITLE
8343739: Test java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java failed: Wrong extended key code

### DIFF
--- a/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,7 @@ import java.awt.event.KeyAdapter;
  * @test
  * @key headful
  * @bug 8007156 8025126
- * @summary Extended key code is not set for a key event
- * @author Alexandr Scherbatiy
+ * @summary Tests that ExtendedKeyCode is set for key events
  * @library /lib/client
  * @build ExtendedRobot
  * @run main ExtendedKeyCodeTest
@@ -75,7 +74,8 @@ public class ExtendedKeyCodeTest {
         frame.dispose();
 
         if (eventsCount != 2 || !setExtendedKeyCode) {
-            throw new RuntimeException("Wrong extended key code");
+            throw new RuntimeException("Wrong extended key code\n" +
+                    "eventsCount: " + eventsCount);
         }
 
         frame = new Frame();


### PR DESCRIPTION
Backporting JDK-8343739: Test java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java failed: Wrong extended key code.

This PR adds eventsCount metadata in the RuntimeException that it can propagated.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java JTREG="RUN_PROBLEM_LISTS=true"

Results:

[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29802429/macos-aarch64-specific-test.log)
[windows-x64-specific-test.log](https://github.com/user-attachments/files/29802440/windows-x64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29802441/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29802442/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8343739](https://bugs.openjdk.org/browse/JDK-8343739) needs maintainer approval

### Issue
 * [JDK-8343739](https://bugs.openjdk.org/browse/JDK-8343739): Test java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java failed: Wrong extended key code (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4564/head:pull/4564` \
`$ git checkout pull/4564`

Update a local copy of the PR: \
`$ git checkout pull/4564` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4564`

View PR using the GUI difftool: \
`$ git pr show -t 4564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4564.diff">https://git.openjdk.org/jdk17u-dev/pull/4564.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4564#issuecomment-4915198511)
</details>
