### PR TITLE
8365498: jdk/jfr/event/os/TestCPULoad.java fails with Expected at least one event

### DIFF
--- a/test/jdk/jdk/jfr/event/os/TestCPULoad.java
+++ b/test/jdk/jdk/jfr/event/os/TestCPULoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,12 @@
 
 package jdk.jfr.event.os;
 
-import java.util.List;
+import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 
-import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingStream;
 import jdk.test.lib.jfr.EventNames;
 import jdk.test.lib.jfr.Events;
 
@@ -40,56 +42,18 @@ import jdk.test.lib.jfr.Events;
 public class TestCPULoad {
     private final static String EVENT_NAME = EventNames.CPULoad;
 
-    public static boolean isPrime(int num) {
-        if (num <= 1) return false;
-        for (int i = 2; i <= Math.sqrt(num); i++) {
-            if (num % i == 0) return false;
+    public static void main(String... args) throws Exception {
+        try (RecordingStream rs = new RecordingStream()) {
+            BlockingQueue<RecordedEvent> cpuEvent = new ArrayBlockingQueue<>(1);
+            rs.setReuse(false);
+            rs.enable(EVENT_NAME).withPeriod(Duration.ofMillis(100));
+            rs.onEvent(cpuEvent::offer);
+            rs.startAsync();
+            RecordedEvent event = cpuEvent.take();
+            System.out.println(event);
+            Events.assertField(event, "jvmUser").atLeast(0.0f).atMost(1.0f);
+            Events.assertField(event, "jvmSystem").atLeast(0.0f).atMost(1.0f);
+            Events.assertField(event, "machineTotal").atLeast(0.0f).atMost(1.0f);
         }
-        return true;
-    }
-
-    public static int burnCpuCycles(int limit) {
-        int primeCount = 0;
-        for (int i = 2; i < limit; i++) {
-            if (isPrime(i)) {
-                primeCount++;
-            }
-        }
-        return primeCount;
-    }
-
-    public static void main(String[] args) throws Throwable {
-        Recording recording = new Recording();
-        recording.enable(EVENT_NAME);
-        recording.start();
-        // burn some cycles to check increase of CPU related counters
-        int pn = burnCpuCycles(2500000);
-        recording.stop();
-        System.out.println("Found " + pn + " primes while burning cycles");
-
-        List<RecordedEvent> events = Events.fromRecording(recording);
-        if (events.isEmpty()) {
-            // CPU Load events are unreliable on Windows because
-            // the way processes are identified with perf. counters.
-            // See BUG 8010378.
-            // Workaround is to detect Windows and allow
-            // test to pass if events are missing.
-            if (isWindows()) {
-                return;
-            }
-            throw new AssertionError("Expected at least one event");
-        }
-        for (RecordedEvent event : events) {
-            System.out.println("Event: " + event);
-            for (String loadName : loadNames) {
-                Events.assertField(event, loadName).atLeast(0.0f).atMost(1.0f);
-            }
-        }
-    }
-
-    private static final String[] loadNames = {"jvmUser", "jvmSystem", "machineTotal"};
-
-    private static boolean isWindows() {
-        return System.getProperty("os.name").startsWith("Windows");
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8365498](https://bugs.openjdk.org/browse/JDK-8365498), commit [52a01cf9](https://github.com/openjdk/jdk25u-dev/commit/52a01cf9bfa8f7005cb0fbca249fcffa9889dcd6) from the [openjdk/jdk25u-dev](https://git.openjdk.org/jdk25u-dev) repository.

It is a fix for a test issue, that we see in 17u as well.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8365498](https://bugs.openjdk.org/browse/JDK-8365498) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8365498](https://bugs.openjdk.org/browse/JDK-8365498): jdk/jfr/event/os/TestCPULoad.java fails with Expected at least one event (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4582/head:pull/4582` \
`$ git checkout pull/4582`

Update a local copy of the PR: \
`$ git checkout pull/4582` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4582`

View PR using the GUI difftool: \
`$ git pr show -t 4582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4582.diff">https://git.openjdk.org/jdk17u-dev/pull/4582.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4582#issuecomment-5058597212)
</details>
