### PR TITLE
8300167: Add validation of the raster's layout before using in native

### DIFF
--- a/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSImageLayout.java
+++ b/src/java.desktop/share/classes/sun/java2d/cmm/lcms/LCMSImageLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -354,7 +354,8 @@ final class LCMSImageLayout {
 
             ComponentSampleModel csm = (ComponentSampleModel)r.getSampleModel();
 
-            l.pixelType = CHANNELS_SH(br.getNumBands()) | BYTES_SH(1);
+            int numBands = br.getNumBands();
+            l.pixelType = CHANNELS_SH(numBands) | BYTES_SH(1);
 
             int[] bandOffsets = csm.getBandOffsets();
             BandOrder order = BandOrder.getBandOrder(bandOffsets);
@@ -363,7 +364,7 @@ final class LCMSImageLayout {
             switch (order) {
                 case INVERTED:
                     l.pixelType |= DOSWAP;
-                    firstBand  = csm.getNumBands() - 1;
+                    firstBand  = numBands - 1;
                     break;
                 case DIRECT:
                     // do nothing
@@ -377,11 +378,14 @@ final class LCMSImageLayout {
             l.nextPixelOffset = br.getPixelStride();
 
             l.offset = br.getDataOffset(firstBand);
-            l.dataArray = br.getDataStorage();
             l.dataType = DT_BYTE;
+            byte[] data = br.getDataStorage();
+            l.dataArray = data;
+            l.dataArrayLength = data.length;
 
             l.width = br.getWidth();
             l.height = br.getHeight();
+            l.verify();
 
             if (l.nextRowOffset == l.width * br.getPixelStride()) {
                 l.imageAtOnce = true;


### PR DESCRIPTION
I backport this for parity with 17.0.21-oracle. 

Needed resolve because https://bugs.openjdk.org/browse/JDK-8295430: "Use cmsDoTransformLineStride instead of cmsDoTransform in the loop" is not in 17.

Clean anyways.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8300167](https://bugs.openjdk.org/browse/JDK-8300167) needs maintainer approval

### Issue
 * [JDK-8300167](https://bugs.openjdk.org/browse/JDK-8300167): Add validation of the raster's layout before using in native (**Bug** - P4 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4592/head:pull/4592` \
`$ git checkout pull/4592`

Update a local copy of the PR: \
`$ git checkout pull/4592` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4592`

View PR using the GUI difftool: \
`$ git pr show -t 4592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4592.diff">https://git.openjdk.org/jdk17u-dev/pull/4592.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4592#issuecomment-5128677531)
</details>
