### PR TITLE
8390327: [17u] test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java fails to compile in Java 17 after JDK-8343855 backport

### DIFF
--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -434,7 +434,7 @@ public interface HttpServerAdapters {
     public static class HttpHeadOrGetHandler implements HttpTestHandler {
         final String responseBody;
         public HttpHeadOrGetHandler() {
-            this("pâté de tête persillé");
+            this("p\u00e2t\u00e9 de t\u00eate persill\u00e9");
         }
         public HttpHeadOrGetHandler(String responseBody) {
             this.responseBody = Objects.requireNonNull(responseBody);


### PR DESCRIPTION
JDK-8390327: [17u] test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java fails to compile in Java 17 after JDK-8343855 backport

This PR converts relevant UTF-8 strings to ASCII Java Unicode escapes because Java 17 doesn't support JEP 400.

Ran related tests on linux-x64, linux-aarch64, macos-aarch64 and windows-x64:

make test TEST=test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java

Results:

[windows-x64-specific-test.log](https://github.com/user-attachments/files/31123641/windows-x64-specific-test.log)
[macos-aarch64-specific-test.log](https://github.com/user-attachments/files/31123642/macos-aarch64-specific-test.log)
[linux-x64-specific-test.log](https://github.com/user-attachments/files/31123643/linux-x64-specific-test.log)
[linux-aarch64-specific-test.log](https://github.com/user-attachments/files/31123644/linux-aarch64-specific-test.log)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8390327](https://bugs.openjdk.org/browse/JDK-8390327) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390327](https://bugs.openjdk.org/browse/JDK-8390327): [17u] test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java fails to compile in Java 17 after JDK-8343855 backport (**Bug** - P4 - Approved)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4618/head:pull/4618` \
`$ git checkout pull/4618`

Update a local copy of the PR: \
`$ git checkout pull/4618` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4618`

View PR using the GUI difftool: \
`$ git pr show -t 4618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4618.diff">https://git.openjdk.org/jdk17u-dev/pull/4618.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4618#issuecomment-5309804344)
</details>
