### PR TITLE
8389492: [21u] java/io/Serializable/records/ProhibitedMethods.java fails after JDK-8307843 backport in othervm mode

### DIFF
--- a/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
+++ b/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
@@ -295,7 +295,7 @@ public class ProhibitedMethods {
             MethodVisitor mv = cv.visitMethod(ACC_PRIVATE, READ_OBJECT_NAME, READ_OBJECT_DESC, null, null);
             mv.visitCode();
             mv.visitLdcInsn(READ_OBJECT_NAME + " should not be invoked");
-            mv.visitMethodInsn(INVOKESTATIC, "org/testng/Assert", "fail", "(Ljava/lang/String;)V", false);
+            mv.visitMethodInsn(INVOKESTATIC, "org/junit/jupiter/api/Assertions", "fail", "(Ljava/lang/String;)Ljava/lang/Object;", false);
             mv.visitInsn(RETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
@@ -314,7 +314,7 @@ public class ProhibitedMethods {
             MethodVisitor mv = cv.visitMethod(ACC_PRIVATE, READ_OBJECT_NO_DATA_NAME, READ_OBJECT_NO_DATA_DESC, null, null);
             mv.visitCode();
             mv.visitLdcInsn(READ_OBJECT_NO_DATA_NAME + " should not be invoked");
-            mv.visitMethodInsn(INVOKESTATIC, "org/testng/Assert", "fail", "(Ljava/lang/String;)V", false);
+            mv.visitMethodInsn(INVOKESTATIC, "org/junit/jupiter/api/Assertions", "fail", "(Ljava/lang/String;)Ljava/lang/Object;", false);
             mv.visitInsn(RETURN);
             mv.visitMaxs(0, 0);
             mv.visitEnd();
@@ -372,3 +372,4 @@ public class ProhibitedMethods {
         }
     }
 }
+


### PR DESCRIPTION
Backporting JDK-8389492: [21u] java/io/Serializable/records/ProhibitedMethods.java fails after JDK-8307843 backport in othervm mode.

This PR fixes the generated bytecode in ProhibitedMethods.java to call JUnit 5 Assertions.fail instead of the removed TestNG Assert.fail.

The initial backport (JDK-8373623) testing passed because ```make test``` loaded the TestNG classes, which does not happen when JTREG is run directly.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

```make test TEST=test/jdk/java/io/Serializable/records/ProhibitedMethods.java```

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/30935563/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/30935564/macos-aarch64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/30935565/linux-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/30935566/linux-x64-specific-test.log)

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

```../jtreg/build/images/jtreg/bin/jtreg -jdk build/*/images/jdk test/jdk/java/io/Serializable/records/ProhibitedMethods.java```

Results:

[ProhibitedMethods.jtr.windows-x64.log](https://github.com/user-attachments/files/30935573/ProhibitedMethods.jtr.windows-x64.log)
[ProhibitedMethods.jtr.macos-aarch64.log](https://github.com/user-attachments/files/30935574/ProhibitedMethods.jtr.macos-aarch64.log)
[ProhibitedMethods.jtr.linux-x64.log](https://github.com/user-attachments/files/30935575/ProhibitedMethods.jtr.linux-x64.log)
[ProhibitedMethods.jtr.linux-aarch64.log](https://github.com/user-attachments/files/30935576/ProhibitedMethods.jtr.linux-aarch64.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] [JDK-8389492](https://bugs.openjdk.org/browse/JDK-8389492) needs maintainer approval
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8389492](https://bugs.openjdk.org/browse/JDK-8389492): [21u] java/io/Serializable/records/ProhibitedMethods.java fails after JDK-8307843 backport in othervm mode (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4605/head:pull/4605` \
`$ git checkout pull/4605`

Update a local copy of the PR: \
`$ git checkout pull/4605` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4605`

View PR using the GUI difftool: \
`$ git pr show -t 4605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4605.diff">https://git.openjdk.org/jdk17u-dev/pull/4605.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4605#issuecomment-5253473755)
</details>
