### PR TITLE
8352565: Add native method implementation of Reference.get()

### DIFF
--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -178,6 +178,7 @@ JVM_RawMonitorDestroy
 JVM_RawMonitorEnter
 JVM_RawMonitorExit
 JVM_ReferenceClear
+JVM_ReferenceGet
 JVM_ReferenceRefersTo
 JVM_RegisterLambdaProxyClassForArchiving
 JVM_RegisterSignal

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -135,7 +135,7 @@ bool Compiler::is_intrinsic_supported(const methodHandle& method) {
   case vmIntrinsics::_arraycopy:
   case vmIntrinsics::_currentTimeMillis:
   case vmIntrinsics::_nanoTime:
-  case vmIntrinsics::_Reference_get:
+  case vmIntrinsics::_Reference_get0:
     // Use the intrinsic version of Reference.get() so that the value in
     // the referent field can be registered by the G1 pre-barrier code.
     // Also to prevent commoning reads from this field across safepoint

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -3283,7 +3283,7 @@ GraphBuilder::GraphBuilder(Compilation* compilation, IRScope* scope)
       break;
     }
 
-  case vmIntrinsics::_Reference_get:
+  case vmIntrinsics::_Reference_get0:
     {
       {
         // With java.lang.ref.reference.get() we must go through the

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1206,7 +1206,7 @@ void LIRGenerator::do_Return(Return* x) {
 
 // Examble: ref.get()
 // Combination of LoadField and g1 pre-write barrier
-void LIRGenerator::do_Reference_get(Intrinsic* x) {
+void LIRGenerator::do_Reference_get0(Intrinsic* x) {
 
   const int referent_offset = java_lang_ref_Reference::referent_offset();
 
@@ -3163,8 +3163,8 @@ void LIRGenerator::do_Intrinsic(Intrinsic* x) {
   case vmIntrinsics::_onSpinWait:
     __ on_spin_wait();
     break;
-  case vmIntrinsics::_Reference_get:
-    do_Reference_get(x);
+  case vmIntrinsics::_Reference_get0:
+    do_Reference_get0(x);
     break;
 
   case vmIntrinsics::_updateCRC32:

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -264,7 +264,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_CompareAndSwap(Intrinsic* x, ValueType* type);
   void do_NIOCheckIndex(Intrinsic* x);
   void do_FPIntrinsics(Intrinsic* x);
-  void do_Reference_get(Intrinsic* x);
+  void do_Reference_get0(Intrinsic* x);
   void do_update_CRC32(Intrinsic* x);
   void do_update_CRC32C(Intrinsic* x);
   void do_vectorizedMismatch(Intrinsic* x);

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -914,6 +914,7 @@ class java_lang_ref_Reference: AllStatic {
  public:
   // Accessors
   static inline oop weak_referent_no_keepalive(oop ref);
+  static inline oop weak_referent(oop ref);
   static inline oop phantom_referent_no_keepalive(oop ref);
   static inline oop unknown_referent_no_keepalive(oop ref);
   static inline void clear_referent(oop ref);

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -135,6 +135,11 @@ oop java_lang_ref_Reference::weak_referent_no_keepalive(oop ref) {
   return ref->obj_field_access<ON_WEAK_OOP_REF | AS_NO_KEEPALIVE>(_referent_offset);
 }
 
+oop java_lang_ref_Reference::weak_referent(oop ref) {
+  assert(java_lang_ref_Reference::is_weak(ref) || java_lang_ref_Reference::is_soft(ref), "must be Weak or Soft Reference");
+  return ref->obj_field_access<ON_WEAK_OOP_REF>(_referent_offset);
+}
+
 oop java_lang_ref_Reference::phantom_referent_no_keepalive(oop ref) {
   assert(java_lang_ref_Reference::is_phantom(ref), "must be Phantom Reference");
   return ref->obj_field_access<ON_PHANTOM_OOP_REF | AS_NO_KEEPALIVE>(_referent_offset);

--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -89,7 +89,7 @@ bool vmIntrinsics::preserves_state(vmIntrinsics::ID id) {
   case vmIntrinsics::_dexp:
   case vmIntrinsics::_dpow:
   case vmIntrinsics::_checkIndex:
-  case vmIntrinsics::_Reference_get:
+  case vmIntrinsics::_Reference_get0:
   case vmIntrinsics::_updateCRC32:
   case vmIntrinsics::_updateBytesCRC32:
   case vmIntrinsics::_updateByteBufferCRC32:
@@ -226,7 +226,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
     case vmIntrinsics::_storeFence:
     case vmIntrinsics::_fullFence:
     case vmIntrinsics::_hasNegatives:
-    case vmIntrinsics::_Reference_get:
+    case vmIntrinsics::_Reference_get0:
       break;
     default:
       return true;

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -393,7 +393,7 @@ class methodHandle;
    do_signature(vectorizedMismatch_signature, "(Ljava/lang/Object;JLjava/lang/Object;JII)I")                            \
                                                                                                                         \
   /* java/lang/ref/Reference */                                                                                         \
-  do_intrinsic(_Reference_get,            java_lang_ref_Reference, get_name,    void_object_signature, F_R)             \
+  do_intrinsic(_Reference_get0,          java_lang_ref_Reference, get0_name,    void_object_signature, F_R)             \
   do_intrinsic(_Reference_refersTo0,     java_lang_ref_Reference, refersTo0_name, object_boolean_signature, F_R)        \
   do_intrinsic(_PhantomReference_refersTo0, java_lang_ref_PhantomReference, refersTo0_name, object_boolean_signature, F_R) \
                                                                                                                         \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -393,7 +393,7 @@
   template(run_finalization_name,                     "runFinalization")                          \
   template(dispatchUncaughtException_name,            "dispatchUncaughtException")                \
   template(loadClass_name,                            "loadClass")                                \
-  template(get_name,                                  "get")                                      \
+  template(get0_name,                                 "get0")                                     \
   template(refersTo0_name,                            "refersTo0")                                \
   template(put_name,                                  "put")                                      \
   template(type_name,                                 "type")                                     \

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -321,6 +321,9 @@ JVM_HasReferencePendingList(JNIEnv *env);
 JNIEXPORT void JNICALL
 JVM_WaitForReferencePendingList(JNIEnv *env);
 
+JNIEXPORT jobject JNICALL
+JVM_ReferenceGet(JNIEnv *env, jobject ref);
+
 JNIEXPORT jboolean JNICALL
 JVM_ReferenceRefersTo(JNIEnv *env, jobject ref, jobject o);
 

--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -145,7 +145,7 @@ AbstractInterpreter::MethodKind AbstractInterpreter::method_kind(const methodHan
       case vmIntrinsics::_dexp:              return java_lang_math_exp;
       case vmIntrinsics::_fmaD:              return java_lang_math_fmaD;
       case vmIntrinsics::_fmaF:              return java_lang_math_fmaF;
-      case vmIntrinsics::_Reference_get:     return java_lang_ref_reference_get;
+      case vmIntrinsics::_Reference_get0:    return java_lang_ref_reference_get0;
       case vmIntrinsics::_dsqrt:
         // _dsqrt will be selected for both Math::sqrt and StrictMath::sqrt, but the latter
         // is native. Keep treating it like a native method in the interpreter

--- a/src/hotspot/share/interpreter/abstractInterpreter.hpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.hpp
@@ -80,7 +80,7 @@ class AbstractInterpreter: AllStatic {
     java_lang_math_exp,                                         // implementation of java.lang.Math.exp   (x)
     java_lang_math_fmaF,                                        // implementation of java.lang.Math.fma   (x, y, z)
     java_lang_math_fmaD,                                        // implementation of java.lang.Math.fma   (x, y, z)
-    java_lang_ref_reference_get,                                // implementation of java.lang.ref.Reference.get()
+    java_lang_ref_reference_get0,                               // implementation of java.lang.ref.Reference.get()
     java_util_zip_CRC32_update,                                 // implementation of java.util.zip.CRC32.update()
     java_util_zip_CRC32_updateBytes,                            // implementation of java.util.zip.CRC32.updateBytes()
     java_util_zip_CRC32_updateByteBuffer,                       // implementation of java.util.zip.CRC32.updateByteBuffer()

--- a/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreterGenerator.cpp
@@ -200,7 +200,7 @@ void TemplateInterpreterGenerator::generate_all() {
   method_entry(java_lang_math_pow  )
   method_entry(java_lang_math_fmaF )
   method_entry(java_lang_math_fmaD )
-  method_entry(java_lang_ref_reference_get)
+  method_entry(java_lang_ref_reference_get0)
 
   AbstractInterpreter::initialize_method_handle_entries();
 
@@ -419,8 +419,8 @@ address TemplateInterpreterGenerator::generate_method_entry(
   case Interpreter::java_lang_math_exp     : // fall thru
   case Interpreter::java_lang_math_fmaD    : // fall thru
   case Interpreter::java_lang_math_fmaF    : entry_point = generate_math_entry(kind);      break;
-  case Interpreter::java_lang_ref_reference_get
-                                           : entry_point = generate_Reference_get_entry(); break;
+  case Interpreter::java_lang_ref_reference_get0
+                                           : entry_point = generate_Reference_get_entry(); native = true;  break;
   case Interpreter::java_util_zip_CRC32_update
                                            : native = true; entry_point = generate_CRC32_update_entry();  break;
   case Interpreter::java_util_zip_CRC32_updateBytes

--- a/src/hotspot/share/interpreter/zero/zeroInterpreterGenerator.cpp
+++ b/src/hotspot/share/interpreter/zero/zeroInterpreterGenerator.cpp
@@ -62,7 +62,7 @@ void ZeroInterpreterGenerator::generate_all() {
     method_entry(java_lang_math_exp );
     method_entry(java_lang_math_fmaD );
     method_entry(java_lang_math_fmaF );
-    method_entry(java_lang_ref_reference_get);
+    method_entry(java_lang_ref_reference_get0);
 
     AbstractInterpreter::initialize_method_handle_entries();
 
@@ -104,7 +104,7 @@ address ZeroInterpreterGenerator::generate_method_entry(
   case Interpreter::java_lang_math_exp     : // fall thru
   case Interpreter::java_lang_math_fmaD    : // fall thru
   case Interpreter::java_lang_math_fmaF    : entry_point = generate_math_entry(kind);      break;
-  case Interpreter::java_lang_ref_reference_get
+  case Interpreter::java_lang_ref_reference_get0
                                            : entry_point = generate_Reference_get_entry(); break;
   default:
     fatal("unexpected method kind: %d", kind);

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -633,7 +633,7 @@ bool C2Compiler::is_intrinsic_supported(const methodHandle& method, bool is_virt
   case vmIntrinsics::_doubleToRawLongBits:
   case vmIntrinsics::_doubleToLongBits:
   case vmIntrinsics::_longBitsToDouble:
-  case vmIntrinsics::_Reference_get:
+  case vmIntrinsics::_Reference_get0:
   case vmIntrinsics::_Reference_refersTo0:
   case vmIntrinsics::_PhantomReference_refersTo0:
   case vmIntrinsics::_Class_cast:

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -697,19 +697,9 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
       StartNode* s = new StartNode(root(), tf()->domain());
       initial_gvn()->set_type_bottom(s);
       init_start(s);
-      if (method()->intrinsic_id() == vmIntrinsics::_Reference_get) {
-        // With java.lang.ref.reference.get() we must go through the
-        // intrinsic - even when get() is the root
-        // method of the compile - so that, if necessary, the value in
-        // the referent field of the reference object gets recorded by
-        // the pre-barrier code.
-        cg = find_intrinsic(method(), false);
-      }
-      if (cg == nullptr) {
-        float past_uses = method()->interpreter_invocation_count();
-        float expected_uses = past_uses;
-        cg = CallGenerator::for_inline(method(), expected_uses);
-      }
+      float past_uses = method()->interpreter_invocation_count();
+      float expected_uses = past_uses;
+      cg = CallGenerator::for_inline(method(), expected_uses);
     }
     if (failing())  return;
     if (cg == nullptr) {

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -528,7 +528,7 @@ bool LibraryCallKit::try_to_inline(int predicate) {
 
   case vmIntrinsics::_getCallerClass:           return inline_native_Reflection_getCallerClass();
 
-  case vmIntrinsics::_Reference_get:            return inline_reference_get();
+  case vmIntrinsics::_Reference_get0:           return inline_reference_get0();
   case vmIntrinsics::_Reference_refersTo0:      return inline_reference_refersTo0(false);
   case vmIntrinsics::_PhantomReference_refersTo0: return inline_reference_refersTo0(true);
 
@@ -5791,9 +5791,9 @@ bool LibraryCallKit::inline_updateByteBufferAdler32() {
   return true;
 }
 
-//----------------------------inline_reference_get----------------------------
+//----------------------------inline_reference_get0----------------------------
 // public T java.lang.ref.Reference.get();
-bool LibraryCallKit::inline_reference_get() {
+bool LibraryCallKit::inline_reference_get0() {
   const int referent_offset = java_lang_ref_Reference::referent_offset();
 
   // Get the argument:

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -264,7 +264,7 @@ class LibraryCallKit : public GraphKit {
   bool inline_onspinwait();
   bool inline_fp_conversions(vmIntrinsics::ID id);
   bool inline_number_methods(vmIntrinsics::ID id);
-  bool inline_reference_get();
+  bool inline_reference_get0();
   bool inline_reference_refersTo0(bool is_phantom);
   bool inline_Class_cast();
   bool inline_aescrypt_Block(vmIntrinsics::ID id);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3206,6 +3206,14 @@ JVM_ENTRY(void, JVM_WaitForReferencePendingList(JNIEnv* env))
   }
 JVM_END
 
+JVM_ENTRY(jobject, JVM_ReferenceGet(JNIEnv* env, jobject ref))
+  oop ref_oop = JNIHandles::resolve_non_null(ref);
+  // PhantomReference has its own implementation of get().
+  assert(!java_lang_ref_Reference::is_phantom(ref_oop), "precondition");
+  oop referent = java_lang_ref_Reference::weak_referent(ref_oop);
+  return JNIHandles::make_local(THREAD, referent);
+JVM_END
+
 JVM_ENTRY(jboolean, JVM_ReferenceRefersTo(JNIEnv* env, jobject ref, jobject o))
   oop ref_oop = JNIHandles::resolve_non_null(ref);
   oop referent = java_lang_ref_Reference::weak_referent_no_keepalive(ref_oop);

--- a/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -348,10 +348,17 @@ public abstract class Reference<T> {
      *           {@code null} if this reference object has been cleared
      * @see #refersTo
      */
-    @IntrinsicCandidate
     public T get() {
-        return this.referent;
+        return get0();
     }
+
+    /* Implementation of get().  This method exists to avoid making get() all
+     * of virtual, native, and intrinsic candidate. That could have the
+     * undesirable effect of having the native method used instead of the
+     * intrinsic when devirtualization fails.
+     */
+    @IntrinsicCandidate
+    private native T get0();
 
     /**
      * Tests if the referent of this reference object is {@code obj}.

--- a/src/java.base/share/native/libjava/Reference.c
+++ b/src/java.base/share/native/libjava/Reference.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,12 @@ JNIEXPORT void JNICALL
 Java_java_lang_ref_Reference_waitForReferencePendingList(JNIEnv *env, jclass ignore)
 {
     JVM_WaitForReferencePendingList(env);
+}
+
+JNIEXPORT jobject JNICALL
+Java_java_lang_ref_Reference_get0(JNIEnv *env, jobject ref)
+{
+    return JVM_ReferenceGet(env, ref);
 }
 
 JNIEXPORT jboolean JNICALL

--- a/test/hotspot/jtreg/gc/TestNativeReferenceGet.java
+++ b/test/hotspot/jtreg/gc/TestNativeReferenceGet.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc;
+
+/**
+ * @test
+ * @bug 8352565
+ * @summary Determine whether the native method implementation of
+ * Reference.get() works as expected.  Disable the intrinsic implementation to
+ * force use of the native method.
+ * @library /test/lib
+ * @modules java.base/java.lang.ref:open
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm
+ *    -Xbootclasspath/a:.
+ *    -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *    -XX:DisableIntrinsic=_Reference_get0
+ *    gc.TestNativeReferenceGet
+ */
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import jdk.test.whitebox.WhiteBox;
+
+public final class TestNativeReferenceGet {
+
+    private static final WhiteBox WB = WhiteBox.getWhiteBox();
+
+    private static void gcUntilOld(Object o) {
+        while (!WB.isObjectInOldGen(o)) {
+            WB.fullGC();
+        }
+    }
+
+    private static final class TestObject {
+        public final int value;
+
+        public TestObject(int value) {
+            this.value = value;
+        }
+    }
+
+    private static final ReferenceQueue<TestObject> queue =
+        new ReferenceQueue<TestObject>();
+
+    private static final class Ref extends WeakReference<TestObject> {
+        public Ref(TestObject obj) {
+            super(obj, queue);
+        }
+    }
+
+    private static final int NUM_REFS = 100;
+
+    private static List<Ref> references = null;
+    private static List<TestObject> referents = null;
+
+    // Create all the objects used by the test, and ensure they are all in the
+    // old generation.
+    private static void setup() {
+        references = new ArrayList<Ref>(NUM_REFS);
+        referents = new ArrayList<TestObject>(NUM_REFS);
+
+        for (int i = 0; i < NUM_REFS; ++i) {
+            TestObject obj = new TestObject(i);
+            referents.add(obj);
+            references.add(new Ref(obj));
+        }
+
+        gcUntilOld(references);
+        gcUntilOld(referents);
+        for (int i = 0; i < NUM_REFS; ++i) {
+            gcUntilOld(references.get(i));
+            gcUntilOld(referents.get(i));
+        }
+    }
+
+    // Discard all the strong references.
+    private static void dropReferents() {
+        // Not using List.clear() because it doesn't document null'ing elements.
+        for (int i = 0; i < NUM_REFS; ++i) {
+            referents.set(i, null);
+        }
+    }
+
+    // Create new strong references from the weak references, by using the
+    // native method implementation of Reference.get() and recording the value
+    // in references.
+    private static void strengthenReferents() {
+        for (int i = 0; i < NUM_REFS; ++i) {
+            referents.set(i, references.get(i).get());
+        }
+    }
+
+    private static void check() {
+        // None of the references should have been cleared and enqueued,
+        // because we have strong references to all the referents.
+        try {
+            while (WB.waitForReferenceProcessing()) {}
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Test interrupted");
+        }
+        if (queue.poll() != null) {
+            throw new RuntimeException("Reference enqueued");
+        }
+
+        // Check details of expected state.
+        for (int i = 0; i < NUM_REFS; ++i) {
+            Ref reference = (Ref) references.get(i);
+            TestObject referent = reference.get();
+            if (referent == null) {
+                throw new RuntimeException("Referent not strengthened");
+            } else if (referent != referents.get(i)) {
+                throw new RuntimeException(
+                    "Reference referent differs from saved referent: " + i);
+            } else if (referent.value != i) {
+                throw new RuntimeException(
+                    "Referent " + i + " value: " + referent.value);
+            }
+        }
+    }
+
+    private static void testConcurrent() {
+        System.out.println("Testing concurrent GC");
+        try {
+            WB.concurrentGCAcquireControl();
+            dropReferents();
+            WB.concurrentGCRunTo(WB.BEFORE_MARKING_COMPLETED);
+            strengthenReferents();
+            WB.concurrentGCRunToIdle();
+            check();
+        } finally {
+            WB.concurrentGCReleaseControl();
+        }
+    }
+
+    private static void testNonconcurrent() {
+        System.out.println("Testing nonconcurrent GC");
+        // A GC between clearing and strengthening will result in test failure.
+        // We try to make that unlikely via this immediately preceeding GC.
+        WB.fullGC();
+        dropReferents();
+        strengthenReferents();
+        WB.fullGC();
+        check();
+    }
+
+    public static final void main(String[] args) {
+        setup();
+        if (WB.supportsConcurrentGCBreakpoints()) {
+            testConcurrent();
+        } else {
+            testNonconcurrent();
+        }
+    }
+}


### PR DESCRIPTION
This is a backport of JDK-8352565.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8352565](https://bugs.openjdk.org/browse/JDK-8352565) needs maintainer approval

### Issue
 * [JDK-8352565](https://bugs.openjdk.org/browse/JDK-8352565): Add native method implementation of Reference.get() (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4575/head:pull/4575` \
`$ git checkout pull/4575`

Update a local copy of the PR: \
`$ git checkout pull/4575` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4575`

View PR using the GUI difftool: \
`$ git pr show -t 4575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4575.diff">https://git.openjdk.org/jdk17u-dev/pull/4575.diff</a>

</details>
