### PR TITLE
8390325: [17u] test/jdk/sun/security/x509/GeneralName/DNSNameTest.java fails to compile in Java 17 after JDK-8381771 backport

### DIFF
--- a/test/jdk/sun/security/x509/GeneralName/DNSNameTest.java
+++ b/test/jdk/sun/security/x509/GeneralName/DNSNameTest.java
@@ -52,7 +52,7 @@ public class DNSNameTest {
             "1abc.com",
             "123.com",
             "a-b-c.com", // hyphens
-            IDN.toASCII("公司.江利子") // IDN punycode
+            IDN.toASCII("\u516c\u53f8.\u6c5f\u5229\u5b50") // IDN punycode
     );
 
     private static final List<String> GOOD_SAN_NAMES = Stream.concat(


### PR DESCRIPTION
8390325: [17u] test/jdk/sun/security/x509/GeneralName/DNSNameTest.java fails to compile in Java 17 after JDK-8381771 backport

This PR converts relevant UTF-8 strings to ASCII Java Unicode escapes because Java 17 doesn't support JEP 400.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/sun/security/x509/GeneralName/DNSNameTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/31047736/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/31047737/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/31047738/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/31047739/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8390325](https://bugs.openjdk.org/browse/JDK-8390325) needs maintainer approval

### Issue
 * [JDK-8390325](https://bugs.openjdk.org/browse/JDK-8390325): [17u] test/jdk/sun/security/x509/GeneralName/DNSNameTest.java fails to compile in Java 17 after JDK-8381771 backport (**Bug** - P4 - Approved)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4615/head:pull/4615` \
`$ git checkout pull/4615`

Update a local copy of the PR: \
`$ git checkout pull/4615` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4615`

View PR using the GUI difftool: \
`$ git pr show -t 4615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4615.diff">https://git.openjdk.org/jdk17u-dev/pull/4615.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4615#issuecomment-5286320515)
</details>
