### PR TITLE
8365863: /test/jdk/sun/security/pkcs11/Cipher tests skip without SkippedException

### DIFF
--- a/test/jdk/sun/security/pkcs11/Cipher/ReinitCipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/ReinitCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@
  * @run main/othervm -Djava.security.manager=allow ReinitCipher sm
  */
 
+import jtreg.SkippedException;
+
 import java.security.Provider;
 import java.util.Random;
 import javax.crypto.Cipher;
@@ -47,8 +49,7 @@ public class ReinitCipher extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (p.getService("Cipher", "ARCFOUR") == null) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Algorithm ARCFOUR is not supported by provider, skipping");
         }
         Random random = new Random();
         byte[] data1 = new byte[10 * 1024];

--- a/test/jdk/sun/security/pkcs11/Cipher/Test4512704.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/Test4512704.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,16 @@
  * @run main Test4512704
  * @summary Verify that AES cipher can generate default IV in encrypt mode
  */
-import java.io.PrintStream;
-import java.security.*;
-import java.security.spec.*;
-import java.util.Random;
+import jtreg.SkippedException;
 
-import javax.crypto.*;
-import javax.crypto.spec.*;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import java.security.Provider;
+import java.security.spec.AlgorithmParameterSpec;
 
 public class Test4512704 extends PKCS11Test {
 
@@ -48,9 +50,8 @@ public class Test4512704 extends PKCS11Test {
             transformation = "AES/" + mode + "/NoPadding";
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + mode);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + mode);
         }
         SecretKey key = new SecretKeySpec(new byte[16], "AES");
 

--- a/test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCM.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,21 @@
  * @key randomness
  */
 
-import java.security.*;
-import javax.crypto.*;
-import javax.crypto.spec.*;
-import java.math.*;
-import java.io.*;
+import jtreg.SkippedException;
 
-import java.util.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.security.GeneralSecurityException;
+import java.security.Provider;
+import java.util.Arrays;
+import java.util.Random;
+
 
 public class TestCICOWithGCM extends PKCS11Test {
     public static void main(String[] args) throws Exception {
@@ -55,9 +63,8 @@ public class TestCICOWithGCM extends PKCS11Test {
             String transformation = "AES/" + mode + "/NoPadding";
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + mode);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + mode);
         }
 
         SecretKey key = new SecretKeySpec(new byte[16], "AES");

--- a/test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCMAndAAD.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestCICOWithGCMAndAAD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @summary Test CipherInputStream/OutputStream with AES GCM mode with AAD.
  * @key randomness
  */
+import jtreg.SkippedException;
+
 import java.io.*;
 import java.security.*;
 import java.util.*;
@@ -44,7 +46,6 @@ public class TestCICOWithGCMAndAAD extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         test("GCM", p);
-//        test("CCM", p);
     }
 
     public void test(String mode, Provider p) throws Exception {
@@ -53,9 +54,8 @@ public class TestCICOWithGCMAndAAD extends PKCS11Test {
             String transformation = "AES/" + mode + "/NoPadding";
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + mode);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + mode);
         }
         SecretKey key = new SecretKeySpec(new byte[16], "AES");
 

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPoly.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPoly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.NoSuchPaddingException;
 
