### PR TITLE
8390441: RISC-V: Fix C2 stack-to-stack spill copies with large offsets

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1530,6 +1530,20 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
   int src_offset = ra_->reg2offset(src_lo);
   int dst_offset = ra_->reg2offset(dst_lo);
 
+  // Stack-to-stack copies use t0 for the value. Bail out if the destination
+  // address also needs t0 to materialize an offset outside the 12-bit range.
+  // Vector stack-to-stack copies go through v0 instead and are not affected.
+  if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack &&
+      bottom_type()->isa_vect() == NULL) {
+    if (cbuf != NULL && !Assembler::is_simm12(dst_offset)) {
+      // size() emits into a scratch buffer where recording a failure is not allowed.
+      if (!C->output()->in_scratch_emit_size()) {
+        C->record_method_not_compilable("unsupported large stack-to-stack spill copy");
+      }
+      return 0;
+    }
+  }
+
   if (bottom_type()->isa_vect() != NULL) {
     uint ireg = ideal_reg();
     if (ireg == Op_VecA && cbuf) {


### PR DESCRIPTION
Hi, this patch is a backport of https://github.com/openjdk/jdk/pull/32387 . this is a risc-v specific change. risk is low.

This backport is not clean:
1. jdk17u-dev doesn't have predicate register support
2. In jdk17u-dev, the vector stack-to-stack copy goes through spill_copy_vector_stack_to_stack, where the data is transferred via v0 and t0 is only used for address computation (capable of handling large offsets), so there is no conflict. The scalar path's sd(t0, Address(sp, dst_offset)) only uses t0 as an address temporary when the offset exceeds simm12, which would clobber the value; therefore, only the scalar case's dst_offset needs to be checked.

Testing: the test TestRiscvLargeStackToStack.java[1], which previously had test failures, has now passed.

[1] https://bugs.openjdk.org/secure/attachment/121298/TestRiscvLargeStackToStack.java

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] [JDK-8390441](https://bugs.openjdk.org/browse/JDK-8390441) needs maintainer approval
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Issue
 * [JDK-8390441](https://bugs.openjdk.org/browse/JDK-8390441): RISC-V: Fix C2 stack-to-stack spill copies with large offsets (**Bug** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4623/head:pull/4623` \
`$ git checkout pull/4623`

Update a local copy of the PR: \
`$ git checkout pull/4623` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4623`

View PR using the GUI difftool: \
`$ git pr show -t 4623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4623.diff">https://git.openjdk.org/jdk17u-dev/pull/4623.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4623#issuecomment-5324598530)
</details>
