### PR TITLE
8365776: Convert JShell tests to use JUnit instead of TestNG

### DIFF
--- a/test/langtools/jdk/jshell/AnalysisTest.java
+++ b/test/langtools/jdk/jshell/AnalysisTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,14 @@
  * @test
  * @summary Test SourceCodeAnalysis
  * @build KullaTesting TestingInputStream
- * @run testng AnalysisTest
+ * @run junit AnalysisTest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class AnalysisTest extends KullaTesting {
 
+    @Test
     public void testSource() {
         assertAnalyze("int x=3//test", "int x=3;//test", "", true);
         assertAnalyze("int x=3 ;//test", "int x=3 ;//test", "", true);
@@ -41,6 +41,7 @@ public class AnalysisTest extends KullaTesting {
         assertAnalyze("int ff; int v // hi", "int ff;", " int v // hi", true);
     }
 
+    @Test
     public void testSourceSlashStar() {
         assertAnalyze("/*zoo*/int x=3 /*test*/", "/*zoo*/int x=3; /*test*/", "", true);
         assertAnalyze("/*zoo*/int x=3 ;/*test*/", "/*zoo*/int x=3 ;/*test*/", "", true);
@@ -49,11 +50,13 @@ public class AnalysisTest extends KullaTesting {
         assertAnalyze("int ff; int v /*hgjghj*/", "int ff;", " int v /*hgjghj*/", true);
     }
 
+    @Test
     public void testIncomplete() {
         assertAnalyze("void m() { //erer", null, "void m() { //erer\n", false);
         assertAnalyze("int m=//", null, "int m=//\n", false);
     }
 
+    @Test
     public void testExpression() {
         assertAnalyze("45//test", "45//test", "", true);
         assertAnalyze("45;//test", "45;//test", "", true);

--- a/test/langtools/jdk/jshell/AnalyzeSnippetTest.java
+++ b/test/langtools/jdk/jshell/AnalyzeSnippetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8182270
  * @summary test non-eval Snippet analysis
  * @build KullaTesting TestingInputStream
- * @run testng AnalyzeSnippetTest
+ * @run junit AnalyzeSnippetTest
  */
 
 import java.io.ByteArrayOutputStream;
@@ -34,15 +34,12 @@ import java.io.PrintStream;
 import java.util.List;
 import jdk.jshell.Snippet;
 import jdk.jshell.DeclarationSnippet;
-import org.testng.annotations.Test;
 
 import jdk.jshell.JShell;
 import jdk.jshell.MethodSnippet;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import jdk.jshell.ErroneousSnippet;
 import jdk.jshell.ExpressionSnippet;
 import jdk.jshell.ImportSnippet;
@@ -52,14 +49,16 @@ import jdk.jshell.StatementSnippet;
 import jdk.jshell.TypeDeclSnippet;
 import jdk.jshell.VarSnippet;
 import static jdk.jshell.Snippet.SubKind.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class AnalyzeSnippetTest {
 
     JShell state;
     SourceCodeAnalysis sca;
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         state = JShell.builder()
                 .out(new PrintStream(new ByteArrayOutputStream()))
@@ -69,7 +68,7 @@ public class AnalyzeSnippetTest {
         sca = state.sourceCodeAnalysis();
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDown() {
         if (state != null) {
             state.close();
@@ -78,55 +77,61 @@ public class AnalyzeSnippetTest {
         sca = null;
     }
 
+    @Test
     public void testImport() {
         ImportSnippet sn = (ImportSnippet) assertSnippet("import java.util.List;",
                 SubKind.SINGLE_TYPE_IMPORT_SUBKIND);
-        assertEquals(sn.name(), "List");
+        assertEquals("List", sn.name());
         sn = (ImportSnippet) assertSnippet("import static java.nio.file.StandardOpenOption.CREATE;",
                 SubKind.SINGLE_STATIC_IMPORT_SUBKIND);
         assertTrue(sn.isStatic());
     }
 
+    @Test
     public void testClass() {
         TypeDeclSnippet sn = (TypeDeclSnippet) assertSnippet("class C {}",
                 SubKind.CLASS_SUBKIND);
-        assertEquals(sn.name(), "C");
+        assertEquals("C", sn.name());
         sn = (TypeDeclSnippet) assertSnippet("enum EE {A, B , C}",
                 SubKind.ENUM_SUBKIND);
     }
 
+    @Test
     public void testMethod() {
         MethodSnippet sn = (MethodSnippet) assertSnippet("int m(int x) { return x + x; }",
                 SubKind.METHOD_SUBKIND);
-        assertEquals(sn.name(), "m");
-        assertEquals(sn.signature(), "(int)int");
+        assertEquals("m", sn.name());
+        assertEquals("(int)int", sn.signature());
     }
 
+    @Test
     public void testVar() {
         VarSnippet sn = (VarSnippet) assertSnippet("int i;",
                 SubKind.VAR_DECLARATION_SUBKIND);
-        assertEquals(sn.name(), "i");
-        assertEquals(sn.typeName(), "int");
+        assertEquals("i", sn.name());
+        assertEquals("int", sn.typeName());
         sn = (VarSnippet) assertSnippet("int jj = 6;",
                 SubKind.VAR_DECLARATION_WITH_INITIALIZER_SUBKIND);
         sn = (VarSnippet) assertSnippet("2 + 2",
                 SubKind.TEMP_VAR_EXPRESSION_SUBKIND);
     }
 
+    @Test
     public void testExpression() {
         state.eval("int aa = 10;");
         ExpressionSnippet sn = (ExpressionSnippet) assertSnippet("aa",
                 SubKind.VAR_VALUE_SUBKIND);
-        assertEquals(sn.name(), "aa");
-        assertEquals(sn.typeName(), "int");
+        assertEquals("aa", sn.name());
+        assertEquals("int", sn.typeName());
         sn = (ExpressionSnippet) assertSnippet("aa;",
                 SubKind.VAR_VALUE_SUBKIND);
-        assertEquals(sn.name(), "aa");
-        assertEquals(sn.typeName(), "int");
+        assertEquals("aa", sn.name());
+        assertEquals("int", sn.typeName());
         sn = (ExpressionSnippet) assertSnippet("aa = 99",
                 SubKind.ASSIGNMENT_SUBKIND);
     }
 
+    @Test
     public void testStatement() {
         StatementSnippet sn = (StatementSnippet) assertSnippet("System.out.println(33)",
                 SubKind.STATEMENT_SUBKIND);
@@ -134,6 +139,7 @@ public class AnalyzeSnippetTest {
                 SubKind.STATEMENT_SUBKIND);
     }
 
+    @Test
     public void testErroneous() {
         ErroneousSnippet sn = (ErroneousSnippet) assertSnippet("+++",
                 SubKind.UNKNOWN_SUBKIND);

--- a/test/langtools/jdk/jshell/BadExecutionControlSpecTest.java
+++ b/test/langtools/jdk/jshell/BadExecutionControlSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.jdeps/com.sun.tools.javap
  *          jdk.jshell/jdk.internal.jshell.tool
- * @run testng BadExecutionControlSpecTest
+ * @run junit BadExecutionControlSpecTest
  */
 
 import java.io.ByteArrayInputStream;
@@ -38,12 +38,11 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Collections;
 import java.util.List;
-import org.testng.annotations.Test;
 import jdk.jshell.spi.ExecutionControl;
 import jdk.jshell.spi.ExecutionEnv;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class BadExecutionControlSpecTest {
     private static void assertIllegal(String spec) throws Throwable {
         try {
@@ -80,6 +79,7 @@ public class BadExecutionControlSpecTest {
         }
     }
 
+    @Test
     public void syntaxTest() throws Throwable {
         assertIllegal(":launch(true)");
         assertIllegal("jdi:launch(true");
@@ -87,6 +87,7 @@ public class BadExecutionControlSpecTest {
         assertIllegal("jdi:,");
     }
 
+    @Test
     public void notFoundTest() throws Throwable {
         assertIllegal("fruitbats");
         assertIllegal("jdi:baz(true)");

--- a/test/langtools/jdk/jshell/ClassMembersTest.java
+++ b/test/langtools/jdk/jshell/ClassMembersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8139829
  * @summary Test access to members of user defined class.
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
- * @run testng/timeout=600 ClassMembersTest
+ * @run junit/timeout=600 ClassMembersTest
  */
 
 import java.lang.annotation.RetentionPolicy;
@@ -36,22 +36,26 @@ import java.util.List;
 import javax.tools.Diagnostic;
 
 import jdk.jshell.SourceCodeAnalysis;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
 import jdk.jshell.TypeDeclSnippet;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
 import static jdk.jshell.Snippet.Status.VALID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ClassMembersTest extends KullaTesting {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine("local"));
     }
 
-    @Test(dataProvider = "memberTestCase")
+    @ParameterizedTest
+    @MethodSource("memberTestCaseGenerator")
     public void memberTest(AccessModifier accessModifier, CodeChunk codeChunk, Static isStaticMember, Static isStaticReference) {
         MemberTestCase testCase = new MemberTestCase(accessModifier, codeChunk, isStaticMember, isStaticReference);
         assertEval(testCase.generateSource());
@@ -78,7 +82,8 @@ public class ClassMembersTest extends KullaTesting {
         return list;
     }
 
-    @Test(dataProvider = "memberTestCase")
+    @ParameterizedTest
+    @MethodSource("memberTestCaseGenerator")
     public void extendsMemberTest(AccessModifier accessModifier, CodeChunk codeChunk, Static isStaticMember, Static isStaticReference) {
         MemberTestCase testCase = new ExtendsMemberTestCase(accessModifier, codeChunk, isStaticMember, isStaticReference);
         String input = testCase.generateSource();
@@ -151,7 +156,8 @@ public class ClassMembersTest extends KullaTesting {
                 new ExpectedDiagnostic("compiler.err.non-static.cant.be.ref", 0, 8, 1, -1, -1, Diagnostic.Kind.ERROR));
     }
 
-    @Test(dataProvider = "retentionPolicyTestCase")
+    @ParameterizedTest
+    @MethodSource("retentionPolicyTestCaseGenerator")
     public void annotationTest(RetentionPolicy policy) {
         assertEval("import java.lang.annotation.*;");
         String annotationSource =
@@ -174,7 +180,6 @@ public class ClassMembersTest extends KullaTesting {
         assertEval("C.Inner.class.getAnnotationsByType(A.class).length > 0;", isRuntimeVisible);
     }
 
-    @DataProvider(name = "retentionPolicyTestCase")
     public Object[][] retentionPolicyTestCaseGenerator() {
         List<Object[]> list = new ArrayList<>();
         for (RetentionPolicy policy : RetentionPolicy.values()) {
@@ -183,7 +188,6 @@ public class ClassMembersTest extends KullaTesting {
         return list.toArray(new Object[list.size()][]);
     }
 
-    @DataProvider(name = "memberTestCase")
     public Object[][] memberTestCaseGenerator() {
         List<Object[]> list = new ArrayList<>();
         for (AccessModifier accessModifier : AccessModifier.values()) {

--- a/test/langtools/jdk/jshell/ClassPathTest.java
+++ b/test/langtools/jdk/jshell/ClassPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,20 +30,20 @@
  * @library /tools/lib
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build KullaTesting TestingInputStream Compiler
- * @run testng ClassPathTest
+ * @run junit ClassPathTest
  */
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ClassPathTest extends KullaTesting {
 
     private final Compiler compiler = new Compiler();
     private final Path outDir = Paths.get("class_path_test");
 
+    @Test
     public void testDirectory() {
         compiler.compile(outDir, "package pkg; public class TestDirectory { }");
         assertDeclareFail("import pkg.TestDirectory;", "compiler.err.doesnt.exist");
@@ -52,6 +52,7 @@ public class ClassPathTest extends KullaTesting {
         assertEval("new pkg.TestDirectory();");
     }
 
+    @Test
     public void testJar() {
         compiler.compile(outDir, "package pkg; public class TestJar { }");
         String jarName = "test.jar";
@@ -62,6 +63,7 @@ public class ClassPathTest extends KullaTesting {
         assertEval("new pkg.TestJar();");
     }
 
+    @Test
     public void testAmbiguousDirectory() {
         Path p1 = outDir.resolve("dir1");
         compiler.compile(p1,
@@ -82,6 +84,7 @@ public class ClassPathTest extends KullaTesting {
         assertEval("new p.TestAmbiguous();", "first");
     }
 
+    @Test
     public void testAmbiguousJar() {
         Path p1 = outDir.resolve("dir1");
         compiler.compile(p1,
@@ -104,11 +107,13 @@ public class ClassPathTest extends KullaTesting {
         assertEval("new p.TestAmbiguous();", "first");
     }
 
+    @Test
     public void testEmptyClassPath() {
         addToClasspath("");
         assertEval("new java.util.ArrayList<String>();");
     }
 
+    @Test
     public void testUnknown() {
         addToClasspath(compiler.getPath(outDir.resolve("UNKNOWN")));
         assertDeclareFail("new Unknown();", "compiler.err.cant.resolve.location");

--- a/test/langtools/jdk/jshell/ClassesTest.java
+++ b/test/langtools/jdk/jshell/ClassesTest.java
@@ -26,7 +26,7 @@
  * @bug 8145239 8129559 8080354 8189248 8010319 8246353 8247456 8292755
  * @summary Tests for EvaluationState.classes
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
- * @run testng ClassesTest
+ * @run junit ClassesTest
  */
 
 import java.util.ArrayList;
@@ -37,8 +37,6 @@ import javax.tools.Diagnostic;
 import jdk.jshell.Snippet;
 import jdk.jshell.TypeDeclSnippet;
 import jdk.jshell.VarSnippet;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import jdk.jshell.Diag;
 import jdk.jshell.Snippet.Status;
@@ -51,16 +49,22 @@ import static jdk.jshell.Snippet.Status.REJECTED;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
 import static jdk.jshell.Snippet.Status.NONEXISTENT;
 import static jdk.jshell.Snippet.SubKind.*;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ClassesTest extends KullaTesting {
 
+    @Test
     public void noClasses() {
         assertNumberOfActiveClasses(0);
     }
 
+    @Test
     public void testSignature1() {
         TypeDeclSnippet c1 = classKey(assertEval("class A extends B {}", added(RECOVERABLE_NOT_DEFINED)));
         assertTypeDeclSnippet(c1, "A", RECOVERABLE_NOT_DEFINED, CLASS_SUBKIND, 1, 0);
@@ -82,6 +86,7 @@ public class ClassesTest extends KullaTesting {
         assertTypeDeclSnippet(c5, "A", RECOVERABLE_NOT_DEFINED, CLASS_SUBKIND, 1, 0);
     }
 
+    @Test
     public void testSignature2() {
         TypeDeclSnippet c1 = (TypeDeclSnippet) assertDeclareFail("class A { void f() { return g(); } }", "compiler.err.prob.found.req");
         assertTypeDeclSnippet(c1, "A", REJECTED, CLASS_SUBKIND, 0, 2);
@@ -92,27 +97,32 @@ public class ClassesTest extends KullaTesting {
                 ste(c2, RECOVERABLE_DEFINED, DROPPED, true, null));
     }
 
+    @Test
     public void classDeclaration() {
         assertEval("class A { }");
         assertClasses(clazz(KullaTesting.ClassType.CLASS, "A"));
     }
 
 
+    @Test
     public void interfaceDeclaration() {
         assertEval("interface A { }");
         assertClasses(clazz(KullaTesting.ClassType.INTERFACE, "A"));
     }
 
+    @Test
     public void annotationDeclaration() {
         assertEval("@interface A { }");
         assertClasses(clazz(KullaTesting.ClassType.ANNOTATION, "A"));
     }
 
+    @Test
     public void enumDeclaration() {
         assertEval("enum A { }");
         assertClasses(clazz(KullaTesting.ClassType.ENUM, "A"));
     }
 
+    @Test
     public void classesDeclaration() {
         assertEval("interface A { }");
         assertEval("class B implements A { }");
@@ -128,6 +138,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void classesRedeclaration1() {
         Snippet a = classKey(assertEval("class A { }"));
         Snippet b = classKey(assertEval("interface B { }"));
@@ -149,6 +160,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void classesRedeclaration2() {
         assertEval("class A { }");
         assertClasses(clazz(KullaTesting.ClassType.CLASS, "A"));
@@ -180,6 +192,7 @@ public class ClassesTest extends KullaTesting {
     }
 
     //8154496: test3 update: sig change should false
+    @Test
     public void classesRedeclaration3() {
         Snippet a = classKey(assertEval("class A { }"));
         assertClasses(clazz(KullaTesting.ClassType.CLASS, "A"));
@@ -201,6 +214,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void classesCyclic1() {
         Snippet b = classKey(assertEval("class B extends A { }",
                 added(RECOVERABLE_NOT_DEFINED)));
@@ -221,11 +235,12 @@ public class ClassesTest extends KullaTesting {
             diags = diagsA;
             assertTrue(diagsB.isEmpty());
         }
-        assertEquals(diags.size(), 1, "Expected one error");
-        assertEquals(diags.get(0).getCode(), "compiler.err.cyclic.inheritance", "Expected cyclic inheritance error");
+        assertEquals(1, diags.size(), "Expected one error");
+        assertEquals("compiler.err.cyclic.inheritance", diags.get(0).getCode(), "Expected cyclic inheritance error");
         assertActiveKeys();
     }
 
+    @Test
     public void classesCyclic2() {
         Snippet d = classKey(assertEval("class D extends E { }", added(RECOVERABLE_NOT_DEFINED)));
         assertEval("class E { D d; }",
@@ -234,6 +249,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void classesCyclic3() {
         Snippet outer = classKey(assertEval("class Outer { class Inner extends Foo { } }",
                 added(RECOVERABLE_NOT_DEFINED)));
@@ -247,6 +263,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void classesIgnoredModifiers() {
         assertEval("public interface A { }");
         assertEval("static class B implements A { }");
@@ -254,6 +271,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void classesIgnoredModifiersAnnotation() {
         assertEval("public @interface X { }");
         assertEval("@X public interface A { }");
@@ -262,6 +280,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void classesIgnoredModifiersOtherModifiers() {
         assertEval("strictfp public interface A { }");
         assertEval("strictfp static class B implements A { }");
@@ -269,6 +288,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void ignoreModifierSpaceIssue() {
         assertEval("interface I { void f(); } ");
         // there should not be a space between 'I' and '{' to reproduce the failure
@@ -277,7 +297,6 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
-    @DataProvider(name = "innerClasses")
     public Object[][] innerClasses() {
         List<Object[]> list = new ArrayList<>();
         for (ClassType outerClassType : ClassType.values()) {
@@ -288,7 +307,8 @@ public class ClassesTest extends KullaTesting {
         return list.toArray(new Object[list.size()][]);
     }
 
-    @Test(dataProvider = "innerClasses")
+    @ParameterizedTest
+    @MethodSource("innerClasses")
     public void innerClasses(ClassType outerClassType, ClassType innerClassType) {
         String source =
                 outerClassType + " A {" + (outerClassType == ClassType.ENUM ? ";" : "") +
@@ -299,6 +319,7 @@ public class ClassesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testInnerClassesCrash() {
         Snippet a = classKey(assertEval("class A { class B extends A {} }"));
         Snippet a2 = classKey(assertEval("class A { interface I1 extends I2 {} interface I2 {} }",
@@ -309,20 +330,23 @@ public class ClassesTest extends KullaTesting {
                 ste(a2, VALID, OVERWRITTEN, false, MAIN_SNIPPET));
     }
 
+    @Test
     public void testInnerClassesCrash1() {
         assertEval("class A { class B extends A {} B getB() { return new B();} }");
-        assertEquals(varKey(assertEval("A a = new A();")).name(), "a");
+        assertEquals("a", varKey(assertEval("A a = new A();")).name());
         VarSnippet variableKey = varKey(assertEval("a.getB();"));
-        assertEquals(variableKey.typeName(), "A.B");
+        assertEquals("A.B", variableKey.typeName());
     }
 
+    @Test
     public void testInnerClassesCrash2() {
         assertEval("class A { interface I1 extends I2 {} interface I2 {} I1 x; }");
-        assertEquals(varKey(assertEval("A a = new A();")).name(), "a");
+        assertEquals("a", varKey(assertEval("A a = new A();")).name());
         VarSnippet variableKey = varKey(assertEval("a.x;"));
-        assertEquals(variableKey.typeName(), "A.I1");
+        assertEquals("A.I1", variableKey.typeName());
     }
 
+    @Test
     public void testCircular() {
         assertEval("import java.util.function.Supplier;");
         TypeDeclSnippet aClass =
@@ -342,6 +366,7 @@ public class ClassesTest extends KullaTesting {
         assertEval("new A()");
     }
 
+    @Test
     public void testDefaultMethodInInterface() {
         assertEvalFail("""
                        interface C {

--- a/test/langtools/jdk/jshell/CommandCompletionTest.java
+++ b/test/langtools/jdk/jshell/CommandCompletionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  * @library /tools/lib
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build ReplToolTesting TestingInputStream Compiler
- * @run testng CommandCompletionTest
+ * @run junit CommandCompletionTest
  */
 
 import java.io.IOException;
@@ -49,16 +49,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.testng.SkipException;
-import org.testng.annotations.Test;
 
 import jdk.internal.jshell.tool.JShellTool;
 import jdk.internal.jshell.tool.JShellToolBuilder;
 import jdk.jshell.SourceCodeAnalysis.Suggestion;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 public class CommandCompletionTest extends ReplToolTesting {
 
@@ -86,8 +86,9 @@ public class CommandCompletionTest extends ReplToolTesting {
 
     public void assertCompletion(String code, boolean isSmart, String... expected) {
         List<String> completions = computeCompletions(code, isSmart);
-        assertEquals(completions, Arrays.asList(expected), "Command: " + code + ", output: " +
-                completions.toString());
+        List<String> expectedL = Arrays.asList(expected);
+        assertEquals(expectedL, completions, "Command: " + code + ", output: " +
+                completions.toString() + ", expected: " + expectedL.toString());
     }
 
     private List<String> computeCompletions(String code, boolean isSmart) {
@@ -359,9 +360,7 @@ public class CommandCompletionTest extends ReplToolTesting {
                                   .map(file -> file.getFileName().toString().replace(" ", "\\ "))
                                   .orElse(null);
         }
-        if (selectedFile == null) {
-            throw new SkipException("No suitable file(s) found for this test in " + home);
-        }
+        Assumptions.assumeFalse(selectedFile == null, "No suitable file(s) found for this test in " + home);
         try (Stream<Path> content = Files.list(home)) {
             completions = content.filter(CLASSPATH_FILTER)
                                  .filter(file -> file.getFileName().toString().startsWith(selectedFile.replace("\\ ", " ")))

--- a/test/langtools/jdk/jshell/CompilerOptionsTest.java
+++ b/test/langtools/jdk/jshell/CompilerOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,28 +26,29 @@
  * @bug 8159635
  * @summary Test setting compiler options
  * @build KullaTesting TestingInputStream
- * @run testng CompilerOptionsTest
+ * @run junit CompilerOptionsTest
  */
 
 import javax.tools.Diagnostic;
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
 import static jdk.jshell.Snippet.Status.VALID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class CompilerOptionsTest extends KullaTesting {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(b -> b.compilerOptions("-source", "7", "-Xlint:cast,-options"));
     }
 
+    @Test
     public void testLint() {
         assertDeclareWarn1("String s = (String)\"hello\";",
                 new ExpectedDiagnostic("compiler.warn.redundant.cast", 11, 26, 11, -1, -1, Diagnostic.Kind.WARNING));
     }
 
+    @Test
     public void testSourceVersion() {
         assertEval("import java.util.function.*;", added(VALID));
         assertDeclareFail("Function<Integer,Integer> f = x -> x*2;",

--- a/test/langtools/jdk/jshell/CompletenessStressTest.java
+++ b/test/langtools/jdk/jshell/CompletenessStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,12 +64,12 @@ import com.sun.tools.javac.api.JavacTaskImpl;
 
 import jdk.jshell.SourceCodeAnalysis;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
 import static jdk.jshell.SourceCodeAnalysis.Completeness.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class CompletenessStressTest extends KullaTesting {
     public final static String JDK_ROOT_SRC_PROP = "jdk.root.src";
@@ -99,7 +99,6 @@ public class CompletenessStressTest extends KullaTesting {
         };
     }
 
-    @DataProvider(name = "crawler")
     public Object[][] dataProvider() throws IOException {
         File[] srcDirs = getDirectoriesToTest();
         List<String[]> list = new ArrayList<>();
@@ -121,7 +120,8 @@ public class CompletenessStressTest extends KullaTesting {
         return list.toArray(new String[list.size()][]);
     }
 
-    @Test(dataProvider = "crawler")
+    @ParameterizedTest
+    @MethodSource("dataProvider")
     public void testFile(String fileName) throws IOException {
         File file = getSourceFile(fileName);
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();

--- a/test/langtools/jdk/jshell/CompletenessTest.java
+++ b/test/langtools/jdk/jshell/CompletenessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8149524 8131024 8165211 8080071 8130454 8167343 8129559 8114842 8182268 8223782 8235474 8246774
  * @summary Test SourceCodeAnalysis
  * @build KullaTesting TestingInputStream
- * @run testng CompletenessTest
+ * @run junit CompletenessTest
  */
 
 import java.util.Map;
@@ -35,13 +35,11 @@ import java.util.function.Consumer;
 import javax.lang.model.SourceVersion;
 import jdk.jshell.JShell;
 
-import org.testng.annotations.Test;
 import jdk.jshell.SourceCodeAnalysis.Completeness;
 
 import static jdk.jshell.SourceCodeAnalysis.Completeness.*;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class CompletenessTest extends KullaTesting {
 
     // Add complete units that end with semicolon to complete_with_semi (without
@@ -270,30 +268,37 @@ public class CompletenessTest extends KullaTesting {
         }
     }
 
+    @Test
     public void test_complete() {
          assertStatus(complete, COMPLETE);
     }
 
+    @Test
     public void test_expression() {
         assertStatus(expression, COMPLETE);
     }
 
+    @Test
     public void test_complete_with_semi() {
         assertStatus(complete_with_semi, COMPLETE_WITH_SEMI);
     }
 
+    @Test
     public void test_considered_incomplete() {
         assertStatus(considered_incomplete, CONSIDERED_INCOMPLETE);
     }
 
+    @Test
     public void test_definitely_incomplete() {
         assertStatus(definitely_incomplete, DEFINITELY_INCOMPLETE);
     }
 
+    @Test
     public void test_unknown() {
         assertStatus(definitely_incomplete, DEFINITELY_INCOMPLETE);
     }
 
+    @Test
     public void testCompleted_complete_with_semi() {
         for (String in : complete_with_semi) {
             String input = in + ";";
@@ -301,6 +306,7 @@ public class CompletenessTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testCompleted_expression_with_semi() {
         for (String in : expression) {
             String input = in + ";";
@@ -308,6 +314,7 @@ public class CompletenessTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testCompleted_considered_incomplete() {
         for (String in : considered_incomplete) {
             String input = in + ";";
@@ -324,12 +331,14 @@ public class CompletenessTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testCompleteSource_complete() {
         for (String input : complete) {
             assertSourceByStatus(input);
         }
     }
 
+    @Test
     public void testCompleteSource_complete_with_semi() {
         for (String in : complete_with_semi) {
             String input = in + ";";
@@ -337,6 +346,7 @@ public class CompletenessTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testCompleteSource_expression() {
         for (String in : expression) {
             String input = in + ";";
@@ -344,6 +354,7 @@ public class CompletenessTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testCompleteSource_considered_incomplete() {
         for (String in : considered_incomplete) {
             String input = in + ";";
@@ -351,15 +362,18 @@ public class CompletenessTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testTrailingSlash() {
         assertStatus("\"abc\\", UNKNOWN, "\"abc\\");
     }
 
+    @Test
     public void testOpenComment() {
         assertStatus("int xx; /* hello", DEFINITELY_INCOMPLETE, null);
         assertStatus("/**  test", DEFINITELY_INCOMPLETE, null);
     }
 
+    @Test
     public void testTextBlocks() {
         assertStatus("\"\"\"", DEFINITELY_INCOMPLETE, null);
         assertStatus("\"\"\"broken", DEFINITELY_INCOMPLETE, null);
@@ -372,6 +386,7 @@ public class CompletenessTest extends KullaTesting {
         assertStatus("\"\"\"\ntext\\\"\"\"\\\"\"\"\"\"\"", COMPLETE, "\"\"\"\ntext\\\"\"\"\\\"\"\"\"\"\"");
     }
 
+    @Test
     public void testMiscSource() {
         assertStatus("if (t) if ", DEFINITELY_INCOMPLETE, "if (t) if"); //Bug
         assertStatus("int m() {} dfd", COMPLETE, "int m() {}");

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -32,7 +32,7 @@
  *          jdk.jshell/jdk.jshell:open
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build KullaTesting TestingInputStream Compiler
- * @run testng CompletionSuggestionTest
+ * @run junit CompletionSuggestionTest
  */
 
 import java.io.IOException;
@@ -50,18 +50,19 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
 import jdk.jshell.Snippet;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import static jdk.jshell.Snippet.Status.VALID;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class CompletionSuggestionTest extends KullaTesting {
 
     private final Compiler compiler = new Compiler();
     private final Path outDir = Paths.get("completion_suggestion_test");
 
+    @Test
     public void testMemberExpr() {
         assertEval("class Test { static void test() { } }");
         assertCompletion("Test.t|", "test()");
@@ -111,16 +112,19 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("\"\"\"\n\"\"\".leng|", "length()");
     }
 
+    @Test
     public void testStartOfExpression() {
         assertEval("int ccTest = 0;");
         assertCompletion("System.err.println(cc|", "ccTest");
         assertCompletion("for (int i = cc|", "ccTest");
     }
 
+    @Test
     public void testParameter() {
         assertCompletion("class C{void method(int num){num|", "num");
     }
 
+    @Test
     public void testPrimitive() {
         Set<String> primitives = new HashSet<>(Arrays.asList("boolean", "char", "byte", "short", "int", "long", "float", "double"));
         Set<String> onlyVoid = new HashSet<>(Collections.singletonList("void"));
@@ -153,6 +157,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("class A<T extends doubl|");
     }
 
+    @Test
     public void testEmpty() {
         assertCompletionIncludesExcludes("|",
                 new HashSet<>(Arrays.asList("Object", "Void")),
@@ -165,6 +170,7 @@ public class CompletionSuggestionTest extends KullaTesting {
                 new HashSet<>(Arrays.asList("$REPL00DOESNOTMATTER")));
     }
 
+    @Test
     public void testSmartCompletion() {
         assertEval("int ccTest1 = 0;");
         assertEval("int ccTest2 = 0;");
@@ -197,6 +203,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("new Klass(|", true, "ccTest1", "ccTest2");
     }
 
+    @Test
     public void testSmartCompletionInOverriddenMethodInvocation() {
         assertEval("int ccTest1 = 0;");
         assertEval("int ccTest2 = 0;");
@@ -207,6 +214,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("new Extend().method(|", true, "ccTest1", "ccTest2");
     }
 
+    @Test
     public void testSmartCompletionForBoxedType() {
         assertEval("int ccTest1 = 0;");
         assertEval("Integer ccTest2 = 0;");
@@ -222,6 +230,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("method3(|", true, "ccTest1", "ccTest2", "ccTest3", "method1(", "method2(", "method3(");
     }
 
+    @Test
     public void testNewClass() {
         assertCompletion("String str = new Strin|", "String(", "StringBuffer(", "StringBuilder(", "StringIndexOutOfBoundsException(");
         assertCompletion("String str = new java.lang.Strin|", "String(", "StringBuffer(", "StringBuilder(", "StringIndexOutOfBoundsException(");
@@ -242,6 +251,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("new String(I.A|", "A");
     }
 
+    @Test
     public void testFullyQualified() {
         assertCompletion("Optional<String> opt = java.u|", "util.");
         assertCompletionIncludesExcludes("Optional<Strings> opt = java.util.O|", new HashSet<>(Collections.singletonList("Optional")), Collections.emptySet());
@@ -270,15 +280,18 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("p1.p3.|", "Test");
     }
 
+    @Test
     public void testCheckAccessibility() {
         assertCompletion("java.util.regex.Pattern.co|", "compile(");
     }
 
+    @Test
     public void testCompletePackages() {
         assertCompletion("java.u|", "util.");
         assertCompletionIncludesExcludes("jav|", new HashSet<>(Arrays.asList("java.", "javax.")), Collections.emptySet());
     }
 
+    @Test
     public void testImports() {
         assertCompletion("import java.u|", "util.");
         assertCompletionIncludesExcludes("import jav|", new HashSet<>(Arrays.asList("java.", "javax.")), Collections.emptySet());
@@ -297,10 +310,12 @@ public class CompletionSuggestionTest extends KullaTesting {
                 new HashSet<>(Arrays.asList("class")));
     }
 
+    @Test
     public void testImportStart() {
         assertCompletionIncludesExcludes("import c|", Set.of("com."), Set.of());
     }
 
+    @Test
     public void testBrokenClassFile() throws Exception {
         Compiler compiler = new Compiler();
         Path testOutDir = Paths.get("CompletionTestBrokenClassFile");
@@ -310,6 +325,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("import inner.|");
     }
 
+    @Test
     public void testDocumentation() throws Exception {
         dontReadParameterNamesFromClassFile();
         assertSignature("System.getProperty(|",
@@ -337,6 +353,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertSignature("field.FieldTest.field2|");
     }
 
+    @Test
     public void testMethodsWithNoArguments() throws Exception {
         dontReadParameterNamesFromClassFile();
         assertSignature("System.out.println(|",
@@ -352,11 +369,13 @@ public class CompletionSuggestionTest extends KullaTesting {
                 "void java.io.PrintStream.println(Object)");
     }
 
+    @Test
     public void testErroneous() {
         assertCompletion("Undefined.|");
         assertSignature("does.not.exist|");
     }
 
+    @Test
     public void testClinit() {
         assertEval("enum E{;}");
         assertEval("class C{static{}}");
@@ -364,6 +383,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletionIncludesExcludes("C.|", Collections.emptySet(), new HashSet<>(Collections.singletonList("<clinit>")));
     }
 
+    @Test
     public void testMethodHeaderContext() {
         assertCompletion("private void f(Runn|", "Runnable");
         assertCompletion("void f(Runn|", "Runnable");
@@ -375,6 +395,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("void f(Object o1) throws HogeHoge.|", true, "HogeHogeException");
     }
 
+    @Test
     public void testTypeVariables() {
         assertCompletion("class A<TYPE> { public void test() { TY|", "TYPE");
         assertCompletion("class A<TYPE> { public static void test() { TY|");
@@ -382,6 +403,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("class A<TYPE> { public static <TYPE> void test() { TY|", "TYPE");
     }
 
+    @Test
     public void testGeneric() {
         assertEval("import java.util.concurrent.*;");
         assertCompletion("java.util.List<Integ|", "Integer");
@@ -392,6 +414,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("class A<TYPE extends Callable<? super TY|", "TYPE");
     }
 
+    @Test
     public void testFields() {
         assertEval("interface Interface { int field = 0; }");
         Snippet clazz = classKey(assertEval("class Clazz {" +
@@ -412,6 +435,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("new Clazz() {}.fiel|");
     }
 
+    @Test
     public void testMethods() {
         assertEval("interface Interface {" +
                 "default int defaultMethod() { return 0; }" +
@@ -477,6 +501,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("class A <T extends Clazz & Interf|", true, "Interface", "Interface1");
     }
 
+    @Test
     public void testMethodDeclaration() {
         assertEval("void ClazzM() {}");
         assertEval("void InterfaceM() {}");
@@ -488,6 +513,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("void m(Interface i1) throws Interf|", true, "InterfaceException");
     }
 
+    @Test
     public void testDocumentationOfUserDefinedMethods() {
         assertEval("void f() {}");
         assertSignature("f(|", "void f()");
@@ -500,10 +526,12 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertSignature("f(|", "void f()", "void f(int i)", "void <T>f(T... ts)", "void f(A a)");
     }
 
+    @Test
     public void testClass() {
         assertSignature("String|", "java.lang.String");
     }
 
+    @Test
     public void testDocumentationOfUserDefinedConstructors() {
         Snippet a = classKey(assertEval("class A {}"));
         assertSignature("new A(|", "A()");
@@ -517,6 +545,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertSignature("new A(|", "A<T>(T a)", "A<T>(int i)", "<U> A<T>(T t, U u)");
     }
 
+    @Test
     public void testDocumentationOfOverriddenMethods() throws Exception {
         dontReadParameterNamesFromClassFile();
         assertSignature("\"\".wait(|",
@@ -532,6 +561,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertSignature("new Extend().method(|", "void Extend.method()");
     }
 
+    @Test
     public void testDocumentationOfInvisibleMethods() {
         assertSignature("Object.wait(|");
         assertSignature("\"\".indexOfSupplementary(|");
@@ -543,12 +573,14 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertSignature("new A().method(|");
     }
 
+    @Test
     public void testDocumentationOfInvisibleConstructors() {
         assertSignature("new Compiler(|");
         assertEval("class A { private A() {} }");
         assertSignature("new A(|");
     }
 
+    @Test
     public void testDocumentationWithBoxing() {
         assertEval("int primitive = 0;");
         assertEval("Integer boxed = 0;");
@@ -565,6 +597,7 @@ public class CompletionSuggestionTest extends KullaTesting {
                 "void method(Object n, int o)");
     }
 
+    @Test
     public void testDocumentationWithGenerics() {
         class TestDocumentationWithGenerics {
             private final Function<Integer, String> codeFacotry;
@@ -619,6 +652,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         });
     }
 
+    @Test
     public void testVarArgs() {
         assertEval("int i = 0;");
         assertEval("class Foo1 { static void m(int... i) { } } ");
@@ -644,6 +678,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("Foo4.m(ia, |", true, "str");
     }
 
+    @Test
     public void testConstructorAsMemberOf() {
         assertEval("class Baz<X> { Baz(X x) { } } ");
         assertEval("String str = null;");
@@ -655,6 +690,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("Foo.m(new Baz<>(|", true, "str");
     }
 
+    @Test
     public void testIntersection() {
         assertEval("<Z extends Runnable & CharSequence> Z get() { return null; }");
         assertEval("var v = get();");
@@ -664,6 +700,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("Number r = |", true);
     }
 
+    @Test
     public void testAnonymous() {
         assertEval("var v = new Runnable() { public void run() { } public int length() { return 0; } };");
         assertCompletionIncludesExcludes("v.|", true, Set.of("run()", "length()"), Set.of());
@@ -671,10 +708,12 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("CharSequence r = |", true);
     }
 
+    @Test
     public void testCompletionInAnonymous() {
         assertCompletionIncludesExcludes("new Undefined() { int i = \"\".l|", Set.of("length()"), Set.of());
     }
 
+    @Test
     public void testMemberReferences() {
         assertEval("class C {" +
                    "    public static String stat() { return null; }" +
@@ -698,6 +737,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("FI2<Object, String> fi = C::|", true, "statConvert1", "statConvert3");
     }
 
+    @Test
     public void testBrokenLambdaCompletion() {
         assertEval("interface Consumer<T> { public void consume(T t); }");
         assertEval("interface Function<T, R> { public R convert(T t); }");
@@ -719,7 +759,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("String s = m8(x -> {x.tri|", "trim()");
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         setUp(builder -> builder.executionEngine("local"));
 
@@ -751,7 +791,8 @@ public class CompletionSuggestionTest extends KullaTesting {
         keepParameterNames.set(getAnalysis(), new String[0]);
     }
 
-    @Test(enabled = false) //TODO 8171829
+    @Test //TODO 8171829
+    @Disabled
     public void testBrokenClassFile2() throws IOException {
         Path broken = outDir.resolve("broken");
         compiler.compile(broken,

--- a/test/langtools/jdk/jshell/ComputeFQNsTest.java
+++ b/test/langtools/jdk/jshell/ComputeFQNsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          jdk.jshell/jdk.jshell:open
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build KullaTesting TestingInputStream Compiler
- * @run testng ComputeFQNsTest
+ * @run junit ComputeFQNsTest
  */
 
 import java.io.Writer;
@@ -41,15 +41,16 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 
 import jdk.jshell.SourceCodeAnalysis.QualifiedNames;
-import static org.testng.Assert.*;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ComputeFQNsTest extends KullaTesting {
 
     private final Compiler compiler = new Compiler();
     private final Path outDir = Paths.get("ComputeFQNsTest");
 
+    @Test
     public void testAddImport() throws Exception {
         compiler.compile(outDir, "package test1; public class FQNTestClass { }", "package test2; public class FQNTestClass { }");
         String jarName = "test.jar";
@@ -77,7 +78,8 @@ public class ComputeFQNsTest extends KullaTesting {
         assertInferredFQNs("class X { ArrayList", "ArrayList".length(), false, "java.util.ArrayList");
     }
 
-    @Test(enabled = false) //TODO 8161165
+    @Test //TODO 8161165
+    @Disabled
     public void testSuspendIndexing() throws Throwable {
         compiler.compile(outDir, "package test; public class FQNTest { }");
         String jarName = "test.jar";
@@ -127,8 +129,8 @@ public class ComputeFQNsTest extends KullaTesting {
 
         QualifiedNames candidates = getAnalysis().listQualifiedNames(code, code.length());
 
-        assertEquals(candidates.getNames(), Arrays.asList(), "Input: " + code + ", candidates=" + candidates.getNames());
-        assertEquals(candidates.isUpToDate(), false, "Input: " + code + ", up-to-date=" + candidates.isUpToDate());
+        assertEquals(Arrays.asList(), candidates.getNames(), "Input: " + code + ", candidates=" + candidates.getNames());
+        assertEquals(false, candidates.isUpToDate(), "Input: " + code + ", up-to-date=" + candidates.isUpToDate());
 
         Files.delete(continueMarkFile);
 
@@ -136,7 +138,7 @@ public class ComputeFQNsTest extends KullaTesting {
 
         candidates = getAnalysis().listQualifiedNames(code, code.length());
 
-        assertEquals(candidates.getNames(), Arrays.asList("test.FQNTest"), "Input: " + code + ", candidates=" + candidates.getNames());
+        assertEquals(Arrays.asList("test.FQNTest"), candidates.getNames(), "Input: " + code + ", candidates=" + candidates.getNames());
         assertEquals(true, candidates.isUpToDate(), "Input: " + code + ", up-to-date=" + candidates.isUpToDate());
     }
 

--- a/test/langtools/jdk/jshell/CustomInputToolBuilder.java
+++ b/test/langtools/jdk/jshell/CustomInputToolBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Verify JavaShellToolBuilder uses provided inputs
  * @modules jdk.jshell
  * @build KullaTesting TestingInputStream
- * @run testng CustomInputToolBuilder
+ * @run junit CustomInputToolBuilder
  */
 
 import java.io.ByteArrayInputStream;
@@ -38,15 +38,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import jdk.jshell.tool.JavaShellToolBuilder;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertTrue;
-
-@Test
 public class CustomInputToolBuilder extends KullaTesting {
 
     private static final String TEST_JDK = "test.jdk";
 
+    @Test
     public void checkCustomInput() throws Exception {
         String testJdk = System.getProperty(TEST_JDK);
         try {
@@ -102,6 +101,7 @@ public class CustomInputToolBuilder extends KullaTesting {
             }
     }
 
+    @Test
     public void checkInteractiveTerminal() throws Exception {
         String testJdk = System.getProperty(TEST_JDK);
         try {

--- a/test/langtools/jdk/jshell/DropTest.java
+++ b/test/langtools/jdk/jshell/DropTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,20 +26,20 @@
  * @bug 8081431 8080069 8167128 8199623
  * @summary Test of JShell#drop().
  * @build KullaTesting TestingInputStream
- * @run testng DropTest
+ * @run junit DropTest
  */
 
 import jdk.jshell.DeclarationSnippet;
 import jdk.jshell.Snippet;
 import jdk.jshell.MethodSnippet;
 import jdk.jshell.VarSnippet;
-import org.testng.annotations.Test;
 
 import static jdk.jshell.Snippet.Status.*;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class DropTest extends KullaTesting {
 
+    @Test
     public void testDrop() {
         Snippet var = varKey(assertEval("int x;"));
         Snippet method = methodKey(assertEval("int mu() { return x * 4; }"));
@@ -88,6 +88,7 @@ public class DropTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testDropImport() {
         Snippet imp = importKey(assertEval("import java.util.*;"));
         Snippet decl = varKey(
@@ -101,11 +102,13 @@ public class DropTest extends KullaTesting {
         assertDeclareFail("list;", "compiler.err.cant.resolve.location");
     }
 
+    @Test
     public void testDropStatement() {
         Snippet x = key(assertEval("if (true);"));
         assertDrop(x, ste(x, VALID, DROPPED, true, null));
     }
 
+    @Test
     public void testDropVarToMethod() {
         Snippet x = varKey(assertEval("int x;"));
         DeclarationSnippet method = methodKey(assertEval("double mu() { return x * 4; }"));
@@ -123,6 +126,7 @@ public class DropTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testDropMethodToMethod() {
         Snippet a = methodKey(assertEval("double a() { return 2; }"));
         DeclarationSnippet b = methodKey(assertEval("double b() { return a() * 10; }"));
@@ -139,6 +143,7 @@ public class DropTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testDropClassToMethod() {
         Snippet c = classKey(assertEval("class C { int f() { return 7; } }"));
         DeclarationSnippet m = methodKey(assertEval("int m() { return new C().f(); }"));
@@ -150,6 +155,7 @@ public class DropTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testDropVarToClass() {
         Snippet x = varKey(assertEval("int x;"));
         DeclarationSnippet a = classKey(assertEval("class A { double a = 4 * x; }"));
@@ -165,6 +171,7 @@ public class DropTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testDropMethodToClass() {
         Snippet x = methodKey(assertEval("int x() { return 0; }"));
         DeclarationSnippet a = classKey(assertEval("class A { double a = 4 * x(); }"));
@@ -179,6 +186,7 @@ public class DropTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testDropClassToClass() {
         Snippet a = classKey(assertEval("class A {}"));
         Snippet b = classKey(assertEval("class B extends A {}"));
@@ -204,6 +212,7 @@ public class DropTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testDropNoUpdate() {
         String as1 = "class A {}";
         String as2 = "class A extends java.util.ArrayList<Boolean> {}";
@@ -228,6 +237,7 @@ public class DropTest extends KullaTesting {
     }
 
     // 8199623
+    @Test
     public void testTwoForkedDrop() {
         MethodSnippet p = methodKey(assertEval("void p() throws Exception { ((String) null).toString(); }"));
         MethodSnippet n = methodKey(assertEval("void n() throws Exception { try { p(); } catch (Exception ex) { throw new RuntimeException(\"bar\", ex); }}"));

--- a/test/langtools/jdk/jshell/EditorTestBase.java
+++ b/test/langtools/jdk/jshell/EditorTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public abstract class EditorTestBase extends ReplToolTesting {
 
@@ -61,11 +61,11 @@ public abstract class EditorTestBase extends ReplToolTesting {
     }
 
     void assertEditInput(boolean after, String cmd, String input, Action action) {
-        assertEditInput(after, cmd, s -> assertEquals(s, input, "Input"), action);
+        assertEditInput(after, cmd, s -> assertEquals(input, s, "Input"), action);
     }
 
     void assertEditOutput(boolean after, String cmd, String output, Action action) {
-        assertEditOutput(after, cmd, s -> assertEquals(s.trim(), output.trim(), "command"), action);
+        assertEditOutput(after, cmd, s -> assertEquals(output.trim(), s.trim(), "command"), action);
     }
 
     @Test
@@ -219,16 +219,15 @@ public abstract class EditorTestBase extends ReplToolTesting {
 
     @Test
     public void testNoArguments() {
-        testEditor(
-                a -> assertVariable(a, "int", "a"),
+        testEditor(a -> assertVariable(a, "int", "a"),
                 a -> assertMethod(a, "void f() {}", "()void", "f"),
                 a -> assertClass(a, "class A {}", "class", "A"),
                 a -> assertEditInput(a, "/ed", s -> {
                     String[] ss = s.split("\n");
-                    assertEquals(ss.length, 3, "Expected 3 lines: " + s);
-                    assertEquals(ss[0], "int a;");
-                    assertEquals(ss[1], "void f() {}");
-                    assertEquals(ss[2], "class A {}");
+                    assertEquals(3, ss.length, "Expected 3 lines: " + s);
+                    assertEquals("int a;", ss[0]);
+                    assertEquals("void f() {}", ss[1]);
+                    assertEquals("class A {}", ss[2]);
                 }, this::exit)
         );
     }
@@ -263,7 +262,8 @@ public abstract class EditorTestBase extends ReplToolTesting {
         );
     }
 
-    @Test(enabled = false) // TODO JDK-8191875
+    @Test // TODO JDK-8191875
+    @Disabled
     public void testStatementMush() {
         testEditor(
                 a -> assertCommand(a, "System.out.println(\"Hello\")",

--- a/test/langtools/jdk/jshell/EmptyTest.java
+++ b/test/langtools/jdk/jshell/EmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,34 +25,39 @@
  * @test
  * @summary null test
  * @build KullaTesting TestingInputStream
- * @run testng EmptyTest
+ * @run junit EmptyTest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class EmptyTest extends KullaTesting {
 
+    @Test
     public void testEmpty() {
         assertEvalEmpty("");
     }
 
+    @Test
     public void testSpace() {
         assertEvalEmpty("    ");
     }
 
+    @Test
     public void testSemicolon() {
         assertEval(";", "");
     }
 
+    @Test
     public void testSlashStarComment() {
         assertEvalEmpty("/*test*/");
     }
 
+    @Test
     public void testSlashStarCommentSemicolon() {
         assertEval("/*test*/;", "");
     }
 
+    @Test
     public void testSlashComment() {
         assertEvalEmpty("// test");
     }

--- a/test/langtools/jdk/jshell/ErrorTranslationTest.java
+++ b/test/langtools/jdk/jshell/ErrorTranslationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          jdk.jshell/jdk.internal.jshell.tool
  * @library /tools/lib
  * @build KullaTesting TestingInputStream ExpectedDiagnostic toolbox.ToolBox Compiler
- * @run testng ErrorTranslationTest
+ * @run junit ErrorTranslationTest
  */
 
 import java.nio.file.Path;
@@ -41,15 +41,15 @@ import java.util.function.Consumer;
 
 import javax.tools.Diagnostic;
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-@Test
 public class ErrorTranslationTest extends ReplToolTesting {
 
-    @Test(enabled = false) // TODO 8080353
+    @Test // TODO 8080353
+    @Disabled
     public void testErrors() {
         test(
                 a -> assertDiagnostic(a, "abstract void f();", newExpectedDiagnostic(0, 8, 0, -1, -1, Diagnostic.Kind.ERROR)),
@@ -60,6 +60,7 @@ public class ErrorTranslationTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testlvtiErrors() {
         test(
                 a -> assertDiagnostic(a, "var broken = () -> {};", newExpectedDiagnostic(0, 22, 0, -1, -1, Diagnostic.Kind.ERROR)),
@@ -67,13 +68,15 @@ public class ErrorTranslationTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testExceptionErrors() {
         test(
                 a -> assertDiagnostic(a, "try { } catch (IllegalStateException | java.io.IOException ex) { }", newExpectedDiagnostic(39, 58, -1, -1, -1, Diagnostic.Kind.ERROR))
         );
     }
 
-    @Test(enabled = false) // TODO 8132147
+    @Test // TODO 8132147
+    @Disabled
     public void stressTest() {
         Compiler compiler = new Compiler();
         Path oome = compiler.getPath("OOME.repl");
@@ -115,11 +118,11 @@ public class ErrorTranslationTest extends ReplToolTesting {
                 throw new AssertionError("Not enough lines: " + s);
             }
             String kind = getKind(expectedDiagnostic.getKind());
-            assertEquals(lines[0], kind);
+            assertEquals(kind, lines[0]);
             boolean found = false;
             for (int i = 0; i < lines.length; i++) {
                 if (lines[i].endsWith(expectedSource)) {
-                    assertEquals(lines[i + 1], expectedMarkingLine, "Input: " + expectedSource + ", marking line: ");
+                    assertEquals(expectedMarkingLine, lines[i + 1], "Input: " + expectedSource + ", marking line: ");
                     found = true;
                 }
             }
@@ -146,6 +149,7 @@ public class ErrorTranslationTest extends ReplToolTesting {
         return sb.toString();
     }
 
+    @Test
     public String getKind(Diagnostic.Kind kind) {
         switch (kind) {
             case WARNING:

--- a/test/langtools/jdk/jshell/ExceptionMessageTest.java
+++ b/test/langtools/jdk/jshell/ExceptionMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @bug 8185108
  * @summary Test exception().getMessage() in events returned by eval()
- * @run testng ExceptionMessageTest
+ * @run junit ExceptionMessageTest
  * @key intermittent
  */
 
@@ -42,22 +42,23 @@ import jdk.jshell.spi.ExecutionControl;
 import jdk.jshell.spi.ExecutionControlProvider;
 import jdk.jshell.spi.ExecutionEnv;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ExceptionMessageTest {
 
+    @Test
     public void testDefaultEC() {
         doTestCases(new JdiExecutionControlProvider(), "default");
     }
 
+    @Test
     public void testLocalEC() {
         doTestCases(new LocalExecutionControlProvider(), "local");
     }
 
+    @Test
     public void testDirectEC() {
         doTestCases(new ExecutionControlProvider() {
             public ExecutionControl generate(ExecutionEnv env, Map<String, String> param) throws Throwable {
@@ -85,11 +86,11 @@ public class ExceptionMessageTest {
 
     private void doTest(JShell jshell, String label, String code, String expected) {
         List<SnippetEvent> result = jshell.eval(code);
-        assertEquals(result.size(), 1, "Expected only one event");
+        assertEquals(1, result.size(), "Expected only one event");
         SnippetEvent evt = result.get(0);
         Exception exc = evt.exception();
         String out = exc.getMessage();
-        assertEquals(out, expected, "Exception message not as expected: " +
+        assertEquals(expected, out, "Exception message not as expected: " +
                 label + " -- " + code);
     }
 }

--- a/test/langtools/jdk/jshell/ExceptionsTest.java
+++ b/test/langtools/jdk/jshell/ExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  * @library /tools/lib
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build KullaTesting TestingInputStream Compiler
- * @run testng ExceptionsTest
+ * @run junit ExceptionsTest
  */
 
 import java.io.IOException;
@@ -46,16 +46,16 @@ import jdk.jshell.UnresolvedReferenceException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.*;
-
-@Test
 public class ExceptionsTest extends KullaTesting {
 
     private final Compiler compiler = new Compiler();
     private final Path outDir = Paths.get("test_class_path");
 
+    @Test
     public void throwUncheckedException() {
         String message = "error_message";
         SnippetEvent cr = assertEvalException("throw new RuntimeException(\"" + message + "\");");
@@ -64,6 +64,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr.snippet(), 1)));
     }
 
+    @Test
     public void throwCheckedException() {
         String message = "error_message";
         SnippetEvent cr = assertEvalException("throw new Exception(\"" + message + "\");");
@@ -72,6 +73,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr.snippet(), 1)));
     }
 
+    @Test
     public void throwFromStaticMethodOfClass() {
         String message = "error_message";
         Snippet s1 = methodKey(assertEval("void f() { throw new RuntimeException(\"" + message + "\"); }"));
@@ -84,6 +86,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr3.snippet(), 1)));
     }
 
+    @Test
     public void throwFromStaticMethodOfInterface() {
         String message = "error_message";
         Snippet s1 = methodKey(assertEval("void f() { throw new RuntimeException(\"" + message + "\"); }"));
@@ -96,6 +99,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr3.snippet(), 1)));
     }
 
+    @Test
     public void throwChained() {
         String message1 = "error_message1";
         String message2 = "error_message2";
@@ -122,6 +126,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr4.snippet(), 1)));
     }
 
+    @Test
     public void throwChainedUnresolved() {
         String message1 = "error_message1";
         String message2 = "error_message2";
@@ -144,6 +149,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr4.snippet(), 1)));
     }
 
+    @Test
     public void throwFromConstructor() {
         String message = "error_message";
         Snippet s1 = methodKey(assertEval("void f() { throw new RuntimeException(\"" + message + "\"); }"));
@@ -156,6 +162,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr3.snippet(), 1)));
     }
 
+    @Test
     public void throwFromDefaultMethodOfInterface() {
         String message = "error_message";
         Snippet s1 = methodKey(assertEval("void f() { throw new RuntimeException(\"" + message + "\"); }"));
@@ -168,6 +175,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr3.snippet(), 1)));
     }
 
+    @Test
     public void throwFromLambda() {
         String message = "lambda";
         Snippet s1 = varKey(assertEval(
@@ -182,6 +190,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr2.snippet(), 1)));
     }
 
+    @Test
     public void throwFromAnonymousClass() {
         String message = "anonymous";
         Snippet s1 = varKey(assertEval(
@@ -198,6 +207,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", cr2.snippet(), 1)));
     }
 
+    @Test
     public void throwFromLocalClass() {
         String message = "local";
         Snippet s1 = methodKey(assertEval(
@@ -219,6 +229,7 @@ public class ExceptionsTest extends KullaTesting {
     }
 
     // test 8210527
+    @Test
     public void throwFromWithoutSource() {
         String message = "show this";
         SnippetEvent se = assertEvalException("java.lang.reflect.Proxy.newProxyInstance(" +
@@ -232,6 +243,7 @@ public class ExceptionsTest extends KullaTesting {
     }
 
     // test 8210527
+    @Test
     public void throwFromNoSource() {
         Path path = outDir.resolve("fail");
         compiler.compile(path,
@@ -249,6 +261,7 @@ public class ExceptionsTest extends KullaTesting {
     }
 
     // test 8212167
+    @Test
     public void throwLineFormat1() {
         SnippetEvent se = assertEvalException(
                 "if (true) { \n" +
@@ -260,6 +273,7 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", se.snippet(), 3)));
     }
 
+    @Test
     public void throwLineFormat3() {
         Snippet sp = methodKey(assertEval(
                 "int p() \n" +
@@ -291,13 +305,15 @@ public class ExceptionsTest extends KullaTesting {
                         newStackTraceElement("", "", se.snippet(), 1)));
     }
 
-    @Test(enabled = false) // TODO 8129427
+    @Test // TODO 8129427
+    @Disabled
     public void outOfMemory() {
         assertEval("import java.util.*;");
         assertEval("List<byte[]> list = new ArrayList<>();");
         assertExecuteException("while (true) { list.add(new byte[10000]); }", OutOfMemoryError.class);
     }
 
+    @Test
     public void stackOverflow() {
         assertEval("void f() { f(); }");
         assertExecuteException("f();", StackOverflowError.class);
@@ -360,11 +376,11 @@ public class ExceptionsTest extends KullaTesting {
             EvalException ex = (EvalException) exception;
             String actualException = ex.getExceptionClassName();
             String expectedException = exceptionInfo.exception.getCanonicalName();
-            assertEquals(actualException, expectedException,
+            assertEquals(expectedException, actualException,
                     String.format("Given \"%s\" expected exception: %s, got: %s%nStack trace:%n%s",
                             source, expectedException, actualException, getStackTrace(ex)));
             if (exceptionInfo.message != null) {
-                assertEquals(ex.getMessage(), exceptionInfo.message,
+                assertEquals(exceptionInfo.message, ex.getMessage(),
                         String.format("Given \"%s\" expected message: %s, got: %s",
                                 source, exceptionInfo.message, ex.getMessage()));
             }
@@ -394,7 +410,7 @@ public class ExceptionsTest extends KullaTesting {
                     "Expected UnresolvedReferenceException: " + exception);
             UnresolvedExceptionInfo uei = (UnresolvedExceptionInfo) exceptionInfo;
             UnresolvedReferenceException ure = (UnresolvedReferenceException) exception;
-            assertEquals(ure.getSnippet(), uei.sn);
+            assertEquals(uei.sn, ure.getSnippet());
             assertStackMatch(ure, "", exceptionInfo);
         }
     }
@@ -404,20 +420,20 @@ public class ExceptionsTest extends KullaTesting {
             if (actual == null || expected == null) {
                 fail(message);
             } else {
-                assertEquals(actual.length, expected.length, message + " : arrays do not have the same size");
+                assertEquals(expected.length, actual.length, message + " : arrays do not have the same size");
                 for (int i = 0; i < actual.length; ++i) {
                     StackTraceElement actualElement = actual[i];
                     StackTraceElement expectedElement = expected[i];
-                    assertEquals(actualElement.getClassName(), expectedElement.getClassName(), message + " : class names [" + i + "]");
+                    assertEquals(expectedElement.getClassName(), actualElement.getClassName(), message + " : class names [" + i + "]");
                     String expectedMethodName = expectedElement.getMethodName();
                     if (expectedMethodName.startsWith("lambda$")) {
                         assertTrue(actualElement.getMethodName().startsWith("lambda$"), message + " : method names");
                     } else {
-                        assertEquals(actualElement.getMethodName(), expectedElement.getMethodName(), message + " : method names [" + i + "]");
+                        assertEquals(expectedElement.getMethodName(), actualElement.getMethodName(), message + " : method names [" + i + "]");
                     }
-                    assertEquals(actualElement.getFileName(), expectedElement.getFileName(), message + " : file names [" + i + "]");
+                    assertEquals(expectedElement.getFileName(), actualElement.getFileName(), message + " : file names [" + i + "]");
                     if (expectedElement.getLineNumber() >= 0) {
-                        assertEquals(actualElement.getLineNumber(), expectedElement.getLineNumber(), message + " : line numbers [" + i + "]"
+                        assertEquals(expectedElement.getLineNumber(), actualElement.getLineNumber(), message + " : line numbers [" + i + "]"
                                 + " -- actual: " + actualElement.getLineNumber() + ", expected: " + expectedElement.getLineNumber() +
                                 " -- in: " + actualElement.getClassName());
                     }

--- a/test/langtools/jdk/jshell/ExecutionControlSpecTest.java
+++ b/test/langtools/jdk/jshell/ExecutionControlSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,20 +34,20 @@
  * @library /tools/lib
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build KullaTesting Compiler
- * @run testng ExecutionControlSpecTest
+ * @run junit ExecutionControlSpecTest
  */
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ExecutionControlSpecTest extends KullaTesting {
 
     ClassLoader ccl;
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         String mod = "my.ec";
@@ -86,7 +86,7 @@ public class ExecutionControlSpecTest extends KullaTesting {
         setUp(builder -> builder.executionEngine("prefixing"));
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void tearDown() {
         super.tearDown();

--- a/test/langtools/jdk/jshell/ExecutionControlTestBase.java
+++ b/test/langtools/jdk/jshell/ExecutionControlTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,11 @@
 
 import javax.tools.Diagnostic;
 
-import org.testng.annotations.Test;
 import jdk.jshell.VarSnippet;
 
 import static jdk.jshell.Snippet.Status.VALID;
 import static jdk.jshell.Snippet.SubKind.*;
+import org.junit.jupiter.api.Test;
 
 public class ExecutionControlTestBase extends KullaTesting {
 

--- a/test/langtools/jdk/jshell/ExpectedDiagnostic.java
+++ b/test/langtools/jdk/jshell/ExpectedDiagnostic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 import javax.tools.Diagnostic;
 
 import jdk.jshell.Diag;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExpectedDiagnostic {
 
@@ -79,16 +79,16 @@ public class ExpectedDiagnostic {
 
     public void assertDiagnostic(Diag diagnostic) {
         String code = diagnostic.getCode();
-        assertEquals(code, this.code, "Expected error: " + this.code + ", got: " + code);
-        assertEquals(diagnostic.isError(), kind == Diagnostic.Kind.ERROR);
+        assertEquals(this.code, code, "Expected error: " + this.code + ", got: " + code);
+        assertEquals(kind == Diagnostic.Kind.ERROR, diagnostic.isError());
         if (startPosition != -1) {
-            assertEquals(diagnostic.getStartPosition(), startPosition, "Start position");
+            assertEquals(startPosition, diagnostic.getStartPosition(), "Start position");
         }
         if (endPosition != -1) {
-            assertEquals(diagnostic.getEndPosition(), endPosition, "End position");
+            assertEquals(endPosition, diagnostic.getEndPosition(), "End position");
         }
         if (position != -1) {
-            assertEquals(diagnostic.getPosition(), position, "Position");
+            assertEquals(position, diagnostic.getPosition(), "Position");
         }
     }
 }

--- a/test/langtools/jdk/jshell/ExternalEditorTest.java
+++ b/test/langtools/jdk/jshell/ExternalEditorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @bug 8143955 8080843 8163816 8143006 8169828 8171130 8162989 8210808
  * @modules jdk.jshell/jdk.internal.jshell.tool
  * @build ReplToolTesting CustomEditor EditorTestBase
- * @run testng ExternalEditorTest
+ * @run junit ExternalEditorTest
  * @key intermittent
  */
 
@@ -47,15 +47,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
-
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ExternalEditorTest extends EditorTestBase {
 
     private static Path executionScript;
@@ -133,21 +135,19 @@ public class ExternalEditorTest extends EditorTestBase {
 
     @Test
     public void testStatementSemicolonAddition() {
-        testEditor(
-                a -> assertCommand(a, "if (true) {}", ""),
+        testEditor(a -> assertCommand(a, "if (true) {}", ""),
                 a -> assertCommand(a, "if (true) {} else {}", ""),
                 a -> assertCommand(a, "Object o", "o ==> null"),
                 a -> assertCommand(a, "if (true) o = new Object() { int x; }", ""),
                 a -> assertCommand(a, "if (true) o = new Object() { int y; }", ""),
                 a -> assertCommand(a, "System.err.flush()", ""), // test still ; for expression statement
                 a -> assertEditOutput(a, "/ed", "", () -> {
-                    assertEquals(getSource(),
-                            "if (true) {}\n" +
+                    assertEquals(                            "if (true) {}\n" +
                             "if (true) {} else {}\n" +
                             "Object o;\n" +
                             "if (true) o = new Object() { int x; };\n" +
                             "if (true) o = new Object() { int y; };\n" +
-                            "System.err.flush();\n");
+                            "System.err.flush();\n", getSource());
                     exit();
                 })
         );
@@ -173,7 +173,7 @@ public class ExternalEditorTest extends EditorTestBase {
         return System.getProperty("os.name").startsWith("Windows");
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpExternalEditorTest() throws IOException {
         listener = new ServerSocket(0);
         listener.setSoTimeout(30000);
@@ -250,7 +250,8 @@ public class ExternalEditorTest extends EditorTestBase {
         );
     }
 
-    @Test(enabled = false) // TODO 8159229
+    @Test // TODO 8159229
+    @Disabled
     public void testRemoveTempFile() {
         test(new String[]{"--no-startup"},
                 a -> assertCommandCheckOutput(a, "/set editor " + executionScript,
@@ -264,7 +265,7 @@ public class ExternalEditorTest extends EditorTestBase {
         );
     }
 
-    @AfterClass
+    @AfterAll
     public static void shutdown() throws IOException {
         executorShutdown();
         if (listener != null) {

--- a/test/langtools/jdk/jshell/FailOverDirectExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/FailOverDirectExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  * @library /tools/lib
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build KullaTesting ExecutionControlTestBase Compiler
- * @run testng FailOverDirectExecutionControlTest
+ * @run junit FailOverDirectExecutionControlTest
  * @key intermittent
  */
 
@@ -48,16 +48,15 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
 import jdk.jshell.execution.FailOverExecutionControlProvider;
 import jdk.jshell.spi.ExecutionControlProvider;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase {
 
     ClassLoader ccl;
@@ -93,7 +92,7 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
 
     }
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         logger = Logger.getLogger("jdk.jshell.execution");
@@ -134,7 +133,7 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
         setUp(builder -> builder.executionEngine(provider, pm));
     }
 
-    @AfterMethod
+    @AfterEach
     @Override
     public void tearDown() {
         super.tearDown();
@@ -144,11 +143,12 @@ public class FailOverDirectExecutionControlTest extends ExecutionControlTestBase
     }
 
     @Override
+    @Test
     public void variables() {
         super.variables();
-        assertEquals(logged.get(Level.FINEST).size(), 1);
-        assertEquals(logged.get(Level.FINE).size(), 2);
-        assertEquals(logged.get(Level.WARNING).size(), 2);
+        assertEquals(1, logged.get(Level.FINEST).size());
+        assertEquals(2, logged.get(Level.FINE).size());
+        assertEquals(2, logged.get(Level.WARNING).size());
         assertNull(logged.get(Level.SEVERE));
         String log = logged.get(Level.WARNING).get(0);
         assertTrue(log.contains("Failure failover -- 0 = alwaysFailing"), log);

--- a/test/langtools/jdk/jshell/FailOverExecutionControlDyingLaunchTest.java
+++ b/test/langtools/jdk/jshell/FailOverExecutionControlDyingLaunchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,17 +28,15 @@
  * @modules jdk.jshell/jdk.jshell.execution
  *          jdk.jshell/jdk.jshell.spi
  * @build KullaTesting ExecutionControlTestBase DyingRemoteAgent
- * @run testng FailOverExecutionControlDyingLaunchTest
+ * @run junit FailOverExecutionControlDyingLaunchTest
  * @key intermittent
  */
 
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.BeforeEach;
 
-@Test
 public class FailOverExecutionControlDyingLaunchTest extends ExecutionControlTestBase {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine(

--- a/test/langtools/jdk/jshell/FailOverExecutionControlHangingLaunchTest.java
+++ b/test/langtools/jdk/jshell/FailOverExecutionControlHangingLaunchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,16 +28,14 @@
  * @modules jdk.jshell/jdk.jshell.execution
  *          jdk.jshell/jdk.jshell.spi
  * @build KullaTesting ExecutionControlTestBase
- * @run testng FailOverExecutionControlHangingLaunchTest
+ * @run junit FailOverExecutionControlHangingLaunchTest
  */
 
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.BeforeEach;
 
-@Test
 public class FailOverExecutionControlHangingLaunchTest extends ExecutionControlTestBase {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine(

--- a/test/langtools/jdk/jshell/FailOverExecutionControlHangingListenTest.java
+++ b/test/langtools/jdk/jshell/FailOverExecutionControlHangingListenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,18 +28,16 @@
  * @modules jdk.jshell/jdk.jshell.execution
  *          jdk.jshell/jdk.jshell.spi
  * @build KullaTesting ExecutionControlTestBase
- * @run testng FailOverExecutionControlHangingListenTest
+ * @run junit FailOverExecutionControlHangingListenTest
  * @key intermittent
  */
 
 import java.net.InetAddress;
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.BeforeEach;
 
-@Test
 public class FailOverExecutionControlHangingListenTest extends ExecutionControlTestBase {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         String loopback = InetAddress.getLoopbackAddress().getHostAddress();

--- a/test/langtools/jdk/jshell/FailOverExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/FailOverExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,16 +28,14 @@
  * @modules jdk.jshell/jdk.jshell.execution
  *          jdk.jshell/jdk.jshell.spi
  * @build KullaTesting ExecutionControlTestBase
- * @run testng FailOverExecutionControlTest
+ * @run junit FailOverExecutionControlTest
  */
 
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.BeforeEach;
 
-@Test
 public class FailOverExecutionControlTest extends ExecutionControlTestBase {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine("failover:0(expectedFailureNonExistent1), 1(expectedFailureNonExistent2), "

--- a/test/langtools/jdk/jshell/FileManagerTest.java
+++ b/test/langtools/jdk/jshell/FileManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test 8173845
  * @summary test custom file managers
  * @build KullaTesting TestingInputStream
- * @run testng FileManagerTest
+ * @run junit FileManagerTest
  */
 
 
@@ -37,12 +37,10 @@ import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.StandardJavaFileManager;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertTrue;
-
-@Test
 public class FileManagerTest extends KullaTesting {
 
     boolean encountered;
@@ -100,12 +98,13 @@ public class FileManagerTest extends KullaTesting {
 
     }
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(b -> b.fileManager(fm -> new MyFileManager(fm)));
     }
 
+    @Test
     public void testSnippetMemberAssignment() {
         assertEval("java.lang.reflect.Array.get(new String[1], 0) == null");
         assertTrue(encountered, "java.lang.reflect not encountered");

--- a/test/langtools/jdk/jshell/ForwardReferenceImportTest.java
+++ b/test/langtools/jdk/jshell/ForwardReferenceImportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,18 @@
  * @test 8173232
  * @summary Test of forward referencing of snippets (related to import).
  * @build KullaTesting TestingInputStream
- * @run testng ForwardReferenceImportTest
+ * @run junit ForwardReferenceImportTest
  */
 
 import jdk.jshell.Snippet;
 import jdk.jshell.DeclarationSnippet;
-import org.testng.annotations.Test;
 
 import static jdk.jshell.Snippet.Status.*;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ForwardReferenceImportTest extends KullaTesting {
 
+    @Test
     public void testImportDeclare() {
         Snippet singleImport = importKey(assertEval("import java.util.List;", added(VALID)));
         Snippet importOnDemand = importKey(assertEval("import java.util.*;", added(VALID)));
@@ -57,6 +57,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardSingleImportMethodToMethod() {
         DeclarationSnippet string = methodKey(assertEval("String string() { return format(\"string\"); }",
                 added(RECOVERABLE_DEFINED)));
@@ -76,6 +77,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardImportMethodOnDemandToMethod() {
         DeclarationSnippet string = methodKey(assertEval("String string() { return format(\"string\"); }",
                 added(RECOVERABLE_DEFINED)));
@@ -95,6 +97,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardSingleImportFieldToMethod() {
         DeclarationSnippet pi = methodKey(assertEval("double pi() { return PI; }",
                 added(RECOVERABLE_DEFINED)));
@@ -114,6 +117,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardImportFieldOnDemandToMethod() {
         DeclarationSnippet pi = methodKey(assertEval("double pi() { return PI; }",
                 added(RECOVERABLE_DEFINED)));
@@ -133,6 +137,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardSingleImportMethodToClass1() {
         Snippet a = classKey(assertEval("class A { String s = format(\"%d\", 10); }",
                 added(RECOVERABLE_DEFINED)));
@@ -153,6 +158,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(a, RECOVERABLE_DEFINED, VALID, false, format));
     }
 
+    @Test
     public void testForwardSingleImportMethodToClass2() {
         Snippet a = classKey(assertEval("class A { String s() { return format(\"%d\", 10); } }",
                 added(RECOVERABLE_DEFINED)));
@@ -173,6 +179,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(a, RECOVERABLE_DEFINED, VALID, false, format));
     }
 
+    @Test
     public void testForwardSingleImportClassToClass1() {
         Snippet a = classKey(assertEval("class A { static List<Integer> list; }",
                 added(RECOVERABLE_NOT_DEFINED)));
@@ -195,6 +202,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(a, RECOVERABLE_NOT_DEFINED, VALID, true, list));
     }
 
+    @Test
     public void testForwardSingleImportClassToClass2() {
         Snippet clsA = classKey(assertEval("class A extends ArrayList<Integer> { }",
                 added(RECOVERABLE_NOT_DEFINED)));
@@ -219,6 +227,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(clsA, RECOVERABLE_NOT_DEFINED, VALID, true, arraylist));
     }
 
+    @Test
     public void testForwardImportOnDemandMethodToClass1() {
         Snippet a = classKey(assertEval("class A { String s = format(\"%d\", 10); }",
                 added(RECOVERABLE_DEFINED)));
@@ -241,6 +250,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
         assertEval("x.s;", "\"10\"");
     }
 
+    @Test
     public void testForwardImportOnDemandMethodToClass2() {
         Snippet a = classKey(assertEval("class A { String s() { return format(\"%d\", 10); } }",
                 added(RECOVERABLE_DEFINED)));
@@ -261,6 +271,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(a, RECOVERABLE_DEFINED, VALID, false, format));
     }
 
+    @Test
     public void testForwardImportOnDemandClassToClass1() {
         Snippet a = classKey(assertEval("class A { static List<Integer> list; }",
                 added(RECOVERABLE_NOT_DEFINED)));
@@ -282,6 +293,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(a, RECOVERABLE_NOT_DEFINED, VALID, true, list));
     }
 
+    @Test
     public void testForwardImportOnDemandClassToClass2() {
         Snippet clsA = classKey(assertEval("class A extends ArrayList<Integer> { }",
                 added(RECOVERABLE_NOT_DEFINED)));
@@ -305,6 +317,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(vara, RECOVERABLE_NOT_DEFINED, VALID, true, clsA));
     }
 
+    @Test
     public void testForwardSingleImportFieldToClass1() {
         Snippet a = classKey(assertEval("class A { static double pi() { return PI; } }",
                 added(RECOVERABLE_DEFINED)));
@@ -326,6 +339,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(a, RECOVERABLE_DEFINED, VALID, false, list));
     }
 
+    @Test
     public void testForwardSingleImportFieldToClass2() {
         Snippet a = classKey(assertEval("class A { static double pi = PI; }",
                 added(RECOVERABLE_DEFINED)));
@@ -347,6 +361,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(a, RECOVERABLE_DEFINED, VALID, true, list));
     }
 
+    @Test
     public void testForwardImportOnDemandFieldToClass1() {
         Snippet a = classKey(assertEval("class A { static double pi() { return PI; } }",
                 added(RECOVERABLE_DEFINED)));
@@ -368,6 +383,7 @@ public class ForwardReferenceImportTest extends KullaTesting {
                 ste(a, RECOVERABLE_DEFINED, VALID, false, list));
     }
 
+    @Test
     public void testForwardImportOnDemandFieldToClass2() {
         Snippet a = classKey(assertEval("class A { static double pi = PI; }",
                 added(RECOVERABLE_DEFINED)));

--- a/test/langtools/jdk/jshell/ForwardReferenceTest.java
+++ b/test/langtools/jdk/jshell/ForwardReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test 8173232 8010319
  * @summary Test of forward referencing of snippets.
  * @build KullaTesting TestingInputStream
- * @run testng ForwardReferenceTest
+ * @run junit ForwardReferenceTest
  */
 
 import java.util.List;
@@ -33,17 +33,17 @@ import jdk.jshell.Snippet;
 import jdk.jshell.MethodSnippet;
 import jdk.jshell.VarSnippet;
 import jdk.jshell.DeclarationSnippet;
-import org.testng.annotations.Test;
 
 import jdk.jshell.SnippetEvent;
 import jdk.jshell.UnresolvedReferenceException;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static jdk.jshell.Snippet.Status.*;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ForwardReferenceTest extends KullaTesting {
 
+    @Test
     public void testOverwriteMethodForwardReferenceClass() {
         Snippet k1 = methodKey(assertEval("int q(Boo b) { return b.x; }",
                 added(RECOVERABLE_NOT_DEFINED)));
@@ -56,6 +56,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testOverwriteMethodForwardReferenceClassImport() {
         MethodSnippet k1 = methodKey(assertEval("int ff(List lis) { return lis.size(); }",
                 added(RECOVERABLE_NOT_DEFINED)));
@@ -68,6 +69,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardVarToMethod() {
         DeclarationSnippet t = methodKey(assertEval("int t() { return x; }", added(RECOVERABLE_DEFINED)));
         assertUnresolvedDependencies1(t, RECOVERABLE_DEFINED, "variable x");
@@ -87,6 +89,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardMethodToMethod() {
         Snippet t = methodKey(assertEval("int t() { return f(); }", added(RECOVERABLE_DEFINED)));
         Snippet f = methodKey(assertEval("int f() { return g(); }",
@@ -109,6 +112,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardClassToMethod() {
         DeclarationSnippet t = methodKey(assertEval("int t() { return new A().f(); }", added(RECOVERABLE_DEFINED)));
         assertUnresolvedDependencies1(t, RECOVERABLE_DEFINED, "class A");
@@ -133,6 +137,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardVarToClass() {
         DeclarationSnippet a = classKey(assertEval("class A { int f() { return g; } }", added(RECOVERABLE_DEFINED)));
         assertUnresolvedDependencies1(a, RECOVERABLE_DEFINED, "variable g");
@@ -150,6 +155,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardVarToClassGeneric() {
         DeclarationSnippet a = classKey(assertEval("class A<T> { final T x; A(T v) { this.x = v; } ; T get() { return x; } int core() { return g; } }", added(RECOVERABLE_DEFINED)));
         assertUnresolvedDependencies1(a, RECOVERABLE_DEFINED, "variable g");
@@ -159,9 +165,9 @@ public class ForwardReferenceTest extends KullaTesting {
         SnippetEvent ste = events.get(0);
         Snippet assn = ste.snippet();
         DeclarationSnippet unsn = ((UnresolvedReferenceException) ste.exception()).getSnippet();
-        assertEquals(unsn.name(), "A", "Wrong with unresolved");
-        assertEquals(getState().unresolvedDependencies(unsn).count(), 1, "Wrong size unresolved");
-        assertEquals(getState().diagnostics(unsn).count(), 0L, "Expected no diagnostics");
+        assertEquals("A", unsn.name(), "Wrong with unresolved");
+        assertEquals(1, getState().unresolvedDependencies(unsn).count(), "Wrong size unresolved");
+        assertEquals(0L, getState().diagnostics(unsn).count(), "Expected no diagnostics");
 
         Snippet g = varKey(assertEval("int g = 10;", "10",
                 added(VALID),
@@ -174,6 +180,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
    public void testForwardVarToClassExtendsImplements() {
         DeclarationSnippet ik = classKey(assertEval("interface I { default int ii() { return 1; } }", added(VALID)));
         DeclarationSnippet jk = classKey(assertEval("interface J { default int jj() { return 2; } }", added(VALID)));
@@ -200,6 +207,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardVarToInterface() {
         DeclarationSnippet i = classKey(assertEval("interface I { default int f() { return x; } }", added(RECOVERABLE_DEFINED)));
         assertUnresolvedDependencies1(i, RECOVERABLE_DEFINED, "variable x");
@@ -215,6 +223,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardVarToEnum() {
         DeclarationSnippet a = classKey(assertEval("enum E { Q, W, E; float ff() { return fff; } }", added(RECOVERABLE_DEFINED)));
         assertUnresolvedDependencies1(a, RECOVERABLE_DEFINED, "variable fff");
@@ -232,6 +241,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardMethodToClass() {
         DeclarationSnippet a = classKey(assertEval("class A { int f() { return g(); } }", added(RECOVERABLE_DEFINED)));
         assertUnresolvedDependencies1(a, RECOVERABLE_DEFINED, "method g()");
@@ -251,6 +261,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardClassToClass1() {
         Snippet a = classKey(assertEval("class A { B b = new B(); }", added(RECOVERABLE_NOT_DEFINED)));
         assertDeclareFail("new A().b;", "compiler.err.cant.resolve.location");
@@ -269,6 +280,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardClassToClass2() {
         Snippet a = classKey(assertEval("class A extends B { }", added(RECOVERABLE_NOT_DEFINED)));
         assertDeclareFail("new A();", "compiler.err.cant.resolve.location");
@@ -287,6 +299,7 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardClassToClass3() {
         Snippet a = classKey(assertEval("interface A extends B { static int f() { return 10; } }", added(RECOVERABLE_NOT_DEFINED)));
         assertDeclareFail("A.f();", "compiler.err.cant.resolve.location");
@@ -305,12 +318,14 @@ public class ForwardReferenceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testForwardVariable() {
         assertEval("int f() { return x; }", added(RECOVERABLE_DEFINED));
         assertEvalUnresolvedException("f();", "f", 1, 0);
         assertActiveKeys();
     }
 
+    @Test
     public void testLocalClassInUnresolved() {
         Snippet f = methodKey(assertEval("void f() { class A {} g(); }", added(RECOVERABLE_DEFINED)));
         assertEval("void g() {}",

--- a/test/langtools/jdk/jshell/GetResourceTest.java
+++ b/test/langtools/jdk/jshell/GetResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,18 +27,18 @@
  * @summary Check that ClassLoader.getResource works as expected in the JShell agent.
  * @modules jdk.jshell
  * @build KullaTesting TestingInputStream
- * @run testng GetResourceTest
+ * @run junit GetResourceTest
  */
 
 import jdk.jshell.Snippet;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
 import static jdk.jshell.Snippet.Status.VALID;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 
-@Test
 public class GetResourceTest extends KullaTesting {
 
+    @Test
     public void checkGetResource() {
         assertEval("import java.util.Arrays;");
         assertEval("boolean match(byte[] data, byte[] snippet) {\n" +
@@ -57,6 +57,7 @@ public class GetResourceTest extends KullaTesting {
         assertEval("test()", "true");
     }
 
+    @Test
     public void checkRedefine() {
         assertEval("import java.util.Arrays;");
         assertEval("boolean match(byte[] data, byte[] snippet) {\n" +
@@ -85,6 +86,7 @@ public class GetResourceTest extends KullaTesting {
         assertEval("test()", "true");
     }
 
+    @Test
     public void checkResourceSize() {
         assertEval("import java.net.*;");
         assertEval("boolean test() throws Exception {\n" +
@@ -97,6 +99,7 @@ public class GetResourceTest extends KullaTesting {
         assertEval("test()", "true");
     }
 
+    @Test
     public void checkTimestampCheck() {
         assertEval("import java.net.*;");
         assertEval("import java.time.*;");
@@ -138,6 +141,7 @@ public class GetResourceTest extends KullaTesting {
         assertEval("nue[0] == nue[2]", "true");
     }
 
+    @Test
     public void checkFieldAccess() {
         assertEval("import java.net.*;");
         assertEval("Class c = new Object() {}.getClass().getEnclosingClass();");
@@ -154,6 +158,7 @@ public class GetResourceTest extends KullaTesting {
         assertEval("connection.getHeaderField(3) == null", "true");
     }
 
+    @Test
     public void checkGetResources() {
         assertEval("import java.net.*;");
         assertEval("Class c = new Object() {}.getClass().getEnclosingClass();");

--- a/test/langtools/jdk/jshell/HistoryTest.java
+++ b/test/langtools/jdk/jshell/HistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @modules jdk.internal.le/jdk.internal.org.jline.reader
  *          jdk.jshell/jdk.internal.jshell.tool:+open
  * @build HistoryTest
- * @run testng HistoryTest
+ * @run junit HistoryTest
  */
 
 import java.lang.reflect.Field;
@@ -37,12 +37,12 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.testng.annotations.Test;
 import jdk.internal.jshell.tool.JShellTool;
 import jdk.internal.jshell.tool.JShellToolBuilder;
 import jdk.internal.org.jline.reader.History;
-import static org.testng.Assert.*;
-import org.testng.annotations.BeforeMethod;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class HistoryTest extends ReplToolTesting {
 
@@ -180,16 +180,16 @@ public class HistoryTest extends ReplToolTesting {
                  }
                   assertCommand(a, "/exit", "");
              });
-        assertEquals(prefsMap.get("HISTORY_LINE_00"), "/debug 0");
-        assertEquals(prefsMap.get("HISTORY_LINE_01"), "void test() {\\");
-        assertEquals(prefsMap.get("HISTORY_LINE_02"), "    System.err.println(1);\\");
-        assertEquals(prefsMap.get("HISTORY_LINE_03"), "    System.err.println(`\\\\\\\\\\");
-        assertEquals(prefsMap.get("HISTORY_LINE_04"), "    \\\\\\");
-        assertEquals(prefsMap.get("HISTORY_LINE_05"), "`);\\");
-        assertEquals(prefsMap.get("HISTORY_LINE_06"), "} //test");
-        assertEquals(prefsMap.get("HISTORY_LINE_07"), "/debug 0");
-        assertEquals(prefsMap.get("HISTORY_LINE_08"), "int i");
-        assertEquals(prefsMap.get("HISTORY_LINE_09"), "/exit");
+        assertEquals("/debug 0", prefsMap.get("HISTORY_LINE_00"));
+        assertEquals("void test() {\\", prefsMap.get("HISTORY_LINE_01"));
+        assertEquals("    System.err.println(1);\\", prefsMap.get("HISTORY_LINE_02"));
+        assertEquals("    System.err.println(`\\\\\\\\\\", prefsMap.get("HISTORY_LINE_03"));
+        assertEquals("    \\\\\\", prefsMap.get("HISTORY_LINE_04"));
+        assertEquals("`);\\", prefsMap.get("HISTORY_LINE_05"));
+        assertEquals("} //test", prefsMap.get("HISTORY_LINE_06"));
+        assertEquals("/debug 0", prefsMap.get("HISTORY_LINE_07"));
+        assertEquals("int i", prefsMap.get("HISTORY_LINE_08"));
+        assertEquals("/exit", prefsMap.get("HISTORY_LINE_09"));
         System.err.println("prefsMap: " + prefsMap);
     }
 
@@ -204,10 +204,10 @@ public class HistoryTest extends ReplToolTesting {
 
     private void previousAndAssert(History history, String expected) {
         assertTrue(history.previous());
-        assertEquals(history.current().toString(), expected);
+        assertEquals(expected, history.current().toString());
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         super.setUp();
         System.setProperty("jshell.test.allow.incomplete.inputs", "false");

--- a/test/langtools/jdk/jshell/HistoryUITest.java
+++ b/test/langtools/jdk/jshell/HistoryUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,18 +35,18 @@
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build Compiler UITesting
  * @compile HistoryUITest.java
- * @run testng HistoryUITest
+ * @run junit HistoryUITest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class HistoryUITest extends UITesting {
 
     public HistoryUITest() {
         super(true);
     }
 
+    @Test
     public void testPrevNextSnippet() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("void test1() {\nSystem.err.println(1);\n}\n");
@@ -78,6 +78,7 @@ public class HistoryUITest extends UITesting {
         });
     }
 
+    @Test
     public void testReRun() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("System.err.println(\"RAN\");\n");

--- a/test/langtools/jdk/jshell/IOTest.java
+++ b/test/langtools/jdk/jshell/IOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,28 +25,29 @@
  * @test
  * @summary Test input/output
  * @build KullaTesting TestingInputStream
- * @run testng IOTest
+ * @run junit IOTest
  */
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertEquals;
-
-@Test
 public class IOTest extends KullaTesting {
 
     String LINE_SEPARATOR = System.getProperty("line.separator");
 
+    @Test
     public void testOutput() {
         assertEval("System.out.println(\"Test\");");
-        assertEquals(getOutput(), "Test" + LINE_SEPARATOR);
+        assertEquals("Test" + LINE_SEPARATOR, getOutput());
     }
 
+    @Test
     public void testErrorOutput() {
         assertEval("System.err.println(\"Oops\");");
-        assertEquals(getErrorOutput(), "Oops" + LINE_SEPARATOR);
+        assertEquals("Oops" + LINE_SEPARATOR, getErrorOutput());
     }
 
+    @Test
     public void testInput() {
         setInput("x");
         assertEval("(char)System.in.read();", "'x'");

--- a/test/langtools/jdk/jshell/IdGeneratorTest.java
+++ b/test/langtools/jdk/jshell/IdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @summary Test custom id generators
  * @build KullaTesting TestingInputStream
- * @run testng IdGeneratorTest
+ * @run junit IdGeneratorTest
  */
 
 import java.io.ByteArrayOutputStream;
@@ -38,14 +38,13 @@ import jdk.jshell.JShell;
 import jdk.jshell.SnippetEvent;
 import jdk.jshell.UnresolvedReferenceException;
 import jdk.jshell.VarSnippet;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-@Test
 public class IdGeneratorTest {
 
+    @Test
     public JShell.Builder getBuilder() {
         TestingInputStream inStream = new TestingInputStream();
         ByteArrayOutputStream outStream = new ByteArrayOutputStream();
@@ -57,6 +56,7 @@ public class IdGeneratorTest {
                 .executionEngine(Presets.TEST_DEFAULT_EXECUTION);
     }
 
+    @Test
     public void testTempNameGenerator() {
         JShell.Builder builder = getBuilder().tempVariableNameGenerator(new Supplier<String>() {
             int count = 0;
@@ -69,11 +69,12 @@ public class IdGeneratorTest {
         try (JShell jShell = builder.build()) {
             for (int i = 0; i < 3; ++i) {
                 VarSnippet v = (VarSnippet) jShell.eval("2 + " + (i + 1)).get(0).snippet();
-                assertEquals("temp" + (i + 1), v.name(), "Custom id: ");
+                assertEquals(v.name(), "temp" + (i + 1), "Custom id: ");
             }
         }
     }
 
+    @Test
     public void testResetTempNameGenerator() {
         JShell.Builder builder = getBuilder().tempVariableNameGenerator(() -> {
             throw new AssertionError("Should not be called");
@@ -83,6 +84,7 @@ public class IdGeneratorTest {
         }
     }
 
+    @Test
     public void testIdGenerator() {
         JShell.Builder builder = getBuilder().idGenerator(((snippet, id) -> "custom" + id));
         try (JShell jShell = builder.build()) {
@@ -99,6 +101,7 @@ public class IdGeneratorTest {
         }
     }
 
+    @Test
     public void testIdInException() {
         JShell.Builder builder = getBuilder().idGenerator(((snippet, id) -> "custom" + id));
         try (JShell jShell = builder.build()) {
@@ -116,6 +119,7 @@ public class IdGeneratorTest {
         }
     }
 
+    @Test
     public void testResetIdGenerator() {
         JShell.Builder builder = getBuilder().idGenerator((sn, id) -> {
             throw new AssertionError("Should not be called");

--- a/test/langtools/jdk/jshell/IgnoreTest.java
+++ b/test/langtools/jdk/jshell/IgnoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,20 +26,20 @@
  * @bug 8129559 8246353 8247456
  * @summary Test the ignoring of comments and certain modifiers
  * @build KullaTesting TestingInputStream
- * @run testng IgnoreTest
+ * @run junit IgnoreTest
  */
 
-import org.testng.annotations.Test;
 
 import jdk.jshell.MethodSnippet;
 import jdk.jshell.TypeDeclSnippet;
 import jdk.jshell.VarSnippet;
 import static jdk.jshell.Snippet.Status.VALID;
 import static jdk.jshell.Snippet.SubKind.*;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class IgnoreTest extends KullaTesting {
 
+    @Test
     public void testComment() {
         assertVarKeyMatch("//t1\n int//t2\n x//t3\n =//t4\n 12//t5\n ;//t6\n",
                 true, "x", VAR_DECLARATION_WITH_INITIALIZER_SUBKIND, "int", added(VALID));
@@ -58,6 +58,7 @@ public class IgnoreTest extends KullaTesting {
                 false, "f", METHOD_SUBKIND, added(VALID));
     }
 
+    @Test
     public void testVarModifier() {
         VarSnippet x1 = varKey(assertEval("public int x1;"));
         assertVariableDeclSnippet(x1, "x1", "int", VALID, VAR_DECLARATION_SUBKIND, 0, 0);
@@ -71,6 +72,7 @@ public class IgnoreTest extends KullaTesting {
         assertVariableDeclSnippet(x5, "x5", "int", VALID, VAR_DECLARATION_SUBKIND, 0, 0);
     }
 
+    @Test
     public void testVarModifierAnnotation() {
         assertEval("@interface A { int value() default 0; }");
         VarSnippet x1 = varKey(assertEval("@A public int x1;"));
@@ -85,6 +87,7 @@ public class IgnoreTest extends KullaTesting {
         assertVariableDeclSnippet(x5, "x5", "int", VALID, VAR_DECLARATION_SUBKIND, 0, 0);
     }
 
+    @Test
     public void testVarModifierOtherModifier() {
         VarSnippet x1 = varKey(assertEval("volatile public int x1;"));
         assertVariableDeclSnippet(x1, "x1", "int", VALID, VAR_DECLARATION_SUBKIND, 0, 0);
@@ -98,12 +101,14 @@ public class IgnoreTest extends KullaTesting {
         assertVariableDeclSnippet(x5, "x5", "int", VALID, VAR_DECLARATION_SUBKIND, 0, 0);
     }
 
+    @Test
     public void testMisplacedIgnoredModifier() {
         assertEvalFail("int public y;");
         assertEvalFail("String private x;");
         assertEvalFail("(protected 34);");
     }
 
+    @Test
     public void testMethodModifier() {
         MethodSnippet m4 = methodKey(assertEval("static void m4() {}"));
         assertMethodDeclSnippet(m4, "m4", "()void", VALID, 0, 0);
@@ -111,6 +116,7 @@ public class IgnoreTest extends KullaTesting {
         assertMethodDeclSnippet(m5, "m5", "()void", VALID, 0, 0);
     }
 
+    @Test
     public void testMethodModifierAnnotation() {
         assertEval("@interface A { int value() default 0; }");
         MethodSnippet m4 = methodKey(assertEval("@A static void m4() {}"));
@@ -119,6 +125,7 @@ public class IgnoreTest extends KullaTesting {
         assertMethodDeclSnippet(m5, "m5", "()void", VALID, 0, 0);
     }
 
+    @Test
     public void testClassModifier() {
         TypeDeclSnippet c4 = classKey(assertEval("static class C4 {}"));
         assertTypeDeclSnippet(c4, "C4", VALID, CLASS_SUBKIND, 0, 0);
@@ -126,6 +133,7 @@ public class IgnoreTest extends KullaTesting {
         assertTypeDeclSnippet(c5, "C5", VALID, CLASS_SUBKIND, 0, 0);
     }
 
+    @Test
     public void testInsideModifier() {
         assertEval("import static java.lang.reflect.Modifier.*;");
         assertEval("class C {"

--- a/test/langtools/jdk/jshell/IllegalArgumentExceptionTest.java
+++ b/test/langtools/jdk/jshell/IllegalArgumentExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @summary Testing IllegalArgumentException.
  * @build KullaTesting TestingInputStream IllegalArgumentExceptionTest
- * @run testng IllegalArgumentExceptionTest
+ * @run junit IllegalArgumentExceptionTest
  */
 
 import java.util.function.Consumer;
@@ -33,12 +33,10 @@ import java.util.function.Consumer;
 import jdk.jshell.DeclarationSnippet;
 import jdk.jshell.Snippet;
 import jdk.jshell.VarSnippet;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static jdk.jshell.Snippet.Status.VALID;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class IllegalArgumentExceptionTest extends KullaTesting {
 
     private void testIllegalArgumentException(Consumer<Snippet> action) {
@@ -54,22 +52,27 @@ public class IllegalArgumentExceptionTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testVarValue() {
         testIllegalArgumentException((key) -> getState().varValue((VarSnippet) key));
     }
 
+    @Test
     public void testStatus() {
         testIllegalArgumentException((key) -> getState().status(key));
     }
 
+    @Test
     public void testDrop() {
         testIllegalArgumentException((key) -> getState().drop(key));
     }
 
+    @Test
     public void testUnresolved() {
         testIllegalArgumentException((key) -> getState().unresolvedDependencies((DeclarationSnippet) key));
     }
 
+    @Test
     public void testDiagnostics() {
         testIllegalArgumentException((key) -> getState().diagnostics(key));
     }

--- a/test/langtools/jdk/jshell/ImportTest.java
+++ b/test/langtools/jdk/jshell/ImportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  *          jdk.jdeps/com.sun.tools.javap
  * @library /tools/lib
  * @build KullaTesting TestingInputStream toolbox.Task.ExpectedDiagnostic
- * @run testng ImportTest
+ * @run junit ImportTest
  */
 
 import java.nio.file.Path;
@@ -39,7 +39,6 @@ import java.nio.file.Paths;
 import javax.tools.Diagnostic;
 
 import jdk.jshell.Snippet;
-import org.testng.annotations.Test;
 
 import static jdk.jshell.Snippet.Status.VALID;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
@@ -47,10 +46,14 @@ import static jdk.jshell.Snippet.SubKind.SINGLE_TYPE_IMPORT_SUBKIND;
 import static jdk.jshell.Snippet.SubKind.SINGLE_STATIC_IMPORT_SUBKIND;
 import static jdk.jshell.Snippet.SubKind.TYPE_IMPORT_ON_DEMAND_SUBKIND;
 import static jdk.jshell.Snippet.SubKind.STATIC_IMPORT_ON_DEMAND_SUBKIND;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
-@Test
 public class ImportTest extends KullaTesting {
 
+    @Test
     public void testImport() {
         assertImportKeyMatch("import java.util.List;", "List", SINGLE_TYPE_IMPORT_SUBKIND, added(VALID));
         assertImportKeyMatch("import java.util.ArrayList;", "ArrayList", SINGLE_TYPE_IMPORT_SUBKIND, added(VALID));
@@ -59,6 +62,7 @@ public class ImportTest extends KullaTesting {
         assertEval("list.size();", "1");
     }
 
+    @Test
     public void testImportOnDemand() {
         assertImportKeyMatch("import java.util.*;", "java.util.*", TYPE_IMPORT_ON_DEMAND_SUBKIND, added(VALID));
         assertEval("List<Integer> list = new ArrayList<>();");
@@ -66,17 +70,20 @@ public class ImportTest extends KullaTesting {
         assertEval("list.size();", "1");
     }
 
+    @Test
     public void testImportStatic() {
         assertImportKeyMatch("import static java.lang.Math.PI;", "PI", SINGLE_STATIC_IMPORT_SUBKIND, added(VALID));
         assertEval("Double.valueOf(PI).toString().substring(0, 16).equals(\"3.14159265358979\");", "true");
     }
 
+    @Test
     public void testImportStaticOnDemand() {
         assertImportKeyMatch("import static java.lang.Math.*;", "java.lang.Math.*", STATIC_IMPORT_ON_DEMAND_SUBKIND, added(VALID));
         assertEval("abs(cos(PI / 2)) < 0.00001;", "true");
     }
 
-    @Test(enabled = false) // TODO 8129418
+    @Test
+    @Disabled("TODO 8129418")
     public void testUnknownPackage() {
         assertDeclareFail("import unknown.qqq;",
                 new ExpectedDiagnostic("compiler.err.doesnt.exist", 7, 18, 14, -1, -1, Diagnostic.Kind.ERROR));
@@ -84,22 +91,26 @@ public class ImportTest extends KullaTesting {
                 new ExpectedDiagnostic("compiler.err.doesnt.exist", 7, 15, 7, -1, -1, Diagnostic.Kind.ERROR));
     }
 
+    @Test
     public void testBogusImportIgnoredInFuture() {
         assertDeclareFail("import unknown.qqq;", "compiler.err.doesnt.exist");
         assertDeclareFail("import unknown.*;", "compiler.err.doesnt.exist");
         assertEval("2 + 2;");
     }
 
+    @Test
     public void testBadImport() {
         assertDeclareFail("import static java.lang.reflect.Modifier;",
                 new ExpectedDiagnostic("compiler.err.cant.resolve.location", 14, 31, 23, -1, -1, Diagnostic.Kind.ERROR));
     }
 
+    @Test
     public void testBadSyntaxImport() {
         assertDeclareFail("import not found.*;",
                 new ExpectedDiagnostic("compiler.err.expected", 10, 10, 10, -1, -1, Diagnostic.Kind.ERROR));
     }
 
+    @Test
     public void testImportRedefinition() {
         Compiler compiler = new Compiler();
         Path path = Paths.get("testImport");
@@ -140,6 +151,7 @@ public class ImportTest extends KullaTesting {
         assertEval("new ArrayList();", "MyInnerList");
     }
 
+    @Test
     public void testImportMemberRedefinition() {
         Compiler compiler = new Compiler();
         Path path = Paths.get("testImport");
@@ -164,6 +176,7 @@ public class ImportTest extends KullaTesting {
         assertEval("method();", "\"A\"");
     }
 
+    @Test
     public void testImportWithComment() {
         assertImportKeyMatch("import java.util.List;//comment", "List", SINGLE_TYPE_IMPORT_SUBKIND, added(VALID));
         assertEval("List l = null;");

--- a/test/langtools/jdk/jshell/InaccessibleExpressionTest.java
+++ b/test/langtools/jdk/jshell/InaccessibleExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,23 +29,21 @@
  *          jdk.jdeps/com.sun.tools.javap
  * @library /tools/lib
  * @build KullaTesting Compiler
- * @run testng InaccessibleExpressionTest
+ * @run junit InaccessibleExpressionTest
  */
 
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.testng.annotations.BeforeMethod;
 import jdk.jshell.VarSnippet;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertEquals;
-
-@Test
 public class InaccessibleExpressionTest extends KullaTesting {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         Path path = Paths.get("eit");
@@ -76,20 +74,22 @@ public class InaccessibleExpressionTest extends KullaTesting {
                 .compilerOptions("--class-path", tpath));
     }
 
+    @Test
     public void testExternal() {
         assertEval("import static priv.GetPriv.*;");
         VarSnippet down = varKey(assertEval("down()", "Packp"));
-        assertEquals(down.typeName(), "priv.Packp");
+        assertEquals("priv.Packp", down.typeName());
         assertEval(down.name() + ".get()", "5");
         VarSnippet list = varKey(assertEval("list()", "[]"));
-        assertEquals(list.typeName(), "priv.MyList");
+        assertEquals("priv.MyList", list.typeName());
         assertEval(list.name() + ".size()", "0");
         VarSnippet one = varKey(assertEval("priv()", "One"));
-        assertEquals(one.typeName(), "priv.GetPriv.Count");
+        assertEquals("priv.GetPriv.Count", one.typeName());
         assertEval("var v = down();", "Packp");
         assertDeclareFail("v.toString()", "compiler.err.not.def.access.class.intf.cant.access");
     }
 
+    @Test
     public void testInternal() {
         assertEval(
                 "class Top {" +
@@ -98,7 +98,7 @@ public class InaccessibleExpressionTest extends KullaTesting {
                 "    }" +
                 "    Inner n = new Inner(); }");
         VarSnippet n = varKey(assertEval("new Top().n", "Inner"));
-        assertEquals(n.typeName(), "Top.Inner");
+        assertEquals("Top.Inner", n.typeName());
     }
 
 }

--- a/test/langtools/jdk/jshell/IndentUITest.java
+++ b/test/langtools/jdk/jshell/IndentUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,18 +35,18 @@
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build Compiler UITesting
  * @compile IndentUITest.java
- * @run testng IndentUITest
+ * @run junit IndentUITest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class IndentUITest extends UITesting {
 
     public IndentUITest() {
         super(true);
     }
 
+    @Test
     public void testIdent() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("void test1() {\nSystem.err.println(1);\n}\n");

--- a/test/langtools/jdk/jshell/InferTypeTest.java
+++ b/test/langtools/jdk/jshell/InferTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,14 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.jdeps/com.sun.tools.javap
  * @build KullaTesting TestingInputStream toolbox.ToolBox Compiler
- * @run testng InferTypeTest
+ * @run junit InferTypeTest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class InferTypeTest extends KullaTesting {
 
+    @Test
     public void testTypeInference() {
         assertInferredType("1", "int");
         assertEval("import java.util.*;");

--- a/test/langtools/jdk/jshell/JShellQueryTest.java
+++ b/test/langtools/jdk/jshell/JShellQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,21 +26,21 @@
  * @bug 8143964
  * @summary test queries to the JShell that return Streams
  * @build KullaTesting
- * @run testng JShellQueryTest
+ * @run junit JShellQueryTest
  */
 import jdk.jshell.Snippet;
-import org.testng.annotations.Test;
 
 import jdk.jshell.ImportSnippet;
 import jdk.jshell.MethodSnippet;
 import jdk.jshell.TypeDeclSnippet;
 import jdk.jshell.VarSnippet;
 import static java.util.stream.Collectors.joining;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JShellQueryTest extends KullaTesting {
 
+    @Test
     public void testSnippets() {
         assertStreamMatch(getState().snippets());
         VarSnippet sx = varKey(assertEval("int x = 5;"));
@@ -54,6 +54,7 @@ public class JShellQueryTest extends KullaTesting {
         assertStreamMatch(getState().snippets(), sx, sfoo, smm, svv, sc, si, simp);
     }
 
+    @Test
     public void testVars() {
         assertStreamMatch(getState().variables());
         VarSnippet sx = varKey(assertEval("int x = 5;"));
@@ -67,6 +68,7 @@ public class JShellQueryTest extends KullaTesting {
         assertStreamMatch(getState().variables(), sx, sfoo);
     }
 
+    @Test
     public void testMethods() {
         assertStreamMatch(getState().methods());
         VarSnippet sx = varKey(assertEval("int x = 5;"));
@@ -79,6 +81,7 @@ public class JShellQueryTest extends KullaTesting {
         assertStreamMatch(getState().methods(), smm, svv);
     }
 
+    @Test
     public void testTypes() {
         assertStreamMatch(getState().types());
         VarSnippet sx = varKey(assertEval("int x = 5;"));
@@ -91,6 +94,7 @@ public class JShellQueryTest extends KullaTesting {
         assertStreamMatch(getState().types(), sc, si);
     }
 
+    @Test
     public void testImports() {
         assertStreamMatch(getState().imports());
         VarSnippet sx = varKey(assertEval("int x = 5;"));
@@ -103,6 +107,7 @@ public class JShellQueryTest extends KullaTesting {
         assertStreamMatch(getState().imports(), simp);
     }
 
+    @Test
     public void testDiagnostics() {
         Snippet sx = varKey(assertEval("int x = 5;"));
         assertStreamMatch(getState().diagnostics(sx));
@@ -110,9 +115,10 @@ public class JShellQueryTest extends KullaTesting {
         String res = getState().diagnostics(broken)
                 .map(d -> d.getCode())
                 .collect(joining("+"));
-        assertEquals(res, "compiler.err.cant.resolve.location.args+compiler.err.prob.found.req");
+        assertEquals("compiler.err.cant.resolve.location.args+compiler.err.prob.found.req", res);
     }
 
+    @Test
     public void testUnresolvedDependencies() {
         VarSnippet sx = varKey(assertEval("int x = 5;"));
         assertStreamMatch(getState().unresolvedDependencies(sx));

--- a/test/langtools/jdk/jshell/JShellStateClosedTest.java
+++ b/test/langtools/jdk/jshell/JShellStateClosedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test 8164277
  * @summary Testing IllegalStateException.
  * @build KullaTesting TestingInputStream JShellStateClosedTest
- * @run testng JShellStateClosedTest
+ * @run junit JShellStateClosedTest
  */
 
 import java.util.function.Consumer;
@@ -36,11 +36,9 @@ import jdk.jshell.MethodSnippet;
 import jdk.jshell.Snippet;
 import jdk.jshell.TypeDeclSnippet;
 import jdk.jshell.VarSnippet;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.fail;
-
-@Test
 public class JShellStateClosedTest extends KullaTesting {
 
     private void testStateClosedException(Runnable action) {
@@ -53,6 +51,7 @@ public class JShellStateClosedTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testClasses() {
         TypeDeclSnippet sc = classKey(assertEval("class C { }"));
         TypeDeclSnippet si = classKey(assertEval("interface I { }"));
@@ -60,6 +59,7 @@ public class JShellStateClosedTest extends KullaTesting {
         assertStreamMatch(getState().types(), sc, si);
     }
 
+    @Test
     public void testVariables() {
         VarSnippet sx = varKey(assertEval("int x = 5;"));
         VarSnippet sfoo = varKey(assertEval("String foo;"));
@@ -67,6 +67,7 @@ public class JShellStateClosedTest extends KullaTesting {
         assertStreamMatch(getState().variables(), sx, sfoo);
     }
 
+    @Test
     public void testMethods() {
         MethodSnippet smm = methodKey(assertEval("int mm() { return 6; }"));
         MethodSnippet svv = methodKey(assertEval("void vv() { }"));
@@ -74,12 +75,14 @@ public class JShellStateClosedTest extends KullaTesting {
         assertStreamMatch(getState().methods(), smm, svv);
     }
 
+    @Test
     public void testImports() {
         ImportSnippet simp = importKey(assertEval("import java.lang.reflect.*;"));
         getState().close();
         assertStreamMatch(getState().imports(), simp);
     }
 
+    @Test
     public void testSnippets() {
         VarSnippet sx = varKey(assertEval("int x = 5;"));
         VarSnippet sfoo = varKey(assertEval("String foo;"));
@@ -92,6 +95,7 @@ public class JShellStateClosedTest extends KullaTesting {
         assertStreamMatch(getState().snippets(), sx, sfoo, smm, svv, sc, si, simp);
     }
 
+    @Test
     public void testEval() {
         testStateClosedException(() -> getState().eval("int a;"));
     }
@@ -117,22 +121,27 @@ public class JShellStateClosedTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testStatus() {
         testStateClosedWithoutException((key) -> getState().status(key));
     }
 
+    @Test
     public void testVarValue() {
         testStateClosedException((key) -> getState().varValue((VarSnippet) key));
     }
 
+    @Test
     public void testDrop() {
         testStateClosedException((key) -> getState().drop(key));
     }
 
+    @Test
     public void testUnresolved() {
         testStateClosedWithoutException((key) -> getState().unresolvedDependencies((DeclarationSnippet) key));
     }
 
+    @Test
     public void testDiagnostics() {
         testStateClosedWithoutException((key) -> getState().diagnostics(key));
     }

--- a/test/langtools/jdk/jshell/JavadocTest.java
+++ b/test/langtools/jdk/jshell/JavadocTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  *          jdk.jshell/jdk.jshell:open
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build KullaTesting TestingInputStream Compiler
- * @run testng JavadocTest
+ * @run junit JavadocTest
  */
 
 import java.io.IOException;
@@ -43,13 +43,13 @@ import java.util.Arrays;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JavadocTest extends KullaTesting {
 
     private final Compiler compiler = new Compiler();
 
+    @Test
     public void testJavadoc() {
         prepareZip();
         assertJavadoc("test.Clazz|", "test.Clazz\n" +
@@ -65,6 +65,7 @@ public class JavadocTest extends KullaTesting {
         assertJavadoc("clz.undef|");
     }
 
+    @Test
     public void testVariableInRepl() {
         assertEval("Object o;");
         assertSignature("o|", "o:java.lang.Object");
@@ -107,6 +108,7 @@ public class JavadocTest extends KullaTesting {
         addToClasspath(compiler.getClassDir());
     }
 
+    @Test
     public void testCollectionsMin() {
         prepareJavaUtilZip();
         assertJavadoc("java.util.Collections.min(|",

--- a/test/langtools/jdk/jshell/JdiBadOptionLaunchExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiBadOptionLaunchExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,22 +26,22 @@
  * @bug 8169519 8166581
  * @summary Tests for JDI connector failure
  * @modules jdk.jshell/jdk.jshell jdk.jshell/jdk.jshell.spi jdk.jshell/jdk.jshell.execution
- * @run testng JdiBadOptionLaunchExecutionControlTest
+ * @run junit JdiBadOptionLaunchExecutionControlTest
  */
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.testng.annotations.Test;
 import jdk.jshell.JShell;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JdiBadOptionLaunchExecutionControlTest {
 
     private static final String EXPECTED_ERROR =
             "Launching JShell execution engine threw: Failed remote launch: java.util.concurrent.ExecutionException: com.sun.jdi.connect.VMStartException: VM initialization failed";
 
+    @Test
     public void badOptionLaunchTest() {
         try {
             // turn on logging of launch failures

--- a/test/langtools/jdk/jshell/JdiBadOptionListenExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiBadOptionListenExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,22 +26,22 @@
  * @bug 8169519 8166581
  * @summary Tests for JDI connector failure
  * @modules jdk.jshell/jdk.jshell jdk.jshell/jdk.jshell.spi jdk.jshell/jdk.jshell.execution
- * @run testng JdiBadOptionListenExecutionControlTest
+ * @run junit JdiBadOptionListenExecutionControlTest
  */
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.testng.annotations.Test;
 import jdk.jshell.JShell;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JdiBadOptionListenExecutionControlTest {
 
     private static final String EXPECTED_ERROR =
             "Unrecognized option: -BadBadOption";
 
+    @Test
     public void badOptionListenTest() {
         try {
             // turn on logging of launch failures

--- a/test/langtools/jdk/jshell/JdiBogusHostListenExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiBogusHostListenExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,17 +26,16 @@
  * @bug 8169519 8168615 8176474
  * @summary Tests for JDI connector failure
  * @modules jdk.jshell/jdk.jshell jdk.jshell/jdk.jshell.spi jdk.jshell/jdk.jshell.execution
- * @run testng JdiBogusHostListenExecutionControlTest
+ * @run junit JdiBogusHostListenExecutionControlTest
  */
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.testng.annotations.Test;
 import jdk.jshell.JShell;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JdiBogusHostListenExecutionControlTest {
 
     private static final String EXPECTED_ERROR =
@@ -44,6 +43,7 @@ public class JdiBogusHostListenExecutionControlTest {
     private static final String EXPECTED_LOCATION =
             "@ com.sun.jdi.SocketListen";
 
+    @Test
     public void badOptionListenTest() {
         try {
             // turn on logging of launch failures

--- a/test/langtools/jdk/jshell/JdiFailingLaunchExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiFailingLaunchExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,19 +27,19 @@
  * @summary Tests for JDI connector failure
  * @modules jdk.jshell/jdk.jshell jdk.jshell/jdk.jshell.spi jdk.jshell/jdk.jshell.execution
  * @build DyingRemoteAgent
- * @run testng JdiFailingLaunchExecutionControlTest
+ * @run junit JdiFailingLaunchExecutionControlTest
  */
 
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JdiFailingLaunchExecutionControlTest {
 
     private static final String EXPECTED_ERROR =
             "Launching JShell execution engine threw: Accept timed out";
 
+    @Test
     public void failLaunchTest() {
         try {
             System.err.printf("Unexpected return value: %s\n", DyingRemoteAgent.state(true, null).eval("33;"));

--- a/test/langtools/jdk/jshell/JdiFailingListenExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiFailingListenExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,19 +27,19 @@
  * @summary Tests for JDI connector failure
  * @modules jdk.jshell/jdk.jshell jdk.jshell/jdk.jshell.spi jdk.jshell/jdk.jshell.execution
  * @build DyingRemoteAgent
- * @run testng JdiFailingListenExecutionControlTest
+ * @run junit JdiFailingListenExecutionControlTest
  */
 
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JdiFailingListenExecutionControlTest {
 
     private static final String EXPECTED_ERROR =
             "Launching JShell execution engine threw: Accept timed out";
 
+    @Test
     public void failListenTest() {
         try {
             System.err.printf("Unexpected return value: %s\n", DyingRemoteAgent.state(true, null).eval("33;"));

--- a/test/langtools/jdk/jshell/JdiHangingLaunchExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiHangingLaunchExecutionControlTest.java
@@ -27,19 +27,19 @@
  * @summary Tests for JDI connector timeout failure
  * @modules jdk.jshell/jdk.jshell jdk.jshell/jdk.jshell.spi jdk.jshell/jdk.jshell.execution
  * @build HangingRemoteAgent
- * @run testng JdiHangingLaunchExecutionControlTest
+ * @run junit JdiHangingLaunchExecutionControlTest
  */
 
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JdiHangingLaunchExecutionControlTest {
 
     private static final String EXPECTED_ERROR =
             "Launching JShell execution engine threw: Accept timed out";
 
+    @Test
     public void hangLaunchTimeoutTest() {
         try {
             System.err.printf("Unexpected return value: %s\n",

--- a/test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiHangingListenExecutionControlTest.java
@@ -27,20 +27,20 @@
  * @summary Tests for JDI connector timeout failure
  * @modules jdk.jshell/jdk.jshell jdk.jshell/jdk.jshell.spi jdk.jshell/jdk.jshell.execution
  * @build HangingRemoteAgent
- * @run testng JdiHangingListenExecutionControlTest
+ * @run junit JdiHangingListenExecutionControlTest
  * @key intermittent
  */
 
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JdiHangingListenExecutionControlTest {
 
     private static final String EXPECTED_ERROR =
             "Launching JShell execution engine threw: Accept timed out";
 
+    @Test
     public void hangListenTimeoutTest() {
         try {
             System.err.printf("Unexpected return value: %s\n",

--- a/test/langtools/jdk/jshell/JdiLaunchingExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiLaunchingExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,18 +27,16 @@
  * @summary Tests for standard JDI connector (without failover) -- launching
  * @modules jdk.jshell/jdk.jshell.execution
  * @build KullaTesting ExecutionControlTestBase
- * @run testng JdiLaunchingExecutionControlTest
+ * @run junit JdiLaunchingExecutionControlTest
  * @key intermittent
  */
 
 
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.BeforeEach;
 
-@Test
 public class JdiLaunchingExecutionControlTest extends ExecutionControlTestBase {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine("jdi:launch(true)"));

--- a/test/langtools/jdk/jshell/JdiListeningExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiListeningExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,18 +27,16 @@
  * @summary Tests for alternate JDI connector -- listening
  * @modules jdk.jshell/jdk.jshell.execution
  * @build KullaTesting ExecutionControlTestBase
- * @run testng JdiListeningExecutionControlTest
+ * @run junit JdiListeningExecutionControlTest
  * @key intermittent
  */
 
 
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.BeforeEach;
 
-@Test
 public class JdiListeningExecutionControlTest extends ExecutionControlTestBase {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine("jdi"));

--- a/test/langtools/jdk/jshell/JdiListeningLocalhostExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/JdiListeningLocalhostExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,18 +27,16 @@
  * @summary Tests for alternate JDI connector -- listening to "localhost"
  * @modules jdk.jshell/jdk.jshell.execution
  * @build KullaTesting ExecutionControlTestBase
- * @run testng JdiListeningLocalhostExecutionControlTest
+ * @run junit JdiListeningLocalhostExecutionControlTest
  * @key intermittent
  */
 
 
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.BeforeEach;
 
-@Test
 public class JdiListeningLocalhostExecutionControlTest extends ExecutionControlTestBase {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine("jdi:hostname(localhost)"));

--- a/test/langtools/jdk/jshell/KullaCompletenessStressTest.java
+++ b/test/langtools/jdk/jshell/KullaCompletenessStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,19 @@
  * @summary Test SourceCodeAnalysis
  * @modules jdk.compiler/com.sun.tools.javac.api
  * @build KullaTesting TestingInputStream KullaCompletenessStressTest CompletenessStressTest
- * @run testng KullaCompletenessStressTest
+ * @run junit KullaCompletenessStressTest
  */
 
 import java.io.File;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class KullaCompletenessStressTest extends CompletenessStressTest {
     @Override
+    @Test
     public File[] getDirectoriesToTest() {
         String src = System.getProperty("test.src");
         File file;
@@ -44,11 +47,10 @@ public class KullaCompletenessStressTest extends CompletenessStressTest {
         } else {
             file = new File(src, "../../../src/jdk.jshell/share/classes");
         }
-        if (!file.exists()) {
-            System.out.println("jdk.jshell sources are not exist. Test has been skipped. Path: " + file.toString());
-            return new File[]{};
-        }else {
-            return new File[]{file};
-        }
+
+        Assumptions.assumeTrue(file.exists(),
+                               "jdk.jshell sources are not exist. Test has been skipped. Path: " + file.toString());
+
+        return new File[]{file};
     }
 }

--- a/test/langtools/jdk/jshell/KullaTesting.java
+++ b/test/langtools/jdk/jshell/KullaTesting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,8 +71,6 @@ import jdk.jshell.SourceCodeAnalysis.Completeness;
 import jdk.jshell.SourceCodeAnalysis.QualifiedNames;
 import jdk.jshell.SourceCodeAnalysis.Suggestion;
 import jdk.jshell.UnresolvedReferenceException;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 
 import jdk.jshell.Diag;
 
@@ -80,9 +78,11 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import static jdk.jshell.Snippet.Status.*;
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static jdk.jshell.Snippet.SubKind.METHOD_SUBKIND;
 import jdk.jshell.SourceCodeAnalysis.Documentation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class KullaTesting {
 
@@ -166,7 +166,7 @@ public class KullaTesting {
         addToClasspath(path.toString());
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         setUp(b -> {});
     }
@@ -202,7 +202,7 @@ public class KullaTesting {
         idToSnippet = new LinkedHashMap<>();
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDown() {
         if (state != null) state.close();
         state = null;
@@ -226,16 +226,16 @@ public class KullaTesting {
 
     public List<String> assertUnresolvedDependencies(DeclarationSnippet key, int unresolvedSize) {
         List<String> unresolved = getState().unresolvedDependencies(key).collect(toList());
-        assertEquals(unresolved.size(), unresolvedSize, "Input: " + key.source() + ", checking unresolved: ");
+        assertEquals(unresolvedSize, unresolved.size(), "Input: " + key.source() + ", checking unresolved: ");
         return unresolved;
     }
 
     public DeclarationSnippet assertUnresolvedDependencies1(DeclarationSnippet key, Status status, String name) {
         List<String> unresolved = assertUnresolvedDependencies(key, 1);
         String input = key.source();
-        assertEquals(unresolved.size(), 1, "Given input: " + input + ", checking unresolved");
-        assertEquals(unresolved.get(0), name, "Given input: " + input + ", checking unresolved: ");
-        assertEquals(getState().status(key), status, "Given input: " + input + ", checking status: ");
+        assertEquals(1, unresolved.size(), "Given input: " + input + ", checking unresolved");
+        assertEquals(name, unresolved.get(0), "Given input: " + input + ", checking unresolved: ");
+        assertEquals(status, getState().status(key), "Given input: " + input + ", checking status: ");
         return key;
     }
 
@@ -243,24 +243,24 @@ public class KullaTesting {
         List<SnippetEvent> events = assertEval(input, null, UnresolvedReferenceException.class, DiagCheck.DIAG_OK, DiagCheck.DIAG_OK, null);
         SnippetEvent ste = events.get(0);
         DeclarationSnippet sn = ((UnresolvedReferenceException) ste.exception()).getSnippet();
-        assertEquals(sn.name(), name, "Given input: " + input + ", checking name");
-        assertEquals(getState().unresolvedDependencies(sn).count(), unresolvedSize, "Given input: " + input + ", checking unresolved");
-        assertEquals(getState().diagnostics(sn).count(), (long) diagnosticsSize, "Given input: " + input + ", checking diagnostics");
+        assertEquals(name, sn.name(), "Given input: " + input + ", checking name");
+        assertEquals(unresolvedSize, getState().unresolvedDependencies(sn).count(), "Given input: " + input + ", checking unresolved");
+        assertEquals((long) diagnosticsSize, getState().diagnostics(sn).count(), "Given input: " + input + ", checking diagnostics");
         return sn;
     }
 
     public Snippet assertKeyMatch(String input, boolean isExecutable, SubKind expectedSubKind, STEInfo mainInfo, STEInfo... updates) {
         Snippet key = key(assertEval(input, IGNORE_VALUE, mainInfo, updates));
         String source = key.source();
-        assertEquals(source, input, "Key \"" + input + "\" source mismatch, got: " + source + ", expected: " + input);
+        assertEquals(input, source, "Key \"" + input + "\" source mismatch, got: " + source + ", expected: " + input);
         SubKind subkind = key.subKind();
-        assertEquals(subkind, expectedSubKind, "Key \"" + input + "\" subkind mismatch, got: "
+        assertEquals(expectedSubKind, subkind, "Key \"" + input + "\" subkind mismatch, got: "
                 + subkind + ", expected: " + expectedSubKind);
-        assertEquals(subkind.isExecutable(), isExecutable, "Key \"" + input + "\", expected isExecutable: "
+        assertEquals(isExecutable, subkind.isExecutable(), "Key \"" + input + "\", expected isExecutable: "
                 + isExecutable + ", got: " + subkind.isExecutable());
         Snippet.Kind expectedKind = getKind(key);
-        assertEquals(key.kind(), expectedKind, "Checking kind: ");
-        assertEquals(expectedSubKind.kind(), expectedKind, "Checking kind: ");
+        assertEquals(expectedKind, key.kind(), "Checking kind: ");
+        assertEquals(expectedKind, expectedSubKind.kind(), "Checking kind: ");
         return key;
     }
 
@@ -309,9 +309,9 @@ public class KullaTesting {
 
         assertTrue(key instanceof ImportSnippet, "Expected an ImportKey, got: " + key.getClass().getName());
         ImportSnippet importKey = (ImportSnippet) key;
-        assertEquals(importKey.name(), name, "Input \"" + input +
+        assertEquals(name, importKey.name(), "Input \"" + input +
                 "\" name mismatch, got: " + importKey.name() + ", expected: " + name);
-        assertEquals(importKey.kind(), Kind.IMPORT, "Checking kind: ");
+        assertEquals(Kind.IMPORT, importKey.kind(), "Checking kind: ");
         return importKey;
     }
 
@@ -320,7 +320,7 @@ public class KullaTesting {
 
         assertTrue(key instanceof DeclarationSnippet, "Expected a DeclarationKey, got: " + key.getClass().getName());
         DeclarationSnippet declKey = (DeclarationSnippet) key;
-        assertEquals(declKey.name(), name, "Input \"" + input +
+        assertEquals(name, declKey.name(), "Input \"" + input +
                 "\" name mismatch, got: " + declKey.name() + ", expected: " + name);
         return declKey;
     }
@@ -330,9 +330,9 @@ public class KullaTesting {
         assertTrue(sn instanceof VarSnippet, "Expected a VarKey, got: " + sn.getClass().getName());
         VarSnippet variableKey = (VarSnippet) sn;
         String signature = variableKey.typeName();
-        assertEquals(signature, typeName, "Key \"" + input +
+        assertEquals(typeName, signature, "Key \"" + input +
                 "\" typeName mismatch, got: " + signature + ", expected: " + typeName);
-        assertEquals(variableKey.kind(), Kind.VAR, "Checking kind: ");
+        assertEquals(Kind.VAR, variableKey.kind(), "Checking kind: ");
         return variableKey;
     }
 
@@ -340,11 +340,11 @@ public class KullaTesting {
         Snippet key = assertKeyMatch(input, true, kind, added(VALID));
         assertTrue(key instanceof ExpressionSnippet, "Expected a ExpressionKey, got: " + key.getClass().getName());
         ExpressionSnippet exprKey = (ExpressionSnippet) key;
-        assertEquals(exprKey.name(), name, "Input \"" + input +
+        assertEquals(name, exprKey.name(), "Input \"" + input +
                 "\" name mismatch, got: " + exprKey.name() + ", expected: " + name);
-        assertEquals(exprKey.typeName(), typeName, "Key \"" + input +
+        assertEquals(typeName, exprKey.typeName(), "Key \"" + input +
                 "\" typeName mismatch, got: " + exprKey.typeName() + ", expected: " + typeName);
-        assertEquals(exprKey.kind(), Kind.EXPRESSION, "Checking kind: ");
+        assertEquals(Kind.EXPRESSION, exprKey.kind(), "Checking kind: ");
     }
 
     // For expressions throwing an EvalException
@@ -402,7 +402,7 @@ public class KullaTesting {
     <T> void assertStreamMatch(Stream<T> result, T... expected) {
         Set<T> sns = result.collect(toSet());
         Set<T> exp = Stream.of(expected).collect(toSet());
-        assertEquals(sns, exp);
+        assertEquals(exp, sns);
     }
 
     private Map<Snippet, Snippet> closure(List<SnippetEvent> events) {
@@ -483,9 +483,9 @@ public class KullaTesting {
         });
         List<SnippetEvent> events = toTest.get();
         getState().unsubscribe(token);
-        assertEquals(dispatched.size(), events.size(), "dispatched event size not the same as event size");
+        assertEquals(events.size(), dispatched.size(), "dispatched event size not the same as event size");
         for (int i = events.size() - 1; i >= 0; --i) {
-            assertEquals(dispatched.get(i), events.get(i), "Event element " + i + " does not match");
+            assertEquals(events.get(i), dispatched.get(i), "Event element " + i + " does not match");
         }
         dispatched.add(null); // mark end of dispatchs
 
@@ -499,11 +499,11 @@ public class KullaTesting {
                 if (old != null) {
                     switch (evt.status()) {
                         case DROPPED:
-                            assertEquals(old, evt.snippet(),
+                            assertEquals(evt.snippet(), old,
                                     "Drop: Old snippet must be what is dropped -- input: " + descriptor);
                             break;
                         case OVERWRITTEN:
-                            assertEquals(old, evt.snippet(),
+                            assertEquals(evt.snippet(), old,
                                     "Overwrite: Old snippet (" + old
                                     + ") must be what is overwritten -- input: "
                                     + descriptor + " -- " + evt);
@@ -511,12 +511,12 @@ public class KullaTesting {
                         default:
                             if (evt.causeSnippet() == null) {
                                 // New source
-                                assertNotEquals(old, evt.snippet(),
+                                assertNotEquals(evt.snippet(), old,
                                         "New source: Old snippet must be different from the replacing -- input: "
                                         + descriptor);
                             } else {
                                 // An update (key Overwrite??)
-                                assertEquals(old, evt.snippet(),
+                                assertEquals(evt.snippet(), old,
                                         "Update: Old snippet must be equal to the replacing -- input: "
                                         + descriptor);
                             }
@@ -556,7 +556,7 @@ public class KullaTesting {
 
         int impactId = 0;
         Map<Snippet, List<SnippetEvent>> groupedEvents = groupByCauseSnippet(events);
-        assertEquals(groupedEvents.size(), eventChains.length, "Number of main events");
+        assertEquals(eventChains.length, groupedEvents.size(), "Number of main events");
         for (Map.Entry<Snippet, List<SnippetEvent>> entry : groupedEvents.entrySet()) {
             EventChain eventChain = eventChains[impactId++];
             SnippetEvent main = entry.getValue().get(0);
@@ -579,12 +579,12 @@ public class KullaTesting {
                 }
             }
             if (((Object) eventChain.value) != IGNORE_VALUE) {
-                assertEquals(main.value(), eventChain.value, "Expected execution value of: " + eventChain.value +
+                assertEquals(eventChain.value, main.value(), "Expected execution value of: " + eventChain.value +
                         ", but got: " + main.value());
             }
             if (eventChain.exceptionClass != IGNORE_EXCEPTION) {
                 if (main.exception() == null) {
-                    assertEquals(eventChain.exceptionClass, null, "Expected an exception of class "
+                    assertEquals(null, eventChain.exceptionClass, "Expected an exception of class "
                             + eventChain.exceptionClass + " got no exception");
                 } else if (eventChain.exceptionClass == null) {
                     fail("Expected no exception but got " + main.exception().toString());
@@ -597,7 +597,7 @@ public class KullaTesting {
             List<Diag> diagnostics = getState().diagnostics(mainKey).collect(toList());
             switch (diagMain) {
                 case DIAG_OK:
-                    assertEquals(diagnostics.size(), 0, "Expected no diagnostics, got: " + diagnosticsToString(diagnostics));
+                    assertEquals(0, diagnostics.size(), "Expected no diagnostics, got: " + diagnosticsToString(diagnostics));
                     break;
                 case DIAG_WARNING:
                     assertFalse(hasFatalError(diagnostics), "Expected no errors, got: " + diagnosticsToString(diagnostics));
@@ -611,7 +611,7 @@ public class KullaTesting {
                     diagnostics = getState().diagnostics(ste.snippet()).collect(toList());
                     switch (diagUpdates) {
                         case DIAG_OK:
-                            assertEquals(diagnostics.size(), 0, "Expected no diagnostics, got: " + diagnosticsToString(diagnostics));
+                            assertEquals(0, diagnostics.size(), "Expected no diagnostics, got: " + diagnosticsToString(diagnostics));
                             break;
                         case DIAG_WARNING:
                             assertFalse(hasFatalError(diagnostics), "Expected no errors, got: " + diagnosticsToString(diagnostics));
@@ -626,7 +626,7 @@ public class KullaTesting {
     // Use this for all EMPTY calls to eval()
     public void assertEvalEmpty(String input) {
         List<SnippetEvent> events = getState().eval(input);
-        assertEquals(events.size(), 0, "Expected no events, got: " + events.size());
+        assertEquals(0, events.size(), "Expected no events, got: " + events.size());
     }
 
     public VarSnippet varKey(List<SnippetEvent> events) {
@@ -660,7 +660,7 @@ public class KullaTesting {
 
     public void assertVarValue(Snippet key, String expected) {
         String value = state.varValue((VarSnippet) key);
-        assertEquals(value, expected, "Expected var value of: " + expected + ", but got: " + value);
+        assertEquals(expected, value, "Expected var value of: " + expected + ", but got: " + value);
     }
 
     public Snippet assertDeclareFail(String input, String expectedErrorCode) {
@@ -684,7 +684,7 @@ public class KullaTesting {
                 DiagCheck.DIAG_ERROR, DiagCheck.DIAG_IGNORE, mainInfo, updates);
         SnippetEvent e = events.get(0);
         Snippet key = e.snippet();
-        assertEquals(getState().status(key), REJECTED);
+        assertEquals(REJECTED, getState().status(key));
         List<Diag> diagnostics = getState().diagnostics(e.snippet()).collect(toList());
         assertTrue(diagnostics.size() > 0, "Expected diagnostics, got none");
         assertDiagnostic(input, diagnostics.get(0), expectedDiagnostic);
@@ -727,7 +727,7 @@ public class KullaTesting {
         assertDeclarationSnippet(method, expectedName, expectedStatus,
                 METHOD_SUBKIND, unressz, othersz);
         String signature = method.signature();
-        assertEquals(signature, expectedSignature,
+        assertEquals(expectedSignature, signature,
                 "Expected " + method.source() + " to have the name: " +
                         expectedSignature + ", got: " + signature);
     }
@@ -739,7 +739,7 @@ public class KullaTesting {
         assertDeclarationSnippet(var, expectedName, expectedStatus,
                 expectedSubKind, unressz, othersz);
         String signature = var.typeName();
-        assertEquals(signature, expectedTypeName,
+        assertEquals(expectedTypeName, signature,
                 "Expected " + var.source() + " to have the type name: " +
                         expectedTypeName + ", got: " + signature);
     }
@@ -750,27 +750,27 @@ public class KullaTesting {
             int unressz, int othersz) {
         assertKey(declarationKey, expectedStatus, expectedSubKind);
         String source = declarationKey.source();
-        assertEquals(declarationKey.name(), expectedName,
+        assertEquals(expectedName, declarationKey.name(),
                 "Expected " + source + " to have the name: " + expectedName + ", got: " + declarationKey.name());
         long unresolved = getState().unresolvedDependencies(declarationKey).count();
-        assertEquals(unresolved, unressz, "Expected " + source + " to have " + unressz
+        assertEquals(unressz, unresolved, "Expected " + source + " to have " + unressz
                 + " unresolved symbols, got: " + unresolved);
         long otherCorralledErrorsCount = getState().diagnostics(declarationKey).count();
-        assertEquals(otherCorralledErrorsCount, othersz, "Expected " + source + " to have " + othersz
+        assertEquals(othersz, otherCorralledErrorsCount, "Expected " + source + " to have " + othersz
                 + " other errors, got: " + otherCorralledErrorsCount);
     }
 
     public void assertKey(Snippet key, Status expectedStatus, SubKind expectedSubKind) {
         String source = key.source();
         SubKind actualSubKind = key.subKind();
-        assertEquals(actualSubKind, expectedSubKind,
+        assertEquals(expectedSubKind, actualSubKind,
                 "Expected " + source + " to have the subkind: " + expectedSubKind + ", got: " + actualSubKind);
         Status status = getState().status(key);
-        assertEquals(status, expectedStatus, "Expected " + source + " to be "
+        assertEquals(expectedStatus, status, "Expected " + source + " to be "
                 + expectedStatus + ", but it is " + status);
         Snippet.Kind expectedKind = getKind(key);
-        assertEquals(key.kind(), expectedKind, "Checking kind: ");
-        assertEquals(expectedSubKind.kind(), expectedKind, "Checking kind: ");
+        assertEquals(expectedKind, key.kind(), "Checking kind: ");
+        assertEquals(expectedKind, expectedSubKind.kind(), "Checking kind: ");
     }
 
     public void assertDrop(Snippet key, STEInfo mainInfo, STEInfo... updates) {
@@ -795,36 +795,36 @@ public class KullaTesting {
 
     public void assertAnalyze(String input, Completeness status, String source, String remaining, Boolean isComplete) {
         CompletionInfo ci = getAnalysis().analyzeCompletion(input);
-        if (status != null) assertEquals(ci.completeness(), status, "Input : " + input + ", status: ");
-        assertEquals(ci.source(), source, "Input : " + input + ", source: ");
-        if (remaining != null) assertEquals(ci.remaining(), remaining, "Input : " + input + ", remaining: ");
+        if (status != null) assertEquals(status, ci.completeness(), "Input : " + input + ", status: ");
+        assertEquals(source, ci.source(), "Input : " + input + ", source: ");
+        if (remaining != null) assertEquals(remaining, ci.remaining(), "Input : " + input + ", remaining: ");
         if (isComplete != null) {
             boolean isExpectedComplete = isComplete;
-            assertEquals(ci.completeness().isComplete(), isExpectedComplete, "Input : " + input + ", isComplete: ");
+            assertEquals(isExpectedComplete, ci.completeness().isComplete(), "Input : " + input + ", isComplete: ");
         }
     }
 
     public void assertNumberOfActiveVariables(int cnt) {
-        assertEquals(getState().variables().count(), cnt, "Variables : " + getState().variables().collect(toList()));
+        assertEquals(cnt, getState().variables().count(), "Variables : " + getState().variables().collect(toList()));
     }
 
     public void assertNumberOfActiveMethods(int cnt) {
-        assertEquals(getState().methods().count(), cnt, "Methods : " + getState().methods().collect(toList()));
+        assertEquals(cnt, getState().methods().count(), "Methods : " + getState().methods().collect(toList()));
     }
 
     public void assertNumberOfActiveClasses(int cnt) {
-        assertEquals(getState().types().count(), cnt, "Types : " + getState().types().collect(toList()));
+        assertEquals(cnt, getState().types().count(), "Types : " + getState().types().collect(toList()));
     }
 
     public void assertKeys(MemberInfo... expected) {
         int index = 0;
         List<Snippet> snippets = getState().snippets().collect(toList());
-        assertEquals(allSnippets.size(), snippets.size());
+        assertEquals(snippets.size(), allSnippets.size());
         for (Snippet sn : snippets) {
             if (sn.kind().isPersistent() && getState().status(sn).isActive()) {
                 MemberInfo actual = getMemberInfo(sn);
                 MemberInfo exp = expected[index];
-                assertEquals(actual, exp, String.format("Difference in #%d. Expected: %s, actual: %s",
+                assertEquals(exp, actual, String.format("Difference in #%d. Expected: %s, actual: %s",
                         index, exp, actual));
                 ++index;
             }
@@ -840,7 +840,7 @@ public class KullaTesting {
         int index = 0;
         for (Snippet key : getState().snippets().collect(toList())) {
             if (state.status(key).isActive()) {
-                assertEquals(expected[index], key, String.format("Difference in #%d. Expected: %s, actual: %s", index, key, expected[index]));
+                assertEquals(key, expected[index], String.format("Difference in #%d. Expected: %s, actual: %s", index, key, expected[index]));
                 ++index;
             }
         }
@@ -852,7 +852,7 @@ public class KullaTesting {
                 .collect(Collectors.toSet());
         Set<Snippet> got = snippets
                 .collect(Collectors.toSet());
-        assertEquals(active, got, label);
+        assertEquals(got, active, label);
     }
 
     public void assertVariables() {
@@ -872,8 +872,8 @@ public class KullaTesting {
         Set<MemberInfo> got = members
                         .map(this::getMemberInfo)
                         .collect(Collectors.toSet());
-        assertEquals(got.size(), expected.size(), "Expected : " + expected + ", actual : " + members);
-        assertEquals(got, expected);
+        assertEquals(expected.size(), got.size(), "Expected : " + expected + ", actual : " + members);
+        assertEquals(expected, got);
     }
 
     public void assertVariables(MemberInfo...expected) {
@@ -891,7 +891,7 @@ public class KullaTesting {
             }
             assertNotNull(expectedInfo, "Not found method: " + methodKey.name());
             int lastIndexOf = expectedInfo.type.lastIndexOf(')');
-            assertEquals(methodKey.parameterTypes(), expectedInfo.type.substring(1, lastIndexOf), "Parameter types");
+            assertEquals(expectedInfo.type.substring(1, lastIndexOf), methodKey.parameterTypes(), "Parameter types");
         });
     }
 
@@ -905,7 +905,7 @@ public class KullaTesting {
 
     public void assertCompletion(String code, Boolean isSmart, String... expected) {
         List<String> completions = computeCompletions(code, isSmart);
-        assertEquals(completions, Arrays.asList(expected), "Input: " + code + ", " + completions.toString());
+        assertEquals(Arrays.asList(expected), completions, "Input: " + code + ", " + completions.toString());
     }
 
     public void assertCompletionIncludesExcludes(String code, Set<String> expected, Set<String> notExpected) {
@@ -939,7 +939,7 @@ public class KullaTesting {
     public void assertInferredType(String code, String expectedType) {
         String inferredType = getAnalysis().analyzeType(code, code.length());
 
-        assertEquals(inferredType, expectedType, "Input: " + code + ", " + inferredType);
+        assertEquals(expectedType, inferredType, "Input: " + code + ", " + inferredType);
     }
 
     public void assertInferredFQNs(String code, String... fqns) {
@@ -951,9 +951,9 @@ public class KullaTesting {
 
         QualifiedNames candidates = getAnalysis().listQualifiedNames(code, code.length());
 
-        assertEquals(candidates.getNames(), Arrays.asList(fqns), "Input: " + code + ", candidates=" + candidates.getNames());
-        assertEquals(candidates.getSimpleNameLength(), simpleNameLen, "Input: " + code + ", simpleNameLen=" + candidates.getSimpleNameLength());
-        assertEquals(candidates.isResolvable(), resolvable, "Input: " + code + ", resolvable=" + candidates.isResolvable());
+        assertEquals(Arrays.asList(fqns), candidates.getNames(), "Input: " + code + ", candidates=" + candidates.getNames());
+        assertEquals(simpleNameLen, candidates.getSimpleNameLength(), "Input: " + code + ", simpleNameLen=" + candidates.getSimpleNameLength());
+        assertEquals(resolvable, candidates.isResolvable(), "Input: " + code + ", resolvable=" + candidates.isResolvable());
     }
 
     protected void waitIndexingFinished() {
@@ -974,7 +974,7 @@ public class KullaTesting {
         List<Documentation> documentation = getAnalysis().documentation(code, cursor, false);
         Set<String> docSet = documentation.stream().map(doc -> doc.signature()).collect(Collectors.toSet());
         Set<String> expectedSet = Stream.of(expected).collect(Collectors.toSet());
-        assertEquals(docSet, expectedSet, "Input: " + code);
+        assertEquals(expectedSet, docSet, "Input: " + code);
     }
 
     public void assertJavadoc(String code, String... expected) {
@@ -986,7 +986,7 @@ public class KullaTesting {
                                           .map(doc -> doc.signature() + "\n" + doc.javadoc())
                                           .collect(Collectors.toSet());
         Set<String> expectedSet = Stream.of(expected).collect(Collectors.toSet());
-        assertEquals(docSet, expectedSet, "Input: " + code);
+        assertEquals(expectedSet, docSet, "Input: " + code);
     }
 
     public enum ClassType {
@@ -1182,7 +1182,7 @@ public class KullaTesting {
             assertStatusMatch(ste, ste.previousStatus(), previousStatus());
             assertStatusMatch(ste, ste.status(), status());
             if (checkIsSignatureChange) {
-                assertEquals(ste.isSignatureChange(), isSignatureChange(),
+                assertEquals(isSignatureChange(), ste.isSignatureChange(),
                         "Expected " +
                                 (isSignatureChange()? "" : "no ") +
                                 "signature-change, got: " +
@@ -1205,10 +1205,10 @@ public class KullaTesting {
                     assertTrue(sn != testKey,
                             "Main-event: Expected new snippet to be != : " + testKey
                             + "\n   got-event: " + toString(ste));
-                    assertEquals(sn.id(), testKey.id(), "Expected IDs to match: " + testKey + ", got: " + sn
+                    assertEquals(testKey.id(), sn.id(), "Expected IDs to match: " + testKey + ", got: " + sn
                             + "\n   expected-event: " + this + "\n   got-event: " + toString(ste));
                 } else {
-                    assertEquals(sn, testKey, "Expected key to be: " + testKey + ", got: " + sn
+                    assertEquals(testKey, sn, "Expected key to be: " + testKey + ", got: " + sn
                             + "\n   expected-event: " + this + "\n   got-event: " + toString(ste));
                 }
             }
@@ -1216,7 +1216,7 @@ public class KullaTesting {
 
         private void assertStatusMatch(SnippetEvent ste, Status status, Status expected) {
             if (expected != null) {
-                assertEquals(status, expected, "Expected status to be: " + expected + ", got: " + status +
+                assertEquals(expected, status, "Expected status to be: " + expected + ", got: " + status +
                         "\n   expected-event: " + this + "\n   got-event: " + toString(ste));
             }
         }

--- a/test/langtools/jdk/jshell/MethodsTest.java
+++ b/test/langtools/jdk/jshell/MethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8080357 8167643 8187359 8199762 8080353 8246353 8247456 8267221
  * @summary Tests for EvaluationState.methods
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
- * @run testng MethodsTest
+ * @run junit MethodsTest
  */
 
 import javax.tools.Diagnostic;
@@ -34,21 +34,23 @@ import javax.tools.Diagnostic;
 import jdk.jshell.Snippet;
 import jdk.jshell.MethodSnippet;
 import jdk.jshell.Snippet.Status;
-import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static jdk.jshell.Snippet.Status.*;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class MethodsTest extends KullaTesting {
 
+    @Test
     public void noMethods() {
         assertNumberOfActiveMethods(0);
     }
 
+    @Test
     public void testSignature1() {
         MethodSnippet m1 = methodKey(assertEval("void f() { g(); }", added(RECOVERABLE_DEFINED)));
         assertMethodDeclSnippet(m1, "f", "()void", RECOVERABLE_DEFINED, 1, 0);
@@ -58,6 +60,7 @@ public class MethodsTest extends KullaTesting {
         assertMethodDeclSnippet(m2, "g", "()void", VALID, 0, 0);
     }
 
+    @Test
     public void testSignature2() {
         MethodSnippet m1 = (MethodSnippet) assertDeclareFail("void f() { return g(); }", "compiler.err.prob.found.req");
         assertMethodDeclSnippet(m1, "f", "()void", REJECTED, 0, 2);
@@ -67,7 +70,8 @@ public class MethodsTest extends KullaTesting {
         assertMethodDeclSnippet(m2, "f", "()int", RECOVERABLE_DEFINED, 1, 0);
     }
 
-    @Test(enabled = false) // TODO 8081690
+    @Test // TODO 8081690
+    @Disabled
     public void testSignature3() {
         MethodSnippet m1 = methodKey(assertEval("void f(Bar b) { }", added(RECOVERABLE_NOT_DEFINED)));
         assertMethodDeclSnippet(m1, "f", "(Bar)void", RECOVERABLE_NOT_DEFINED, 1, 0);
@@ -79,6 +83,7 @@ public class MethodsTest extends KullaTesting {
     }
 
     // 8080357
+    @Test
     public void testNonReplUnresolved() {
         // internal case
         assertEval("class CCC {}", added(VALID));
@@ -87,6 +92,7 @@ public class MethodsTest extends KullaTesting {
         assertDeclareFail("void f2() { System.xxxx(); }", "compiler.err.cant.resolve.location.args");
     }
 
+    @Test
     public void methods() {
         assertEval("int x() { return 10; }");
         assertEval("String y() { return null; }");
@@ -95,6 +101,7 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void methodOverload() {
         assertEval("int m() { return 1; }");
         assertEval("int m(int x) { return 2; }");
@@ -139,6 +146,7 @@ public class MethodsTest extends KullaTesting {
     }
     ***/
 
+    @Test
     public void methodsRedeclaration1() {
         Snippet x = methodKey(assertEval("int x() { return 10; }"));
         Snippet y = methodKey(assertEval("String y() { return \"\"; }"));
@@ -158,6 +166,7 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void methodsRedeclaration2() {
         assertEval("int a() { return 1; }");
         assertMethods(method("()int", "a"));
@@ -179,6 +188,7 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void methodsRedeclaration3() {
         Snippet x = methodKey(assertEval("int x(Object...a) { return 10; }"));
         assertMethods(method("(Object...)int", "x"));
@@ -192,6 +202,7 @@ public class MethodsTest extends KullaTesting {
     }
 
 
+    @Test
     public void methodsRedeclaration4() {
         Snippet a = methodKey(assertEval("int foo(int a) { return a; }"));
         assertEval("int x = foo(10);");
@@ -204,6 +215,7 @@ public class MethodsTest extends KullaTesting {
     }
 
     // 8199762
+    @Test
     public void methodsRedeclaration5() {
         Snippet m1 = methodKey(assertEval("int m(Object o) { return 10; }"));
         assertMethods(method("(Object)int", "m"));
@@ -220,22 +232,23 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void methodsAbstract() {
         MethodSnippet m1 = methodKey(assertEval("abstract String f();",
                 ste(MAIN_SNIPPET, NONEXISTENT, RECOVERABLE_DEFINED, true, null)));
-        assertEquals(getState().unresolvedDependencies(m1).collect(Collectors.toList()),
-                List.of("method f()"));
+        assertEquals(                List.of("method f()"), getState().unresolvedDependencies(m1).collect(Collectors.toList()));
         MethodSnippet m2 = methodKey(assertEval("abstract int mm(Blah b);",
                 ste(MAIN_SNIPPET, NONEXISTENT, RECOVERABLE_NOT_DEFINED, false, null)));
         List<String> unr = getState().unresolvedDependencies(m2).collect(Collectors.toList());
-        assertEquals(unr.size(), 2);
+        assertEquals(2, unr.size());
         unr.remove("class Blah");
         unr.remove("method mm(Blah)");
-        assertEquals(unr.size(), 0, "unexpected entry: " + unr);
+        assertEquals(0, unr.size(), "unexpected entry: " + unr);
         assertNumberOfActiveMethods(2);
         assertActiveKeys();
     }
 
+    @Test
     public void methodsErrors() {
         assertDeclareFail("String f();",
                 new ExpectedDiagnostic("compiler.err.missing.meth.body.or.decl.abstract", 0, 11, 7, -1, -1, Diagnostic.Kind.ERROR));
@@ -267,6 +280,7 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void objectMethodNamedMethodsErrors() {
         assertDeclareFail("boolean equals(double d1, double d2) {  return d1 == d2; }",
                 new ExpectedDiagnostic("jdk.eval.error.object.method", 8, 14, 8, -1, -1, Diagnostic.Kind.ERROR));
@@ -286,6 +300,7 @@ public class MethodsTest extends KullaTesting {
     }
 
 
+    @Test
     public void methodsAccessModifierIgnored() {
         Snippet f = methodKey(assertEval("public String f() {return null;}",
                 added(VALID)));
@@ -305,6 +320,7 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void methodsIgnoredModifiers() {
         Snippet f = methodKey(assertEval("static String f() {return null;}"));
         assertNumberOfActiveMethods(1);
@@ -318,6 +334,7 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void methodSignatureUnresolved() {
         MethodSnippet key = (MethodSnippet) methodKey(assertEval("und m() { return new und(); }", added(RECOVERABLE_NOT_DEFINED)));
         assertMethodDeclSnippet(key, "m", "()und", RECOVERABLE_NOT_DEFINED, 1, 0);
@@ -330,7 +347,8 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
-    @Test(enabled = false) // TODO 8081689
+    @Test // TODO 8081689
+    @Disabled
     public void classMethodsAreNotVisible() {
         assertEval(
             "class A {" +
@@ -351,6 +369,7 @@ public class MethodsTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void lambdas() {
         assertEval("class Inner1 implements Runnable {" +
                 "public Runnable lambda1 = () -> {};" +
@@ -376,12 +395,13 @@ public class MethodsTest extends KullaTesting {
     }
 
     //JDK-8267221:
+    @Test
     public void testMethodArrayParameters() {
         MethodSnippet m1 = methodKey(assertEval("void m1(int... p) { }", added(VALID)));
-        assertEquals(m1.parameterTypes(), "int...");
+        assertEquals("int...", m1.parameterTypes());
         MethodSnippet m2 = methodKey(assertEval("void m2(int[]... p) { }", added(VALID)));
-        assertEquals(m2.parameterTypes(), "int[]...");
+        assertEquals("int[]...", m2.parameterTypes());
         MethodSnippet m3 = methodKey(assertEval("void m3(int[][] p) { }", added(VALID)));
-        assertEquals(m3.parameterTypes(), "int[][]");
+        assertEquals("int[][]", m3.parameterTypes());
     }
 }

--- a/test/langtools/jdk/jshell/ModifiersTest.java
+++ b/test/langtools/jdk/jshell/ModifiersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test 8167643 8129559 8247456
  * @summary Tests for modifiers
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
- * @run testng ModifiersTest
+ * @run junit ModifiersTest
  */
 
 import java.util.ArrayList;
@@ -34,13 +34,14 @@ import java.util.List;
 import java.util.function.Consumer;
 import javax.tools.Diagnostic;
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@Test
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ModifiersTest extends KullaTesting {
 
-    @DataProvider(name = "ignoredModifiers")
     public Object[][] getTestCases() {
         List<Object[]> testCases = new ArrayList<>();
         String[] ignoredModifiers = new String[] {
@@ -77,7 +78,8 @@ public class ModifiersTest extends KullaTesting {
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
-    @Test(dataProvider = "ignoredModifiers")
+    @ParameterizedTest
+    @MethodSource("getTestCases")
     public void ignoredModifiers(String modifier, ClassType classType,
             Consumer<String> eval, String preface, String context) {
         if (context != null) {
@@ -95,6 +97,7 @@ public class ModifiersTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void accessToStaticFieldsOfClass() {
         assertEval("class A {" +
                 "int x = 14;" +
@@ -108,6 +111,7 @@ public class ModifiersTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void accessToStaticMethodsOfClass() {
         assertEval("class A {" +
                 "void x() {}" +
@@ -119,6 +123,7 @@ public class ModifiersTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void accessToStaticFieldsOfInterface() {
         assertEval("interface A {" +
                 "int x = 14;" +
@@ -134,12 +139,14 @@ public class ModifiersTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void accessToStaticMethodsOfInterface() {
         assertEval("interface A { static void x() {} }");
         assertEval("A.x();");
         assertActiveKeys();
     }
 
+    @Test
     public void finalMethod() {
         assertEval("class A { final void f() {} }");
         assertDeclareFail("class B extends A { void f() {} }",
@@ -148,6 +155,7 @@ public class ModifiersTest extends KullaTesting {
     }
 
     //TODO: is this the right semantics?
+    @Test
     public void finalConstructor() {
         assertDeclareFail("class A { final A() {} }",
                 new ExpectedDiagnostic("compiler.err.mod.not.allowed.here", 10, 22, 16, -1, -1, Diagnostic.Kind.ERROR));
@@ -155,6 +163,7 @@ public class ModifiersTest extends KullaTesting {
     }
 
     //TODO: is this the right semantics?
+    @Test
     public void finalDefaultMethod() {
         assertDeclareFail("interface A { final default void a() {} }",
                 new ExpectedDiagnostic("compiler.err.mod.not.allowed.here", 14, 39, 33, -1, -1, Diagnostic.Kind.ERROR));

--- a/test/langtools/jdk/jshell/MyExecutionControl.java
+++ b/test/langtools/jdk/jshell/MyExecutionControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import jdk.jshell.execution.Util;
 import jdk.jshell.spi.ExecutionControl;
 import jdk.jshell.spi.ExecutionControl.EngineTerminationException;
 import jdk.jshell.spi.ExecutionEnv;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static jdk.jshell.execution.Util.remoteInputOutput;
 
 class MyExecutionControl extends JdiExecutionControl {

--- a/test/langtools/jdk/jshell/NullTest.java
+++ b/test/langtools/jdk/jshell/NullTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,14 @@
  * @test
  * @summary null test
  * @build KullaTesting TestingInputStream
- * @run testng NullTest
+ * @run junit NullTest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class NullTest extends KullaTesting {
 
+    @Test
     public void testNull() {
         assertEval("null;", "null");
         assertEval("(Object)null;", "null");

--- a/test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
+++ b/test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build Compiler UITesting
  * @build PasteAndMeasurementsUITest
- * @run testng/othervm PasteAndMeasurementsUITest
+ * @run junit/othervm PasteAndMeasurementsUITest
  */
 
 import java.io.Console;
@@ -46,15 +46,15 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import jdk.internal.org.jline.reader.impl.LineReaderImpl;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class PasteAndMeasurementsUITest extends UITesting {
 
     public PasteAndMeasurementsUITest() {
         super(true);
     }
 
+    @Test
     public void testPrevNextSnippet() throws Exception {
         Field cons = System.class.getDeclaredField("cons");
         cons.setAccessible(true);
@@ -77,6 +77,7 @@ public class PasteAndMeasurementsUITest extends UITesting {
     }
         private static final String LOC = "\033[12;1R";
 
+    @Test
     public void testBracketedPaste() throws Exception {
         Field cons = System.class.getDeclaredField("cons");
         cons.setAccessible(true);
@@ -91,6 +92,7 @@ public class PasteAndMeasurementsUITest extends UITesting {
         });
     }
 
+    @Test
     public void testBracketedPasteNonAscii() throws Exception {
         Field cons = System.class.getDeclaredField("cons");
         cons.setAccessible(true);

--- a/test/langtools/jdk/jshell/PipeInputStreamTest.java
+++ b/test/langtools/jdk/jshell/PipeInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @summary Verify PipeInputStream works.
  * @modules jdk.compiler/com.sun.tools.javac.util
  *          jdk.jshell/jdk.jshell.execution:open
- * @run testng PipeInputStreamTest
+ * @run junit PipeInputStreamTest
  */
 
 import java.io.InputStream;
@@ -34,28 +34,28 @@ import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
-import org.testng.annotations.Test;
 
 import com.sun.tools.javac.util.Pair;
 
-import static org.testng.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class PipeInputStreamTest {
 
+    @Test
     public void testReadArrayNotBlocking() throws Exception {
         Pair<InputStream, OutputStream> streams = createPipeStream();
         InputStream in = streams.fst;
         OutputStream out = streams.snd;
         out.write('a');
         byte[] data = new byte[12];
-        assertEquals(in.read(data), 1);
-        assertEquals(data[0], 'a');
+        assertEquals(1, in.read(data));
+        assertEquals('a', data[0]);
         out.write('a'); out.write('b'); out.write('c');
-        assertEquals(in.read(data), 3);
-        assertEquals(data[0], 'a');
-        assertEquals(data[1], 'b');
-        assertEquals(data[2], 'c');
+        assertEquals(3, in.read(data));
+        assertEquals('a', data[0]);
+        assertEquals('b', data[1]);
+        assertEquals('c', data[2]);
     }
 
     private Pair<InputStream, OutputStream> createPipeStream() throws Exception {

--- a/test/langtools/jdk/jshell/RecordsTest.java
+++ b/test/langtools/jdk/jshell/RecordsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,27 +27,27 @@
  * @summary Tests for evalution of records
  * @modules jdk.jshell
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
- * @run testng RecordsTest
+ * @run junit RecordsTest
  */
 
-import org.testng.annotations.Test;
 
 import javax.lang.model.SourceVersion;
 import jdk.jshell.Snippet.Status;
 import jdk.jshell.UnresolvedReferenceException;
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.BeforeMethod;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class RecordsTest extends KullaTesting {
 
+    @Test
     public void testRecordClass() {
         assertEval("record R(String s, int i) { }");
-        assertEquals(varKey(assertEval("R r = new R(\"r\", 42);")).name(), "r");
+        assertEquals("r", varKey(assertEval("R r = new R(\"r\", 42);")).name());
         assertEval("r.s()", "\"r\"");
         assertEval("r.i()", "42");
     }
 
+    @Test
     public void testRecordCorralling() {
         //simple record with a mistake that can be fixed by corralling:
         assertEval("record R1(int i) { int g() { return j; } }", ste(MAIN_SNIPPET, Status.NONEXISTENT, Status.RECOVERABLE_DEFINED, true, null));
@@ -66,13 +66,15 @@ public class RecordsTest extends KullaTesting {
         assertEval("R5 r5 = new R5(1);", null, UnresolvedReferenceException.class, DiagCheck.DIAG_OK, DiagCheck.DIAG_OK, added(Status.VALID));
     }
 
+    @Test
     public void testRecordField() {
-        assertEquals(varKey(assertEval("String record = \"\";")).name(), "record");
+        assertEquals("record", varKey(assertEval("String record = \"\";")).name());
         assertEval("record.length()", "0");
     }
 
+    @Test
     public void testRecordMethod() {
-        assertEquals(methodKey(assertEval("String record(String record) { return record + record; }")).name(), "record");
+        assertEquals("record", methodKey(assertEval("String record(String record) { return record + record; }")).name());
         assertEval("record(\"r\")", "\"rr\"");
         assertEval("record(\"r\").length()", "2");
     }

--- a/test/langtools/jdk/jshell/RejectedFailedTest.java
+++ b/test/langtools/jdk/jshell/RejectedFailedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,12 @@
  * @test 8080352
  * @summary Tests for hard errors, like syntax errors
  * @build KullaTesting
- * @run testng RejectedFailedTest
+ * @run junit RejectedFailedTest
  */
 
 import java.util.List;
 
 import jdk.jshell.Snippet.SubKind;
-import org.testng.annotations.Test;
 
 import jdk.jshell.Diag;
 import jdk.jshell.Snippet;
@@ -40,31 +39,31 @@ import jdk.jshell.Snippet.Status;
 
 import jdk.jshell.SnippetEvent;
 import static java.util.stream.Collectors.toList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class RejectedFailedTest extends KullaTesting {
 
     private String bad(String input, Kind kind, String prevId) {
         List<SnippetEvent> events = assertEvalFail(input);
-        assertEquals(events.size(), 1, "Expected one event, got: " + events.size());
+        assertEquals(1, events.size(), "Expected one event, got: " + events.size());
         SnippetEvent e = events.get(0);
         List<Diag> diagnostics = getState().diagnostics(e.snippet()).collect(toList());
         assertTrue(diagnostics.size() > 0, "Expected diagnostics, got none");
-        assertEquals(e.exception(), null, "Expected exception to be null.");
-        assertEquals(e.value(), null, "Expected value to be null.");
+        assertEquals(null, e.exception(), "Expected exception to be null.");
+        assertEquals(null, e.value(), "Expected value to be null.");
 
         Snippet key = e.snippet();
         assertTrue(key != null, "key must be non-null, but was null.");
-        assertEquals(key.kind(), kind, "Expected kind: " + kind + ", got: " + key.kind());
+        assertEquals(kind, key.kind(), "Expected kind: " + kind + ", got: " + key.kind());
         SubKind expectedSubKind = kind == Kind.ERRONEOUS ? SubKind.UNKNOWN_SUBKIND : SubKind.METHOD_SUBKIND;
-        assertEquals(key.subKind(), expectedSubKind, "SubKind: ");
+        assertEquals(expectedSubKind, key.subKind(), "SubKind: ");
         assertTrue(key.id().compareTo(prevId) > 0, "Current id: " + key.id() + ", previous: " + prevId);
-        assertEquals(getState().diagnostics(key).collect(toList()), diagnostics, "Expected retrieved diagnostics to match, but didn't.");
-        assertEquals(key.source(), input, "Expected retrieved source: " +
+        assertEquals(diagnostics, getState().diagnostics(key).collect(toList()), "Expected retrieved diagnostics to match, but didn't.");
+        assertEquals(input, key.source(), "Expected retrieved source: " +
                 key.source() + " to match input: " + input);
-        assertEquals(getState().status(key), Status.REJECTED, "Expected status of REJECTED, got: " + getState().status(key));
+        assertEquals(Status.REJECTED, getState().status(key), "Expected status of REJECTED, got: " + getState().status(key));
         return key.id();
     }
 
@@ -75,6 +74,7 @@ public class RejectedFailedTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testErroneous() {
         String[] inputsErroneous = {
                 "%&^%&",
@@ -86,6 +86,7 @@ public class RejectedFailedTest extends KullaTesting {
         checkByKind(inputsErroneous, Kind.ERRONEOUS);
     }
 
+    @Test
     public void testBadMethod() {
         String[] inputsMethod = {
                 "transient int m() { return x; }",

--- a/test/langtools/jdk/jshell/ReplToolTesting.java
+++ b/test/langtools/jdk/jshell/ReplToolTesting.java
@@ -45,14 +45,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
-import org.testng.annotations.BeforeMethod;
 
 import jdk.jshell.tool.JavaShellToolBuilder;
 import static java.util.stream.Collectors.toList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeEach;
 
 public class ReplToolTesting {
 
@@ -142,7 +142,7 @@ public class ReplToolTesting {
                     .filter(l -> !l.isEmpty())
                     .collect(Collectors.toList());
             int previousId = Integer.MIN_VALUE;
-            assertEquals(lines.size(), keys.size(), "Number of keys");
+            assertEquals(keys.size(), lines.size(), "Number of keys");
             for (int i = 0; i < lines.size(); ++i) {
                 String line = lines.get(i);
                 Matcher matcher = idPattern.matcher(line);
@@ -165,7 +165,7 @@ public class ReplToolTesting {
                     .filter(l -> !l.isEmpty())
                     .filter(l -> !l.startsWith("|     ")) // error/unresolved info
                     .collect(Collectors.toList());
-            assertEquals(lines.size(), set.size(), message + " : expected: " + set.keySet() + "\ngot:\n" + lines);
+            assertEquals(set.size(), lines.size(), message + " : expected: " + set.keySet() + "\ngot:\n" + lines);
             for (String line : lines) {
                 Matcher matcher = extractPattern.matcher(line);
                 assertTrue(matcher.find(), line);
@@ -265,7 +265,7 @@ public class ReplToolTesting {
         }
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         prefsMap = new HashMap<>();
         prefsMap.put("INDENT", "0");
@@ -526,7 +526,7 @@ public class ReplToolTesting {
 
     public void assertOutput(String got, String expected, String display) {
         if (expected != null) {
-            assertEquals(got, expected, display + ".\n");
+            assertEquals(expected, got, display + ".\n");
         }
     }
 

--- a/test/langtools/jdk/jshell/ReplaceTest.java
+++ b/test/langtools/jdk/jshell/ReplaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test 8080069 8152925
  * @summary Test of Snippet redefinition and replacement.
  * @build KullaTesting TestingInputStream
- * @run testng ReplaceTest
+ * @run junit ReplaceTest
  */
 
 import java.util.Iterator;
@@ -34,16 +34,16 @@ import jdk.jshell.Snippet;
 import jdk.jshell.MethodSnippet;
 import jdk.jshell.TypeDeclSnippet;
 import jdk.jshell.VarSnippet;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static jdk.jshell.Snippet.Status.*;
 import static jdk.jshell.Snippet.SubKind.*;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ReplaceTest extends KullaTesting {
 
+    @Test
     public void testRedefine() {
         Snippet vx = varKey(assertEval("int x;"));
         Snippet mu = methodKey(assertEval("int mu() { return x * 4; }"));
@@ -69,6 +69,7 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testReplaceClassToVar() {
         Snippet oldA = classKey(assertEval("class A { public String toString() { return \"old\"; } }"));
         Snippet v = varKey(assertEval("A a = new A();", "old"));
@@ -92,6 +93,7 @@ public class ReplaceTest extends KullaTesting {
         assertFalse(it.hasNext(), "expected exactly one");
     }
 
+    @Test
     public void testReplaceVarToMethod() {
         Snippet x = varKey(assertEval("int x;"));
         MethodSnippet musn = methodKey(assertEval("double mu() { return x * 4; }"));
@@ -106,6 +108,7 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testReplaceMethodToMethod() {
         Snippet a = methodKey(assertEval("double a() { return 2; }"));
         Snippet b = methodKey(assertEval("double b() { return a() * 10; }"));
@@ -119,6 +122,7 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testReplaceClassToMethod() {
         Snippet c = classKey(assertEval("class C { int f() { return 7; } }"));
         Snippet m = methodKey(assertEval("int m() { return new C().f(); }"));
@@ -130,6 +134,7 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testReplaceVarToClass() {
         Snippet x = varKey(assertEval("int x;"));
         TypeDeclSnippet c = classKey(assertEval("class A { double a = 4 * x; }"));
@@ -144,6 +149,7 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testReplaceMethodToClass() {
         Snippet x = methodKey(assertEval("int x() { return 0; }"));
         TypeDeclSnippet c = classKey(assertEval("class A { double a = 4 * x(); }"));
@@ -159,6 +165,7 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testReplaceClassToClass() {
         TypeDeclSnippet a = classKey(assertEval("class A {}"));
         assertTypeDeclSnippet(a, "A", VALID, CLASS_SUBKIND, 0, 0);
@@ -178,6 +185,7 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testOverwriteReplaceMethod() {
         MethodSnippet k1 = methodKey(assertEval("String m(Integer i) { return i.toString(); }"));
         MethodSnippet k2 = methodKey(assertEval("String m(java.lang.Integer i) { return \"java.lang.\" + i.toString(); }",
@@ -193,6 +201,7 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testImportDeclare() {
         Snippet singleImport = importKey(assertEval("import java.util.List;", added(VALID)));
         Snippet importOnDemand = importKey(assertEval("import java.util.*;", added(VALID)));
@@ -213,7 +222,8 @@ public class ReplaceTest extends KullaTesting {
         assertActiveKeys();
     }
 
-    @Test(enabled = false) // TODO 8129420
+    @Test // TODO 8129420
+    @Disabled
     public void testLocalClassEvolve() {
         Snippet j = methodKey(assertEval("Object j() { return null; }", added(VALID)));
         assertEval("Object j() { class B {}; return null; }",
@@ -227,6 +237,7 @@ public class ReplaceTest extends KullaTesting {
         assertEval("j();", "Yep");
     }
 
+    @Test
     public void testReplaceCausesMethodReferenceError() {
         Snippet l = classKey(assertEval("interface Logger { public void log(String message); }", added(VALID)));
         Snippet v = varKey(assertEval("Logger l = System.out::println;", added(VALID)));
@@ -238,6 +249,7 @@ public class ReplaceTest extends KullaTesting {
                 ste(v, VALID, RECOVERABLE_NOT_DEFINED, true, MAIN_SNIPPET));
     }
 
+    @Test
     public void testReplaceCausesClassCompilationError() {
         Snippet l = classKey(assertEval("interface L { }", added(VALID)));
         Snippet c = classKey(assertEval("class C implements L { }", added(VALID)));
@@ -249,6 +261,7 @@ public class ReplaceTest extends KullaTesting {
                 ste(c, VALID, RECOVERABLE_NOT_DEFINED, true, MAIN_SNIPPET));
     }
 
+    @Test
     public void testOverwriteNoUpdate() {
         String xsi = "int x = 5;";
         String xsd = "double x = 3.14159;";

--- a/test/langtools/jdk/jshell/SealedClassesTest.java
+++ b/test/langtools/jdk/jshell/SealedClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Test sealed class in jshell
  * @modules jdk.jshell
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
- * @run testng SealedClassesTest
+ * @run junit SealedClassesTest
  */
 
 import javax.lang.model.SourceVersion;
@@ -35,14 +35,13 @@ import javax.lang.model.SourceVersion;
 import jdk.jshell.TypeDeclSnippet;
 import jdk.jshell.Snippet.Status;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import static jdk.jshell.Snippet.Status.VALID;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class SealedClassesTest extends KullaTesting {
 
+    @Test
     public void testSealed() {
         TypeDeclSnippet base = classKey(
                 assertEval("sealed class B permits I {}",
@@ -53,6 +52,7 @@ public class SealedClassesTest extends KullaTesting {
         assertEval("new I()");
     }
 
+    @Test
     public void testNonSealed() {
         TypeDeclSnippet base = classKey(
                 assertEval("sealed class B permits I {}",

--- a/test/langtools/jdk/jshell/ShutdownTest.java
+++ b/test/langtools/jdk/jshell/ShutdownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,21 @@
  * @test
  * @summary Shutdown tests
  * @build KullaTesting TestingInputStream
- * @run testng ShutdownTest
+ * @run junit ShutdownTest
  */
 
 import java.util.function.Consumer;
 
 import jdk.jshell.JShell;
 import jdk.jshell.JShell.Subscription;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
-import static org.testng.Assert.assertEquals;
-
-@Test
 public class ShutdownTest extends KullaTesting {
 
     int shutdownCount;
@@ -45,29 +48,33 @@ public class ShutdownTest extends KullaTesting {
         ++shutdownCount;
     }
 
-    @Test(enabled = false) //TODO 8139873
+    @Test //TODO 8139873
+    @Disabled
     public void testExit() {
         shutdownCount = 0;
         getState().onShutdown(this::shutdownCounter);
         assertEval("System.exit(1);");
-        assertEquals(shutdownCount, 1);
+        assertEquals(1, shutdownCount);
     }
 
+    @Test
     public void testCloseCallback() {
         shutdownCount = 0;
         getState().onShutdown(this::shutdownCounter);
         getState().close();
-        assertEquals(shutdownCount, 1);
+        assertEquals(1, shutdownCount);
     }
 
+    @Test
     public void testCloseUnsubscribe() {
         shutdownCount = 0;
         Subscription token = getState().onShutdown(this::shutdownCounter);
         getState().unsubscribe(token);
         getState().close();
-        assertEquals(shutdownCount, 0);
+        assertEquals(0, shutdownCount);
     }
 
+    @Test
     public void testTwoShutdownListeners() {
         ShutdownListener listener1 = new ShutdownListener();
         ShutdownListener listener2 = new ShutdownListener();
@@ -76,46 +83,56 @@ public class ShutdownTest extends KullaTesting {
         getState().unsubscribe(subscription1);
         getState().close();
 
-        assertEquals(listener1.getEvents(), 0, "Checking got events");
-        assertEquals(listener2.getEvents(), 1, "Checking got events");
+        assertEquals(0, listener1.getEvents(), "Checking got events");
+        assertEquals(1, listener2.getEvents(), "Checking got events");
 
         getState().close();
 
-        assertEquals(listener1.getEvents(), 0, "Checking got events");
-        assertEquals(listener2.getEvents(), 1, "Checking got events");
+        assertEquals(0, listener1.getEvents(), "Checking got events");
+        assertEquals(1, listener2.getEvents(), "Checking got events");
 
         getState().unsubscribe(subscription2);
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test
     public void testCloseException() {
-        getState().close();
-        getState().eval("45");
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            getState().close();
+            getState().eval("45");
+        });
     }
 
-    @Test(expectedExceptions = IllegalStateException.class,
-          enabled = false) //TODO 8139873
+    @Test //TODO 8139873
+    @Disabled
     public void testShutdownException() {
-        assertEval("System.exit(0);");
-        getState().eval("45");
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            assertEval("System.exit(0);");
+            getState().eval("45");
+        });
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testNullCallback() {
-        getState().onShutdown(null);
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            getState().onShutdown(null);
+        });
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test
     public void testSubscriptionAfterClose() {
-        getState().close();
-        getState().onShutdown(e -> {});
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            getState().close();
+            getState().onShutdown(e -> {});
+        });
     }
 
-    @Test(expectedExceptions = IllegalStateException.class,
-          enabled = false) //TODO 8139873
+    @Test //TODO 8139873
+    @Disabled
     public void testSubscriptionAfterShutdown() {
-        assertEval("System.exit(0);");
-        getState().onShutdown(e -> {});
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            assertEval("System.exit(0);");
+            getState().onShutdown(e -> {});
+        });
     }
 
     private static class ShutdownListener implements Consumer<JShell> {

--- a/test/langtools/jdk/jshell/SimpleRegressionTest.java
+++ b/test/langtools/jdk/jshell/SimpleRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test 8130450 8158906 8154374 8166400 8171892 8173807 8173848
  * @summary simple regression test
  * @build KullaTesting TestingInputStream
- * @run testng SimpleRegressionTest
+ * @run junit SimpleRegressionTest
  */
 
 
@@ -36,53 +36,56 @@ import javax.tools.Diagnostic;
 import jdk.jshell.Snippet;
 import jdk.jshell.VarSnippet;
 import jdk.jshell.SnippetEvent;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
 import static jdk.jshell.Snippet.SubKind.TEMP_VAR_EXPRESSION_SUBKIND;
 import static jdk.jshell.Snippet.Status.VALID;
-import org.testng.annotations.BeforeMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class SimpleRegressionTest extends KullaTesting {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine("local"));
     }
 
+    @Test
     public void testSnippetMemberAssignment() {
         assertEval("class C { int y; }");
         assertEval("C c = new C();");
         assertVarKeyMatch("c.y = 4;", true, "$1", TEMP_VAR_EXPRESSION_SUBKIND, "int", added(VALID));
     }
 
+    @Test
     public void testUserTakesTempVarName() {
         assertEval("int $2 = 4;");
         assertEval("String $1;");
         assertVarKeyMatch("1234;", true, "$3", TEMP_VAR_EXPRESSION_SUBKIND, "int", added(VALID));
     }
 
+    @Test
     public void testCompileThrow() {
         assertEvalException("throw new Exception();");
     }
 
+    @Test
     public void testMultiSnippetDependencies() {
         List<SnippetEvent> events = assertEval("int a = 3, b = a+a, c = b *100;",
                 DiagCheck.DIAG_OK, DiagCheck.DIAG_OK,
                 chain(added(VALID)),
                 chain(added(VALID)),
                 chain(added(VALID)));
-        assertEquals(events.get(0).value(), "3");
-        assertEquals(events.get(1).value(), "6");
-        assertEquals(events.get(2).value(), "600");
+        assertEquals("3", events.get(0).value());
+        assertEquals("6", events.get(1).value());
+        assertEquals("600", events.get(2).value());
         assertEval("c;", "600");
     }
 
+    @Test
     public void testLessThanParsing() {
         assertEval("int x = 3;", "3");
         assertEval("int y = 4;", "4");
@@ -92,18 +95,22 @@ public class SimpleRegressionTest extends KullaTesting {
         assertEval("x < y && y < z", "true");
     }
 
+    @Test
     public void testNotStmtCannotResolve() {
         assertDeclareFail("dfasder;", new ExpectedDiagnostic("compiler.err.cant.resolve.location", 0, 7, 0, -1, -1, Diagnostic.Kind.ERROR));
     }
 
+    @Test
     public void testNotStmtIncomparable() {
         assertDeclareFail("true == 5.0;", new ExpectedDiagnostic("compiler.err.incomparable.types", 0, 11, 5, -1, -1, Diagnostic.Kind.ERROR));
     }
 
+    @Test
     public void testStringAdd() {
         assertEval("String s = \"a\" + \"b\";", "\"ab\"");
     }
 
+    @Test
     public void testExprSanity() {
         assertEval("int x = 3;", "3");
         assertEval("int y = 4;", "4");
@@ -111,13 +118,15 @@ public class SimpleRegressionTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testGenericMethodCrash() {
         assertDeclareWarn1("<T> void f(T...a) {}", (ExpectedDiagnostic) null);
         Snippet sn = methodKey(assertEval("<R> R n(R x) { return x; }", added(VALID)));
         VarSnippet sne = varKey(assertEval("n(5)", added(VALID)));
-        assertEquals(sne.typeName(), "Integer");
+        assertEquals("Integer", sne.typeName());
     }
 
+    @Test
     public void testLongRemoteStrings() { //8158906
         assertEval("String m(int x) { byte[] b = new byte[x]; for (int i = 0; i < x; ++i) b[i] = (byte) 'a'; return new String(b); }");
         boolean[] shut = new boolean[1];
@@ -127,12 +136,13 @@ public class SimpleRegressionTest extends KullaTesting {
         for (String len : new String[]{"12345", "64000", "65535", "65536", "120000"}) {
             List<SnippetEvent> el = assertEval("m(" + len + ");");
             assertFalse(shut[0], "JShell died with long string");
-            assertEquals(el.size(), 1, "Excepted one event");
+            assertEquals(1, el.size(), "Excepted one event");
             assertTrue(el.get(0).value().length() > 10000,
                     "Expected truncated but long String, got: " + el.get(0).value().length());
         }
     }
 
+    @Test
     public void testLongRemoteJapaneseStrings() { //8158906
         assertEval("import java.util.stream.*;");
         assertEval("String m(int x) { return Stream.generate(() -> \"\u3042\").limit(x).collect(Collectors.joining()); }");
@@ -143,13 +153,14 @@ public class SimpleRegressionTest extends KullaTesting {
         for (String len : new String[]{"12345", "21843", "21844", "21845", "21846", "64000", "65535", "65536", "120000"}) {
             List<SnippetEvent> el = assertEval("m(" + len + ");");
             assertFalse(shut[0], "JShell died with long string");
-            assertEquals(el.size(), 1, "Excepted one event");
+            assertEquals(1, el.size(), "Excepted one event");
             assertTrue(el.get(0).value().length() > 10000,
                     "Expected truncated but long String, got: " + el.get(0).value().length());
         }
     }
 
     // 8130450
+    @Test
     public void testDuplicate() {
         Snippet snm = methodKey(assertEval("void mm() {}", added(VALID)));
         assertEval("void mm() {}",
@@ -161,11 +172,13 @@ public class SimpleRegressionTest extends KullaTesting {
                 ste(snv, VALID, OVERWRITTEN, false, MAIN_SNIPPET));
     }
 
+    @Test
     public void testContextClassLoader() {
         assertEval("class C {}");
         assertEval("C.class.getClassLoader() == Thread.currentThread().getContextClassLoader()", "true");
     }
 
+    @Test
     public void testArrayRepresentation() {
         assertEval("new int[4]", "int[4] { 0, 0, 0, 0 }");
         assertEval("new int[0]", "int[0] {  }");
@@ -183,6 +196,7 @@ public class SimpleRegressionTest extends KullaTesting {
                 "Object[3] { \"howdy\", int[3] { 33, 44, 55 }, String[2] { \"up\", \"down\" } }");
     }
 
+    @Test
     public void testMultiDimArrayRepresentation() {
         assertEval("new int[3][1]",
                 "int[3][] { int[1] { 0 }, int[1] { 0 }, int[1] { 0 } }");
@@ -199,6 +213,7 @@ public class SimpleRegressionTest extends KullaTesting {
                 "boolean[2][][] { boolean[1][] { boolean[3] { false, false, false } }, boolean[1][] { boolean[3] { false, false, false } } }");
     }
 
+    @Test
     public void testStringRepresentation() {
         assertEval("\"A!\\rB!\"",
                    "\"A!\\rB!\"");
@@ -216,6 +231,7 @@ public class SimpleRegressionTest extends KullaTesting {
                    "null");
     }
 
+    @Test
     public void testCharRepresentation() {
         for (String s : new String[]{"'A'", "'Z'", "'0'", "'9'",
             "'a'", "'z'", "'*'", "'%'",

--- a/test/langtools/jdk/jshell/SnippetStatusListenerTest.java
+++ b/test/langtools/jdk/jshell/SnippetStatusListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @summary Subscribe tests
  * @build KullaTesting TestingInputStream
- * @run testng SnippetStatusListenerTest
+ * @run junit SnippetStatusListenerTest
  */
 
 import java.util.ArrayList;
@@ -37,14 +37,16 @@ import jdk.jshell.DeclarationSnippet;
 import jdk.jshell.JShell.Subscription;
 import jdk.jshell.SnippetEvent;
 import jdk.jshell.TypeDeclSnippet;
-import org.testng.annotations.Test;
 
 import static jdk.jshell.Snippet.Status.*;
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class SnippetStatusListenerTest extends KullaTesting {
 
+    @Test
     public void testTwoSnippetEventListeners() {
         SnippetListener listener1 = new SnippetListener();
         SnippetListener listener2 = new SnippetListener();
@@ -61,45 +63,52 @@ public class SnippetStatusListenerTest extends KullaTesting {
         assertEval("int a = 0;");
 
         List<SnippetEvent> events1 = Collections.unmodifiableList(listener1.getEvents());
-        assertEquals(events1, listener2.getEvents(), "Checking got events");
+        assertEquals(listener2.getEvents(), events1, "Checking got events");
         getState().unsubscribe(subscription1);
 
         assertDrop(f, DiagCheck.DIAG_IGNORE, DiagCheck.DIAG_IGNORE, ste(f, REJECTED, DROPPED, false, null));
         assertEval("void f() { }", added(VALID));
         assertEvalException("throw new RuntimeException();");
-        assertEquals(listener1.getEvents(), events1, "Checking that unsubscribed listener does not get events");
+        assertEquals(events1, listener1.getEvents(), "Checking that unsubscribed listener does not get events");
 
         List<SnippetEvent> events2 = new ArrayList<>(listener2.getEvents());
         events2.removeAll(events1);
 
-        assertEquals(events2.size(), 3, "The second listener got events");
+        assertEquals(3, events2.size(), "The second listener got events");
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testNullCallback() {
-        getState().onSnippetEvent(null);
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            getState().onSnippetEvent(null);
+        });
     }
 
-    @Test(expectedExceptions = IllegalStateException.class)
+    @Test
     public void testSubscriptionAfterClose() {
-        getState().close();
-        getState().onSnippetEvent(e -> {});
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            getState().close();
+            getState().onSnippetEvent(e -> {});
+        });
     }
 
-    @Test(expectedExceptions = IllegalStateException.class,
-          enabled = false) //TODO 8139873
+    @Test //TODO 8139873
+    @Disabled
     public void testSubscriptionAfterShutdown() {
-        assertEval("System.exit(0);");
-        getState().onSnippetEvent(e -> {});
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            assertEval("System.exit(0);");
+            getState().onSnippetEvent(e -> {});
+        });
     }
 
+    @Test
     public void testSubscriptionToAnotherState() {
         SnippetListener listener = new SnippetListener();
         Subscription subscription = getState().onSnippetEvent(listener);
         tearDown();
         setUp();
         assertEval("int x;");
-        assertEquals(Collections.emptyList(), listener.getEvents(), "No events");
+        assertEquals(listener.getEvents(), Collections.emptyList(), "No events");
         getState().unsubscribe(subscription);
     }
 

--- a/test/langtools/jdk/jshell/SnippetTest.java
+++ b/test/langtools/jdk/jshell/SnippetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,74 +26,86 @@
  * @bug 8139829
  * @summary test accessors of Snippet
  * @build KullaTesting TestingInputStream
- * @run testng SnippetTest
+ * @run junit SnippetTest
  */
 
 import jdk.jshell.Snippet;
 import jdk.jshell.DeclarationSnippet;
-import org.testng.annotations.Test;
 
 import jdk.jshell.MethodSnippet;
 import jdk.jshell.Snippet.Status;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static jdk.jshell.Snippet.Status.VALID;
 import static jdk.jshell.Snippet.Status.RECOVERABLE_DEFINED;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
 import static jdk.jshell.Snippet.Status.RECOVERABLE_NOT_DEFINED;
 import static jdk.jshell.Snippet.SubKind.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class SnippetTest extends KullaTesting {
 
+    @Test
     public void testImportKey() {
         assertImportKeyMatch("import java.util.List;", "List", SINGLE_TYPE_IMPORT_SUBKIND, added(VALID));
         assertImportKeyMatch("import java.util.*;", "java.util.*", TYPE_IMPORT_ON_DEMAND_SUBKIND, added(VALID));
         assertImportKeyMatch("import static java.lang.String.*;", "java.lang.String.*", STATIC_IMPORT_ON_DEMAND_SUBKIND, added(VALID));
     }
 
+    @Test
     public void testClassKey() {
         assertDeclarationKeyMatch("class X {}", false, "X", CLASS_SUBKIND, added(VALID));
     }
 
+    @Test
     public void testInterfaceKey() {
         assertDeclarationKeyMatch("interface I {}", false, "I", INTERFACE_SUBKIND, added(VALID));
     }
 
+    @Test
     public void testEnumKey() {
         assertDeclarationKeyMatch("enum E {}", false, "E", ENUM_SUBKIND, added(VALID));
     }
 
+    @Test
     public void testAnnotationKey() {
         assertDeclarationKeyMatch("@interface A {}", false, "A", ANNOTATION_TYPE_SUBKIND, added(VALID));
     }
 
+    @Test
     public void testMethodKey() {
         assertDeclarationKeyMatch("void m() {}", false, "m", METHOD_SUBKIND, added(VALID));
     }
 
+    @Test
     public void testVarDeclarationKey() {
         assertVarKeyMatch("int a;", true, "a", VAR_DECLARATION_SUBKIND, "int", added(VALID));
     }
 
+    @Test
     public void testVarDeclarationWithInitializerKey() {
         assertVarKeyMatch("double b = 9.0;", true, "b", VAR_DECLARATION_WITH_INITIALIZER_SUBKIND, "double", added(VALID));
     }
 
+    @Test
     public void testTempVarExpressionKey() {
         assertVarKeyMatch("47;", true, "$1", TEMP_VAR_EXPRESSION_SUBKIND, "int", added(VALID));
     }
 
+    @Test
     public void testVarValueKey() {
         assertEval("double x = 4;", "4.0");
         assertExpressionKeyMatch("x;", "x", VAR_VALUE_SUBKIND, "double");
     }
 
+    @Test
     public void testAssignmentKey() {
         assertEval("int y;");
         assertExpressionKeyMatch("y = 4;", "y", ASSIGNMENT_SUBKIND, "int");
     }
 
+    @Test
     public void testStatementKey() {
         assertKeyMatch("if (true) {}", true, STATEMENT_SUBKIND, added(VALID));
         assertKeyMatch("while (true) { break; }", true, STATEMENT_SUBKIND, added(VALID));
@@ -101,10 +113,12 @@ public class SnippetTest extends KullaTesting {
         assertKeyMatch("for (;;) { break; }", true, STATEMENT_SUBKIND, added(VALID));
     }
 
+    @Test
     public void noKeys() {
         assertActiveKeys(new DeclarationSnippet[0]);
     }
 
+    @Test
     public void testKeyId1() {
         Snippet a = classKey(assertEval("class A { }"));
         assertEval("void f() {  }");
@@ -116,7 +130,8 @@ public class SnippetTest extends KullaTesting {
         assertActiveKeys();
     }
 
-    @Test(enabled = false) // TODO 8081689
+    @Test // TODO 8081689
+    @Disabled
     public void testKeyId2() {
         Snippet g = methodKey(assertEval("void g() { f(); }", added(RECOVERABLE_DEFINED)));
         Snippet f = methodKey(assertEval("void f() { }",
@@ -136,6 +151,7 @@ public class SnippetTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testKeyId3() {
         Snippet g = methodKey(assertEval("void g() { f(); }", added(RECOVERABLE_DEFINED)));
         Snippet f = methodKey(assertEval("void f() { }",
@@ -154,6 +170,7 @@ public class SnippetTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void testBooleanSnippetQueries() {
         Snippet nd = varKey(assertEval("blort x;", added(RECOVERABLE_NOT_DEFINED)));
         assertTrue(nd.kind().isPersistent(), "nd.isPersistent");

--- a/test/langtools/jdk/jshell/SourceLevelTest.java
+++ b/test/langtools/jdk/jshell/SourceLevelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,15 +26,16 @@
  * @bug 8259820
  * @summary Check JShell can handle -source 8
  * @modules jdk.jshell
- * @run testng SourceLevelTest
+ * @run junit SourceLevelTest
  */
 
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SourceLevelTest extends ReplToolTesting {
 
-    @DataProvider(name="sourceLevels")
     public Object[][] sourceLevels() {
         return new Object[][] {
             new Object[] {"8"},
@@ -42,7 +43,8 @@ public class SourceLevelTest extends ReplToolTesting {
         };
     }
 
-    @Test(dataProvider="sourceLevels")
+    @ParameterizedTest
+    @MethodSource("sourceLevels")
     public void testSourceLevel(String sourceLevel) {
         test(new String[] {"-C", "-source", "-C", sourceLevel},
                 (a) -> assertCommand(a, "1 + 1", "$1 ==> 2"),

--- a/test/langtools/jdk/jshell/StartOptionTest.java
+++ b/test/langtools/jdk/jshell/StartOptionTest.java
@@ -30,7 +30,7 @@
  *          jdk.jshell/jdk.internal.jshell.tool
  * @library /tools/lib
  * @build Compiler toolbox.ToolBox
- * @run testng StartOptionTest
+ * @run junit StartOptionTest
  */
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -46,16 +46,15 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 import jdk.jshell.tool.JavaShellToolBuilder;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class StartOptionTest {
 
     protected ByteArrayOutputStream cmdout;
@@ -97,7 +96,7 @@ public class StartOptionTest {
         if (checkOut != null) {
             checkOut.accept(out);
         } else {
-            assertEquals(out, "", label + ": Expected empty -- ");
+            assertEquals("", out, label + ": Expected empty -- ");
         }
     }
 
@@ -105,7 +104,7 @@ public class StartOptionTest {
         if (checkCode != null) {
             checkCode.accept(ec);
         } else {
-            assertEquals(ec, 0, "Expected standard exit code (0), but found: " + ec);
+            assertEquals(0, ec, "Expected standard exit code (0), but found: " + ec);
         }
     }
 
@@ -128,8 +127,7 @@ public class StartOptionTest {
 
     // Start with an exit code and command error check
     protected void startExCe(int eec, Consumer<String> checkError, String... args) {
-        StartOptionTest.this.startExCoUoCeCn(
-                (Integer ec) -> assertEquals((int) ec, eec,
+        StartOptionTest.this.startExCoUoCeCn((Integer ec) -> assertEquals(eec, (int) ec,
                         "Expected error exit code (" + eec + "), but found: " + ec),
                 null, null, checkError, null, args);
     }
@@ -142,7 +140,7 @@ public class StartOptionTest {
     private Consumer<String> assertOrNull(String expected, String label) {
         return expected == null
                 ? null
-                : s -> assertEquals(s.replaceAll("\\r\\n?", "\n").trim(), expected.trim(), label);
+                : s -> assertEquals(expected.trim(), s.replaceAll("\\r\\n?", "\n").trim(), label);
     }
 
     // Start and check the resultant: exit code (Ex), command output (Co),
@@ -153,10 +151,9 @@ public class StartOptionTest {
             String expectedError,
             String expectedConsole,
             String... args) {
-        startExCoUoCeCn(
-                expectedExitCode == 0
+        startExCoUoCeCn(expectedExitCode == 0
                         ? null
-                        : (Integer i) -> assertEquals((int) i, expectedExitCode,
+                        : (Integer i) -> assertEquals(expectedExitCode, (int) i,
                         "Expected exit code (" + expectedExitCode + "), but found: " + i),
                 assertOrNull(expectedCmdOutput, "cmdout: "),
                 assertOrNull(expectedUserOutput, "userout: "),
@@ -180,7 +177,7 @@ public class StartOptionTest {
         startExCoUoCeCn(0, null, expectedUserOutput, null, null, args);
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUp() {
         cmdout = new ByteArrayOutputStream();
         cmderr = new ByteArrayOutputStream();
@@ -203,6 +200,7 @@ public class StartOptionTest {
     }
 
     // Test load files
+    @Test
     public void testCommandFile() {
         String fn = writeToFile("String str = \"Hello \"\n" +
                 "/list\n" +
@@ -217,6 +215,7 @@ public class StartOptionTest {
     }
 
     // Test that the usage message is printed
+    @Test
     public void testUsage() {
         for (String opt : new String[]{"-?", "-h", "--help"}) {
             startCo(s -> {
@@ -229,6 +228,7 @@ public class StartOptionTest {
     }
 
     // Test the --help-extra message
+    @Test
     public void testHelpExtra() {
         for (String opt : new String[]{"-X", "--help-extra"}) {
             startCo(s -> {
@@ -241,12 +241,14 @@ public class StartOptionTest {
     }
 
     // Test handling of bogus options
+    @Test
     public void testUnknown() {
         startExCe(1, "Unknown option: u", "-unknown");
         startExCe(1, "Unknown option: unknown", "--unknown");
     }
 
     // Test that input is read with "-" and there is no extra output.
+    @Test
     public void testHypenFile() {
         setIn("System.out.print(\"Hello\");\n");
         startUo("Hello", "-");
@@ -263,6 +265,7 @@ public class StartOptionTest {
     }
 
     // Test that user specified exit codes are propagated
+    @Test
     public void testExitCode() {
         setIn("/exit 57\n");
         startExCoUoCeCn(57, null, null, null, "-> /exit 57", "-s");
@@ -277,11 +280,13 @@ public class StartOptionTest {
     }
 
     // Test that non-existent load file sends output to stderr and does not startExCe (no welcome).
+    @Test
     public void testUnknownLoadFile() {
         startExCe(1, "File 'UNKNOWN' for 'jshell' is not found.", "UNKNOWN");
     }
 
     // Test bad usage of the --startup option
+    @Test
     public void testStartup() {
         String fn = writeToFile("");
         startExCe(1, "Argument to startup missing.", "--startup");
@@ -291,18 +296,21 @@ public class StartOptionTest {
     }
 
     // Test an option that causes the back-end to fail is propagated
+    @Test
     public void testStartupFailedOption() {
         startExCe(1, s -> assertTrue(s.contains("Unrecognized option: -hoge-foo-bar"), "cmderr: " + s),
                 "-R-hoge-foo-bar");
     }
 
     // Test the use of non-existant files with the --startup option
+    @Test
     public void testStartupUnknown() {
         startExCe(1, "File 'UNKNOWN' for '--startup' is not found.", "--startup", "UNKNOWN");
         startExCe(1, "File 'UNKNOWN' for '--startup' is not found.", "--startup", "DEFAULT", "--startup", "UNKNOWN");
     }
 
     // Test bad usage of --class-path option
+    @Test
     public void testClasspath() {
         for (String cp : new String[]{"--class-path"}) {
             startExCe(1, "Only one --class-path option may be used.", cp, ".", "--class-path", ".");
@@ -311,12 +319,14 @@ public class StartOptionTest {
     }
 
     // Test bogus module on --add-modules option
+    @Test
     public void testUnknownModule() {
         startExCe(1, s -> assertTrue(s.contains("rror") && s.contains("unKnown"), "cmderr: " + s),
                 "--add-modules", "unKnown");
     }
 
     // Test that muliple feedback options fail
+    @Test
     public void testFeedbackOptionConflict() {
         startExCe(1, "Only one feedback option (--feedback, -q, -s, or -v) may be used.",
                 "--feedback", "concise", "--feedback", "verbose");
@@ -331,12 +341,14 @@ public class StartOptionTest {
     }
 
     // Test bogus arguments to the --feedback option
+    @Test
     public void testNegFeedbackOption() {
         startExCe(1, "Argument to feedback missing.", "--feedback");
         startExCe(1, "Does not match any current feedback mode: blorp -- --feedback blorp", "--feedback", "blorp");
     }
 
     // Test --version
+    @Test
     public void testVersion() {
         startCo(s -> {
             assertTrue(s.startsWith("jshell"), "unexpected version: " + s);
@@ -346,6 +358,7 @@ public class StartOptionTest {
     }
 
     // Test --show-version
+    @Test
     public void testShowVersion() {
         startExCoUoCeCn(null,
                 s -> {
@@ -358,7 +371,7 @@ public class StartOptionTest {
                 "--show-version");
     }
 
-    @AfterMethod
+    @AfterEach
     public void tearDown() {
         cmdout = null;
         cmderr = null;

--- a/test/langtools/jdk/jshell/StopExecutionTest.java
+++ b/test/langtools/jdk/jshell/StopExecutionTest.java
@@ -27,7 +27,7 @@
  * @summary Test JShell#stop
  * @modules jdk.jshell/jdk.internal.jshell.tool
  * @build KullaTesting TestingInputStream
- * @run testng StopExecutionTest
+ * @run junit StopExecutionTest
  */
 
 import java.io.IOException;
@@ -42,28 +42,30 @@ import java.util.function.Consumer;
 import jdk.internal.jshell.tool.StopDetectingInputStream;
 import jdk.internal.jshell.tool.StopDetectingInputStream.State;
 import jdk.jshell.JShell;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
-
-@Test
 public class StopExecutionTest extends KullaTesting {
 
     private final Object lock = new Object();
     private boolean isStopped;
 
-    @Test(enabled = false) // TODO 8129546
+    @Test // TODO 8129546
+    @Disabled
     public void testStopLoop() throws InterruptedException {
         scheduleStop("while (true) ;");
     }
 
-    @Test(enabled = false) // TODO 8129546
+    @Test // TODO 8129546
+    @Disabled
     public void testStopASleep() throws InterruptedException {
         scheduleStop("while (true) { try { Thread.sleep(100); } catch (InterruptedException ex) { } }");
     }
 
-    @Test(enabled = false) // TODO 8129546
+    @Test // TODO 8129546
+    @Disabled
     public void testScriptCatchesStop() throws Exception {
         scheduleStop("for (int i = 0; i < 30; i++) { try { Thread.sleep(100); } catch (Throwable ex) { } }");
     }
@@ -104,6 +106,7 @@ public class StopExecutionTest extends KullaTesting {
         t.join();
     }
 
+    @Test
     public void testStopDetectingInputRandom() throws IOException {
         long seed = System.nanoTime();
         Random r = new Random(seed);
@@ -129,10 +132,11 @@ public class StopExecutionTest extends KullaTesting {
         for (int c = 0; c < chunkSize; c++) {
             int read = buffer.read();
 
-            assertEquals(read, c);
+            assertEquals(c, read);
         }
     }
 
+    @Test
     public void testStopDetectingInputBufferWaitStop() throws Exception {
         Runnable shouldNotHappenRun =
                 () -> { throw new AssertionError("Should not happen."); };

--- a/test/langtools/jdk/jshell/T8146368/JShellTest8146368.java
+++ b/test/langtools/jdk/jshell/T8146368/JShellTest8146368.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,14 @@
  * @summary Test Smashing Error when user language is Japanese
  * @library /tools/lib /jdk/jshell
  * @build KullaTesting
- * @run testng/othervm -Duser.language=ja JShellTest8146368
+ * @run junit/othervm -Duser.language=ja JShellTest8146368
  */
 
 import static jdk.jshell.Snippet.Status.RECOVERABLE_NOT_DEFINED;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JShellTest8146368 extends KullaTesting {
+    @Test
     public void test() {
         assertEval("class A extends B {}", added(RECOVERABLE_NOT_DEFINED));
         assertEval("und m() { return new und(); }", added(RECOVERABLE_NOT_DEFINED));

--- a/test/langtools/jdk/jshell/T8146368/JShellToolTest8146368.java
+++ b/test/langtools/jdk/jshell/T8146368/JShellToolTest8146368.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,13 @@
  * @modules jdk.jshell/jdk.internal.jshell.tool
  * @library /tools/lib /jdk/jshell
  * @build ReplToolTesting
- * @run testng/othervm -Duser.language=ja JShellToolTest8146368
+ * @run junit/othervm -Duser.language=ja JShellToolTest8146368
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class JShellToolTest8146368 extends ReplToolTesting {
+    @Test
     public void test() {
         test(
                 a -> assertCommand(a, "class A extends B {}", "|  created class A, however, it cannot be referenced until class B is declared\n"),

--- a/test/langtools/jdk/jshell/ToolBasicTest.java
+++ b/test/langtools/jdk/jshell/ToolBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
  * @library /tools/lib
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build KullaTesting TestingInputStream Compiler
- * @run testng/timeout=600 ToolBasicTest
+ * @run junit/timeout=600 ToolBasicTest
  * @key intermittent
  */
 
@@ -57,19 +57,18 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.sun.net.httpserver.HttpServer;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.fail;
-
-@Test
 public class ToolBasicTest extends ReplToolTesting {
 
+    @Test
     public void elideStartUpFromList() {
-        test(
-                (a) -> assertCommandOutputContains(a, "123", "==> 123"),
+        test((a) -> assertCommandOutputContains(a, "123", "==> 123"),
                 (a) -> assertCommandCheckOutput(a, "/list", (s) -> {
                     int cnt;
                     try (Scanner scanner = new Scanner(s)) {
@@ -81,11 +80,12 @@ public class ToolBasicTest extends ReplToolTesting {
                             }
                         }
                     }
-                    assertEquals(cnt, 1, "Expected only one listed line");
+                    assertEquals(1, cnt, "Expected only one listed line");
                 })
         );
     }
 
+    @Test
     public void elideStartUpFromSave() throws IOException {
         Compiler compiler = new Compiler();
         Path path = compiler.getPath("myfile");
@@ -94,10 +94,11 @@ public class ToolBasicTest extends ReplToolTesting {
                 (a) -> assertCommand(a, "/save " + path.toString(), "")
         );
         try (Stream<String> lines = Files.lines(path)) {
-            assertEquals(lines.count(), 1, "Expected only one saved line");
+            assertEquals(1, lines.count(), "Expected only one saved line");
         }
     }
 
+    @Test
     public void testInterrupt() {
         ReplTest interrupt = (a) -> assertCommand(a, "\u0003", "");
         for (String s : new String[] { "", "\u0003" }) {
@@ -132,6 +133,7 @@ public class ToolBasicTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testCtrlD() {
         test(false, new String[]{"--no-startup"},
                 a -> {
@@ -193,6 +195,7 @@ public class ToolBasicTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testStop() {
         test(
                 (a) -> assertStop(a, "while (true) {}", ""),
@@ -200,6 +203,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRerun() {
         test(false, new String[] {"--no-startup"},
                 (a) -> assertCommand(a, "/0", "|  No snippet with ID: 0"),
@@ -221,7 +225,7 @@ public class ToolBasicTest extends ReplToolTesting {
             final int finalI = i;
             Consumer<String> check = (s) -> {
                 String[] ss = s.split("\n");
-                assertEquals(ss[0], codes[finalI]);
+                assertEquals(codes[finalI], ss[0]);
                 assertTrue(ss.length > 1, s);
             };
             tests.add((a) -> assertCommandCheckOutput(a, "/" + (finalI + 1), check));
@@ -231,7 +235,7 @@ public class ToolBasicTest extends ReplToolTesting {
             final int finalI = i;
             Consumer<String> check = (s) -> {
                 String[] ss = s.split("\n");
-                assertEquals(ss[0], codes[codes.length - finalI - 1]);
+                assertEquals(codes[codes.length - finalI - 1], ss[0]);
                 assertTrue(ss.length > 1, s);
             };
             tests.add((a) -> assertCommandCheckOutput(a, "/-" + (2 * finalI + 1), check));
@@ -241,11 +245,12 @@ public class ToolBasicTest extends ReplToolTesting {
                 tests.toArray(new ReplTest[tests.size()]));
     }
 
+    @Test
     public void test8142447() {
         Function<String, BiFunction<String, Integer, ReplTest>> assertRerun = cmd -> (code, assertionCount) ->
                 (a) -> assertCommandCheckOutput(a, cmd, s -> {
                             String[] ss = s.split("\n");
-                            assertEquals(ss[0], code);
+                            assertEquals(code, ss[0]);
                             loadVariable(a, "int", "assertionCount", Integer.toString(assertionCount), Integer.toString(assertionCount));
                         });
         ReplTest assertVariables = (a) -> assertCommandCheckOutput(a, "/v", assertVariables());
@@ -256,7 +261,7 @@ public class ToolBasicTest extends ReplToolTesting {
                 "void add(int n) { assertionCount += n; }");
         test(new String[]{"--startup", startup.toString()},
                 (a) -> assertCommand(a, "add(1)", ""), // id: 1
-                (a) -> assertCommandCheckOutput(a, "add(ONE)", s -> assertEquals(s.split("\n")[0], "|  Error:")), // id: e1
+                (a) -> assertCommandCheckOutput(a, "add(ONE)", s -> assertEquals("|  Error:", s.split("\n")[0])), // id: e1
                 (a) -> assertVariable(a, "int", "ONE", "1", "1"),
                 assertRerun.apply("/1").apply("add(1)", 2), assertVariables,
                 assertRerun.apply("/e1").apply("add(ONE)", 3), assertVariables,
@@ -270,6 +275,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testClasspathDirectory() {
         Compiler compiler = new Compiler();
         Path outDir = Paths.get("testClasspathDirectory");
@@ -285,6 +291,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testEnvInStartUp() {
         Compiler compiler = new Compiler();
         Path outDir = Paths.get("testClasspathDirectory");
@@ -320,6 +327,7 @@ public class ToolBasicTest extends ReplToolTesting {
         return compiler.getPath(outDir).resolve(jarName).toString();
     }
 
+    @Test
     public void testClasspathJar() {
         String jarPath = makeSimpleJar();
         test(
@@ -332,6 +340,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testClasspathUserHomeExpansion() {
         String jarPath = makeSimpleJar();
         String tilde = "~" + File.separator;
@@ -346,6 +355,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testBadClasspath() {
         String jarPath = makeSimpleJar();
         Compiler compiler = new Compiler();
@@ -373,6 +383,7 @@ public class ToolBasicTest extends ReplToolTesting {
         return compiler.getPath(outDir).resolve(jarName).toString();
     }
 
+    @Test
     public void testBadSourceJarClasspath() {
         String jarPath = makeBadSourceJar();
         test(
@@ -391,6 +402,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testModulePath() {
         Compiler compiler = new Compiler();
         Path modsDir = Paths.get("mods");
@@ -406,6 +418,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testModulePathUserHomeExpansion() {
         String tilde = "~" + File.separatorChar;
         test(
@@ -415,6 +428,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testBadModulePath() {
         Compiler compiler = new Compiler();
         Path t1 = compiler.getPath("whatever/thing.zip");
@@ -425,6 +439,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testStartupFileOption() {
         Compiler compiler = new Compiler();
         Path startup = compiler.getPath("StartupFileOption/startup.txt");
@@ -440,6 +455,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testLoadingFromArgs() {
         Compiler compiler = new Compiler();
         Path path = compiler.getPath("loading.repl");
@@ -450,6 +466,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReset() {
         test(
                 (a) -> assertReset(a, "/res"),
@@ -470,6 +487,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testOpen() {
         Compiler compiler = new Compiler();
         Path path = compiler.getPath("testOpen.repl");
@@ -504,6 +522,7 @@ public class ToolBasicTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testOpenLocalFileUrl() {
         Compiler compiler = new Compiler();
         Path path = compiler.getPath("testOpen.repl");
@@ -518,6 +537,7 @@ public class ToolBasicTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testOpenFileOverHttp() throws IOException {
         var script = "int a = 10;int b = 20;int c = a + b;";
 
@@ -547,6 +567,7 @@ public class ToolBasicTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testOpenResource() {
         test(new String[]{"-R", "-Duser.language=en", "-R", "-Duser.country=US"},
                 (a) -> assertCommand(a, "/open PRINTING", ""),
@@ -557,6 +578,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testSave() throws IOException {
         Compiler compiler = new Compiler();
         Path path = compiler.getPath("testSave.repl");
@@ -571,7 +593,7 @@ public class ToolBasicTest extends ReplToolTesting {
                     (a) -> assertClass(a, "class A { public String toString() { return \"A\"; } }", "class", "A"),
                     (a) -> assertCommand(a, "/save " + path.toString(), "")
             );
-            assertEquals(Files.readAllLines(path), list);
+            assertEquals(list, Files.readAllLines(path));
         }
         {
             List<String> output = new ArrayList<>();
@@ -587,7 +609,7 @@ public class ToolBasicTest extends ReplToolTesting {
                             .collect(Collectors.toList()))),
                     (a) -> assertCommand(a, "/save -all " + path.toString(), "")
             );
-            assertEquals(Files.readAllLines(path), output);
+            assertEquals(output, Files.readAllLines(path));
         }
         {
             List<String> output = new ArrayList<>();
@@ -604,7 +626,7 @@ public class ToolBasicTest extends ReplToolTesting {
                             .collect(Collectors.toList()))),
                     (a) -> assertCommand(a, "/save 2-3 1 4 " + path.toString(), "")
             );
-            assertEquals(Files.readAllLines(path), output);
+            assertEquals(output, Files.readAllLines(path));
         }
         {
             List<String> output = new ArrayList<>();
@@ -619,10 +641,11 @@ public class ToolBasicTest extends ReplToolTesting {
                     (a) -> assertCommand(a, "/save -history " + path.toString(), "")
             );
             output.add("/save -history " + path.toString());
-            assertEquals(Files.readAllLines(path), output);
+            assertEquals(output, Files.readAllLines(path));
         }
     }
 
+    @Test
     public void testStartRetain() {
         Compiler compiler = new Compiler();
         Path startUpFile = compiler.getPath("startUp.txt");
@@ -653,6 +676,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testStartSave() throws IOException {
         Compiler compiler = new Compiler();
         Path startSave = compiler.getPath("startSave.txt");
@@ -660,9 +684,10 @@ public class ToolBasicTest extends ReplToolTesting {
         List<String> lines = Files.lines(startSave)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toList());
-        assertEquals(lines, START_UP);
+        assertEquals(START_UP, lines);
     }
 
+    @Test
     public void testConstrainedUpdates() {
         test(
                 a -> assertClass(a, "class XYZZY { }", "class", "XYZZY"),
@@ -672,6 +697,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRemoteExit() {
         test(
                 a -> assertVariable(a, "int", "x"),
@@ -684,11 +710,13 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testFeedbackNegative() {
         test(a -> assertCommandCheckOutput(a, "/set feedback aaaa",
                 assertStartsWith("|  Does not match any current feedback mode")));
     }
 
+    @Test
     public void testFeedbackSilent() {
         for (String off : new String[]{"s", "silent"}) {
             test(
@@ -700,6 +728,7 @@ public class ToolBasicTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testFeedbackNormal() {
         Compiler compiler = new Compiler();
         Path testNormalFile = compiler.getPath("testConciseNormal");
@@ -726,6 +755,7 @@ public class ToolBasicTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testVarsWithNotActive() {
         test(
                 a -> assertVariable(a, "Blath", "x"),
@@ -733,6 +763,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testHistoryReference() {
         test(false, new String[]{"--no-startup"},
                 a -> assertCommand(a, "System.err.println(99)", "", "", null, "", "99\n"),
@@ -765,6 +796,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRerunIdRange() {
         Compiler compiler = new Compiler();
         Path startup = compiler.getPath("rangeStartup");
@@ -823,7 +855,8 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
-    @Test(enabled = false) // TODO 8158197
+    @Test // TODO 8158197
+    @Disabled
     public void testHeadlessEditPad() {
         String prevHeadless = System.getProperty("java.awt.headless");
         try {
@@ -836,6 +869,7 @@ public class ToolBasicTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testAddExports() {
         test(false, new String[]{"--no-startup"},
                 a -> assertCommandOutputStartsWith(a, "import jdk.internal.misc.VM;", "|  Error:")
@@ -852,6 +886,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRedeclareVariableNoInit() {
         test(
                 a -> assertCommand(a, "Integer a;", "a ==> null"),
@@ -863,6 +898,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
      }
 
+    @Test
     public void testWarningUnchecked() { //8223688
         test(false, new String[]{"--no-startup"},
                 a -> assertCommand(a, "abstract class A<T> { A(T t){} }", "|  created class A"),
@@ -874,6 +910,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testIndent() { //8223688
         prefsMap.remove("INDENT");
         test(false, new String[]{"--no-startup"},
@@ -885,6 +922,7 @@ public class ToolBasicTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testSystemExitStartUp() {
         Compiler compiler = new Compiler();
         Path startup = compiler.getPath("SystemExitStartUp/startup.txt");

--- a/test/langtools/jdk/jshell/ToolCommandOptionTest.java
+++ b/test/langtools/jdk/jshell/ToolCommandOptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,16 +30,16 @@
  *          jdk.compiler/com.sun.tools.javac.main
  * @library /tools/lib
  * @build ToolCommandOptionTest ReplToolTesting
- * @run testng ToolCommandOptionTest
+ * @run junit ToolCommandOptionTest
  */
 import java.nio.file.Path;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ToolCommandOptionTest extends ReplToolTesting {
 
+    @Test
     public void listTest() {
         test(
                 (a) -> assertCommand(a, "int x;",
@@ -67,6 +67,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void typesTest() {
         test(
                 (a) -> assertCommand(a, "int x",
@@ -92,6 +93,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void dropTest() {
         test(false, new String[]{"--no-startup"},
                 (a) -> assertCommand(a, "int x = 5;",
@@ -120,6 +122,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void setEditorTest() {
         test(
                 (a) -> assertCommand(a, "/set editor -furball",
@@ -157,6 +160,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void retainEditorTest() {
         test(
                 (a) -> assertCommand(a, "/set editor -retain -furball",
@@ -211,6 +215,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void setEditorEnvTest() {
         setEnvVar("EDITOR", "best one");
         setEditorEnvSubtest();
@@ -244,6 +249,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void setStartTest() {
         Compiler compiler = new Compiler();
         Path startup = compiler.getPath("StartTest/startup.txt");
@@ -288,6 +294,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void retainStartTest() {
         Compiler compiler = new Compiler();
         Path startup = compiler.getPath("StartTest/startup.txt");
@@ -337,6 +344,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void setModeTest() {
         test(
                 (a) -> assertCommandOutputContains(a, "/set mode",
@@ -399,6 +407,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void setModeSmashTest() {
         test(
                 (a) -> assertCommand(a, "/set mode mymode -command",
@@ -428,6 +437,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void retainModeTest() {
         test(
                 (a) -> assertCommandOutputStartsWith(a, "/set mode -retain",
@@ -531,6 +541,7 @@ public class ToolCommandOptionTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void retainModeDeleteLocalTest() {
         test(
                 (a) -> assertCommand(a, "/set mode rmdlt normal -command",

--- a/test/langtools/jdk/jshell/ToolEnablePreviewTest.java
+++ b/test/langtools/jdk/jshell/ToolEnablePreviewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,11 @@
  * @test
  * @bug 8199193
  * @summary Tests for the --enable-preview option
- * @run testng ToolEnablePreviewTest
+ * @run junit ToolEnablePreviewTest
  */
 
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class ToolEnablePreviewTest extends ReplToolTesting {
 

--- a/test/langtools/jdk/jshell/ToolFormatTest.java
+++ b/test/langtools/jdk/jshell/ToolFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,21 +31,22 @@
  *          jdk.jdeps/com.sun.tools.javap
  *          jdk.jshell/jdk.internal.jshell.tool
  * @build KullaTesting TestingInputStream toolbox.ToolBox Compiler
- * @run testng ToolFormatTest
+ * @run junit ToolFormatTest
  */
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ToolFormatTest extends ReplToolTesting {
 
+    @Test
     public void testSetFormat() {
         try {
             test(
@@ -86,6 +87,7 @@ public class ToolFormatTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testSetFormatOverride() {
         test(
                 (a) -> assertCommand(a, "/set mode tm -c", "|  Created new feedback mode: tm"),
@@ -138,6 +140,7 @@ public class ToolFormatTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testSetFormatSelectorSample() {
         test(
                 (a) -> assertCommandOutputStartsWith(a, "/set mode ate -quiet",
@@ -197,7 +200,8 @@ public class ToolFormatTest extends ReplToolTesting {
     // A sampling of these has been added (above: testSetFormatSelectorSample).
     // See 8173007
     // Save for possible future deep testing or debugging
-    @Test(enabled = false)
+    @Test
+    @Disabled
     public void testSetFormatSelector() {
         List<ReplTest> tests = new ArrayList<>();
         tests.add((a) -> assertCommandOutputStartsWith(a, "/set mode ate -quiet",
@@ -278,6 +282,7 @@ public class ToolFormatTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testSetTruncation() {
         try {
             test(
@@ -308,6 +313,7 @@ public class ToolFormatTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testDefaultTruncation() {
         test(
                     (a) -> assertCommand(a, "char[] cs = new char[2000];", null),
@@ -330,9 +336,9 @@ public class ToolFormatTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testPrompt() {
-        test(
-                (a) -> assertCommand(a, "/set mode tp -quiet", "|  Created new feedback mode: tp"),
+        test((a) -> assertCommand(a, "/set mode tp -quiet", "|  Created new feedback mode: tp"),
                 (a) -> assertCommand(a, "/set prompt tp 'aaa' 'bbb'", ""),
                 (a) -> assertCommand(a, "/set prompt tp",
                         "|  /set prompt tp \"aaa\" \"bbb\""),
@@ -346,21 +352,21 @@ public class ToolFormatTest extends ReplToolTesting {
                         (s) -> {
                             try {
                                 BufferedReader rdr = new BufferedReader(new StringReader(s));
-                                assertEquals(rdr.readLine(), "|  /set mode tp -quiet",
+                                assertEquals("|  /set mode tp -quiet", rdr.readLine(),
                                         "|  /set mode tp -quiet");
-                                assertEquals(rdr.readLine(), "|  /set prompt tp \"aaa\" \"bbb\"",
+                                assertEquals("|  /set prompt tp \"aaa\" \"bbb\"", rdr.readLine(),
                                         "|  /set prompt tp \"aaa\" \"bbb\"");
                                 String l = rdr.readLine();
                                 while (l.startsWith("|  /set format tp ")) {
                                     l = rdr.readLine();
                                 }
-                                assertEquals(l, "|  /set mode -retain tp",
+                                assertEquals("|  /set mode -retain tp", l,
                                         "|  /set mode -retain tp");
-                                assertEquals(rdr.readLine(), "|  ",
+                                assertEquals("|  ", rdr.readLine(),
                                         "|  ");
-                                assertEquals(rdr.readLine(), "|  /set mode tp -quiet",
+                                assertEquals("|  /set mode tp -quiet", rdr.readLine(),
                                         "|  /set mode tp -quiet");
-                                assertEquals(rdr.readLine(), "|  /set prompt tp \"ccc\" \"ddd\"",
+                                assertEquals("|  /set prompt tp \"ccc\" \"ddd\"", rdr.readLine(),
                                         "|  /set prompt tp \"ccc\" \"ddd\"");
                             } catch (IOException ex) {
                                 fail("threw " + ex);
@@ -369,12 +375,14 @@ public class ToolFormatTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testShowFeedbackModes() {
         test(
                 (a) -> assertCommandOutputContains(a, "/set feedback", "normal")
         );
     }
 
+    @Test
     public void testSetNewModeQuiet() {
         try {
             test(
@@ -395,6 +403,7 @@ public class ToolFormatTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testSetError() {
         try {
             test(
@@ -472,6 +481,7 @@ public class ToolFormatTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testSetHelp() {
         try {
             test(

--- a/test/langtools/jdk/jshell/ToolLocalSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolLocalSimpleTest.java
@@ -30,12 +30,12 @@
  *          jdk.jdeps/com.sun.tools.javap
  *          jdk.jshell/jdk.internal.jshell.tool
  * @build KullaTesting TestingInputStream ToolSimpleTest
- * @run testng/othervm ToolLocalSimpleTest
+ * @run junit/othervm ToolLocalSimpleTest
  */
 
 import java.util.Locale;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class ToolLocalSimpleTest extends ToolSimpleTest {
 
@@ -51,12 +51,12 @@ public class ToolLocalSimpleTest extends ToolSimpleTest {
     @Test
     public void verifyLocal() {
         System.setProperty("LOCAL_CHECK", "Here");
-        assertEquals(System.getProperty("LOCAL_CHECK"), "Here");
+        assertEquals("Here", System.getProperty("LOCAL_CHECK"));
         test(new String[]{"--no-startup"},
                 a -> assertCommand(a, "System.getProperty(\"LOCAL_CHECK\")", "$1 ==> \"Here\""),
                 a -> assertCommand(a, "System.setProperty(\"LOCAL_CHECK\", \"After\")", "$2 ==> \"Here\"")
         );
-        assertEquals(System.getProperty("LOCAL_CHECK"), "After");
+        assertEquals("After", System.getProperty("LOCAL_CHECK"));
     }
 
     @Override

--- a/test/langtools/jdk/jshell/ToolLocaleMessageTest.java
+++ b/test/langtools/jdk/jshell/ToolLocaleMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,16 +31,15 @@
  *          jdk.jdeps/com.sun.tools.javap
  *          jdk.jshell/jdk.internal.jshell.tool
  * @build KullaTesting TestingInputStream toolbox.ToolBox Compiler
- * @run testng ToolLocaleMessageTest
+ * @run junit ToolLocaleMessageTest
  * @key intermittent
  */
 
 import java.util.Locale;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ToolLocaleMessageTest extends ReplToolTesting {
 
     void testLocale(ReplTest... tests) {
@@ -67,12 +66,14 @@ public class ToolLocaleMessageTest extends ReplToolTesting {
         });
     }
 
+    @Test
     public void testTerminate() {
         testLocale(
                 (a) -> assertCommandOK(a, "System.exit(1)", "/reload")
         );
     }
 
+    @Test
     public void testSample() {
         try {
             testLocale(
@@ -98,6 +99,7 @@ public class ToolLocaleMessageTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testCommand() {
         try {
             testLocale(
@@ -132,6 +134,7 @@ public class ToolLocaleMessageTest extends ReplToolTesting {
         }
     }
 
+    @Test
     public void testHelp() {
         testLocale(
                 (a) -> assertCommandOK(a, "/help", "/list", "/save", "/set", "[-restore]"),
@@ -153,6 +156,7 @@ public class ToolLocaleMessageTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testFeedbackError() {
         try {
             testLocale(

--- a/test/langtools/jdk/jshell/ToolMultilineSnippetHistoryTest.java
+++ b/test/langtools/jdk/jshell/ToolMultilineSnippetHistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,18 +31,18 @@
  *     jdk.jshell/jdk.jshell:open
  * @build UITesting
  * @build ToolMultilineSnippetHistoryTest
- * @run testng ToolMultilineSnippetHistoryTest
+ * @run junit ToolMultilineSnippetHistoryTest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ToolMultilineSnippetHistoryTest extends UITesting {
 
     public ToolMultilineSnippetHistoryTest() {
         super(true);
     }
 
+    @Test
     public void testUpArrow() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("int x=\n44\n");

--- a/test/langtools/jdk/jshell/ToolProviderTest.java
+++ b/test/langtools/jdk/jshell/ToolProviderTest.java
@@ -23,8 +23,8 @@
 
 import java.util.ServiceLoader;
 import javax.tools.Tool;
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 /*
  * @test
@@ -36,9 +36,8 @@ import static org.testng.Assert.assertTrue;
  *          jdk.jshell/jdk.internal.jshell.tool
  * @library /tools/lib
  * @build Compiler toolbox.ToolBox
- * @run testng ToolProviderTest
+ * @run junit ToolProviderTest
  */
-@Test
 public class ToolProviderTest extends StartOptionTest {
 
     // Through the provider, the console and console go to command out (we assume,
@@ -71,6 +70,7 @@ public class ToolProviderTest extends StartOptionTest {
 
     // Test --show-version
     @Override
+    @Test
     public void testShowVersion() {
         startCo(s -> {
             assertTrue(s.startsWith("jshell "), "unexpected version: " + s);

--- a/test/langtools/jdk/jshell/ToolReloadTest.java
+++ b/test/langtools/jdk/jshell/ToolReloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,20 +32,20 @@
  *          jdk.jshell/jdk.internal.jshell.tool
  * @library /tools/lib
  * @build KullaTesting TestingInputStream toolbox.ToolBox Compiler
- * @run testng ToolReloadTest
+ * @run junit ToolReloadTest
  */
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Function;
 
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 
-@Test
 public class ToolReloadTest extends ReplToolTesting {
 
+    @Test
     public void testReloadSnippets() {
         test(
                 (a) -> assertVariable(a, "int", "x", "5", "5"),
@@ -63,6 +63,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReloadClasspath() {
         Function<String,String> prog = (s) -> String.format(
                 "package pkg; public class A { public String toString() { return \"%s\"; } }\n", s);
@@ -89,6 +90,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReloadDrop() {
         test(false, new String[]{"--no-startup"},
                 a -> assertVariable(a, "int", "a"),
@@ -112,6 +114,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReloadQuiet() {
         test(false, new String[]{"--no-startup"},
                 a -> assertVariable(a, "int", "a"),
@@ -129,6 +132,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReloadRepeat() {
         test(false, new String[]{"--no-startup"},
                 (a) -> assertVariable(a, "int", "c", "7", "7"),
@@ -149,6 +153,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReloadIgnore() {
         test(false, new String[]{"--no-startup"},
                 (a) -> assertCommand(a, "(-)", null),
@@ -162,6 +167,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReloadResetRestore() {
         test(
                 (a) -> assertVariable(a, "int", "x", "5", "5"),
@@ -180,6 +186,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReloadCrashRestore() {
         test(
                 (a) -> assertVariable(a, "int", "x", "5", "5"),
@@ -200,6 +207,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testEnvBadModule() {
         test(new String[] {"--execution", Presets.TEST_STANDARD_EXECUTION},
                 (a) -> assertVariable(a, "int", "x", "5", "5"),
@@ -221,6 +229,7 @@ public class ToolReloadTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testReloadExitRestore() {
         test(false, new String[]{"--no-startup"},
                 (a) -> assertVariable(a, "int", "x", "5", "5"),

--- a/test/langtools/jdk/jshell/ToolRetainTest.java
+++ b/test/langtools/jdk/jshell/ToolRetainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,15 +27,15 @@
  * @summary Tests of what information is retained across jshell tool runs
  * @modules jdk.jshell/jdk.internal.jshell.tool
  * @build ToolRetainTest ReplToolTesting
- * @run testng ToolRetainTest
+ * @run junit ToolRetainTest
  */
 
 import java.util.Locale;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ToolRetainTest extends ReplToolTesting {
 
+    @Test
     public void testRetainMode() {
         test(
                 (a) -> assertCommand(a, "/set mode trm -quiet", "|  Created new feedback mode: trm"),
@@ -53,6 +53,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRetain2Mode() {
         test(
                 (a) -> assertCommand(a, "/set mode trm1 -quiet", "|  Created new feedback mode: trm1"),
@@ -81,6 +82,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRetainFeedback() {
         test(
                 (a) -> assertCommand(a, "/set feedback -retain verbose", "|  Feedback mode: verbose"),
@@ -95,6 +97,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRetainFeedbackBlank() {
         String feedbackOut =
                         "|  /set feedback -retain verbose\n" +
@@ -116,6 +119,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRetainEditor() {
         test(
                 (a) -> assertCommand(a, "/set editor -retain nonexistent",
@@ -130,6 +134,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRetainEditorBlank() {
         test(
                 (a) -> assertCommand(a, "/set editor nonexistent", "|  Editor set to: nonexistent"),
@@ -142,6 +147,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRetainModeNeg() {
         test(
                 (a) -> assertCommandOutputStartsWith(a, "/set mode -retain verbose",
@@ -151,6 +157,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testRetainFeedbackNeg() {
         test(
                 (a) -> assertCommandOutputStartsWith(a, "/set feedback -retain babble1",
@@ -167,6 +174,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testNoRetainMode() {
         test(
                 (a) -> assertCommand(a, "/set mode trm -quiet", "|  Created new feedback mode: trm"),
@@ -182,6 +190,7 @@ public class ToolRetainTest extends ReplToolTesting {
         );
     }
 
+    @Test
     public void testNoRetainFeedback() {
         test(
                 (a) -> assertCommand(a, "/set feedback verbose", "|  Feedback mode: verbose"),

--- a/test/langtools/jdk/jshell/ToolShiftTabTest.java
+++ b/test/langtools/jdk/jshell/ToolShiftTabTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,18 +31,18 @@
  *     jdk.jshell/jdk.jshell:open
  * @build UITesting
  * @build ToolShiftTabTest
- * @run testng/timeout=300 ToolShiftTabTest
+ * @run junit/timeout=300 ToolShiftTabTest
  */
 
 import java.util.regex.Pattern;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ToolShiftTabTest extends UITesting {
 
     // Shift-tab as escape sequence
     private String FIX = "\033\133\132";
 
+    @Test
     public void testFixVariable() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("3+4");
@@ -54,6 +54,7 @@ public class ToolShiftTabTest extends UITesting {
         });
     }
 
+    @Test
     public void testFixMethod() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("5.5 >= 3.1415926535");
@@ -68,6 +69,7 @@ public class ToolShiftTabTest extends UITesting {
         });
     }
 
+    @Test
     public void testFixMethodVoid() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("System.out.println(\"Testing\")");
@@ -81,6 +83,7 @@ public class ToolShiftTabTest extends UITesting {
         });
     }
 
+    @Test
     public void testFixMethodNoLeaks() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("4");
@@ -106,6 +109,7 @@ public class ToolShiftTabTest extends UITesting {
         });
     }
 
+    @Test
     public void testFixImport() throws Exception {
         doRunTest((inputSink, out) -> {
             do {
@@ -123,6 +127,7 @@ public class ToolShiftTabTest extends UITesting {
         });
     }
 
+    @Test
     public void testFixBad() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("123");

--- a/test/langtools/jdk/jshell/ToolSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolSimpleTest.java
@@ -30,7 +30,7 @@
  *          jdk.jdeps/com.sun.tools.javap
  *          jdk.jshell/jdk.internal.jshell.tool
  * @build KullaTesting TestingInputStream
- * @run testng ToolSimpleTest
+ * @run junit ToolSimpleTest
  */
 
 import java.util.ArrayList;
@@ -42,10 +42,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class ToolSimpleTest extends ReplToolTesting {
 
@@ -538,7 +537,7 @@ public class ToolSimpleTest extends ReplToolTesting {
         String[] res = trimmed.isEmpty()
                 ? new String[0]
                 : trimmed.split("\n");
-        assertEquals(res.length, match.size(), "Got: " + Arrays.asList(res));
+        assertEquals(match.size(), res.length, "Got: " + Arrays.asList(res));
         for (int i = 0; i < match.size(); ++i) {
             assertTrue(res[i].contains(match.get(i)));
         }
@@ -614,7 +613,7 @@ public class ToolSimpleTest extends ReplToolTesting {
                 a -> assertCommandCheckOutput(a, "/methods print println printf",
                         s -> checkLineToList(s, printingMethodList)),
                 a -> assertCommandCheckOutput(a, "/methods println",
-                        s -> assertEquals(s.trim().split("\n").length, 10)),
+                        s -> assertEquals(10, s.trim().split("\n").length)),
                 a -> assertCommandCheckOutput(a, "/methods",
                         s -> checkLineToList(s, printingMethodList)),
                 a -> assertCommandOutputStartsWith(a, "/methods " + arg,

--- a/test/langtools/jdk/jshell/ToolTabCommandTest.java
+++ b/test/langtools/jdk/jshell/ToolTabCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,18 +34,18 @@
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build Compiler UITesting
  * @build ToolTabCommandTest
- * @run testng ToolTabCommandTest
+ * @run junit ToolTabCommandTest
  */
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ToolTabCommandTest extends UITesting {
 
     public ToolTabCommandTest() {
         super(true);
     }
 
+    @Test
     public void testCommand() throws Exception {
         // set terminal height so that help output won't hit page breaks
         System.setProperty("test.terminal.height", "1000000");
@@ -133,6 +133,7 @@ public class ToolTabCommandTest extends UITesting {
         });
     }
 
+    @Test
     public void testRerunCommands() throws Exception {
         // set terminal height so that help output won't hit page breaks
         System.setProperty("test.terminal.height", "1000000");
@@ -170,6 +171,7 @@ public class ToolTabCommandTest extends UITesting {
         });
     }
 
+    @Test
     public void testHelp() throws Exception {
         // set terminal height so that help output won't hit page breaks
         System.setProperty("test.terminal.height", "1000000");

--- a/test/langtools/jdk/jshell/ToolTabSnippetTest.java
+++ b/test/langtools/jdk/jshell/ToolTabSnippetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
  * @build Compiler UITesting
  * @build ToolTabSnippetTest
- * @run testng/timeout=300 ToolTabSnippetTest
+ * @run junit/timeout=300 ToolTabSnippetTest
  */
 
 import java.io.IOException;
@@ -48,15 +48,15 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
 import jdk.internal.jshell.tool.ConsoleIOContextTestSupport;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class ToolTabSnippetTest extends UITesting {
 
     public ToolTabSnippetTest() {
         super(true);
     }
 
+    @Test
     public void testExpression() throws Exception {
         Path classes = prepareZip();
         doRunTest((inputSink, out) -> {
@@ -208,6 +208,7 @@ public class ToolTabSnippetTest extends UITesting {
         });
     }
 
+    @Test
     public void testCleaningCompletionTODO() throws Exception {
         doRunTest((inputSink, out) -> {
             CountDownLatch testCompleteComputationStarted = new CountDownLatch(1);
@@ -241,6 +242,7 @@ public class ToolTabSnippetTest extends UITesting {
         });
     }
 
+    @Test
     public void testNoRepeat() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("String xyzAA;\n");
@@ -266,6 +268,7 @@ public class ToolTabSnippetTest extends UITesting {
         });
     }
 
+    @Test
     public void testCrash8221759() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("java.io.File.path" + TAB);
@@ -331,6 +334,7 @@ public class ToolTabSnippetTest extends UITesting {
     //where:
         private final Compiler compiler = new Compiler();
 
+    @Test
     public void testDocumentationAfterInsert() throws Exception {
         doRunTest((inputSink, out) -> {
             inputSink.write("import java.time.*\n");

--- a/test/langtools/jdk/jshell/TypeNameTest.java
+++ b/test/langtools/jdk/jshell/TypeNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,14 +26,12 @@
  * @bug 8144903 8171981 8191802 8191842
  * @summary Tests for determining the type from the expression
  * @build KullaTesting TestingInputStream
- * @run testng TypeNameTest
+ * @run junit TypeNameTest
  */
 
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import static org.testng.Assert.assertEquals;
-
-@Test
 public class TypeNameTest extends KullaTesting {
 
 
@@ -42,10 +40,11 @@ public class TypeNameTest extends KullaTesting {
     }
 
     private void assertType(String expr, String type, String inferType) {
-        assertEquals(varKey(assertEval(expr)).typeName(), type);
+        assertEquals(type, varKey(assertEval(expr)).typeName());
         assertInferredType(expr, inferType);
     }
 
+    @Test
     public void testTypeInference() {
         assertEval("import java.util.List;");
         assertEval("import java.util.ArrayList;");
@@ -75,6 +74,7 @@ public class TypeNameTest extends KullaTesting {
         assertType("(P<?>) null", "P<?>");
     }
 
+    @Test
     public void testConditionals() {
         assertEval("import java.util.List;");
         assertEval("import java.util.ArrayList;");
@@ -95,6 +95,7 @@ public class TypeNameTest extends KullaTesting {
         assertType("b? new B() : new C()", "X");
     }
 
+    @Test
     public void testJEP286NonDenotable() {
         assertEval("import java.util.List;");
         assertEval("import java.util.Arrays;");
@@ -144,6 +145,7 @@ public class TypeNameTest extends KullaTesting {
         assertType("unbStringIter().iterator().next().get(0)", "Object");
     }
 
+    @Test
     public void testJEP286NonDenotable2() {
         assertEval("import java.util.List;");
         assertEval("import java.util.Arrays;");
@@ -197,6 +199,7 @@ public class TypeNameTest extends KullaTesting {
                 "Number");
     }
 
+    @Test
     public void testVariableTypeName() {
         assertType("\"x\"", "String");
 
@@ -213,30 +216,36 @@ public class TypeNameTest extends KullaTesting {
         assertType("java.util.Locale.Category.FORMAT", "Category");
     }
 
+    @Test
     public void testReplNestedClassName() {
         assertEval("class D { static class E {} }");
         assertType("new D.E();", "D.E");
     }
 
+    @Test
     public void testAnonymousClassName() {
         assertEval("class C {}");
         assertType("new C();", "C");
         assertType("new C() { int x; };", "<anonymous class extending C>", "C");
     }
 
+    @Test
     public void testCapturedTypeName() {
         assertType("\"\".getClass();", "Class<? extends String>");
         assertType("\"\".getClass().getEnumConstants();", "String[]");
     }
 
+    @Test
     public void testJavaLang() {
         assertType("\"\";", "String");
     }
 
+    @Test
     public void testNotOverEagerPackageEating() {
         assertType("\"\".getClass().getDeclaredMethod(\"hashCode\");", "java.lang.reflect.Method");
     }
 
+    @Test
     public void testBounds() {
         assertEval("java.util.List<? extends String> list1 = java.util.Arrays.asList(\"\");");
         assertType("list1.iterator().next()", "String");

--- a/test/langtools/jdk/jshell/UITesting.java
+++ b/test/langtools/jdk/jshell/UITesting.java
@@ -61,7 +61,7 @@ public class UITesting {
         this.laxLineEndings = laxLineEndings;
     }
 
-    protected void doRunTest(Test test) throws Exception {
+    protected void doRunTest(UITest test) throws Exception {
         // turn on logging of launch failures
         Logger.getLogger("jdk.jshell.execution").setLevel(Level.ALL);
 
@@ -130,7 +130,7 @@ public class UITesting {
         }
     }
 
-    protected interface Test {
+    protected interface UITest {
         public void test(Writer inputSink, StringBuilder out) throws Exception;
     }
 

--- a/test/langtools/jdk/jshell/UnicodeTest.java
+++ b/test/langtools/jdk/jshell/UnicodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,27 +26,28 @@
  * @bug 8248157
  * @summary test Unicode characters in Snippets
  * @build KullaTesting TestingInputStream
- * @run testng UnicodeTest
+ * @run junit UnicodeTest
  */
 
 import jdk.jshell.Snippet;
 import jdk.jshell.DeclarationSnippet;
-import org.testng.annotations.Test;
 
 import jdk.jshell.Snippet.Status;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static jdk.jshell.Snippet.Status.VALID;
 import static jdk.jshell.Snippet.SubKind.*;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class UnicodeTest extends KullaTesting {
 
+    @Test
     public void testVarDeclarationKey() {
         assertVarKeyMatch("int \\u00aa;", true, "\u00aa", VAR_DECLARATION_SUBKIND, "int", added(VALID));
         assertEval("\\u00aa", "0");
     }
 
+    @Test
     public void testVarDeclarationWithInitializerKey() {
         assertVarKeyMatch("double \\u00ba\\u0044\\u0577 = 9.4;", true, "\u00ba\u0044\u0577",
                           VAR_DECLARATION_WITH_INITIALIZER_SUBKIND, "double", added(VALID));

--- a/test/langtools/jdk/jshell/UserExecutionControlTest.java
+++ b/test/langtools/jdk/jshell/UserExecutionControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,29 +26,29 @@
  * @bug 8156101 8159935 8159122 8168615
  * @summary Tests for ExecutionControl SPI
  * @build KullaTesting ExecutionControlTestBase
- * @run testng UserExecutionControlTest
+ * @run junit UserExecutionControlTest
  */
 
 
-import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.BeforeMethod;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class UserExecutionControlTest extends ExecutionControlTestBase {
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         setUp(builder -> builder.executionEngine("local"));
     }
 
+    @Test
     public void verifyLocal() throws ClassNotFoundException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
         System.setProperty("LOCAL_CHECK", "TBD");
-        assertEquals(System.getProperty("LOCAL_CHECK"), "TBD");
+        assertEquals("TBD", System.getProperty("LOCAL_CHECK"));
         assertEval("System.getProperty(\"LOCAL_CHECK\")", "\"TBD\"");
         assertEval("System.setProperty(\"LOCAL_CHECK\", \"local\")");
-        assertEquals(System.getProperty("LOCAL_CHECK"), "local");
+        assertEquals("local", System.getProperty("LOCAL_CHECK"));
     }
 
 }

--- a/test/langtools/jdk/jshell/UserInputTest.java
+++ b/test/langtools/jdk/jshell/UserInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,18 +26,18 @@
  * @bug 8131023 8167461
  * @summary Verify that the user's code can read System.in
  * @build KullaTesting TestingInputStream
- * @run testng UserInputTest
+ * @run junit UserInputTest
  * @key intermittent
  */
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class UserInputTest extends KullaTesting {
 
+    @Test
     public void testReadInput() {
         setInput("AB\n");
         assertEval("System.in.read()", "65");
@@ -45,6 +45,7 @@ public class UserInputTest extends KullaTesting {
         assertEval("System.in.read()", "67");
     }
 
+    @Test
     public void testScanner() {
         assertEval("import java.util.Scanner;");
         assertEval("Scanner s = new Scanner(System.in);");
@@ -52,6 +53,7 @@ public class UserInputTest extends KullaTesting {
         assertEval("s.nextInt();", "12");
     }
 
+    @Test
     public void testClose() {
         setInput(new InputStream() {
             private final byte[] data = new byte[] {0, 1, 2};
@@ -73,6 +75,7 @@ public class UserInputTest extends KullaTesting {
         assertEval("System.in.read();", "-1");
     }
 
+    @Test
     public void testException() {
         setInput(new InputStream() {
             private final int[] data = new int[] {0, 1, -2, 2};

--- a/test/langtools/jdk/jshell/UserJdiUserRemoteTest.java
+++ b/test/langtools/jdk/jshell/UserJdiUserRemoteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,46 +26,48 @@
  * @bug 8160128 8159935 8168615
  * @summary Tests for Aux channel, custom remote agents, custom JDI implementations.
  * @build KullaTesting ExecutionControlTestBase MyExecutionControl MyRemoteExecutionControl MyExecutionControlProvider
- * @run testng UserJdiUserRemoteTest
+ * @run junit UserJdiUserRemoteTest
  * @key intermittent
  */
 import java.io.ByteArrayOutputStream;
-import org.testng.annotations.Test;
-import org.testng.annotations.BeforeMethod;
 import jdk.jshell.Snippet;
 import static jdk.jshell.Snippet.Status.OVERWRITTEN;
 import static jdk.jshell.Snippet.Status.VALID;
 import jdk.jshell.VarSnippet;
 import jdk.jshell.spi.ExecutionControl;
 import jdk.jshell.spi.ExecutionControl.ExecutionControlException;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class UserJdiUserRemoteTest extends ExecutionControlTestBase {
 
     ExecutionControl currentEC;
     ByteArrayOutputStream auxStream;
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         auxStream = new ByteArrayOutputStream();
         setUp(builder -> builder.executionEngine(new MyExecutionControlProvider(this), null));
     }
 
+    @Test
     public void testVarValue() {
         VarSnippet dv = varKey(assertEval("double aDouble = 1.5;"));
         String vd = getState().varValue(dv);
-        assertEquals(vd, "1.5");
-        assertEquals(auxStream.toString(), "aDouble");
+        assertEquals("1.5", vd);
+        assertEquals("aDouble", auxStream.toString());
     }
 
+    @Test
     public void testExtension() throws ExecutionControlException {
         assertEval("42;");
         Object res = currentEC.extensionCommand("FROG", "test");
-        assertEquals(res, "ribbit");
+        assertEquals("ribbit", res);
     }
 
+    @Test
     public void testRedefine() {
         Snippet vx = varKey(assertEval("int x;"));
         Snippet mu = methodKey(assertEval("int mu() { return x * 4; }"));

--- a/test/langtools/jdk/jshell/VariablesTest.java
+++ b/test/langtools/jdk/jshell/VariablesTest.java
@@ -30,7 +30,7 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.jshell
  * @build Compiler KullaTesting TestingInputStream ExpectedDiagnostic
- * @run testng VariablesTest
+ * @run junit VariablesTest
  */
 
 import java.nio.file.Path;
@@ -44,18 +44,19 @@ import jdk.jshell.TypeDeclSnippet;
 import jdk.jshell.VarSnippet;
 import jdk.jshell.Snippet.SubKind;
 import jdk.jshell.SnippetEvent;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import static java.util.stream.Collectors.toList;
 import static jdk.jshell.Snippet.Status.*;
 import static jdk.jshell.Snippet.SubKind.VAR_DECLARATION_SUBKIND;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class VariablesTest extends KullaTesting {
 
+    @Test
     public void noVariables() {
         assertNumberOfActiveVariables(0);
     }
@@ -69,6 +70,7 @@ public class VariablesTest extends KullaTesting {
         }
     }
 
+    @Test
     public void testVarValue1() {
         VarSnippet v1 = varKey(assertEval("und1 a;", added(RECOVERABLE_NOT_DEFINED)));
         badVarValue(v1);
@@ -89,6 +91,7 @@ public class VariablesTest extends KullaTesting {
         badVarValue(v2);
     }
 
+    @Test
     public void testVarValue2() {
         VarSnippet v1 = (VarSnippet) assertDeclareFail("int a = 0.0;", "compiler.err.prob.found.req");
         badVarValue(v1);
@@ -97,6 +100,7 @@ public class VariablesTest extends KullaTesting {
         badVarValue(v2);
     }
 
+    @Test
     public void testSignature1() {
         VarSnippet v1 = varKey(assertEval("und1 a;", added(RECOVERABLE_NOT_DEFINED)));
         assertVariableDeclSnippet(v1, "a", "und1", RECOVERABLE_NOT_DEFINED, VAR_DECLARATION_SUBKIND, 1, 0);
@@ -116,6 +120,7 @@ public class VariablesTest extends KullaTesting {
         assertVariableDeclSnippet(v2, "a", "und2", RECOVERABLE_NOT_DEFINED, VAR_DECLARATION_SUBKIND, 1, 0);
     }
 
+    @Test
     public void testSignature2() {
         VarSnippet v1 = (VarSnippet) assertDeclareFail("int a = 0.0;", "compiler.err.prob.found.req");
         assertVariableDeclSnippet(v1, "a", "int", REJECTED, SubKind.VAR_DECLARATION_WITH_INITIALIZER_SUBKIND, 0, 1);
@@ -126,6 +131,7 @@ public class VariablesTest extends KullaTesting {
         assertVariableDeclSnippet(v2, "a", "int", DROPPED, SubKind.VAR_DECLARATION_WITH_INITIALIZER_SUBKIND, 0, 0);
     }
 
+    @Test
     public void variables() {
         VarSnippet snx = varKey(assertEval("int x = 10;"));
         VarSnippet sny = varKey(assertEval("String y = \"hi\";"));
@@ -137,22 +143,25 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void variablesArray() {
         VarSnippet sn = varKey(assertEval("int[] a = new int[12];"));
-        assertEquals(sn.typeName(), "int[]");
+        assertEquals("int[]", sn.typeName());
         assertEval("int len = a.length;", "12");
         assertVariables(variable("int[]", "a"), variable("int", "len"));
         assertActiveKeys();
     }
 
+    @Test
     public void variablesArrayOld() {
         VarSnippet sn = varKey(assertEval("int a[] = new int[12];"));
-        assertEquals(sn.typeName(), "int[]");
+        assertEquals("int[]", sn.typeName());
         assertEval("int len = a.length;", "12");
         assertVariables(variable("int[]", "a"), variable("int", "len"));
         assertActiveKeys();
     }
 
+    @Test
     public void variablesRedefinition() {
         Snippet x = varKey(assertEval("int x = 10;"));
         Snippet y = varKey(assertEval("String y = \"\";", added(VALID)));
@@ -170,6 +179,7 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void variablesTemporary() {
         assertEval("int $1 = 10;", added(VALID));
         assertEval("2 * $1;", added(VALID));
@@ -180,6 +190,7 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void variablesTemporaryNull() {
         assertEval("null;", added(VALID));
         assertVariables(variable("Object", "$1"));
@@ -194,6 +205,7 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void variablesTemporaryArrayOfCapturedType() {
         assertEval("class Test<T> { T[][] get() { return null; } }", added(VALID));
         assertEval("Test<? extends String> test() { return new Test<>(); }", added(VALID));
@@ -204,6 +216,7 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void variablesClassReplace() {
         assertEval("import java.util.*;", added(VALID));
         Snippet var = varKey(assertEval("List<Integer> list = new ArrayList<>();", "[]",
@@ -223,12 +236,14 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void variablesErrors() {
         assertDeclareFail("String;", new ExpectedDiagnostic("compiler.err.cant.resolve.location", 0, 6, 0, -1, -1, Diagnostic.Kind.ERROR));
         assertNumberOfActiveVariables(0);
         assertActiveKeys();
     }
 
+    @Test
     public void variablesUnresolvedActiveFailed() {
         VarSnippet key = varKey(assertEval("und x;", added(RECOVERABLE_NOT_DEFINED)));
         assertVariableDeclSnippet(key, "x", "und", RECOVERABLE_NOT_DEFINED, VAR_DECLARATION_SUBKIND, 1, 0);
@@ -237,12 +252,14 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void variablesUnresolvedError() {
         assertDeclareFail("und y = null;", new ExpectedDiagnostic("compiler.err.cant.resolve.location", 0, 3, 0, -1, -1, Diagnostic.Kind.ERROR));
         assertNumberOfActiveVariables(0);
         assertActiveKeys();
     }
 
+    @Test
     public void variablesMultiByteCharacterType() {
         assertEval("class \u3042 {}");
         assertEval("\u3042 \u3042 = null;", added(VALID));
@@ -261,7 +278,8 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
-    @Test(enabled = false) // TODO 8081689
+    @Test // TODO 8081689
+    @Disabled
     public void methodVariablesAreNotVisible() {
         Snippet foo = varKey(assertEval("int foo() {" +
                         "int x = 10;" +
@@ -283,7 +301,8 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
-    @Test(enabled = false) // TODO 8081689
+    @Test // TODO 8081689
+    @Disabled
     public void classFieldsAreNotVisible() {
         Snippet key = classKey(assertEval("class clazz {" +
                         "int x = 10;" +
@@ -303,6 +322,7 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void multiVariables() {
         List<SnippetEvent> abc = assertEval("int a, b, c = 10;",
                 DiagCheck.DIAG_OK, DiagCheck.DIAG_OK,
@@ -324,12 +344,14 @@ public class VariablesTest extends KullaTesting {
         assertActiveKeys();
     }
 
+    @Test
     public void syntheticVariables() {
         assertEval("assert false;");
         assertNumberOfActiveVariables(0);
         assertActiveKeys();
     }
 
+    @Test
     public void undefinedReplaceVariable() {
         Snippet key = varKey(assertEval("int d = 234;", "234"));
         assertVariables(variable("int", "d"));
@@ -339,13 +361,14 @@ public class VariablesTest extends KullaTesting {
                 ste(key, VALID, OVERWRITTEN, false, MAIN_SNIPPET)));
         //assertEquals(getState().source(snippet), src);
         //assertEquals(snippet, undefKey);
-        assertEquals(getState().status(undefKey), RECOVERABLE_NOT_DEFINED);
-        List<String> unr = getState().unresolvedDependencies((VarSnippet) undefKey).collect(toList());;
-        assertEquals(unr.size(), 1);
-        assertEquals(unr.get(0), "class undefined");
+        assertEquals(RECOVERABLE_NOT_DEFINED, getState().status(undefKey));
+        List<String> unr = getState().unresolvedDependencies((VarSnippet) undefKey).collect(toList());
+        assertEquals(1, unr.size());
+        assertEquals("class undefined", unr.get(0));
         assertVariables(variable("undefined", "d"));
     }
 
+    @Test
     public void lvti() {
         assertEval("var d = 234;", "234");
         assertEval("class Test<T> { T[][] get() { return null; } }", added(VALID));
@@ -410,12 +433,14 @@ public class VariablesTest extends KullaTesting {
         assertEval("var r16d = r16d();");
     }
 
+    @Test
     public void test8191842() {
         assertEval("import java.util.stream.*;");
         assertEval("var list = Stream.of(1, 2, 3).map(j -> new Object() { int i = j; }).collect(Collectors.toList());");
         assertEval("list.stream().map(a -> String.valueOf(a.i)).collect(Collectors.joining(\", \"));", "\"1, 2, 3\"");
     }
 
+    @Test
     public void lvtiRecompileDependentsWithIntersectionTypes() {
         assertEval("<Z extends Runnable & CharSequence> Z get1() { return null; }", added(VALID));
         assertEval("var i1 = get1();", added(VALID));
@@ -428,27 +453,32 @@ public class VariablesTest extends KullaTesting {
         assertEval("void t2() { i2.run(); i2.count(); }", added(VALID));
     }
 
+    @Test
     public void arrayInit() {
         assertEval("int[] d = {1, 2, 3};");
     }
 
+    @Test
     public void testAnonymousVar() {
         assertEval("new Object() { public String get() { return \"a\"; } }");
         assertEval("$1.get()", "\"a\"");
     }
 
+    @Test
     public void testIntersectionVar() {
         assertEval("<Z extends Runnable & CharSequence> Z get() { return null; }", added(VALID));
         assertEval("get();", added(VALID));
         assertEval("void t1() { $1.run(); $1.length(); }", added(VALID));
     }
 
+    @Test
     public void multipleCaptures() {
         assertEval("class D { D(int foo, String bar) { this.foo = foo; this.bar = bar; } int foo; String bar; } ");
         assertEval("var d = new D(34, \"hi\") { String z = foo + bar; };");
         assertEval("d.z", "\"34hi\"");
     }
 
+    @Test
     public void multipleAnonymous() {
         VarSnippet v1 = varKey(assertEval("new Object() { public int i = 42; public int i1 = i; public int m1() { return i1; } };"));
         VarSnippet v2 = varKey(assertEval("new Object() { public int i = 42; public int i2 = i; public int m2() { return i2; } };"));
@@ -466,6 +496,7 @@ public class VariablesTest extends KullaTesting {
                                                  -1, -1, Diagnostic.Kind.ERROR));
     }
 
+    @Test
     public void displayName() {
         assertVarDisplayName("var v1 = 234;", "int");
         assertVarDisplayName("var v2 = new int[] {234};", "int[]");
@@ -478,6 +509,7 @@ public class VariablesTest extends KullaTesting {
         assertVarDisplayName("var v6 = new Runnable() { public void run() { } };", "<anonymous class implementing Runnable>");
     }
 
+    @Test
     public void varType() {
         assertEval("import java.util.*;");
         var firstVar = varKey(assertEval("var v1 = List.of(1);", added(VALID)));
@@ -487,6 +519,7 @@ public class VariablesTest extends KullaTesting {
         assertEval("v2", "[1]");
     }
 
+    @Test
     public void varDeclNoInit() {
         assertVarDeclNoInit("byte", "b",  "0");
         assertVarDeclNoInit("short", "h",  "0");
@@ -500,6 +533,7 @@ public class VariablesTest extends KullaTesting {
         assertVarDeclNoInit("String", "s", "null");
     }
 
+    @Test
     public void varDeclRedefNoInit() {
         assertVarDeclRedefNoInit("byte", "b", "1", "0");
         assertVarDeclRedefNoInit("short", "h", "2", "0");
@@ -513,6 +547,7 @@ public class VariablesTest extends KullaTesting {
         assertVarDeclRedefNoInit("String", "s", "\"hi\"", "null");
     }
 
+    @Test
     public void badPkgVarDecl() {
         Compiler compiler = new Compiler();
         Path nopkgdirpath = Paths.get("cp", "xyz");
@@ -545,16 +580,16 @@ public class VariablesTest extends KullaTesting {
 
     private VarSnippet assertVarDeclNoInit(String typeName, String name, String dvalue, STEInfo mainInfo, STEInfo... updates) {
         VarSnippet vs = varKey(assertEval(typeName + " " + name + ";", dvalue, mainInfo, updates));
-        assertEquals(vs.typeName(), typeName);
+        assertEquals(typeName, vs.typeName());
         assertEval(name, dvalue, added(VALID));
         return vs;
     }
 
     private void assertVarDisplayName(String var, String typeName) {
-        assertEquals(varKey(assertEval(var)).typeName(), typeName);
+        assertEquals(typeName, varKey(assertEval(var)).typeName());
     }
 
-    @BeforeMethod
+    @BeforeEach
     @Override
     public void setUp() {
         Path path = Paths.get("cp");
@@ -611,6 +646,7 @@ public class VariablesTest extends KullaTesting {
                 .compilerOptions("--class-path", tpath));
     }
 
+    @Test
     public void varIntersection() {
         assertEval("interface Marker {}");
         assertEval("var v = (Marker & Runnable) () -> {};", added(VALID));

--- a/test/langtools/jdk/jshell/WrapperTest.java
+++ b/test/langtools/jdk/jshell/WrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,28 +27,28 @@
  * @summary test wrappers and dependencies
  * @modules jdk.jshell/jdk.jshell
  * @build KullaTesting
- * @run testng WrapperTest
+ * @run junit WrapperTest
  */
 
 import java.util.Collection;
 import java.util.List;
-import org.testng.annotations.Test;
 import jdk.jshell.ErroneousSnippet;
 import jdk.jshell.Snippet;
 import jdk.jshell.Snippet.Kind;
 import jdk.jshell.SourceCodeAnalysis.SnippetWrapper;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static jdk.jshell.Snippet.Status.RECOVERABLE_DEFINED;
 import static jdk.jshell.Snippet.Status.VALID;
+import org.junit.jupiter.api.Test;
 
-@Test
 public class WrapperTest extends KullaTesting {
 
+    @Test
     public void testMethod() {
         String src = "void glib() { System.out.println(\"hello\"); }";
         List<SnippetWrapper> swl = getState().sourceCodeAnalysis().wrappers(src);
-        assertEquals(swl.size(), 1, "unexpected list length");
+        assertEquals(1, swl.size(), "unexpected list length");
         assertWrapperHas(swl.get(0), src, Kind.METHOD, "void", "glib", "println");
         assertPosition(swl.get(0), src, 0, 4);
         assertPosition(swl.get(0), src, 5, 4);
@@ -63,6 +63,7 @@ public class WrapperTest extends KullaTesting {
     }
 
     // test 8159740
+    @Test
     public void testMethodCorralled() {
         String src = "void glib() { f(); }";
         //            _123456789_123456789
@@ -75,6 +76,7 @@ public class WrapperTest extends KullaTesting {
     }
 
     // test 8159740
+    @Test
     public void testClassCorralled0() {
         String src = "class AAA { float mmm(double d1234) { return (float) (f0 * d1234); } }";
         //            _123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789
@@ -91,6 +93,7 @@ public class WrapperTest extends KullaTesting {
     }
 
     // test 8159740
+    @Test
     public void testClassCorralled() {
         String src = "class AAA { int xxx = x0 + 4; float mmm(float ffff) { return f0 * ffff; } }";
         //            _123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789
@@ -109,6 +112,7 @@ public class WrapperTest extends KullaTesting {
     }
 
     // test 8159740
+    @Test
     public void testClassWithConstructorCorralled() {
         String src = "public class AAA { AAA(String b) {} int xxx = x0 + 4; float mmm(float ffff) { return f0 * ffff; } }";
         //            _123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789
@@ -130,6 +134,7 @@ public class WrapperTest extends KullaTesting {
     }
 
     // test 8159740
+    @Test
     public void testInterfaceCorralled() {
         String src = "interface AAA { default float mmm(double d1234) { return (float) (f0 * d1234); } }";
         //            _123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789
@@ -147,6 +152,7 @@ public class WrapperTest extends KullaTesting {
     }
 
     // test 8159740
+    @Test
     public void testEnumCorralled() {
         String src =
                 "public enum Planet {\n" +
@@ -182,25 +188,27 @@ public class WrapperTest extends KullaTesting {
                 "radius", "surfaceGravity", "surfaceWeight");
     }
 
+    @Test
     public void testMethodBad() {
         String src = "void flob() { ?????; }";
         List<SnippetWrapper> swl = getState().sourceCodeAnalysis().wrappers(src);
-        assertEquals(swl.size(), 1, "unexpected list length");
+        assertEquals(1, swl.size(), "unexpected list length");
         assertWrapperHas(swl.get(0), src, Kind.METHOD, "void", "flob", "?????");
         assertPosition(swl.get(0), src, 9, 2);
 
         Snippet f = key(assertEvalFail(src));
-        assertEquals(f.kind(), Kind.ERRONEOUS);
-        assertEquals(((ErroneousSnippet)f).probableKind(), Kind.METHOD);
+        assertEquals(Kind.ERRONEOUS, f.kind());
+        assertEquals(Kind.METHOD, ((ErroneousSnippet)f).probableKind());
         SnippetWrapper sw = getState().sourceCodeAnalysis().wrapper(f);
         assertWrapperHas(sw, src, Kind.METHOD, "void", "flob", "?????");
         assertPosition(swl.get(0), src, 14, 5);
     }
 
+    @Test
     public void testVar() {
         String src = "int gx = 1234;";
         List<SnippetWrapper> swl = getState().sourceCodeAnalysis().wrappers(src);
-        assertEquals(swl.size(), 1, "unexpected list length");
+        assertEquals(1, swl.size(), "unexpected list length");
         assertWrapperHas(swl.get(0), src, Kind.VAR, "int", "gx", "1234");
         assertPosition(swl.get(0), src, 4, 2);
 
@@ -210,25 +218,27 @@ public class WrapperTest extends KullaTesting {
         assertPosition(swg, src, 0, 3);
     }
 
+    @Test
     public void testVarBad() {
         String src = "double dd = ?????;";
         List<SnippetWrapper> swl = getState().sourceCodeAnalysis().wrappers(src);
-        assertEquals(swl.size(), 1, "unexpected list length");
+        assertEquals(1, swl.size(), "unexpected list length");
         assertWrapperHas(swl.get(0), src, Kind.VAR, "double", "dd", "?????");
         assertPosition(swl.get(0), src, 9, 2);
 
         Snippet f = key(assertEvalFail(src));
-        assertEquals(f.kind(), Kind.ERRONEOUS);
-        assertEquals(((ErroneousSnippet)f).probableKind(), Kind.VAR);
+        assertEquals(Kind.ERRONEOUS, f.kind());
+        assertEquals(Kind.VAR, ((ErroneousSnippet)f).probableKind());
         SnippetWrapper sw = getState().sourceCodeAnalysis().wrapper(f);
         assertWrapperHas(sw, src, Kind.VAR, "double", "dd", "?????");
         assertPosition(swl.get(0), src, 12, 5);
     }
 
+    @Test
     public void testImport() {
         String src = "import java.lang.*;";
         List<SnippetWrapper> swl = getState().sourceCodeAnalysis().wrappers(src);
-        assertEquals(swl.size(), 1, "unexpected list length");
+        assertEquals(1, swl.size(), "unexpected list length");
         assertWrapperHas(swl.get(0), src, Kind.IMPORT, "import", "java.lang");
         assertPosition(swl.get(0), src, 7, 4);
 
@@ -238,61 +248,65 @@ public class WrapperTest extends KullaTesting {
         assertPosition(swg, src, 0, 6);
     }
 
+    @Test
     public void testImportBad() {
         String src = "import java.?????;";
         List<SnippetWrapper> swl = getState().sourceCodeAnalysis().wrappers(src);
-        assertEquals(swl.size(), 1, "unexpected list length");
+        assertEquals(1, swl.size(), "unexpected list length");
         assertWrapperHas(swl.get(0), src, Kind.IMPORT, "import", "?????");
         assertPosition(swl.get(0), src, 7, 4);
 
         Snippet f = key(assertEvalFail(src));
-        assertEquals(f.kind(), Kind.ERRONEOUS);
-        assertEquals(((ErroneousSnippet)f).probableKind(), Kind.IMPORT);
+        assertEquals(Kind.ERRONEOUS, f.kind());
+        assertEquals(Kind.IMPORT, ((ErroneousSnippet)f).probableKind());
         SnippetWrapper sw = getState().sourceCodeAnalysis().wrapper(f);
         assertWrapperHas(sw, src, Kind.IMPORT, "import", "?????");
         assertPosition(swl.get(0), src, 0, 6);
     }
 
+    @Test
     public void testErroneous() {
         String src = "@@@@@@@@@@";
         List<SnippetWrapper> swl = getState().sourceCodeAnalysis().wrappers(src);
-        assertEquals(swl.size(), 1, "unexpected list length");
+        assertEquals(1, swl.size(), "unexpected list length");
         assertWrapperHas(swl.get(0), src, Kind.ERRONEOUS, "@@@@@@@@@@");
         assertPosition(swl.get(0), src, 0, 10);
 
         Snippet f = key(assertEvalFail(src));
-        assertEquals(f.kind(), Kind.ERRONEOUS);
-        assertEquals(((ErroneousSnippet)f).probableKind(), Kind.ERRONEOUS);
+        assertEquals(Kind.ERRONEOUS, f.kind());
+        assertEquals(Kind.ERRONEOUS, ((ErroneousSnippet)f).probableKind());
         SnippetWrapper sw = getState().sourceCodeAnalysis().wrapper(f);
         assertWrapperHas(sw, src, Kind.ERRONEOUS, "@@@@@@@@@@");
         assertPosition(swl.get(0), src, 0, 10);
     }
 
+    @Test
     public void testEmpty() {
         String src = "";
         List<SnippetWrapper> swl = getState().sourceCodeAnalysis().wrappers(src);
-        assertEquals(swl.size(), 0, "expected empty list");
+        assertEquals(0, swl.size(), "expected empty list");
     }
 
+    @Test
     public void testDependencies() {
         Snippet a = key(assertEval("int aaa = 6;", added(VALID)));
         Snippet b = key(assertEval("class B { B(int x) { aaa = x; } }", added(VALID)));
         Snippet c = key(assertEval("B ccc() { return new B(aaa); }", added(VALID)));
         Collection<Snippet> dep;
         dep = getState().sourceCodeAnalysis().dependents(c);
-        assertEquals(dep.size(), 0);
+        assertEquals(0, dep.size());
         dep = getState().sourceCodeAnalysis().dependents(b);
-        assertEquals(dep.size(), 1);
+        assertEquals(1, dep.size());
         assertTrue(dep.contains(c));
         dep = getState().sourceCodeAnalysis().dependents(a);
-        assertEquals(dep.size(), 2);
+        assertEquals(2, dep.size());
         assertTrue(dep.contains(c));
         assertTrue(dep.contains(b));
     }
 
     private void assertWrapperHas(SnippetWrapper sw, String source, Kind kind, String... has) {
-        assertEquals(sw.source(), source);
-        assertEquals(sw.kind(), kind);
+        assertEquals(source, sw.source());
+        assertEquals(kind, sw.kind());
         String s = sw.wrapped();
         if (kind == Kind.IMPORT) {
             assertHas(s, "import");
@@ -322,8 +336,8 @@ public class WrapperTest extends KullaTesting {
         //System.err.printf("#  wrapped @ wrappedPos: %s\n", wrappedPart);
         //System.err.printf("#  source @ start: %s\n", sourcePart);
 
-        assertEquals(wrappedPart, sourcePart,
+        assertEquals(sourcePart, wrappedPart,
                 "position " + wpg + " in " + sw.wrapped());
-        assertEquals(sw.wrappedToSourcePosition(wpg), start);
+        assertEquals(start, sw.wrappedToSourcePosition(wpg));
     }
 }


### PR DESCRIPTION
Backporting for parity with Oracle.

As with the newer versions, a bunch of simple conflicts needed to be resolved.

test/langtools/jdk/jshell/ClassesTest.java
- Omitted changes to test cases absent from JDK 17

test/langtools/jdk/jshell/CommandCompletionTest.java
- Conflict in an assert because of missing JDK-8295814: JDK-8295814 extended the error message of the assert — I took a liberty to take the extended version as it improves the error message, even though it comes from a different change

test/langtools/jdk/jshell/CompilerOptionsTest.java
- Copyright years

test/langtools/jdk/jshell/CompletenessTest.java
- Copyright years

test/langtools/jdk/jshell/CompletionSuggestionTest.java
- Omitted changes to test cases absent from JDK 17

test/langtools/jdk/jshell/HistoryUITest.java
- Copyright years

test/langtools/jdk/jshell/ImportTest.java
- Replaced `@Test(enabled = false) // TODO 8129418` with `@Disabled("TODO 8129418")` (required `import org.junit.jupiter.api.Disabled;`)

test/langtools/jdk/jshell/IndentUITest.java
- Copyright years

test/langtools/jdk/jshell/MethodsTest.java
- Copyright years
- Omitted changes to test cases absent from JDK 17

test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
- Copyright years

test/langtools/jdk/jshell/PipeInputStreamTest.java
- Conflict in the test header because of a difference in neighboring lines

test/langtools/jdk/jshell/ReplToolTesting.java
- Conflict in an assert because of missing JDK-8295984: JDK-8295984 replaced assertTrue with assertEquals checking the updated behavior — I kept the existing assertTrue, it did not need any adaptation to JUnit

test/langtools/jdk/jshell/SealedClassesTest.java
- Omitted changes to test cases absent from JDK 17

test/langtools/jdk/jshell/StartOptionTest.java
- Omitted changes to test cases absent from JDK 17

test/langtools/jdk/jshell/ToolBasicTest.java
- Copyright years

test/langtools/jdk/jshell/ToolEnablePreviewTest.java
- Copyright years

test/langtools/jdk/jshell/ToolMultilineSnippetHistoryTest.java
- Copyright years

test/langtools/jdk/jshell/ToolShiftTabTest.java
- Copyright years

test/langtools/jdk/jshell/ToolTabCommandTest.java
- Copyright years

test/langtools/jdk/jshell/ToolTabSnippetTest.java
- Copyright years

test/langtools/jdk/jshell/UndefinedClassTest.java
- Copyright years

test/langtools/jdk/jshell/UserInputTest.java
- Omitted changes to test cases absent from JDK 17

test/langtools/jdk/jshell/VariablesTest.java
- Omitted changes to test cases absent from JDK 17
- Conflict because of a redundant `;` which did not exist in JDK 21 — removed the redundant `;`

Files that are completely absent from JDK 17, so changes to them were omitted: test/langtools/jdk/jshell/Test8294583.java, test/langtools/jdk/jshell/Test8296012.java, test/langtools/jdk/jshell/ConsoleTest.java, test/langtools/jdk/jshell/ErrorRecoveryTest.java, test/langtools/jdk/jshell/HighlightUITest.java, test/langtools/jdk/jshell/MultipleDocumentationTest.java, test/langtools/jdk/jshell/SnippetEventToStringTest.java, test/langtools/jdk/jshell/SnippetHighlightTest.java, test/langtools/jdk/jshell/ToolEnableNativeAccessTest.java, test/langtools/jdk/jshell/ToolingTest.java, test/langtools/jdk/jshell/UnnamedTest.java b/test/langtools/jdk/jshell/UnnamedTest.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8365776](https://bugs.openjdk.org/browse/JDK-8365776) needs maintainer approval

### Issue
 * [JDK-8365776](https://bugs.openjdk.org/browse/JDK-8365776): Convert JShell tests to use JUnit instead of TestNG (**Task** - P4 - Approved)


### Reviewers
 * [Alexey Bakhtin](https://openjdk.org/census#abakhtin) (@alexeybakhtin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4619/head:pull/4619` \
`$ git checkout pull/4619`

Update a local copy of the PR: \
`$ git checkout pull/4619` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4619`

View PR using the GUI difftool: \
`$ git pr show -t 4619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4619.diff">https://git.openjdk.org/jdk17u-dev/pull/4619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4619#issuecomment-5315575175)
</details>
