### PR TITLE
8265604: Support unlinked classes in dynamic CDS archive

### DIFF
--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -258,8 +258,14 @@ void DynamicArchiveBuilder::sort_methods(InstanceKlass* ik) const {
   if (ik->default_methods() != NULL) {
     Method::sort_methods(ik->default_methods(), /*set_idnums=*/false, dynamic_dump_method_comparator);
   }
-  ik->vtable().initialize_vtable();
-  ik->itable().initialize_itable();
+  if (ik->is_linked()) {
+    // If the class has already been linked, we must relayout the i/v tables, whose order depends
+    // on the method sorting order.
+    // If the class is unlinked, we cannot layout the i/v tables yet. This is OK, as the
+    // i/v tables will be initialized at runtime after bytecode verification.
+    ik->vtable().initialize_vtable();
+    ik->itable().initialize_itable();
+  }
 
   // Set all the pointer marking bits after sorting.
   remark_pointers_for_instance_klass(ik, true);

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -390,7 +390,7 @@ static void rewrite_nofast_bytecode(const methodHandle& method) {
 void MetaspaceShared::rewrite_nofast_bytecodes_and_calculate_fingerprints(Thread* thread, InstanceKlass* ik) {
   for (int i = 0; i < ik->methods()->length(); i++) {
     methodHandle m(thread, ik->methods()->at(i));
-    if (ik->can_be_verified_at_dumptime()) {
+    if (ik->can_be_verified_at_dumptime() && ik->is_linked()) {
       rewrite_nofast_bytecode(m);
     }
     Fingerprinter fp(m);
@@ -570,10 +570,26 @@ public:
   ClassLoaderData* cld_at(int index) { return _loaded_cld.at(index); }
 };
 
-bool MetaspaceShared::linking_required(InstanceKlass* ik) {
-  // For static CDS dump, do not link old classes.
-  // For dynamic CDS dump, only link classes loaded by the builtin class loaders.
-  return DumpSharedSpaces ? ik->can_be_verified_at_dumptime() : !ik->is_shared_unregistered_class();
+// Check if we can eagerly link this class at dump time, so we can avoid the
+// runtime linking overhead (especially verification)
+bool MetaspaceShared::may_be_eagerly_linked(InstanceKlass* ik) {
+  if (!ik->can_be_verified_at_dumptime()) {
+    // For old classes, try to leave them in the unlinked state, so
+    // we can still store them in the archive. They must be
+    // linked/verified at runtime.
+    return false;
+  }
+  if (DynamicDumpSharedSpaces && ik->is_shared_unregistered_class()) {
+    // Linking of unregistered classes at this stage may cause more
+    // classes to be resolved, resulting in calls to ClassLoader.loadClass()
+    // that may not be expected by custom class loaders.
+    //
+    // It's OK to do this for the built-in loaders as we know they can
+    // tolerate this. (Note that unregistered classes are loaded by the NULL
+    // loader during DumpSharedSpaces).
+    return false;
+  }
+  return true;
 }
 
 bool MetaspaceShared::link_class_for_cds(InstanceKlass* ik, TRAPS) {
@@ -612,7 +628,7 @@ void MetaspaceShared::link_and_cleanup_shared_classes(TRAPS) {
       for (Klass* klass = cld->klasses(); klass != NULL; klass = klass->next_link()) {
         if (klass->is_instance_klass()) {
           InstanceKlass* ik = InstanceKlass::cast(klass);
-          if (linking_required(ik)) {
+          if (may_be_eagerly_linked(ik)) {
             has_linked |= link_class_for_cds(ik, CHECK);
           }
         }

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -136,7 +136,7 @@ public:
   static bool try_link_class(JavaThread* current, InstanceKlass* ik);
   static void link_and_cleanup_shared_classes(TRAPS) NOT_CDS_RETURN;
   static bool link_class_for_cds(InstanceKlass* ik, TRAPS) NOT_CDS_RETURN_(false);
-  static bool linking_required(InstanceKlass* ik) NOT_CDS_RETURN_(false);
+  static bool may_be_eagerly_linked(InstanceKlass* ik) NOT_CDS_RETURN_(false);
 
 #if INCLUDE_CDS
   // Alignment for the 2 core CDS regions (RW/RO) only.

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1376,6 +1376,12 @@ bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
   if (k->is_in_error_state()) {
     return warn_excluded(k, "In error state");
   }
+  if (k->is_scratch_class()) {
+    return warn_excluded(k, "A scratch class");
+  }
+  if (!k->is_loaded()) {
+    return warn_excluded(k, "Not in loaded state");
+  }
   if (has_been_redefined(k)) {
     return warn_excluded(k, "Has been redefined");
   }
@@ -1397,36 +1403,21 @@ bool SystemDictionaryShared::check_for_exclusion_impl(InstanceKlass* k) {
     // support them and make CDS more complicated.
     return warn_excluded(k, "JFR event class");
   }
-  if (k->init_state() < InstanceKlass::linked) {
-    // In CDS dumping, we will attempt to link all classes. Those that fail to link will
-    // be recorded in DumpTimeSharedClassInfo.
-    Arguments::assert_is_dumping_archive();
 
-    // TODO -- rethink how this can be handled.
-    // We should try to link ik, however, we can't do it here because
-    // 1. We are at VM exit
-    // 2. linking a class may cause other classes to be loaded, which means
-    //    a custom ClassLoader.loadClass() may be called, at a point where the
-    //    class loader doesn't expect it.
+  if (!k->is_linked()) {
     if (has_class_failed_verification(k)) {
       return warn_excluded(k, "Failed verification");
-    } else {
-      if (k->can_be_verified_at_dumptime()) {
-        return warn_excluded(k, "Not linked");
-      }
     }
-  }
-  if (DynamicDumpSharedSpaces && k->major_version() < 50 /*JAVA_6_VERSION*/) {
-    // In order to support old classes during dynamic dump, class rewriting needs to
-    // be reverted. This would result in more complex code and testing but not much gain.
-    ResourceMark rm;
-    log_warning(cds)("Pre JDK 6 class not supported by CDS: %u.%u %s",
-                     k->major_version(),  k->minor_version(), k->name()->as_C_string());
-    return true;
-  }
-
-  if (!k->can_be_verified_at_dumptime() && k->is_linked()) {
-    return warn_excluded(k, "Old class has been linked");
+  } else {
+    if (!k->can_be_verified_at_dumptime()) {
+      // We have an old class that has been linked (e.g., it's been executed during
+      // dump time). This class has been verified using the old verifier, which
+      // doesn't save the verification constraints, so check_verification_constraints()
+      // won't work at runtime.
+      // As a result, we cannot store this class. It must be loaded and fully verified
+      // at runtime.
+      return warn_excluded(k, "Old class has been linked");
+    }
   }
 
   if (k->is_hidden() && !is_registered_lambda_proxy_class(k)) {

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -571,7 +571,6 @@ void Rewriter::rewrite(InstanceKlass* klass, TRAPS) {
 #if INCLUDE_CDS
   if (klass->is_shared()) {
     assert(!klass->is_rewritten(), "rewritten shared classes cannot be rewritten again");
-    assert(!klass->can_be_verified_at_dumptime(), "only shared old classes aren't rewritten");
   }
 #endif // INCLUDE_CDS
   ResourceMark rm(THREAD);

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -370,6 +370,12 @@ void ConstantPool::restore_unshareable_info(TRAPS) {
 }
 
 void ConstantPool::remove_unshareable_info() {
+  // Shared ConstantPools are in the RO region, so the _flags cannot be modified.
+  // The _on_stack flag is used to prevent ConstantPools from deallocation during
+  // class redefinition. Since shared ConstantPools cannot be deallocated anyway,
+  // we always set _on_stack to true to avoid having to change _flags during runtime.
+  _flags |= (_on_stack | _is_shared);
+
   if (!_pool_holder->is_linked() && !_pool_holder->verified_at_dump_time()) {
     return;
   }
@@ -382,11 +388,6 @@ void ConstantPool::remove_unshareable_info() {
     resolved_references() != NULL ? resolved_references()->length() : 0);
   set_resolved_references(OopHandle());
 
-  // Shared ConstantPools are in the RO region, so the _flags cannot be modified.
-  // The _on_stack flag is used to prevent ConstantPools from deallocation during
-  // class redefinition. Since shared ConstantPools cannot be deallocated anyway,
-  // we always set _on_stack to true to avoid having to change _flags during runtime.
-  _flags |= (_on_stack | _is_shared);
   int num_klasses = 0;
   for (int index = 1; index < length(); index++) { // Index 0 is unused
     if (tag_at(index).is_unresolved_klass_in_error()) {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -909,6 +909,9 @@ bool InstanceKlass::link_class_impl(TRAPS) {
 
     if (!is_linked()) {
       if (!is_rewritten()) {
+        if (is_shared()) {
+          assert(!verified_at_dump_time(), "must be");
+        }
         {
           bool verify_ok = verify_code(THREAD);
           if (!verify_ok) {
@@ -940,9 +943,11 @@ bool InstanceKlass::link_class_impl(TRAPS) {
       // initialize_vtable and initialize_itable need to be rerun
       // for a shared class if
       // 1) the class is loaded by custom class loader or
-      // 2) the class is loaded by built-in class loader but failed to add archived loader constraints
+      // 2) the class is loaded by built-in class loader but failed to add archived loader constraints or
+      // 3) the class was not verified during dump time
       bool need_init_table = true;
-      if (is_shared() && SystemDictionaryShared::check_linking_constraints(THREAD, this)) {
+      if (is_shared() && verified_at_dump_time() &&
+          SystemDictionaryShared::check_linking_constraints(THREAD, this)) {
         need_init_table = false;
       }
       if (need_init_table) {
@@ -2447,7 +2452,8 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 
 void InstanceKlass::remove_unshareable_info() {
 
-  if (can_be_verified_at_dumptime()) {
+  if (is_linked()) {
+    assert(can_be_verified_at_dumptime(), "must be");
     // Remember this so we can avoid walking the hierarchy at runtime.
     set_verified_at_dump_time();
   }

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -519,9 +519,14 @@ void Klass::metaspace_pointers_do(MetaspaceClosure* it) {
     it->push(&_primary_supers[i]);
   }
   it->push(&_super);
-  it->push((Klass**)&_subklass);
-  it->push((Klass**)&_next_sibling);
-  it->push(&_next_link);
+  if (!Arguments::is_dumping_archive()) {
+    // If dumping archive, these may point to excluded classes. There's no need
+    // to follow these pointers anyway, as they will be set to NULL in
+    // remove_unshareable_info().
+    it->push((Klass**)&_subklass);
+    it->push((Klass**)&_next_sibling);
+    it->push(&_next_link);
+  }
 
   vtableEntry* vt = start_of_vtable();
   for (int i=0; i<vtable_length(); i++) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/OldClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OldClassTest.java
@@ -62,7 +62,7 @@ public class OldClassTest implements Opcodes {
     OutputAnalyzer output = TestCommon.dump(jar, appClasses, "-Xlog:class+load,cds=debug");
     TestCommon.checkExecReturn(output, 0,
                                dynamicMode ? true : false,
-                               "Pre JDK 6 class not supported by CDS");
+                               "Skipping Hello: Old class has been linked");
 
     TestCommon.run(
         "-cp", jar,
@@ -83,7 +83,7 @@ public class OldClassTest implements Opcodes {
     output = TestCommon.dump(classpath, appClasses);
     TestCommon.checkExecReturn(output, 0,
                                dynamicMode ? true : false,
-                               "Pre JDK 6 class not supported by CDS");
+                               "Skipping Hello: Old class has been linked");
 
     TestCommon.run(
         "-cp", classpath,

--- a/test/hotspot/jtreg/runtime/cds/appcds/OldInfExtendsInfDefMeth.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OldInfExtendsInfDefMeth.java
@@ -52,7 +52,7 @@ public class OldInfExtendsInfDefMeth {
         OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:class+load,cds=debug,verification=trace");
         TestCommon.checkExecReturn(output, 0,
                                    dynamicMode ? true : false,
-                                   "Pre JDK 6 class not supported by CDS: 49.0 OldInfDefMeth");
+                                   "Skipping OldInfDefMeth: Old class has been linked");
 
         // run with archive
         TestCommon.run(

--- a/test/hotspot/jtreg/runtime/cds/appcds/OldSuperClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OldSuperClass.java
@@ -52,7 +52,7 @@ public class OldSuperClass {
         OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:class+load,cds=debug,verification=trace");
         TestCommon.checkExecReturn(output, 0,
                                    dynamicMode ? true : false,
-                                   "Pre JDK 6 class not supported by CDS: 49.0 OldSuper",
+                                   "Skipping OldSuper: Old class has been linked",
                                    "Skipping ChildOldSuper: Old class has been linked",
                                    "Skipping GChild: Old class has been linked");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/OldSuperInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OldSuperInf.java
@@ -55,7 +55,7 @@ public class OldSuperInf {
         OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:class+load,cds=debug,verification=trace");
         TestCommon.checkExecReturn(output, 0,
                                    dynamicMode ? true : false,
-                                   "Pre JDK 6 class not supported by CDS: 49.0 OldInf",
+                                   "Skipping OldInf: Old class has been linked",
                                    "Skipping ChildOldInf: Old class has been linked",
                                    "Skipping GChild2: Old class has been linked");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/OldSuperInfIndirect.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OldSuperInfIndirect.java
@@ -56,7 +56,7 @@ public class OldSuperInfIndirect {
         OutputAnalyzer output = TestCommon.dump(appJar, appClasses, "-Xlog:class+load,cds=debug,verification=trace");
         TestCommon.checkExecReturn(output, 0,
                                    dynamicMode ? true : false,
-                                   "Pre JDK 6 class not supported by CDS: 49.0 OldInf",
+                                   "Skipping OldInf: Old class has been linked",
                                    "Skipping IndirectImpInf: Old class has been linked");
 
         // run with archive

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaProxyDuringShutdown.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdaProxyDuringShutdown.java
@@ -60,8 +60,8 @@ public class LambdaProxyDuringShutdown extends DynamicArchiveTestBase {
             use_whitebox_jar,
             "-cp", appJar, mainClass)
             .assertNormalExit(output -> {
-                // Nest host should be skipped since it is not in the linked state.
-                output.shouldContain("Skipping Outer: Not linked")
+                // Nest host should not be skipped although it is not in the linked state.
+                output.shouldNotContain("Skipping Outer: Not linked")
                 // Lambda proxy is loaded normally.
                       .shouldMatch("class.load.*Outer[$]Inner[$][$]Lambda[$].*0x.*source:.Outer")
                       .shouldContain(appOutput)
@@ -75,10 +75,10 @@ public class LambdaProxyDuringShutdown extends DynamicArchiveTestBase {
             "-Xlog:class+load=debug",
             "-cp", appJar, mainClass, "run")
             .assertNormalExit(output -> {
-                // Only the Inner class is loaded from the dynamic archive.
-                // The nest host (Outer) and its lambda proxy are not loaded
+                // Only the nest host (Outer) and the Inner class are loaded
                 // from the dynamic archive.
-                output.shouldMatch("class.load.*Outer.source:.*lambda_proxy_shutdown.jar")
+                // The lambda proxy is not loaded from the dynamic archive.
+                output.shouldMatch("class.load.*Outer.source:.*shared.*objects.*file.*(top)")
                       .shouldMatch("class.load.*Outer[$]Inner[$][$]Lambda[$].*0x.*source:.Outer")
                       .shouldMatch("class.load. Outer[$]Inner.source:.*shared.*objects.*file.*(top)")
                       .shouldContain(appOutput)

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/OldClassAndInf.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/OldClassAndInf.java
@@ -84,9 +84,6 @@ public class OldClassAndInf extends DynamicArchiveTestBase {
              loadees))
              .assertNormalExit(output -> {
                  output.shouldContain("Written dynamic archive 0x")
-                       .shouldContain("Pre JDK 6 class not supported by CDS: 49.0 " + loadeesArray[0])
-                       .shouldMatch("Skipping " + loadeesArray[1] +":.*" + loadeesArray[0] + " is excluded")
-                       .shouldMatch("Skipping " + loadeesArray[2] +": super.*" + loadeesArray[1] + " is excluded")
                        .shouldHaveExitValue(0);
                  });
 
@@ -105,7 +102,7 @@ public class OldClassAndInf extends DynamicArchiveTestBase {
             .assertNormalExit(output -> {
                 output.shouldHaveExitValue(0);
                 for (String loadee : loadees) {
-                    output.shouldMatch(".class.load. " + loadee + " source:.*" + loadeesJar);
+                    output.shouldContain(loadee + " source: shared objects file (top)");
                 }
                 });
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/CustomLoaderApp.java
@@ -36,20 +36,26 @@ public class CustomLoaderApp {
         System.out.println(path);
         System.out.println(url);
 
+        boolean init = false;
+        if (args.length ==2 && args[1].equals("init")) {
+            init = true;
+        }
+
         URLClassLoader urlClassLoader =
             new URLClassLoader("HelloClassLoader", urls, null);
-        Class c = Class.forName(className, true, urlClassLoader);
+        Class c = Class.forName(className, init, urlClassLoader);
         System.out.println(c);
         System.out.println(c.getClassLoader());
-        Object o = c.newInstance();
-
         if (c.getClassLoader() != urlClassLoader) {
             throw new RuntimeException("c.getClassLoader() == " + c.getClassLoader() +
                                        ", expected == " + urlClassLoader);
         }
 
-        Method method = c.getMethod("main", String[].class);
-        String[] params = null;
-        method.invoke(null, (Object)params);
+        if (init) {
+            Object o = c.newInstance();
+            Method method = c.getMethod("main", String[].class);
+            String[] params = null;
+            method.invoke(null, (Object)params);
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/dumpingWithAgent/OldClassWithJavaAgent.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/dumpingWithAgent/OldClassWithJavaAgent.java
@@ -34,7 +34,6 @@
  */
 
 import jdk.test.lib.cds.CDSOptions;
-import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.helpers.ClassFileInstaller;
 
@@ -55,15 +54,8 @@ public class OldClassWithJavaAgent {
             "-XX:+UnlockDiagnosticVMOptions", diagnosticOption,
             "-javaagent:" + agentJar + "=OldSuper");
 
-        boolean dynamicMode = CDSTestUtils.DYNAMIC_DUMP;
-
         // The java agent will load and link the class. We will skip old classes
-        // which have been linked during static CDS dump.
-        // Dynamic CDS dump doesn't support old class.
-        if (!dynamicMode) {
-            output.shouldContain("Skipping OldSuper: Old class has been linked");
-        } else {
-            output.shouldContain("Pre JDK 6 class not supported by CDS: 49.0 OldSuper");
-        }
+        // which have been linked during CDS dump.
+        output.shouldContain("Skipping OldSuper: Old class has been linked");
     }
 }


### PR DESCRIPTION
This is a clean backport with no additional modifications beyond the original commit.
The changes affect core CDS archiving logic during dump time and are well-tested upstream in JDK 21+. Risk is medium. 

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8265604](https://bugs.openjdk.org/browse/JDK-8265604) needs maintainer approval

### Issue
 * [JDK-8265604](https://bugs.openjdk.org/browse/JDK-8265604): Support unlinked classes in dynamic CDS archive (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk17u-dev.git pull/4632/head:pull/4632` \
`$ git checkout pull/4632`

Update a local copy of the PR: \
`$ git checkout pull/4632` \
`$ git pull https://git.openjdk.org/jdk17u-dev.git pull/4632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4632`

View PR using the GUI difftool: \
`$ git pr show -t 4632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk17u-dev/pull/4632.diff">https://git.openjdk.org/jdk17u-dev/pull/4632.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk17u-dev/pull/4632#issuecomment-5426095210)
</details>