-import jdk.test.lib.Utils;
+import jtreg.SkippedException;
 
 public class TestChaChaPoly extends PKCS11Test {
 
@@ -70,8 +70,7 @@ public class TestChaChaPoly extends PKCS11Test {
         try {
             Cipher.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO);
         }
         this.p = p;
         testTransformations();

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,22 +26,25 @@
  * @bug 8255410
  * @library /test/lib ..
  * @modules jdk.crypto.cryptoki
- * @build jdk.test.lib.Convert
  * @run main/othervm TestChaChaPolyKAT
  * @summary ChaCha20-Poly1305 Cipher Implementation (KAT)
  */
 
-import java.util.*;
+import jtreg.SkippedException;
+
 import java.security.GeneralSecurityException;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Cipher;
-import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.crypto.AEADBadTagException;
 import java.nio.ByteBuffer;
-import jdk.test.lib.Convert;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 
 public class TestChaChaPolyKAT extends PKCS11Test {
     public static class TestData {
@@ -126,8 +129,7 @@ public class TestChaChaPolyKAT extends PKCS11Test {
         try {
             Cipher.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO);
         }
 
         int testsPassed = 0;

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyNoReuse.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyNoReuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,18 +30,22 @@
  * (key/nonce reuse check)
  */
 
-import java.util.*;
+import jtreg.SkippedException;
+
 import javax.crypto.Cipher;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
-import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.crypto.AEADBadTagException;
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
 import java.security.InvalidAlgorithmParameterException;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
 
 public class TestChaChaPolyNoReuse extends PKCS11Test {
 
@@ -238,8 +242,7 @@ public class TestChaChaPolyNoReuse extends PKCS11Test {
         try {
             Cipher.getInstance(CIPHER_ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + CIPHER_ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + CIPHER_ALGO);
         }
 
         int testsPassed = 0;

--- a/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyOutputSize.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestChaChaPolyOutputSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,14 @@
  * @run main TestChaChaPolyOutputSize
  */
 
+import jtreg.SkippedException;
+
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
-import java.security.Key;
 import java.security.SecureRandom;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
 import javax.crypto.Cipher;
-import javax.crypto.spec.ChaCha20ParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -60,8 +60,7 @@ public class TestChaChaPolyOutputSize extends PKCS11Test {
         try {
             Cipher.getInstance(ALGO, p);
         } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("Skip; no support for " + ALGO);
-            return;
+            throw new SkippedException("Skip; no support for " + ALGO);
         }
         testGetOutSize(p);
         testMultiPartAEADDec(p);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestGCMKeyAndIvCheck.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestGCMKeyAndIvCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,13 +31,21 @@
  */
 
 
-import java.security.*;
-import java.security.spec.AlgorithmParameterSpec;
-import javax.crypto.*;
-import javax.crypto.spec.*;
-import java.math.*;
+import jtreg.SkippedException;
 
-import java.util.*;
+import java.security.AlgorithmParameters;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Provider;
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.util.Arrays;
 
 public class TestGCMKeyAndIvCheck extends PKCS11Test {
 
@@ -77,9 +85,8 @@ public class TestGCMKeyAndIvCheck extends PKCS11Test {
             String transformation = "AES/" + mode + "/NoPadding";
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + mode);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + mode);
         }
         System.out.println("Testing against " + p.getName());
         SecretKey key = new SecretKeySpec(new byte[16], "AES");

--- a/test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestKATForGCM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@
  * @summary Known Answer Test for AES cipher with GCM mode support in
  * PKCS11 provider.
  */
+import jtreg.SkippedException;
+
 import java.security.GeneralSecurityException;
 import java.security.Provider;
 import java.util.Arrays;
@@ -311,9 +313,8 @@ public class TestKATForGCM extends PKCS11Test {
         try {
             c = Cipher.getInstance(transformation, p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Skip testing " + p.getName() +
-                    ", no support for " + transformation);
-            return;
+            throw new SkippedException("Skip testing " + p.getName() +
+                                       ", no support for " + transformation);
         }
         try {
             if (execute(testValues, c)) {

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import jdk.test.lib.security.SecurityUtils;
+import jtreg.SkippedException;
 
 public class TestRSACipher extends PKCS11Test {
 
@@ -56,8 +57,7 @@ public class TestRSACipher extends PKCS11Test {
         try {
             Cipher.getInstance(RSA_ALGOS[0], p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Algorithm " + RSA_ALGOS[0] + " is not supported by provider, skipping");
         }
         String kpgAlgorithm = "RSA";
         int keySize = SecurityUtils.getTestKeySize(kpgAlgorithm);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRSACipherWrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import jdk.test.lib.security.SecurityUtils;
+import jtreg.SkippedException;
 
 public class TestRSACipherWrap extends PKCS11Test {
 
@@ -55,8 +56,7 @@ public class TestRSACipherWrap extends PKCS11Test {
         try {
             Cipher.getInstance(RSA_ALGOS[0], p);
         } catch (GeneralSecurityException e) {
-            System.out.println(RSA_ALGOS[0] + " unsupported, skipping");
-            return;
+            throw new SkippedException(RSA_ALGOS[0] + " unsupported, skipping");
         }
         String kpgAlgorithm = "RSA";
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, p);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestRawRSACipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ import java.util.HexFormat;
 import java.util.Random;
 import javax.crypto.Cipher;
 import jdk.test.lib.security.SecurityUtils;
+import jtreg.SkippedException;
 
 public class TestRawRSACipher extends PKCS11Test {
 
@@ -50,8 +51,7 @@ public class TestRawRSACipher extends PKCS11Test {
         try {
             Cipher.getInstance("RSA/ECB/NoPadding", p);
         } catch (GeneralSecurityException e) {
-            System.out.println("Not supported by provider, skipping");
-            return;
+            throw new SkippedException("Algorithm RSA/ECB/NoPadding is not supported by provider, skipping");
         }
 
         String kpgAlgorithm = "RSA";

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,11 +33,15 @@
  * @run main/othervm -Djava.security.manager=allow TestSymmCiphers sm
  */
 
+import jtreg.SkippedException;
+
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.security.AlgorithmParameters;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
@@ -45,42 +49,32 @@ import javax.crypto.SecretKey;
 
 public class TestSymmCiphers extends PKCS11Test {
 
-    private static class CI { // class for holding Cipher Information
+    private record CI (String transformation, String keyAlgo, int dataSize){}  // record for holding Cipher Information
 
-        String transformation;
-        String keyAlgo;
-        int dataSize;
-
-        CI(String transformation, String keyAlgo, int dataSize) {
-            this.transformation = transformation;
-            this.keyAlgo = keyAlgo;
-            this.dataSize = dataSize;
-        }
-    }
     private static final CI[] TEST_LIST = {
-        new CI("ARCFOUR", "ARCFOUR", 400),
-        new CI("RC4", "RC4", 401),
-        new CI("DES/CBC/NoPadding", "DES", 400),
-        new CI("DESede/CBC/NoPadding", "DESede", 160),
-        new CI("AES/CBC/NoPadding", "AES", 4800),
-        new CI("Blowfish/CBC/NoPadding", "Blowfish", 24),
-        new CI("DES/cbc/PKCS5Padding", "DES", 6401),
-        new CI("DESede/CBC/PKCS5Padding", "DESede", 402),
-        new CI("AES/CBC/PKCS5Padding", "AES", 30),
-        new CI("Blowfish/CBC/PKCS5Padding", "Blowfish", 19),
-        new CI("DES/ECB/NoPadding", "DES", 400),
-        new CI("DESede/ECB/NoPadding", "DESede", 160),
-        new CI("AES/ECB/NoPadding", "AES", 4800),
-        new CI("DES/ECB/PKCS5Padding", "DES", 32),
-        new CI("DES/ECB/PKCS5Padding", "DES", 6400),
-        new CI("DESede/ECB/PKCS5Padding", "DESede", 400),
-        new CI("AES/ECB/PKCS5Padding", "AES", 64),
+            new CI("ARCFOUR", "ARCFOUR", 400),
+            new CI("RC4", "RC4", 401),
+            new CI("DES/CBC/NoPadding", "DES", 400),
+            new CI("DESede/CBC/NoPadding", "DESede", 160),
+            new CI("AES/CBC/NoPadding", "AES", 4800),
+            new CI("Blowfish/CBC/NoPadding", "Blowfish", 24),
+            new CI("DES/cbc/PKCS5Padding", "DES", 6401),
+            new CI("DESede/CBC/PKCS5Padding", "DESede", 402),
+            new CI("AES/CBC/PKCS5Padding", "AES", 30),
+            new CI("Blowfish/CBC/PKCS5Padding", "Blowfish", 19),
+            new CI("DES/ECB/NoPadding", "DES", 400),
+            new CI("DESede/ECB/NoPadding", "DESede", 160),
+            new CI("AES/ECB/NoPadding", "AES", 4800),
+            new CI("DES/ECB/PKCS5Padding", "DES", 32),
+            new CI("DES/ECB/PKCS5Padding", "DES", 6400),
+            new CI("DESede/ECB/PKCS5Padding", "DESede", 400),
+            new CI("AES/ECB/PKCS5Padding", "AES", 64),
 
-        new CI("DES", "DES", 6400),
-        new CI("DESede", "DESede", 408),
-        new CI("AES", "AES", 128),
+            new CI("DES", "DES", 6400),
+            new CI("DESede", "DESede", 408),
+            new CI("AES", "AES", 128),
 
-        new CI("AES/CTR/NoPadding", "AES", 3200)
+            new CI("AES/CTR/NoPadding", "AES", 3200)
 
     };
     private static StringBuffer debugBuf = new StringBuffer();
@@ -90,11 +84,10 @@ public class TestSymmCiphers extends PKCS11Test {
         // NSS reports CKR_DEVICE_ERROR when the data passed to
         // its EncryptUpdate/DecryptUpdate is not multiple of blocks
         int firstBlkSize = 16;
-        boolean status = true;
+        List<CI> skippedList = new ArrayList<>();
         Random random = new Random();
         try {
-            for (int i = 0; i < TEST_LIST.length; i++) {
-                CI currTest = TEST_LIST[i];
+            for (CI currTest : TEST_LIST) {
                 System.out.println("===" + currTest.transformation + "===");
                 try {
                     KeyGenerator kg =
@@ -123,7 +116,8 @@ public class TestSymmCiphers extends PKCS11Test {
                     System.out.println("Decryption tests: DONE");
                 } catch (NoSuchAlgorithmException nsae) {
                     System.out.println("Skipping unsupported algorithm: " +
-                            nsae);
+                                       nsae);
+                    skippedList.add(currTest);
                 }
             }
         } catch (Exception ex) {
@@ -134,11 +128,15 @@ public class TestSymmCiphers extends PKCS11Test {
             }
             throw ex;
         }
+
+        if (!skippedList.isEmpty()){
+            throw new SkippedException("Some tests skipped: " + skippedList);
+        }
     }
 
     private static void test(Cipher cipher, int mode, SecretKey key,
-            AlgorithmParameters params, int firstBlkSize,
-            byte[] in, byte[] answer) throws Exception {
+                             AlgorithmParameters params, int firstBlkSize,
+                             byte[] in, byte[] answer) throws Exception {
         // test setup
         long startTime, endTime;
         cipher.init(mode, key, params);

--- a/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
+++ b/test/jdk/sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@
  * @run main/othervm -Djava.security.manager=allow TestSymmCiphersNoPad sm
  */
 
+import jtreg.SkippedException;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -40,6 +42,8 @@ import java.nio.ByteBuffer;
 import java.security.AlgorithmParameters;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
@@ -48,46 +52,35 @@ import javax.crypto.SecretKey;
 
 public class TestSymmCiphersNoPad extends PKCS11Test {
 
-    private static class CI { // class for holding Cipher Information
-        String transformation;
-        String keyAlgo;
-        int dataSize;
-
-        CI(String transformation, String keyAlgo, int dataSize) {
-            this.transformation = transformation;
-            this.keyAlgo = keyAlgo;
-            this.dataSize = dataSize;
-        }
-    }
-
-    private static final CI TEST_LIST[] = {
-        new CI("ARCFOUR", "ARCFOUR", 400),
-        new CI("RC4", "RC4", 401),
-        new CI("DES/CBC/NoPadding", "DES", 400),
-        new CI("DESede/CBC/NoPadding", "DESede", 160),
-        new CI("AES/CBC/NoPadding", "AES", 4800),
-        new CI("Blowfish/CBC/NoPadding", "Blowfish", 24),
-        new CI("AES/CTR/NoPadding", "AES", 1600),
-        new CI("AES/CTR/NoPadding", "AES", 65)
-    };
+    private record CI (String transformation, String keyAlgo, int dataSize){}  // record for holding Cipher Information
 
     private static StringBuffer debugBuf;
 
+    private static final CI[] TEST_LIST = {
+            new CI("ARCFOUR", "ARCFOUR", 400),
+            new CI("RC4", "RC4", 401),
+            new CI("DES/CBC/NoPadding", "DES", 400),
+            new CI("DESede/CBC/NoPadding", "DESede", 160),
+            new CI("AES/CBC/NoPadding", "AES", 4800),
+            new CI("Blowfish/CBC/NoPadding", "Blowfish", 24),
+            new CI("AES/CTR/NoPadding", "AES", 1600),
+            new CI("AES/CTR/NoPadding", "AES", 65)
+    };
+
     @Override
     public void main(Provider p) throws Exception {
-        boolean status = true;
+        List<CI> skippedList = new ArrayList<>();
         Random random = new Random();
         try {
-            for (int i = 0; i < TEST_LIST.length; i++) {
-                CI currTest = TEST_LIST[i];
+            for (CI currTest : TEST_LIST) {
                 System.out.println("===" + currTest.transformation + "===");
                 try {
                     KeyGenerator kg =
-                        KeyGenerator.getInstance(currTest.keyAlgo, p);
+                            KeyGenerator.getInstance(currTest.keyAlgo, p);
                     SecretKey key = kg.generateKey();
                     Cipher c1 = Cipher.getInstance(currTest.transformation, p);
                     Cipher c2 = Cipher.getInstance(currTest.transformation,
-                               System.getProperty("test.provider.name", "SunJCE"));
+                            System.getProperty("test.provider.name", "SunJCE"));
 
                     byte[] plainTxt = new byte[currTest.dataSize];
                     random.nextBytes(plainTxt);
@@ -97,16 +90,17 @@ public class TestSymmCiphersNoPad extends PKCS11Test {
                     AlgorithmParameters params = c2.getParameters();
                     byte[] answer = c2.doFinal(plainTxt);
                     test(c1, Cipher.ENCRYPT_MODE, key, params,
-                         plainTxt, answer);
+                            plainTxt, answer);
                     System.out.println("Encryption tests: DONE");
                     c2.init(Cipher.DECRYPT_MODE, key, params);
                     byte[] answer2 = c2.doFinal(answer);
                     test(c1, Cipher.DECRYPT_MODE, key, params,
-                         answer, answer2);
+                            answer, answer2);
                     System.out.println("Decryption tests: DONE");
                 } catch (NoSuchAlgorithmException nsae) {
                     System.out.println("Skipping unsupported algorithm: " +
                                        nsae);
+                    skippedList.add(currTest);
                 }
             }
         } catch (Exception ex) {
@@ -115,6 +109,10 @@ public class TestSymmCiphersNoPad extends PKCS11Test {
                 System.out.println(debugBuf.toString());
             }
             throw ex;
+        }
+
+        if (!skippedList.isEmpty()){
+            throw new SkippedException("Some tests skipped: " + skippedList);
         }
     }
 


### PR DESCRIPTION
Backporting JDK-8365863: /test/jdk/sun/security/pkcs11/Cipher tests skip without SkippedException.

This PR updates tests to use SkippedException instead of silently passing.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/sun/security/pkcs11/Cipher

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/29849152/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/29849153/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/29849154/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/29849156/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8365863](https://bugs.openjdk.org/browse/JDK-8365863) needs maintainer approval

### Issue
 * [JDK-8365863](https://bugs.openjdk.org/browse/JDK-8365863): /test/jdk/sun/security/pkcs11/Cipher tests skip without SkippedException (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4567/head:pull/4567` \
`$ git checkout pull/4567`

Update a local copy of the PR: \
`$ git checkout pull/4567` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4567`

View PR using the GUI difftool: \
`$ git pr show -t 4567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4567.diff">https://git.openjdk.org/jdk17u-dev/pull/4567.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4567#issuecomment-4925356462)
</details>
