### PR TITLE
8372757: MacOS, Accessibility: Crash in [MenuAccessibility accessibilityChildren] after JDK-8341311

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/MenuAccessibility.m
@@ -68,6 +68,11 @@ static jclass sjc_CAccessibility = NULL;
                                                              sjm_getCurrentAccessiblePopupMenu,
                                                              fAccessible, fComponent);
 
+    CHECK_EXCEPTION();
+    if (axComponent == nil) {
+        return nil;
+    }
+
     CommonComponentAccessibility *currentElement = [CommonComponentAccessibility createWithAccessible:axComponent
                                                             withEnv:env withView:self->fView isCurrent:YES];
 


### PR DESCRIPTION


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] [JDK-8372757](https://bugs.openjdk.org/browse/JDK-8372757) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8372757](https://bugs.openjdk.org/browse/JDK-8372757): MacOS, Accessibility: Crash in [MenuAccessibility accessibilityChildren] after JDK-8341311 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4579/head:pull/4579` \
`$ git checkout pull/4579`

Update a local copy of the PR: \
`$ git checkout pull/4579` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4579`

View PR using the GUI difftool: \
`$ git pr show -t 4579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4579.diff">https://git.openjdk.org/jdk17u-dev/pull/4579.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4579#issuecomment-5045482736)
</details>
