### PR TITLE
8365983: Tests should throw SkippedException when SCTP not supported

### DIFF
--- a/test/jdk/com/sun/nio/sctp/SctpChannel/Bind.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/Bind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -48,18 +49,14 @@ import com.sun.nio.sctp.SctpServerChannel;
 import com.sun.nio.sctp.ShutdownNotification;
 import static java.lang.System.out;
 
+import jtreg.SkippedException;
+
 /**
  * Tests bind, bindAddress, unbindAddress, getLocalAddress, and
  * getAllLocalAddresses.
  */
 public class Bind {
      void test(String[] args) {
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
-
         /* Simply bind tests */
         testBind();
 
@@ -341,6 +338,10 @@ public class Bind {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message) {if(debug) { System.out.println(message); }  }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
@@ -45,6 +45,8 @@ import java.util.Optional;
 import com.sun.nio.sctp.SctpChannel;
 import com.sun.nio.sctp.SctpServerChannel;
 
+import jtreg.SkippedException;
+
 public class CloseDescriptors {
     private static Selector selector;
     private static final int LOOP = 10;
@@ -54,7 +56,7 @@ public class CloseDescriptors {
 
     public static void main(String[] args) throws Exception {
         if (!Util.isSCTPSupported()) {
-            throw new jtreg.SkippedException("SCTP protocol is not supported");
+            throw new SkippedException("SCTP protocol is not supported");
         }
 
         List<String> lsofDirs = List.of("/usr/bin", "/usr/sbin");
@@ -63,7 +65,7 @@ public class CloseDescriptors {
                             .filter(f -> Files.isExecutable(f))
                             .findFirst();
         if (!lsof.isPresent()) {
-            throw new jtreg.SkippedException("Cannot locate lsof in " + lsofDirs);
+            throw new SkippedException("Cannot locate lsof in " + lsofDirs);
         }
 
         try (ServerSocket ss = new ServerSocket(0)) {

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CommUp.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CommUp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 6863110
+ * @library /test/lib
  * @summary Newly connected/accepted SctpChannel should fire OP_READ if registered with a Selector
  * @author chegar
  */
@@ -49,6 +50,8 @@ import static java.lang.System.err;
 import static java.nio.channels.SelectionKey.OP_CONNECT;
 import static java.nio.channels.SelectionKey.OP_READ;
 
+import jtreg.SkippedException;
+
 public class CommUp {
     static CountDownLatch acceptLatch = new CountDownLatch(1);
     static final int TIMEOUT = 10000;
@@ -60,12 +63,6 @@ public class CommUp {
 
     void test(String[] args) {
         SocketAddress address = null;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -355,6 +352,10 @@ public class CommUp {
     void sleep(long millis) { try { Thread.currentThread().sleep(millis); }
                           catch(InterruptedException ie) { unexpected(ie); }}
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/Connect.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/Connect.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -43,6 +44,8 @@ import com.sun.nio.sctp.SctpServerChannel;
 import static java.lang.System.out;
 import static java.lang.System.err;
 
+import jtreg.SkippedException;
+
 /**
  * Tests connect, finishConnect, isConnectionPending,
  * getRemoteAddresses and association.
@@ -50,12 +53,6 @@ import static java.lang.System.err;
 public class Connect {
 
     void test(String[] args) {
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
-
         doTest();
     }
 
@@ -235,6 +232,10 @@ public class Connect {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message) {if(debug) { System.out.println(message); }  }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/Receive.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/Receive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -48,6 +49,8 @@ import com.sun.nio.sctp.ShutdownNotification;
 import static java.lang.System.out;
 import static java.lang.System.err;
 
+import jtreg.SkippedException;
+
 public class Receive {
     /* Latches used to synchronize between the client and server so that
      * connections without any IO may not be closed without being accepted */
@@ -60,13 +63,6 @@ public class Receive {
     void test(String[] args) {
         SocketAddress address = null;
         Server server;
-
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -349,6 +345,10 @@ public class Receive {
     void debug(String message) {if(debug) {
           System.out.println(Thread.currentThread() + " " + message); } }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/ReceiveIntoDirect.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/ReceiveIntoDirect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 8034181
+ * @library /test/lib
  * @summary SIGBUS in SctpChannelImpl receive
  * @author chegar
  */
@@ -45,6 +46,8 @@ import static java.lang.System.out;
 import static java.lang.System.err;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import jtreg.SkippedException;
+
 public class ReceiveIntoDirect {
     /* suitably small message to NOT overrun small buffers */
     final byte[] msgBytes =  "Hello".getBytes(US_ASCII);
@@ -55,12 +58,6 @@ public class ReceiveIntoDirect {
     void test(String[] args) throws IOException {
         SocketAddress address = null;
         Server server;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -264,6 +261,10 @@ public class ReceiveIntoDirect {
     void debug(String message) {if(debug) {
           System.out.println(Thread.currentThread() + " " + message); } }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/Send.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/Send.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -48,6 +49,8 @@ import com.sun.nio.sctp.SctpServerChannel;
 import static java.lang.System.out;
 import static java.lang.System.err;
 
+import jtreg.SkippedException;
+
 public class Send {
     /* Latches used to synchronize between the client and server so that
      * connections without any IO may not be closed without being accepted */
@@ -59,12 +62,6 @@ public class Send {
     void test(String[] args) {
         SocketAddress address = null;
         Server server = null;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -451,6 +448,10 @@ public class Send {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message) {if(debug) { System.out.println(message); }  }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/Shutdown.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/Shutdown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -43,6 +44,8 @@ import com.sun.nio.sctp.ShutdownNotification;
 import static java.lang.System.out;
 import static java.lang.System.err;
 
+import jtreg.SkippedException;
+
 public class Shutdown {
     static CountDownLatch finishedLatch = new CountDownLatch(1);
     static CountDownLatch sentLatch = new CountDownLatch(1);
@@ -50,12 +53,6 @@ public class Shutdown {
     void test(String[] args) {
         SocketAddress address = null;
         ShutdownServer server = null;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -272,6 +269,10 @@ public class Shutdown {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message) {if(debug) { System.out.println(message); }  }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpChannel/SocketOptionTests.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/SocketOptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -42,6 +43,8 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import static com.sun.nio.sctp.SctpStandardSocketOptions.*;
 import static java.lang.System.out;
+
+import jtreg.SkippedException;
 
 public class SocketOptionTests {
     final String osName = AccessController.doPrivileged(
@@ -66,12 +69,6 @@ public class SocketOptionTests {
     }
 
     void test(String[] args) {
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
-
         try (SctpChannel sc = SctpChannel.open()) {
 
             /* check supported options */
@@ -190,6 +187,10 @@ public class SocketOptionTests {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message) {if(debug) { System.out.println(message); }  }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Branch.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Branch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -48,6 +49,8 @@ import com.sun.nio.sctp.ShutdownNotification;
 import static java.lang.System.out;
 import static java.lang.System.err;
 
+import jtreg.SkippedException;
+
 public class Branch {
     /* Latches used to synchronize between the client and server so that
      * connections without any IO may not be closed without being accepted */
@@ -57,12 +60,6 @@ public class Branch {
     void test(String[] args) {
         SocketAddress address = null;
         Server server = null;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -277,6 +274,10 @@ public class Branch {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message) {if(debug) { System.out.println(message); }  }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/CloseDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 8269481
+ * @library /test/lib
  * @summary Tests that file descriptors are closed
  * @requires (os.family == "linux")
  * @run main/othervm CloseDescriptors
@@ -38,6 +39,8 @@ import java.util.Optional;
 import com.sun.nio.sctp.MessageInfo;
 import com.sun.nio.sctp.SctpMultiChannel;
 
+import jtreg.SkippedException;
+
 public class CloseDescriptors {
 
     private static final int NUM      = 5;
@@ -46,9 +49,7 @@ public class CloseDescriptors {
 
     public static void main(String[] args) throws Exception {
         if (!Util.isSCTPSupported()) {
-            System.out.println("SCTP protocol is not supported");
-            System.out.println("Test cannot be run");
-            return;
+            throw new SkippedException("SCTP protocol is not supported");
         }
 
         List<String> lsofDirs = List.of("/usr/bin", "/usr/sbin");
@@ -57,9 +58,7 @@ public class CloseDescriptors {
                 .filter(f -> Files.isExecutable(f))
                 .findFirst();
         if (!lsof.isPresent()) {
-            System.out.println("Cannot locate lsof in " + lsofDirs);
-            System.out.println("Test cannot be run");
-            return;
+            throw new SkippedException("Cannot locate lsof in " + lsofDirs);
         }
 
         try (ServerSocket ss = new ServerSocket(0)) {

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Send.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/Send.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -42,6 +43,8 @@ import com.sun.nio.sctp.SctpMultiChannel;
 import static java.lang.System.out;
 import static java.lang.System.err;
 
+import jtreg.SkippedException;
+
 public class Send {
     /* Latches used to synchronize between the client and server so that
      * connections without any IO may not be closed without being accepted */
@@ -51,12 +54,6 @@ public class Send {
     void test(String[] args) {
         SocketAddress address = null;
         Server server = null;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -355,6 +352,10 @@ public class Send {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message) {if(debug) { System.out.println(message); }  }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SendFailed.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SendFailed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 8067846
+ * @library /test/lib
  * @summary Test for send failed notification
  */
 
@@ -35,6 +36,8 @@ import java.nio.ByteBuffer;
 import static java.lang.System.out;
 import static java.nio.ByteBuffer.*;
 
+import jtreg.SkippedException;
+
 public class SendFailed {
 
     static final SocketAddress remoteAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 3000);
@@ -44,12 +47,6 @@ public class SendFailed {
 
     void test(String[] args) throws IOException {
         SocketAddress address = null;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         System.out.println("remote address: " + remoteAddress);
         System.out.println("Note, remote address should not be up");
@@ -186,6 +183,10 @@ public class SendFailed {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message, Object... args) {if(debug) { out.printf(message, args); } }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SocketOptionTests.java
+++ b/test/jdk/com/sun/nio/sctp/SctpMultiChannel/SocketOptionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -51,6 +52,8 @@ import java.security.PrivilegedAction;
 import static com.sun.nio.sctp.SctpStandardSocketOptions.*;
 import static java.lang.System.out;
 
+import jtreg.SkippedException;
+
 public class SocketOptionTests {
     final String osName = AccessController.doPrivileged(
                     (PrivilegedAction<String>)() -> System.getProperty("os.name"));
@@ -74,12 +77,6 @@ public class SocketOptionTests {
     }
 
     void test(String[] args) {
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
-
         try {
             SctpMultiChannel smc = SctpMultiChannel.open();
 
@@ -244,6 +241,10 @@ public class SocketOptionTests {
     void check(boolean cond, String failMessage) {if (cond) pass(); else fail(failMessage);}
     void debug(String message) {if(debug) { System.out.println(message); }  }
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpServerChannel/Accept.java
+++ b/test/jdk/com/sun/nio/sctp/SctpServerChannel/Accept.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -41,6 +42,8 @@ import com.sun.nio.sctp.SctpServerChannel;
 import static java.lang.System.out;
 import static java.lang.System.err;
 
+import jtreg.SkippedException;
+
 public class Accept {
     static CountDownLatch acceptLatch = new CountDownLatch(1);
     static CountDownLatch closeByIntLatch = new CountDownLatch(1);
@@ -49,12 +52,6 @@ public class Accept {
 
     void test(String[] args) {
         SocketAddress address = null;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -262,6 +259,10 @@ public class Accept {
     void join(Thread thread, long millis) { try { thread.join(millis); }
                           catch(InterruptedException ie) { unexpected(ie); }}
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}

--- a/test/jdk/com/sun/nio/sctp/SctpServerChannel/NonBlockingAccept.java
+++ b/test/jdk/com/sun/nio/sctp/SctpServerChannel/NonBlockingAccept.java
@@ -23,6 +23,7 @@
 
 /* @test
  * @bug 4927640
+ * @library /test/lib
  * @summary Tests the SCTP protocol implementation
  * @author chegar
  */
@@ -42,6 +43,8 @@ import com.sun.nio.sctp.SctpServerChannel;
 import static java.lang.System.out;
 import static java.lang.System.err;
 
+import jtreg.SkippedException;
+
 public class NonBlockingAccept {
     static CountDownLatch acceptLatch = new CountDownLatch(1);
     static final int SEL_TIMEOUT = 10000;
@@ -50,12 +53,6 @@ public class NonBlockingAccept {
     void test(String[] args) {
         SocketAddress address = null;
         NonblockingServer server;
-
-        if (!Util.isSCTPSupported()) {
-            out.println("SCTP protocol is not supported");
-            out.println("Test cannot be run");
-            return;
-        }
 
         if (args.length == 2) {
             /* requested to connecct to a specific address */
@@ -218,6 +215,10 @@ public class NonBlockingAccept {
     void sleep(long millis) { try { Thread.currentThread().sleep(millis); }
                           catch(InterruptedException ie) { unexpected(ie); }}
     public static void main(String[] args) throws Throwable {
+        if (!Util.isSCTPSupported()) {
+            throw new SkippedException("SCTP protocol is not supported");
+        }
+
         Class<?> k = new Object(){}.getClass().getEnclosingClass();
         try {k.getMethod("instanceMain",String[].class)
                 .invoke( k.newInstance(), (Object) args);}


### PR DESCRIPTION
Backporting JDK-8365983: Tests should throw SkippedException when SCTP not supported.

This PR updates tests to use SkippedException instead of silently passing.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/com/sun/nio/sctp/SctpChannel
make test TEST=test/jdk/com/sun/nio/sctp/SctpMultiChannel
make test TEST=test/jdk/com/sun/nio/sctp/SctpServerChannel

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29849089/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/29849090/windows-x64-specific-2-test.log)
[windows-x64-specific-3-test.log](https://github.com/user-attachments/files/29849091/windows-x64-specific-3-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29849092/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/29849093/macos-aarch64-specific-2-test.log)
[macos-aarch64-specific-3-test.log](https://github.com/user-attachments/files/29849094/macos-aarch64-specific-3-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29849095/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/29849098/linux-x64-specific-2-test.log)
[linux-x64-specific-3-test.log](https://github.com/user-attachments/files/29849099/linux-x64-specific-3-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29849100/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/29849101/linux-aarch64-specific-2-test.log)
[linux-aarch64-specific-3-test.log](https://github.com/user-attachments/files/29849102/linux-aarch64-specific-3-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8365983](https://bugs.openjdk.org/browse/JDK-8365983) needs maintainer approval

### Issue
 * [JDK-8365983](https://bugs.openjdk.org/browse/JDK-8365983): Tests should throw SkippedException when SCTP not supported (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4566/head:pull/4566` \
`$ git checkout pull/4566`

Update a local copy of the PR: \
`$ git checkout pull/4566` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4566`

View PR using the GUI difftool: \
`$ git pr show -t 4566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4566.diff">https://git.openjdk.org/jdk17u-dev/pull/4566.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4566#issuecomment-4925311766)
</details>
