### PR TITLE
8313612: Use JUnit in lib-test/jdk tests

### DIFF
--- a/test/lib-test/jdk/test/lib/format/ArrayDiffTest.java
+++ b/test/lib-test/jdk/test/lib/format/ArrayDiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,22 +23,20 @@
 
 package jdk.test.lib.format;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * @test
  * @summary Check ArrayDiff formatting
  * @library /test/lib
- * @run testng jdk.test.lib.format.ArrayDiffTest
+ * @run junit jdk.test.lib.format.ArrayDiffTest
  */
-public class ArrayDiffTest {
+class ArrayDiffTest {
 
     @Test
-    public void testEqualArrays() {
+    void testEqualArrays() {
         char[] first = new char[]  {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
         char[] second = new char[] {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
 
@@ -46,7 +44,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testOutputFitsWidth() {
+    void testOutputFitsWidth() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -62,7 +60,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testIntegers() {
+    void testIntegers() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -78,7 +76,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testLongs() {
+    void testLongs() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -94,7 +92,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testFirstElementIsWrong() {
+    void testFirstElementIsWrong() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -110,7 +108,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testOneElementIsEmpty() {
+    void testOneElementIsEmpty() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -126,7 +124,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testOutputDoesntFitWidth() {
+    void testOutputDoesntFitWidth() {
         new AssertBuilder()
             .withParams(20, Integer.MAX_VALUE)
             .withArrays(
@@ -142,7 +140,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testVariableElementWidthOutputDoesntFitWidth() {
+    void testVariableElementWidthOutputDoesntFitWidth() {
         new AssertBuilder()
             .withParams(20, Integer.MAX_VALUE)
             .withArrays(
@@ -158,7 +156,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testContextBefore() {
+    void testContextBefore() {
         new AssertBuilder()
             .withParams(20, 2)
             .withArrays(
@@ -174,7 +172,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testBoundedBytesWithDifferentWidth() {
+    void testBoundedBytesWithDifferentWidth() {
         new AssertBuilder()
             .withParams(24, 2)
             .withArrays(
@@ -190,7 +188,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testBoundedFirstElementIsWrong() {
+    void testBoundedFirstElementIsWrong() {
         new AssertBuilder()
             .withParams(25, 2)
             .withArrays(
@@ -206,7 +204,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testBoundedOneArchiveIsEmpty() {
+    void testBoundedOneArchiveIsEmpty() {
         new AssertBuilder()
             .withParams(10, 2)
             .withArrays(
@@ -222,7 +220,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testUnboundedOneArchiveIsEmpty() {
+    void testUnboundedOneArchiveIsEmpty() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -238,7 +236,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testUnprintableCharFormatting() {
+    void testUnprintableCharFormatting() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -254,7 +252,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testStringElements() {
+    void testStringElements() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -270,7 +268,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testToStringableObjects() {
+    void testToStringableObjects() {
         class StrObj {
             private final String value;
             public boolean equals(Object another) { return ((StrObj)another).value.equals(value); }
@@ -294,7 +292,7 @@ public class ArrayDiffTest {
     }
 
     @Test
-    public void testNullElements() {
+    void testNullElements() {
         new AssertBuilder()
             .withDefaultParams()
             .withArrays(
@@ -309,14 +307,14 @@ public class ArrayDiffTest {
             .assertTwoWay();
     }
 
-    @Test (expectedExceptions = NullPointerException.class)
-    public void testFirstArrayIsNull() {
-        var diff = ArrayDiff.of(null, new String[] {"a", "b"});
+    @Test
+    void testFirstArrayIsNull() {
+        assertThrows(NullPointerException.class, () -> ArrayDiff.of(null, new String[] {"a", "b"}));
     }
 
-    @Test (expectedExceptions = NullPointerException.class)
-    public void testSecondArrayIsNull() {
-        var diff = ArrayDiff.of(null, new String[] {"a", "b"});
+    @Test
+    void testSecondArrayIsNull() {
+        assertThrows(NullPointerException.class, () -> ArrayDiff.of(new String[] {"a", "b"}, null));
     }
 
     class AssertBuilder {
@@ -331,30 +329,30 @@ public class ArrayDiffTest {
         private String secondFormattedArray;
         private String failureMark;
 
-        public AssertBuilder withDefaultParams() {
+        AssertBuilder withDefaultParams() {
             defaultParameters = true;
             return this;
         }
 
-        public AssertBuilder withParams(int width, int contextBefore) {
+        AssertBuilder withParams(int width, int contextBefore) {
             defaultParameters = false;
             this.width = width;
             this.contextBefore = contextBefore;
             return this;
         }
 
-        public AssertBuilder withArrays(Object first, Object second) {
+        AssertBuilder withArrays(Object first, Object second) {
             firstArray = first;
             secondArray = second;
             return this;
         }
 
-        public AssertBuilder thatResultIs(boolean result) {
+        AssertBuilder thatResultIs(boolean result) {
             expectedResult = result;
             return this;
         }
 
-        public AssertBuilder thatFormattedValuesAre(
+        AssertBuilder thatFormattedValuesAre(
                 int idx, String first, String second, String mark) {
             expectedIndex = idx;
             firstFormattedArray = first;
@@ -363,7 +361,7 @@ public class ArrayDiffTest {
             return this;
         }
 
-        public void assertTwoWay() {
+        void assertTwoWay() {
             ArrayDiff<?> diff;
 
             // Direct
@@ -382,7 +380,7 @@ public class ArrayDiffTest {
                     expectedIndex, firstFormattedArray, secondFormattedArray, failureMark);
 
                 assertFalse(diff.areEqual());
-                assertEquals(diff.format(), expected);
+                assertEquals(expected, diff.format());
             }
 
             // Reversed
@@ -401,7 +399,7 @@ public class ArrayDiffTest {
                     expectedIndex, secondFormattedArray, firstFormattedArray, failureMark);
 
                 assertFalse(diff.areEqual());
-                assertEquals(diff.format(), expected);
+                assertEquals(expected, diff.format());
             }
         }
 

--- a/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
+++ b/test/lib-test/jdk/test/lib/hexdump/ASN1FormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,7 @@
 
 package jdk.test.lib.hexdump;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -34,7 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /*
  * @test
@@ -42,14 +41,13 @@ import static org.testng.Assert.*;
  * @modules java.base/sun.security.util
  * @library /test/lib
  * @compile ASN1FormatterTest.java
- * @run testng jdk.test.lib.hexdump.ASN1FormatterTest
+ * @run junit jdk.test.lib.hexdump.ASN1FormatterTest
  */
-@Test
-public class ASN1FormatterTest {
+class ASN1FormatterTest {
     private static final String DIR = System.getProperty("test.src", ".");
 
     @Test
-    static void testPEM() throws IOException {
+    void testPEM() throws IOException {
         String certFile = "openssl.p12.pem";
         Path certPath = Path.of(DIR, certFile);
         System.out.println("certPath: " + certPath);
@@ -64,18 +62,18 @@ public class ASN1FormatterTest {
             String result = ASN1Formatter.formatter().annotate(is);
             System.out.println(result);
 
-            Assert.assertEquals(result.lines().count(), 76, "Lines");
-            Assert.assertEquals(result.lines().filter(s -> s.contains("SEQUENCE")).count(),24, "Sequences");
-            Assert.assertEquals(result.lines().filter(s -> s.contains("OBJECT ID")).count(), 17, "ObjectIDs");
-            Assert.assertEquals(result.lines().filter(s -> s.contains("UTCTIME")).count(), 2, "UTCTIME");
-            Assert.assertEquals(result.lines().filter(s -> s.contains("BIT STRING")).count(), 3, "BitStrings");
+            assertEquals(76, result.lines().count(), "Lines");
+            assertEquals(24, result.lines().filter(s -> s.contains("SEQUENCE")).count(),"Sequences");
+            assertEquals(17, result.lines().filter(s -> s.contains("OBJECT ID")).count(), "ObjectIDs");
+            assertEquals(2, result.lines().filter(s -> s.contains("UTCTIME")).count(), "UTCTIME");
+            assertEquals(3, result.lines().filter(s -> s.contains("BIT STRING")).count(), "BitStrings");
         } catch (EOFException eof) {
             // done
         }
     }
 
     @Test
-    static void dumpPEM() throws IOException {
+    void dumpPEM() throws IOException {
         String file = "openssl.p12.pem";
         Path path = Path.of(DIR, file);
         System.out.println("path: " + path);
@@ -92,34 +90,34 @@ public class ASN1FormatterTest {
             String result = p.toString(wis);
             System.out.println(result);
 
-            Assert.assertEquals(result.lines().count(), 126, "Lines");
-            Assert.assertEquals(result.lines().filter(s -> s.contains("SEQUENCE")).count(), 24, "Sequences");
-            Assert.assertEquals(result.lines().filter(s -> s.contains("OBJECT ID")).count(), 17, "ObjectIDs");
-            Assert.assertEquals(result.lines().filter(s -> s.contains("UTCTIME")).count(), 2, "UTCTIME");
-            Assert.assertEquals(result.lines().filter(s -> s.contains("BIT STRING")).count(), 3, "BitStrings");
+            assertEquals(126, result.lines().count(), "Lines");
+            assertEquals(24, result.lines().filter(s -> s.contains("SEQUENCE")).count(), "Sequences");
+            assertEquals(17, result.lines().filter(s -> s.contains("OBJECT ID")).count(), "ObjectIDs");
+            assertEquals(2, result.lines().filter(s -> s.contains("UTCTIME")).count(), "UTCTIME");
+            assertEquals(3, result.lines().filter(s -> s.contains("BIT STRING")).count(), "BitStrings");
         } catch (EOFException eof) {
             // done
         }
     }
 
     @Test
-    static void testIndefinite() {
+    void testIndefinite() {
         byte[] bytes = {0x24, (byte) 0x80, 4, 2, 'a', 'b', 4, 2, 'c', 'd', 0, 0};
         HexPrinter p = HexPrinter.simple()
                 .formatter(ASN1Formatter.formatter(), "; ", 100);
         String result = p.toString(bytes);
         System.out.println(result);
 
-        Assert.assertEquals(result.lines().filter(s -> s.contains("OCTET STRING [INDEFINITE]")).count(),
-                1, "Indefinite length");
-        Assert.assertEquals(result.lines().filter(s -> s.contains(";   OCTET STRING [2]")).count(),
-                2, "Octet Sequences");
-        Assert.assertEquals(result.lines().filter(s -> s.contains(";   END-OF-CONTENT")).count(),
-                1, "end of content");
+        assertEquals(1, result.lines().filter(s -> s.contains("OCTET STRING [INDEFINITE]")).count(),
+                "Indefinite length");
+        assertEquals(2, result.lines().filter(s -> s.contains(";   OCTET STRING [2]")).count(),
+                "Octet Sequences");
+        assertEquals(1, result.lines().filter(s -> s.contains(";   END-OF-CONTENT")).count(),
+                "end of content");
     }
 
     @Test
-    static void testMain() {
+    void testMain() {
         String file = "openssl.p12.pem";
         Path path = Path.of(DIR, file);
         String[] args = { path.toString() };


### PR DESCRIPTION
Backporting JDK-8313612: Use JUnit in lib-test/jdk tests.

This PR migrates lib-test/jdk tests from TestNG to JUnit.

For parity with Oracle JDK. Already backported to 21.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/lib-test/jdk/test/lib/format/ArrayDiffTest.java
make test TEST=test/lib-test/jdk/test/lib/hexdump

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/30089893/windows-x64-specific-test.log)
[windows-x64-specific-2-test.log](https://github.com/user-attachments/files/30089894/windows-x64-specific-2-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/30089895/macos-aarch64-specific-test.log)
[macos-aarch64-specific-2-test.log](https://github.com/user-attachments/files/30089896/macos-aarch64-specific-2-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/30089897/linux-x64-specific-test.log)
[linux-x64-specific-2-test.log](https://github.com/user-attachments/files/30089899/linux-x64-specific-2-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/30089901/linux-aarch64-specific-test.log)
[linux-aarch64-specific-2-test.log](https://github.com/user-attachments/files/30089902/linux-aarch64-specific-2-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8313612](https://bugs.openjdk.org/browse/JDK-8313612) needs maintainer approval

### Issue
 * [JDK-8313612](https://bugs.openjdk.org/browse/JDK-8313612): Use JUnit in lib-test/jdk tests (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4573/head:pull/4573` \
`$ git checkout pull/4573`

Update a local copy of the PR: \
`$ git checkout pull/4573` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4573`

View PR using the GUI difftool: \
`$ git pr show -t 4573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4573.diff">https://git.openjdk.org/jdk17u-dev/pull/4573.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4573#issuecomment-4992386872)
</details>
