### PR TITLE
8354926: Remove remnants of debugging in the fix for JDK-8348561 and JDK-8349721

### DIFF
--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -36,7 +36,7 @@ static bool    returns_to_call_stub(address return_pc)   {
 
 enum platform_dependent_constants {
   code_size1 = 19000,          // simply increase if too small (assembler will crash if too small)
-  code_size2 = 68000           // simply increase if too small (assembler will crash if too small)
+  code_size2 = 70000           // simply increase if too small (assembler will crash if too small)
 };
 
 class aarch64 {

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -36,7 +36,7 @@ static bool    returns_to_call_stub(address return_pc)   {
 
 enum platform_dependent_constants {
   code_size1 = 19000,          // simply increase if too small (assembler will crash if too small)
-  code_size2 = 70000           // simply increase if too small (assembler will crash if too small)
+  code_size2 = 68000           // simply increase if too small (assembler will crash if too small)
 };
 
 class aarch64 {

--- a/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_ext_aarch64.cpp
@@ -56,7 +56,6 @@ void VM_Version_Ext::initialize_cpu_information(void) {
   VM_Version::get_compatible_board(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len);
   desc_len = (int)strlen(_cpu_desc);
   snprintf(_cpu_desc + desc_len, CPU_DETAILED_DESC_BUF_SIZE - desc_len, " %s", _features_string);
-  fprintf(stderr, "_features_string = \"%s\"", _features_string);
 
   _initialized = true;
 }


### PR DESCRIPTION
I backport this for parity with 17.0.21-oracle.

Resolved both files.  Code in 17 is different, but trivial to adapt.

Update: because of a build failure I had to increase the code buffer size to the old size, so that the change in the second file is removed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8354926](https://bugs.openjdk.org/browse/JDK-8354926) needs maintainer approval

### Issue
 * [JDK-8354926](https://bugs.openjdk.org/browse/JDK-8354926): Remove remnants of debugging in the fix for JDK-8348561 and JDK-8349721 (**Enhancement** - P3 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4614/head:pull/4614` \
`$ git checkout pull/4614`

Update a local copy of the PR: \
`$ git checkout pull/4614` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4614`

View PR using the GUI difftool: \
`$ git pr show -t 4614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4614.diff">https://git.openjdk.org/jdk17u-dev/pull/4614.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4614#issuecomment-5282227634)
</details>
