### PR TITLE
8298240: Replace the usage of ImageLayoutException by the CMMException

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSImageLayout.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSImageLayout.java
@@ -25,6 +25,7 @@
 
 package sun.java2d.cmm.lcms;
 
+import java.awt.color.CMMException;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.ComponentColorModel;
@@ -37,39 +38,32 @@ import sun.awt.image.ShortComponentRaster;
 
 final class LCMSImageLayout {
 
-    public static int BYTES_SH(int x) {
+    static int BYTES_SH(int x) {
         return x;
     }
 
-    public static int EXTRA_SH(int x) {
+    private static int EXTRA_SH(int x) {
         return x << 7;
     }
 
-    public static int CHANNELS_SH(int x) {
+    static int CHANNELS_SH(int x) {
         return x << 3;
     }
-    public static final int SWAPFIRST = 1 << 14;
-    public static final int DOSWAP = 1 << 10;
-    public static final int PT_RGB_8 =
-            CHANNELS_SH(3) | BYTES_SH(1);
-    public static final int PT_GRAY_8 =
-            CHANNELS_SH(1) | BYTES_SH(1);
-    public static final int PT_GRAY_16 =
-            CHANNELS_SH(1) | BYTES_SH(2);
-    public static final int PT_RGBA_8 =
-            EXTRA_SH(1) | CHANNELS_SH(3) | BYTES_SH(1);
-    public static final int PT_ARGB_8 =
-            EXTRA_SH(1) | CHANNELS_SH(3) | BYTES_SH(1) | SWAPFIRST;
-    public static final int PT_BGR_8 =
-            DOSWAP | CHANNELS_SH(3) | BYTES_SH(1);
-    public static final int PT_ABGR_8 =
-            DOSWAP | EXTRA_SH(1) | CHANNELS_SH(3) | BYTES_SH(1);
-    public static final int PT_BGRA_8 = EXTRA_SH(1) | CHANNELS_SH(3)
-            | BYTES_SH(1) | DOSWAP | SWAPFIRST;
-    public static final int DT_BYTE = 0;
-    public static final int DT_SHORT = 1;
-    public static final int DT_INT = 2;
-    public static final int DT_DOUBLE = 3;
+    private static final int SWAPFIRST  = 1 << 14;
+    private static final int DOSWAP     = 1 << 10;
+    private static final int PT_GRAY_8  = CHANNELS_SH(1) | BYTES_SH(1);
+    private static final int PT_GRAY_16 = CHANNELS_SH(1) | BYTES_SH(2);
+    private static final int PT_RGB_8   = CHANNELS_SH(3) | BYTES_SH(1);
+    private static final int PT_RGBA_8  = PT_RGB_8  | EXTRA_SH(1);
+    private static final int PT_ARGB_8  = PT_RGBA_8 | SWAPFIRST;
+    private static final int PT_BGR_8   = PT_RGB_8  | DOSWAP;
+    private static final int PT_ABGR_8  = PT_BGR_8  | EXTRA_SH(1);
+//  private static final int PT_BGRA_8  = PT_ABGR_8 | SWAPFIRST;
+
+    private static final int DT_BYTE = 0;
+    private static final int DT_SHORT = 1;
+    private static final int DT_INT = 2;
+    private static final int DT_DOUBLE = 3;
     boolean isIntPacked = false;
     int pixelType;
     int dataType;
@@ -88,9 +82,7 @@ final class LCMSImageLayout {
 
     private int dataArrayLength; /* in bytes */
 
-    private LCMSImageLayout(int np, int pixelType, int pixelSize)
-            throws ImageLayoutException
-    {
+    private LCMSImageLayout(int np, int pixelType, int pixelSize) {
         this.pixelType = pixelType;
         width = np;
         height = 1;
@@ -99,9 +91,7 @@ final class LCMSImageLayout {
         offset = 0;
     }
 
-    private LCMSImageLayout(int width, int height, int pixelType,
-                            int pixelSize)
-            throws ImageLayoutException
+    private LCMSImageLayout(int width, int height, int pixelType, int pixelSize)
     {
         this.pixelType = pixelType;
         this.width = width;
@@ -111,10 +101,7 @@ final class LCMSImageLayout {
         offset = 0;
     }
 
-
-    public LCMSImageLayout(byte[] data, int np, int pixelType, int pixelSize)
-            throws ImageLayoutException
-    {
+    LCMSImageLayout(byte[] data, int np, int pixelType, int pixelSize) {
         this(np, pixelType, pixelSize);
         dataType = DT_BYTE;
         dataArray = data;
@@ -123,9 +110,7 @@ final class LCMSImageLayout {
         verify();
     }
 
-    public LCMSImageLayout(short[] data, int np, int pixelType, int pixelSize)
-            throws ImageLayoutException
-    {
+    LCMSImageLayout(short[] data, int np, int pixelType, int pixelSize) {
         this(np, pixelType, pixelSize);
         dataType = DT_SHORT;
         dataArray = data;
@@ -134,9 +119,7 @@ final class LCMSImageLayout {
         verify();
     }
 
-    public LCMSImageLayout(int[] data, int np, int pixelType, int pixelSize)
-            throws ImageLayoutException
-    {
+    LCMSImageLayout(int[] data, int np, int pixelType, int pixelSize) {
         this(np, pixelType, pixelSize);
         dataType = DT_INT;
         dataArray = data;
@@ -145,9 +128,7 @@ final class LCMSImageLayout {
         verify();
     }
 
-    public LCMSImageLayout(double[] data, int np, int pixelType, int pixelSize)
-            throws ImageLayoutException
-    {
+    LCMSImageLayout(double[] data, int np, int pixelType, int pixelSize) {
         this(np, pixelType, pixelSize);
         dataType = DT_DOUBLE;
         dataArray = data;
@@ -162,7 +143,7 @@ final class LCMSImageLayout {
     /* This method creates a layout object for given image.
      * Returns null if the image is not supported by current implementation.
      */
-    public static LCMSImageLayout createImageLayout(BufferedImage image) throws ImageLayoutException {
+    static LCMSImageLayout createImageLayout(BufferedImage image) {
         LCMSImageLayout l = new LCMSImageLayout();
 
         switch (image.getType()) {
@@ -308,7 +289,7 @@ final class LCMSImageLayout {
         ARBITRARY,
         UNKNOWN;
 
-        public static BandOrder getBandOrder(int[] bandOffsets) {
+        static BandOrder getBandOrder(int[] bandOffsets) {
             BandOrder order = UNKNOWN;
 
             int numBands = bandOffsets.length;
@@ -340,10 +321,10 @@ final class LCMSImageLayout {
         }
     }
 
-    private void verify() throws ImageLayoutException {
+    private void verify() {
         checkIndex(offset, dataArrayLength);
         if (nextPixelOffset != getBytesPerPixel(pixelType)) {
-            throw new ImageLayoutException("Invalid image layout");
+            throw new CMMException("Invalid image layout");
         }
 
         int lastScanOffset = safeMult(nextRowOffset, (height - 1));
@@ -353,27 +334,19 @@ final class LCMSImageLayout {
         checkIndex(off, dataArrayLength);
     }
 
-    private static int checkIndex(long index, int length)
-            throws ImageLayoutException
-    {
+    private static int checkIndex(long index, int length) {
         if (index < 0 || index >= length) {
-            throw new ImageLayoutException("Invalid image layout");
+            throw new CMMException("Invalid image layout");
         }
         return (int) index;
     }
 
-    private static int safeMult(int a, int b) throws ImageLayoutException {
+    private static int safeMult(int a, int b) {
         long res = (long) a * b;
         return checkIndex(res, Integer.MAX_VALUE);
     }
 
-    @SuppressWarnings("serial") // JDK-implementation class
-    public static class ImageLayoutException extends Exception {
-        public ImageLayoutException(String message) {
-            super(message);
-        }
-    }
-    public static LCMSImageLayout createImageLayout(Raster r) {
+    static LCMSImageLayout createImageLayout(Raster r) {
         LCMSImageLayout l = new LCMSImageLayout();
         if (r instanceof ByteComponentRaster &&
                 r.getSampleModel() instanceof ComponentSampleModel) {

--- a/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSTransform.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSTransform.java
@@ -35,7 +35,6 @@
 
 package sun.java2d.cmm.lcms;
 
-import java.awt.color.CMMException;
 import java.awt.color.ColorSpace;
 import java.awt.color.ICC_Profile;
 import java.awt.image.BufferedImage;
@@ -47,8 +46,6 @@ import java.awt.image.WritableRaster;
 import java.lang.ref.Reference;
 
 import sun.java2d.cmm.ColorTransform;
-
-import static sun.java2d.cmm.lcms.LCMSImageLayout.ImageLayoutException;
 
 final class LCMSTransform implements ColorTransform {
 
@@ -178,22 +175,17 @@ final class LCMSTransform implements ColorTransform {
 
     public void colorConvert(BufferedImage src, BufferedImage dst) {
         LCMSImageLayout srcIL, dstIL;
-        try {
-            if (isLCMSSupport(src, dst)) {
-                dstIL = LCMSImageLayout.createImageLayout(dst);
+        if (isLCMSSupport(src, dst)) {
+            dstIL = LCMSImageLayout.createImageLayout(dst);
 
-                if (dstIL != null) {
-                    srcIL = LCMSImageLayout.createImageLayout(src);
-                    if (srcIL != null) {
-                        doTransform(srcIL, dstIL);
-                        return;
-                    }
+            if (dstIL != null) {
+                srcIL = LCMSImageLayout.createImageLayout(src);
+                if (srcIL != null) {
+                    doTransform(srcIL, dstIL);
+                    return;
                 }
             }
-        }  catch (ImageLayoutException e) {
-            throw new CMMException("Unable to convert images");
         }
-
         Raster srcRas = src.getRaster();
         WritableRaster dstRas = dst.getRaster();
         ColorModel srcCM = src.getColorModel();
@@ -249,18 +241,14 @@ final class LCMSTransform implements ColorTransform {
             }
             int idx;
             // TODO check for src npixels = dst npixels
-            try {
-                srcIL = new LCMSImageLayout(
-                        srcLine, srcLine.length/getNumInComponents(),
-                        LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
-                        LCMSImageLayout.BYTES_SH(1), getNumInComponents());
-                dstIL = new LCMSImageLayout(
-                        dstLine, dstLine.length/getNumOutComponents(),
-                        LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
-                        LCMSImageLayout.BYTES_SH(1), getNumOutComponents());
-            } catch (ImageLayoutException e) {
-                throw new CMMException("Unable to convert images");
-            }
+            srcIL = new LCMSImageLayout(
+                    srcLine, srcLine.length/getNumInComponents(),
+                    LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
+                    LCMSImageLayout.BYTES_SH(1), getNumInComponents());
+            dstIL = new LCMSImageLayout(
+                    dstLine, dstLine.length/getNumOutComponents(),
+                    LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
+                    LCMSImageLayout.BYTES_SH(1), getNumOutComponents());
             // process each scanline
             for (int y = 0; y < h; y++) {
                 // convert src scanline
@@ -309,19 +297,15 @@ final class LCMSTransform implements ColorTransform {
                 alpha = new float[w];
             }
             int idx;
-            try {
-                srcIL = new LCMSImageLayout(
+            srcIL = new LCMSImageLayout(
                     srcLine, srcLine.length/getNumInComponents(),
                     LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
                     LCMSImageLayout.BYTES_SH(2), getNumInComponents()*2);
 
-                dstIL = new LCMSImageLayout(
+            dstIL = new LCMSImageLayout(
                     dstLine, dstLine.length/getNumOutComponents(),
                     LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
                     LCMSImageLayout.BYTES_SH(2), getNumOutComponents()*2);
-            } catch (ImageLayoutException e) {
-                throw new CMMException("Unable to convert images");
-            }
             // process each scanline
             for (int y = 0; y < h; y++) {
                 // convert src scanline
@@ -430,19 +414,15 @@ final class LCMSTransform implements ColorTransform {
         short[] srcLine = new short[w * srcNumBands];
         short[] dstLine = new short[w * dstNumBands];
         int idx;
-        try {
-            srcIL = new LCMSImageLayout(
-                    srcLine, srcLine.length/getNumInComponents(),
-                    LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
-                    LCMSImageLayout.BYTES_SH(2), getNumInComponents()*2);
+        srcIL = new LCMSImageLayout(
+                srcLine, srcLine.length/getNumInComponents(),
+                LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
+                LCMSImageLayout.BYTES_SH(2), getNumInComponents()*2);
 
-            dstIL = new LCMSImageLayout(
-                    dstLine, dstLine.length/getNumOutComponents(),
-                    LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
-                    LCMSImageLayout.BYTES_SH(2), getNumOutComponents()*2);
-        } catch (ImageLayoutException e) {
-            throw new CMMException("Unable to convert rasters");
-        }
+        dstIL = new LCMSImageLayout(
+                dstLine, dstLine.length/getNumOutComponents(),
+                LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
+                LCMSImageLayout.BYTES_SH(2), getNumOutComponents()*2);
         // process each scanline
         for (int y = 0; y < h; y++, ys++, yd++) {
             // get src scanline
@@ -533,18 +513,14 @@ final class LCMSTransform implements ColorTransform {
             byte[] dstLine = new byte[w * dstNumBands];
             int idx;
             // TODO check for src npixels = dst npixels
-            try {
-                srcIL = new LCMSImageLayout(
-                        srcLine, srcLine.length/getNumInComponents(),
-                        LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
-                        LCMSImageLayout.BYTES_SH(1), getNumInComponents());
-                dstIL = new LCMSImageLayout(
-                        dstLine, dstLine.length/getNumOutComponents(),
-                        LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
-                        LCMSImageLayout.BYTES_SH(1), getNumOutComponents());
-            } catch (ImageLayoutException e) {
-                throw new CMMException("Unable to convert rasters");
-            }
+            srcIL = new LCMSImageLayout(
+                    srcLine, srcLine.length/getNumInComponents(),
+                    LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
+                    LCMSImageLayout.BYTES_SH(1), getNumInComponents());
+            dstIL = new LCMSImageLayout(
+                    dstLine, dstLine.length/getNumOutComponents(),
+                    LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
+                    LCMSImageLayout.BYTES_SH(1), getNumOutComponents());
             // process each scanline
             for (int y = 0; y < h; y++, ys++, yd++) {
                 // get src scanline
@@ -576,20 +552,15 @@ final class LCMSTransform implements ColorTransform {
             short[] srcLine = new short[w * srcNumBands];
             short[] dstLine = new short[w * dstNumBands];
             int idx;
+            srcIL = new LCMSImageLayout(
+                    srcLine, srcLine.length/getNumInComponents(),
+                    LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
+                    LCMSImageLayout.BYTES_SH(2), getNumInComponents()*2);
 
-            try {
-                srcIL = new LCMSImageLayout(
-                        srcLine, srcLine.length/getNumInComponents(),
-                        LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
-                        LCMSImageLayout.BYTES_SH(2), getNumInComponents()*2);
-
-                dstIL = new LCMSImageLayout(
-                        dstLine, dstLine.length/getNumOutComponents(),
-                        LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
-                        LCMSImageLayout.BYTES_SH(2), getNumOutComponents()*2);
-            } catch (ImageLayoutException e) {
-                throw new CMMException("Unable to convert rasters");
-            }
+            dstIL = new LCMSImageLayout(
+                    dstLine, dstLine.length/getNumOutComponents(),
+                    LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
+                    LCMSImageLayout.BYTES_SH(2), getNumOutComponents()*2);
             // process each scanline
             for (int y = 0; y < h; y++, ys++, yd++) {
                 // get src scanline
@@ -629,47 +600,37 @@ final class LCMSTransform implements ColorTransform {
         if (dst == null) {
             dst = new short [(src.length/getNumInComponents())*getNumOutComponents()];
         }
+        LCMSImageLayout srcIL = new LCMSImageLayout(
+                src, src.length/getNumInComponents(),
+                LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
+                LCMSImageLayout.BYTES_SH(2), getNumInComponents()*2);
 
-        try {
-            LCMSImageLayout srcIL = new LCMSImageLayout(
-                    src, src.length/getNumInComponents(),
-                    LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
-                    LCMSImageLayout.BYTES_SH(2), getNumInComponents()*2);
+        LCMSImageLayout dstIL = new LCMSImageLayout(
+                dst, dst.length/getNumOutComponents(),
+                LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
+                LCMSImageLayout.BYTES_SH(2), getNumOutComponents()*2);
 
-            LCMSImageLayout dstIL = new LCMSImageLayout(
-                    dst, dst.length/getNumOutComponents(),
-                    LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
-                    LCMSImageLayout.BYTES_SH(2), getNumOutComponents()*2);
+        doTransform(srcIL, dstIL);
 
-            doTransform(srcIL, dstIL);
-
-            return dst;
-        } catch (ImageLayoutException e) {
-            throw new CMMException("Unable to convert data");
-        }
+        return dst;
     }
 
     public byte[] colorConvert(byte[] src, byte[] dst) {
         if (dst == null) {
             dst = new byte [(src.length/getNumInComponents())*getNumOutComponents()];
         }
+        LCMSImageLayout srcIL = new LCMSImageLayout(
+                src, src.length/getNumInComponents(),
+                LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
+                LCMSImageLayout.BYTES_SH(1), getNumInComponents());
 
-        try {
-            LCMSImageLayout srcIL = new LCMSImageLayout(
-                    src, src.length/getNumInComponents(),
-                    LCMSImageLayout.CHANNELS_SH(getNumInComponents()) |
-                    LCMSImageLayout.BYTES_SH(1), getNumInComponents());
+        LCMSImageLayout dstIL = new LCMSImageLayout(
+                dst, dst.length/getNumOutComponents(),
+                LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
+                LCMSImageLayout.BYTES_SH(1), getNumOutComponents());
 
-            LCMSImageLayout dstIL = new LCMSImageLayout(
-                    dst, dst.length/getNumOutComponents(),
-                    LCMSImageLayout.CHANNELS_SH(getNumOutComponents()) |
-                    LCMSImageLayout.BYTES_SH(1), getNumOutComponents());
+        doTransform(srcIL, dstIL);
 
-            doTransform(srcIL, dstIL);
-
-            return dst;
-        } catch (ImageLayoutException e) {
-            throw new CMMException("Unable to convert data");
-        }
+        return dst;
     }
 }


### PR DESCRIPTION
I backport this for parity with oracle.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8298240](https://bugs.openjdk.org/browse/JDK-8298240) needs maintainer approval

### Issue
 * [JDK-8298240](https://bugs.openjdk.org/browse/JDK-8298240): Replace the usage of ImageLayoutException by the CMMException (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4587/head:pull/4587` \
`$ git checkout pull/4587`

Update a local copy of the PR: \
`$ git checkout pull/4587` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4587`

View PR using the GUI difftool: \
`$ git pr show -t 4587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4587.diff">https://git.openjdk.org/jdk17u-dev/pull/4587.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4587#issuecomment-5102878085)
</details>
