### PR TITLE
8359735: [Ubuntu 25.10] java/lang/ProcessBuilder/Basic.java, java/lang/ProcessHandle/InfoTest.java fail due to rust-coreutils

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -681,7 +681,7 @@ public class Basic {
         public static String path() { return path; }
         private static final String path = path0();
         private static String path0(){
-            if (!Platform.isBusybox("/bin/true")) {
+            if (!Files.isSymbolicLink(Paths.get("/bin/true"))) {
                 return "/bin/true";
             } else {
                 File trueExe = new File("true");
@@ -696,7 +696,7 @@ public class Basic {
         public static String path() { return path; }
         private static final String path = path0();
         private static String path0(){
-            if (!Platform.isBusybox("/bin/false")) {
+            if (!Files.isSymbolicLink(Paths.get("/bin/false"))) {
                 return "/bin/false";
             } else {
                 File falseExe = new File("false");

--- a/test/jdk/java/lang/ProcessHandle/InfoTest.java
+++ b/test/jdk/java/lang/ProcessHandle/InfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -294,10 +294,12 @@ public class InfoTest {
                     String expected = "sleep";
                     if (Platform.isWindows()) {
                         expected = "sleep.exe";
-                    } else if (Platform.isBusybox("/bin/sleep")) {
-                        // With busybox sleep is just a sym link to busybox.
-                        // The busbox executable is seen as ProcessHandle.Info command.
-                        expected = "busybox";
+                    } else if (Files.isSymbolicLink(Paths.get("/bin/sleep"))) {
+                        // Busybox sleep is a symbolic link to /bin/busybox.
+                        // Rust coreutils sleep is a symbolic link to coreutils
+                        // The busbox/coreutils executables are seen as ProcessHandle.Info command.
+                        Path executable = Files.readSymbolicLink(Paths.get("/bin/sleep"));
+                        expected = executable.getFileName().toString();
                     }
                     Assert.assertTrue(command.endsWith(expected), "Command: expected: \'" +
                             expected + "\', actual: " + command);


### PR DESCRIPTION
This is the backport of "JDK-8359735: [Ubuntu 25.10] java/lang/ProcessBuilder/Basic.java, java/lang/ProcessHandle/InfoTest.java fail due to rust-coreutils" to jdk17u-dev. I'm backporting this as the tests have the same problem as in jdk25.

Clean backport. No risk, test changes only. Tier1 is OK. The build problems in SignatureUtil.java are not related to the change.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8359735](https://bugs.openjdk.org/browse/JDK-8359735) needs maintainer approval

### Issue
 * [JDK-8359735](https://bugs.openjdk.org/browse/JDK-8359735): [Ubuntu 25.10] java/lang/ProcessBuilder/Basic.java, java/lang/ProcessHandle/InfoTest.java fail due to rust-coreutils (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4624/head:pull/4624` \
`$ git checkout pull/4624`

Update a local copy of the PR: \
`$ git checkout pull/4624` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4624`

View PR using the GUI difftool: \
`$ git pr show -t 4624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4624.diff">https://git.openjdk.org/jdk17u-dev/pull/4624.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4624#issuecomment-5329889376)
</details>
